### PR TITLE
Backport 58825 to stable/8.9

### DIFF
--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -50,7 +50,7 @@ ARG JATTACH_CHECKSUM_ARM64
 
 # hadolint ignore=DL4006,DL3018
 RUN --mount=type=cache,target=/root/.jattach,rw \
-    apk add -q --no-cache curl 2>/dev/null && \
+    apk add -q --no-cache curl && \
     if [ "${TARGETARCH}" = "amd64" ]; then \
       BINARY="linux-x64"; \
       CHECKSUM="${JATTACH_CHECKSUM_AMD64}"; \
@@ -58,7 +58,9 @@ RUN --mount=type=cache,target=/root/.jattach,rw \
       BINARY="linux-arm64"; \
       CHECKSUM="${JATTACH_CHECKSUM_ARM64}"; \
     fi && \
-    curl -sL "https://github.com/jattach/jattach/releases/download/${JATTACH_VERSION}/jattach-${BINARY}.tgz" -o jattach.tgz && \
+    curl -sSL --retry 3 --retry-delay 5 --retry-connrefused \
+      "https://github.com/jattach/jattach/releases/download/${JATTACH_VERSION}/jattach-${BINARY}.tgz" \
+      -o jattach.tgz && \
     echo "${CHECKSUM} jattach.tgz" | sha256sum -c && \
     tar -xzf "jattach.tgz" && \
     chmod +x jattach && \

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -58,7 +58,7 @@ RUN --mount=type=cache,target=/root/.jattach,rw \
       BINARY="linux-arm64"; \
       CHECKSUM="${JATTACH_CHECKSUM_ARM64}"; \
     fi && \
-    curl -sSL --retry 3 --retry-delay 5 --retry-connrefused \
+    curl -fsSL --retry 3 --retry-delay 5 --retry-connrefused \
       "https://github.com/jattach/jattach/releases/download/${JATTACH_VERSION}/jattach-${BINARY}.tgz" \
       -o jattach.tgz && \
     echo "${CHECKSUM} jattach.tgz" | sha256sum -c && \


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/camunda/pull/58825

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
