### PR TITLE
test: fix flaky tasklist backup restore test

### DIFF
--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/TasklistAPICaller.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/TasklistAPICaller.java
@@ -10,6 +10,7 @@ package io.camunda.tasklist.qa.backup;
 import static io.camunda.tasklist.qa.backup.BackupRestoreTest.BACKUP_ID;
 import static io.camunda.tasklist.qa.backup.BackupRestoreTest.INDEX_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.fasterxml.jackson.core.JsonParser;
@@ -25,12 +26,14 @@ import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskResponse;
 import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskSearchRequest;
 import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskSearchResponse;
 import io.camunda.tasklist.webapp.dto.VariableInputDTO;
+import io.camunda.webapps.backup.BackupStateDto;
 import io.camunda.webapps.backup.GetBackupStateResponseDto;
 import io.camunda.webapps.backup.TakeBackupRequestDto;
 import io.camunda.webapps.backup.TakeBackupResponseDto;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -163,27 +166,36 @@ public class TasklistAPICaller {
     return mapper;
   }
 
-  @Retryable(
-      maxRetries = 100,
-      delay = 10,
-      includes = {AssertionError.class, HttpClientErrorException.NotFound.class})
   public void assertBackupState() {
-    try {
-      final var backupState = getBackupState(BACKUP_ID).getState();
-      switch (backupState) {
-        case COMPLETED:
-          LOGGER.info("Backup completed successfully.");
-          break;
-        case IN_PROGRESS:
-          LOGGER.info("Backup is still in progress, retrying...");
-          throw new AssertionError("Backup is still in progress"); // Triggers retry
-        default:
-          LOGGER.error("Unhealthy backup state: {}", backupState);
-          throw new IllegalStateException("Unhealthy backup state: " + backupState);
-      }
-    } catch (final HttpClientErrorException.NotFound er) {
-      LOGGER.warn("Error when checking backup state: {}", er.getMessage());
-      throw er;
-    }
+    // The timeout must cover the time a snapshot actually needs on a loaded CI agent. The poll
+    // interval is kept short because the assertion also guards against the backup reporting an
+    // unhealthy (e.g. INCOMPLETE) state on its way to COMPLETED.
+    await("Backup completed")
+        .atMost(Duration.ofMinutes(2))
+        .pollInterval(Duration.ofMillis(250))
+        .untilAsserted(
+            () -> {
+              final BackupStateDto backupState;
+              try {
+                backupState = getBackupState(BACKUP_ID).getState();
+              } catch (final HttpClientErrorException.NotFound er) {
+                LOGGER.warn("Error when checking backup state: {}", er.getMessage());
+                // The backup may not be visible yet, keep polling.
+                throw new AssertionError("Backup not found yet", er);
+              }
+
+              switch (backupState) {
+                case COMPLETED:
+                  LOGGER.info("Backup completed successfully.");
+                  break;
+                case IN_PROGRESS:
+                  LOGGER.info("Backup is still in progress, retrying...");
+                  throw new AssertionError("Backup is still in progress");
+                default:
+                  LOGGER.error("Unhealthy backup state: {}", backupState);
+                  // Not an AssertionError, so this aborts the polling immediately.
+                  throw new IllegalStateException("Unhealthy backup state: " + backupState);
+              }
+            });
   }
 }


### PR DESCRIPTION
## Description

`BackupRestoreTest.testBackupRestore` fails intermittently on `stable/8.9` with:

```
java.lang.AssertionError: Backup is still in progress
  at io.camunda.tasklist.qa.backup.TasklistAPICaller.assertBackupState(TasklistAPICaller.java:179)
  at io.camunda.tasklist.qa.backup.BackupRestoreTest.createBackup(BackupRestoreTest.java:86)
```

### Cause

`assertBackupState()` polls the backup actuator and re-throws an `AssertionError` while the backup
is `IN_PROGRESS`, relying on `@Retryable` to retry. The budget was `maxRetries = 100` with
`delay = 10` ms, so the method gave up after roughly **one second** of polling. An Elasticsearch
snapshot on a loaded CI agent regularly takes longer than that, so the test fails on timing alone
rather than on any product defect.

The tiny delay was not an oversight — it came from the original spring-retry annotation, which
carried the comment *"short delay to verify that INCOMPLETE state is not returned"*, i.e. it polled
tightly on purpose so that a briefly-appearing unhealthy state would be caught. It was carried over
verbatim in 6d13abfe320 during the Spring Framework 7 resilience migration. The polling intent was
sound; the overall timeout was simply never sized for a real snapshot.

### Change

Replace the hand-rolled retry with an Awaitility wait, matching the convention already used in this
module (`AbstractBackupRestoreDataGenerator`) and in the successor test on `main`
(`AbstractBackupRestoreIT`). It polls every 250 ms until the backup reports `COMPLETED`, for up to
2 minutes.

### Trade-off, please review

This **reduces sensitivity to a transient unhealthy state**, which was the point of the original
10 ms delay: at a 250 ms interval we are 25x less likely to observe an `INCOMPLETE` state that
appears only briefly between polls. An unhealthy state that *is* observed still aborts the wait
immediately, because `untilAsserted` only swallows `AssertionError` while an unhealthy state raises
`IllegalStateException`.

If that detection matters more than the extra HTTP chatter, I am happy to drop the poll interval
back down (e.g. 25 ms) and keep only the longer timeout — that would preserve the original
sensitivity exactly. Flagging it rather than deciding silently.

One further behavioural note: a `404` was previously retried via `@Retryable`'s `includes` and is
now converted into an `AssertionError` so Awaitility retries it. Same net effect, except a backup
that never appears now surfaces as an Awaitility timeout rather than a raw
`HttpClientErrorException`.

## Related issues

Flaky CI job: https://github.com/camunda/camunda/actions/runs/30343203170/job/90224720740

## Definition of Done

<!-- Please check the applicable boxes -->

Not applicable items can be removed from this list.

### Code changes:

- [x] The changes are backwards compatible with previous versions
- [x] Test-only change, no production code is touched

### Backport

Not needed. On `main` this module was removed in 70465faa977 and replaced by
`io.camunda.it.backup.AbstractBackupRestoreIT`, which already uses Awaitility with a proper
timeout. This fix only applies to `stable/8.9` and older.
