### PR TITLE
feat: run CCSaaS user-id migration on CSL login

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCslLoginSuccessListener.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCslLoginSuccessListener.java
@@ -67,6 +67,24 @@ public final class OptimizeCslLoginSuccessListener {
     }
     LOG.debug("CSL OIDC login success for subject [{}]", oidcUser.getSubject());
 
+    try {
+      migrateIfIdentityChanged(oidcUser);
+    } catch (final RuntimeException e) {
+      // Never let a migration problem fail the login. This event is published before the success
+      // handler redirects (AbstractAuthenticationProcessingFilter#successfulAuthentication), and
+      // Spring propagates listener exceptions to the publisher, so an escape would turn a
+      // successful login into an error page. Resolving the CSL authentication can throw, for
+      // example when no CamundaAuthenticationConverter matches or the claims mapping is empty.
+      // The migration is best effort: the user keeps their session and a later login retries.
+      LOG.warn(
+          "User-id migration failed for subject [{}]; the login itself is unaffected and entities"
+              + " owned by the previous identity stay with it until a later login retries.",
+          oidcUser.getSubject(),
+          e);
+    }
+  }
+
+  private void migrateIfIdentityChanged(final OidcUser oidcUser) {
     final String originalUserId = oidcUser.getClaimAsString(ORIGINAL_USER_ID_CLAIM);
     if (originalUserId == null || originalUserId.isBlank()) {
       return;

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCslLoginSuccessListener.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCslLoginSuccessListener.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.csl;
+
+import io.camunda.optimize.service.security.UserIdMigrationService;
+import io.camunda.optimize.service.util.configuration.condition.CCSaaSCondition;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.security.api.model.CamundaAuthentication;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.event.EventListener;
+import org.springframework.security.authentication.event.InteractiveAuthenticationSuccessEvent;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Component;
+
+/**
+ * Runs the CCSaaS user-id migration on login under CSL. See <a
+ * href="https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md">ADR-0038</a>.
+ *
+ * <p>The legacy {@code CCSaaSSecurityConfigurerAdapter} did this inside its own OAuth2 login
+ * success handler. Under CSL the success handler belongs to the library, so Optimize reacts to
+ * Spring Security's {@link InteractiveAuthenticationSuccessEvent} instead. {@code
+ * OAuth2LoginAuthenticationFilter} publishes it after populating the {@code SecurityContext}, so
+ * the authenticated principal is already resolvable here. No CSL change is needed.
+ *
+ * <p>A user who adds a new SSO login method gets a new SaaS identity, and Auth0 then carries the
+ * previous one in the {@code https://camunda.com/originalUserId} claim. When it differs from the id
+ * the user is now authenticated as, stored entity ownership is rewritten so the user keeps their
+ * entities. Repeated logins are safe: {@link UserIdMigrationService#migrateUserIdIfNeeded} owns the
+ * deduplication and no-ops once an old id has been migrated.
+ */
+@Component
+@Conditional(CCSaaSCondition.class)
+@ConditionalOnProperty(name = "optimize.security.csl.enabled", havingValue = "true")
+public final class OptimizeCslLoginSuccessListener {
+
+  /** Auth0 claim carrying the user's previous SaaS identity, absent unless it changed. */
+  static final String ORIGINAL_USER_ID_CLAIM = "https://camunda.com/originalUserId";
+
+  private static final Logger LOG = LoggerFactory.getLogger(OptimizeCslLoginSuccessListener.class);
+
+  private final UserIdMigrationService userIdMigrationService;
+  private final CamundaAuthenticationProvider camundaAuthenticationProvider;
+
+  public OptimizeCslLoginSuccessListener(
+      final UserIdMigrationService userIdMigrationService,
+      final CamundaAuthenticationProvider camundaAuthenticationProvider) {
+    this.userIdMigrationService = userIdMigrationService;
+    this.camundaAuthenticationProvider = camundaAuthenticationProvider;
+  }
+
+  @EventListener
+  public void onInteractiveAuthenticationSuccess(
+      final InteractiveAuthenticationSuccessEvent event) {
+    final Authentication authentication = event.getAuthentication();
+    if (!(authentication instanceof final OAuth2AuthenticationToken oauthToken)
+        || !(oauthToken.getPrincipal() instanceof final OidcUser oidcUser)) {
+      return;
+    }
+    LOG.debug("CSL OIDC login success for subject [{}]", oidcUser.getSubject());
+
+    final String originalUserId = oidcUser.getClaimAsString(ORIGINAL_USER_ID_CLAIM);
+    if (originalUserId == null || originalUserId.isBlank()) {
+      return;
+    }
+
+    final String currentUserId = resolveCurrentUserId();
+    if (currentUserId == null || currentUserId.isBlank()) {
+      // Fail safe rather than guess: migrating onto the wrong id would reassign entity ownership.
+      LOG.warn(
+          "Skipping user-id migration for subject [{}]: CSL resolved no authenticated username."
+              + " Entities owned by the previous identity stay with it until the next login.",
+          oidcUser.getSubject());
+      return;
+    }
+    if (originalUserId.equals(currentUserId)) {
+      return;
+    }
+
+    userIdMigrationService.migrateUserIdIfNeeded(currentUserId, originalUserId);
+  }
+
+  /**
+   * Resolves the id Optimize stores entity ownership under, which is CSL's authenticated username
+   * (the configured {@code username-claim}), the same source {@code
+   * CCSMTokenService#getCurrentUserIdFromAuthToken} reads. Deriving it from the OIDC principal name
+   * instead would silently diverge whenever {@code username-claim} is not {@code sub}.
+   */
+  private String resolveCurrentUserId() {
+    final CamundaAuthentication authentication =
+        camundaAuthenticationProvider.getCamundaAuthentication();
+    return authentication == null ? null : authentication.authenticatedUsername();
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCslLoginSuccessListener.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCslLoginSuccessListener.java
@@ -26,11 +26,10 @@ import org.springframework.stereotype.Component;
  * Runs the CCSaaS user-id migration on login under CSL. See <a
  * href="https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md">ADR-0038</a>.
  *
- * <p>The legacy {@code CCSaaSSecurityConfigurerAdapter} did this inside its own OAuth2 login
- * success handler. Under CSL the success handler belongs to the library, so Optimize reacts to
- * Spring Security's {@link InteractiveAuthenticationSuccessEvent} instead. {@code
- * OAuth2LoginAuthenticationFilter} publishes it after populating the {@code SecurityContext}, so
- * the authenticated principal is already resolvable here. No CSL change is needed.
+ * <p>The OIDC login success handler belongs to CSL, so the hook is an event listener rather than a
+ * handler of Optimize's own. {@code OAuth2LoginAuthenticationFilter} publishes {@link
+ * InteractiveAuthenticationSuccessEvent} after populating the {@code SecurityContext}, so the
+ * authenticated principal is already resolvable here.
  *
  * <p>A user who adds a new SSO login method gets a new SaaS identity, and Auth0 then carries the
  * previous one in the {@code https://camunda.com/originalUserId} claim. When it differs from the id

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeCslLoginSuccessEventTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeCslLoginSuccessEventTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.csl;
+
+import static io.camunda.optimize.rest.security.csl.OptimizeCslLoginSuccessListener.ORIGINAL_USER_ID_CLAIM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.service.security.UserIdMigrationService;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.security.api.model.CamundaAuthentication;
+import jakarta.servlet.FilterChain;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2LoginAuthenticationToken;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationExchange;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponse;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+/**
+ * Wires the real {@link OAuth2LoginAuthenticationFilter} to a real Spring context holding {@link
+ * OptimizeCslLoginSuccessListener} and completes an OIDC authorization-code callback, to prove the
+ * hook actually fires: Spring Security publishes {@code InteractiveAuthenticationSuccessEvent} on
+ * login success, the annotated listener receives it, and the migration runs.
+ *
+ * <p>Only the token exchange is stubbed (via the {@code AuthenticationManager}), so no IdP is
+ * needed. Everything between the filter and the listener is the production wiring.
+ */
+class OptimizeCslLoginSuccessEventTest {
+
+  private static final String REGISTRATION_ID = "auth0";
+  private static final String CALLBACK_PATH = "/login/oauth2/code/" + REGISTRATION_ID;
+  private static final String STATE = "state-value";
+  private static final String CURRENT_USER_ID = "auth0|new-identity";
+  private static final String PREVIOUS_USER_ID = "auth0|old-identity";
+
+  private final UserIdMigrationService userIdMigrationService = mock(UserIdMigrationService.class);
+  private final CamundaAuthenticationProvider camundaAuthenticationProvider =
+      mock(CamundaAuthenticationProvider.class);
+
+  private AnnotationConfigApplicationContext context;
+
+  @BeforeEach
+  void setUp() {
+    final CamundaAuthentication camundaAuthentication = mock(CamundaAuthentication.class);
+    when(camundaAuthentication.authenticatedUsername()).thenReturn(CURRENT_USER_ID);
+    when(camundaAuthenticationProvider.getCamundaAuthentication())
+        .thenReturn(camundaAuthentication);
+
+    context = new AnnotationConfigApplicationContext();
+    // The listener carries the CCSaaS + CSL-flag conditions, so the context has to satisfy them for
+    // the bean to exist at all.
+    context.getEnvironment().setActiveProfiles("cloud");
+    context
+        .getEnvironment()
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "csl-flag", Map.of("optimize.security.csl.enabled", Boolean.TRUE.toString())));
+    context.registerBean(UserIdMigrationService.class, () -> userIdMigrationService);
+    context.registerBean(CamundaAuthenticationProvider.class, () -> camundaAuthenticationProvider);
+    context.registerBean(OptimizeCslLoginSuccessListener.class);
+    context.refresh();
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+    context.close();
+  }
+
+  @Test
+  void shouldMigrateUserIdWhenSpringSecurityCompletesTheOidcLogin() throws Exception {
+    final MockHttpServletRequest request = callbackRequest();
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+
+    loginFilter().doFilter(request, response, mock(FilterChain.class));
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication())
+        .describedAs("login must have succeeded for the success event to be published")
+        .isNotNull();
+    verify(userIdMigrationService).migrateUserIdIfNeeded(CURRENT_USER_ID, PREVIOUS_USER_ID);
+  }
+
+  private OAuth2LoginAuthenticationFilter loginFilter() {
+    final ClientRegistration clientRegistration = clientRegistration();
+    final OAuth2LoginAuthenticationFilter filter =
+        new OAuth2LoginAuthenticationFilter(
+            new InMemoryClientRegistrationRepository(clientRegistration),
+            new HttpSessionOAuth2AuthorizedClientRepository(),
+            OAuth2LoginAuthenticationFilter.DEFAULT_FILTER_PROCESSES_URI);
+    // Stands in for the token exchange and userinfo call an IdP would answer.
+    filter.setAuthenticationManager(
+        authentication ->
+            new OAuth2LoginAuthenticationToken(
+                clientRegistration,
+                new OAuth2AuthorizationExchange(authorizationRequest(), authorizationResponse()),
+                oidcUser(),
+                AuthorityUtils.createAuthorityList("ROLE_USER"),
+                accessToken()));
+    filter.setApplicationEventPublisher(context);
+    return filter;
+  }
+
+  private MockHttpServletRequest callbackRequest() {
+    final MockHttpServletRequest request = new MockHttpServletRequest("GET", CALLBACK_PATH);
+    request.setServletPath(CALLBACK_PATH);
+    request.addParameter(OAuth2ParameterNames.CODE, "authorization-code");
+    request.addParameter(OAuth2ParameterNames.STATE, STATE);
+    new HttpSessionOAuth2AuthorizationRequestRepository()
+        .saveAuthorizationRequest(authorizationRequest(), request, new MockHttpServletResponse());
+    return request;
+  }
+
+  private static ClientRegistration clientRegistration() {
+    return ClientRegistration.withRegistrationId(REGISTRATION_ID)
+        .clientId("optimize")
+        .clientSecret("secret")
+        .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+        .redirectUri("{baseUrl}" + CALLBACK_PATH)
+        .scope("openid")
+        .authorizationUri("https://idp.example.com/authorize")
+        .tokenUri("https://idp.example.com/token")
+        .jwkSetUri("https://idp.example.com/jwks")
+        .build();
+  }
+
+  private static OAuth2AuthorizationRequest authorizationRequest() {
+    return OAuth2AuthorizationRequest.authorizationCode()
+        .authorizationUri("https://idp.example.com/authorize")
+        .clientId("optimize")
+        .redirectUri("http://localhost" + CALLBACK_PATH)
+        .scope("openid")
+        .state(STATE)
+        .attributes(Map.of(OAuth2ParameterNames.REGISTRATION_ID, REGISTRATION_ID))
+        .build();
+  }
+
+  private static OAuth2AuthorizationResponse authorizationResponse() {
+    return OAuth2AuthorizationResponse.success("authorization-code")
+        .redirectUri("http://localhost" + CALLBACK_PATH)
+        .state(STATE)
+        .build();
+  }
+
+  private static OidcUser oidcUser() {
+    final OidcIdToken idToken =
+        new OidcIdToken(
+            "id-token",
+            Instant.now(),
+            Instant.now().plusSeconds(300),
+            Map.of("sub", CURRENT_USER_ID, ORIGINAL_USER_ID_CLAIM, PREVIOUS_USER_ID));
+    return new DefaultOidcUser(AuthorityUtils.createAuthorityList("ROLE_USER"), idToken);
+  }
+
+  private static OAuth2AccessToken accessToken() {
+    return new OAuth2AccessToken(
+        OAuth2AccessToken.TokenType.BEARER,
+        "access-token",
+        Instant.now(),
+        Instant.now().plusSeconds(300),
+        java.util.Set.copyOf(List.of("openid")));
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeCslLoginSuccessEventTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeCslLoginSuccessEventTest.java
@@ -11,6 +11,7 @@ import static io.camunda.optimize.rest.security.csl.OptimizeCslLoginSuccessListe
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.optimize.service.security.UserIdMigrationService;
@@ -108,6 +109,26 @@ class OptimizeCslLoginSuccessEventTest {
         .describedAs("login must have succeeded for the success event to be published")
         .isNotNull();
     verify(userIdMigrationService).migrateUserIdIfNeeded(CURRENT_USER_ID, PREVIOUS_USER_ID);
+  }
+
+  @Test
+  void shouldCompleteTheLoginEvenWhenTheMigrationHookFails() throws Exception {
+    // given — resolving the CSL user throws, as it does when no CamundaAuthenticationConverter
+    // matches. The event is published before the success handler runs, so a propagated exception
+    // would turn a successful login into an error.
+    when(camundaAuthenticationProvider.getCamundaAuthentication())
+        .thenThrow(new IllegalStateException("no matching converter"));
+
+    final MockHttpServletRequest request = callbackRequest();
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+
+    // when
+    loginFilter().doFilter(request, response, mock(FilterChain.class));
+
+    // then — the session is established and the success handler still redirected
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+    assertThat(response.getStatus()).isEqualTo(302);
+    verifyNoInteractions(userIdMigrationService);
   }
 
   private OAuth2LoginAuthenticationFilter loginFilter() {

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeCslLoginSuccessListenerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeCslLoginSuccessListenerTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.csl;
+
+import static io.camunda.optimize.rest.security.csl.OptimizeCslLoginSuccessListener.ORIGINAL_USER_ID_CLAIM;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.service.security.UserIdMigrationService;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.security.api.model.CamundaAuthentication;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.authentication.event.InteractiveAuthenticationSuccessEvent;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+
+/**
+ * Verifies the CCSaaS user-id migration hook on the CSL login-success event. The listener only
+ * decides whether a migration is warranted; deduplicating repeat logins for an already-migrated old
+ * id is {@link UserIdMigrationService}'s job and is covered by its own test.
+ */
+@ExtendWith(MockitoExtension.class)
+class OptimizeCslLoginSuccessListenerTest {
+
+  private static final String CURRENT_USER_ID = "auth0|new-identity";
+  private static final String PREVIOUS_USER_ID = "auth0|old-identity";
+
+  @Mock private UserIdMigrationService userIdMigrationService;
+  @Mock private CamundaAuthenticationProvider camundaAuthenticationProvider;
+  @Mock private CamundaAuthentication camundaAuthentication;
+
+  @InjectMocks private OptimizeCslLoginSuccessListener listener;
+
+  @BeforeEach
+  void setUp() {
+    lenient()
+        .when(camundaAuthenticationProvider.getCamundaAuthentication())
+        .thenReturn(camundaAuthentication);
+    lenient().when(camundaAuthentication.authenticatedUsername()).thenReturn(CURRENT_USER_ID);
+  }
+
+  @Test
+  void shouldMigrateOnFirstLoginAfterIdentityChange() {
+    listener.onInteractiveAuthenticationSuccess(loginEventWith(PREVIOUS_USER_ID));
+
+    verify(userIdMigrationService).migrateUserIdIfNeeded(CURRENT_USER_ID, PREVIOUS_USER_ID);
+  }
+
+  @Test
+  void shouldDelegateEveryLoginSoTheMigrationServiceCanDeduplicate() {
+    // Auth0 keeps sending the claim after a migration, so the listener keeps delegating and
+    // UserIdMigrationService no-ops on an old id it has already handled.
+    listener.onInteractiveAuthenticationSuccess(loginEventWith(PREVIOUS_USER_ID));
+    listener.onInteractiveAuthenticationSuccess(loginEventWith(PREVIOUS_USER_ID));
+
+    verify(userIdMigrationService, times(2))
+        .migrateUserIdIfNeeded(CURRENT_USER_ID, PREVIOUS_USER_ID);
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"", "   ", CURRENT_USER_ID})
+  void shouldNotMigrateWhenThereIsNoDifferentPreviousIdentity(final String originalUserId) {
+    listener.onInteractiveAuthenticationSuccess(loginEventWith(originalUserId));
+
+    verifyNoInteractions(userIdMigrationService);
+  }
+
+  @Test
+  void shouldNotMigrateWhenCslResolvesNoAuthenticatedUsername() {
+    // Fail safe: migrating onto a guessed id would reassign entity ownership to the wrong user.
+    when(camundaAuthentication.authenticatedUsername()).thenReturn(null);
+
+    listener.onInteractiveAuthenticationSuccess(loginEventWith(PREVIOUS_USER_ID));
+
+    verifyNoInteractions(userIdMigrationService);
+  }
+
+  @Test
+  void shouldIgnoreNonOidcAuthentication() {
+    final Authentication authentication =
+        new TestingAuthenticationToken(CURRENT_USER_ID, "credentials");
+
+    listener.onInteractiveAuthenticationSuccess(
+        new InteractiveAuthenticationSuccessEvent(authentication, getClass()));
+
+    verify(userIdMigrationService, never()).migrateUserIdIfNeeded(anyString(), any());
+  }
+
+  private static InteractiveAuthenticationSuccessEvent loginEventWith(final String originalUserId) {
+    final Map<String, Object> claims = new HashMap<>();
+    claims.put("sub", CURRENT_USER_ID);
+    if (originalUserId != null) {
+      claims.put(ORIGINAL_USER_ID_CLAIM, originalUserId);
+    }
+    final OidcIdToken idToken =
+        new OidcIdToken("token", Instant.now(), Instant.now().plusSeconds(300), claims);
+    final OAuth2AuthenticationToken authentication =
+        new OAuth2AuthenticationToken(
+            new DefaultOidcUser(AuthorityUtils.createAuthorityList("ROLE_USER"), idToken),
+            List.of(),
+            "auth0");
+    return new InteractiveAuthenticationSuccessEvent(
+        authentication, OptimizeCslLoginSuccessListenerTest.class);
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeCslLoginSuccessListenerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeCslLoginSuccessListenerTest.java
@@ -8,8 +8,10 @@
 package io.camunda.optimize.rest.security.csl;
 
 import static io.camunda.optimize.rest.security.csl.OptimizeCslLoginSuccessListener.ORIGINAL_USER_ID_CLAIM;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -101,6 +103,31 @@ class OptimizeCslLoginSuccessListenerTest {
     listener.onInteractiveAuthenticationSuccess(loginEventWith(PREVIOUS_USER_ID));
 
     verifyNoInteractions(userIdMigrationService);
+  }
+
+  @Test
+  void shouldNotPropagateWhenResolvingTheCslUserThrows() {
+    // given — the delegating converter throws when no converter matches the authentication, which
+    // must not surface as a failed login: the event fires before the success handler redirects
+    when(camundaAuthenticationProvider.getCamundaAuthentication())
+        .thenThrow(new IllegalStateException("no matching converter"));
+
+    // when - then
+    assertThatNoException()
+        .isThrownBy(
+            () -> listener.onInteractiveAuthenticationSuccess(loginEventWith(PREVIOUS_USER_ID)));
+    verifyNoInteractions(userIdMigrationService);
+  }
+
+  @Test
+  void shouldNotPropagateWhenTheMigrationItselfThrows() {
+    doThrow(new IllegalStateException("boom"))
+        .when(userIdMigrationService)
+        .migrateUserIdIfNeeded(CURRENT_USER_ID, PREVIOUS_USER_ID);
+
+    assertThatNoException()
+        .isThrownBy(
+            () -> listener.onInteractiveAuthenticationSuccess(loginEventWith(PREVIOUS_USER_ID)));
   }
 
   @Test


### PR DESCRIPTION
## Description

Ports the CCSaaS user-id migration to the CSL login flow. Only active with `optimize.security.csl.enabled=true` on CCSaaS; nothing changes otherwise.

A SaaS user who adds an SSO login method gets a new identity, and Auth0 then carries the previous one in the `https://camunda.com/originalUserId` claim. The legacy `CCSaaSSecurityConfigurerAdapter` reacted to that inside its own OAuth2 login success handler and rewrote stored entity ownership. Under CSL the success handler belongs to the library, so Optimize listens to Spring Security's `InteractiveAuthenticationSuccessEvent` instead, which `OAuth2LoginAuthenticationFilter` publishes after populating the `SecurityContext`. Without this, such users lose access to their existing entities after the switch to `oauth2Login`. No CSL change needed.

## Notes for reviewers

The migration target is resolved from CSL's authenticated username (`CamundaAuthenticationProvider`), not from the OIDC principal name. Those agree on default config, both being `sub`, but they diverge as soon as `camunda.security.authentication.oidc.username-claim` is set to something else, and it is the CSL username that Optimize stores entity ownership under (see `CCSMTokenService#getCurrentUserIdFromAuthToken`). Picking the wrong one would reassign entities to an id the user never authenticates as. For the same reason the listener skips the migration and warns when CSL resolves no username, rather than falling back to a guess.

Deduplication across repeat logins stays in `UserIdMigrationService#migrateUserIdIfNeeded`, which no-ops once an old id has been handled. Auth0 keeps sending the claim after a migration, so the listener delegates on every login and lets the service decide, exactly as the legacy handler did.

## Related issues

Closes #58477
Parent epic #58403
Decision: [ADR-0038](https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
