### PR TITLE
test: enable ignored nesting depth validation test

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/InputMappingNestingDepthIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/InputMappingNestingDepthIncidentTest.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -67,11 +66,7 @@ public final class InputMappingNestingDepthIncidentTest {
             .getProcessDefinitionKey();
   }
 
-  //   TODO: This test will fail due to a recursive call in the FEEL engine when evaluating the
-  //   expression. FeelToMessagePackTransformer can result in stack overflows through the recursive
-  //   handling of nested objects. This will be addressed in a follow-up issue.
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/57504")
   public void shouldCreateIncidentWhenInputMappingExceedsNestingDepth() {
     // when
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Missed removing the `@Ignore` on this test. Since #57504 is closed, this test can be safely re-enabled.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
