### PR TITLE
feat: add GCP Secret Manager secret store implementation

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -446,6 +446,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-secret-store-gcp</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
@@ -8,6 +8,10 @@
 package io.camunda.application.commons.secrets;
 
 import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Secrets.AwsSecretsManagerStore;
+import io.camunda.configuration.Secrets.FileStore;
+import io.camunda.configuration.Secrets.GcpSecretManagerStore;
+import io.camunda.configuration.Secrets.Stores;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.secretstore.NoopSecretStore;
 import io.camunda.secretstore.SecretStore;
@@ -15,11 +19,14 @@ import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.secretstore.aws.AwsSecretsManagerSecretStore;
 import io.camunda.secretstore.aws.AwsSecretsManagerStoreConfig;
 import io.camunda.secretstore.file.FileBasedSecretStore;
+import io.camunda.secretstore.gcp.GcpSecretManagerSecretStore;
+import io.camunda.secretstore.gcp.GcpSecretManagerStoreConfig;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +41,19 @@ public class SecretStoreConfiguration {
   private static final Logger LOG = LoggerFactory.getLogger(SecretStoreConfiguration.class);
   private static final NoopSecretStore NOOP_STORE = new NoopSecretStore();
 
+  /**
+   * One entry per supported secret store type. Adding a new backend means adding a single binding
+   * here (plus its factory method) — the per-tenant count check and registration loop below are
+   * type-agnostic and never need to change.
+   */
+  private static final List<StoreBinding<?>> STORE_BINDINGS =
+      List.of(
+          new StoreBinding<>("file", Stores::getFile, SecretStoreConfiguration::fileStore),
+          new StoreBinding<>(
+              "AWS Secrets Manager", Stores::getAws, SecretStoreConfiguration::awsStore),
+          new StoreBinding<>(
+              "GCP Secret Manager", Stores::getGcp, SecretStoreConfiguration::gcpStore));
+
   @Bean
   public SecretStoreRegistries secretStoreRegistries(final PhysicalTenantResolver resolver) {
     final Map<String, SecretStoreRegistry> registries = new LinkedHashMap<>();
@@ -45,71 +65,35 @@ public class SecretStoreConfiguration {
       resolver
           .mapValues(Camunda::getSecrets)
           .forEach(
-              (tenantId, secrets) -> {
-                final var fileStores = secrets.getStores().getFile();
-                final var awsStores = secrets.getStores().getAws();
-                // cap is one store total per tenant, counted across all store types combined
-                final var totalStores = fileStores.size() + awsStores.size();
-                if (totalStores > 1) {
-                  throw new IllegalStateException(
-                      "Physical tenant '"
-                          + tenantId
-                          + "' has "
-                          + totalStores
-                          + " secret stores configured, but only one is supported at this time");
-                }
-                final Map<String, SecretStore> stores = new LinkedHashMap<>();
-                fileStores.forEach(
-                    (storeId, fileStore) -> {
-                      final var path = fileStore.getPath();
-                      if (path.isBlank()) {
-                        throw new IllegalStateException(
-                            "File store '"
-                                + storeId
-                                + "' for physical tenant '"
-                                + tenantId
-                                + "' has no path configured");
-                      }
-                      registerStore(
-                          stores,
-                          created,
-                          storeId,
-                          tenantId,
-                          "file",
-                          new FileBasedSecretStore(Path.of(path)));
-                    });
-                awsStores.forEach(
-                    (storeId, awsStore) -> {
-                      final var config =
-                          new AwsSecretsManagerStoreConfig(
-                              awsStore.getRegion(),
-                              awsStore.getPathPrefix(),
-                              awsStore.getContainerSecretId(),
-                              null,
-                              AwsSecretsManagerStoreConfig.DEFAULT_MAX_RETRIES,
-                              awsStore.isBatchEnabled(),
-                              awsStore.getBatchSize());
-                      registerStore(
-                          stores,
-                          created,
-                          storeId,
-                          tenantId,
-                          "AWS Secrets Manager",
-                          AwsSecretsManagerSecretStore.fromConfig(config));
-                    });
-                if (stores.isEmpty()) {
-                  stores.put("default", NOOP_STORE);
-                  LOG.info(
-                      "No secret stores configured for physical tenant '{}', using noop store",
-                      tenantId);
-                }
-                registries.put(tenantId, new SecretStoreRegistry(Map.copyOf(stores)));
-              });
+              (tenantId, secrets) ->
+                  registries.put(tenantId, buildRegistry(tenantId, secrets.getStores(), created)));
     } catch (final RuntimeException e) {
       closeAll(created);
       throw e;
     }
     return new SecretStoreRegistries(Map.copyOf(registries));
+  }
+
+  private static SecretStoreRegistry buildRegistry(
+      final String tenantId, final Stores config, final List<SecretStore> created) {
+    // cap is one store total per tenant, counted across all store types combined
+    final long totalStores =
+        STORE_BINDINGS.stream().mapToLong(binding -> binding.count(config)).sum();
+    if (totalStores > 1) {
+      throw new IllegalStateException(
+          "Physical tenant '"
+              + tenantId
+              + "' has "
+              + totalStores
+              + " secret stores configured, but only one is supported at this time");
+    }
+    final Map<String, SecretStore> stores = new LinkedHashMap<>();
+    STORE_BINDINGS.forEach(binding -> binding.registerAll(config, stores, created, tenantId));
+    if (stores.isEmpty()) {
+      stores.put("default", NOOP_STORE);
+      LOG.info("No secret stores configured for physical tenant '{}', using noop store", tenantId);
+    }
+    return new SecretStoreRegistry(Map.copyOf(stores));
   }
 
   private static void closeAll(final List<SecretStore> stores) {
@@ -137,5 +121,84 @@ public class SecretStoreConfiguration {
         storeType,
         normalizedId,
         tenantId);
+  }
+
+  private static SecretStore fileStore(
+      final String storeId, final String tenantId, final FileStore config) {
+    final var path = config.getPath();
+    if (path.isBlank()) {
+      throw new IllegalStateException(
+          "File store '"
+              + storeId
+              + "' for physical tenant '"
+              + tenantId
+              + "' has no path configured");
+    }
+    return new FileBasedSecretStore(Path.of(path));
+  }
+
+  private static SecretStore awsStore(
+      final String storeId, final String tenantId, final AwsSecretsManagerStore config) {
+    return AwsSecretsManagerSecretStore.fromConfig(
+        new AwsSecretsManagerStoreConfig(
+            config.getRegion(),
+            config.getPathPrefix(),
+            config.getContainerSecretId(),
+            null,
+            AwsSecretsManagerStoreConfig.DEFAULT_MAX_RETRIES,
+            config.isBatchEnabled(),
+            config.getBatchSize()));
+  }
+
+  private static SecretStore gcpStore(
+      final String storeId, final String tenantId, final GcpSecretManagerStore config) {
+    return GcpSecretManagerSecretStore.fromConfig(
+        new GcpSecretManagerStoreConfig(
+            config.getProjectId(),
+            config.getPathPrefix(),
+            config.getEndpoint(),
+            config.getContainerSecretId()));
+  }
+
+  /** Builds one {@link SecretStore} from a single configured entry of a given store type. */
+  @FunctionalInterface
+  private interface StoreFactory<C> {
+    SecretStore create(String storeId, String tenantId, C config);
+  }
+
+  /**
+   * Binds a secret store type to the config entries it reads and the factory that turns one such
+   * entry into a {@link SecretStore}. The type parameter {@code C} keeps the selected config type
+   * and the factory's input type in lock-step, so the registration loop can iterate a heterogeneous
+   * {@code List<StoreBinding<?>>} without any casts.
+   *
+   * @param displayName human-readable store type name used in log messages
+   * @param selector reads this type's {@code storeId -> config} entries from the tenant's stores
+   * @param factory builds a store from one entry, applying any per-type validation
+   */
+  private record StoreBinding<C>(
+      String displayName, Function<Stores, Map<String, C>> selector, StoreFactory<C> factory) {
+
+    private int count(final Stores config) {
+      return selector.apply(config).size();
+    }
+
+    private void registerAll(
+        final Stores config,
+        final Map<String, SecretStore> stores,
+        final List<SecretStore> created,
+        final String tenantId) {
+      selector
+          .apply(config)
+          .forEach(
+              (storeId, entry) ->
+                  registerStore(
+                      stores,
+                      created,
+                      storeId,
+                      tenantId,
+                      displayName,
+                      factory.create(storeId, tenantId, entry)));
+    }
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
@@ -9,6 +9,9 @@ package io.camunda.application.commons.secrets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.verify;
 
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.configuration.Camunda;
@@ -200,6 +203,64 @@ class SecretStoreConfigurationTest {
         .isThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
         .withMessageContaining(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
         .withMessageContaining("only one is supported");
+  }
+
+  @Test
+  void shouldThrowWhenFileAndGcpStoresCombinedExceedOne() {
+    // given one file store and one gcp store for the same tenant
+    final var resolver =
+        resolverFor(
+            Map.of(
+                "camunda.secrets.stores.file.file-store.path", "/etc/camunda/secrets",
+                "camunda.secrets.stores.gcp.gcp-store.project-id", "my-project"));
+
+    // when / then — the per-tenant cap is enforced before any GCP client is built
+    assertThatIllegalStateException()
+        .isThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
+        .withMessageContaining(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+        .withMessageContaining("only one is supported");
+  }
+
+  @Test
+  void shouldCloseAlreadyBuiltStoresWhenALaterTenantFailsToBuild() {
+    // given two tenants each with a single file store; the second store's construction blows up,
+    // simulating a store that fails to build after an earlier tenant's store was already created.
+    // Counting constructions (not tenants) keeps this deterministic regardless of tenant iteration
+    // order: whichever tenant is processed first builds successfully, the second one fails.
+    try (var construction =
+        mockConstruction(
+            FileBasedSecretStore.class,
+            (mock, context) -> {
+              if (context.getCount() == 2) {
+                throw new IllegalStateException("second tenant's store failed to build");
+              }
+            })) {
+      final var resolver =
+          resolverFor(
+              Map.of(
+                  "camunda.physical-tenants.tenanta.secrets.stores.file.main.path",
+                  "/etc/tenanta/secrets",
+                  "camunda.physical-tenants.tenanta.security.initialization.default-roles.admin.users[0]",
+                  "tenanta-admin",
+                  "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+                  "tenanta",
+                  "camunda.physical-tenants.tenantb.secrets.stores.file.other.path",
+                  "/etc/tenantb/secrets",
+                  "camunda.physical-tenants.tenantb.security.initialization.default-roles.admin.users[0]",
+                  "tenantb-admin",
+                  "camunda.physical-tenants.tenantb.data.secondary-storage.elasticsearch.index-prefix",
+                  "tenantb"));
+
+      // when / then — the build fails and the failure propagates (Mockito wraps the construction
+      // failure, but it is still a RuntimeException the rollback path catches)
+      assertThatThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
+          .isInstanceOf(RuntimeException.class)
+          .hasRootCauseInstanceOf(IllegalStateException.class);
+
+      // then — the first tenant's already-built store is rolled back (closed) so its client does
+      // not leak
+      verify(construction.constructed().get(0)).close();
+    }
   }
 
   private static PhysicalTenantResolver resolverFor(final Map<String, Object> properties) {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1008,6 +1008,11 @@
         <artifactId>camunda-secret-store-aws</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-secret-store-gcp</artifactId>
+        <version>${project.version}</version>
+      </dependency>
 
       <!-- Camunda Process Testing modules -->
 

--- a/secret-store/pom.xml
+++ b/secret-store/pom.xml
@@ -24,6 +24,7 @@
     <module>secret-store-api</module>
     <module>secret-store-file</module>
     <module>secret-store-aws</module>
+    <module>secret-store-gcp</module>
   </modules>
 
 </project>

--- a/secret-store/secret-store-gcp/pom.xml
+++ b/secret-store/secret-store-gcp/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>camunda-secret-store</artifactId>
+    <version>8.10.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>camunda-secret-store-gcp</artifactId>
+
+  <name>Camunda Secret Store GCP Secret Manager Implementation</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-secret-store-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-secretmanager</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-secretmanager-v1</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax-grpc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>api-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/ContainerSecretResolver.java
+++ b/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/ContainerSecretResolver.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.gcp;
+
+import static io.camunda.secretstore.SecretErrorCode.INVALID_REF;
+import static io.camunda.secretstore.SecretErrorCode.NOT_FOUND;
+import static io.camunda.secretstore.gcp.GcpSecretManagerErrors.classify;
+import static io.camunda.secretstore.gcp.GcpSecretManagerErrors.messageFor;
+import static io.camunda.secretstore.gcp.GcpSecretManagerErrors.storeUnavailable;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
+import io.camunda.secretstore.SecretErrorCode;
+import io.camunda.secretstore.SecretResolutionResult;
+import io.camunda.secretstore.SecretResolutionResult.Failed;
+import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import io.camunda.secretstore.SecretStoreUnavailableException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * JSON-container resolution mode: every reference is a key inside one shared GCP secret (a JSON
+ * object of key-value pairs), fetched once per {@link #resolve}/{@link #list} call instead of one
+ * GCP secret per reference.
+ *
+ * <p>Expected format: the container secret's value must be a flat JSON <b>object</b> whose
+ * top-level values are all JSON strings, e.g. {@code {"db-password": "s3cr3t", "api-token":
+ * "tok3n"}}. Nested objects/arrays are not traversed. Deviations are handled as follows:
+ *
+ * <ul>
+ *   <li>Not valid JSON at all &mdash; {@link #resolve} fails every requested reference with {@link
+ *       io.camunda.secretstore.SecretErrorCode#INVALID_REF}; {@link #list} throws {@link
+ *       io.camunda.secretstore.SecretStoreUnavailableException}.
+ *   <li>Valid JSON but not an object (e.g. an array or a bare string/number) &mdash; same as above;
+ *       the container secret is unusable regardless of which method is called.
+ *   <li>The requested key is absent &mdash; {@link #resolve} fails only that reference with {@link
+ *       io.camunda.secretstore.SecretErrorCode#NOT_FOUND}; {@link #list} does not return it, since
+ *       an absent key is not one of the container's top-level field names.
+ *   <li>The requested key is present with a JSON {@code null} value &mdash; {@link #resolve} fails
+ *       only that reference with {@link io.camunda.secretstore.SecretErrorCode#NOT_FOUND}, treating
+ *       a null value as no value; {@link #list} <b>does</b> return it, because it reports the
+ *       container's top-level field names regardless of their values (just as it lists a key whose
+ *       value is a non-string).
+ *   <li>A valid object whose value for a requested key is present but not a JSON string (number,
+ *       object, array) &mdash; {@link #resolve} fails only that reference with {@link
+ *       io.camunda.secretstore.SecretErrorCode#INVALID_REF}; {@link #list} is unaffected, since it
+ *       only inspects field names, not values.
+ * </ul>
+ */
+final class ContainerSecretResolver implements GcpSecretResolver {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ContainerSecretResolver.class);
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final String LATEST_VERSION = "latest";
+
+  private final SecretManagerServiceClient client;
+  private final @Nullable String projectId;
+  private final String containerId;
+
+  ContainerSecretResolver(
+      final SecretManagerServiceClient client,
+      final @Nullable String projectId,
+      final String pathPrefix,
+      final String containerSecretId) {
+    this.client = client;
+    this.projectId = projectId;
+    containerId = pathPrefix + containerSecretId;
+  }
+
+  @Override
+  public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
+    if (names.isEmpty()) {
+      return Map.of();
+    }
+    LOG.debug(
+        "Resolving {} secret refs from GCP Secret Manager container '{}'",
+        names.size(),
+        containerId);
+    final JsonNode json;
+    try {
+      json = OBJECT_MAPPER.readTree(fetchRawSecret());
+    } catch (final JsonProcessingException e) {
+      return failAll(
+          names, INVALID_REF, "Container secret '" + containerId + "' is not valid JSON");
+    } catch (final ApiException e) {
+      final var code = classify(e);
+      return failAll(names, code, messageFor(code, "container secret", containerId));
+    } catch (final RuntimeException e) {
+      throw storeUnavailable(e);
+    }
+    if (!json.isObject()) {
+      return failAll(
+          names,
+          INVALID_REF,
+          "Container secret '"
+              + containerId
+              + "' is not a JSON object (was "
+              + json.getNodeType()
+              + ")");
+    }
+
+    final Map<String, SecretResolutionResult> results = new LinkedHashMap<>(names.size());
+    for (final var name : names) {
+      results.put(name, extractKey(json, name));
+    }
+    return results;
+  }
+
+  @Override
+  public List<String> list() {
+    LOG.debug("Listing keys from GCP Secret Manager container secret '{}'", containerId);
+    final JsonNode json;
+    try {
+      json = OBJECT_MAPPER.readTree(fetchRawSecret());
+    } catch (final JsonProcessingException e) {
+      throw new SecretStoreUnavailableException(
+          "Container secret '" + containerId + "' is not valid JSON");
+    } catch (final RuntimeException e) {
+      throw storeUnavailable(e);
+    }
+    // Kept outside the try so this deterministic malformed-content error is not caught by the broad
+    // RuntimeException handler above and re-wrapped as a misleading "GCP is unavailable"
+    // (transient)
+    // failure.
+    if (!json.isObject()) {
+      throw new SecretStoreUnavailableException(
+          "Container secret '"
+              + containerId
+              + "' is not a JSON object (was "
+              + json.getNodeType()
+              + ")");
+    }
+    final var names = new ArrayList<String>();
+    json.fieldNames().forEachRemaining(names::add);
+    return names;
+  }
+
+  private String fetchRawSecret() {
+    final var response =
+        client.accessSecretVersion(SecretVersionName.of(projectId, containerId, LATEST_VERSION));
+    return response.getPayload().getData().toStringUtf8();
+  }
+
+  @Override
+  public void validateConnectivity() {
+    // container mode reads exactly one secret at runtime, so accessSecretVersion on it is both the
+    // minimal probe and the one that matches this mode's IAM footprint.
+    fetchRawSecret();
+  }
+
+  private SecretResolutionResult extractKey(final JsonNode container, final String key) {
+    final var node = container.get(key);
+    if (node == null || node.isNull()) {
+      return new Failed(
+          NOT_FOUND, "Key '" + key + "' not found in container secret '" + containerId + "'", null);
+    }
+    if (!node.isTextual()) {
+      return new Failed(
+          INVALID_REF,
+          "Key '" + key + "' in container secret '" + containerId + "' is not a string value",
+          null);
+    }
+    return new Resolved(node.asText());
+  }
+
+  private static Map<String, SecretResolutionResult> failAll(
+      final Set<String> names, final SecretErrorCode code, final String message) {
+    final Map<String, SecretResolutionResult> results = new LinkedHashMap<>(names.size());
+    for (final var name : names) {
+      results.put(name, new Failed(code, message, null));
+    }
+    return results;
+  }
+}

--- a/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/GcpSecretManagerErrors.java
+++ b/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/GcpSecretManagerErrors.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.gcp;
+
+import static io.camunda.secretstore.SecretErrorCode.ACCESS_DENIED;
+import static io.camunda.secretstore.SecretErrorCode.INVALID_REF;
+import static io.camunda.secretstore.SecretErrorCode.NOT_FOUND;
+
+import com.google.api.gax.rpc.ApiException;
+import io.camunda.secretstore.SecretErrorCode;
+import io.camunda.secretstore.SecretStoreUnavailableException;
+
+/** GCP error classification and messaging shared by every {@link GcpSecretResolver}. */
+final class GcpSecretManagerErrors {
+
+  private GcpSecretManagerErrors() {}
+
+  /**
+   * Maps a per-secret GCP Secret Manager exception to a {@link SecretErrorCode}.
+   *
+   * @throws SecretStoreUnavailableException if {@code e} indicates a store-wide failure rather than
+   *     a per-secret one (e.g. throttling, unavailable, internal service error)
+   */
+  static SecretErrorCode classify(final ApiException e) {
+    return switch (e.getStatusCode().getCode()) {
+      case NOT_FOUND -> NOT_FOUND;
+      case INVALID_ARGUMENT, FAILED_PRECONDITION, OUT_OF_RANGE -> INVALID_REF;
+      case PERMISSION_DENIED, UNAUTHENTICATED -> ACCESS_DENIED;
+      default -> throw storeUnavailable(e);
+    };
+  }
+
+  /**
+   * A human-readable per-secret failure message, shared by every resolver so the wording is
+   * consistent regardless of resolution mode.
+   *
+   * @param what what {@code id} identifies, e.g. {@code "secret"} or {@code "container secret"}
+   */
+  static String messageFor(final SecretErrorCode code, final String what, final String id) {
+    return switch (code) {
+      case NOT_FOUND -> capitalize(what) + " not found: " + id;
+      case INVALID_REF -> "Invalid " + what + " reference: " + id;
+      case ACCESS_DENIED -> "Access denied for " + what + ": " + id;
+      case UNREADABLE -> capitalize(what) + " is unreadable: " + id;
+    };
+  }
+
+  private static String capitalize(final String s) {
+    return s.isEmpty() ? s : Character.toUpperCase(s.charAt(0)) + s.substring(1);
+  }
+
+  static SecretStoreUnavailableException storeUnavailable(final Exception e) {
+    return new SecretStoreUnavailableException(
+        "GCP Secret Manager is unavailable: " + e.getMessage(), e);
+  }
+}

--- a/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/GcpSecretManagerSecretStore.java
+++ b/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/GcpSecretManagerSecretStore.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.gcp;
+
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceSettings;
+import io.camunda.secretstore.SecretResolutionResult;
+import io.camunda.secretstore.SecretResolutionResult.Failed;
+import io.camunda.secretstore.SecretStore;
+import io.camunda.secretstore.SecretStoreUnavailableException;
+import io.grpc.ManagedChannelBuilder;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link SecretStore} backed by GCP Secret Manager.
+ *
+ * <p>References are mapped to GCP secret ids by prepending the configured {@code pathPrefix} and
+ * read from the {@code latest} version within the configured project. Authentication uses the GCP
+ * Application Default Credentials chain (identity-based, no static credentials).
+ *
+ * <p>How a reference is actually looked up is delegated to one {@link GcpSecretResolver}, chosen
+ * once at construction time: {@link OneByOneSecretResolver} by default (one GCP secret per
+ * reference), or {@link ContainerSecretResolver} when a container secret id is set (every reference
+ * is a JSON key inside one shared secret). This class itself only owns the GCP client and picks the
+ * resolver; adding a new resolution mode means adding a new {@link GcpSecretResolver}
+ * implementation, not touching this class or the existing ones.
+ *
+ * <p>Per-secret failures (missing secret, access denied, invalid reference) are returned as {@link
+ * Failed} results. Store-wide failures (connectivity, throttling after retries, service errors) are
+ * surfaced as {@link SecretStoreUnavailableException} so callers can retry or back off.
+ *
+ * <p>This class is thread-safe: {@link SecretManagerServiceClient} is thread-safe, {@link
+ * GcpSecretResolver} implementations keep no mutable state between calls, and neither does this
+ * class.
+ */
+public final class GcpSecretManagerSecretStore implements SecretStore {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GcpSecretManagerSecretStore.class);
+
+  private final SecretManagerServiceClient client;
+  private final GcpSecretResolver resolver;
+
+  /**
+   * Creates a store using an already-built client, with no JSON container. Package-private and
+   * test-only: it skips the config resolution and startup probe done by {@link
+   * #fromConfig(GcpSecretManagerStoreConfig)}, so production code must go through {@code
+   * fromConfig} and only same-package tests can reach this constructor.
+   */
+  GcpSecretManagerSecretStore(
+      final SecretManagerServiceClient client,
+      final @Nullable String projectId,
+      final @Nullable String pathPrefix) {
+    this(client, projectId, pathPrefix, null);
+  }
+
+  /**
+   * Creates a store using an already-built client, optionally treating every reference as a JSON
+   * key inside the given container secret. Package-private and test-only: it skips the config
+   * resolution and startup probe done by {@link #fromConfig(GcpSecretManagerStoreConfig)}, so
+   * production code must go through {@code fromConfig} and only same-package tests can reach this
+   * constructor.
+   */
+  GcpSecretManagerSecretStore(
+      final SecretManagerServiceClient client,
+      final @Nullable String projectId,
+      final @Nullable String pathPrefix,
+      final @Nullable String containerSecretId) {
+    this(client, buildResolver(client, projectId, normalize(pathPrefix), containerSecretId));
+  }
+
+  private GcpSecretManagerSecretStore(
+      final SecretManagerServiceClient client, final GcpSecretResolver resolver) {
+    this.client = client;
+    this.resolver = resolver;
+  }
+
+  /**
+   * Builds a store from configuration, eagerly constructing the underlying client and probing
+   * connectivity with a minimal GCP call. Two failure modes are distinguished:
+   *
+   * <ul>
+   *   <li>Building the client fails (e.g. credentials cannot be loaded from the Application Default
+   *       Credentials chain): this fails fast with a {@link SecretStoreUnavailableException}, since
+   *       a client that cannot even be constructed can never resolve a secret.
+   *   <li>The client builds but the startup probe fails (e.g. an unreachable endpoint or a bad
+   *       project): this is best-effort — it is logged as a warning at startup but does not prevent
+   *       the store from being built, so a transient GCP problem during boot cannot stop the whole
+   *       application from starting. Such a misconfiguration then surfaces on the first real {@link
+   *       #resolve} or {@link #list} call.
+   * </ul>
+   *
+   * <p>A missing project id is treated differently: if the config omits it and no default project
+   * can be resolved from the environment, this fails fast with a {@link
+   * SecretStoreUnavailableException}, since that is a deterministic configuration error rather than
+   * a transient connectivity problem.
+   */
+  public static GcpSecretManagerSecretStore fromConfig(final GcpSecretManagerStoreConfig config) {
+    // Resolve the project id before opening the client: it does not depend on the client, and doing
+    // it here keeps the throwing calls outside the try below so a failure cannot leak an
+    // already-open client.
+    final var projectId =
+        config.projectId() != null ? config.projectId() : ServiceOptions.getDefaultProjectId();
+    if (projectId == null || projectId.isBlank()) {
+      // A missing project id is a deterministic configuration error, not a transient connectivity
+      // problem, so fail fast with a clear message instead of deferring to a low-signal NPE from
+      // ProjectName.of(null)/SecretVersionName.of(null, ...) on the first resolve/list.
+      throw new SecretStoreUnavailableException(
+          "GCP Secret Manager projectId is not configured and no default project could be resolved "
+              + "from the environment; set projectId explicitly or provide GOOGLE_CLOUD_PROJECT / a "
+              + "gcloud default project / a compute metadata server");
+    }
+    final SecretManagerServiceClient client;
+    try {
+      final var settings = SecretManagerServiceSettings.newBuilder();
+      if (config.withoutAuthentication()) {
+        // Emulator/testing only: no credentials and a plaintext gRPC channel to a local endpoint.
+        settings.setCredentialsProvider(NoCredentialsProvider.create());
+        settings.setTransportChannelProvider(
+            SecretManagerServiceSettings.defaultGrpcTransportProviderBuilder()
+                .setEndpoint(config.endpoint())
+                .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
+                .build());
+      } else if (config.endpoint() != null && !config.endpoint().isBlank()) {
+        settings.setEndpoint(config.endpoint());
+      }
+      client = SecretManagerServiceClient.create(settings.build());
+    } catch (final IOException | RuntimeException e) {
+      throw new SecretStoreUnavailableException(
+          "Failed to initialize GCP Secret Manager client: " + e.getMessage(), e);
+    }
+    final var resolver =
+        buildResolver(
+            client, projectId, normalize(config.pathPrefix()), config.containerSecretId());
+    validateConnectivity(resolver);
+    return new GcpSecretManagerSecretStore(client, resolver);
+  }
+
+  /**
+   * Probes GCP connectivity/credentials at startup, delegating to the resolver so it uses the exact
+   * API — and thus the minimal IAM policy — that mode resolves with. The probe is best-effort: on
+   * failure it logs a warning and lets the store be built anyway, so a transient GCP problem during
+   * boot cannot stop the application from starting. The misconfiguration then surfaces on the first
+   * real {@link #resolve} or {@link #list} call. The client is kept open on failure because the
+   * store retains it for those later calls.
+   *
+   * <p>Package-private so the warn-and-continue behaviour can be unit-tested with a stub resolver;
+   * the per-mode probe choice is tested on the resolvers themselves.
+   */
+  static void validateConnectivity(final GcpSecretResolver resolver) {
+    try {
+      resolver.validateConnectivity();
+    } catch (final RuntimeException e) {
+      LOG.warn(
+          "Failed to validate GCP Secret Manager connectivity/credentials at startup; "
+              + "the store will still be created and the error will surface on first use: {}",
+          e.getMessage(),
+          e);
+    }
+  }
+
+  @Override
+  public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
+    return resolver.resolve(names);
+  }
+
+  @Override
+  public List<String> list() {
+    return resolver.list();
+  }
+
+  @Override
+  public void close() {
+    client.close();
+  }
+
+  private static GcpSecretResolver buildResolver(
+      final SecretManagerServiceClient client,
+      final @Nullable String projectId,
+      final String pathPrefix,
+      final @Nullable String containerSecretId) {
+    return containerSecretId == null || containerSecretId.isBlank()
+        ? new OneByOneSecretResolver(client, projectId, pathPrefix)
+        : new ContainerSecretResolver(client, projectId, pathPrefix, containerSecretId);
+  }
+
+  private static String normalize(final @Nullable String pathPrefix) {
+    return pathPrefix == null || pathPrefix.isBlank() ? "" : pathPrefix;
+  }
+}

--- a/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/GcpSecretManagerStoreConfig.java
+++ b/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/GcpSecretManagerStoreConfig.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.gcp;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Configuration for a {@link GcpSecretManagerSecretStore}.
+ *
+ * <p>Authentication is always identity-based: the GCP Application Default Credentials chain is used
+ * (workload identity, service-account key from {@code GOOGLE_APPLICATION_CREDENTIALS}, metadata
+ * server). No static credentials are accepted here by design.
+ *
+ * @param projectId the GCP project id owning the secrets, or {@code null} to let the client resolve
+ *     it from the environment (the {@code GOOGLE_CLOUD_PROJECT} variable, {@code gcloud} config, or
+ *     the compute metadata server via the Application Default Credentials chain)
+ * @param pathPrefix optional prefix prepended to every reference name to form the GCP secret id
+ *     (e.g. {@code camunda-}); {@code null} or blank means references map to bare secret ids
+ * @param endpoint optional endpoint override, primarily for testing against an emulator; {@code
+ *     null} uses the default Secret Manager endpoint
+ * @param containerSecretId opt-in: when set, every reference is treated as a JSON key inside this
+ *     one named secret instead of its own GCP secret; {@code null} keeps the default one-secret
+ *     per-reference behavior
+ * @param withoutAuthentication testing only: when {@code true}, the client connects to {@code
+ *     endpoint} over a plaintext channel with no credentials, so an integration test can point it
+ *     at a local Secret Manager emulator. Requires {@code endpoint} to be set and must never be
+ *     enabled against real GCP; production always leaves this {@code false} and authenticates via
+ *     the Application Default Credentials chain.
+ */
+public record GcpSecretManagerStoreConfig(
+    @Nullable String projectId,
+    @Nullable String pathPrefix,
+    @Nullable String endpoint,
+    @Nullable String containerSecretId,
+    boolean withoutAuthentication) {
+
+  public GcpSecretManagerStoreConfig {
+    if (projectId != null && projectId.isBlank()) {
+      throw new IllegalArgumentException("projectId must not be blank when set");
+    }
+    if (containerSecretId != null && containerSecretId.isBlank()) {
+      throw new IllegalArgumentException("containerSecretId must not be blank, but was empty");
+    }
+    if (withoutAuthentication && (endpoint == null || endpoint.isBlank())) {
+      throw new IllegalArgumentException(
+          "endpoint must be set when authentication is disabled (emulator testing only)");
+    }
+  }
+
+  /**
+   * Authenticated config (production default): connects to the given endpoint (or the default one
+   * when {@code null}) using the Application Default Credentials chain.
+   */
+  public GcpSecretManagerStoreConfig(
+      final @Nullable String projectId,
+      final @Nullable String pathPrefix,
+      final @Nullable String endpoint,
+      final @Nullable String containerSecretId) {
+    this(projectId, pathPrefix, endpoint, containerSecretId, false);
+  }
+
+  /**
+   * Creates a config with only a project id and path prefix; endpoint and container default to
+   * {@code null} (one GCP secret per reference against the default endpoint).
+   */
+  public static GcpSecretManagerStoreConfig of(
+      final @Nullable String projectId, final @Nullable String pathPrefix) {
+    return new GcpSecretManagerStoreConfig(projectId, pathPrefix, null, null);
+  }
+}

--- a/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/GcpSecretResolver.java
+++ b/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/GcpSecretResolver.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.gcp;
+
+import io.camunda.secretstore.SecretResolutionResult;
+import io.camunda.secretstore.SecretStoreUnavailableException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * One GCP Secret Manager resolution algorithm: how reference names are mapped to secret ids and
+ * read. {@link GcpSecretManagerSecretStore} picks exactly one implementation at construction time
+ * based on configuration and delegates every call to it.
+ */
+interface GcpSecretResolver {
+
+  /**
+   * @throws SecretStoreUnavailableException if the backing store cannot be accessed
+   */
+  Map<String, SecretResolutionResult> resolve(Set<String> names);
+
+  /**
+   * @throws SecretStoreUnavailableException if the backing store cannot be accessed or its content
+   *     is malformed
+   */
+  List<String> list();
+
+  /**
+   * Probes GCP with the same API this resolver uses at runtime, so a startup connectivity check
+   * never demands a broader IAM policy than resolution itself needs. Any GCP/gRPC error propagates
+   * to the caller, which logs a warning and continues; called once at store build time.
+   */
+  void validateConnectivity();
+}

--- a/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/OneByOneSecretResolver.java
+++ b/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/OneByOneSecretResolver.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.gcp;
+
+import static io.camunda.secretstore.gcp.GcpSecretManagerErrors.classify;
+import static io.camunda.secretstore.gcp.GcpSecretManagerErrors.messageFor;
+import static io.camunda.secretstore.gcp.GcpSecretManagerErrors.storeUnavailable;
+
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.secretmanager.v1.ListSecretsRequest;
+import com.google.cloud.secretmanager.v1.ProjectName;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretName;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
+import io.camunda.secretstore.SecretResolutionResult;
+import io.camunda.secretstore.SecretResolutionResult.Failed;
+import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default resolution mode: each reference name maps 1:1 to a GCP secret id ({@code pathPrefix +
+ * name}). Issues one {@code accessSecretVersion} call per reference against the {@code latest}
+ * version.
+ */
+final class OneByOneSecretResolver implements GcpSecretResolver {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OneByOneSecretResolver.class);
+  private static final String LATEST_VERSION = "latest";
+
+  private final SecretManagerServiceClient client;
+  private final @Nullable String projectId;
+  private final String pathPrefix;
+
+  OneByOneSecretResolver(
+      final SecretManagerServiceClient client,
+      final @Nullable String projectId,
+      final String pathPrefix) {
+    this.client = client;
+    this.projectId = projectId;
+    this.pathPrefix = pathPrefix;
+  }
+
+  @Override
+  public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
+    if (names.isEmpty()) {
+      return Map.of();
+    }
+    LOG.debug("Resolving {} secret refs from GCP Secret Manager", names.size());
+    final Map<String, SecretResolutionResult> results = new LinkedHashMap<>(names.size());
+    for (final var name : names) {
+      results.put(name, resolveSingle(name));
+    }
+    return results;
+  }
+
+  private SecretResolutionResult resolveSingle(final String name) {
+    final var secretId = secretId(name);
+    try {
+      final var response =
+          client.accessSecretVersion(SecretVersionName.of(projectId, secretId, LATEST_VERSION));
+      return new Resolved(response.getPayload().getData().toStringUtf8());
+    } catch (final ApiException e) {
+      final var code = classify(e);
+      return new Failed(code, messageFor(code, "secret", secretId), e);
+    } catch (final RuntimeException e) {
+      throw storeUnavailable(e);
+    }
+  }
+
+  @Override
+  public List<String> list() {
+    LOG.debug(
+        "Listing secrets from GCP Secret Manager project '{}' with prefix '{}'",
+        projectId,
+        pathPrefix);
+    final var names = new ArrayList<String>();
+    try {
+      for (final var secret : client.listSecrets(ProjectName.of(projectId)).iterateAll()) {
+        final var secretId = SecretName.parse(secret.getName()).getSecret();
+        if (secretId.startsWith(pathPrefix)) {
+          final var logicalName = secretId.substring(pathPrefix.length());
+          if (!logicalName.isBlank()) {
+            names.add(logicalName);
+          }
+        }
+      }
+      return names;
+    } catch (final RuntimeException e) {
+      throw storeUnavailable(e);
+    }
+  }
+
+  private String secretId(final String name) {
+    return pathPrefix + name;
+  }
+
+  @Override
+  public void validateConnectivity() {
+    // one-by-one mode resolves via accessSecretVersion and lists via listSecrets; a single-result
+    // listSecrets is the cheapest probe that exercises this mode's IAM footprint.
+    client.listSecrets(
+        ListSecretsRequest.newBuilder()
+            .setParent(ProjectName.of(projectId).toString())
+            .setPageSize(1)
+            .build());
+  }
+}

--- a/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/package-info.java
+++ b/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.secretstore.gcp;
+
+import org.jspecify.annotations.NullMarked;

--- a/secret-store/secret-store-gcp/src/test/java/io/camunda/secretstore/gcp/GcpSecretManagerSecretStoreIT.java
+++ b/secret-store/secret-store-gcp/src/test/java/io/camunda/secretstore/gcp/GcpSecretManagerSecretStoreIT.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.gcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.cloud.secretmanager.v1.ProjectName;
+import com.google.cloud.secretmanager.v1.Replication;
+import com.google.cloud.secretmanager.v1.Secret;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceSettings;
+import com.google.cloud.secretmanager.v1.SecretName;
+import com.google.cloud.secretmanager.v1.SecretPayload;
+import com.google.protobuf.ByteString;
+import io.camunda.secretstore.SecretErrorCode;
+import io.camunda.secretstore.SecretResolutionResult.Failed;
+import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import io.camunda.secretstore.SecretStoreUnavailableException;
+import io.camunda.secretstore.gcp.util.SecretManagerEmulatorContainer;
+import io.grpc.ManagedChannelBuilder;
+import java.util.Set;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * End-to-end integration tests that drive the real gax {@link SecretManagerServiceClient} against a
+ * GCP Secret Manager emulator, built through the production {@link
+ * GcpSecretManagerSecretStore#fromConfig} path (client init + startup connectivity validation).
+ * Fine-grained error-code classification is covered by {@link GcpSecretManagerSecretStoreTest};
+ * this suite proves the wire path works against a real server.
+ */
+@Testcontainers
+class GcpSecretManagerSecretStoreIT {
+
+  private static final String PROJECT = "test-project";
+  private static final String PREFIX = "camunda-";
+  private static final String CONTAINER_PREFIX = "cfg-";
+
+  @Container
+  private static final SecretManagerEmulatorContainer EMULATOR =
+      new SecretManagerEmulatorContainer();
+
+  private static SecretManagerServiceClient adminClient;
+
+  @BeforeAll
+  static void seed() throws Exception {
+    adminClient = SecretManagerServiceClient.create(emulatorSettings());
+
+    createSecret("camunda-db-password", "s3cr3t");
+    createSecret("camunda-api-token", "tok3n");
+    createSecret("other-unrelated", "ignored");
+    createSecret(
+        "cfg-app-config", "{\"DB_PASSWORD\":\"c0nt41ner\",\"API_KEY\":\"k3y\",\"NUM\":42}");
+    createSecret("cfg-bad-json", "not json");
+    createSecret("cfg-arr", "[\"a\",\"b\"]");
+  }
+
+  @AfterAll
+  static void tearDown() {
+    if (adminClient != null) {
+      adminClient.close();
+    }
+  }
+
+  @Test
+  void shouldResolveSecretViaFromConfig() {
+    // given — the production build path against a real server
+    try (final var store = oneByOneStore()) {
+      // when
+      final var result = store.resolve(Set.of("db-password"));
+
+      // then
+      assertThat(result.get("db-password"))
+          .isInstanceOf(Resolved.class)
+          .extracting(r -> ((Resolved) r).value())
+          .isEqualTo("s3cr3t");
+    }
+  }
+
+  @Test
+  void shouldReturnNotFoundForMissingSecret() {
+    // given
+    try (final var store = oneByOneStore()) {
+      // when
+      final var result = store.resolve(Set.of("does-not-exist"));
+
+      // then
+      assertThat(((Failed) result.get("does-not-exist")).code())
+          .isEqualTo(SecretErrorCode.NOT_FOUND);
+    }
+  }
+
+  @Test
+  void shouldResolveBatchWithHitAndMiss() {
+    // given
+    try (final var store = oneByOneStore()) {
+      // when
+      final var result = store.resolve(Set.of("db-password", "api-token", "does-not-exist"));
+
+      // then — every requested ref has a result, hits resolved and the miss failed
+      assertThat(result.get("db-password"))
+          .isInstanceOf(Resolved.class)
+          .extracting(r -> ((Resolved) r).value())
+          .isEqualTo("s3cr3t");
+      assertThat(result.get("api-token"))
+          .isInstanceOf(Resolved.class)
+          .extracting(r -> ((Resolved) r).value())
+          .isEqualTo("tok3n");
+      assertThat(result.get("does-not-exist")).isInstanceOf(Failed.class);
+    }
+  }
+
+  @Test
+  void shouldListSecretsUnderPrefixWithPrefixStripped() {
+    // given
+    try (final var store = oneByOneStore()) {
+      // when
+      final var refs = store.list();
+
+      // then — only camunda-* secrets, prefix stripped; other-* and cfg-* excluded
+      assertThat(refs).containsExactlyInAnyOrder("db-password", "api-token");
+    }
+  }
+
+  @Test
+  void shouldResolveMultipleKeysFromContainer() {
+    // given
+    try (final var store = containerStore("app-config")) {
+      // when
+      final var result = store.resolve(Set.of("DB_PASSWORD", "API_KEY"));
+
+      // then
+      assertThat(result.get("DB_PASSWORD"))
+          .isInstanceOf(Resolved.class)
+          .extracting(r -> ((Resolved) r).value())
+          .isEqualTo("c0nt41ner");
+      assertThat(result.get("API_KEY"))
+          .isInstanceOf(Resolved.class)
+          .extracting(r -> ((Resolved) r).value())
+          .isEqualTo("k3y");
+    }
+  }
+
+  @Test
+  void shouldReturnNotFoundForMissingKeyInContainer() {
+    // given
+    try (final var store = containerStore("app-config")) {
+      // when
+      final var result = store.resolve(Set.of("MISSING"));
+
+      // then
+      assertThat(((Failed) result.get("MISSING")).code()).isEqualTo(SecretErrorCode.NOT_FOUND);
+    }
+  }
+
+  @Test
+  void shouldReturnInvalidRefForNonStringKeyInContainer() {
+    // given
+    try (final var store = containerStore("app-config")) {
+      // when
+      final var result = store.resolve(Set.of("NUM"));
+
+      // then
+      assertThat(((Failed) result.get("NUM")).code()).isEqualTo(SecretErrorCode.INVALID_REF);
+    }
+  }
+
+  @Test
+  void shouldFailAllKeysWhenContainerIsNotValidJson() {
+    // given
+    try (final var store = containerStore("bad-json")) {
+      // when
+      final var result = store.resolve(Set.of("A", "B"));
+
+      // then
+      assertThat(((Failed) result.get("A")).code()).isEqualTo(SecretErrorCode.INVALID_REF);
+      assertThat(((Failed) result.get("B")).code()).isEqualTo(SecretErrorCode.INVALID_REF);
+    }
+  }
+
+  @Test
+  void shouldFailAllKeysWhenContainerIsNotJsonObject() {
+    // given — a valid JSON array is not usable as a key/value container
+    try (final var store = containerStore("arr")) {
+      // when
+      final var result = store.resolve(Set.of("A"));
+
+      // then
+      assertThat(((Failed) result.get("A")).code()).isEqualTo(SecretErrorCode.INVALID_REF);
+    }
+  }
+
+  @Test
+  void shouldListKeysFromContainer() {
+    // given
+    try (final var store = containerStore("app-config")) {
+      // when
+      final var refs = store.list();
+
+      // then
+      assertThat(refs).containsExactlyInAnyOrder("DB_PASSWORD", "API_KEY", "NUM");
+    }
+  }
+
+  @Test
+  void shouldThrowUnavailableWhenContainerListIsNotJsonObject() {
+    // given
+    try (final var store = containerStore("arr")) {
+      // when / then — the malformed-content message must surface, not a generic "unavailable" one
+      assertThatThrownBy(store::list)
+          .isInstanceOf(SecretStoreUnavailableException.class)
+          .hasMessageContaining("is not a JSON object");
+    }
+  }
+
+  @Test
+  void shouldNotFailFastButSurfaceErrorOnFirstUseWhenEndpointIsUnreachable() {
+    // given — the startup connectivity probe is best-effort (mirrors the AWS store): an unreachable
+    // endpoint is logged as a warning at build time rather than failing fast
+    final var config = new GcpSecretManagerStoreConfig(PROJECT, PREFIX, "localhost:1", null, true);
+
+    // when — the store is still built despite the dead endpoint
+    try (final var store = GcpSecretManagerSecretStore.fromConfig(config)) {
+      // then — the connectivity failure surfaces on the first real call instead
+      assertThatThrownBy(store::list).isInstanceOf(SecretStoreUnavailableException.class);
+    }
+  }
+
+  private static GcpSecretManagerSecretStore oneByOneStore() {
+    return GcpSecretManagerSecretStore.fromConfig(
+        new GcpSecretManagerStoreConfig(PROJECT, PREFIX, EMULATOR.grpcEndpoint(), null, true));
+  }
+
+  private static GcpSecretManagerSecretStore containerStore(final String containerSecretId) {
+    return GcpSecretManagerSecretStore.fromConfig(
+        new GcpSecretManagerStoreConfig(
+            PROJECT, CONTAINER_PREFIX, EMULATOR.grpcEndpoint(), containerSecretId, true));
+  }
+
+  private static void createSecret(final String secretId, final String value) {
+    adminClient.createSecret(
+        ProjectName.of(PROJECT),
+        secretId,
+        Secret.newBuilder()
+            .setReplication(
+                Replication.newBuilder()
+                    .setAutomatic(Replication.Automatic.newBuilder().build())
+                    .build())
+            .build());
+    adminClient.addSecretVersion(
+        SecretName.of(PROJECT, secretId),
+        SecretPayload.newBuilder().setData(ByteString.copyFromUtf8(value)).build());
+  }
+
+  private static SecretManagerServiceSettings emulatorSettings() throws java.io.IOException {
+    return SecretManagerServiceSettings.newBuilder()
+        .setCredentialsProvider(NoCredentialsProvider.create())
+        .setTransportChannelProvider(
+            SecretManagerServiceSettings.defaultGrpcTransportProviderBuilder()
+                .setEndpoint(EMULATOR.grpcEndpoint())
+                .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
+                .build())
+        .build();
+  }
+}

--- a/secret-store/secret-store-gcp/src/test/java/io/camunda/secretstore/gcp/GcpSecretManagerSecretStoreTest.java
+++ b/secret-store/secret-store-gcp/src/test/java/io/camunda/secretstore/gcp/GcpSecretManagerSecretStoreTest.java
@@ -1,0 +1,633 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.gcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.StatusCode.Code;
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
+import com.google.cloud.secretmanager.v1.ListSecretsRequest;
+import com.google.cloud.secretmanager.v1.ProjectName;
+import com.google.cloud.secretmanager.v1.Secret;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient.ListSecretsPagedResponse;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceSettings;
+import com.google.cloud.secretmanager.v1.SecretPayload;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
+import com.google.protobuf.ByteString;
+import io.camunda.secretstore.SecretErrorCode;
+import io.camunda.secretstore.SecretResolutionResult.Failed;
+import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import io.camunda.secretstore.SecretStoreUnavailableException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GcpSecretManagerSecretStoreTest {
+
+  private static final String PROJECT = "my-project";
+
+  @Mock private SecretManagerServiceClient client;
+
+  @Test
+  void shouldResolveKnownSecret() {
+    // given
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "camunda-");
+    when(client.accessSecretVersion(any(SecretVersionName.class))).thenReturn(response("s3cr3t"));
+
+    // when
+    final var result = store.resolve(Set.of("db-password"));
+
+    // then
+    assertThat(result.get("db-password"))
+        .isInstanceOf(Resolved.class)
+        .extracting(r -> ((Resolved) r).value())
+        .isEqualTo("s3cr3t");
+  }
+
+  @Test
+  void shouldPrependPathPrefixToSecretId() {
+    // given
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "camunda-");
+    when(client.accessSecretVersion(any(SecretVersionName.class))).thenReturn(response("v"));
+
+    // when
+    store.resolve(Set.of("token"));
+
+    // then
+    final var captor = ArgumentCaptor.forClass(SecretVersionName.class);
+    verify(client).accessSecretVersion(captor.capture());
+    assertThat(captor.getValue().getSecret()).isEqualTo("camunda-token");
+    assertThat(captor.getValue().getProject()).isEqualTo(PROJECT);
+  }
+
+  @Test
+  void shouldUseBareNameWhenPrefixIsNull() {
+    // given
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, null);
+    when(client.accessSecretVersion(any(SecretVersionName.class))).thenReturn(response("v"));
+
+    // when
+    store.resolve(Set.of("token"));
+
+    // then
+    final var captor = ArgumentCaptor.forClass(SecretVersionName.class);
+    verify(client).accessSecretVersion(captor.capture());
+    assertThat(captor.getValue().getSecret()).isEqualTo("token");
+  }
+
+  @Test
+  void shouldReturnNotFoundForMissingSecret() {
+    // given
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "");
+    when(client.accessSecretVersion(any(SecretVersionName.class)))
+        .thenThrow(apiException(Code.NOT_FOUND));
+
+    // when
+    final var result = store.resolve(Set.of("missing"));
+
+    // then
+    assertThat(((Failed) result.get("missing")).code()).isEqualTo(SecretErrorCode.NOT_FOUND);
+  }
+
+  @Test
+  void shouldReturnInvalidRefForInvalidArgument() {
+    // given
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "");
+    when(client.accessSecretVersion(any(SecretVersionName.class)))
+        .thenThrow(apiException(Code.INVALID_ARGUMENT));
+
+    // when
+    final var result = store.resolve(Set.of("bad"));
+
+    // then
+    assertThat(((Failed) result.get("bad")).code()).isEqualTo(SecretErrorCode.INVALID_REF);
+  }
+
+  @Test
+  void shouldReturnAccessDeniedForPermissionDenied() {
+    // given
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "");
+    when(client.accessSecretVersion(any(SecretVersionName.class)))
+        .thenThrow(apiException(Code.PERMISSION_DENIED));
+
+    // when
+    final var result = store.resolve(Set.of("secret"));
+
+    // then
+    assertThat(((Failed) result.get("secret")).code()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+  }
+
+  @Test
+  void shouldThrowUnavailableOnConnectivityError() {
+    // given
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "");
+    when(client.accessSecretVersion(any(SecretVersionName.class)))
+        .thenThrow(apiException(Code.UNAVAILABLE));
+
+    // when / then
+    assertThatThrownBy(() -> store.resolve(Set.of("any")))
+        .isInstanceOf(SecretStoreUnavailableException.class);
+  }
+
+  @Test
+  void shouldReturnResultForEveryRefInBatch() {
+    // given
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "");
+    when(client.accessSecretVersion(any(SecretVersionName.class)))
+        .thenAnswer(
+            invocation -> {
+              final SecretVersionName name = invocation.getArgument(0);
+              if (name.getSecret().equals("known")) {
+                return response("value");
+              }
+              throw apiException(Code.NOT_FOUND);
+            });
+
+    // when
+    final var result = store.resolve(Set.of("known", "missing"));
+
+    // then
+    assertThat(result).containsKeys("known", "missing");
+    assertThat(result.get("known")).isInstanceOf(Resolved.class);
+    assertThat(result.get("missing")).isInstanceOf(Failed.class);
+  }
+
+  @Test
+  void shouldReturnEmptyMapForEmptyRefs() {
+    // given
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "");
+
+    // when
+    final var result = store.resolve(Set.of());
+
+    // then
+    assertThat(result).isEmpty();
+    verifyNoInteractions(client);
+  }
+
+  @Test
+  void shouldListSecretsFilteredByPrefixAndStripIt() {
+    // given
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "camunda-");
+    mockListSecrets("camunda-db", "camunda-api", "other-ignored");
+
+    // when
+    final var refs = store.list();
+
+    // then — only prefixed secrets, with the prefix stripped
+    assertThat(refs).containsExactlyInAnyOrder("db", "api");
+  }
+
+  @Test
+  void shouldSkipSecretWhoseIdEqualsPrefixWhenListing() {
+    // given — a secret named exactly like the prefix yields an empty logical name
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "camunda-");
+    mockListSecrets("camunda-db", "camunda-");
+
+    // when
+    final var refs = store.list();
+
+    // then — the prefix-only secret is skipped, not returned as an empty ref
+    assertThat(refs).containsExactly("db");
+  }
+
+  @Test
+  void shouldThrowUnavailableWhenListFails() {
+    // given
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "");
+    when(client.listSecrets(any(ProjectName.class))).thenThrow(apiException(Code.UNAVAILABLE));
+
+    // when / then
+    assertThatThrownBy(store::list).isInstanceOf(SecretStoreUnavailableException.class);
+  }
+
+  @Test
+  void shouldNotLeakSecretValueInResolvedToString() {
+    // given
+    final var resolved = new Resolved("super-secret");
+
+    // when / then — value must be masked in toString
+    assertThat(resolved.toString()).doesNotContain("super-secret");
+  }
+
+  // ---- JSON container mode ----
+
+  @Test
+  void shouldResolveMultipleKeysFromOneContainerFetch() {
+    // given
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "camunda-", "app-config");
+    when(client.accessSecretVersion(any(SecretVersionName.class)))
+        .thenReturn(response("{\"DB_PASSWORD\":\"s3cr3t\",\"API_KEY\":\"k3y\"}"));
+
+    // when
+    final var result = store.resolve(Set.of("DB_PASSWORD", "API_KEY"));
+
+    // then — only one access call for both keys, at the prefixed container id
+    assertThat(result.get("DB_PASSWORD"))
+        .isInstanceOf(Resolved.class)
+        .extracting(r -> ((Resolved) r).value())
+        .isEqualTo("s3cr3t");
+    assertThat(result.get("API_KEY"))
+        .isInstanceOf(Resolved.class)
+        .extracting(r -> ((Resolved) r).value())
+        .isEqualTo("k3y");
+    final var captor = ArgumentCaptor.forClass(SecretVersionName.class);
+    verify(client, times(1)).accessSecretVersion(captor.capture());
+    assertThat(captor.getValue().getSecret()).isEqualTo("camunda-app-config");
+  }
+
+  @Test
+  void shouldReturnNotFoundForMissingKeyInContainer() {
+    // given
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "", "app-config");
+    when(client.accessSecretVersion(any(SecretVersionName.class)))
+        .thenReturn(response("{\"OTHER\":\"v\"}"));
+
+    // when
+    final var result = store.resolve(Set.of("MISSING"));
+
+    // then
+    assertThat(((Failed) result.get("MISSING")).code()).isEqualTo(SecretErrorCode.NOT_FOUND);
+  }
+
+  @Test
+  void shouldReturnNotFoundForNullValuedKeyInContainer() {
+    // given — a key present in the container but with a JSON null value
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "", "app-config");
+    when(client.accessSecretVersion(any(SecretVersionName.class)))
+        .thenReturn(response("{\"NULLED\":null}"));
+
+    // when
+    final var result = store.resolve(Set.of("NULLED"));
+
+    // then — a null value is treated as no value, not as a resolvable secret
+    assertThat(((Failed) result.get("NULLED")).code()).isEqualTo(SecretErrorCode.NOT_FOUND);
+  }
+
+  @Test
+  void shouldReturnInvalidRefForNonStringKeyInContainer() {
+    // given
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "", "app-config");
+    when(client.accessSecretVersion(any(SecretVersionName.class)))
+        .thenReturn(response("{\"NUM\":42}"));
+
+    // when
+    final var result = store.resolve(Set.of("NUM"));
+
+    // then
+    assertThat(((Failed) result.get("NUM")).code()).isEqualTo(SecretErrorCode.INVALID_REF);
+  }
+
+  @Test
+  void shouldReturnInvalidRefForAllKeysWhenContainerIsNotValidJson() {
+    // given
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "", "app-config");
+    when(client.accessSecretVersion(any(SecretVersionName.class))).thenReturn(response("not json"));
+
+    // when
+    final var result = store.resolve(Set.of("A", "B"));
+
+    // then — the shared parse failure applies to every requested key
+    assertThat(((Failed) result.get("A")).code()).isEqualTo(SecretErrorCode.INVALID_REF);
+    assertThat(((Failed) result.get("B")).code()).isEqualTo(SecretErrorCode.INVALID_REF);
+  }
+
+  @Test
+  void shouldReturnInvalidRefForAllKeysWhenContainerIsNotJsonObject() {
+    // given — valid JSON, but an array rather than an object
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "", "app-config");
+    when(client.accessSecretVersion(any(SecretVersionName.class)))
+        .thenReturn(response("[\"a\",\"b\"]"));
+
+    // when
+    final var result = store.resolve(Set.of("A"));
+
+    // then
+    assertThat(((Failed) result.get("A")).code()).isEqualTo(SecretErrorCode.INVALID_REF);
+  }
+
+  @Test
+  void shouldListKeysFromContainer() {
+    // given
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "", "app-config");
+    when(client.accessSecretVersion(any(SecretVersionName.class)))
+        .thenReturn(response("{\"DB_PASSWORD\":\"s3cr3t\",\"API_KEY\":\"k3y\"}"));
+
+    // when
+    final var refs = store.list();
+
+    // then
+    assertThat(refs).containsExactlyInAnyOrder("DB_PASSWORD", "API_KEY");
+  }
+
+  @Test
+  void shouldListNullValuedKeyFromContainer() {
+    // given — list reports every top-level field name, including one whose value is JSON null
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "", "app-config");
+    when(client.accessSecretVersion(any(SecretVersionName.class)))
+        .thenReturn(response("{\"API_KEY\":\"k3y\",\"NULLED\":null}"));
+
+    // when
+    final var refs = store.list();
+
+    // then — the null-valued key is listed even though resolve() would report it NOT_FOUND
+    assertThat(refs).containsExactlyInAnyOrder("API_KEY", "NULLED");
+  }
+
+  @Test
+  void shouldThrowUnavailableWhenContainerListIsNotJsonObject() {
+    // given — valid JSON, but not an object: list() cannot enumerate keys
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "", "app-config");
+    when(client.accessSecretVersion(any(SecretVersionName.class))).thenReturn(response("[\"a\"]"));
+
+    // when / then — the malformed-content message must surface, not a generic "unavailable" one
+    assertThatThrownBy(store::list)
+        .isInstanceOf(SecretStoreUnavailableException.class)
+        .hasMessageContaining("is not a JSON object");
+  }
+
+  @Test
+  void shouldNotCallListSecretsWhenContainerModeEnabled() {
+    // given — container mode must never fall back to the flat listSecrets scan
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "", "app-config");
+    when(client.accessSecretVersion(any(SecretVersionName.class))).thenReturn(response("{}"));
+
+    // when
+    store.list();
+
+    // then
+    verify(client, times(0)).listSecrets(any(ProjectName.class));
+  }
+
+  @Test
+  void shouldUseOneByOneModeWhenContainerSecretIdIsBlank() {
+    // given — a blank container id must not enable container mode
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "", " ");
+    when(client.accessSecretVersion(any(SecretVersionName.class))).thenReturn(response("v"));
+
+    // when
+    store.resolve(Set.of("token"));
+
+    // then — resolves the reference as its own secret, not a container key
+    final var captor = ArgumentCaptor.forClass(SecretVersionName.class);
+    verify(client).accessSecretVersion(captor.capture());
+    assertThat(captor.getValue().getSecret()).isEqualTo("token");
+  }
+
+  @Test
+  void shouldFailAllKeysWithClassifiedCodeWhenContainerFetchThrowsApiException() {
+    // given — container mode; the access call itself fails with an API error
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "", "app-config");
+    when(client.accessSecretVersion(any(SecretVersionName.class)))
+        .thenThrow(apiException(Code.PERMISSION_DENIED));
+
+    // when
+    final var result = store.resolve(Set.of("A", "B"));
+
+    // then — every requested key fails with the classified code
+    assertThat(((Failed) result.get("A")).code()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+    assertThat(((Failed) result.get("B")).code()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+  }
+
+  @Test
+  void shouldThrowUnavailableWhenContainerResolveFetchThrowsRuntimeException() {
+    // given — container mode; a non-API runtime failure during resolve is store-wide
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "", "app-config");
+    when(client.accessSecretVersion(any(SecretVersionName.class)))
+        .thenThrow(new RuntimeException("boom"));
+
+    // when / then
+    assertThatThrownBy(() -> store.resolve(Set.of("A")))
+        .isInstanceOf(SecretStoreUnavailableException.class);
+  }
+
+  @Test
+  void shouldThrowUnavailableWhenContainerListIsNotValidJson() {
+    // given — container mode; list() over a syntactically invalid container
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "", "app-config");
+    when(client.accessSecretVersion(any(SecretVersionName.class))).thenReturn(response("not json"));
+
+    // when / then
+    assertThatThrownBy(store::list).isInstanceOf(SecretStoreUnavailableException.class);
+  }
+
+  @Test
+  void shouldThrowUnavailableWhenContainerListFetchThrowsRuntimeException() {
+    // given — container mode; a non-API runtime failure during list is store-wide
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "", "app-config");
+    when(client.accessSecretVersion(any(SecretVersionName.class)))
+        .thenThrow(new RuntimeException("boom"));
+
+    // when / then
+    assertThatThrownBy(store::list).isInstanceOf(SecretStoreUnavailableException.class);
+  }
+
+  // ---- optional project id ----
+
+  @Test
+  void shouldConstructStoreWithNullProjectId() {
+    // given / when — a null project id is allowed; it is resolved from the environment at build
+    // time and only matters once a real GCP call is made
+    final var store = new GcpSecretManagerSecretStore(client, null, "camunda-");
+
+    // then — construction succeeds without touching GCP
+    assertThat(store).isNotNull();
+    verifyNoInteractions(client);
+  }
+
+  @Test
+  void shouldResolveProjectIdFromEnvironmentWhenConfigOmitsIt() {
+    try (var serviceOptions = mockStatic(ServiceOptions.class);
+        var clientFactory = mockStatic(SecretManagerServiceClient.class)) {
+      // given — the config omits the project id, so it must fall back to the environment
+      serviceOptions.when(ServiceOptions::getDefaultProjectId).thenReturn("env-project");
+      clientFactory
+          .when(() -> SecretManagerServiceClient.create(any(SecretManagerServiceSettings.class)))
+          .thenReturn(client);
+      final var config = new GcpSecretManagerStoreConfig(null, "camunda-", null, null);
+
+      // when
+      final var store = GcpSecretManagerSecretStore.fromConfig(config);
+
+      // then — the startup probe (one-by-one mode) targets the env-resolved project
+      assertThat(store).isNotNull();
+      final var captor = ArgumentCaptor.forClass(ListSecretsRequest.class);
+      verify(client).listSecrets(captor.capture());
+      assertThat(captor.getValue().getParent()).isEqualTo(ProjectName.of("env-project").toString());
+    }
+  }
+
+  @Test
+  void shouldFailFastWhenProjectIdIsNeitherConfiguredNorResolvableFromEnvironment() {
+    try (var serviceOptions = mockStatic(ServiceOptions.class);
+        var clientFactory = mockStatic(SecretManagerServiceClient.class)) {
+      // given — the config omits the project id and the environment provides none either
+      serviceOptions.when(ServiceOptions::getDefaultProjectId).thenReturn(null);
+      final var config = new GcpSecretManagerStoreConfig(null, "camunda-", null, null);
+
+      // when / then — a missing project id is a clear configuration error, not a deferred NPE, and
+      // no client is opened
+      assertThatThrownBy(() -> GcpSecretManagerSecretStore.fromConfig(config))
+          .isInstanceOf(SecretStoreUnavailableException.class)
+          .hasMessageContaining("projectId");
+      clientFactory.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void shouldFailFastWhenClientCannotBeCreated() {
+    try (var clientFactory = mockStatic(SecretManagerServiceClient.class)) {
+      // given — building the client fails because the Application Default Credentials chain cannot
+      // produce credentials
+      clientFactory
+          .when(() -> SecretManagerServiceClient.create(any(SecretManagerServiceSettings.class)))
+          .thenThrow(
+              new IOException("no credentials in the Application Default Credentials chain"));
+      final var config = new GcpSecretManagerStoreConfig(PROJECT, "camunda-", null, null);
+
+      // when / then — a client that cannot even be constructed can never resolve a secret, so this
+      // fails fast at startup rather than deferring to first use
+      assertThatThrownBy(() -> GcpSecretManagerSecretStore.fromConfig(config))
+          .isInstanceOf(SecretStoreUnavailableException.class)
+          .hasMessageContaining("Failed to initialize GCP Secret Manager client")
+          .hasCauseInstanceOf(IOException.class);
+    }
+  }
+
+  @Test
+  void shouldApplyEndpointOverrideWhenAuthenticationEnabled() {
+    try (var clientFactory = mockStatic(SecretManagerServiceClient.class)) {
+      // given — an authenticated (production) config with an explicit endpoint override, e.g. a
+      // regional or Private Service Connect endpoint
+      final var settingsCaptor = ArgumentCaptor.forClass(SecretManagerServiceSettings.class);
+      clientFactory
+          .when(() -> SecretManagerServiceClient.create(settingsCaptor.capture()))
+          .thenReturn(client);
+      final var endpoint = "secretmanager.europe-west1.rep.googleapis.com:443";
+      final var config = new GcpSecretManagerStoreConfig(PROJECT, "camunda-", endpoint, null);
+
+      // when
+      final var store = GcpSecretManagerSecretStore.fromConfig(config);
+
+      // then — the override is applied to the client settings without disabling authentication
+      assertThat(store).isNotNull();
+      assertThat(settingsCaptor.getValue().getEndpoint()).isEqualTo(endpoint);
+    }
+  }
+
+  // ---- startup connectivity probe: warns and continues (keeps the client) when the probe fails --
+
+  @Test
+  void shouldReturnAfterSuccessfulProbeWithoutClosingClient() {
+    // given
+    final var resolver = mock(GcpSecretResolver.class);
+
+    // when
+    GcpSecretManagerSecretStore.validateConnectivity(resolver);
+
+    // then — the probe ran and the client stays open for the store to use
+    verify(resolver).validateConnectivity();
+  }
+
+  @Test
+  void shouldWarnAndContinueWithoutClosingClientWhenProbeFails() {
+    // given
+    final var resolver = mock(GcpSecretResolver.class);
+    doThrow(apiException(Code.UNAVAILABLE)).when(resolver).validateConnectivity();
+
+    // when — a failing startup probe must not fail fast
+    GcpSecretManagerSecretStore.validateConnectivity(resolver);
+
+    // then — the client is kept open so the error surfaces on first real use instead
+    verify(resolver).validateConnectivity();
+  }
+
+  @Test
+  void shouldProbeConnectivityViaListSecretsInOneByOneMode() {
+    // given — one-by-one mode lists via listSecrets, so the probe must exercise that exact API
+    final var resolver = new OneByOneSecretResolver(client, PROJECT, "camunda-");
+
+    // when
+    resolver.validateConnectivity();
+
+    // then — a minimal single-result list on the configured project
+    final var captor = ArgumentCaptor.forClass(ListSecretsRequest.class);
+    verify(client).listSecrets(captor.capture());
+    assertThat(captor.getValue().getParent()).isEqualTo(ProjectName.of(PROJECT).toString());
+    assertThat(captor.getValue().getPageSize()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldProbeConnectivityViaAccessSecretVersionInContainerMode() {
+    // given — container mode reads exactly one secret, so the probe must access that container
+    final var resolver = new ContainerSecretResolver(client, PROJECT, "", "app-config");
+    when(client.accessSecretVersion(any(SecretVersionName.class))).thenReturn(response("{}"));
+
+    // when
+    resolver.validateConnectivity();
+
+    // then — accessSecretVersion targets the container secret
+    final var captor = ArgumentCaptor.forClass(SecretVersionName.class);
+    verify(client).accessSecretVersion(captor.capture());
+    assertThat(captor.getValue().getSecret()).isEqualTo("app-config");
+  }
+
+  private void mockListSecrets(final String... secretIds) {
+    final var paged = mock(ListSecretsPagedResponse.class);
+    final var secrets =
+        Arrays.stream(secretIds)
+            .map(
+                id -> Secret.newBuilder().setName("projects/" + PROJECT + "/secrets/" + id).build())
+            .toList();
+    when(paged.iterateAll()).thenReturn(secrets);
+    when(client.listSecrets(any(ProjectName.class))).thenReturn(paged);
+  }
+
+  private static AccessSecretVersionResponse response(final String value) {
+    return AccessSecretVersionResponse.newBuilder()
+        .setPayload(SecretPayload.newBuilder().setData(ByteString.copyFromUtf8(value)).build())
+        .build();
+  }
+
+  private static ApiException apiException(final Code code) {
+    return new ApiException(new RuntimeException("boom"), statusCode(code), false);
+  }
+
+  private static StatusCode statusCode(final Code code) {
+    return new StatusCode() {
+      @Override
+      public Code getCode() {
+        return code;
+      }
+
+      @Override
+      public Object getTransportCode() {
+        return null;
+      }
+    };
+  }
+}

--- a/secret-store/secret-store-gcp/src/test/java/io/camunda/secretstore/gcp/GcpSecretManagerStoreConfigTest.java
+++ b/secret-store/secret-store-gcp/src/test/java/io/camunda/secretstore/gcp/GcpSecretManagerStoreConfigTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.gcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class GcpSecretManagerStoreConfigTest {
+
+  @Test
+  void shouldAllowNullProjectId() {
+    // given / when — a null project id defers resolution to the environment at client build time
+    final var config = new GcpSecretManagerStoreConfig(null, null, null, null);
+
+    // then
+    assertThat(config.projectId()).isNull();
+  }
+
+  @Test
+  void shouldRejectBlankProjectId() {
+    // when / then
+    assertThatThrownBy(() -> new GcpSecretManagerStoreConfig(" ", null, null, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("projectId");
+  }
+
+  @Test
+  void shouldRejectBlankContainerSecretId() {
+    // when / then
+    assertThatThrownBy(() -> new GcpSecretManagerStoreConfig("my-project", null, null, " "))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("containerSecretId");
+  }
+
+  @Test
+  void shouldDefaultOptionalFieldsInFactory() {
+    // when
+    final var config = GcpSecretManagerStoreConfig.of("my-project", "camunda-");
+
+    // then
+    assertThat(config.projectId()).isEqualTo("my-project");
+    assertThat(config.pathPrefix()).isEqualTo("camunda-");
+    assertThat(config.endpoint()).isNull();
+    assertThat(config.containerSecretId()).isNull();
+    assertThat(config.withoutAuthentication()).isFalse();
+  }
+
+  @Test
+  void shouldRejectDisabledAuthenticationWithoutEndpoint() {
+    // when / then — no-auth mode is emulator-only and meaningless without a local endpoint
+    assertThatThrownBy(() -> new GcpSecretManagerStoreConfig("my-project", null, null, null, true))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("endpoint");
+  }
+
+  @Test
+  void shouldRejectDisabledAuthenticationWithBlankEndpoint() {
+    // when / then
+    assertThatThrownBy(() -> new GcpSecretManagerStoreConfig("my-project", null, " ", null, true))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("endpoint");
+  }
+
+  @Test
+  void shouldAllowDisabledAuthenticationWithEndpoint() {
+    // when
+    final var config =
+        new GcpSecretManagerStoreConfig("my-project", null, "localhost:9090", null, true);
+
+    // then
+    assertThat(config.withoutAuthentication()).isTrue();
+    assertThat(config.endpoint()).isEqualTo("localhost:9090");
+  }
+}

--- a/secret-store/secret-store-gcp/src/test/java/io/camunda/secretstore/gcp/util/SecretManagerEmulatorContainer.java
+++ b/secret-store/secret-store-gcp/src/test/java/io/camunda/secretstore/gcp/util/SecretManagerEmulatorContainer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.gcp.util;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Testcontainers wrapper around a community GCP Secret Manager emulator, mirroring the approach the
+ * GCS backup store takes with {@code fsouza/fake-gcs-server}. GCP ships no official Secret Manager
+ * emulator, so this uses the {@code blackwell-systems} image, which implements the full Secret
+ * Manager gRPC API without requiring credentials.
+ *
+ * <p>The image is a third-party community image, so it is pinned by immutable {@code @sha256}
+ * digest rather than a floating tag: the digest is tamper-evident and guarantees a reproducible CI
+ * pull even if the {@code 1.9} tag is later moved or deleted upstream. When bumping the emulator
+ * version, update the digest and the {@code 1.9} reference in the comment below together.
+ */
+public final class SecretManagerEmulatorContainer
+    extends GenericContainer<SecretManagerEmulatorContainer> {
+
+  // ghcr.io/blackwell-systems/gcp-secret-manager-emulator-dual:1.9 (multi-arch index digest)
+  private static final DockerImageName IMAGE =
+      DockerImageName.parse(
+          "ghcr.io/blackwell-systems/gcp-secret-manager-emulator-dual"
+              + "@sha256:2c9d3bb0453fdff102b29af00b4abd9b2c6fa466031a9d8e6d93a270ba22a6e2");
+  private static final int GRPC_PORT = 9090;
+
+  public SecretManagerEmulatorContainer() {
+    super(IMAGE);
+    withExposedPorts(GRPC_PORT)
+        .waitingFor(Wait.forLogMessage(".*Ready to accept both gRPC and REST requests.*", 1));
+  }
+
+  /** The {@code host:port} endpoint of the emulator's plaintext gRPC server. */
+  public String grpcEndpoint() {
+    return "%s:%d".formatted(getHost(), getMappedPort(GRPC_PORT));
+  }
+}


### PR DESCRIPTION
## Description

Implements the GCP Secret Manager backend for the per-tenant secret store, building on the configuration surface introduced in the base PR (#56578). This adds a new `camunda-secret-store-gcp` module and wires it into the `SecretStoreConfiguration` so a physical tenant configured with a `gcp` store resolves secrets from GCP Secret Manager at runtime.

### What's included

- **New module `secret-store/secret-store-gcp`** with `GcpSecretManagerSecretStore`, a `SecretStore` implementation backed by GCP Secret Manager:
  - **Identity-based auth only** — uses the GCP Application Default Credentials chain (workload identity, `GOOGLE_APPLICATION_CREDENTIALS`, metadata server). No static credentials are accepted by design.
  - **Optional `projectId`** — when omitted, the project is resolved from the environment via `ServiceOptions.getDefaultProjectId()` (`GOOGLE_CLOUD_PROJECT`, `gcloud` config, or the compute metadata server), mirroring how the AWS store treats an unset `region`. A configured `projectId` must be non-blank.
  - **Best-effort startup probe** — `fromConfig(...)` eagerly builds the client and probes connectivity/credentials with a minimal GCP call. The probe is delegated to the active resolver so it uses the exact API — and thus the minimal IAM policy — that mode resolves with (`listSecrets` for one-by-one, `accessSecretVersion` on the container for container mode). On failure it logs a warning and still builds the store, so a transient GCP problem during boot cannot stop the application from starting; the misconfiguration then surfaces on the first `resolve`/`list`. Client-initialization failures still fail fast.
  - **Two resolution modes** behind a `GcpSecretResolver`, chosen once at construction: `OneByOneSecretResolver` (one GCP secret per reference, the default) and `ContainerSecretResolver` (every reference is a JSON key inside a single shared container secret when `containerSecretId` is set).
  - **Reference mapping** — references are prefixed with the configured `pathPrefix` and read from the `latest` version within the resolved project.
  - **Error semantics** — per-secret problems (missing secret, access denied, invalid reference) return `Failed` results; store-wide problems (connectivity, throttling after retries, service errors) surface as `SecretStoreUnavailableException` so callers can retry/back off.
  - **Emulator support** — an opt-in no-authentication plaintext mode connects the client to a local endpoint with no credentials, so integration tests can point it at a Secret Manager emulator (never enabled against real GCP).
  - Thread-safe; `close()` releases the underlying client.

- **Wiring** — `SecretStoreConfiguration` in `dist` now registers the GCP store per physical tenant. The registration was refactored to a type-agnostic `StoreBinding` list (file / AWS / GCP), so adding a future backend means adding one binding plus its factory rather than editing the registration loop.

- **Tests** — unit tests cover both resolution modes, error classification, config validation, optional-`projectId` env resolution, and the best-effort per-mode probe; an end-to-end integration test exercises the store against a Secret Manager emulator running in a Testcontainer.

## Checklist

- [ ] Enable backports when necessary.

## Related issues

closes #56579
