### PR TITLE
feat: generate static partition distribution per physical tenant

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/FixedPartition.java
+++ b/configuration/src/main/java/io/camunda/configuration/FixedPartition.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration;
 
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
 import java.util.Collections;
 import java.util.List;
@@ -24,6 +25,8 @@ public class FixedPartition {
    * #DEFAULT_PARTITION_ID} (1).
    */
   private int partitionId = DEFAULT_PARTITION_ID;
+
+  private String physicalTenantId = PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 
   /**
    * The list of nodes assigned to this fixed partition configuration. Initialized as an empty list.
@@ -45,6 +48,14 @@ public class FixedPartition {
     this.partitionId = partitionId;
   }
 
+  public String getPhysicalTenantId() {
+    return physicalTenantId;
+  }
+
+  public void setPhysicalTenantId(final String physicalTenantId) {
+    this.physicalTenantId = physicalTenantId;
+  }
+
   public List<Node> getNodes() {
     return nodes;
   }
@@ -56,6 +67,7 @@ public class FixedPartition {
   public FixedPartitionCfg toFixedPartitionCfg() {
     final var fixedPartitionCfg = new FixedPartitionCfg();
     fixedPartitionCfg.setPartitionId(partitionId);
+    fixedPartitionCfg.setPhysicalTenantId(physicalTenantId);
     fixedPartitionCfg.setNodes(nodes.stream().map(Node::toNodeCfg).toList());
     return fixedPartitionCfg;
   }

--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreNodeIdProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreNodeIdProviderConfiguration.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.application.commons.configuration.WorkingDirectoryConfiguration.WorkingDirectory;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.configuration.Cluster;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.beans.BrokerBasedProperties;
@@ -40,6 +41,7 @@ import io.camunda.zeebe.restore.validation.PostRestoreValidator;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -204,7 +206,10 @@ public class RestoreNodeIdProviderConfiguration {
     final var localMember = MemberId.from(cluster.getZone(), cluster.getNodeId());
     final var clusterTopology =
         new PartitionDistribution(
-            StaticConfigurationGenerator.getStaticConfiguration(brokerCfg, localMember)
+            StaticConfigurationGenerator.getStaticConfiguration(
+                    brokerCfg,
+                    Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, brokerCfg),
+                    localMember)
                 .generatePartitionDistribution());
 
     final var partitionsToRestore =

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorBuilder.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorBuilder.java
@@ -21,18 +21,12 @@ import java.util.Set;
 public final class FixedPartitionDistributorBuilder {
   private final Map<PartitionId, Set<FixedDistributionMember>> partitions = new HashMap<>();
 
-  private final String partitionGroupName;
-
   /**
    * Creates a new builder with the specific partition group name. The group name will be used to
    * generated {@link PartitionId} from raw integers. This effectively scopes the distributor to a
    * given partition group - you should not use the distributor with a different partition group.
-   *
-   * @param partitionGroupName the name of the partition group for which the distributor is built
    */
-  public FixedPartitionDistributorBuilder(final String partitionGroupName) {
-    this.partitionGroupName = partitionGroupName;
-  }
+  public FixedPartitionDistributorBuilder() {}
 
   /**
    * Assigns a member, with a given priority, to the given partition. Members assigned to a
@@ -47,11 +41,8 @@ public final class FixedPartitionDistributorBuilder {
    * @return this builder for chaining
    */
   public FixedPartitionDistributorBuilder assignMember(
-      final int partitionId, final int nodeId, final int priority) {
-    return assignMember(
-        new PartitionId(partitionGroupName, partitionId),
-        MemberId.from(String.valueOf(nodeId)),
-        priority);
+      final PartitionId partitionId, final int nodeId, final int priority) {
+    return assignMember(partitionId, MemberId.from(String.valueOf(nodeId)), priority);
   }
 
   /**

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.partitioning.topology;
 
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -24,6 +25,8 @@ import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.nio.file.Path;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 
 public class DynamicClusterConfigurationService implements ClusterConfigurationService {
@@ -212,8 +215,24 @@ public class DynamicClusterConfigurationService implements ClusterConfigurationS
     final var localMember =
         brokerStartupContext.getClusterServices().getMembershipService().getLocalMember().id();
 
+    final Map<String, BrokerCfg> physicalTenantConfigs;
+
+    if (ClusterConfigurationManagerService.USE_NEW_CONFIG) {
+      physicalTenantConfigs =
+          brokerStartupContext.getPhysicalTenantIds().known().stream()
+              .collect(
+                  Collectors.toMap(
+                      id -> id, id -> brokerStartupContext.getPhysicalTenantContext(id).config()));
+    } else {
+      // Until we have a proper multi-tenant configuration, we cannot generate partition
+      // distribution for multiple tenants.
+      physicalTenantConfigs =
+          Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, brokerConfiguration);
+    }
+
     final var staticConfiguration =
-        StaticConfigurationGenerator.getStaticConfiguration(brokerConfiguration, localMember);
+        StaticConfigurationGenerator.getStaticConfiguration(
+            brokerConfiguration, physicalTenantConfigs, localMember);
 
     return clusterConfigurationManagerService.start(
         brokerStartupContext.getActorSchedulingService(), staticConfiguration);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.broker.partitioning.topology;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PartitionId;
-import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.partitioning.distribution.FixedPartitionDistributor;
 import io.camunda.zeebe.broker.partitioning.distribution.FixedPartitionDistributorBuilder;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -29,6 +28,7 @@ import io.camunda.zeebe.dynamic.config.util.ZoneAwarePartitionDistributor;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -40,15 +40,20 @@ public final class StaticConfigurationGenerator {
   private StaticConfigurationGenerator() {}
 
   public static StaticConfiguration getStaticConfiguration(
-      final BrokerCfg brokerCfg, final MemberId localMemberId) {
+      final BrokerCfg brokerCfg,
+      final Map<String, BrokerCfg> physicalTenantConfigs,
+      final MemberId localMemberId) {
     final var clusterCfg = brokerCfg.getCluster();
     final var partitioningCfg = brokerCfg.getExperimental().getPartitioning();
-    final var partitionCount = clusterCfg.getPartitionsCount();
     final var replicationFactor = clusterCfg.getReplicationFactor();
-
     final var partitionDistributor = getPartitionDistributor(partitioningCfg);
     final var clusterMembers = getRaftGroupMembers(clusterCfg, partitioningCfg);
-    final var partitionIds = getSortedPartitionIds(partitionCount);
+    final var partitionCountPerTenant =
+        physicalTenantConfigs.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Entry::getKey, e -> e.getValue().getCluster().getPartitionsCount()));
+    final var partitionIds = getSortedPartitionIds(partitionCountPerTenant);
     final var partitionConfig = generatePartitionConfig(brokerCfg);
     final var clusterId = clusterCfg.getClusterId();
 
@@ -127,10 +132,14 @@ public final class StaticConfigurationGenerator {
         .collect(Collectors.toSet());
   }
 
-  private static List<PartitionId> getSortedPartitionIds(final int partitionCount) {
+  private static List<PartitionId> getSortedPartitionIds(
+      final Map<String, Integer> partitionCountPerTenant) {
     // partition ids start from 1
-    return IntStream.rangeClosed(1, partitionCount)
-        .mapToObj(p -> new PartitionId(PartitionManagerImpl.DEFAULT_GROUP_NAME, p))
+    return partitionCountPerTenant.entrySet().stream()
+        .flatMap(
+            ptConfig ->
+                IntStream.rangeClosed(1, ptConfig.getValue())
+                    .mapToObj(p -> new PartitionId(ptConfig.getKey(), p)))
         .sorted()
         .toList();
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
@@ -85,13 +85,14 @@ public final class StaticConfigurationGenerator {
 
   private static FixedPartitionDistributor buildFixedPartitionDistributor(
       final PartitioningCfg config) {
-    final var distributionBuilder =
-        new FixedPartitionDistributorBuilder(PartitionManagerImpl.DEFAULT_GROUP_NAME);
+    final var distributionBuilder = new FixedPartitionDistributorBuilder();
 
     for (final var partition : config.getFixed()) {
       for (final var node : partition.getNodes()) {
         distributionBuilder.assignMember(
-            partition.getPartitionId(), node.getNodeId(), node.getPriority());
+            new PartitionId(partition.getPhysicalTenantId(), partition.getPartitionId()),
+            node.getNodeId(),
+            node.getPriority());
       }
     }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/FixedPartitionCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/FixedPartitionCfg.java
@@ -57,7 +57,7 @@ public final class FixedPartitionCfg {
     return "FixedPartitionCfg{"
         + "partitionId="
         + partitionId
-        + ",  physicalTenantId="
+        + ", physicalTenantId="
         + physicalTenantId
         + ", nodes="
         + nodes

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/FixedPartitionCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/FixedPartitionCfg.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.configuration.partitioning;
 
+import io.camunda.cluster.PhysicalTenantIds;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,6 +26,7 @@ public final class FixedPartitionCfg {
 
   private int partitionId = DEFAULT_PARTITION_ID;
   private List<NodeCfg> nodes = new ArrayList<>();
+  private String physicalTenantId = PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 
   public int getPartitionId() {
     return partitionId;
@@ -32,6 +34,14 @@ public final class FixedPartitionCfg {
 
   public void setPartitionId(final int partitionId) {
     this.partitionId = partitionId;
+  }
+
+  public String getPhysicalTenantId() {
+    return physicalTenantId;
+  }
+
+  public void setPhysicalTenantId(final String physicalTenantId) {
+    this.physicalTenantId = physicalTenantId;
   }
 
   public List<NodeCfg> getNodes() {
@@ -44,7 +54,14 @@ public final class FixedPartitionCfg {
 
   @Override
   public String toString() {
-    return "FixedPartitionCfg{" + "partitionId=" + partitionId + ", nodes=" + nodes + '}';
+    return "FixedPartitionCfg{"
+        + "partitionId="
+        + partitionId
+        + ",  physicalTenantId="
+        + physicalTenantId
+        + ", nodes="
+        + nodes
+        + '}';
   }
 
   /**

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorTest.java
@@ -161,16 +161,16 @@ final class FixedPartitionDistributorTest {
     final var expectedDistribution =
         Set.of(
             new PartitionMetadata(
-                partition("tenantA", 1), Set.of(node(0)), Map.of(node(0), 1), 1, node(0)),
+                partition("tenanta", 1), Set.of(node(0)), Map.of(node(0), 1), 1, node(0)),
             new PartitionMetadata(
-                partition("tenantB", 1), Set.of(node(1)), Map.of(node(1), 1), 1, node(1)));
+                partition("tenantb", 1), Set.of(node(1)), Map.of(node(1), 1), 1, node(1)));
     final var distributor =
         new FixedPartitionDistributorBuilder()
-            .assignMember(partition("tenantA", 1), 0, 1)
-            .assignMember(partition("tenantB", 1), 1, 1)
+            .assignMember(partition("tenanta", 1), 0, 1)
+            .assignMember(partition("tenantb", 1), 1, 1)
             .build();
     final var clusterMembers = Set.of(node(0), node(1));
-    final var sortedPartitionIds = List.of(partition("tenantA", 1), partition("tenantB", 1));
+    final var sortedPartitionIds = List.of(partition("tenanta", 1), partition("tenantb", 1));
 
     // when
     final var distribution =

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorTest.java
@@ -25,7 +25,7 @@ final class FixedPartitionDistributorTest {
   void shouldFailOnMissingPartition() {
     // given
     final var distributor =
-        new FixedPartitionDistributorBuilder(PARTITION_GROUP_NAME).assignMember(2, 0, 1).build();
+        new FixedPartitionDistributorBuilder().assignMember(partition(2), 0, 1).build();
     final var clusterMembers = Set.of(node(0));
     final var sortedPartitionIds = List.of(partition(1), partition(2));
 
@@ -40,7 +40,7 @@ final class FixedPartitionDistributorTest {
   void shouldFailOnUnknownMember() {
     // given
     final var distributor =
-        new FixedPartitionDistributorBuilder(PARTITION_GROUP_NAME).assignMember(1, 0, 1).build();
+        new FixedPartitionDistributorBuilder().assignMember(partition(1), 0, 1).build();
     final var clusterMembers = Set.of(node(1));
     final var sortedPartitionIds = List.of(partition(1), partition(2));
 
@@ -57,7 +57,7 @@ final class FixedPartitionDistributorTest {
   void shouldFailOnMissingReplica() {
     // given
     final var distributor =
-        new FixedPartitionDistributorBuilder(PARTITION_GROUP_NAME).assignMember(1, 0, 1).build();
+        new FixedPartitionDistributorBuilder().assignMember(partition(1), 0, 1).build();
     final var clusterMembers = Set.of(node(0));
     final var sortedPartitionIds = List.of(partition(1), partition(2));
 
@@ -84,11 +84,11 @@ final class FixedPartitionDistributorTest {
                 2,
                 node(0)));
     final var distributor =
-        new FixedPartitionDistributorBuilder(PARTITION_GROUP_NAME)
-            .assignMember(1, 0, 1)
-            .assignMember(1, 1, 2)
-            .assignMember(2, 0, 2)
-            .assignMember(2, 1, 1)
+        new FixedPartitionDistributorBuilder()
+            .assignMember(partition(1), 0, 1)
+            .assignMember(partition(1), 1, 2)
+            .assignMember(partition(2), 0, 2)
+            .assignMember(partition(2), 1, 1)
             .build();
     final var clusterMembers = Set.of(node(0), node(1));
     final var sortedPartitionIds = List.of(partition(1), partition(2));
@@ -111,9 +111,9 @@ final class FixedPartitionDistributorTest {
             new PartitionMetadata(partition(1), Set.of(node(0)), Map.of(node(0), 2), 2, node(0)),
             new PartitionMetadata(partition(2), Set.of(node(0)), Map.of(node(0), 2), 2, node(0)));
     final var distributor =
-        new FixedPartitionDistributorBuilder(PARTITION_GROUP_NAME)
-            .assignMember(1, 0, 2)
-            .assignMember(2, 0, 2)
+        new FixedPartitionDistributorBuilder()
+            .assignMember(partition(1), 0, 2)
+            .assignMember(partition(2), 0, 2)
             .build();
     final var clusterMembers = Set.of(node(0), node(1));
     final var sortedPartitionIds = List.of(partition(1), partition(2));
@@ -137,10 +137,10 @@ final class FixedPartitionDistributorTest {
             new PartitionMetadata(
                 partition(1), Set.of(node(0), node(1)), Map.of(node(0), 2, node(1), 2), 2, null));
     final var distributor =
-        new FixedPartitionDistributorBuilder(PARTITION_GROUP_NAME)
+        new FixedPartitionDistributorBuilder()
             // two members with the same priority
-            .assignMember(1, 0, 2)
-            .assignMember(1, 1, 2)
+            .assignMember(partition(1), 0, 2)
+            .assignMember(partition(1), 1, 2)
             .build();
     final var clusterMembers = Set.of(node(0), node(1));
     final var sortedPartitionIds = List.of(partition(1));
@@ -155,8 +155,113 @@ final class FixedPartitionDistributorTest {
         .containsExactlyInAnyOrderElementsOf(expectedDistribution);
   }
 
+  @Test
+  void shouldDistributePartitionsIndependentlyAcrossMultipleTenants() {
+    // given -- two tenants, each with a partition numbered 1, assigned to different members
+    final var expectedDistribution =
+        Set.of(
+            new PartitionMetadata(
+                partition("tenantA", 1), Set.of(node(0)), Map.of(node(0), 1), 1, node(0)),
+            new PartitionMetadata(
+                partition("tenantB", 1), Set.of(node(1)), Map.of(node(1), 1), 1, node(1)));
+    final var distributor =
+        new FixedPartitionDistributorBuilder()
+            .assignMember(partition("tenantA", 1), 0, 1)
+            .assignMember(partition("tenantB", 1), 1, 1)
+            .build();
+    final var clusterMembers = Set.of(node(0), node(1));
+    final var sortedPartitionIds = List.of(partition("tenantA", 1), partition("tenantB", 1));
+
+    // when
+    final var distribution =
+        distributor.distributePartitions(clusterMembers, sortedPartitionIds, 1);
+
+    // then -- each tenant's partition is distributed to its own configured members only
+    assertThat(distribution)
+        .as("should distribute each tenant's partitions independently")
+        .containsExactlyInAnyOrderElementsOf(expectedDistribution);
+  }
+
+  @Test
+  void shouldDistributeSamePartitionNumberDifferentlyPerTenant() {
+    // given -- tenant A and tenant B both configure partition 1 and 2, but with different
+    // members and priorities per tenant
+    final var expectedDistribution =
+        Set.of(
+            new PartitionMetadata(
+                partition("tenantA", 1),
+                Set.of(node(0), node(1)),
+                Map.of(node(0), 1, node(1), 2),
+                2,
+                node(1)),
+            new PartitionMetadata(
+                partition("tenantA", 2),
+                Set.of(node(0), node(1)),
+                Map.of(node(0), 2, node(1), 1),
+                2,
+                node(0)),
+            new PartitionMetadata(
+                partition("tenantB", 1),
+                Set.of(node(2), node(3)),
+                Map.of(node(2), 2, node(3), 1),
+                2,
+                node(2)),
+            new PartitionMetadata(
+                partition("tenantB", 2),
+                Set.of(node(2), node(3)),
+                Map.of(node(2), 1, node(3), 2),
+                2,
+                node(3)));
+    final var distributor =
+        new FixedPartitionDistributorBuilder()
+            .assignMember(partition("tenantA", 1), 0, 1)
+            .assignMember(partition("tenantA", 1), 1, 2)
+            .assignMember(partition("tenantA", 2), 0, 2)
+            .assignMember(partition("tenantA", 2), 1, 1)
+            .assignMember(partition("tenantB", 1), 2, 2)
+            .assignMember(partition("tenantB", 1), 3, 1)
+            .assignMember(partition("tenantB", 2), 2, 1)
+            .assignMember(partition("tenantB", 2), 3, 2)
+            .build();
+    final var clusterMembers = Set.of(node(0), node(1), node(2), node(3));
+    final var sortedPartitionIds =
+        List.of(
+            partition("tenantA", 1),
+            partition("tenantA", 2),
+            partition("tenantB", 1),
+            partition("tenantB", 2));
+
+    // when
+    final var distribution =
+        distributor.distributePartitions(clusterMembers, sortedPartitionIds, 2);
+
+    // then
+    assertThat(distribution)
+        .as("should distribute the partitions of each tenant according to its own configuration")
+        .containsExactlyInAnyOrderElementsOf(expectedDistribution);
+  }
+
+  @Test
+  void shouldFailOnMissingPartitionWhenOnlyConfiguredForAnotherTenant() {
+    // given -- partition 1 is only configured for tenantA, but tenantB also requests partition 1
+    final var distributor =
+        new FixedPartitionDistributorBuilder().assignMember(partition("tenantA", 1), 0, 1).build();
+    final var clusterMembers = Set.of(node(0));
+    final var sortedPartitionIds = List.of(partition("tenantA", 1), partition("tenantB", 1));
+
+    // when - then
+    assertThatCode(() -> distributor.distributePartitions(clusterMembers, sortedPartitionIds, 1))
+        .as("should fail because tenantB's partition 1 was not configured")
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Expected to distribute partition 1, but no members configured for it");
+  }
+
   private PartitionId partition(final int id) {
     return new PartitionId(PARTITION_GROUP_NAME, id);
+  }
+
+  private PartitionId partition(final String tenant, final int id) {
+    return new PartitionId(tenant, id);
   }
 
   private MemberId node(final int id) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGeneratorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGeneratorTest.java
@@ -13,6 +13,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
 import io.camunda.zeebe.broker.system.configuration.PartitioningCfg;
@@ -59,7 +61,10 @@ class StaticConfigurationGeneratorTest {
 
     // when
     final var partitionDistribution =
-        StaticConfigurationGenerator.getStaticConfiguration(brokerCfg, MemberId.from("1"))
+        StaticConfigurationGenerator.getStaticConfiguration(
+                brokerCfg,
+                Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, brokerCfg),
+                MemberId.from("1"))
             .generatePartitionDistribution();
 
     // then
@@ -125,13 +130,109 @@ fixed:
 
     // when
     final var partitionDistribution =
-        StaticConfigurationGenerator.getStaticConfiguration(brokerCfg, MemberId.from("1"))
+        StaticConfigurationGenerator.getStaticConfiguration(
+                brokerCfg,
+                Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, brokerCfg),
+                MemberId.from("1"))
             .generatePartitionDistribution();
 
     // then
     // FixedPartitionDistributorTest verifies more cases.
     final var actualDistribution = getDistribution(partitionDistribution);
     assertThat(actualDistribution).containsExactlyInAnyOrderEntriesOf(expectedDistribution);
+  }
+
+  @Test
+  void shouldGeneratePartitionsAcrossMultiplePhysicalTenants() {
+    // given -- two physical tenants, each with their own partition count
+    final PartitioningCfg partitioningCfg = new PartitioningCfg();
+    partitioningCfg.setScheme(Scheme.ROUND_ROBIN);
+    final ClusterCfg clusterCfg = new ClusterCfg();
+    clusterCfg.setClusterSize(3);
+    clusterCfg.setPartitionsCount(2);
+    clusterCfg.setReplicationFactor(3);
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg.setCluster(clusterCfg);
+    brokerCfg.getExperimental().setPartitioning(partitioningCfg);
+    brokerCfg.setExporters(Map.of());
+
+    final ClusterCfg tenantBClusterCfg = new ClusterCfg();
+    tenantBClusterCfg.setClusterSize(3);
+    tenantBClusterCfg.setPartitionsCount(3);
+    tenantBClusterCfg.setReplicationFactor(3);
+    final BrokerCfg tenantBBrokerCfg = new BrokerCfg();
+    tenantBBrokerCfg.setCluster(tenantBClusterCfg);
+    tenantBBrokerCfg.getExperimental().setPartitioning(partitioningCfg);
+    tenantBBrokerCfg.setExporters(Map.of());
+
+    final var physicalTenantConfigs = Map.of("tenantA", brokerCfg, "tenantB", tenantBBrokerCfg);
+
+    // when
+    final var staticConfiguration =
+        StaticConfigurationGenerator.getStaticConfiguration(
+            brokerCfg, physicalTenantConfigs, MemberId.from("1"));
+
+    // then -- partition ids are generated per tenant, starting from 1 for each tenant
+    assertThat(staticConfiguration.partitionIds())
+        .containsExactlyInAnyOrder(
+            new PartitionId("tenantA", 1),
+            new PartitionId("tenantA", 2),
+            new PartitionId("tenantB", 1),
+            new PartitionId("tenantB", 2),
+            new PartitionId("tenantB", 3));
+
+    final var partitionDistribution = staticConfiguration.generatePartitionDistribution();
+    assertThat(partitionDistribution).hasSize(5);
+    assertThat(partitionDistribution.stream().map(PartitionMetadata::id))
+        .containsExactlyInAnyOrder(
+            new PartitionId("tenantA", 1),
+            new PartitionId("tenantA", 2),
+            new PartitionId("tenantB", 1),
+            new PartitionId("tenantB", 2),
+            new PartitionId("tenantB", 3));
+  }
+
+  @Test
+  void shouldGenerateFixedDistributionUsingConfiguredPhysicalTenantId() throws IOException {
+    // given -- fixed partitions explicitly assigned to different physical tenants
+    final String config =
+"""
+fixed:
+   - partitionId: 1
+     physicalTenantId: tenantA
+     nodes:
+       - nodeId: 0
+         priority: 1
+   - partitionId: 1
+     physicalTenantId: tenantB
+     nodes:
+       - nodeId: 1
+         priority: 1
+""";
+
+    final var partitioningCfg =
+        new ObjectMapper(new YAMLFactory()).readValue(config, PartitioningCfg.class);
+    final var clusterCfg = new ClusterCfg();
+    clusterCfg.setClusterSize(2);
+    clusterCfg.setReplicationFactor(1);
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg.setCluster(clusterCfg);
+    brokerCfg.getExperimental().setPartitioning(partitioningCfg);
+    brokerCfg.setExporters(Map.of());
+
+    final var physicalTenantConfigs = Map.of("tenantA", brokerCfg, "tenantB", brokerCfg);
+
+    // when
+    final var partitionDistribution =
+        StaticConfigurationGenerator.getStaticConfiguration(
+                brokerCfg, physicalTenantConfigs, MemberId.from("0"))
+            .generatePartitionDistribution();
+
+    // then -- each partition is assigned to the members configured for its physical tenant
+    final var byId =
+        partitionDistribution.stream().collect(Collectors.toMap(PartitionMetadata::id, p -> p));
+    assertThat(byId.get(new PartitionId("tenantA", 1)).members()).containsExactly(member(0));
+    assertThat(byId.get(new PartitionId("tenantB", 1)).members()).containsExactly(member(1));
   }
 
   private static MemberId member(final int id) {
@@ -161,7 +262,10 @@ fixed:
 
     // when
     final var partitionDistribution =
-        StaticConfigurationGenerator.getStaticConfiguration(brokerCfg, MemberId.from("us-east", 0))
+        StaticConfigurationGenerator.getStaticConfiguration(
+                brokerCfg,
+                Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, brokerCfg),
+                MemberId.from("us-east", 0))
             .generatePartitionDistribution();
 
     // then — every partition has 3 members (RF=3)
@@ -173,6 +277,75 @@ fixed:
         p -> p.members().forEach(m -> assertThat(m.zone()).isNotNull().isIn("us-east", "us-west")));
 
     // Primary should be from the highest-priority zone (us-east)
+    partitionDistribution.forEach(
+        p -> assertThat(p.getPrimary().orElseThrow().isInZone("us-east")).isTrue());
+  }
+
+  @Test
+  void shouldGenerateZoneAwareDistributionAcrossMultiplePhysicalTenants() {
+    // given — 2 zones: us-east (2 brokers, 2 replicas), us-west (1 broker, 1 replica)
+    // and 2 physical tenants with a different number of partitions each
+    final var zoneAwareCfg =
+        new ZoneAwareCfg(
+            List.of(new ZoneCfg("us-east", 4, 2, 1000), new ZoneCfg("us-west", 2, 1, 500)));
+
+    final var partitioningCfg = new PartitioningCfg();
+    partitioningCfg.setScheme(Scheme.ZONE_AWARE);
+    partitioningCfg.setZoneAware(zoneAwareCfg);
+
+    final var clusterCfg = new ClusterCfg();
+    clusterCfg.setClusterSize(3);
+    clusterCfg.setPartitionsCount(2);
+    clusterCfg.setReplicationFactor(3);
+
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg.setCluster(clusterCfg);
+    brokerCfg.getExperimental().setPartitioning(partitioningCfg);
+    brokerCfg.setExporters(Map.of());
+
+    final var tenantBClusterCfg = new ClusterCfg();
+    tenantBClusterCfg.setClusterSize(3);
+    tenantBClusterCfg.setPartitionsCount(3);
+    tenantBClusterCfg.setReplicationFactor(3);
+    final var tenantBBrokerCfg = new BrokerCfg();
+    tenantBBrokerCfg.setCluster(tenantBClusterCfg);
+    tenantBBrokerCfg.getExperimental().setPartitioning(partitioningCfg);
+    tenantBBrokerCfg.setExporters(Map.of());
+
+    final var physicalTenantConfigs = Map.of("tenantA", brokerCfg, "tenantB", tenantBBrokerCfg);
+
+    // when
+    final var staticConfiguration =
+        StaticConfigurationGenerator.getStaticConfiguration(
+            brokerCfg, physicalTenantConfigs, MemberId.from("us-east", 0));
+
+    // then -- partition ids are generated per tenant, starting from 1 for each tenant
+    assertThat(staticConfiguration.partitionIds())
+        .containsExactlyInAnyOrder(
+            new PartitionId("tenantA", 1),
+            new PartitionId("tenantA", 2),
+            new PartitionId("tenantB", 1),
+            new PartitionId("tenantB", 2),
+            new PartitionId("tenantB", 3));
+
+    final var partitionDistribution = staticConfiguration.generatePartitionDistribution();
+
+    // then — 5 partitions in total (2 for tenantA, 3 for tenantB), each with 3 members (RF=3)
+    assertThat(partitionDistribution).hasSize(5);
+    assertThat(partitionDistribution.stream().map(PartitionMetadata::id))
+        .containsExactlyInAnyOrder(
+            new PartitionId("tenantA", 1),
+            new PartitionId("tenantA", 2),
+            new PartitionId("tenantB", 1),
+            new PartitionId("tenantB", 2),
+            new PartitionId("tenantB", 3));
+    partitionDistribution.forEach(p -> assertThat(p.members()).hasSize(3));
+
+    // All members use zone_nodeId format
+    partitionDistribution.forEach(
+        p -> p.members().forEach(m -> assertThat(m.zone()).isNotNull().isIn("us-east", "us-west")));
+
+    // Primary should be from the highest-priority zone (us-east) for every tenant's partitions
     partitionDistribution.forEach(
         p -> assertThat(p.getPrimary().orElseThrow().isInZone("us-east")).isTrue());
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -68,7 +68,7 @@ public final class ClusterConfigurationManagerService
    * exercised via the {@code useNewConfig} constructor parameter (see {@link #USE_NEW_CONFIG}).
    * When {@code false}, the legacy code path runs completely unchanged.
    */
-  static final boolean USE_NEW_CONFIG = false;
+  public static final boolean USE_NEW_CONFIG = false;
 
   private final ClusterConfigurationManagerImpl clusterConfigurationManager;
   private final ClusterConfigurationGossiper clusterConfigurationGossiper;

--- a/zeebe/restore-standalone/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore-standalone/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.restore;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.partition.RaftPartition;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupMetadata;
@@ -271,7 +272,10 @@ public class RestoreManager implements CloseableSilently {
         Path.of(configuration.getData().getDirectory())
             .resolve(ClusterConfigurationManagerService.TOPOLOGY_FILE_NAME);
     final var staticConfiguration =
-        StaticConfigurationGenerator.getStaticConfiguration(configuration, coordinatorId);
+        StaticConfigurationGenerator.getStaticConfiguration(
+            configuration,
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, configuration),
+            coordinatorId);
     final var initializer = new StaticInitializer<>(staticConfiguration::generateTopology);
     // it's ok to block, it's not really async
     final var base = initializer.initialize().get();
@@ -325,7 +329,10 @@ public class RestoreManager implements CloseableSilently {
     final var localMember = MemberId.from(cluster.getZone(), cluster.getNodeId());
     final var clusterTopology =
         new PartitionDistribution(
-            StaticConfigurationGenerator.getStaticConfiguration(configuration, localMember)
+            StaticConfigurationGenerator.getStaticConfiguration(
+                    configuration,
+                    Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, configuration),
+                    localMember)
                 .generatePartitionDistribution());
     final var raftPartitionFactory = new RaftPartitionFactory(configuration);
 


### PR DESCRIPTION
## Summary
- Allow configuring fixed partitioning with multiple physical tenants (`FixedPartitionCfg#physicalTenantId`, `FixedPartitionDistributorBuilder`)
- Generate the static partition distribution grouped by physical tenant instead of a single fixed group name

The configuration is not used until the feature flag to use the new data model is on. PartitionManagers still use the config for the default tenant. The full integration will be in a follow up PR.

Stacked on #58537 
closes #58531
