### PR TITLE
feat: make Optimize SPA routing and external sharing CSL-aware

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
@@ -85,7 +85,8 @@ public class OptimizeTomcatConfig {
    * {@link #ALLOWED_URL_EXTENSION}. CSL serves login initiation from {@code
    * /oauth2/authorization/{registrationId}} and logout from {@code /logout}; neither exists in the
    * legacy stack, so both would otherwise be rewritten to the SPA home instead of reaching the
-   * security chain (ADR-0038).
+   * security chain. See <a
+   * href="https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md">ADR-0038</a>.
    *
    * <p>The CSL OIDC callback needs no entry of its own: it is {@code /api/authentication/callback}
    * on CCSM and {@code /sso-callback} on CCSaaS, both already covered above.

--- a/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
@@ -80,6 +80,19 @@ public class OptimizeTomcatConfig {
             "/index.html"
           });
 
+  /**
+   * Extra allowed suffixes for CSL mode ({@code optimize.security.csl.enabled=true}), appended to
+   * {@link #ALLOWED_URL_EXTENSION}. CSL serves login initiation from {@code
+   * /oauth2/authorization/{registrationId}} and logout from {@code /logout}; neither exists in the
+   * legacy stack, so both would otherwise be rewritten to the SPA home instead of reaching the
+   * security chain (ADR-0038).
+   *
+   * <p>The CSL OIDC callback needs no entry of its own: it is {@code /api/authentication/callback}
+   * on CCSM and {@code /sso-callback} on CCSaaS, both already covered above.
+   */
+  private static final String CSL_ALLOWED_URL_EXTENSION =
+      String.join("|", new String[] {"/oauth2", "/logout"});
+
   private static final String HTTP11_NIO_PROTOCOL = "org.apache.coyote.http11.Http11Nio2Protocol";
 
   @Autowired private ConfigurationService configurationService;
@@ -125,17 +138,32 @@ public class OptimizeTomcatConfig {
     LOG.debug("Registering filter 'urlRedirector'...");
 
     final String contextPath = getContextPath().orElse("");
-
-    // This regex includes all the URL suffixes that we allow.
-    // The list of suffixes is stored in ALLOWED_URL_EXTENSION, and the regex does not
-    // handle the home page URL: that is handled explicitly from within the URLRedirectFilter.
-    final String regex = "^(?!" + "(" + contextPath + ALLOWED_URL_EXTENSION + ")).+";
+    final String regex = buildRedirectExclusionRegex(contextPath, isCslEnabled());
 
     final URLRedirectFilter filter = new URLRedirectFilter(regex, contextPath + URL_BASE);
     final FilterRegistrationBean<URLRedirectFilter> registration = new FilterRegistrationBean<>();
     registration.addUrlPatterns("/*");
     registration.setFilter(filter);
     return registration;
+  }
+
+  /**
+   * Builds the regex matching every request URI the SPA-routing filter should rewrite to {@code
+   * /#}, that is everything which is not one of the allowed suffixes. The home page URL is not
+   * covered here; {@link URLRedirectFilter} handles it explicitly.
+   *
+   * @param cslEnabled when {@code true}, the CSL auth endpoints are allowed through as well
+   */
+  static String buildRedirectExclusionRegex(final String contextPath, final boolean cslEnabled) {
+    final String allowed =
+        cslEnabled
+            ? ALLOWED_URL_EXTENSION + "|" + CSL_ALLOWED_URL_EXTENSION
+            : ALLOWED_URL_EXTENSION;
+    return "^(?!" + "(" + contextPath + allowed + ")).+";
+  }
+
+  private boolean isCslEnabled() {
+    return environment.getProperty("optimize.security.csl.enabled", Boolean.class, false);
   }
 
   @Bean

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCamundaSecurityConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCamundaSecurityConfig.java
@@ -73,7 +73,8 @@ public class OptimizeCamundaSecurityConfig {
    * <p>{@link CCSMRequestAdjustmentFilter} serves both editions here despite its name: all it does
    * is strip the servlet context path, rewrite {@code /external/api/**} to {@code /api/external/**}
    * and serve the static share resources. The CCSaaS-only cluster-id stripping its SaaS counterpart
-   * adds is not needed, because in CSL mode the cluster id is the servlet context path (ADR-0038).
+   * adds is not needed, because in CSL mode the cluster id is the servlet context path (see <a
+   * href="https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md">ADR-0038</a>).
    *
    * <p>Registered at highest precedence so the rewrite lands before the Spring Security filter
    * chain, which matches on the (wrapped) request URI.

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCamundaSecurityConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCamundaSecurityConfig.java
@@ -7,14 +7,19 @@
  */
 package io.camunda.optimize.rest.security.csl;
 
+import io.camunda.optimize.tomcat.CCSMRequestAdjustmentFilter;
 import io.camunda.security.core.port.out.MembershipPort;
 import io.camunda.security.core.port.out.SecurityPathPort;
 import io.camunda.security.spring.CamundaSecurityAutoConfiguration;
 import io.camunda.security.spring.spi.OidcAuthenticationEntryPoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 
@@ -45,6 +50,8 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 @ImportAutoConfiguration(CamundaSecurityAutoConfiguration.class)
 public class OptimizeCamundaSecurityConfig {
 
+  private static final Logger LOG = LoggerFactory.getLogger(OptimizeCamundaSecurityConfig.class);
+
   @Bean
   public SecurityPathPort securityPathPort() {
     return new OptimizeSecurityPathAdapter();
@@ -56,6 +63,30 @@ public class OptimizeCamundaSecurityConfig {
   @Bean
   public MembershipPort membershipPort() {
     return new OptimizeMembershipAdapter();
+  }
+
+  /**
+   * Keeps external sharing working under CSL. The legacy adapters each register their own
+   * request-adjustment filter, and both back off in CSL mode, so without this bean the {@code
+   * /external/api/**} rewrite and the static share resources stop resolving.
+   *
+   * <p>{@link CCSMRequestAdjustmentFilter} serves both editions here despite its name: all it does
+   * is strip the servlet context path, rewrite {@code /external/api/**} to {@code /api/external/**}
+   * and serve the static share resources. The CCSaaS-only cluster-id stripping its SaaS counterpart
+   * adds is not needed, because in CSL mode the cluster id is the servlet context path (ADR-0038).
+   *
+   * <p>Registered at highest precedence so the rewrite lands before the Spring Security filter
+   * chain, which matches on the (wrapped) request URI.
+   */
+  @Bean
+  public FilterRegistrationBean<CCSMRequestAdjustmentFilter> externalSharingRequestAdjuster() {
+    LOG.debug("Registering filter 'externalSharingRequestAdjuster' (CSL)...");
+    final FilterRegistrationBean<CCSMRequestAdjustmentFilter> registration =
+        new FilterRegistrationBean<>();
+    registration.setFilter(new CCSMRequestAdjustmentFilter());
+    registration.addUrlPatterns("/*");
+    registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+    return registration;
   }
 
   /** Overrides CSL's default OIDC entry point; see {@link OptimizeOidcAuthenticationEntryPoint}. */

--- a/optimize/backend/src/test/java/io/camunda/optimize/URLRedirectFilterRoutingTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/URLRedirectFilterRoutingTest.java
@@ -27,7 +27,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 /**
  * Verifies which request URIs the SPA-routing filter rewrites to {@code /#} for each {@code
  * optimize.security.csl.enabled} state. In CSL mode the auth endpoints must reach the security
- * chain unrewritten, otherwise OIDC login initiation bounces to the SPA home (ADR-0038).
+ * chain unrewritten, otherwise OIDC login initiation bounces to the SPA home. See <a
+ * href="https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md">ADR-0038</a>.
  */
 @ExtendWith(MockitoExtension.class)
 class URLRedirectFilterRoutingTest {

--- a/optimize/backend/src/test/java/io/camunda/optimize/URLRedirectFilterRoutingTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/URLRedirectFilterRoutingTest.java
@@ -18,9 +18,13 @@ import io.camunda.optimize.tomcat.URLRedirectFilter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -29,91 +33,109 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * optimize.security.csl.enabled} state. In CSL mode the auth endpoints must reach the security
  * chain unrewritten, otherwise OIDC login initiation bounces to the SPA home. See <a
  * href="https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md">ADR-0038</a>.
+ *
+ * <p>Every case runs twice, once without a servlet context path and once with one, because CCSaaS
+ * derives the context path from the cluster id. The filter strips the context path before matching,
+ * so the outcome has to be the same either way.
  */
 @ExtendWith(MockitoExtension.class)
 class URLRedirectFilterRoutingTest {
 
-  private static final String REDIRECT_TARGET = "/#";
+  private static final String SPA_HOME = "/#";
+  private static final List<String> CONTEXT_PATHS = List.of("", "/cluster-id");
 
   @Mock private HttpServletRequest request;
   @Mock private HttpServletResponse response;
   @Mock private FilterChain filterChain;
 
-  @ParameterizedTest
-  @ValueSource(strings = {"/oauth2/authorization/optimize", "/logout"})
-  void shouldRewriteCslAuthEndpointsWhenCslDisabled(final String requestUri) throws Exception {
-    givenRequestTo(requestUri);
-
-    filterFor(false).doFilter(request, response, filterChain);
-
-    thenRedirectedToSpa();
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {"/oauth2/authorization/optimize", "/logout"})
-  void shouldPassCslAuthEndpointsThroughWhenCslEnabled(final String requestUri) throws Exception {
-    givenRequestTo(requestUri);
-
-    filterFor(true).doFilter(request, response, filterChain);
-
-    thenPassedThrough();
+  /** CSL's own endpoints: login initiation and logout. */
+  private static Stream<Arguments> cslAuthEndpoints() {
+    return perContextPath("/oauth2/authorization/optimize", "/logout");
   }
 
   /**
-   * Paths the legacy stack already allows. They must keep passing through in CSL mode: {@code
+   * Paths the legacy stack already allows, which must keep passing through in CSL mode: {@code
    * /login} and {@code /external/**} back the login picker and the public share links, and the CSL
    * OIDC callback is {@code /api/authentication/callback} on CCSM / {@code /sso-callback} on
    * CCSaaS.
    */
-  @ParameterizedTest
-  @ValueSource(
-      strings = {
+  private static Stream<Arguments> pathsAllowedInBothModes() {
+    return perContextPath(
         "/login",
         "/external/share-id",
         "/external/api/shared-report",
         "/sso-callback",
         "/api/authentication/callback",
-        "/actuator/health"
-      })
-  void shouldPassSharedAllowedPathsThroughInBothModes(final String requestUri) throws Exception {
-    givenRequestTo(requestUri);
+        "/actuator/health");
+  }
 
-    filterFor(false).doFilter(request, response, filterChain);
-    filterFor(true).doFilter(request, response, filterChain);
+  private static Stream<Arguments> unknownSpaRoutes() {
+    return perContextPath("/dashboard/some-id", "/collection", "/unknown");
+  }
+
+  private static Stream<Arguments> perContextPath(final String... paths) {
+    return CONTEXT_PATHS.stream()
+        .flatMap(contextPath -> Arrays.stream(paths).map(path -> Arguments.of(contextPath, path)));
+  }
+
+  @ParameterizedTest(name = "contextPath=''{0}'' path={1}")
+  @MethodSource("cslAuthEndpoints")
+  void shouldRewriteCslAuthEndpointsWhenCslDisabled(final String contextPath, final String path)
+      throws Exception {
+    givenRequestTo(contextPath, path);
+
+    filterFor(contextPath, false).doFilter(request, response, filterChain);
+
+    verify(response).sendRedirect(contextPath + SPA_HOME);
+    verifyNoInteractions(filterChain);
+  }
+
+  @ParameterizedTest(name = "contextPath=''{0}'' path={1}")
+  @MethodSource("cslAuthEndpoints")
+  void shouldPassCslAuthEndpointsThroughWhenCslEnabled(final String contextPath, final String path)
+      throws Exception {
+    givenRequestTo(contextPath, path);
+
+    filterFor(contextPath, true).doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+    verify(response, never()).sendRedirect(any());
+  }
+
+  @ParameterizedTest(name = "contextPath=''{0}'' path={1}")
+  @MethodSource("pathsAllowedInBothModes")
+  void shouldPassAlreadyAllowedPathsThroughInBothModes(final String contextPath, final String path)
+      throws Exception {
+    givenRequestTo(contextPath, path);
+
+    filterFor(contextPath, false).doFilter(request, response, filterChain);
+    filterFor(contextPath, true).doFilter(request, response, filterChain);
 
     verify(filterChain, times(2)).doFilter(request, response);
     verify(response, never()).sendRedirect(any());
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {"/dashboard/some-id", "/collection", "/unknown"})
-  void shouldRewriteUnknownSpaRoutesInBothModes(final String requestUri) throws Exception {
-    givenRequestTo(requestUri);
+  @ParameterizedTest(name = "contextPath=''{0}'' path={1}")
+  @MethodSource("unknownSpaRoutes")
+  void shouldRewriteUnknownSpaRoutesInBothModes(final String contextPath, final String path)
+      throws Exception {
+    givenRequestTo(contextPath, path);
 
-    filterFor(false).doFilter(request, response, filterChain);
-    filterFor(true).doFilter(request, response, filterChain);
+    filterFor(contextPath, false).doFilter(request, response, filterChain);
+    filterFor(contextPath, true).doFilter(request, response, filterChain);
 
-    verify(response, times(2)).sendRedirect(REDIRECT_TARGET);
+    verify(response, times(2)).sendRedirect(contextPath + SPA_HOME);
     verifyNoInteractions(filterChain);
   }
 
-  private void givenRequestTo(final String requestUri) {
-    when(request.getContextPath()).thenReturn("");
-    when(request.getRequestURI()).thenReturn(requestUri);
+  private void givenRequestTo(final String contextPath, final String path) {
+    when(request.getContextPath()).thenReturn(contextPath);
+    when(request.getRequestURI()).thenReturn(contextPath + path);
   }
 
-  private URLRedirectFilter filterFor(final boolean cslEnabled) {
+  private URLRedirectFilter filterFor(final String contextPath, final boolean cslEnabled) {
     return new URLRedirectFilter(
-        OptimizeTomcatConfig.buildRedirectExclusionRegex("", cslEnabled), REDIRECT_TARGET);
-  }
-
-  private void thenPassedThrough() throws Exception {
-    verify(filterChain).doFilter(request, response);
-    verify(response, never()).sendRedirect(any());
-  }
-
-  private void thenRedirectedToSpa() throws Exception {
-    verify(response).sendRedirect(REDIRECT_TARGET);
-    verifyNoInteractions(filterChain);
+        OptimizeTomcatConfig.buildRedirectExclusionRegex(contextPath, cslEnabled),
+        contextPath + SPA_HOME);
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/URLRedirectFilterRoutingTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/URLRedirectFilterRoutingTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.tomcat.URLRedirectFilter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Verifies which request URIs the SPA-routing filter rewrites to {@code /#} for each {@code
+ * optimize.security.csl.enabled} state. In CSL mode the auth endpoints must reach the security
+ * chain unrewritten, otherwise OIDC login initiation bounces to the SPA home (ADR-0038).
+ */
+@ExtendWith(MockitoExtension.class)
+class URLRedirectFilterRoutingTest {
+
+  private static final String REDIRECT_TARGET = "/#";
+
+  @Mock private HttpServletRequest request;
+  @Mock private HttpServletResponse response;
+  @Mock private FilterChain filterChain;
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/oauth2/authorization/optimize", "/logout"})
+  void shouldRewriteCslAuthEndpointsWhenCslDisabled(final String requestUri) throws Exception {
+    givenRequestTo(requestUri);
+
+    filterFor(false).doFilter(request, response, filterChain);
+
+    thenRedirectedToSpa();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/oauth2/authorization/optimize", "/logout"})
+  void shouldPassCslAuthEndpointsThroughWhenCslEnabled(final String requestUri) throws Exception {
+    givenRequestTo(requestUri);
+
+    filterFor(true).doFilter(request, response, filterChain);
+
+    thenPassedThrough();
+  }
+
+  /**
+   * Paths the legacy stack already allows. They must keep passing through in CSL mode: {@code
+   * /login} and {@code /external/**} back the login picker and the public share links, and the CSL
+   * OIDC callback is {@code /api/authentication/callback} on CCSM / {@code /sso-callback} on
+   * CCSaaS.
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "/login",
+        "/external/share-id",
+        "/external/api/shared-report",
+        "/sso-callback",
+        "/api/authentication/callback",
+        "/actuator/health"
+      })
+  void shouldPassSharedAllowedPathsThroughInBothModes(final String requestUri) throws Exception {
+    givenRequestTo(requestUri);
+
+    filterFor(false).doFilter(request, response, filterChain);
+    filterFor(true).doFilter(request, response, filterChain);
+
+    verify(filterChain, times(2)).doFilter(request, response);
+    verify(response, never()).sendRedirect(any());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/dashboard/some-id", "/collection", "/unknown"})
+  void shouldRewriteUnknownSpaRoutesInBothModes(final String requestUri) throws Exception {
+    givenRequestTo(requestUri);
+
+    filterFor(false).doFilter(request, response, filterChain);
+    filterFor(true).doFilter(request, response, filterChain);
+
+    verify(response, times(2)).sendRedirect(REDIRECT_TARGET);
+    verifyNoInteractions(filterChain);
+  }
+
+  private void givenRequestTo(final String requestUri) {
+    when(request.getContextPath()).thenReturn("");
+    when(request.getRequestURI()).thenReturn(requestUri);
+  }
+
+  private URLRedirectFilter filterFor(final boolean cslEnabled) {
+    return new URLRedirectFilter(
+        OptimizeTomcatConfig.buildRedirectExclusionRegex("", cslEnabled), REDIRECT_TARGET);
+  }
+
+  private void thenPassedThrough() throws Exception {
+    verify(filterChain).doFilter(request, response);
+    verify(response, never()).sendRedirect(any());
+  }
+
+  private void thenRedirectedToSpa() throws Exception {
+    verify(response).sendRedirect(REDIRECT_TARGET);
+    verifyNoInteractions(filterChain);
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/CslSecurityChainSelectionTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/CslSecurityChainSelectionTest.java
@@ -20,11 +20,15 @@ import io.camunda.optimize.service.security.SessionService;
 import io.camunda.optimize.service.security.UserIdMigrationService;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.ConfigurationServiceBuilder;
+import io.camunda.optimize.tomcat.CCSMRequestAdjustmentFilter;
 import io.camunda.security.core.port.out.MembershipPort;
 import io.camunda.security.core.port.out.SecurityPathPort;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.LazyInitializationBeanFactoryPostProcessor;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.Ordered;
 
 /**
  * Verifies that exactly one security setup is active per {@code optimize.security.csl.enabled}
@@ -101,6 +105,7 @@ class CslSecurityChainSelectionTest {
           assertThat(context).hasSingleBean(CCSMSecurityConfigurerAdapter.class);
           assertThat(context).doesNotHaveBean(OptimizeCamundaSecurityConfig.class);
           assertThat(context).doesNotHaveBean(SecurityPathPort.class);
+          assertThat(context).doesNotHaveBean("externalSharingRequestAdjuster");
         });
   }
 
@@ -118,6 +123,7 @@ class CslSecurityChainSelectionTest {
                   .isInstanceOf(OptimizeSecurityPathAdapter.class);
               assertThat(context.getBean(MembershipPort.class))
                   .isInstanceOf(OptimizeMembershipAdapter.class);
+              assertExternalSharingFilterRegistered(context);
             });
   }
 
@@ -145,6 +151,20 @@ class CslSecurityChainSelectionTest {
               assertThat(context).hasSingleBean(OptimizeCamundaSecurityConfig.class);
               assertThat(context.getBean(MembershipPort.class))
                   .isInstanceOf(OptimizeMembershipAdapter.class);
+              assertExternalSharingFilterRegistered(context);
             });
+  }
+
+  /**
+   * External sharing is served by a request-adjustment filter that each legacy adapter registers
+   * for itself. Both back off in CSL mode, so {@link OptimizeCamundaSecurityConfig} must register
+   * one, ahead of the security chain, which matches on the rewritten URI.
+   */
+  private static void assertExternalSharingFilterRegistered(final ApplicationContext context) {
+    final FilterRegistrationBean<?> registration =
+        context.getBean("externalSharingRequestAdjuster", FilterRegistrationBean.class);
+    assertThat(registration.getFilter()).isInstanceOf(CCSMRequestAdjustmentFilter.class);
+    assertThat(registration.getOrder()).isEqualTo(Ordered.HIGHEST_PRECEDENCE);
+    assertThat(registration.getUrlPatterns()).containsExactly("/*");
   }
 }


### PR DESCRIPTION
## Description

Two host-side gaps the CSL adoption flag leaves open. Both only reachable with `optimize.security.csl.enabled=true`; with the flag off behaviour is byte-identical to today.

**SPA routing.** `URLRedirectFilter` rewrites unknown paths to the SPA home. CSL serves login initiation from `/oauth2/authorization/{registrationId}` and logout from `/logout`. Neither exists in the legacy stack, so neither is in the allowed-suffix list and both get rewritten instead of reaching the security chain. They are now allowed through in CSL mode. The CSL OIDC callback needs no new entry: it is `/api/authentication/callback` on CCSM and `/sso-callback` on CCSaaS, both already allowed, as are `/login` and `/external/**`.

**External sharing.** The `/external/api/**` to `/api/external/**` rewrite and the static share resources are served by a request-adjustment filter that each legacy security adapter registers for itself. Both adapters back off in CSL mode, so under CSL neither ran and public share links stopped resolving. `OptimizeCamundaSecurityConfig` now registers one at highest precedence, ahead of Spring Security matching on the URI.

## Notes for reviewers

`CCSMRequestAdjustmentFilter` is reused for both editions despite its name: it only strips the context path, does the `/external/api` rewrite and serves the static share resources. The cluster-id stripping its CCSaaS counterpart adds is not needed under CSL, where the cluster id is the servlet context path. Not renamed, to keep the diff off legacy code that Phase 3 (#58484) deletes.

The `/oauth2/**` entry is partly defensive. With the CSL chains as merged, `OAuth2AuthorizationRequestRedirectFilter` handles that path and terminates before the servlet filters run, so it should not reach `URLRedirectFilter` today; `GET /logout` is the case that does. Keeping both makes the allowed set match the endpoints CSL owns rather than depending on filter ordering.

## Related issues

Closes #58479
Parent epic #58403
Decision: [ADR-0038](https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
