### PR TITLE
test: cover physical-tenant backpressure, disk-full, leader re-election and rejoin

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContext.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
 import io.camunda.zeebe.broker.system.management.BrokerAdminService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
+import java.util.Map;
 
 /** Context for components/actors managed directly by the Broker */
 public interface BrokerContext {
@@ -29,6 +30,14 @@ public interface BrokerContext {
   DiskSpaceUsageMonitor getDiskSpaceUsageMonitor();
 
   PartitionManager getPartitionManager();
+
+  /**
+   * Returns the partition manager of every physical tenant running on this broker, keyed by
+   * physical-tenant ID (including the {@code default} tenant). {@link #getPartitionManager()} only
+   * ever exposes the default tenant's manager; this accessor exists mainly for test / introspection
+   * access to non-default tenants' partitions.
+   */
+  Map<String, PartitionManager> getPartitionManagers();
 
   BrokerAdminService getBrokerAdminService();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContextImpl.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
 import io.camunda.zeebe.broker.system.management.BrokerAdminService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
+import java.util.Map;
 
 final class BrokerContextImpl implements BrokerContext {
 
@@ -22,6 +23,7 @@ final class BrokerContextImpl implements BrokerContext {
   private final EmbeddedGatewayService embeddedGatewayService;
   private final DiskSpaceUsageMonitor diskSpaceUsageMonitor;
   private final PartitionManager partitionManager;
+  private final Map<String, PartitionManager> partitionManagers;
   private final BrokerAdminService brokerAdminService;
   private final ManagedMessagingService apiMessagingService;
 
@@ -30,12 +32,14 @@ final class BrokerContextImpl implements BrokerContext {
       final ClusterServicesImpl clusterServices,
       final EmbeddedGatewayService embeddedGatewayService,
       final PartitionManager partitionManager,
+      final Map<String, PartitionManager> partitionManagers,
       final BrokerAdminService brokerAdminService,
       final ManagedMessagingService apiMessagingService) {
     this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
     this.clusterServices = requireNonNull(clusterServices);
     this.embeddedGatewayService = embeddedGatewayService;
     this.partitionManager = requireNonNull(partitionManager);
+    this.partitionManagers = requireNonNull(partitionManagers);
     this.brokerAdminService = requireNonNull(brokerAdminService);
     this.apiMessagingService = requireNonNull(apiMessagingService);
   }
@@ -58,6 +62,11 @@ final class BrokerContextImpl implements BrokerContext {
   @Override
   public PartitionManager getPartitionManager() {
     return partitionManager;
+  }
+
+  @Override
+  public Map<String, PartitionManager> getPartitionManagers() {
+    return partitionManagers;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -118,6 +118,7 @@ public final class BrokerStartupProcess {
         bsc.getClusterServices(),
         bsc.getEmbeddedGatewayService(),
         bsc.getPartitionManagers().get(PartitionManagerImpl.DEFAULT_GROUP_NAME),
+        bsc.getPartitionManagers(),
         bsc.getBrokerAdminService(PartitionManagerImpl.DEFAULT_GROUP_NAME),
         bsc.getApiMessagingService());
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantBackpressureIsolationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantBackpressureIsolationIT.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ClientStatusException;
+import io.camunda.zeebe.broker.Broker;
+import io.camunda.zeebe.broker.system.configuration.FlowControlCfg;
+import io.camunda.zeebe.broker.system.configuration.backpressure.RateLimitCfg;
+import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.grpc.Status.Code;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end test of physical tenant isolation with respect to backpressure: {@code FlowControl} is
+ * instantiated per (physical tenant, partition), unlike the shared, broker-wide disk space monitor
+ * (see {@link PhysicalTenantDiskUsageIsolationIT}). Backpressuring one physical tenant's engine
+ * must therefore not degrade another physical tenant's engine.
+ *
+ * <p>Writes are exercised with {@code publishMessage}, which is routed to a single partition by its
+ * correlation key, so the broker's exact rejection reason is surfaced to the client (a
+ * gateway-round-robined command such as {@code createProcessInstance} would collapse it into a
+ * generic "all partitions failed" error).
+ */
+@ZeebeIntegration
+final class PhysicalTenantBackpressureIsolationIT {
+
+  private static final String TENANT_A = "tenanta";
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
+
+  @AutoClose private CamundaClient defaultClient;
+  @AutoClose private CamundaClient tenantAClient;
+
+  private ZeebePartition tenantAPartition;
+
+  @BeforeEach
+  void beforeEach() {
+    defaultClient =
+        TENANTS.newClientBuilder(broker, PhysicalTenantsITHelper.DEFAULT_TENANT_ID).build();
+    tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build();
+
+    tenantAPartition = awaitTenantAPartitionReady();
+    awaitWritesAccepted(defaultClient);
+    awaitWritesAccepted(tenantAClient);
+  }
+
+  @Test
+  void shouldNotDegradeDefaultTenantWhenOtherTenantIsBackpressured() {
+    // given - tenant A's write throughput is throttled to reject (almost) every user command. A
+    // FIXED request-concurrency limit cannot express this: LimitCfg rejects a limit of 0 outright,
+    // and a limit of 1 never rejects sequential (non-overlapping) requests since each permit is
+    // released before the next is acquired. A write-rate limit of 1 permit/second with no ramp-up
+    // does reject deterministically: its underlying Guava RateLimiter starts "full", so the first
+    // write succeeds but every write within the following second is rejected once the single
+    // permit is exhausted - the same mechanism FlowControlTest#setup relies on.
+    tenantAPartition.getAdminAccess().configureFlowControl(restrictiveWriteRateLimit()).join();
+
+    // when - tenant A's writes are repeatedly attempted; the first may succeed, but subsequent ones
+    // within the same second are rejected once the single permit is exhausted
+    final var tenantARejection = captureFirstRejection(tenantAClient);
+
+    // then - tenant A's write is backpressured with RESOURCE_EXHAUSTED (the write-rate limiter's
+    // rejection message, as opposed to the request-limiter's "Reached maximum capacity...")
+    assertThat(tenantARejection)
+        .isInstanceOf(ClientStatusException.class)
+        .hasStackTraceContaining("write limit is exhausted")
+        .satisfies(
+            t ->
+                assertThat(((ClientStatusException) t).getStatusCode())
+                    .isEqualTo(Code.RESOURCE_EXHAUSTED));
+
+    // ...while the exact same command against the default tenant succeeds: FlowControl is a
+    // per-(physical tenant, partition) instance, so throttling tenant A's engine does not affect
+    // the default engine's independent instance - this is the core isolation property under test
+    assertThatCode(() -> publishMessage(defaultClient)).doesNotThrowAnyException();
+
+    // and - white-box: the two tenants have independent partition managers and FlowControl state
+    final var partitionManagers =
+        broker.bean(Broker.class).getBrokerContext().getPartitionManagers();
+    assertThat(partitionManagers.get(TENANT_A))
+        .isNotSameAs(partitionManagers.get(PhysicalTenantsITHelper.DEFAULT_TENANT_ID));
+
+    final var defaultLimits =
+        partitionManagers
+            .get(PhysicalTenantsITHelper.DEFAULT_TENANT_ID)
+            .getZeebePartitions()
+            .iterator()
+            .next()
+            .getAdminAccess()
+            .getFlowControlConfiguration()
+            .join();
+    assertThat(defaultLimits.writeRateLimit())
+        .satisfiesAnyOf(
+            rateLimit -> assertThat(rateLimit).isNull(),
+            rateLimit -> assertThat(rateLimit.enabled()).isFalse());
+  }
+
+  @Test
+  void shouldRecoverWhenTenantIsNoLongerBackpressured() {
+    // given - tenant A is backpressured and rejecting writes
+    tenantAPartition.getAdminAccess().configureFlowControl(restrictiveWriteRateLimit()).join();
+    assertThat(captureFirstRejection(tenantAClient)).isInstanceOf(ClientStatusException.class);
+
+    // when - tenant A's write-rate limit is explicitly lifted (a disabled limit must be set: an
+    // empty FlowControlCfg leaves getWrite() null, and configureFlowControl only touches a limit
+    // when its config is non-null, so it would not clear the existing limit)
+    final var lift = new FlowControlCfg();
+    final var disabledWriteLimit = new RateLimitCfg();
+    disabledWriteLimit.setEnabled(false);
+    lift.setWrite(disabledWriteLimit);
+    tenantAPartition.getAdminAccess().configureFlowControl(lift).join();
+
+    // then - tenant A accepts writes again
+    awaitWritesAccepted(tenantAClient);
+  }
+
+  private static FlowControlCfg restrictiveWriteRateLimit() {
+    final var flowControl = new FlowControlCfg();
+    final var writeLimit = new RateLimitCfg();
+    writeLimit.setEnabled(true);
+    writeLimit.setLimit(1);
+    flowControl.setWrite(writeLimit);
+    return flowControl;
+  }
+
+  // repeatedly attempts writes (polling faster than the ~1s write-rate permit accrues) until one is
+  // rejected, and returns that rejection
+  private static Throwable captureFirstRejection(final CamundaClient client) {
+    final var rejection = new AtomicReference<Throwable>();
+    await("write is rejected once the write-rate limit is exhausted")
+        .atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(10))
+        .untilAsserted(
+            () -> {
+              try {
+                publishMessage(client);
+              } catch (final Exception e) {
+                rejection.set(e);
+              }
+              assertThat(rejection.get()).isNotNull();
+            });
+    return rejection.get();
+  }
+
+  private static void awaitWritesAccepted(final CamundaClient client) {
+    await("tenant accepts writes")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> assertThatCode(() -> publishMessage(client)).doesNotThrowAnyException());
+  }
+
+  // publishMessage (MessageIntent.PUBLISH) is not whitelisted in FlowControl - see
+  // WhiteListedCommands - so it is subject to backpressure; it is also routed to a single partition
+  // by its correlation key, so the broker's rejection reason is preserved on the client exception
+  private static void publishMessage(final CamundaClient client) {
+    client
+        .newPublishMessageCommand()
+        .messageName("backpressure-msg")
+        .correlationKey(UUID.randomUUID().toString())
+        .send()
+        .join();
+  }
+
+  // tenant A's ZeebePartition exists as soon as the partition manager starts, but its admin access
+  // is only usable once the log stream is installed on the (elected) leader; poll a lightweight
+  // admin call until it stops failing rather than relying on the default topology RPC, which
+  // cannot represent non-default physical tenants' partitions
+  private ZeebePartition awaitTenantAPartitionReady() {
+    final var reference = new AtomicReference<ZeebePartition>();
+    await("tenant A's partition is leader-ready for admin access")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var partitions =
+                  broker
+                      .bean(Broker.class)
+                      .getBrokerContext()
+                      .getPartitionManagers()
+                      .get(TENANT_A)
+                      .getZeebePartitions();
+              assertThat(partitions).isNotEmpty();
+              final var partition = partitions.iterator().next();
+              partition.getAdminAccess().getFlowControlConfiguration().join();
+              reference.set(partition);
+            });
+    return reference.get();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantDiskUsageIsolationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantDiskUsageIsolationIT.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ClientStatusException;
+import io.camunda.zeebe.broker.Broker;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.grpc.Status.Code;
+import java.time.Duration;
+import java.util.UUID;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end test of physical tenant isolation with respect to disk space: the {@code
+ * DiskSpaceUsageMonitor} is a single broker-wide component shared by every physical tenant's
+ * partition group, unlike per-tenant flow control (see {@link
+ * PhysicalTenantBackpressureIsolationIT}). Running out of disk space is therefore a shared-fate
+ * event: it must reject writes on every physical tenant, and recovering disk space must restore
+ * writes on every physical tenant.
+ *
+ * <p>Writes are exercised with {@code publishMessage}, which is routed to a single partition by its
+ * correlation key. Unlike {@code createProcessInstance}, whose command the gateway attempts on
+ * every partition in turn (collapsing the per-partition rejection into a generic "all partitions
+ * failed" error), a partition-pinned command surfaces the broker's exact rejection reason to the
+ * client - the same reason {@code DiskSpaceRecoveryTest} asserts on.
+ */
+@ZeebeIntegration
+final class PhysicalTenantDiskUsageIsolationIT {
+
+  private static final String TENANT_A = "tenanta";
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(
+          new TestStandaloneBroker()
+              .withUnauthenticatedAccess()
+              // a short monitoring interval so the shared disk space monitor re-checks the
+              // (test-overridden) free space supplier quickly, keeping the test fast
+              .withDataConfig(
+                  data ->
+                      data.getPrimaryStorage()
+                          .getDisk()
+                          .setMonitoringInterval(Duration.ofMillis(100))));
+
+  @AutoClose private CamundaClient defaultClient;
+  @AutoClose private CamundaClient tenantAClient;
+
+  @BeforeEach
+  void beforeEach() {
+    defaultClient =
+        TENANTS.newClientBuilder(broker, PhysicalTenantsITHelper.DEFAULT_TENANT_ID).build();
+    tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build();
+
+    // each physical tenant's partition group may need a moment to elect a leader after startup;
+    // wait until each tenant accepts a write before the disk space is manipulated (a non-default
+    // tenant's leadership is not observable via the default topology RPC)
+    awaitWritesAccepted(defaultClient);
+    awaitWritesAccepted(tenantAClient);
+  }
+
+  @Test
+  void shouldRejectWritesForAllPhysicalTenantsWhenDiskFull() {
+    // given - the broker's single, shared disk space monitor reports the disk as full
+    final var diskSpaceMonitor =
+        broker.bean(Broker.class).getBrokerContext().getDiskSpaceUsageMonitor();
+    diskSpaceMonitor.setFreeDiskSpaceSupplier(() -> 0L);
+
+    // when/then - both the default tenant's and tenant A's writes are rejected: disk space is a
+    // broker-wide resource, so the outage is not scoped to a single physical tenant
+    await("default tenant rejects writes once the shared disk space monitor sees the disk as full")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(() -> assertRejectedForOutOfDiskSpace(defaultClient));
+    await("tenant A rejects writes once the shared disk space monitor sees the disk as full")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(() -> assertRejectedForOutOfDiskSpace(tenantAClient));
+  }
+
+  @Test
+  void shouldRecoverWritesForAllPhysicalTenantsWhenDiskSpaceAvailableAgain() {
+    // given - the disk is full and both tenants are rejecting writes
+    final var diskSpaceMonitor =
+        broker.bean(Broker.class).getBrokerContext().getDiskSpaceUsageMonitor();
+    diskSpaceMonitor.setFreeDiskSpaceSupplier(() -> 0L);
+    await("default tenant rejects writes once the shared disk space monitor sees the disk as full")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(() -> assertRejectedForOutOfDiskSpace(defaultClient));
+    await("tenant A rejects writes once the shared disk space monitor sees the disk as full")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(() -> assertRejectedForOutOfDiskSpace(tenantAClient));
+
+    // when - disk space becomes available again
+    diskSpaceMonitor.setFreeDiskSpaceSupplier(() -> Long.MAX_VALUE);
+
+    // then - both the default tenant and tenant A recover and accept writes again
+    awaitWritesAccepted(defaultClient);
+    awaitWritesAccepted(tenantAClient);
+  }
+
+  private static void awaitWritesAccepted(final CamundaClient client) {
+    await("tenant accepts writes")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> assertThatCode(() -> publishMessage(client)).doesNotThrowAnyException());
+  }
+
+  private static void assertRejectedForOutOfDiskSpace(final CamundaClient client) {
+    assertThatThrownBy(() -> publishMessage(client))
+        .isInstanceOf(ClientStatusException.class)
+        .hasStackTraceContaining("Broker is out of disk space")
+        .satisfies(
+            t ->
+                assertThat(((ClientStatusException) t).getStatusCode())
+                    .isEqualTo(Code.RESOURCE_EXHAUSTED));
+  }
+
+  // publishMessage is routed to a single partition by its correlation key, so the broker's
+  // per-partition rejection reason is preserved on the client exception; each call uses a unique
+  // correlation key so buffered messages never accumulate against a fixed key
+  private static void publishMessage(final CamundaClient client) {
+    client
+        .newPublishMessageCommand()
+        .messageName("disk-full-msg")
+        .correlationKey(UUID.randomUUID().toString())
+        .send()
+        .join();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantLeaderReElectionIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantLeaderReElectionIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.client.CamundaClient;
+import io.camunda.zeebe.broker.Broker;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestClusterBuilder;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A physical tenant is a Raft partition group of its own (see {@code PhysicalTenantResolver}),
+ * spanning every broker in the cluster just like the {@code default} group. Losing a broker must
+ * therefore trigger leader re-election independently in every physical tenant's group, and the
+ * cluster must remain available for every physical tenant once re-election completes - not just for
+ * {@code default}.
+ */
+@ZeebeIntegration
+final class PhysicalTenantLeaderReElectionIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final List<String> GROUPS =
+      List.of(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, TENANT_A);
+  private static final int PARTITIONS_COUNT = 3;
+
+  // withPtConfig is flattened as a diff against a pristine default Camunda(): an empty modifier
+  // produces an empty diff, so the tenant would never be discovered and never bootstrapped.
+  // Routing through PhysicalTenantsITHelper both supplies a real diff (secondary storage = none)
+  // and declares the per-tenant security.initialization block that
+  // PhysicalTenantRequiredOverrideValidation requires once a non-default tenant is declared.
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  @TestZeebe
+  private final TestCluster cluster =
+      new TestClusterBuilder()
+          .withBrokersCount(3)
+          .withReplicationFactor(3)
+          .withPartitionsCount(PARTITIONS_COUNT)
+          .withBrokerConfig(broker -> TENANTS.configure(broker.withUnauthenticatedAccess()))
+          .build();
+
+  @Test
+  void shouldReelectLeadersForAllPhysicalTenantsWhenBrokerIsKilled() {
+    // given - every partition of every physical tenant's group has a leader
+    GROUPS.forEach(this::awaitLeaderForEveryPartition);
+    final Map<String, Map<Integer, MemberId>> leadersBefore =
+        GROUPS.stream().collect(Collectors.toMap(g -> g, this::currentLeaders));
+
+    // a broker leading at least one partition in both groups is picked when one exists, so the
+    // kill exercises re-election in both groups at once; otherwise any broker still leads at
+    // least one partition in one of the two groups (3 partitions, RF3, 3 brokers)
+    final var victim = pickVictim(leadersBefore);
+
+    // when - the leader is killed
+    cluster.brokers().get(victim).stop();
+
+    // then - every partition of every physical tenant's group has a new leader among the
+    // surviving brokers, and any partition the victim used to lead now has a different leader
+    GROUPS.forEach(group -> awaitLeaderForEveryPartitionAmongSurvivors(group, victim));
+    GROUPS.forEach(
+        group -> {
+          final var leadersAfter = currentLeaders(group);
+          leadersBefore
+              .get(group)
+              .forEach(
+                  (partition, previousLeader) -> {
+                    if (previousLeader.equals(victim)) {
+                      assertThat(leadersAfter.get(partition))
+                          .describedAs(
+                              "new leader of partition %d in group '%s' after killing %s",
+                              partition, group, victim)
+                          .isNotEqualTo(victim);
+                    }
+                  });
+        });
+
+    // and - the cluster remains available for both physical tenants
+    try (final var defaultClient =
+            TENANTS
+                .newClientBuilder(
+                    cluster.availableGateway(), PhysicalTenantsITHelper.DEFAULT_TENANT_ID)
+                .build();
+        final var tenantAClient =
+            TENANTS.newClientBuilder(cluster.availableGateway(), TENANT_A).build()) {
+      assertThatCode(() -> publishMessage(defaultClient)).doesNotThrowAnyException();
+      assertThatCode(() -> publishMessage(tenantAClient)).doesNotThrowAnyException();
+    }
+  }
+
+  // prefers a broker leading at least one partition in both groups, so a single kill exercises
+  // re-election in both groups; falls back to any leader if no such broker exists
+  private MemberId pickVictim(final Map<String, Map<Integer, MemberId>> leadersBefore) {
+    final var defaultLeaders =
+        leadersBefore.get(PhysicalTenantsITHelper.DEFAULT_TENANT_ID).values();
+    final var tenantALeaders = leadersBefore.get(TENANT_A).values();
+    return defaultLeaders.stream()
+        .filter(tenantALeaders::contains)
+        .findFirst()
+        .orElseGet(() -> defaultLeaders.iterator().next());
+  }
+
+  private void awaitLeaderForEveryPartition(final String group) {
+    Awaitility.await("every partition of physical tenant '" + group + "' has a leader")
+        .atMost(Duration.ofSeconds(60))
+        .pollInSameThread()
+        .untilAsserted(
+            () ->
+                IntStream.rangeClosed(1, PARTITIONS_COUNT)
+                    .forEach(partition -> assertThat(leadersOf(group, partition)).hasSize(1)));
+  }
+
+  private void awaitLeaderForEveryPartitionAmongSurvivors(
+      final String group, final MemberId excludedBroker) {
+    Awaitility.await(
+            "every partition of physical tenant '"
+                + group
+                + "' has a leader among the surviving brokers after "
+                + excludedBroker
+                + " was killed")
+        .atMost(Duration.ofSeconds(60))
+        .pollInSameThread()
+        .untilAsserted(
+            () ->
+                IntStream.rangeClosed(1, PARTITIONS_COUNT)
+                    .forEach(
+                        partition -> {
+                          final var leaders = leadersOf(group, partition);
+                          assertThat(leaders).hasSize(1);
+                          assertThat(leaders).doesNotContain(excludedBroker);
+                        }));
+  }
+
+  // maps every partition number (1..PARTITIONS_COUNT) of the given group to its current leader's
+  // MemberId, by asking every (still reachable) broker for its own raft roles
+  private Map<Integer, MemberId> currentLeaders(final String group) {
+    return IntStream.rangeClosed(1, PARTITIONS_COUNT)
+        .boxed()
+        .collect(
+            Collectors.toMap(
+                partition -> partition,
+                partition -> leadersOf(group, partition).iterator().next()));
+  }
+
+  private List<MemberId> leadersOf(final String group, final int partition) {
+    return cluster.brokers().entrySet().stream()
+        .filter(entry -> entry.getValue().isStarted())
+        .filter(entry -> isLeaderOf(entry.getValue(), group, partition))
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toList());
+  }
+
+  private static boolean isLeaderOf(
+      final TestStandaloneBroker broker, final String group, final int partition) {
+    final var partitionManager =
+        broker.bean(Broker.class).getBrokerContext().getPartitionManagers().get(group);
+    if (partitionManager == null) {
+      return false;
+    }
+    return partitionManager.getRaftPartitions().stream()
+        .filter(raftPartition -> raftPartition.id().number() == partition)
+        .anyMatch(raftPartition -> raftPartition.getRole() == Role.LEADER);
+  }
+
+  private static void publishMessage(final CamundaClient client) {
+    client
+        .newPublishMessageCommand()
+        .messageName("reelection-msg")
+        .correlationKey(UUID.randomUUID().toString())
+        .send()
+        .join();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantRejoinIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantRejoinIT.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.RaftServer.Role;
+import io.atomix.raft.partition.RaftPartition;
+import io.camunda.client.CamundaClient;
+import io.camunda.zeebe.broker.Broker;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestClusterBuilder;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A physical tenant is a Raft partition group of its own (see {@code PhysicalTenantResolver}),
+ * spanning every broker in the cluster just like the {@code default} group. A broker that restarts
+ * after being stopped must therefore rejoin every physical tenant's partition group it used to host
+ * - not just {@code default}'s.
+ */
+@ZeebeIntegration
+final class PhysicalTenantRejoinIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final List<String> GROUPS =
+      List.of(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, TENANT_A);
+  private static final int PARTITIONS_COUNT = 3;
+
+  // withPtConfig is flattened as a diff against a pristine default Camunda(): an empty modifier
+  // produces an empty diff, so the tenant would never be discovered and never bootstrapped.
+  // Routing through PhysicalTenantsITHelper both supplies a real diff (secondary storage = none)
+  // and declares the per-tenant security.initialization block that
+  // PhysicalTenantRequiredOverrideValidation requires once a non-default tenant is declared.
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  @TestZeebe
+  private final TestCluster cluster =
+      new TestClusterBuilder()
+          .withBrokersCount(3)
+          .withReplicationFactor(3)
+          .withPartitionsCount(PARTITIONS_COUNT)
+          .withBrokerConfig(broker -> TENANTS.configure(broker.withUnauthenticatedAccess()))
+          .build();
+
+  @Test
+  void shouldRejoinAllPhysicalTenantPartitionGroupsWhenBrokerRestarts() {
+    // given - every partition of every physical tenant's group has a leader, and the broker under
+    // test hosts partitions in both groups (replicationFactor == brokersCount, so every broker
+    // hosts every partition of every group)
+    GROUPS.forEach(this::awaitLeaderForEveryPartition);
+    final var restarted = cluster.brokers().keySet().iterator().next();
+
+    // when - the broker is stopped; the cluster re-stabilises on the survivors...
+    cluster.brokers().get(restarted).stop();
+    GROUPS.forEach(group -> awaitLeaderForEveryPartitionAmongSurvivors(group, restarted));
+
+    // ...and the broker is restarted
+    cluster.brokers().get(restarted).start();
+
+    // then - the restarted broker rejoins every partition of every physical tenant's group in an
+    // active raft role (FOLLOWER or LEADER, not INACTIVE)
+    GROUPS.forEach(group -> awaitBrokerRejoinsEveryPartition(restarted, group));
+
+    // and - both engines remain writable
+    try (final var defaultClient =
+            TENANTS
+                .newClientBuilder(
+                    cluster.availableGateway(), PhysicalTenantsITHelper.DEFAULT_TENANT_ID)
+                .build();
+        final var tenantAClient =
+            TENANTS.newClientBuilder(cluster.availableGateway(), TENANT_A).build()) {
+      assertThatCode(() -> publishMessage(defaultClient)).doesNotThrowAnyException();
+      assertThatCode(() -> publishMessage(tenantAClient)).doesNotThrowAnyException();
+    }
+  }
+
+  private void awaitLeaderForEveryPartition(final String group) {
+    Awaitility.await("every partition of physical tenant '" + group + "' has a leader")
+        .atMost(Duration.ofSeconds(60))
+        .pollInSameThread()
+        .untilAsserted(
+            () ->
+                IntStream.rangeClosed(1, PARTITIONS_COUNT)
+                    .forEach(
+                        partition ->
+                            assertThat(hasLeaderAmongSurvivors(group, partition, null)).isTrue()));
+  }
+
+  private void awaitLeaderForEveryPartitionAmongSurvivors(
+      final String group, final MemberId excludedBroker) {
+    Awaitility.await(
+            "every partition of physical tenant '"
+                + group
+                + "' has a leader among the surviving brokers after "
+                + excludedBroker
+                + " was stopped")
+        .atMost(Duration.ofSeconds(60))
+        .pollInSameThread()
+        .untilAsserted(
+            () ->
+                IntStream.rangeClosed(1, PARTITIONS_COUNT)
+                    .forEach(
+                        partition ->
+                            assertThat(hasLeaderAmongSurvivors(group, partition, excludedBroker))
+                                .isTrue()));
+  }
+
+  private boolean hasLeaderAmongSurvivors(
+      final String group, final int partition, final MemberId excludedBroker) {
+    return cluster.brokers().entrySet().stream()
+        .filter(entry -> !entry.getKey().equals(excludedBroker))
+        .filter(entry -> entry.getValue().isStarted())
+        .anyMatch(entry -> roleOf(entry.getValue(), group, partition) == Role.LEADER);
+  }
+
+  // asserts that, for every partition the restarted broker should host in the given group, it now
+  // reports an active raft role (FOLLOWER or LEADER) rather than INACTIVE
+  private void awaitBrokerRejoinsEveryPartition(final MemberId restarted, final String group) {
+    Awaitility.await(
+            "broker "
+                + restarted
+                + " rejoins every partition of physical tenant '"
+                + group
+                + "' in an active role")
+        .atMost(Duration.ofSeconds(90))
+        .pollInSameThread()
+        .untilAsserted(
+            () -> {
+              final var broker = cluster.brokers().get(restarted);
+              assertThat(broker.isStarted()).isTrue();
+              final var partitionManager =
+                  broker.bean(Broker.class).getBrokerContext().getPartitionManagers().get(group);
+              assertThat(partitionManager)
+                  .describedAs(
+                      "physical tenant '%s' partition manager on restarted broker %s",
+                      group, restarted)
+                  .isNotNull();
+              final var hostedPartitions =
+                  partitionManager.getRaftPartitions().stream()
+                      .map(raftPartition -> raftPartition.id().number())
+                      .collect(Collectors.toSet());
+              assertThat(hostedPartitions)
+                  .describedAs(
+                      "partitions hosted by restarted broker %s in physical tenant '%s'",
+                      restarted, group)
+                  .containsExactlyInAnyOrderElementsOf(expectedPartitions());
+              final Set<Role> roles =
+                  partitionManager.getRaftPartitions().stream()
+                      .map(RaftPartition::getRole)
+                      .collect(Collectors.toSet());
+              assertThat(roles)
+                  .describedAs(
+                      "raft roles reported by restarted broker %s in physical tenant '%s'",
+                      restarted, group)
+                  .doesNotContain((Role) null, Role.INACTIVE);
+            });
+  }
+
+  // replicationFactor == brokersCount, so every broker hosts every partition of every group
+  private static Set<Integer> expectedPartitions() {
+    return IntStream.rangeClosed(1, PARTITIONS_COUNT).boxed().collect(Collectors.toSet());
+  }
+
+  private static Role roleOf(
+      final TestStandaloneBroker broker, final String group, final int partition) {
+    final var partitionManager =
+        broker.bean(Broker.class).getBrokerContext().getPartitionManagers().get(group);
+    if (partitionManager == null) {
+      return null;
+    }
+    return partitionManager.getRaftPartitions().stream()
+        .filter(raftPartition -> raftPartition.id().number() == partition)
+        .map(RaftPartition::getRole)
+        .findFirst()
+        .orElse(null);
+  }
+
+  private static void publishMessage(final CamundaClient client) {
+    client
+        .newPublishMessageCommand()
+        .messageName("rejoin-msg")
+        .correlationKey(UUID.randomUUID().toString())
+        .send()
+        .join();
+  }
+}


### PR DESCRIPTION
Adds integration-test coverage for four of the physical-tenants increment-1 QA scenarios in #50580, all exercising the deliberate difference in scope between per-tenant and broker-wide resources.

## Scenarios covered

**Backpressure isolation** (`PhysicalTenantBackpressureIsolationIT`) — `FlowControl` is instantiated per `(physical tenant, partition)`, so backpressuring tenant A's engine (a write-rate limit of 1) must not degrade the default engine, which keeps accepting writes. Reaches tenant A's partition via the new `BrokerContext#getPartitionManagers` accessor and drives its flow control through the actor-safe `PartitionAdminAccess#configureFlowControl`; also covers recovery once the limit is lifted.

**Disk-full shared fate** (`PhysicalTenantDiskUsageIsolationIT`) — the `DiskSpaceUsageMonitor` is a single broker-wide component shared by every tenant's partition group, so filling the disk rejects writes on *every* physical tenant, and recovering space restores them on every tenant.

**Leader re-election** (`PhysicalTenantLeaderReElectionIT`) — a physical tenant is a Raft partition group spanning every broker, so losing a broker must trigger leader re-election independently in every tenant's group, and the cluster must stay available for every tenant.

**Rejoin** (`PhysicalTenantRejoinIT`) — a restarted broker must rejoin *every* physical tenant's partition group it hosts, not just `default`'s.

All four write via a partition-pinned `publishMessage` so the broker's exact rejection reason survives to the client instead of the gateway's generic all-partitions-failed error.

## Production change

The only non-test change (`refactor:` commit) exposes the already-existing per-tenant `PartitionManager` map on `BrokerContext#getPartitionManagers()`. `getPartitionManager()` only ever returned the default tenant's manager, leaving non-default tenants' partitions unreachable from a running broker for tests/introspection. `BrokerContextImpl` is the sole implementor.

## Not included (from #50580)

- Request routing, tenant isolation, and topology-for-tenant are already covered by existing ITs (`PhysicalTenantRoutingIT`, `PhysicalTenantIsolationIT`, `PhysicalTenantRestIsolationIT`).
- Rolling upgrade 8.9 → SNAPSHOT is adequately covered by the existing `update-tests` (the 8.9 side only ever has the default tenant).
- The observability scenarios (partition-group name in logs / metric label) are covered at unit level and need no new IT.

Closes #50580.
