### PR TITLE
fix: stop bridging a resource audience in CCSaaS mode

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -216,25 +216,28 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
         OIDC_PREFIX + "jwk-set-uri");
   }
 
-  // CSL has one Set-valued audiences property, so we collect every legacy audience source that
-  // applies to the active mode into one comma-joined value that Spring binds to the Set; the old
-  // per-key putIfAbsent kept only the first and silently dropped the rest.
+  // CSL has one Set-valued audiences property applied by the shared factory to every token path,
+  // so we collect the legacy audience sources that apply to the active mode into one comma-joined
+  // value that Spring binds to the Set. The old per-key putIfAbsent kept only the first and
+  // silently dropped the rest.
   //
   // CCSM validated two distinct audiences on two paths: the identity audience on the login/session
   // token and the public-API audience on the bearer path. Both must survive here.
   //
-  // CCSaaS/Auth0 only ever validated the client audience (on the public-API path; the login
-  // id_token was not audience-checked). The public-API audience is a CCSM-only key, so we do not
-  // feed it in Auth0 mode - doing so would accept an audience legacy cloud never honoured.
+  // CCSaaS/Auth0 bridges no audience. Camunda's Auth0 issues id_tokens whose only aud is the
+  // client id (per the OIDC spec), never a resource audience, so an audience gate on the shared
+  // factory would reject every login. SaaS trust instead comes from the issuer plus the
+  // organization and cluster claim validators (see OptimizeCloudSecurityConfiguration), matching
+  // how OC secures its SaaS chain. This replaces the legacy per-path CCSaaS audience check with the
+  // cluster-claim check on the public-API path.
   private void bridgeAudiences(
       final ConfigurableEnvironment env, final Map<String, Object> derived) {
-    final Set<String> audiences = new LinkedHashSet<>();
     if (isAuth0Configured(env)) {
-      addAudience(env, audiences, "CAMUNDA_OPTIMIZE_CLIENT_AUDIENCE");
-    } else {
-      addAudience(env, audiences, "CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE");
-      addAudience(env, audiences, "CAMUNDA_OPTIMIZE_API_AUDIENCE");
+      return;
     }
+    final Set<String> audiences = new LinkedHashSet<>();
+    addAudience(env, audiences, "CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE");
+    addAudience(env, audiences, "CAMUNDA_OPTIMIZE_API_AUDIENCE");
     if (!audiences.isEmpty()) {
       derived.putIfAbsent(OIDC_PREFIX + "audiences", String.join(",", audiences));
     }

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -122,7 +122,9 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("cloud-client");
     assertThat(env.getProperty(OIDC + "client-secret")).isEqualTo("cloud-secret");
     assertThat(env.getProperty(OIDC + "issuer-uri")).isEqualTo("https://weblogin.example.com/");
-    assertThat(env.getProperty(OIDC + "audiences")).isEqualTo("optimize");
+    // Auth0 mode bridges no audience: the id_token only carries the client id, so SaaS relies on
+    // the org/cluster claim validators rather than a resource-audience gate.
+    assertThat(env.getProperty(OIDC + "audiences")).isNull();
     assertThat(env.getProperty(OIDC + "organization-id")).isEqualTo("org-42");
     assertThat(env.getProperty(OIDC + "redirect-uri"))
         .isEqualTo("{baseScheme}://{baseHost}{basePort}/sso-callback?uuid=cluster-7");
@@ -194,18 +196,19 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
   }
 
   @Test
-  void shouldBridgeOnlyClientAudienceInAuth0ModeIgnoringPublicApiAudience() {
+  void shouldNotBridgeAnyAudienceInAuth0Mode() {
     final Map<String, Object> legacy = cslEnabledConfig();
     legacy.put("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID", "cloud-client");
     legacy.put("CAMUNDA_OPTIMIZE_CLIENT_AUDIENCE", "optimize");
-    // The public-API audience is a CCSM-only key; legacy cloud never validated it, so it must not
-    // leak into the audience set in Auth0 mode.
     legacy.put("CAMUNDA_OPTIMIZE_API_AUDIENCE", "optimize-public-api");
 
     final StandardEnvironment env = environmentWith(legacy);
     processor.postProcessEnvironment(env, null);
 
-    assertThat(env.getProperty(OIDC + "audiences")).isEqualTo("optimize");
+    // Camunda's Auth0 id_token only carries the client id as its audience, so a resource-audience
+    // gate would reject every login. SaaS trust comes from the org/cluster claim validators
+    // instead, so the bridge leaves audiences unset in Auth0 mode.
+    assertThat(env.getProperty(OIDC + "audiences")).isNull();
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #58568 (config bridge). Part of the [Optimize → CSL adoption epic](https://github.com/camunda/camunda/issues/58403).

## Problem

The config bridge merged in #58568 mapped `CAMUNDA_OPTIMIZE_CLIENT_AUDIENCE` into `camunda.security.authentication.oidc.audiences` in CCSaaS/Auth0 mode. CSL's shared `TokenValidatorFactory` applies that audience set to the **login id_token** as well as to bearer tokens (both Optimize's `OptimizeCloudSecurityConfiguration#idTokenDecoderFactory` and OC's `OidcOverrideBeansConfiguration#idTokenDecoderFactory` reuse the shared factory).

Camunda's Auth0 issues id_tokens whose only `aud` is the **client id**, per the OIDC spec, never a resource audience. Confirmed against a real dev login:

```
aud=[<client-id>], iss=https://weblogin.cloud.dev.ultrawombat.com/
```

So once `optimize.security.csl.enabled` is on, the audience gate would reject every interactive login, because the id_token's `aud` (the client id) is not in the bridged set (the resource audience).

## Fix

Bridge no audience in Auth0/CCSaaS mode. SaaS trust comes from the issuer plus the organization and cluster claim validators (`OptimizeCloudOrganizationValidator` / `OptimizeCloudClusterValidator` from #58638), which is exactly how OC secures its SaaS chain. When `audiences` is empty, `TokenValidatorFactory` adds no `AudienceValidator`, so the id_token passes on issuer + org/cluster.

CCSM audience bridging is unchanged: it still merges the identity audience (login/session token) and the public-API audience (bearer path).

## Behavior change

Consistent with the "Differences vs Optimize 8.9" already documented in #58638: the legacy per-path CCSaaS public-API audience check (`security.auth.cloud.audience`) is replaced by the `clusterId` claim check on the public-API path. This is the OC SaaS model.

## Acceptance criteria

- [x] In Auth0 mode (`CAMUNDA_OPTIMIZE_AUTH0_CLIENTID` present), no `camunda.security.authentication.oidc.audiences` is derived, even when `CAMUNDA_OPTIMIZE_CLIENT_AUDIENCE` / `CAMUNDA_OPTIMIZE_API_AUDIENCE` are set.
- [x] CCSM audience bridging (identity + public-API) is unchanged.
- [x] Unit test covers the Auth0 no-audience case and the unchanged CCSM merge (`OptimizeSecurityConfigCompatibilityPostProcessorTest`, 15 tests, green).

## Docs

No new operator-facing keys. The deprecation-mapping note tracked at the epic level (#58403) should state that in CCSaaS the legacy `security.auth.cloud.audience` no longer maps to a CSL audience; SaaS access is gated by org/cluster claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
