### PR TITLE
fix(operate): lower log level for expected API error logs

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/ErrorController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/ErrorController.java
@@ -63,8 +63,23 @@ public abstract class ErrorController {
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler(ClientException.class)
   public ResponseEntity<Error> handleInvalidRequest(final ClientException exception) {
-    logger.error(getSummary(exception), exception);
+    logger.info(getSummary(exception));
     logger.debug(exception.getMessage(), exception);
+    return createClientErrorResponse(exception);
+  }
+
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<Error> handleException(final Exception exception) {
+    // Show client only detail message, log all messages
+    final ClientException clientException =
+        new ClientException(getOnlyDetailMessage(exception), exception);
+    logger.error(getSummary(clientException), clientException);
+    logger.debug(exception.getMessage());
+    return createClientErrorResponse(clientException);
+  }
+
+  private ResponseEntity<Error> createClientErrorResponse(final ClientException exception) {
     final Error error =
         new Error()
             .setType(ClientException.TYPE)
@@ -74,13 +89,6 @@ public abstract class ErrorController {
     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .body(error);
-  }
-
-  @ResponseStatus(HttpStatus.BAD_REQUEST)
-  @ExceptionHandler(Exception.class)
-  public ResponseEntity<Error> handleException(final Exception exception) {
-    // Show client only detail message, log all messages
-    return handleInvalidRequest(new ClientException(getOnlyDetailMessage(exception), exception));
   }
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)
@@ -102,7 +110,7 @@ public abstract class ErrorController {
   @ResponseStatus(HttpStatus.NOT_FOUND)
   @ExceptionHandler(ResourceNotFoundException.class)
   public ResponseEntity<Error> handleNotFound(final ResourceNotFoundException exception) {
-    logger.error(getSummary(exception));
+    logger.info(getSummary(exception));
     logger.debug(exception.getMessage(), exception);
     final Error error =
         new Error()


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Lower the expected API logging level to INFO for expected `ClientExceptions` in Operate V1 API.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #51649