### PR TITLE
ci: remove legacy FE SBOM scanning on 8.9

### DIFF
--- a/.github/dependency-review-config.json
+++ b/.github/dependency-review-config.json
@@ -1,5 +1,6 @@
 {
   "_comment": "Vulnerability gate exceptions — governs the pr-vuln-check job in ci.yml. Gate rules (in check.py): block if fixable (any severity) or high/critical (any fix status). Dev-scoped deps excluded. Add GHSA IDs below with reason, tracking issue, and review-by date. File is CODEOWNERS-protected.",
   "_example": "GHSA-xxxx-xxxx-xxxx: Vetted: no exploit path in our usage; INC-XYZ; review by 2026-12-01",
-  "allow-ghsas": []
+  "_GHSA-qwww-vcr4-c8h2": "Vetted: only affects unstable RSC APIs, which our clients do not use; #58809; review by 2026-10-28",
+  "allow-ghsas": ["GHSA-qwww-vcr4-c8h2"]
 }

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -274,50 +274,6 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
-  operate-fe-sbom-snyk:
-    if: inputs.runFeTests
-    name: "Tool / Front End - Snyk SBOM"
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions: {} # GITHUB_TOKEN unused in this job
-    env:
-      TEST_TYPE: Tool
-    defaults:
-      run:
-        working-directory: ${{ env.CLIENT_DIR }}
-    steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@8f6fae58d4594d3a700982c6642d9de28a950fcc # main
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Print metadata
-        uses: ./.github/actions/print-metadata
-      - name: Import Snyk token from Vault
-        id: snyk-secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: |
-            secret/data/products/camunda/ci/snyk zeebe-api-token | SNYK_TOKEN;
-      - name: Generate and scan frontend SBOM
-        uses: ./.github/actions/frontend-sbom-snyk
-        env:
-          SNYK_TOKEN: ${{ steps.snyk-secrets.outputs.SNYK_TOKEN }}
-        with:
-          directory: operate/client
-          sbom-file: operate/client/build/cyclonedx/bom.json
-          project-name: Operate frontend
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-
   # description: This workflow runs a11y accessibility tests on Operate
   operate-fe-a11y-tests:
     if: inputs.runFeTests

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -311,61 +311,6 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
-  optimize-frontend-sbom-snyk:
-    name: "Tool / Front End - Snyk SBOM"
-    if: inputs.runFeTests
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions: { }  # GITHUB_TOKEN unused in this job
-    defaults:
-      run:
-        working-directory: optimize/client
-    env:
-      TEST_TYPE: Tool
-    steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@8f6fae58d4594d3a700982c6642d9de28a950fcc # main
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Print metadata
-        uses: ./.github/actions/print-metadata
-      - name: "Parse pom.xml for versions"
-        id: "pom_info"
-        uses: YunaBraska/java-info-action@11a434ffbf6bb3357363d1933be71a4076a90a6b # 3.0.11
-        with:
-          work-dir: ./optimize
-      - uses: camunda/infra-global-github-actions/setup-yarn-cache@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # setup-yarn-cache: v1.0.0
-        with:
-          directory: optimize/client
-      - name: Import Snyk token from Vault
-        id: snyk-secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: |
-            secret/data/products/camunda/ci/snyk zeebe-api-token | SNYK_TOKEN;
-      - name: Generate and scan frontend SBOM
-        uses: ./.github/actions/frontend-sbom-snyk
-        env:
-          SNYK_TOKEN: ${{ steps.snyk-secrets.outputs.SNYK_TOKEN }}
-        with:
-          directory: optimize/client
-          package-manager: yarn
-          node-version: ${{ steps.pom_info.outputs.x_version_node }}
-          sbom-file: optimize/client/dist/cyclonedx/bom.json
-          project-name: Optimize frontend
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-
   hadolint:
     if: inputs.runBeTests
     name: "Tool / Dockerfile / Hadolint"

--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -220,50 +220,6 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
-  fe-sbom-snyk:
-    if: inputs.runFeTests
-    name: "Tool / Front End - Snyk SBOM"
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions: {} # GITHUB_TOKEN unused in this job
-    env:
-      TEST_TYPE: Tool
-    defaults:
-      run:
-        working-directory: tasklist/client
-    steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@8f6fae58d4594d3a700982c6642d9de28a950fcc # main
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Print metadata
-        uses: ./.github/actions/print-metadata
-      - name: Import Snyk token from Vault
-        id: snyk-secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: |
-            secret/data/products/camunda/ci/snyk zeebe-api-token | SNYK_TOKEN;
-      - name: Generate and scan frontend SBOM
-        uses: ./.github/actions/frontend-sbom-snyk
-        env:
-          SNYK_TOKEN: ${{ steps.snyk-secrets.outputs.SNYK_TOKEN }}
-        with:
-          directory: tasklist/client
-          sbom-file: tasklist/client/build/cyclonedx/bom.json
-          project-name: Tasklist frontend
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-
   fe-visual-regression-tests:
     if: inputs.runFeTests
     name: "Unit - Front End - Visual Regression"


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Replaces legacy in favor of the nightly run with this PR https://github.com/camunda/camunda/pull/58832
