### PR TITLE
test: add e2e coverage for SECRET authorizations in Identity

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -21,6 +21,7 @@ export class IdentityAuthorizationsPage {
   readonly createAuthorizationOwnerOption: (name: string) => Locator;
   readonly createAuthorizationResourceIdField: Locator;
   readonly createAuthorizationAccessPermission: (name: string) => Locator;
+  readonly accessPermissionCheckbox: (name: string) => Locator;
   readonly createAuthorizationOwnerTypeComboBox: Locator;
   readonly createAuthorizationOwnerTypeOption: (name: string) => Locator;
   readonly createAuthorizationSubmitButton: Locator;
@@ -65,6 +66,10 @@ export class IdentityAuthorizationsPage {
       });
     this.createAuthorizationAccessPermission = (name) =>
       this.page.locator(`label[for="${name.toUpperCase()}"]`);
+    // The clickable label and the underlying input are separate nodes; use this
+    // one to assert checked state, and the label above to toggle it.
+    this.accessPermissionCheckbox = (name) =>
+      this.page.locator(`input#${name.toUpperCase()}`);
     this.createAuthorizationOwnerTypeComboBox =
       this.createAuthorizationModal.getByRole('combobox', {name: 'Owner type'});
     this.createAuthorizationOwnerTypeOption = (name) =>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
@@ -332,6 +332,7 @@ test.describe('create authorization modal — resource type field', () => {
 
 test.describe('secret authorizations', () => {
   const createdSecretUserIds: string[] = [];
+  const createdSecretRoleIds: string[] = [];
 
   test.beforeEach(async ({page, loginPage, identityAuthorizationsPage}) => {
     await identityAuthorizationsPage.navigateToAuthorizations();
@@ -344,6 +345,7 @@ test.describe('secret authorizations', () => {
 
   test.afterAll(async ({request}) => {
     await cleanupUsers(request, createdSecretUserIds);
+    await cleanupRoles(request, createdSecretRoleIds);
   });
 
   test.afterEach(async ({page}, testInfo) => {
@@ -352,7 +354,6 @@ test.describe('secret authorizations', () => {
   });
 
   test('renders READ and REVEAL as independent checkboxes on the SECRET tab', async ({
-    page,
     identityAuthorizationsPage,
   }) => {
     await identityAuthorizationsPage.selectResourceTypeTab('Secret');
@@ -361,8 +362,10 @@ test.describe('secret authorizations', () => {
       identityAuthorizationsPage.createAuthorizationModal,
     ).toBeVisible();
 
-    const readCheckbox = page.locator('input#READ');
-    const revealCheckbox = page.locator('input#REVEAL');
+    const readCheckbox =
+      identityAuthorizationsPage.accessPermissionCheckbox('read');
+    const revealCheckbox =
+      identityAuthorizationsPage.accessPermissionCheckbox('reveal');
 
     await expect(readCheckbox).not.toBeChecked();
     await expect(revealCheckbox).not.toBeChecked();
@@ -427,6 +430,51 @@ test.describe('secret authorizations', () => {
       const authorizationRow =
         identityAuthorizationsPage.authorizationRowByOwnerId(testUser.username);
       await expect(authorizationRow).not.toContainText('READ');
+    });
+  });
+
+  test('grants SECRET READ and REVEAL to a role for a single secret reference', async ({
+    page,
+    identityHeader,
+    identityRolesPage,
+    identityAuthorizationsPage,
+  }) => {
+    const testData = createTestData({authRole: true});
+    const testRole = testData.authRole!;
+    const secretReference = `secret-${testData.id}`;
+    createdSecretRoleIds.push(testRole.id);
+
+    await test.step('Create a new test role', async () => {
+      await identityHeader.navigateToRoles();
+      await expect(page).toHaveURL(relativizePath(Paths.roles()));
+      await identityRolesPage.createRole(testRole);
+
+      await identityAuthorizationsPage.navigateToAuthorizations();
+      await expect(page).toHaveURL(/admin\/authorizations/);
+    });
+
+    await test.step('Grant SECRET READ and REVEAL for a concrete resource id', async () => {
+      await identityAuthorizationsPage.createAuthorization(
+        createSecretAuthorization(
+          testRole,
+          ['read', 'reveal'],
+          'Role',
+          secretReference,
+        ),
+      );
+    });
+
+    await test.step('Assert the grant lists both permissions for that reference', async () => {
+      await identityAuthorizationsPage.assertAuthorizationExists(
+        testRole.id,
+        'Role',
+        ['read', 'reveal'],
+        'Secret',
+      );
+
+      await expect(
+        identityAuthorizationsPage.authorizationRowByOwnerId(testRole.id),
+      ).toContainText(secretReference);
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
@@ -12,6 +12,7 @@ import {
   LOGIN_CREDENTIALS,
   createTestData,
   createComponentAuthorization,
+  createSecretAuthorization,
   createUserAuthorization,
 } from 'utils/constants';
 import {waitForItemInList} from 'utils/waitForItemInList';
@@ -326,5 +327,106 @@ test.describe('create authorization modal — resource type field', () => {
     await expect(
       identityAuthorizationsPage.resourceTypeComboBox,
     ).toBeDisabled();
+  });
+});
+
+test.describe('secret authorizations', () => {
+  const createdSecretUserIds: string[] = [];
+
+  test.beforeEach(async ({page, loginPage, identityAuthorizationsPage}) => {
+    await identityAuthorizationsPage.navigateToAuthorizations();
+    await loginPage.login(
+      LOGIN_CREDENTIALS.username,
+      LOGIN_CREDENTIALS.password,
+    );
+    await expect(page).toHaveURL(/admin\/authorizations/);
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupUsers(request, createdSecretUserIds);
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('renders READ and REVEAL as independent checkboxes on the SECRET tab', async ({
+    page,
+    identityAuthorizationsPage,
+  }) => {
+    await identityAuthorizationsPage.selectResourceTypeTab('Secret');
+    await identityAuthorizationsPage.createAuthorizationButton.click();
+    await expect(
+      identityAuthorizationsPage.createAuthorizationModal,
+    ).toBeVisible();
+
+    const readCheckbox = page.locator('input#READ');
+    const revealCheckbox = page.locator('input#REVEAL');
+
+    await expect(readCheckbox).not.toBeChecked();
+    await expect(revealCheckbox).not.toBeChecked();
+
+    // Selecting REVEAL must not cascade to READ.
+    await identityAuthorizationsPage
+      .createAuthorizationAccessPermission('reveal')
+      .click();
+
+    await expect(revealCheckbox).toBeChecked();
+    await expect(readCheckbox).not.toBeChecked();
+
+    // Reset REVEAL, then verify the opposite direction: selecting READ must
+    // not cascade to REVEAL.
+    await identityAuthorizationsPage
+      .createAuthorizationAccessPermission('reveal')
+      .click();
+    await expect(revealCheckbox).not.toBeChecked();
+
+    await identityAuthorizationsPage
+      .createAuthorizationAccessPermission('read')
+      .click();
+
+    await expect(readCheckbox).toBeChecked();
+    await expect(revealCheckbox).not.toBeChecked();
+  });
+
+  test('grants SECRET REVEAL-only with a wildcard resource id', async ({
+    page,
+    identityUsersPage,
+    identityAuthorizationsPage,
+  }) => {
+    const testData = createTestData({user: true});
+    const testUser = testData.user!;
+    createdSecretUserIds.push(testUser.username);
+
+    await test.step('Create a new test user', async () => {
+      await identityUsersPage.navigateToUsers();
+      await identityUsersPage.createUser(testUser);
+
+      await identityAuthorizationsPage.navigateToAuthorizations();
+      await expect(page).toHaveURL(/admin\/authorizations/);
+    });
+
+    await test.step('Grant SECRET REVEAL-only with wildcard resource id', async () => {
+      const secretAuth = createSecretAuthorization(
+        {name: testUser.username},
+        ['reveal'],
+        'User',
+      );
+      await identityAuthorizationsPage.createAuthorization(secretAuth);
+    });
+
+    await test.step('Assert the grant lists REVEAL and not READ', async () => {
+      await identityAuthorizationsPage.assertAuthorizationExists(
+        testUser.username,
+        'User',
+        ['reveal'],
+        'Secret',
+      );
+
+      const authorizationRow =
+        identityAuthorizationsPage.authorizationRowByOwnerId(testUser.username);
+      await expect(authorizationRow).not.toContainText('READ');
+    });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
@@ -138,6 +138,18 @@ export const createComponentAuthorization = (
   accessPermissions: ['access'],
 });
 
+export const createSecretAuthorization = (
+  owner: {name: string},
+  accessPermissions: string[] = ['read'],
+  ownerType: 'Role' | 'User' | 'Group' = 'Role',
+) => ({
+  ownerType,
+  ownerId: owner.name,
+  resourceType: 'Secret',
+  resourceId: '*',
+  accessPermissions,
+});
+
 // Generic function to create specific test data with shared ID
 export const createTestData = (options: {
   user?: boolean;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
@@ -140,13 +140,14 @@ export const createComponentAuthorization = (
 
 export const createSecretAuthorization = (
   owner: {name: string},
-  accessPermissions: string[] = ['read'],
+  accessPermissions: ('read' | 'reveal')[] = ['read'],
   ownerType: 'Role' | 'User' | 'Group' = 'Role',
+  resourceId = '*',
 ) => ({
   ownerType,
   ownerId: owner.name,
   resourceType: 'Secret',
-  resourceId: '*',
+  resourceId,
   accessPermissions,
 });
 


### PR DESCRIPTION
related to #56570

## Description

Adds Playwright e2e coverage for SECRET grants (independent READ/REVEAL checkboxes, REVEAL-only wildcard grant),  [prerequisite bump PR](https://github.com/camunda/camunda/pull/58828) is already merged to main.


## E2E Test Suite Run
https://github.com/camunda/camunda/actions/runs/30391975868/job/90385950947
pre existing failure see notes [here](https://github.com/camunda/camunda/pull/58843#issuecomment-5113408176)

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56570
