### PR TITLE
refactor: add jspecify annotations in zeebe/stream-platform

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
@@ -24,8 +24,11 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Objects;
 import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
+@NullMarked
 public final class InterPartitionCommandSenderImpl implements InterPartitionCommandSender {
 
   public static final String LEGACY_TOPIC_PREFIX = "inter-partition-";
@@ -59,7 +62,7 @@ public final class InterPartitionCommandSenderImpl implements InterPartitionComm
       final int receiverPartitionId,
       final ValueType valueType,
       final Intent intent,
-      final Long recordKey,
+      final @Nullable Long recordKey,
       final UnifiedRecordValue command) {
     sendCommand(receiverPartitionId, valueType, intent, recordKey, command, null);
   }
@@ -69,10 +72,10 @@ public final class InterPartitionCommandSenderImpl implements InterPartitionComm
       final int receiverPartitionId,
       final ValueType valueType,
       final Intent intent,
-      final Long recordKey,
+      final @Nullable Long recordKey,
       final UnifiedRecordValue command,
-      final AuthInfo authInfo) {
-    final MemberId partitionLeader = partitionLeaders.get(receiverPartitionId);
+      final @Nullable AuthInfo authInfo) {
+    final var partitionLeader = partitionLeaders.get(receiverPartitionId);
     if (partitionLeader == null) {
       LOG.warn(
           "Not sending command {} {} to {}, no known leader for this partition",
@@ -125,9 +128,9 @@ public final class InterPartitionCommandSenderImpl implements InterPartitionComm
         final int receiverPartitionId,
         final ValueType valueType,
         final Intent intent,
-        final Long recordKey,
+        final @Nullable Long recordKey,
         final BufferWriter command,
-        final BufferWriter authInfo) {
+        final @Nullable BufferWriter authInfo) {
       final var commandLength = command.getLength();
       final var authInfoLength = authInfo != null ? authInfo.getLength() : 0;
       final var messageLength =

--- a/zeebe/stream-platform/pom.xml
+++ b/zeebe/stream-platform/pom.xml
@@ -28,6 +28,10 @@
       <artifactId>camunda-cluster</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
     </dependency>

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/EventFilter.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/EventFilter.java
@@ -11,6 +11,7 @@ import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
+
 /** Implement to control which events should be handled by a {@link StreamProcessor}. */
 @FunctionalInterface
 public interface EventFilter {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/EventFilter.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/EventFilter.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.zeebe.stream.api;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
-import java.util.Objects;
-
 /** Implement to control which events should be handled by a {@link StreamProcessor}. */
 @FunctionalInterface
 public interface EventFilter {
@@ -23,7 +23,7 @@ public interface EventFilter {
   boolean applies(LoggedEvent event);
 
   default EventFilter and(final EventFilter other) {
-    Objects.requireNonNull(other);
+    requireNonNull(other);
     return (e) -> applies(e) && other.applies(e);
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/InterPartitionCommandSender.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/InterPartitionCommandSender.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Supports sending arbitrary commands to another partition. Sending may be unreliable and fail
@@ -41,7 +42,7 @@ public interface InterPartitionCommandSender {
       final int receiverPartitionId,
       final ValueType valueType,
       final Intent intent,
-      final Long recordKey,
+      final @Nullable Long recordKey,
       final UnifiedRecordValue command) {
     sendCommand(receiverPartitionId, valueType, intent, recordKey, command, null);
   }
@@ -60,7 +61,7 @@ public interface InterPartitionCommandSender {
       final int receiverPartitionId,
       final ValueType valueType,
       final Intent intent,
-      final Long recordKey,
+      final @Nullable Long recordKey,
       final UnifiedRecordValue command,
-      final AuthInfo authInfo);
+      final @Nullable AuthInfo authInfo);
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingSession.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingSession.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.Agent;
 import io.camunda.zeebe.protocol.record.ChannelType;
 import java.util.function.Consumer;
+import org.jspecify.annotations.Nullable;
 
 public interface ProcessingSession {
 
@@ -40,14 +41,14 @@ public interface ProcessingSession {
     }
   }
 
-  default void appendAuthInfoToFollowUps(final AuthInfo authInfo) {
+  default void appendAuthInfoToFollowUps(final @Nullable AuthInfo authInfo) {
     if (authInfo != null && authInfo.hasAnyClaims()) {
       // no explicit copy needed: RecordMetadata.authorization() already copies via copyFrom()
       appendMetadataToFollowUps(metadata -> metadata.authorization(authInfo));
     }
   }
 
-  default void appendAgentInfoToFollowUps(final Agent agentInfo) {
+  default void appendAgentInfoToFollowUps(final @Nullable Agent agentInfo) {
     if (agentInfo != null) {
       // make a copy to rule out any side effects
       final var agent = AgentInfo.of(agentInfo);
@@ -56,7 +57,7 @@ public interface ProcessingSession {
   }
 
   default void appendRequestSourceToFollowUps(
-      final ChannelType channelType, final String toolName) {
+      final @Nullable ChannelType channelType, final @Nullable String toolName) {
     if (channelType != null) {
       appendMetadataToFollowUps(metadata -> metadata.requestChannelType(channelType));
     }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/RecordProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/RecordProcessorContext.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
 public interface RecordProcessorContext {
 
@@ -29,7 +30,7 @@ public interface RecordProcessorContext {
 
   void addLifecycleListeners(final List<StreamProcessorLifecycleAware> lifecycleListeners);
 
-  InterPartitionCommandSender getPartitionCommandSender();
+  @Nullable InterPartitionCommandSender getPartitionCommandSender();
 
   KeyGenerator getKeyGenerator();
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/package-info.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.stream.api;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/records/package-info.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/records/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.stream.api.records;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/package-info.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.stream.api.scheduling;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/state/package-info.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/state/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.stream.api.state;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.stream.impl;
 
+import static io.camunda.zeebe.util.Unit.unit;
+
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -16,7 +18,7 @@ import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService;
 final class AsyncProcessingScheduleServiceActor extends Actor {
 
   private final ProcessingScheduleServiceImpl scheduleService;
-  private CompletableActorFuture<Void> closeFuture = CompletableActorFuture.completed(null);
+  private CompletableActorFuture<Void> closeFuture = CompletableActorFuture.completed(unit());
 
   public AsyncProcessingScheduleServiceActor(
       final String name,
@@ -46,7 +48,7 @@ final class AsyncProcessingScheduleServiceActor extends Actor {
 
   @Override
   protected void onActorClosed() {
-    closeFuture.complete(null);
+    closeFuture.complete(unit());
   }
 
   @Override
@@ -58,7 +60,7 @@ final class AsyncProcessingScheduleServiceActor extends Actor {
   @Override
   public void onActorFailed() {
     scheduleService.close();
-    closeFuture.complete(null);
+    closeFuture.complete(unit());
   }
 
   public SimpleProcessingScheduleService getScheduleService() {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncScheduleServiceContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncScheduleServiceContext.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.stream.impl;
 
+import static io.camunda.zeebe.util.Unit.unit;
+
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
@@ -46,14 +48,14 @@ class AsyncScheduleServiceContext {
                 actorSchedulingService.submitActor(
                     entry.getValue(), entry.getKey().getSchedulingHints()))
         .collect(new ActorFutureCollector<>(concurrencyControl))
-        .thenApply(results -> null, concurrencyControl);
+        .thenApply(results -> unit(), concurrencyControl);
   }
 
   public ActorFuture<Void> closeActors(final ConcurrencyControl concurrencyControl) {
     return asyncActors.values().stream()
         .map(AsyncProcessingScheduleServiceActor::closeAsync)
         .collect(new ActorFutureCollector<>(concurrencyControl))
-        .thenApply(results -> null, concurrencyControl);
+        .thenApply(results -> unit(), concurrencyControl);
   }
 
   private EnumMap<AsyncTaskGroup, AsyncProcessingScheduleServiceActor> createAsyncActors() {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncScheduleServiceContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncScheduleServiceContext.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.ActorFutureCollector;
 import io.camunda.zeebe.stream.api.scheduling.AsyncTaskGroup;
 import java.util.EnumMap;
+import org.jspecify.annotations.Nullable;
 
 class AsyncScheduleServiceContext {
   private final ActorSchedulingService actorSchedulingService;
@@ -37,7 +38,8 @@ class AsyncScheduleServiceContext {
     asyncActors = createAsyncActors();
   }
 
-  public AsyncProcessingScheduleServiceActor geAsyncActor(final AsyncTaskGroup taskGroup) {
+  public @Nullable AsyncProcessingScheduleServiceActor geAsyncActor(
+      final AsyncTaskGroup taskGroup) {
     return asyncActors.get(taskGroup);
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncScheduleServiceContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncScheduleServiceContext.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.ActorFutureCollector;
 import io.camunda.zeebe.stream.api.scheduling.AsyncTaskGroup;
 import java.util.EnumMap;
-import org.jspecify.annotations.Nullable;
 
 class AsyncScheduleServiceContext {
   private final ActorSchedulingService actorSchedulingService;
@@ -38,9 +37,19 @@ class AsyncScheduleServiceContext {
     asyncActors = createAsyncActors();
   }
 
-  public @Nullable AsyncProcessingScheduleServiceActor geAsyncActor(
-      final AsyncTaskGroup taskGroup) {
-    return asyncActors.get(taskGroup);
+  /**
+   * @param taskGroup
+   * @return the actor
+   * @throws IllegalStateException if the async actor is not registerd for that {@param taskGroup}
+   */
+  public AsyncProcessingScheduleServiceActor geAsyncActor(final AsyncTaskGroup taskGroup) {
+    final var actor = asyncActors.get(taskGroup);
+    if (actor == null) {
+      throw new IllegalStateException(
+          "Cannot find an AsyncActor for task group %s".formatted(taskGroup));
+    } else {
+      return actor;
+    }
   }
 
   public ActorFuture<Void> submitActors(final ConcurrencyControl concurrencyControl) {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.util.StringUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Implementation of {@code ProcessingResultBuilder} that buffers the processing results. After
@@ -39,7 +40,7 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
   private final List<PostCommitTask> postCommitTasks = new ArrayList<>();
 
   private final RecordBatch mutableRecordBatch;
-  private ProcessingResponseImpl processingResponse;
+  private @Nullable ProcessingResponseImpl processingResponse;
   private boolean processInASeparateBatch = false;
 
   private final List<Consumer<RecordMetadata>> metadataDecorators = new ArrayList<>();

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedResult.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedResult.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.stream.impl.BufferedProcessingResultBuilder.ProcessingRe
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Implementation of {@link ProcessingResult} and {@link TaskResult} that buffers the processing and
@@ -25,12 +26,12 @@ final class BufferedResult implements ProcessingResult, TaskResult {
 
   private final List<PostCommitTask> postCommitTasks;
   private final ImmutableRecordBatch immutableRecordBatch;
-  private final ProcessingResponseImpl processingResponse;
+  private final @Nullable ProcessingResponseImpl processingResponse;
   private final boolean processInASeparateBatch;
 
   BufferedResult(
       final ImmutableRecordBatch immutableRecordBatch,
-      final ProcessingResponseImpl processingResponse,
+      final @Nullable ProcessingResponseImpl processingResponse,
       final List<PostCommitTask> postCommitTasks,
       final boolean processInASeparateBatch) {
     this.postCommitTasks = new ArrayList<>(postCommitTasks);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ControllableStreamClockImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ControllableStreamClockImpl.java
@@ -20,7 +20,9 @@ import java.util.Objects;
 public final class ControllableStreamClockImpl implements StreamClock.ControllableStreamClock {
 
   private final InstantSource source;
-  private volatile Modification modification;
+
+  // Same as reset(), but added to make nullaway happy
+  private volatile Modification modification = Modification.none();
 
   public ControllableStreamClockImpl(final InstantSource source) {
     this.source = requireNonNull(source);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ControllableStreamClockImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ControllableStreamClockImpl.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.stream.impl;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification.None;
 import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification.Offset;
@@ -21,7 +23,7 @@ public final class ControllableStreamClockImpl implements StreamClock.Controllab
   private volatile Modification modification;
 
   public ControllableStreamClockImpl(final InstantSource source) {
-    this.source = Objects.requireNonNull(source);
+    this.source = requireNonNull(source);
     reset();
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/EventDescription.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/EventDescription.java
@@ -12,15 +12,16 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import org.jspecify.annotations.Nullable;
 
 public class EventDescription {
   private static final int WRITE_ACQUIRE_LOCK_TIMEOUT = 1;
   private static final int READ_ACQUIRE_LOCK_TIMEOUT = 100;
   private static final String FAILED_TO_ACQUIRE_LOCK = "failed to acquire lock";
   private long position;
-  private Intent intent;
-  private ValueType valueType;
-  private String status;
+  private @Nullable Intent intent;
+  private @Nullable ValueType valueType;
+  private String status = "";
   private final Lock lock = new ReentrantLock();
 
   public EventDescription(final String status) {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.stream.impl;
 
 import static io.camunda.zeebe.stream.api.scheduling.AsyncTaskGroup.ASYNC_PROCESSING;
+import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.stream.api.scheduling.AsyncTaskGroup;
@@ -41,7 +42,7 @@ class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService
   @Override
   public void runAtFixedRateAsync(
       final Duration delay, final Task task, final AsyncTaskGroup taskGroup) {
-    final var actor = context.geAsyncActor(taskGroup);
+    final var actor = requireNonNull(context.geAsyncActor(taskGroup));
     final var actorService = actor.getScheduleService();
     actor.run(
         () -> {
@@ -53,7 +54,7 @@ class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService
   @Override
   public ScheduledTask runDelayedAsync(
       final Duration delay, final Task task, final AsyncTaskGroup taskGroup) {
-    final var actor = context.geAsyncActor(taskGroup);
+    final var actor = requireNonNull(context.geAsyncActor(taskGroup));
     final var actorService = actor.getScheduleService();
 
     final var futureScheduledTask = actor.<ScheduledTask>createFuture();
@@ -69,7 +70,7 @@ class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService
   @Override
   public ScheduledTask runAtAsync(
       final long timestamp, final Task task, final AsyncTaskGroup taskGroup) {
-    final var actor = context.geAsyncActor(taskGroup);
+    final var actor = requireNonNull(context.geAsyncActor(taskGroup));
     final var actorService = actor.getScheduleService();
     final var futureScheduledTask = actor.<ScheduledTask>createFuture();
     actor.run(
@@ -83,7 +84,7 @@ class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService
 
   @Override
   public ScheduledTask runDelayed(final Duration delay, final Runnable task) {
-    final var actor = context.geAsyncActor(ASYNC_PROCESSING);
+    final var actor = requireNonNull(context.geAsyncActor(ASYNC_PROCESSING));
     final var actorService = actor.getScheduleService();
     final var futureScheduledTask = actor.<ScheduledTask>createFuture();
     actor.run(
@@ -107,7 +108,7 @@ class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService
 
   @Override
   public ScheduledTask runAt(final long timestamp, final Runnable task) {
-    final var actor = context.geAsyncActor(ASYNC_PROCESSING);
+    final var actor = requireNonNull(context.geAsyncActor(ASYNC_PROCESSING));
     final var actorService = actor.getScheduleService();
     final var futureScheduledTask = actor.<ScheduledTask>createFuture();
     actor.run(

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
@@ -8,15 +8,18 @@
 package io.camunda.zeebe.stream.impl;
 
 import static io.camunda.zeebe.stream.api.scheduling.AsyncTaskGroup.ASYNC_PROCESSING;
-import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.stream.api.scheduling.AsyncTaskGroup;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ExtendedProcessingScheduleServiceImpl.class);
   private final AsyncScheduleServiceContext context;
 
   public ExtendedProcessingScheduleServiceImpl(
@@ -42,7 +45,7 @@ class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService
   @Override
   public void runAtFixedRateAsync(
       final Duration delay, final Task task, final AsyncTaskGroup taskGroup) {
-    final var actor = requireNonNull(context.geAsyncActor(taskGroup));
+    final var actor = context.geAsyncActor(taskGroup);
     final var actorService = actor.getScheduleService();
     actor.run(
         () -> {
@@ -54,7 +57,7 @@ class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService
   @Override
   public ScheduledTask runDelayedAsync(
       final Duration delay, final Task task, final AsyncTaskGroup taskGroup) {
-    final var actor = requireNonNull(context.geAsyncActor(taskGroup));
+    final var actor = context.geAsyncActor(taskGroup);
     final var actorService = actor.getScheduleService();
 
     final var futureScheduledTask = actor.<ScheduledTask>createFuture();
@@ -70,7 +73,7 @@ class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService
   @Override
   public ScheduledTask runAtAsync(
       final long timestamp, final Task task, final AsyncTaskGroup taskGroup) {
-    final var actor = requireNonNull(context.geAsyncActor(taskGroup));
+    final var actor = context.geAsyncActor(taskGroup);
     final var actorService = actor.getScheduleService();
     final var futureScheduledTask = actor.<ScheduledTask>createFuture();
     actor.run(
@@ -84,7 +87,7 @@ class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService
 
   @Override
   public ScheduledTask runDelayed(final Duration delay, final Runnable task) {
-    final var actor = requireNonNull(context.geAsyncActor(ASYNC_PROCESSING));
+    final var actor = context.geAsyncActor(ASYNC_PROCESSING);
     final var actorService = actor.getScheduleService();
     final var futureScheduledTask = actor.<ScheduledTask>createFuture();
     actor.run(
@@ -108,7 +111,7 @@ class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService
 
   @Override
   public ScheduledTask runAt(final long timestamp, final Runnable task) {
-    final var actor = requireNonNull(context.geAsyncActor(ASYNC_PROCESSING));
+    final var actor = context.geAsyncActor(ASYNC_PROCESSING);
     final var actorService = actor.getScheduleService();
     final var futureScheduledTask = actor.<ScheduledTask>createFuture();
     actor.run(
@@ -146,19 +149,20 @@ class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService
      */
     @Override
     public void cancel() {
-      final var actor = context.geAsyncActor(taskGroup);
-      if (actor == null) {
-        return;
+      try {
+        final var actor = context.geAsyncActor(taskGroup);
+        actor.run(
+            () ->
+                actor.runOnCompletion(
+                    futureScheduledTask,
+                    (scheduledTask, throwable) -> {
+                      if (scheduledTask != null) {
+                        scheduledTask.cancel();
+                      }
+                    }));
+      } catch (final IllegalStateException e) {
+        LOG.warn("Failed to get async actor for taskGroup {}, skipping cancel.", taskGroup);
       }
-      actor.run(
-          () ->
-              actor.runOnCompletion(
-                  futureScheduledTask,
-                  (scheduledTask, throwable) -> {
-                    if (scheduledTask != null) {
-                      scheduledTask.cancel();
-                    }
-                  }));
     }
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingException.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingException.java
@@ -9,19 +9,20 @@ package io.camunda.zeebe.stream.impl;
 
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import org.jspecify.annotations.Nullable;
 
 public final class ProcessingException extends RuntimeException {
 
   public ProcessingException(
       final String message,
       final LoggedEvent event,
-      final RecordMetadata metadata,
+      final @Nullable RecordMetadata metadata,
       final Throwable cause) {
     super(formatMessage(message, event, metadata), cause);
   }
 
   private static String formatMessage(
-      final String message, final LoggedEvent event, final RecordMetadata metadata) {
+      final String message, final LoggedEvent event, final @Nullable RecordMetadata metadata) {
     return String.format("%s [%s %s]", message, formatEvent(event), formatMetadata(metadata));
   }
 
@@ -32,7 +33,7 @@ public final class ProcessingException extends RuntimeException {
     return event.toString();
   }
 
-  private static String formatMetadata(final RecordMetadata metadata) {
+  private static String formatMetadata(final @Nullable RecordMetadata metadata) {
     if (metadata == null) {
       return "RecordMetadata{null}";
     }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.stream.impl;
 
+import static io.camunda.zeebe.util.Unit.unit;
+
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.scheduler.ActorControl;
@@ -131,7 +133,7 @@ public class ProcessingScheduleServiceImpl
 
     logStreamWriter = writerSupplier.get();
     actorControl = control;
-    openFuture.complete(null);
+    openFuture.complete(unit());
     actorControl.runAtFixedRate(Duration.ofMillis(interval), this::processScheduledTasks);
     return openFuture;
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.stream.impl;
 
 import static io.camunda.zeebe.util.Unit.unit;
+import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.WriteContext;
@@ -25,6 +26,7 @@ import java.time.InstantSource;
 import java.util.PriorityQueue;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 /**
@@ -45,10 +47,10 @@ public class ProcessingScheduleServiceImpl
   private final long interval;
   private final ScheduledTaskMetrics metrics;
   private final PriorityQueue<ScheduledTaskImpl> scheduledTasks = new PriorityQueue<>();
-  private LogStreamWriter logStreamWriter;
-  private ActorControl actorControl;
-  private AbortableRetryStrategy writeRetryStrategy;
-  private CompletableActorFuture<Void> openFuture;
+  private @Nullable LogStreamWriter logStreamWriter;
+  private @Nullable ActorControl actorControl;
+  private @Nullable AbortableRetryStrategy writeRetryStrategy;
+  private @Nullable CompletableActorFuture<Void> openFuture;
 
   public ProcessingScheduleServiceImpl(
       final Supplier<Phase> streamProcessorPhaseSupplier,
@@ -73,7 +75,7 @@ public class ProcessingScheduleServiceImpl
       LOG.warn("ProcessingScheduleService hasn't been opened yet, ignore scheduled task.");
       return NOOP_SCHEDULED_TASK;
     }
-    return schedule(clock.millis() + delay.toMillis(), task);
+    return schedule(actorControl, clock.millis() + delay.toMillis(), task);
   }
 
   @Override
@@ -92,7 +94,7 @@ public class ProcessingScheduleServiceImpl
       LOG.warn("ProcessingScheduleService hasn't been opened yet, ignore scheduled task.");
       return NOOP_SCHEDULED_TASK;
     }
-    return schedule(timestamp, task);
+    return schedule(actorControl, timestamp, task);
   }
 
   @Override
@@ -151,11 +153,13 @@ public class ProcessingScheduleServiceImpl
     while (scheduledTasks.peek() != null && scheduledTasks.peek().scheduledTime <= now) {
       metrics.decrementScheduledTasks();
       final var expiredTask = scheduledTasks.poll();
-      actorControl.submit(expiredTask);
+      requireNonNull(actorControl).submit(expiredTask);
     }
   }
 
-  private ScheduledTask schedule(final long timestamp, final Runnable task) {
+  // actorControl is the same as the field, but guaranteed to be non-null
+  private ScheduledTask schedule(
+      final ActorControl actorControl, final long timestamp, final Runnable task) {
     final var scheduledTask = new ScheduledTaskImpl(timestamp, task);
     actorControl.run(
         () -> {
@@ -163,7 +167,8 @@ public class ProcessingScheduleServiceImpl
           final var delay = timestamp - clock.millis();
           scheduledTasks.add(scheduledTask);
           if (delay < interval / 2) {
-            actorControl.schedule(Duration.ofMillis(delay), this::processScheduledTasks);
+            requireNonNull(actorControl)
+                .schedule(Duration.ofMillis(delay), this::processScheduledTasks);
           }
         });
     return scheduledTask;
@@ -209,13 +214,14 @@ public class ProcessingScheduleServiceImpl
         LOG.trace(
             "Not able to execute scheduled task right now. [streamProcessorPhase: {}]",
             currentStreamProcessorPhase);
-        actorControl.submit(toRunnable(task));
+        requireNonNull(actorControl).submit(toRunnable(task));
         return;
       }
 
       final var stagedCache = commandCache.stage();
       final var builder =
-          new BufferedTaskResultBuilder(logStreamWriter::canWriteEvents, stagedCache);
+          new BufferedTaskResultBuilder(
+              requireNonNull(logStreamWriter)::canWriteEvents, stagedCache);
       final var result = task.execute(builder);
       final var recordBatch = result.getRecordBatch();
 
@@ -228,18 +234,19 @@ public class ProcessingScheduleServiceImpl
       // it will be freed from the LogStorageAppender concurrently, which means we might be able to
       // write later
       final var writeFuture =
-          writeRetryStrategy.runWithRetry(
-              () -> {
-                LOG.trace("Write scheduled TaskResult to dispatcher!");
-                if (recordBatch.isEmpty()) {
-                  return true;
-                }
+          requireNonNull(writeRetryStrategy)
+              .runWithRetry(
+                  () -> {
+                    LOG.trace("Write scheduled TaskResult to dispatcher!");
+                    if (recordBatch.isEmpty()) {
+                      return true;
+                    }
 
-                return logStreamWriter
-                    .tryWrite(WriteContext.scheduled(), recordBatch.entries())
-                    .isRight();
-              },
-              abortCondition);
+                    return requireNonNull(logStreamWriter)
+                        .tryWrite(WriteContext.scheduled(), recordBatch.entries())
+                        .isRight();
+                  },
+                  abortCondition);
 
       writeFuture.onComplete(
           (v, t) -> {
@@ -268,12 +275,13 @@ public class ProcessingScheduleServiceImpl
 
     @Override
     public void cancel() {
-      actorControl.run(
-          () -> {
-            if (scheduledTasks.remove(this)) {
-              metrics.decrementScheduledTasks();
-            }
-          });
+      requireNonNull(actorControl)
+          .run(
+              () -> {
+                if (scheduledTasks.remove(this)) {
+                  metrics.decrementScheduledTasks();
+                }
+              });
     }
 
     @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.stream.impl;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDbTransaction;
 import io.camunda.zeebe.logstreams.impl.Loggers;
@@ -58,6 +60,7 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.function.BooleanSupplier;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 /**
@@ -146,21 +149,21 @@ public final class ProcessingStateMachine {
   private final StreamProcessorListener streamProcessorListener;
   private final PreviousRecord previousRecord = new PreviousRecord();
   // current iteration
-  private LoggedEvent currentRecord;
-  private ZeebeDbTransaction zeebeDbTransaction;
+  private @Nullable LoggedEvent currentRecord;
+  private @Nullable ZeebeDbTransaction zeebeDbTransaction;
   private long writtenPosition = StreamProcessor.UNSET_POSITION;
   private long lastSuccessfulProcessedRecordPosition = StreamProcessor.UNSET_POSITION;
   private long lastWrittenPosition = StreamProcessor.UNSET_POSITION;
   private int onErrorRetries;
   // Used for processing duration metrics
-  private CloseableSilently processingTimer;
+  private @Nullable CloseableSilently processingTimer;
   private boolean reachedEnd = true;
   private final StreamProcessorContext context;
   private final List<RecordProcessor> recordProcessors;
-  private ProcessingResult currentProcessingResult;
-  private List<LogAppendEntry> pendingWrites;
-  private Collection<ProcessingResponse> pendingResponses;
-  private RecordProcessor currentProcessor;
+  private @Nullable ProcessingResult currentProcessingResult;
+  private @Nullable List<LogAppendEntry> pendingWrites;
+  private @Nullable Collection<ProcessingResponse> pendingResponses;
+  private @Nullable RecordProcessor currentProcessor;
   private final LogStreamWriter logStreamWriter;
   private boolean inProcessing;
   private final int maxCommandsInBatch;
@@ -219,18 +222,19 @@ public final class ProcessingStateMachine {
   }
 
   private void skipRecord() {
-    notifySkippedListener(currentRecord);
+    notifySkippedListener(requireNonNull(currentRecord));
     markProcessingCompleted();
     actor.submit(this::tryToReadNextRecord);
     processingMetrics.eventSkipped();
   }
 
   void markProcessingCompleted() {
+    final var currentRecord = requireNonNull(this.currentRecord);
     final var position = currentRecord.getPosition();
     currentStateDescription.set(
         "finished processing", position, metadata.getIntent(), metadata.getValueType());
     previousRecord.set(position, isEventOrRejection.applies(currentRecord));
-    currentRecord = null;
+    this.currentRecord = null;
     inProcessing = false;
     if (onErrorRetries > 0) {
       onErrorRetries = 0;
@@ -262,7 +266,8 @@ public final class ProcessingStateMachine {
     }
 
     if (shouldProcessNext.getAsBoolean() && hasNext) {
-      currentRecord = logStreamReader.next();
+      final var currentRecord = logStreamReader.next();
+      this.currentRecord = currentRecord;
 
       if (processingFilter.applies(currentRecord)) {
         processCommand(currentRecord);
@@ -293,7 +298,10 @@ public final class ProcessingStateMachine {
     metadata.reset();
     loggedEvent.readMetadata(metadata);
     currentStateDescription.set(
-        "processing", currentRecord.getPosition(), metadata.getIntent(), metadata.getValueType());
+        "processing",
+        requireNonNull(currentRecord).getPosition(),
+        metadata.getIntent(),
+        metadata.getValueType());
 
     try {
       // Here we need to get the current time, since we want to calculate
@@ -304,12 +312,13 @@ public final class ProcessingStateMachine {
           processingMetrics.startProcessingDurationTimer(
               metadata.getValueType(), metadata.getIntent());
 
-      final var value = recordValues.readRecordValue(loggedEvent, metadata.getValueType());
+      final var value =
+          requireNonNull(recordValues.readRecordValue(loggedEvent, metadata.getValueType()));
       typedCommand.wrap(loggedEvent, metadata, value);
 
       zeebeDbTransaction = transactionContext.getCurrentTransaction();
       try (final var timer = processingMetrics.startBatchProcessingDurationTimer()) {
-        zeebeDbTransaction.run(() -> batchProcessing(typedCommand));
+        requireNonNull(zeebeDbTransaction).run(() -> batchProcessing(typedCommand));
         processingMetrics.observeCommandCount(processedCommandsCount);
       }
 
@@ -322,7 +331,8 @@ public final class ProcessingStateMachine {
           loggedEvent,
           metadata,
           recoverableException);
-      actor.schedule(PROCESSING_RETRY_DELAY, () -> processCommand(currentRecord));
+      actor.schedule(
+          PROCESSING_RETRY_DELAY, () -> processCommand(requireNonNull(this.currentRecord)));
     } catch (final UnrecoverableException unrecoverableException) {
       LOG.error(ERROR_MESSAGE_PROCESSING_FAILED_UNRECOVERABLE, loggedEvent, metadata);
       throw unrecoverableException;
@@ -478,7 +488,7 @@ public final class ProcessingStateMachine {
     final ActorFuture<Boolean> retryFuture =
         updateStateRetryStrategy.runWithRetry(
             () -> {
-              zeebeDbTransaction.rollback();
+              requireNonNull(zeebeDbTransaction).rollback();
               return true;
             },
             abortCondition);
@@ -501,6 +511,7 @@ public final class ProcessingStateMachine {
   }
 
   private boolean tryExitOutOfErrorLoop(final Throwable error) {
+    final var currentRecord = requireNonNull(this.currentRecord);
     final var rejectionReason =
         """
             Expected to process command %d (%s.%s), but caught an exception. Check broker logs \
@@ -568,6 +579,7 @@ public final class ProcessingStateMachine {
   }
 
   private void tryRejectingIfUserCommand(final String errorMessage) throws Exception {
+    final var currentRecord = requireNonNull(this.currentRecord);
     final var rejectionReason = errorMessage != null ? errorMessage : "";
     final ProcessingResultBuilder processingResultBuilder =
         newProcessingResultBuilder(typedCommand);
@@ -602,7 +614,7 @@ public final class ProcessingStateMachine {
     pendingResponses = currentProcessingResult.getProcessingResponse().stream().toList();
 
     zeebeDbTransaction = transactionContext.getCurrentTransaction();
-    zeebeDbTransaction.run(this::finalizeCommandProcessing);
+    requireNonNull(zeebeDbTransaction).run(this::finalizeCommandProcessing);
     writeRecords();
   }
 
@@ -614,8 +626,8 @@ public final class ProcessingStateMachine {
           final ProcessingResultBuilder processingResultBuilder =
               newProcessingResultBuilder(typedCommand);
           currentProcessingResult =
-              currentProcessor.onProcessingError(
-                  processingException, typedCommand, processingResultBuilder);
+              requireNonNull(currentProcessor)
+                  .onProcessingError(processingException, typedCommand, processingResultBuilder);
           pendingWrites = currentProcessingResult.getRecordBatch().entries();
           pendingResponses = currentProcessingResult.getProcessingResponse().stream().toList();
           // we need to mark the command as processed, even if the processing failed
@@ -629,16 +641,18 @@ public final class ProcessingStateMachine {
     final var sourceRecordPosition = typedCommand.getPosition();
 
     final ActorFuture<Boolean> writeFuture;
-    if (currentProcessingResult.isEmpty()) {
+    if (requireNonNull(currentProcessingResult).isEmpty()) {
       // we skipped the processing entirely; we have no results
-      notifySkippedListener(currentRecord);
+      notifySkippedListener(requireNonNull(currentRecord));
       processingMetrics.eventSkipped();
       writeFuture = CompletableActorFuture.completed(true);
-    } else if (pendingWrites.isEmpty()) {
+    } else if (requireNonNull(pendingWrites).isEmpty()) {
       // we might have nothing to write but likely something to send as response
       // means we will not mark the record as skipped
       writeFuture = CompletableActorFuture.completed(true);
     } else {
+      final var currentRecord = requireNonNull(this.currentRecord);
+      final var pendingWrites = requireNonNull(this.pendingWrites);
       writeFuture =
           writeRetryStrategy.runWithRetry(
               () -> {
@@ -691,11 +705,13 @@ public final class ProcessingStateMachine {
   }
 
   private void updateState() {
+    final var zeebeDbTransaction = requireNonNull(this.zeebeDbTransaction);
+    final var currentRecord = requireNonNull(this.currentRecord);
     final ActorFuture<Boolean> retryFuture =
         updateStateRetryStrategy.runWithRetry(
             () -> {
               zeebeDbTransaction.commit();
-              lastSuccessfulProcessedRecordPosition = currentRecord.getPosition();
+              lastSuccessfulProcessedRecordPosition = requireNonNull(currentRecord).getPosition();
               processingMetrics.setLastProcessedPosition(lastSuccessfulProcessedRecordPosition);
               lastWrittenPosition = writtenPosition;
               return true;
@@ -712,7 +728,8 @@ public final class ProcessingStateMachine {
             // This will bubble up to `StreamProcessor#onFailure` and result in a dead partition.
             throw new UncommittedStateException(throwable);
           } else {
-            scheduledCommandCache.remove(metadata.getIntent(), currentRecord.getKey());
+            scheduledCommandCache.remove(
+                metadata.getIntent(), requireNonNull(currentRecord).getKey());
             executeSideEffects();
           }
         });
@@ -724,7 +741,7 @@ public final class ProcessingStateMachine {
             () -> {
               // TODO refactor this into two parallel tasks, which are then combined, and on the
               // completion of which the process continues
-              for (final var processingResponse : pendingResponses) {
+              for (final var processingResponse : requireNonNull(pendingResponses)) {
                 final var responseWriter = context.getCommandResponseWriter();
 
                 final var responseValue = processingResponse.responseValue();
@@ -756,7 +773,7 @@ public final class ProcessingStateMachine {
           notifyProcessedListener(typedCommand);
 
           // observe the processing duration
-          processingTimer.close();
+          requireNonNull(processingTimer).close();
 
           // continue with next record
           markProcessingCompleted();
@@ -766,7 +783,7 @@ public final class ProcessingStateMachine {
 
   private boolean executePostCommitTasks() {
     try (final var timer = processingMetrics.startBatchProcessingPostCommitTasksTimer()) {
-      return currentProcessingResult.executePostCommitTasks();
+      return requireNonNull(currentProcessingResult).executePostCommitTasks();
     }
   }
 
@@ -820,7 +837,7 @@ public final class ProcessingStateMachine {
     if (errorHandlingPhase != ErrorHandlingPhase.NO_ERROR) {
       currentStateDescription.set(
           "in error handling phase " + errorHandlingPhase,
-          currentRecord.getPosition(),
+          requireNonNull(currentRecord).getPosition(),
           metadata.getIntent(),
           metadata.getValueType());
     }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/RecordProcessorContextImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/RecordProcessorContextImpl.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.stream.api.state.KeyGeneratorControls;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayList;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
 public final class RecordProcessorContextImpl implements RecordProcessorContext {
 
@@ -29,7 +30,7 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
   private final ZeebeDb zeebeDb;
   private final TransactionContext transactionContext;
   private final List<StreamProcessorLifecycleAware> lifecycleListeners = new ArrayList<>();
-  private final InterPartitionCommandSender partitionCommandSender;
+  private final @Nullable InterPartitionCommandSender partitionCommandSender;
   private final KeyGenerator keyGenerator;
   private final ControllableStreamClock clock;
   private final MeterRegistry meterRegistry;
@@ -39,7 +40,7 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
       final ProcessingScheduleService scheduleService,
       final ZeebeDb zeebeDb,
       final TransactionContext transactionContext,
-      final InterPartitionCommandSender partitionCommandSender,
+      final @Nullable InterPartitionCommandSender partitionCommandSender,
       final KeyGeneratorControls keyGeneratorControls,
       final ControllableStreamClock clock,
       final MeterRegistry meterRegistry) {
@@ -84,7 +85,7 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
   }
 
   @Override
-  public InterPartitionCommandSender getPartitionCommandSender() {
+  public @Nullable InterPartitionCommandSender getPartitionCommandSender() {
     return partitionCommandSender;
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/RecordProcessorContextImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/RecordProcessorContextImpl.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.stream.impl;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
@@ -19,7 +21,6 @@ import io.camunda.zeebe.stream.api.state.KeyGeneratorControls;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 public final class RecordProcessorContextImpl implements RecordProcessorContext {
 
@@ -48,8 +49,8 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
     this.transactionContext = transactionContext;
     this.partitionCommandSender = partitionCommandSender;
     keyGenerator = keyGeneratorControls;
-    this.clock = Objects.requireNonNull(clock, "must specify a stream clock");
-    this.meterRegistry = Objects.requireNonNull(meterRegistry, "must specify a metrics registry");
+    this.clock = requireNonNull(clock, "must specify a stream clock");
+    this.meterRegistry = requireNonNull(meterRegistry, "must specify a metrics registry");
   }
 
   @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.stream.impl;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDbTransaction;
 import io.camunda.zeebe.logstreams.impl.Loggers;
@@ -34,12 +36,14 @@ import io.camunda.zeebe.stream.api.state.MutableLastProcessedPositionState;
 import io.camunda.zeebe.stream.impl.metrics.ReplayMetrics;
 import io.camunda.zeebe.stream.impl.records.RecordValues;
 import io.camunda.zeebe.stream.impl.records.TypedRecordImpl;
+import io.camunda.zeebe.util.CloseableSilently;
 import java.util.List;
 import java.util.function.BooleanSupplier;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 /** Represents the state machine to replay events and rebuild the state. */
-public final class ReplayStateMachine implements LogRecordAwaiter {
+public final class ReplayStateMachine implements LogRecordAwaiter, CloseableSilently {
 
   private static final Logger LOG = Loggers.PROCESSOR_LOGGER;
 
@@ -78,8 +82,8 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
   private long lastReadRecordPosition = StreamProcessor.UNSET_POSITION;
   private long lastReplayedEventPosition = StreamProcessor.UNSET_POSITION;
 
-  private ActorFuture<LastProcessingPositions> recoveryFuture;
-  private ZeebeDbTransaction zeebeDbTransaction;
+  private @Nullable ActorFuture<LastProcessingPositions> recoveryFuture;
+  private @Nullable ZeebeDbTransaction zeebeDbTransaction;
   private final StreamProcessorMode streamProcessorMode;
   private final LogStream logStream;
 
@@ -196,29 +200,30 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
           String.format(
               "Failed to replay records. [snapshot-position: %d, last-read-record-position: %d, last-replayed-event-position: %d]",
               snapshotPosition, lastReadRecordPosition, lastReplayedEventPosition);
-      recoveryFuture.completeExceptionally(new RuntimeException(message, e));
+      requireNonNull(recoveryFuture).completeExceptionally(new RuntimeException(message, e));
     }
   }
 
   private boolean tryToReplayBatch(final Batch batch) throws Exception {
     final boolean onRetry = zeebeDbTransaction != null;
     if (onRetry) {
-      zeebeDbTransaction.rollback();
+      requireNonNull(zeebeDbTransaction).rollback();
       // reading the whole batch from the beginning again
       batch.head();
     }
 
     zeebeDbTransaction = transactionContext.getCurrentTransaction();
-    zeebeDbTransaction.run(
-        () -> {
-          batch.forEachRemaining(this::replayEvent);
+    requireNonNull(zeebeDbTransaction)
+        .run(
+            () -> {
+              batch.forEachRemaining(this::replayEvent);
 
-          if (batchSourceEventPosition > snapshotPosition) {
-            lastProcessedPositionState.markAsProcessed(batchSourceEventPosition);
-          }
-        });
+              if (batchSourceEventPosition > snapshotPosition) {
+                lastProcessedPositionState.markAsProcessed(batchSourceEventPosition);
+              }
+            });
 
-    zeebeDbTransaction.commit();
+    requireNonNull(zeebeDbTransaction).commit();
     zeebeDbTransaction = null;
 
     return true;
@@ -230,7 +235,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
             || currentEvent.getSourceEventPosition()
                 < 0)) { // some events might not have a source pointer
       readMetadata(currentEvent);
-      final var currentTypedEvent = readRecordValue(currentEvent);
+      final var currentTypedEvent = requireNonNull(readRecordValue(currentEvent));
       LOG.trace("Replaying event {}: {}", currentTypedEvent.getPosition(), currentTypedEvent);
       currentStateDescription.set(
           "replaying event",
@@ -291,7 +296,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
         new LastProcessingPositions(lastProcessedPosition, lastWrittenPosition);
 
     LOG.info(LOG_STMT_REPLAY_FINISHED, lastProcessingPositions);
-    recoveryFuture.complete(lastProcessingPositions);
+    requireNonNull(recoveryFuture).complete(lastProcessingPositions);
   }
 
   /**
@@ -337,7 +342,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
 
   private TypedRecord<?> readRecordValue(final LoggedEvent currentEvent) {
     final UnifiedRecordValue value =
-        recordValues.readRecordValue(currentEvent, metadata.getValueType());
+        requireNonNull(recordValues.readRecordValue(currentEvent, metadata.getValueType()));
     typedEvent.wrap(currentEvent, metadata, value);
     return typedEvent;
   }
@@ -354,6 +359,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
     return currentStateDescription.toString();
   }
 
+  @Override
   public void close() {
     logStream.removeRecordAvailableListener(this);
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.stream.impl;
 
+import static io.camunda.zeebe.util.Unit.unit;
+
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.logstreams.impl.Loggers;
@@ -177,7 +179,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
       replayStateMachine =
           new ReplayStateMachine(recordProcessors, streamProcessorContext, this::shouldProcessNext);
 
-      openFuture.complete(null);
+      openFuture.complete(unit());
       replayCompletedFuture = replayStateMachine.startRecover(snapshotPosition);
 
       if (!shouldProcess) {
@@ -221,7 +223,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   @Override
   protected void onActorClosed() {
-    closeFuture.complete(null);
+    closeFuture.complete(unit());
     LOG.debug("Closed stream processor controller {}.", getName());
   }
 
@@ -253,7 +255,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     isOpened.set(false);
     lifecycleAwareListeners.forEach(StreamProcessorLifecycleAware::onFailed);
     tearDown();
-    closeFuture.complete(null);
+    closeFuture.complete(unit());
   }
 
   private boolean shouldProcessNext() {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.stream.impl;
 
 import static io.camunda.zeebe.util.Unit.unit;
+import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -41,6 +42,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.agrona.CloseHelper;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 /*
@@ -100,24 +103,24 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private final ZeebeDb zeebeDb;
   // processing
   private final StreamProcessorContext streamProcessorContext;
-  private LogStreamReader logStreamReader;
-  private ProcessingStateMachine processingStateMachine;
-  private ReplayStateMachine replayStateMachine;
+  private @Nullable LogStreamReader logStreamReader;
+  private @Nullable ProcessingStateMachine processingStateMachine;
+  private @Nullable ReplayStateMachine replayStateMachine;
 
-  private CompletableActorFuture<Void> openFuture;
+  private @Nullable CompletableActorFuture<Void> openFuture;
   private final CompletableActorFuture<Void> closeFuture = new CompletableActorFuture<>();
   private volatile long lastTickTime;
   private volatile boolean shouldProcess = true;
-  private ActorFuture<LastProcessingPositions> replayCompletedFuture;
+  private @Nullable ActorFuture<LastProcessingPositions> replayCompletedFuture;
 
   private final List<RecordProcessor> recordProcessors = new ArrayList<>();
-  private AsyncScheduleServiceContext asyncScheduleServiceContext;
+  private @Nullable AsyncScheduleServiceContext asyncScheduleServiceContext;
 
   protected StreamProcessor(final StreamProcessorBuilder processorBuilder) {
     super("StreamProcessor", processorBuilder.getProcessingContext().partitionId());
-    actorSchedulingService = processorBuilder.getActorSchedulingService();
+    actorSchedulingService = requireNonNull(processorBuilder.getActorSchedulingService());
     lifecycleAwareListeners = new ArrayList<>(processorBuilder.getLifecycleListeners());
-    zeebeDb = processorBuilder.getZeebeDb();
+    zeebeDb = requireNonNull(processorBuilder.getZeebeDb());
     scheduledCommandCache = processorBuilder.scheduledCommandCache();
 
     streamProcessorContext =
@@ -130,7 +133,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     partitionId = logStream.getPartitionId();
     metrics = new StreamProcessorMetrics(streamProcessorContext.getMeterRegistry());
     metrics.initializeProcessorPhase(streamProcessorContext.getStreamProcessorPhase());
-    recordProcessors.addAll(processorBuilder.getRecordProcessors());
+    recordProcessors.addAll(requireNonNull(processorBuilder.getRecordProcessors()));
   }
 
   public static StreamProcessorBuilder builder() {
@@ -164,9 +167,10 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
               streamProcessorContext.getScheduledTaskCheckInterval(),
               scheduledTaskMetrics);
 
-      asyncScheduleServiceContext =
+      final var asyncScheduleServiceContext =
           new AsyncScheduleServiceContext(
               actorSchedulingService, actorServiceFactory, streamProcessorContext.partitionId());
+      this.asyncScheduleServiceContext = asyncScheduleServiceContext;
 
       final var processingScheduleService =
           new ExtendedProcessingScheduleServiceImpl(asyncScheduleServiceContext);
@@ -179,7 +183,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
       replayStateMachine =
           new ReplayStateMachine(recordProcessors, streamProcessorContext, this::shouldProcessNext);
 
-      openFuture.complete(unit());
+      requireNonNull(openFuture).complete(unit());
+
       replayCompletedFuture = replayStateMachine.startRecover(snapshotPosition);
 
       if (!shouldProcess) {
@@ -237,7 +242,11 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   @Override
   public ActorFuture<Void> closeAsync() {
     if (isOpened.getAndSet(false)) {
-      actor.run(() -> asyncScheduleServiceContext.closeActors(actor).andThen(actor::close, actor));
+      actor.run(
+          () ->
+              requireNonNull(asyncScheduleServiceContext)
+                  .closeActors(actor)
+                  .andThen(actor::close, actor));
     }
 
     return closeFuture;
@@ -265,7 +274,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private void tearDown() {
     streamProcessorContext.getLogStreamReader().close();
     logStream.removeRecordAvailableListener(this);
-    replayStateMachine.close();
+    CloseHelper.close(replayStateMachine);
     scheduledCommandCache.clear();
   }
 
@@ -298,7 +307,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
       openFuture = new CompletableActorFuture<>();
       actorSchedulingService.submitActor(this);
     }
-    return openFuture;
+    return requireNonNull(openFuture);
   }
 
   private void initRecordProcessors() {
@@ -334,6 +343,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
             .getLastProcessedPositionState()
             .getLastSuccessfulProcessedRecordPosition();
 
+    final var logStreamReader = requireNonNull(this.logStreamReader);
     final boolean failedToRecoverReader = !logStreamReader.seekToNextEvent(snapshotPosition);
     if (failedToRecoverReader
         && streamProcessorContext.getProcessorMode() == StreamProcessorMode.PROCESSING) {
@@ -354,7 +364,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     streamProcessorContext.streamProcessorPhase(Phase.PROCESSING);
     metrics.setStreamProcessorProcessing();
 
-    asyncScheduleServiceContext
+    requireNonNull(asyncScheduleServiceContext)
         .submitActors(actor)
         .onComplete(
             (ignored, error) -> {
@@ -370,13 +380,16 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private void onFailure(final Throwable throwable) {
     LOG.error("Actor {} failed in phase {}.", getName(), actor.getLifecyclePhase(), throwable);
 
-    asyncScheduleServiceContext
+    requireNonNull(asyncScheduleServiceContext)
         .closeActors(actor)
         .onComplete(
             (v, t) -> {
               actor.fail(throwable);
-              if (!openFuture.isDone()) {
-                openFuture.completeExceptionally(throwable);
+              final var actorClock = ActorClock.current();
+              final var instant = actorClock != null ? actorClock.instant() : Instant.now();
+              final var future = requireNonNull(openFuture);
+              if (!future.isDone()) {
+                future.completeExceptionally(throwable);
               }
 
               if (streamProcessorContext.getProcessorMode().equals(StreamProcessorMode.REPLAY)
@@ -384,17 +397,14 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
                 // If the stream processor is in replay mode, we do not want to report it as dead
                 // because it is not critical. The leaders are still active and able to process
                 // requests.
-                final var report =
-                    HealthReport.unhealthy(this)
-                        .withIssue(throwable, ActorClock.current().instant());
+                final var report = HealthReport.unhealthy(this).withIssue(throwable, instant);
                 failureListeners.forEach(l -> l.onFailure(report));
               } else {
 
                 // If it is a leader, we always want to report it as dead so that all related
                 // services
                 // are shutdown. (https://github.com/camunda/camunda/issues/16180)
-                final var report =
-                    HealthReport.dead(this).withIssue(throwable, ActorClock.current().instant());
+                final var report = HealthReport.dead(this).withIssue(throwable, instant);
                 failureListeners.forEach(l -> l.onUnrecoverableFailure(report));
               }
             });
@@ -416,6 +426,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     return actor.call(
         () -> {
           if (isInReplayOnlyMode() || processingStateMachine == null) {
+            final var replayStateMachine = requireNonNull(this.replayStateMachine);
             return replayStateMachine.getLastSourceEventPosition();
           } else {
             return processingStateMachine.getLastSuccessfulProcessedRecordPosition();
@@ -431,6 +442,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     return actor.call(
         () -> {
           if (isInReplayOnlyMode()) {
+            final var replayStateMachine = requireNonNull(this.replayStateMachine);
             return replayStateMachine.getLastReplayedEventPosition();
           } else if (processingStateMachine == null) {
             // StreamProcessor is still replay mode
@@ -448,8 +460,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   @Override
   public HealthReport getHealthReport() {
-    final var instant =
-        ActorClock.current() != null ? ActorClock.current().instant() : Instant.now();
+    final var actorClock = ActorClock.current();
+    final var instant = actorClock != null ? actorClock.instant() : Instant.now();
     if (actor.isClosed()) {
       return HealthReport.unhealthy(this).withMessage("actor is closed", instant);
     }
@@ -509,7 +521,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   }
 
   private void setStateToPausedAndNotifyListeners() {
-    if (isInReplayOnlyMode() || !replayCompletedFuture.isDone()) {
+    if (isInReplayOnlyMode() || !requireNonNull(replayCompletedFuture).isDone()) {
       LOG.debug("Paused replay for partition {}", partitionId);
     } else {
       lifecycleAwareListeners.forEach(StreamProcessorLifecycleAware::onPaused);
@@ -526,9 +538,10 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
         () -> {
           if (!shouldProcess) {
             shouldProcess = true;
-            if (isInReplayOnlyMode() || !replayCompletedFuture.isDone()) {
+            if (isInReplayOnlyMode() || !requireNonNull(replayCompletedFuture).isDone()) {
               streamProcessorContext.streamProcessorPhase(Phase.REPLAY);
               metrics.setStreamProcessorReplay();
+              final var replayStateMachine = requireNonNull(this.replayStateMachine);
               actor.submit(replayStateMachine::replayNextEvent);
               LOG.debug("Resumed replay for partition {}", partitionId);
             } else {
@@ -548,6 +561,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   @Override
   public void onRecordAvailable() {
+    final var processingStateMachine = requireNonNull(this.processingStateMachine);
     actor.run(processingStateMachine::tryToReadNextRecord);
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -118,9 +118,9 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   protected StreamProcessor(final StreamProcessorBuilder processorBuilder) {
     super("StreamProcessor", processorBuilder.getProcessingContext().partitionId());
-    actorSchedulingService = requireNonNull(processorBuilder.getActorSchedulingService());
+    actorSchedulingService = processorBuilder.getActorSchedulingService();
     lifecycleAwareListeners = new ArrayList<>(processorBuilder.getLifecycleListeners());
-    zeebeDb = requireNonNull(processorBuilder.getZeebeDb());
+    zeebeDb = processorBuilder.getZeebeDb();
     scheduledCommandCache = processorBuilder.scheduledCommandCache();
 
     streamProcessorContext =
@@ -133,7 +133,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     partitionId = logStream.getPartitionId();
     metrics = new StreamProcessorMetrics(streamProcessorContext.getMeterRegistry());
     metrics.initializeProcessorPhase(streamProcessorContext.getStreamProcessorPhase());
-    recordProcessors.addAll(requireNonNull(processorBuilder.getRecordProcessors()));
+    recordProcessors.addAll(processorBuilder.getRecordProcessors());
   }
 
   public static StreamProcessorBuilder builder() {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
@@ -93,8 +93,8 @@ public final class StreamProcessorBuilder {
     return streamProcessorContext;
   }
 
-  public @Nullable ActorSchedulingService getActorSchedulingService() {
-    return actorSchedulingService;
+  public ActorSchedulingService getActorSchedulingService() {
+    return requireNonNull(actorSchedulingService);
   }
 
   public List<StreamProcessorLifecycleAware> getLifecycleListeners() {
@@ -107,12 +107,12 @@ public final class StreamProcessorBuilder {
     return this;
   }
 
-  public @Nullable ZeebeDb getZeebeDb() {
-    return zeebeDb;
+  public ZeebeDb<?> getZeebeDb() {
+    return requireNonNull(zeebeDb);
   }
 
-  public @Nullable List<RecordProcessor> getRecordProcessors() {
-    return recordProcessors;
+  public List<RecordProcessor> getRecordProcessors() {
+    return requireNonNull(recordProcessors);
   }
 
   public StreamProcessorBuilder scheduledCommandCache(
@@ -135,6 +135,7 @@ public final class StreamProcessorBuilder {
     requireNonNull(actorSchedulingService, "No task scheduler provided.");
     requireNonNull(streamProcessorContext.getLogStream(), "No log stream provided.");
     requireNonNull(zeebeDb, "No database provided.");
+    requireNonNull(recordProcessors, "Record processors cannot be empty.");
     if (streamProcessorContext.getProcessorMode() == StreamProcessorMode.PROCESSING) {
       requireNonNull(
           streamProcessorContext.getPartitionCommandSender(),

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
@@ -25,14 +25,16 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
+
 public final class StreamProcessorBuilder {
 
   private final StreamProcessorContext streamProcessorContext;
   private final List<StreamProcessorLifecycleAware> lifecycleListeners = new ArrayList<>();
-  private ActorSchedulingService actorSchedulingService;
-  private ZeebeDb zeebeDb;
+  private @Nullable ActorSchedulingService actorSchedulingService;
+  private @Nullable ZeebeDb zeebeDb;
 
-  private List<RecordProcessor> recordProcessors;
+  private @Nullable List<RecordProcessor> recordProcessors;
   private StageableScheduledCommandCache scheduledCommandCache = new NoopScheduledCommandCache();
 
   public StreamProcessorBuilder() {
@@ -91,7 +93,7 @@ public final class StreamProcessorBuilder {
     return streamProcessorContext;
   }
 
-  public ActorSchedulingService getActorSchedulingService() {
+  public @Nullable ActorSchedulingService getActorSchedulingService() {
     return actorSchedulingService;
   }
 
@@ -105,11 +107,11 @@ public final class StreamProcessorBuilder {
     return this;
   }
 
-  public ZeebeDb getZeebeDb() {
+  public @Nullable ZeebeDb getZeebeDb() {
     return zeebeDb;
   }
 
-  public List<RecordProcessor> getRecordProcessors() {
+  public @Nullable List<RecordProcessor> getRecordProcessors() {
     return recordProcessors;
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.stream.impl;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.logstreams.log.LogStream;
@@ -23,8 +25,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
-
 public final class StreamProcessorBuilder {
 
   private final StreamProcessorContext streamProcessorContext;
@@ -130,11 +130,11 @@ public final class StreamProcessorBuilder {
   }
 
   private void validate() {
-    Objects.requireNonNull(actorSchedulingService, "No task scheduler provided.");
-    Objects.requireNonNull(streamProcessorContext.getLogStream(), "No log stream provided.");
-    Objects.requireNonNull(zeebeDb, "No database provided.");
+    requireNonNull(actorSchedulingService, "No task scheduler provided.");
+    requireNonNull(streamProcessorContext.getLogStream(), "No log stream provided.");
+    requireNonNull(zeebeDb, "No database provided.");
     if (streamProcessorContext.getProcessorMode() == StreamProcessorMode.PROCESSING) {
-      Objects.requireNonNull(
+      requireNonNull(
           streamProcessorContext.getPartitionCommandSender(),
           "No partition command sender provided");
     }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -29,38 +29,39 @@ import io.camunda.zeebe.stream.impl.records.RecordValues;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.function.BooleanSupplier;
+import org.jspecify.annotations.Nullable;
 
 public final class StreamProcessorContext implements ReadonlyStreamProcessorContext {
 
   public static final int DEFAULT_MAX_COMMANDS_IN_BATCH = 100;
   public static final int DEFAULT_MAX_RECOVERABLE_RETRIES = 1000;
   private static final StreamProcessorListener NOOP_LISTENER = processedCommand -> {};
-  private ActorControl actor;
-  private LogStream logStream;
-  private PartitionId partitionId;
-  private LogStreamReader logStreamReader;
-  private RecordValues recordValues;
-  private TransactionContext transactionContext;
+  private @Nullable ActorControl actor;
+  private @Nullable LogStream logStream;
+  private @Nullable PartitionId partitionId;
+  private @Nullable LogStreamReader logStreamReader;
+  private @Nullable RecordValues recordValues;
+  private @Nullable TransactionContext transactionContext;
 
-  private BooleanSupplier abortCondition;
+  private @Nullable BooleanSupplier abortCondition;
   private StreamProcessorListener streamProcessorListener = NOOP_LISTENER;
 
   private StreamProcessorMode streamProcessorMode = StreamProcessorMode.PROCESSING;
-  private ProcessingScheduleService processingScheduleService;
-  private MutableLastProcessedPositionState lastProcessedPositionState;
+  private @Nullable ProcessingScheduleService processingScheduleService;
+  private @Nullable MutableLastProcessedPositionState lastProcessedPositionState;
 
-  private LogStreamWriter logStreamWriter;
-  private CommandResponseWriter commandResponseWriter;
-  private InterPartitionCommandSender partitionCommandSender;
+  private @Nullable LogStreamWriter logStreamWriter;
+  private @Nullable CommandResponseWriter commandResponseWriter;
+  private @Nullable InterPartitionCommandSender partitionCommandSender;
 
   // this is accessed outside, which is why we need to make sure that it is thread-safe
   private volatile StreamProcessor.Phase phase = Phase.INITIAL;
-  private KeyGeneratorControls keyGeneratorControls;
+  private @Nullable KeyGeneratorControls keyGeneratorControls;
   private int maxCommandsInBatch = DEFAULT_MAX_COMMANDS_IN_BATCH;
   private int maxRecoverableRetries = DEFAULT_MAX_RECOVERABLE_RETRIES;
   private EventFilter processingFilter = e -> true;
-  private ControllableStreamClock clock;
-  private MeterRegistry meterRegistry;
+  private @Nullable ControllableStreamClock clock;
+  private @Nullable MeterRegistry meterRegistry;
   private Duration scheduledTaskCheckInterval = Duration.ofSeconds(1);
 
   public StreamProcessorContext actor(final ActorControl actor) {
@@ -75,12 +76,17 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
 
   @Override
   public ProcessingScheduleService getScheduleService() {
-    return processingScheduleService;
+    return requireNonNull(processingScheduleService);
   }
 
   @Override
   public int getPartitionId() {
     return getLogStream().getPartitionId();
+  }
+
+  @Override
+  public ControllableStreamClock getClock() {
+    return requireNonNull(clock);
   }
 
   /**
@@ -99,22 +105,17 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
     return this;
   }
 
-  @Override
-  public ControllableStreamClock getClock() {
-    return clock;
-  }
-
   public StreamProcessorContext clock(final ControllableStreamClock clock) {
     this.clock = requireNonNull(clock);
     return this;
   }
 
   public LogStream getLogStream() {
-    return logStream;
+    return requireNonNull(logStream);
   }
 
   public MutableLastProcessedPositionState getLastProcessedPositionState() {
-    return lastProcessedPositionState;
+    return requireNonNull(lastProcessedPositionState);
   }
 
   StreamProcessorContext listener(final StreamProcessorListener streamProcessorListener) {
@@ -171,27 +172,27 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   }
 
   public KeyGeneratorControls getKeyGeneratorControls() {
-    return keyGeneratorControls;
+    return requireNonNull(keyGeneratorControls);
   }
 
   public ActorControl getActor() {
-    return actor;
+    return requireNonNull(actor);
   }
 
   public LogStreamReader getLogStreamReader() {
-    return logStreamReader;
+    return requireNonNull(logStreamReader);
   }
 
   public RecordValues getRecordValues() {
-    return recordValues;
+    return requireNonNull(recordValues);
   }
 
   public TransactionContext getTransactionContext() {
-    return transactionContext;
+    return requireNonNull(transactionContext);
   }
 
   public BooleanSupplier getAbortCondition() {
-    return abortCondition;
+    return requireNonNull(abortCondition);
   }
 
   public StreamProcessorListener getStreamProcessorListener() {
@@ -207,14 +208,14 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   }
 
   public LogStreamWriter getLogStreamWriter() {
-    return logStreamWriter;
+    return requireNonNull(logStreamWriter);
   }
 
   public CommandResponseWriter getCommandResponseWriter() {
-    return commandResponseWriter;
+    return requireNonNull(commandResponseWriter);
   }
 
-  public InterPartitionCommandSender getPartitionCommandSender() {
+  public @Nullable InterPartitionCommandSender getPartitionCommandSender() {
     return partitionCommandSender;
   }
 
@@ -263,7 +264,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   }
 
   public MeterRegistry getMeterRegistry() {
-    return meterRegistry;
+    return requireNonNull(meterRegistry);
   }
 
   public Duration getScheduledTaskCheckInterval() {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.stream.impl;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.db.TransactionContext;
@@ -26,7 +28,6 @@ import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
 import io.camunda.zeebe.stream.impl.records.RecordValues;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
-import java.util.Objects;
 import java.util.function.BooleanSupplier;
 
 public final class StreamProcessorContext implements ReadonlyStreamProcessorContext {
@@ -104,7 +105,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   }
 
   public StreamProcessorContext clock(final ControllableStreamClock clock) {
-    this.clock = Objects.requireNonNull(clock);
+    this.clock = requireNonNull(clock);
     return this;
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/UncontrolledStreamClock.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/UncontrolledStreamClock.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.stream.impl;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification;
 import java.time.Clock;
@@ -19,7 +21,7 @@ public final class UncontrolledStreamClock implements StreamClock {
   private final InstantSource source;
 
   public UncontrolledStreamClock(final InstantSource source) {
-    this.source = Objects.requireNonNull(source);
+    this.source = requireNonNull(source);
   }
 
   @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/package-info.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.stream.impl.metrics;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/package-info.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/package-info.java
@@ -12,4 +12,7 @@
  * sources, but not for the test sources. The test sources can best be refactored after the engine
  * abstraction was fully introduced.
  */
+@NullMarked
 package io.camunda.zeebe.stream.impl;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/RecordBatch.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/RecordBatch.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.stream.impl.records;
 
+import static io.camunda.zeebe.util.Unit.unit;
+
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
@@ -54,7 +56,7 @@ public final class RecordBatch implements MutableRecordBatch {
 
     recordBatchEntries.add(recordBatchEntry);
     batchSize += entryLength;
-    return Either.right(null);
+    return Either.right(unit());
   }
 
   @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/RecordValues.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/RecordValues.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import java.util.Collections;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 public final class RecordValues {
 
@@ -21,7 +22,8 @@ public final class RecordValues {
     eventCache = Collections.unmodifiableMap(UnifiedRecordValue.allRecordsMap());
   }
 
-  public UnifiedRecordValue readRecordValue(final LoggedEvent event, final ValueType valueType) {
+  public @Nullable UnifiedRecordValue readRecordValue(
+      final LoggedEvent event, final ValueType valueType) {
     final UnifiedRecordValue value = eventCache.get(valueType);
     if (value != null) {
       value.reset();

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.stream.impl.records;
 
+import static java.util.Objects.requireNonNull;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
@@ -24,17 +26,19 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.StringUtil;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 public final class TypedRecordImpl implements TypedRecord, WrittenRecord {
   private final int partitionId;
-  private LoggedEvent rawEvent;
-  private RecordMetadata metadata;
-  private UnifiedRecordValue value;
+  private @Nullable LoggedEvent rawEvent;
+  private @Nullable RecordMetadata metadata;
+  private @Nullable UnifiedRecordValue value;
 
   public TypedRecordImpl(final int partitionId) {
     this.partitionId = partitionId;
   }
 
+  @SuppressWarnings("NullAway.Init")
   public void wrap(
       final LoggedEvent rawEvent, final RecordMetadata metadata, final UnifiedRecordValue value) {
     this.rawEvent = rawEvent;
@@ -43,28 +47,28 @@ public final class TypedRecordImpl implements TypedRecord, WrittenRecord {
   }
 
   @JsonIgnore
-  public RecordMetadata getMetadata() {
+  public @Nullable RecordMetadata getMetadata() {
     return metadata;
   }
 
   @Override
   public long getPosition() {
-    return rawEvent.getPosition();
+    return requireNonNull(rawEvent).getPosition();
   }
 
   @Override
   public long getSourceRecordPosition() {
-    return rawEvent.getSourceEventPosition();
+    return requireNonNull(rawEvent).getSourceEventPosition();
   }
 
   @Override
   public long getTimestamp() {
-    return rawEvent.getTimestamp();
+    return requireNonNull(rawEvent).getTimestamp();
   }
 
   @Override
   public Intent getIntent() {
-    return metadata.getIntent();
+    return requireNonNull(metadata).getIntent();
   }
 
   @Override
@@ -74,106 +78,106 @@ public final class TypedRecordImpl implements TypedRecord, WrittenRecord {
 
   @Override
   public RecordType getRecordType() {
-    return metadata.getRecordType();
+    return requireNonNull(metadata).getRecordType();
   }
 
   @Override
   public RejectionType getRejectionType() {
-    return metadata.getRejectionType();
+    return requireNonNull(metadata).getRejectionType();
   }
 
   @Override
   public String getRejectionReason() {
-    return metadata.getRejectionReason();
+    return requireNonNull(metadata).getRejectionReason();
   }
 
   @Override
   public String getBrokerVersion() {
-    return metadata.getBrokerVersion().toString();
+    return requireNonNull(metadata).getBrokerVersion().toString();
   }
 
   @Override
   public Map<String, Object> getAuthorizations() {
-    return metadata.getAuthorization().toDecodedMap();
+    return requireNonNull(metadata).getAuthorization().toDecodedMap();
   }
 
   @Override
   public Agent getAgent() {
-    return metadata.getAgent();
+    return requireNonNull(metadata).getAgent();
   }
 
   @Override
   public ChannelType getRequestChannelType() {
-    return metadata.getRequestChannelType();
+    return requireNonNull(metadata).getRequestChannelType();
   }
 
   @Override
   public String getRequestToolName() {
-    return metadata.getRequestToolName();
+    return requireNonNull(metadata).getRequestToolName();
   }
 
   @Override
   public int getRecordVersion() {
-    return metadata.getRecordVersion();
+    return requireNonNull(metadata).getRecordVersion();
   }
 
   @Override
   public ValueType getValueType() {
-    return metadata.getValueType();
+    return requireNonNull(metadata).getValueType();
   }
 
   @Override
   public long getOperationReference() {
-    return metadata.getOperationReference();
+    return requireNonNull(metadata).getOperationReference();
   }
 
   @Override
   public long getBatchOperationReference() {
-    return metadata.getBatchOperationReference();
+    return requireNonNull(metadata).getBatchOperationReference();
   }
 
   @Override
   public Record copyOf() {
-    return CopiedRecords.createCopiedRecord(getPartitionId(), rawEvent);
+    return CopiedRecords.createCopiedRecord(getPartitionId(), requireNonNull(rawEvent));
   }
 
   @Override
   public long getKey() {
-    return rawEvent.getKey();
+    return requireNonNull(rawEvent).getKey();
   }
 
   @Override
   public UnifiedRecordValue getValue() {
-    return value;
+    return requireNonNull(value);
   }
 
   @Override
   public AuthInfo getAuthInfo() {
-    return metadata.getAuthorization();
+    return requireNonNull(metadata).getAuthorization();
   }
 
   @Override
   @JsonIgnore
   public int getRequestStreamId() {
-    return metadata.getRequestStreamId();
+    return requireNonNull(metadata).getRequestStreamId();
   }
 
   @Override
   @JsonIgnore
   public long getRequestId() {
-    return metadata.getRequestId();
+    return requireNonNull(metadata).getRequestId();
   }
 
   @Override
   @JsonIgnore
   public int getLength() {
-    return metadata.getLength() + value.getLength();
+    return requireNonNull(metadata).getLength() + requireNonNull(value).getLength();
   }
 
   @Override
   @JsonIgnore
   public int getRawLength() {
-    return rawEvent.getLength();
+    return requireNonNull(rawEvent).getLength();
   }
 
   @Override
@@ -187,7 +191,7 @@ public final class TypedRecordImpl implements TypedRecord, WrittenRecord {
         + "metadata="
         + metadata
         + ", value="
-        + StringUtil.limitString(value.toString(), 1024)
+        + StringUtil.limitString(requireNonNull(value).toString(), 1024)
         + '}';
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/package-info.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.stream.impl.records;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/DbKeyGenerator.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/DbKeyGenerator.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.stream.api.state.KeyGeneratorControls;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -172,7 +173,7 @@ public final class DbKeyGenerator implements KeyGeneratorControls {
    *
    * @return the max key value stored in the state , or null if not set
    */
-  public Long getMaxKeyValue() {
+  public @Nullable Long getMaxKeyValue() {
     final var readValue = maxValueColumnFamily.get(maxKeyValueKey);
     if (readValue != null) {
       return readValue.getValue();

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/package-info.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.stream.impl.state;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
## Description
Adds jspecify annotations for stream-platform module.
Modified also `InterpartitionCommandSenderImpl` from `zeebe-broker` as some `Nullable` annotations were added to the interface. 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53265
