### PR TITLE
chore: remove agentic-ai from MCP codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -169,9 +169,6 @@
 /.claude/skills/operate-frontend/          @camunda/core-features
 /.claude/skills/tasklist-frontend/         @camunda/core-features
 
-# MCP gateway
-/gateways/gateway-mcp @camunda/connectors-agentic-ai
-
 #################
 ## Camunda Ex  ##
 #################


### PR DESCRIPTION
## Description

Remove @camunda/connectors-agentic-ai as codeowner of the MCP module.

Currently only removing the line, so it is in line with the other gateways (e.g. REST), but could also be explicitely configured to a team instead.

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
