### PR TITLE
deps: bump api-zod-schemas to surface SECRET resource type in Identity authorizations

### DIFF
--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "identity-frontend",
       "version": "8.10.0-SNAPSHOT",
       "dependencies": {
-        "@camunda/camunda-api-zod-schemas": "0.0.82",
+        "@camunda/camunda-api-zod-schemas": "0.0.83",
         "@camunda/camunda-composite-components": "0.25.2",
         "@carbon/elements": "11.93.0",
         "@carbon/react": "1.112.0",
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.82",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.82.tgz",
-      "integrity": "sha512-CnBpTJQrpdgT6r7OoHMbaug6Z+kzGECCa4PIN1LnHCk5AfpMwZPnpXrmUqsuQ2W0kyehWOoUTyLDjNgxvWifDg==",
+      "version": "0.0.83",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.83.tgz",
+      "integrity": "sha512-/8NoB3TVvgfeS6rrmCziaNLRKXzwtuS1WidaYEQUu5R3iRKFuaGLDLhHIfGMUJAOPKGUnHb9dx/F4ACqoENEUw==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@camunda/camunda-api-zod-schemas": "0.0.82",
+    "@camunda/camunda-api-zod-schemas": "0.0.83",
     "@camunda/camunda-composite-components": "0.25.2",
     "@carbon/elements": "11.93.0",
     "@carbon/react": "1.112.0",


### PR DESCRIPTION
related to #56570

## Description

Surfaces the `SECRET` authorization resource type (with `READ` / `REVEAL` permissions) in the Identity/Admin authorizations UI, so operators can grant them to roles/users, including wildcard grants (`SECRET:REVEAL:*`).

Bumps Identity's `@camunda/camunda-api-zod-schemas` pin to `0.0.83`, the published version that includes `SECRET` / `REVEAL` (added in #58391). The pin bump is what makes the resource type selectable .
## Changes

- Bump `@camunda/camunda-api-zod-schemas` `0.0.82` → `0.0.83` in `identity/client` (+ lockfile)

TODO [Follow up PR](https://github.com/camunda/camunda/pull/58843) 
add Playwright e2e coverage for SECRET grants (independent READ/REVEAL checkboxes, REVEAL-only wildcard grant), requires bump merged to main first. 


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56570
