### PR TITLE
test: stop waiting for Zeebe records a dropped index cannot deliver in Optimize ITs

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/AbstractCCSMIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/AbstractCCSMIT.java
@@ -54,17 +54,22 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.test.context.ActiveProfiles;
 
 @Tag("ccsm-test")
 @ActiveProfiles(CCSM_PROFILE)
 public abstract class AbstractCCSMIT extends AbstractIT {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractCCSMIT.class);
 
   @RegisterExtension
   @Order(4)
@@ -72,6 +77,9 @@ public abstract class AbstractCCSMIT extends AbstractIT {
 
   protected final Supplier<OptimizeIntegrationTestException> eventNotFoundExceptionSupplier =
       () -> new OptimizeIntegrationTestException("Cannot find exported event");
+
+  /** Set when a test drops Zeebe indices mid-run, which makes later records unobservable. */
+  private boolean zeebeIndicesDroppedMidTest;
 
   protected static boolean isZeebeVersionPre83() {
     final Pattern zeebeVersionPattern = Pattern.compile("8.0.*|8.1.*|8.2.*");
@@ -122,9 +130,25 @@ public abstract class AbstractCCSMIT extends AbstractIT {
   @BeforeEach
   @Order(1)
   public void ensureCleanZeebeState() {
+    zeebeIndicesDroppedMidTest = false;
     // Safety net: records from the previous test may still be in the Zeebe exporter's write queue
     // when after() ran; they can arrive in the window between after() and this @BeforeEach.
     deleteZeebeRecordsAndAssertClean(zeebeExtension.getZeebeRecordPrefix());
+  }
+
+  /**
+   * Drops every Zeebe index for this class except the user-task one, so a test can exercise
+   * user-task import in isolation.
+   *
+   * <p>Dropping the indices is deliberate: the class-scoped exporter keeps writing, and merely
+   * deleting the documents would let later process-instance records land and be imported. The drop
+   * does mean the exporter may not recreate the index, so it also marks the test as no longer able
+   * to observe freshly-generated records — see {@link #after()}.
+   */
+  protected void removeAllZeebeExportRecordsExceptUserTaskRecords() {
+    zeebeIndicesDroppedMidTest = true;
+    databaseIntegrationTestExtension.deleteAllOtherZeebeRecordsWithPrefix(
+        zeebeExtension.getZeebeRecordPrefix(), DatabaseConstants.ZEEBE_USER_TASK_INDEX_NAME);
   }
 
   @BeforeEach
@@ -141,7 +165,12 @@ public abstract class AbstractCCSMIT extends AbstractIT {
   @AfterEach
   public void after() {
     final Set<Long> cancelledKeys = zeebeExtension.cancelAllStartedInstances();
-    waitForCancelledInstancesToExport(cancelledKeys);
+    // Skip the wait when the test dropped the Zeebe indices: the exporter may never recreate
+    // them, so the terminal record we would wait for can never be observed. The retry loop in
+    // deleteZeebeRecordsAndAssertClean handles residual records without blocking.
+    if (!zeebeIndicesDroppedMidTest) {
+      waitForCancelledInstancesToExport(cancelledKeys);
+    }
     deleteZeebeRecordsAndAssertClean(zeebeExtension.getZeebeRecordPrefix());
     // Clean up Optimize's imported data to ensure complete test isolation
     databaseIntegrationTestExtension.deleteAllOptimizeData();
@@ -415,22 +444,61 @@ public abstract class AbstractCCSMIT extends AbstractIT {
   protected void waitUntilMinimumDataExportedCount(
       final long minimumCount, final String indexName, final TermsQueryContainer queryContainer) {
     final String expectedIndex = zeebeExtension.getZeebeRecordPrefix() + "-" + indexName;
-    Awaitility.given()
-        .ignoreExceptions()
-        .timeout(60, TimeUnit.SECONDS)
-        .untilAsserted(
-            () ->
-                assertThat(databaseIntegrationTestExtension.zeebeIndexExists(expectedIndex))
-                    .isTrue());
-    Awaitility.given()
-        .ignoreExceptions()
-        .timeout(60, TimeUnit.SECONDS)
-        .untilAsserted(
-            () ->
-                assertThat(
-                        databaseIntegrationTestExtension.countRecordsByQuery(
-                            queryContainer, expectedIndex))
-                    .isGreaterThanOrEqualTo(minimumCount));
+    // A single wait, not one for the index plus one for the count: a missing index and a
+    // zero count are the same "nothing exported yet" state, so chaining two 60s waits only
+    // doubled the cost of a failure without adding signal.
+    try {
+      Awaitility.given()
+          .ignoreExceptions()
+          .timeout(60, TimeUnit.SECONDS)
+          .untilAsserted(
+              () ->
+                  assertThat(countExportedRecordsOrZero(expectedIndex, queryContainer))
+                      .isGreaterThanOrEqualTo(minimumCount));
+    } catch (final ConditionTimeoutException e) {
+      logZeebeExportDiagnostics(expectedIndex, minimumCount, queryContainer);
+      throw e;
+    }
+  }
+
+  /** Counts matching records, reporting an absent index as zero instead of throwing. */
+  private long countExportedRecordsOrZero(
+      final String expectedIndex, final TermsQueryContainer queryContainer) {
+    if (!databaseIntegrationTestExtension.zeebeIndexExists(expectedIndex)) {
+      return 0L;
+    }
+    return databaseIntegrationTestExtension.countRecordsByQuery(queryContainer, expectedIndex);
+  }
+
+  /** Logs why the export wait gave up, so the next CI occurrence is diagnosable from the log. */
+  private void logZeebeExportDiagnostics(
+      final String expectedIndex,
+      final long minimumCount,
+      final TermsQueryContainer queryContainer) {
+    final boolean indexExists = databaseIntegrationTestExtension.zeebeIndexExists(expectedIndex);
+    Long totalDocs = null;
+    Long matchingDocs = null;
+    if (indexExists) {
+      try {
+        totalDocs =
+            databaseIntegrationTestExtension.countRecordsByQuery(
+                new TermsQueryContainer(), expectedIndex);
+        matchingDocs =
+            databaseIntegrationTestExtension.countRecordsByQuery(queryContainer, expectedIndex);
+      } catch (final Exception e) {
+        LOG.warn("Could not read record counts for index {}", expectedIndex, e);
+      }
+    }
+    LOG.error(
+        "Zeebe export wait timed out. Expected at least {} record(s) in '{}' (prefix '{}'). "
+            + "indexExists={}, totalDocs={}, docsMatchingWaitQuery={}. "
+            + "An absent index here means the exporter never recreated it.",
+        minimumCount,
+        expectedIndex,
+        zeebeExtension.getZeebeRecordPrefix(),
+        indexExists,
+        totalDocs,
+        matchingDocs);
   }
 
   protected Map<String, List<ZeebeUserTaskRecordDto>> getZeebeExportedUserTaskEventsByElementId() {

--- a/optimize/backend/src/it/java/io/camunda/optimize/AbstractCCSMIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/AbstractCCSMIT.java
@@ -69,12 +69,11 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles(CCSM_PROFILE)
 public abstract class AbstractCCSMIT extends AbstractIT {
 
-  private static final Logger LOG = LoggerFactory.getLogger(AbstractCCSMIT.class);
-
   @RegisterExtension
   @Order(4)
   protected static ZeebeExtension zeebeExtension = new ZeebeExtension();
 
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractCCSMIT.class);
   protected final Supplier<OptimizeIntegrationTestException> eventNotFoundExceptionSupplier =
       () -> new OptimizeIntegrationTestException("Cannot find exported event");
 
@@ -444,9 +443,6 @@ public abstract class AbstractCCSMIT extends AbstractIT {
   protected void waitUntilMinimumDataExportedCount(
       final long minimumCount, final String indexName, final TermsQueryContainer queryContainer) {
     final String expectedIndex = zeebeExtension.getZeebeRecordPrefix() + "-" + indexName;
-    // A single wait, not one for the index plus one for the count: a missing index and a
-    // zero count are the same "nothing exported yet" state, so chaining two 60s waits only
-    // doubled the cost of a failure without adding signal.
     try {
       Awaitility.given()
           .ignoreExceptions()
@@ -475,19 +471,20 @@ public abstract class AbstractCCSMIT extends AbstractIT {
       final String expectedIndex,
       final long minimumCount,
       final TermsQueryContainer queryContainer) {
-    final boolean indexExists = databaseIntegrationTestExtension.zeebeIndexExists(expectedIndex);
+    Boolean indexExists = null;
     Long totalDocs = null;
     Long matchingDocs = null;
-    if (indexExists) {
-      try {
+    try {
+      indexExists = databaseIntegrationTestExtension.zeebeIndexExists(expectedIndex);
+      if (indexExists) {
         totalDocs =
             databaseIntegrationTestExtension.countRecordsByQuery(
                 new TermsQueryContainer(), expectedIndex);
         matchingDocs =
             databaseIntegrationTestExtension.countRecordsByQuery(queryContainer, expectedIndex);
-      } catch (final Exception e) {
-        LOG.warn("Could not read record counts for index {}", expectedIndex, e);
       }
+    } catch (final Exception e) {
+      LOG.warn("Could not query diagnostics for index {}", expectedIndex, e);
     }
     LOG.error(
         "Zeebe export wait timed out. Expected at least {} record(s) in '{}' (prefix '{}'). "

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeUserTaskImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeUserTaskImportIT.java
@@ -9,7 +9,6 @@ package io.camunda.optimize.service.importing;
 
 import static io.camunda.optimize.dto.optimize.importing.UserTaskIdentityOperationType.CLAIM_OPERATION_TYPE;
 import static io.camunda.optimize.dto.optimize.importing.UserTaskIdentityOperationType.UNCLAIM_OPERATION_TYPE;
-import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_USER_TASK_INDEX_NAME;
 import static io.camunda.optimize.service.util.importing.ZeebeConstants.FLOW_NODE_TYPE_USER_TASK;
 import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
 import static io.camunda.optimize.util.ZeebeBpmnModels.USER_TASK;
@@ -1023,11 +1022,6 @@ public class ZeebeUserTaskImportIT extends AbstractCCSMIT {
         .map(ZeebeUserTaskRecordDto::getKey)
         .map(String::valueOf)
         .orElseThrow(eventNotFoundExceptionSupplier);
-  }
-
-  private void removeAllZeebeExportRecordsExceptUserTaskRecords() {
-    databaseIntegrationTestExtension.deleteAllOtherZeebeRecordsWithPrefix(
-        zeebeExtension.getZeebeRecordPrefix(), ZEEBE_USER_TASK_INDEX_NAME);
   }
 
   private List<ZeebeUserTaskRecordDto> getZeebeExportedUserTaskEvents() {


### PR DESCRIPTION
## Why

`ZeebeUserTaskImportIT` has been chronically flaky, and when the flake clusters it exhausts the 30-minute budget of the `Optimize / Integration / Elasticsearch ITs (ccsm-test)` job.

The test drops every Zeebe Elasticsearch index except the user-task one (18 call sites) so it can exercise user-task import in isolation. `AbstractCCSMIT.after()` then cancels the still-running instance and waits for that instance's PROCESS-level `ELEMENT_TERMINATED` record — **in the index the test just dropped**. That only succeeds if the Zeebe ES exporter happens to recreate the index and flush in time, so the wait was unsound by construction.

Because the broker and its exporter are class-scoped and shared across all 16 methods, one stall cascades to the rest of the class. That is how a single flake became 9 failures of ~120s each and blew the job budget.

The flake was also present in runs that went green — silently absorbed by `-Dfailsafe.rerunFailingTestsCount=2`, so it stayed invisible until it crossed a time cliff.

## What changed

1. **Teardown no longer waits for a record that cannot arrive.** `removeAllZeebeExportRecordsExceptUserTaskRecords` moved into `AbstractCCSMIT` and marks that indices were dropped; `after()` skips `waitForCancelledInstancesToExport` in that case, falling back to the existing retry-based cleanup. This extends the safeguard `cancelAllStartedInstances` already applied to already-completed instances.
2. **An absent index counts as zero** instead of throwing — a mid-test drop makes absence an expected state.
3. **Two chained 60s Awaitility waits collapsed into one**, halving worst-case cost per occurrence from 120s to 60s. Not a job-timeout increase; a missing index and a zero count are the same "nothing exported yet" state.
4. **Diagnostics logged on wait timeout** (index existence, document counts, record prefix), per `ci.md` §"Flaky tests" — the broker runs in-JVM and its exporter log is not captured today.

The test is not disabled.

## Alternative considered and rejected

Making the mid-test cleanup delete *documents* instead of dropping indices — the obvious fix — **breaks two tests** (`importCompletedUnclaimedZeebeUserTaskData_viaWriter` and `_viaUpdateScript`, `Expected size: 1 but was: 2/3`).

The drop is load-bearing: these tests complete their instance, so the broker keeps emitting process-instance records after the cleanup, and with the index alive those get imported and defeat the `singleElement` assertions. The tests were unknowingly depending on the buggy behaviour. That change was reverted, so `ElasticsearchDatabaseTestService` and `OpenSearchDatabaseTestService` are untouched. Please don't re-attempt it without also reworking those assertions.

## Verification

- `ZeebeUserTaskImportIT`: 16/16 green across 4 runs (43.9s, 38.3s, 47.0s, 44.8s), no reruns consumed.
- Full `ccsm-test` suite: **222 tests, 0 failures, 0 errors** — run in full because the changed teardown is shared by every CCSM IT, so a single-class pass would have been a false green.
- Against real Elasticsearch 8.19.16 using the same compose file CI uses.

**Limitation:** the original flake did not reproduce locally, on either modified or unmodified code. These runs show no regression but do not prove the flake is eliminated. Confirmation needs the repeated-run stress procedure in `ci.md` (~10 `ci.yml` runs on this branch), which has not been done yet.

Closes #58881
