### PR TITLE
fix: route inherited authorization ITs through physical-tenant-aware test client

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedBasicAuthAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedBasicAuthAuthorizationIT.java
@@ -130,7 +130,7 @@ public class InheritedBasicAuthAuthorizationIT {
   @MethodSource("provideAuthorizedUsers")
   void shouldBeAuthorizedToDeploy(final TestUser user) {
     // given
-    final CamundaClient client = createClient(user);
+    final CamundaClient client = getClient(user);
 
     // then
     Assertions.assertThatNoException()
@@ -149,7 +149,7 @@ public class InheritedBasicAuthAuthorizationIT {
   @MethodSource("provideUnauthorizedUsers")
   void shouldBeUnauthorizedToDeploy(final TestUser user) {
     // given
-    final CamundaClient client = createClient(user);
+    final CamundaClient client = getClient(user);
 
     // then
     Assertions.assertThatThrownBy(
@@ -169,7 +169,7 @@ public class InheritedBasicAuthAuthorizationIT {
   @MethodSource("provideAuthorizedUsers")
   void shouldBeAuthorizedToRead(final TestUser user) {
     // given
-    final CamundaClient client = createClient(user);
+    final CamundaClient client = getClient(user);
 
     // then
     Assertions.assertThatNoException()
@@ -186,7 +186,7 @@ public class InheritedBasicAuthAuthorizationIT {
   @MethodSource("provideUnauthorizedUsers")
   void shouldBeUnauthorizedToRead(final TestUser user) {
     // given
-    final CamundaClient client = createClient(user);
+    final CamundaClient client = getClient(user);
 
     // then
     Assertions.assertThatThrownBy(
@@ -200,7 +200,16 @@ public class InheritedBasicAuthAuthorizationIT {
         .hasMessageContaining("403: 'Forbidden'");
   }
 
-  private static CamundaClient createClient(final TestUser user) {
+  /**
+   * Returns the pre-built, physical-tenant-scoped client the {@code MultiDbTest} extension already
+   * created and cached for the given user during test setup. Do not close the returned client: it
+   * is shared across all test methods in this class and is closed once by the extension during
+   * {@code afterAll}; closing it here would break any later test reusing the same user. Building a
+   * client directly (e.g. via {@code BROKER.newClientBuilder()}) instead of going through this
+   * lookup would bypass physical-tenant scoping and can make requests fall back to the "default"
+   * physical tenant, which races with this test's own tenant-scoped setup.
+   */
+  private static CamundaClient getClient(final TestUser user) {
     return clientFactory.getCamundaClient(user.username());
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedBasicAuthAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedBasicAuthAuthorizationIT.java
@@ -11,7 +11,6 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
-import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
 import io.camunda.qa.util.auth.GroupDefinition;
 import io.camunda.qa.util.auth.Membership;
 import io.camunda.qa.util.auth.Permissions;
@@ -20,6 +19,7 @@ import io.camunda.qa.util.auth.TestGroup;
 import io.camunda.qa.util.auth.TestRole;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaClientTestFactory;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.security.api.model.authz.EntityType;
@@ -40,6 +40,9 @@ public class InheritedBasicAuthAuthorizationIT {
   @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+
+  // Injected by the MultiDbTest extension; physical-tenant-aware, unlike BROKER.newClientBuilder()
+  private static CamundaClientTestFactory clientFactory;
 
   @UserDefinition
   private static final TestUser USER_THROUGH_AUTHORIZED_GROUP =
@@ -127,90 +130,78 @@ public class InheritedBasicAuthAuthorizationIT {
   @MethodSource("provideAuthorizedUsers")
   void shouldBeAuthorizedToDeploy(final TestUser user) {
     // given
-    try (final CamundaClient client = createClient(user)) {
+    final CamundaClient client = createClient(user);
 
-      // then
-      Assertions.assertThatNoException()
-          .isThrownBy(
-              () ->
-                  client
-                      .newDeployResourceCommand()
-                      .addProcessModel(
-                          Bpmn.createExecutableProcess().startEvent().endEvent().done(),
-                          "process.bpmn")
-                      .send()
-                      .join());
-    }
+    // then
+    Assertions.assertThatNoException()
+        .isThrownBy(
+            () ->
+                client
+                    .newDeployResourceCommand()
+                    .addProcessModel(
+                        Bpmn.createExecutableProcess().startEvent().endEvent().done(),
+                        "process.bpmn")
+                    .send()
+                    .join());
   }
 
   @ParameterizedTest
   @MethodSource("provideUnauthorizedUsers")
   void shouldBeUnauthorizedToDeploy(final TestUser user) {
     // given
-    try (final CamundaClient client = createClient(user)) {
+    final CamundaClient client = createClient(user);
 
-      // then
-      Assertions.assertThatThrownBy(
-              () ->
-                  client
-                      .newDeployResourceCommand()
-                      .addProcessModel(
-                          Bpmn.createExecutableProcess().startEvent().endEvent().done(),
-                          "process.bpmn")
-                      .send()
-                      .join())
-          .isInstanceOf(ProblemException.class)
-          .hasMessageContaining("403: 'Forbidden'");
-    }
+    // then
+    Assertions.assertThatThrownBy(
+            () ->
+                client
+                    .newDeployResourceCommand()
+                    .addProcessModel(
+                        Bpmn.createExecutableProcess().startEvent().endEvent().done(),
+                        "process.bpmn")
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("403: 'Forbidden'");
   }
 
   @ParameterizedTest
   @MethodSource("provideAuthorizedUsers")
   void shouldBeAuthorizedToRead(final TestUser user) {
     // given
-    try (final CamundaClient client = createClient(user)) {
+    final CamundaClient client = createClient(user);
 
-      // then
-      Assertions.assertThatNoException()
-          .isThrownBy(
-              () ->
-                  client
-                      .newGroupGetRequest(
-                          UNAUTHORIZED_GROUP.id()) // Attempt to read a random group we've created
-                      .send()
-                      .join());
-    }
+    // then
+    Assertions.assertThatNoException()
+        .isThrownBy(
+            () ->
+                client
+                    .newGroupGetRequest(
+                        UNAUTHORIZED_GROUP.id()) // Attempt to read a random group we've created
+                    .send()
+                    .join());
   }
 
   @ParameterizedTest
   @MethodSource("provideUnauthorizedUsers")
   void shouldBeUnauthorizedToRead(final TestUser user) {
     // given
-    try (final CamundaClient client = createClient(user)) {
+    final CamundaClient client = createClient(user);
 
-      // then
-      Assertions.assertThatThrownBy(
-              () ->
-                  client
-                      .newGroupGetRequest(
-                          UNAUTHORIZED_GROUP.id()) // Attempt to read a random group we've created
-                      .send()
-                      .join())
-          .isInstanceOf(ProblemException.class)
-          .hasMessageContaining("403: 'Forbidden'");
-    }
+    // then
+    Assertions.assertThatThrownBy(
+            () ->
+                client
+                    .newGroupGetRequest(
+                        UNAUTHORIZED_GROUP.id()) // Attempt to read a random group we've created
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("403: 'Forbidden'");
   }
 
   private static CamundaClient createClient(final TestUser user) {
-    return BROKER
-        .newClientBuilder()
-        .preferRestOverGrpc(true)
-        .credentialsProvider(
-            new BasicAuthCredentialsProviderBuilder()
-                .username(user.username())
-                .password(user.password())
-                .build())
-        .build();
+    return clientFactory.getCamundaClient(user.username());
   }
 
   private static Stream<Named<TestUser>> provideAuthorizedUsers() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedBasicAuthAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedBasicAuthAuthorizationIT.java
@@ -200,15 +200,7 @@ public class InheritedBasicAuthAuthorizationIT {
         .hasMessageContaining("403: 'Forbidden'");
   }
 
-  /**
-   * Returns the pre-built, physical-tenant-scoped client the {@code MultiDbTest} extension already
-   * created and cached for the given user during test setup. Do not close the returned client: it
-   * is shared across all test methods in this class and is closed once by the extension during
-   * {@code afterAll}; closing it here would break any later test reusing the same user. Building a
-   * client directly (e.g. via {@code BROKER.newClientBuilder()}) instead of going through this
-   * lookup would bypass physical-tenant scoping and can make requests fall back to the "default"
-   * physical tenant, which races with this test's own tenant-scoped setup.
-   */
+  /** Shared client from the {@code MultiDbTest} extension; do not close it. */
   private static CamundaClient getClient(final TestUser user) {
     return clientFactory.getCamundaClient(user.username());
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedOIDCAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedOIDCAuthorizationIT.java
@@ -9,12 +9,10 @@ package io.camunda.it.auth;
 
 import static io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker.DEFAULT_MAPPING_RULE_CLAIM_NAME;
 
-import dasniko.testcontainers.keycloak.KeycloakContainer;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
-import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.camunda.qa.util.auth.GroupDefinition;
 import io.camunda.qa.util.auth.MappingRuleDefinition;
 import io.camunda.qa.util.auth.Membership;
@@ -23,6 +21,7 @@ import io.camunda.qa.util.auth.RoleDefinition;
 import io.camunda.qa.util.auth.TestGroup;
 import io.camunda.qa.util.auth.TestMappingRule;
 import io.camunda.qa.util.auth.TestRole;
+import io.camunda.qa.util.multidb.CamundaClientTestFactory;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.security.api.model.authz.EntityType;
@@ -30,13 +29,11 @@ import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.Strings;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -51,8 +48,8 @@ public class InheritedOIDCAuthorizationIT {
           .withAuthorizationsEnabled()
           .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true));
 
-  // Injected by the MultiDbTest extension
-  private static KeycloakContainer keycloak;
+  // Injected by the MultiDbTest extension; physical-tenant-aware, unlike BROKER.newClientBuilder()
+  private static CamundaClientTestFactory clientFactory;
 
   @MappingRuleDefinition
   private static final TestMappingRule MAPPING_RULE_THROUGH_AUTHORIZED_GROUP =
@@ -143,97 +140,80 @@ public class InheritedOIDCAuthorizationIT {
 
   @ParameterizedTest
   @MethodSource("provideAuthorizedMappingRules")
-  void shouldBeAuthorizedToDeploy(final TestMappingRule mappingRule, @TempDir final Path tempDir) {
+  void shouldBeAuthorizedToDeploy(final TestMappingRule mappingRule) {
     // given
-    try (final CamundaClient client = createClient(mappingRule, tempDir)) {
+    final CamundaClient client = createClient(mappingRule);
 
-      // then
-      Assertions.assertThatNoException()
-          .isThrownBy(
-              () ->
-                  client
-                      .newDeployResourceCommand()
-                      .addProcessModel(
-                          Bpmn.createExecutableProcess().startEvent().endEvent().done(),
-                          "process.bpmn")
-                      .send()
-                      .join());
-    }
+    // then
+    Assertions.assertThatNoException()
+        .isThrownBy(
+            () ->
+                client
+                    .newDeployResourceCommand()
+                    .addProcessModel(
+                        Bpmn.createExecutableProcess().startEvent().endEvent().done(),
+                        "process.bpmn")
+                    .send()
+                    .join());
   }
 
   @ParameterizedTest
   @MethodSource("provideUnauthorizedMappingRules")
-  void shouldBeUnauthorizedToDeploy(
-      final TestMappingRule mappingRule, @TempDir final Path tempDir) {
+  void shouldBeUnauthorizedToDeploy(final TestMappingRule mappingRule) {
     // given
-    try (final CamundaClient client = createClient(mappingRule, tempDir)) {
+    final CamundaClient client = createClient(mappingRule);
 
-      // then
-      Assertions.assertThatThrownBy(
-              () ->
-                  client
-                      .newDeployResourceCommand()
-                      .addProcessModel(
-                          Bpmn.createExecutableProcess().startEvent().endEvent().done(),
-                          "process.bpmn")
-                      .send()
-                      .join())
-          .isInstanceOf(ProblemException.class)
-          .hasMessageContaining("403: 'Forbidden'");
-    }
+    // then
+    Assertions.assertThatThrownBy(
+            () ->
+                client
+                    .newDeployResourceCommand()
+                    .addProcessModel(
+                        Bpmn.createExecutableProcess().startEvent().endEvent().done(),
+                        "process.bpmn")
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("403: 'Forbidden'");
   }
 
   @ParameterizedTest
   @MethodSource("provideAuthorizedMappingRules")
-  void shouldBeAuthorizedToRead(final TestMappingRule mappingRule, @TempDir final Path tempDir) {
+  void shouldBeAuthorizedToRead(final TestMappingRule mappingRule) {
     // given
-    try (final CamundaClient client = createClient(mappingRule, tempDir)) {
+    final CamundaClient client = createClient(mappingRule);
 
-      // then
-      Assertions.assertThatNoException()
-          .isThrownBy(
-              () ->
-                  client
-                      .newGroupGetRequest(
-                          UNAUTHORIZED_GROUP.id()) // Attempt to read a random group we've created
-                      .send()
-                      .join());
-    }
+    // then
+    Assertions.assertThatNoException()
+        .isThrownBy(
+            () ->
+                client
+                    .newGroupGetRequest(
+                        UNAUTHORIZED_GROUP.id()) // Attempt to read a random group we've created
+                    .send()
+                    .join());
   }
 
   @ParameterizedTest
   @MethodSource("provideUnauthorizedMappingRules")
-  void shouldBeUnauthorizedToRead(final TestMappingRule mappingRule, @TempDir final Path tempDir) {
+  void shouldBeUnauthorizedToRead(final TestMappingRule mappingRule) {
     // given
-    try (final CamundaClient client = createClient(mappingRule, tempDir)) {
+    final CamundaClient client = createClient(mappingRule);
 
-      // then
-      Assertions.assertThatThrownBy(
-              () ->
-                  client
-                      .newGroupGetRequest(
-                          UNAUTHORIZED_GROUP.id()) // Attempt to read a random group we've created
-                      .send()
-                      .join())
-          .isInstanceOf(ProblemException.class)
-          .hasMessageContaining("403: 'Forbidden'");
-    }
+    // then
+    Assertions.assertThatThrownBy(
+            () ->
+                client
+                    .newGroupGetRequest(
+                        UNAUTHORIZED_GROUP.id()) // Attempt to read a random group we've created
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("403: 'Forbidden'");
   }
 
-  private CamundaClient createClient(final TestMappingRule mappingRule, final Path tempDir) {
-    return BROKER
-        .newClientBuilder()
-        .preferRestOverGrpc(true)
-        .credentialsProvider(
-            new OAuthCredentialsProviderBuilder()
-                .clientId(mappingRule.claimValue())
-                .clientSecret(mappingRule.claimValue())
-                .audience("zeebe")
-                .authorizationServerUrl(
-                    keycloak.getAuthServerUrl() + "/realms/camunda/protocol/openid-connect/token")
-                .credentialsCachePath(tempDir.resolve("default").toString())
-                .build())
-        .build();
+  private CamundaClient createClient(final TestMappingRule mappingRule) {
+    return clientFactory.getCamundaClient(mappingRule.id());
   }
 
   private static Stream<Named<TestMappingRule>> provideAuthorizedMappingRules() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedOIDCAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedOIDCAuthorizationIT.java
@@ -212,15 +212,7 @@ public class InheritedOIDCAuthorizationIT {
         .hasMessageContaining("403: 'Forbidden'");
   }
 
-  /**
-   * Returns the pre-built, physical-tenant-scoped client the {@code MultiDbTest} extension already
-   * created and cached for the given mapping rule during test setup. Do not close the returned
-   * client: it is shared across all test methods in this class and is closed once by the extension
-   * during {@code afterAll}; closing it here would break any later test reusing the same mapping
-   * rule. Building a client directly (e.g. via {@code BROKER.newClientBuilder()}) instead of going
-   * through this lookup would bypass physical-tenant scoping and can make requests fall back to the
-   * "default" physical tenant, which races with this test's own tenant-scoped setup.
-   */
+  /** Shared client from the {@code MultiDbTest} extension; do not close it. */
   private CamundaClient getClient(final TestMappingRule mappingRule) {
     return clientFactory.getCamundaClient(mappingRule.id());
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedOIDCAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedOIDCAuthorizationIT.java
@@ -142,7 +142,7 @@ public class InheritedOIDCAuthorizationIT {
   @MethodSource("provideAuthorizedMappingRules")
   void shouldBeAuthorizedToDeploy(final TestMappingRule mappingRule) {
     // given
-    final CamundaClient client = createClient(mappingRule);
+    final CamundaClient client = getClient(mappingRule);
 
     // then
     Assertions.assertThatNoException()
@@ -161,7 +161,7 @@ public class InheritedOIDCAuthorizationIT {
   @MethodSource("provideUnauthorizedMappingRules")
   void shouldBeUnauthorizedToDeploy(final TestMappingRule mappingRule) {
     // given
-    final CamundaClient client = createClient(mappingRule);
+    final CamundaClient client = getClient(mappingRule);
 
     // then
     Assertions.assertThatThrownBy(
@@ -181,7 +181,7 @@ public class InheritedOIDCAuthorizationIT {
   @MethodSource("provideAuthorizedMappingRules")
   void shouldBeAuthorizedToRead(final TestMappingRule mappingRule) {
     // given
-    final CamundaClient client = createClient(mappingRule);
+    final CamundaClient client = getClient(mappingRule);
 
     // then
     Assertions.assertThatNoException()
@@ -198,7 +198,7 @@ public class InheritedOIDCAuthorizationIT {
   @MethodSource("provideUnauthorizedMappingRules")
   void shouldBeUnauthorizedToRead(final TestMappingRule mappingRule) {
     // given
-    final CamundaClient client = createClient(mappingRule);
+    final CamundaClient client = getClient(mappingRule);
 
     // then
     Assertions.assertThatThrownBy(
@@ -212,7 +212,16 @@ public class InheritedOIDCAuthorizationIT {
         .hasMessageContaining("403: 'Forbidden'");
   }
 
-  private CamundaClient createClient(final TestMappingRule mappingRule) {
+  /**
+   * Returns the pre-built, physical-tenant-scoped client the {@code MultiDbTest} extension already
+   * created and cached for the given mapping rule during test setup. Do not close the returned
+   * client: it is shared across all test methods in this class and is closed once by the extension
+   * during {@code afterAll}; closing it here would break any later test reusing the same mapping
+   * rule. Building a client directly (e.g. via {@code BROKER.newClientBuilder()}) instead of going
+   * through this lookup would bypass physical-tenant scoping and can make requests fall back to the
+   * "default" physical tenant, which races with this test's own tenant-scoped setup.
+   */
+  private CamundaClient getClient(final TestMappingRule mappingRule) {
     return clientFactory.getCamundaClient(mappingRule.id());
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedSimpleMappingAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedSimpleMappingAuthorizationIT.java
@@ -7,12 +7,10 @@
  */
 package io.camunda.it.auth;
 
-import dasniko.testcontainers.keycloak.KeycloakContainer;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
-import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.camunda.qa.util.auth.ClientDefinition;
 import io.camunda.qa.util.auth.GroupDefinition;
 import io.camunda.qa.util.auth.Membership;
@@ -21,6 +19,7 @@ import io.camunda.qa.util.auth.RoleDefinition;
 import io.camunda.qa.util.auth.TestClient;
 import io.camunda.qa.util.auth.TestGroup;
 import io.camunda.qa.util.auth.TestRole;
+import io.camunda.qa.util.multidb.CamundaClientTestFactory;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.security.api.model.authz.EntityType;
@@ -28,13 +27,11 @@ import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.Strings;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -51,8 +48,8 @@ public class InheritedSimpleMappingAuthorizationIT {
           .withSecurityConfig(c -> c.getAuthentication().getOidc().setClientIdClaim("client_id"))
           .withSecurityConfig(c -> c.getAuthentication().getOidc().setUsernameClaim("no_username"));
 
-  // Injected by the MultiDbTest extension
-  private static KeycloakContainer keycloak;
+  // Injected by the MultiDbTest extension; physical-tenant-aware, unlike BROKER.newClientBuilder()
+  private static CamundaClientTestFactory clientFactory;
 
   @ClientDefinition
   private static final TestClient CLIENT_THROUGH_AUTHORIZED_GROUP = createTestClient();
@@ -133,96 +130,80 @@ public class InheritedSimpleMappingAuthorizationIT {
 
   @ParameterizedTest
   @MethodSource("provideAuthorizedClients")
-  void shouldBeAuthorizedToDeploy(final TestClient testClient, @TempDir final Path tempDir) {
+  void shouldBeAuthorizedToDeploy(final TestClient testClient) {
     // given
-    try (final CamundaClient client = createClient(testClient.clientId(), tempDir)) {
+    final CamundaClient client = createClient(testClient.clientId());
 
-      // then
-      Assertions.assertThatNoException()
-          .isThrownBy(
-              () ->
-                  client
-                      .newDeployResourceCommand()
-                      .addProcessModel(
-                          Bpmn.createExecutableProcess().startEvent().endEvent().done(),
-                          "process.bpmn")
-                      .send()
-                      .join());
-    }
+    // then
+    Assertions.assertThatNoException()
+        .isThrownBy(
+            () ->
+                client
+                    .newDeployResourceCommand()
+                    .addProcessModel(
+                        Bpmn.createExecutableProcess().startEvent().endEvent().done(),
+                        "process.bpmn")
+                    .send()
+                    .join());
   }
 
   @ParameterizedTest
   @MethodSource("provideUnauthorizedClients")
-  void shouldBeUnauthorizedToDeploy(final TestClient testClient, @TempDir final Path tempDir) {
+  void shouldBeUnauthorizedToDeploy(final TestClient testClient) {
     // given
-    try (final CamundaClient client = createClient(testClient.clientId(), tempDir)) {
+    final CamundaClient client = createClient(testClient.clientId());
 
-      // then
-      Assertions.assertThatThrownBy(
-              () ->
-                  client
-                      .newDeployResourceCommand()
-                      .addProcessModel(
-                          Bpmn.createExecutableProcess().startEvent().endEvent().done(),
-                          "process.bpmn")
-                      .send()
-                      .join())
-          .isInstanceOf(ProblemException.class)
-          .hasMessageContaining("403: 'Forbidden'");
-    }
+    // then
+    Assertions.assertThatThrownBy(
+            () ->
+                client
+                    .newDeployResourceCommand()
+                    .addProcessModel(
+                        Bpmn.createExecutableProcess().startEvent().endEvent().done(),
+                        "process.bpmn")
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("403: 'Forbidden'");
   }
 
   @ParameterizedTest
   @MethodSource("provideAuthorizedClients")
-  void shouldBeAuthorizedToRead(final TestClient testClient, @TempDir final Path tempDir) {
+  void shouldBeAuthorizedToRead(final TestClient testClient) {
     // given
-    try (final CamundaClient client = createClient(testClient.clientId(), tempDir)) {
+    final CamundaClient client = createClient(testClient.clientId());
 
-      // then
-      Assertions.assertThatNoException()
-          .isThrownBy(
-              () ->
-                  client
-                      .newGroupGetRequest(
-                          UNAUTHORIZED_GROUP.id()) /* Attempt to read a random group we've */
-                      .send()
-                      .join());
-    }
+    // then
+    Assertions.assertThatNoException()
+        .isThrownBy(
+            () ->
+                client
+                    .newGroupGetRequest(
+                        UNAUTHORIZED_GROUP.id()) /* Attempt to read a random group we've */
+                    .send()
+                    .join());
   }
 
   @ParameterizedTest
   @MethodSource("provideUnauthorizedClients")
-  void shouldBeUnauthorizedToRead(final TestClient testClient, @TempDir final Path tempDir) {
+  void shouldBeUnauthorizedToRead(final TestClient testClient) {
     // given
-    try (final CamundaClient client = createClient(testClient.clientId(), tempDir)) {
+    final CamundaClient client = createClient(testClient.clientId());
 
-      // then
-      Assertions.assertThatThrownBy(
-              () ->
-                  client
-                      .newGroupGetRequest(
-                          UNAUTHORIZED_GROUP.id()) // Attempt to read a random group we've
-                      .send()
-                      .join())
-          .isInstanceOf(ProblemException.class)
-          .hasMessageContaining("403: 'Forbidden'");
-    }
+    // then
+    Assertions.assertThatThrownBy(
+            () ->
+                client
+                    .newGroupGetRequest(
+                        UNAUTHORIZED_GROUP.id()) // Attempt to read a random group we've
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("403: 'Forbidden'");
   }
 
-  private CamundaClient createClient(final String id, final Path tempDir) {
-    return BROKER
-        .newClientBuilder()
-        .preferRestOverGrpc(true)
-        .credentialsProvider(
-            new OAuthCredentialsProviderBuilder()
-                .clientId(id)
-                .clientSecret(id)
-                .audience("zeebe")
-                .authorizationServerUrl(
-                    keycloak.getAuthServerUrl() + "/realms/camunda/protocol/openid-connect/token")
-                .credentialsCachePath(tempDir.resolve("default").toString())
-                .build())
-        .build();
+  private CamundaClient createClient(final String id) {
+    return clientFactory.getCamundaClient(id);
   }
 
   private static Stream<Named<TestClient>> provideAuthorizedClients() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedSimpleMappingAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedSimpleMappingAuthorizationIT.java
@@ -202,15 +202,7 @@ public class InheritedSimpleMappingAuthorizationIT {
         .hasMessageContaining("403: 'Forbidden'");
   }
 
-  /**
-   * Returns the pre-built, physical-tenant-scoped client the {@code MultiDbTest} extension already
-   * created and cached for the given client id during test setup. Do not close the returned client:
-   * it is shared across all test methods in this class and is closed once by the extension during
-   * {@code afterAll}; closing it here would break any later test reusing the same client id.
-   * Building a client directly (e.g. via {@code BROKER.newClientBuilder()}) instead of going
-   * through this lookup would bypass physical-tenant scoping and can make requests fall back to the
-   * "default" physical tenant, which races with this test's own tenant-scoped setup.
-   */
+  /** Shared client from the {@code MultiDbTest} extension; do not close it. */
   private CamundaClient getClient(final String id) {
     return clientFactory.getCamundaClient(id);
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedSimpleMappingAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedSimpleMappingAuthorizationIT.java
@@ -132,7 +132,7 @@ public class InheritedSimpleMappingAuthorizationIT {
   @MethodSource("provideAuthorizedClients")
   void shouldBeAuthorizedToDeploy(final TestClient testClient) {
     // given
-    final CamundaClient client = createClient(testClient.clientId());
+    final CamundaClient client = getClient(testClient.clientId());
 
     // then
     Assertions.assertThatNoException()
@@ -151,7 +151,7 @@ public class InheritedSimpleMappingAuthorizationIT {
   @MethodSource("provideUnauthorizedClients")
   void shouldBeUnauthorizedToDeploy(final TestClient testClient) {
     // given
-    final CamundaClient client = createClient(testClient.clientId());
+    final CamundaClient client = getClient(testClient.clientId());
 
     // then
     Assertions.assertThatThrownBy(
@@ -171,7 +171,7 @@ public class InheritedSimpleMappingAuthorizationIT {
   @MethodSource("provideAuthorizedClients")
   void shouldBeAuthorizedToRead(final TestClient testClient) {
     // given
-    final CamundaClient client = createClient(testClient.clientId());
+    final CamundaClient client = getClient(testClient.clientId());
 
     // then
     Assertions.assertThatNoException()
@@ -188,7 +188,7 @@ public class InheritedSimpleMappingAuthorizationIT {
   @MethodSource("provideUnauthorizedClients")
   void shouldBeUnauthorizedToRead(final TestClient testClient) {
     // given
-    final CamundaClient client = createClient(testClient.clientId());
+    final CamundaClient client = getClient(testClient.clientId());
 
     // then
     Assertions.assertThatThrownBy(
@@ -202,7 +202,16 @@ public class InheritedSimpleMappingAuthorizationIT {
         .hasMessageContaining("403: 'Forbidden'");
   }
 
-  private CamundaClient createClient(final String id) {
+  /**
+   * Returns the pre-built, physical-tenant-scoped client the {@code MultiDbTest} extension already
+   * created and cached for the given client id during test setup. Do not close the returned client:
+   * it is shared across all test methods in this class and is closed once by the extension during
+   * {@code afterAll}; closing it here would break any later test reusing the same client id.
+   * Building a client directly (e.g. via {@code BROKER.newClientBuilder()}) instead of going
+   * through this lookup would bypass physical-tenant scoping and can make requests fall back to the
+   * "default" physical tenant, which races with this test's own tenant-scoped setup.
+   */
+  private CamundaClient getClient(final String id) {
     return clientFactory.getCamundaClient(id);
   }
 

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/BasicAuthCamundaClientTestFactory.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/BasicAuthCamundaClientTestFactory.java
@@ -43,7 +43,13 @@ public final class BasicAuthCamundaClientTestFactory implements CamundaClientTes
 
   @Override
   public CamundaClient getCamundaClient(final String username) {
-    return cachedClients.get(username);
+    final var client = cachedClients.get(username);
+    if (client == null) {
+      throw new IllegalStateException(
+          "No Camunda client cached for username '%s' in %s. Ensure a @UserDefinition with this username exists and that the test is configured for basic auth."
+              .formatted(username, getClass().getSimpleName()));
+    }
+    return client;
   }
 
   @Override

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -983,6 +983,7 @@ public class CamundaMultiDBExtension
     // We want to run tests in an efficient manner, and reduce setup time
     injectStaticClientField(testClass);
     injectStaticDatabaseTypeField(testClass, context);
+    injectStaticClientTestFactoryField(testClass);
   }
 
   private KeycloakContainer setupKeycloak() {
@@ -1215,6 +1216,32 @@ public class CamundaMultiDBExtension
             field.set(null, keycloakContainer);
           } else {
             fail("Keycloak container field couldn't be injected. Make sure it is static.");
+          }
+        }
+      } catch (final Exception ex) {
+        throw new RuntimeException(ex);
+      }
+    }
+  }
+
+  /**
+   * Injects the physical-tenant-aware client factory so tests that need a {@link CamundaClient} for
+   * a runtime-determined identity (e.g. a {@code TestClient} coming from a parameterized
+   * {@code @MethodSource}, rather than a compile-time constant usable with {@link Authenticated})
+   * can look it up via {@link CamundaClientTestFactory#getCamundaClient(String)} instead of
+   * building their own client. A client built directly from the test application (e.g. via {@code
+   * BROKER.newClientBuilder()}) bypasses physical-tenant scoping and ends up talking to the
+   * "default" physical tenant instead of the one the test was set up under.
+   */
+  private void injectStaticClientTestFactoryField(final Class<?> testClass) {
+    for (final Field field : testClass.getDeclaredFields()) {
+      try {
+        if (field.getType() == CamundaClientTestFactory.class) {
+          if (ModifierSupport.isStatic(field)) {
+            field.setAccessible(true);
+            field.set(null, authenticatedClientFactory);
+          } else {
+            fail("CamundaClientTestFactory field couldn't be injected. Make sure it is static.");
           }
         }
       } catch (final Exception ex) {

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -654,11 +654,14 @@ public class CamundaMultiDBExtension
   }
 
   private void awaitTestUserClientsAuthenticated(final TestEntityCollection testEntities) {
+    // @UserDefinition users are only ever created and cached against a
+    // BasicAuthCamundaClientTestFactory (see createClientsForTestEntities); under any other
+    // factory type none of them were created, so there is nothing to await here.
+    if (!(authenticatedClientFactory instanceof BasicAuthCamundaClientTestFactory)) {
+      return;
+    }
     for (final TestUser user : testEntities.users()) {
       final CamundaClient client = authenticatedClientFactory.getCamundaClient(user.username());
-      if (client == null) {
-        continue;
-      }
       Awaitility.await("until user '%s' can authenticate".formatted(user.username()))
           .timeout(Duration.ofSeconds(60))
           .untilAsserted(

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/OidcCamundaClientTestFactory.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/OidcCamundaClientTestFactory.java
@@ -63,8 +63,14 @@ public final class OidcCamundaClientTestFactory implements CamundaClientTestFact
   }
 
   @Override
-  public CamundaClient getCamundaClient(final String mappingRuleId) {
-    return cachedClients.get(mappingRuleId);
+  public CamundaClient getCamundaClient(final String id) {
+    final var client = cachedClients.get(id);
+    if (client == null) {
+      throw new IllegalStateException(
+          "No Camunda client cached for id '%s' in %s. Ensure a @ClientDefinition or @MappingRuleDefinition with this id exists and that the test is configured for OIDC."
+              .formatted(id, getClass().getSimpleName()));
+    }
+    return client;
   }
 
   @Override


### PR DESCRIPTION
## Summary

- `InheritedSimpleMappingAuthorizationIT`, `InheritedBasicAuthAuthorizationIT`, and `InheritedOIDCAuthorizationIT` each built their `CamundaClient` directly via `BROKER.newClientBuilder()`, bypassing the `MultiDbTest` extension's physical-tenant scoping.
- Under the `physical-tenant-identity` CI profile, this made the client's requests silently fall back to the `default` physical tenant instead of the one the test was actually provisioned under (e.g. `tenanta`). Since each physical tenant gets its own independently-populated secondary storage, a group created moments earlier could 404 if the `default` tenant's copy of the same seed data hadn't finished indexing yet — an intermittent flake.
- Exposes the extension's already physical-tenant-aware, pre-built client factory (`CamundaClientTestFactory`) via the same static-field-injection mechanism already used for `CamundaClient`/`DatabaseType`/`KeycloakContainer`, and updates all three affected tests to fetch their client from it instead of building their own.

Closes #58826

## Test plan

- [x] `./mvnw install -pl qa/util -am -Dquickly -T1C`
- [x] `./mvnw verify -pl qa/acceptance-tests -Pmulti-db-test -Dit.test=InheritedSimpleMappingAuthorizationIT,InheritedBasicAuthAuthorizationIT,InheritedOIDCAuthorizationIT -DskipUTs -DskipTests=false -Dquickly` — all pass
- [x] Reproduced the original failure condition locally and confirmed the fix: `./mvnw verify -pl qa/acceptance-tests -Pphysical-tenant-identity -Dtest.integration.camunda.physical-tenant=tenanta -Dit.test=InheritedSimpleMappingAuthorizationIT,InheritedBasicAuthAuthorizationIT,InheritedOIDCAuthorizationIT -DskipUTs -DskipTests=false -Dquickly` — all pass, run repeatedly with no failures
- [x] `./mvnw install -Dquickly -T1C` — full repo compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)