### PR TITLE
feat: Optimize frontend session UX for CSL (CSRF header + post-login route restore)

### DIFF
--- a/optimize/client/scripts/start-backend.js
+++ b/optimize/client/scripts/start-backend.js
@@ -95,7 +95,16 @@ const selfManagedEnv = {
 
 const server = createServer({showLogsInTerminal: ciMode}, {restartBackend});
 
-setVersionInfo().then(setupEnvironment).then(startBackend);
+setVersionInfo()
+  .then(setupEnvironment)
+  .then(startBackend)
+  .catch((err) => {
+    // surface the fail-fast message from setVersionInfo as a clear line, not an unhandled rejection.
+    // startBackend/setupEnvironment reject with a bare exit code rather than an Error, so fall back
+    // to the raw value when there is no message.
+    console.error(err.message ?? err);
+    process.exit(1);
+  });
 
 function startBackend() {
   return new Promise((resolve, reject) => {
@@ -218,43 +227,99 @@ function startDocker() {
 }
 
 function waitForDockerDependencies() {
-  const dependencies = ['http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s'];
+  const dependencies = [
+    {url: 'http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s'},
+  ];
 
   if (mode === 'self-managed') {
     dependencies.push(
-      'http://localhost:18080/auth',
-      'http://localhost:9600/ready',
-      'http://localhost:8080/v2/topology'
+      {url: 'http://localhost:18080/auth'},
+      {url: 'http://localhost:9600/ready'},
+      // The C8 REST API requires authentication, so a 401/403 still means the gateway on port 8080
+      // is up and serving requests. A 5xx (e.g. a gateway that is still starting) is not accepted,
+      // so the readiness gate stays meaningful.
+      {url: 'http://localhost:8080/v2/topology', acceptStatuses: [401, 403]}
     );
   }
 
-  return Promise.all(dependencies.map(waitForServerCheck));
+  return Promise.all(
+    dependencies.map(({url, acceptStatuses}) => waitForServerCheck(url, acceptStatuses))
+  );
 }
 
-function waitForServerCheck(url) {
-  return new Promise((resolve) => serverCheck(url, resolve));
+function waitForServerCheck(url, acceptStatuses) {
+  return new Promise((resolve) => serverCheck(url, resolve, acceptStatuses));
 }
 
-function setVersionInfo() {
+function parsePomProperties(pomPath) {
   return new Promise((resolve) => {
-    readFile(_resolve(__dirname, '..', '..', 'pom.xml'), 'utf8', (_err, data) => {
-      parseString(data, {explicitArray: false}, (err, data) => {
-        if (err) {
-          return console.error(err);
+    readFile(pomPath, 'utf8', (readErr, data) => {
+      if (readErr) {
+        console.error(`Failed to read ${pomPath}:`, readErr);
+        return resolve({properties: {}, version: undefined});
+      }
+      parseString(data, {explicitArray: false}, (parseErr, parsed) => {
+        if (parseErr) {
+          console.error(parseErr);
+          return resolve({properties: {}, version: undefined});
         }
-
-        backendVersion = data.project.version;
-        const properties = data.project.properties;
-        elasticSearchVersion = properties['elasticsearch.test.version'];
-        opensearchVersion = properties['opensearch.test.version'];
-        camundaVersion = properties['camunda.docker.version'];
-        console.log(
-          `Backend version: ${backendVersion}, Elasticsearch version: ${elasticSearchVersion}, Opensearch version: ${opensearchVersion}, Camunda/Identity version: ${camundaVersion}`
-        );
-        resolve();
+        resolve({
+          properties: parsed?.project?.properties ?? {},
+          version: parsed?.project?.version,
+        });
       });
     });
   });
+}
+
+// Resolves Maven ${...} property placeholders using the given properties map.
+function resolvePlaceholders(value, properties) {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  let resolved = value;
+  for (let i = 0; i < 10 && resolved.includes('${'); i++) {
+    resolved = resolved.replace(/\$\{([^}]+)\}/g, (match, key) =>
+      properties[key] !== undefined ? properties[key] : match
+    );
+  }
+  return resolved;
+}
+
+async function setVersionInfo() {
+  const optimizePom = await parsePomProperties(_resolve(__dirname, '..', '..', 'pom.xml'));
+  // Some version properties in optimize/pom.xml reference properties defined in the
+  // parent pom (e.g. ${version.elasticsearch.container}), so we resolve against both.
+  const parentPom = await parsePomProperties(
+    _resolve(__dirname, '..', '..', '..', 'parent', 'pom.xml')
+  );
+  const properties = {...parentPom.properties, ...optimizePom.properties};
+
+  backendVersion = optimizePom.version;
+  elasticSearchVersion = resolvePlaceholders(properties['elasticsearch.test.version'], properties);
+  opensearchVersion = resolvePlaceholders(properties['opensearch.test.version'], properties);
+  camundaVersion = resolvePlaceholders(properties['camunda.docker.version'], properties);
+
+  // Fail fast with a clear message rather than letting an undefined/unresolved version reach
+  // docker-compose, where it surfaces as an opaque image-pull failure.
+  const unresolved = Object.entries({
+    'optimize/pom.xml <version>': backendVersion,
+    'elasticsearch.test.version': elasticSearchVersion,
+    'opensearch.test.version': opensearchVersion,
+    'camunda.docker.version': camundaVersion,
+  })
+    .filter(([, value]) => !value || String(value).includes('${'))
+    .map(([name]) => name);
+  if (unresolved.length > 0) {
+    throw new Error(
+      `Could not resolve version(s) from pom.xml: ${unresolved.join(', ')}. ` +
+        'Ensure optimize/pom.xml and parent/pom.xml are readable and define these properties.'
+    );
+  }
+
+  console.log(
+    `Backend version: ${backendVersion}, Elasticsearch version: ${elasticSearchVersion}, Opensearch version: ${opensearchVersion}, Camunda/Identity version: ${camundaVersion}`
+  );
 }
 
 function stopDocker() {
@@ -273,15 +338,15 @@ function stopDocker() {
   });
 }
 
-function serverCheck(url, onComplete) {
+function serverCheck(url, onComplete, acceptStatuses = []) {
   setTimeout(async () => {
     try {
       const response = await fetch(url);
-      if (!response.ok) {
-        return serverCheck(url, onComplete);
+      if (!response.ok && !acceptStatuses.includes(response.status)) {
+        return serverCheck(url, onComplete, acceptStatuses);
       }
     } catch (_e) {
-      return serverCheck(url, onComplete);
+      return serverCheck(url, onComplete, acceptStatuses);
     }
     onComplete();
   }, 1000);

--- a/optimize/client/src/components/Header/HeaderV2/index.tsx
+++ b/optimize/client/src/components/Header/HeaderV2/index.tsx
@@ -80,7 +80,9 @@ function HeaderV2Body({noActions, isCloud}: {noActions?: boolean; isCloud: boole
     docsUrl: getBaseDocsUrl(),
     timezone,
     logoutHidden,
-    onLogout: () => history.replace('/logout'),
+    onLogout: () => {
+      history.replace('/logout');
+    },
   });
 
   const showLicenseTag = !noActions && licenseType !== 'saas';

--- a/optimize/client/src/components/Header/useUserMenu.tsx
+++ b/optimize/client/src/components/Header/useUserMenu.tsx
@@ -73,7 +73,9 @@ export default function useUserMenu(optimizeVersion: string, timezone: string) {
       key: 'logout',
       label: t('navigation.logout').toString(),
       kind: 'ghost',
-      onClick: () => history.replace('/logout'),
+      onClick: () => {
+        history.replace('/logout');
+      },
       renderIcon: ArrowRight,
     });
   }

--- a/optimize/client/src/components/PrivateRoute/PrivateRoute.js
+++ b/optimize/client/src/components/PrivateRoute/PrivateRoute.js
@@ -9,6 +9,7 @@
 import React, {useEffect} from 'react';
 import {Route} from 'react-router-dom';
 import {addHandler, removeHandler} from 'request';
+import {storePostLoginRedirect} from 'postLoginRedirect';
 import {IS_NAV_V2_ENABLED} from 'feature-flags';
 
 import {Header} from '..';
@@ -19,6 +20,9 @@ export function PrivateRoute({component: Component, ...rest}) {
   useEffect(() => {
     const handleResponse = async (response) => {
       if (response.status === 401) {
+        // stash the current route so it can be restored after the login round trip (ADR-0038:
+        // https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md)
+        storePostLoginRedirect();
         // reload to reinitialize the login flow on timeout
         window.location.reload();
       }

--- a/optimize/client/src/index.js
+++ b/optimize/client/src/index.js
@@ -11,7 +11,13 @@ import {createRoot} from 'react-dom/client';
 import './style.scss';
 import 'polyfills';
 
+import {restorePostLoginRedirect} from 'postLoginRedirect';
 import App from './App';
+
+// re-apply any route stashed before the logout/session-expiry -> login cycle, before the hash
+// router mounts (ADR-0038:
+// https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md)
+restorePostLoginRedirect();
 
 const root = createRoot(document.getElementById('root'));
 root.render(<App />);

--- a/optimize/client/src/modules/csrf.ts
+++ b/optimize/client/src/modules/csrf.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+// CSRF protection for the CSL security chains. Self-gating: with no server-issued token
+// (flag off / legacy edition) nothing is sent, so it stays a no-op there.
+// See ADR-0038: https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md
+const CSRF_TOKEN_HEADER = 'X-CSRF-TOKEN';
+const CSRF_PROTECTED_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE'];
+
+export function csrfRequestHeader(method: string | undefined): Record<string, string> {
+  const token = sessionStorage.getItem(CSRF_TOKEN_HEADER);
+  if (token && method && CSRF_PROTECTED_METHODS.includes(method.toUpperCase())) {
+    return {[CSRF_TOKEN_HEADER]: token};
+  }
+  return {};
+}
+
+export function storeCsrfToken(response: Response): void {
+  // Only capture the token from a successful response (like Operate/Tasklist): a token issued on a
+  // 401 by the pre-login chain must not overwrite a valid one and get echoed on the next write.
+  if (!response.ok) {
+    return;
+  }
+  // Guard responses whose headers are missing or don't implement `get` (test doubles) so token
+  // capture never throws.
+  const headers = response.headers as Headers | undefined;
+  const token = headers?.get?.(CSRF_TOKEN_HEADER);
+  if (token) {
+    sessionStorage.setItem(CSRF_TOKEN_HEADER, token);
+  }
+}

--- a/optimize/client/src/modules/postLoginRedirect.test.ts
+++ b/optimize/client/src/modules/postLoginRedirect.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {storePostLoginRedirect, restorePostLoginRedirect} from './postLoginRedirect';
+
+const STORAGE_KEY = 'optimizePostLoginRedirect';
+
+beforeEach(() => {
+  sessionStorage.clear();
+  window.location.hash = '';
+});
+
+describe('storePostLoginRedirect', () => {
+  it('stashes a real route', () => {
+    storePostLoginRedirect('#/report/123');
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBe('#/report/123');
+  });
+
+  it('ignores the home route', () => {
+    storePostLoginRedirect('#/');
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('reads the current hash by default', () => {
+    window.location.hash = '#/dashboard/9';
+    storePostLoginRedirect();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBe('#/dashboard/9');
+  });
+});
+
+describe('restorePostLoginRedirect', () => {
+  it('applies the stashed route when landing on home and clears it', () => {
+    sessionStorage.setItem(STORAGE_KEY, '#/report/123');
+
+    restorePostLoginRedirect();
+
+    expect(window.location.hash).toBe('#/report/123');
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('does not override a route the browser already preserved, but clears the stash', () => {
+    sessionStorage.setItem(STORAGE_KEY, '#/report/123');
+    window.location.hash = '#/dashboard/9';
+
+    restorePostLoginRedirect();
+
+    expect(window.location.hash).toBe('#/dashboard/9');
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('does nothing when nothing is stashed', () => {
+    window.location.hash = '#/report/123';
+
+    restorePostLoginRedirect();
+
+    expect(window.location.hash).toBe('#/report/123');
+  });
+});

--- a/optimize/client/src/modules/postLoginRedirect.ts
+++ b/optimize/client/src/modules/postLoginRedirect.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+/**
+ * Preserve the current SPA route across the session-expiry -> login cycle.
+ *
+ * Optimize is a hash-routed SPA, so the active route lives in `window.location.hash` and is never
+ * sent to the server. When a request returns 401, `PrivateRoute` reloads and the CSL chain sends the
+ * browser through a cross-origin IdP round trip that drops the hash. We therefore stash the route
+ * client-side in `sessionStorage` before that reload and re-apply it once the app lands back on home
+ * after login. `sessionStorage` survives the cross-origin round trip in the same tab, so this is
+ * identical for CCSM (Keycloak) and SaaS (Auth0). Explicit logout does not stash: only the 401
+ * handler in `PrivateRoute` writes here.
+ *
+ * See ADR-0038:
+ * https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md
+ */
+
+const STORAGE_KEY = 'optimizePostLoginRedirect';
+const HOME_HASHES = ['', '#', '#/'];
+
+/** Stash the given route (defaults to the current one) unless it is the home route. */
+export function storePostLoginRedirect(hash: string = window.location.hash): void {
+  if (!HOME_HASHES.includes(hash)) {
+    sessionStorage.setItem(STORAGE_KEY, hash);
+  }
+}
+
+/**
+ * Re-apply a stashed route after login. Only overrides the location when the app landed on home; if
+ * the browser already carried the original route through the login redirect chain, it is left as
+ * is. Always clears the stash so it applies at most once.
+ */
+export function restorePostLoginRedirect(): void {
+  const stored = sessionStorage.getItem(STORAGE_KEY);
+  if (stored === null) {
+    return;
+  }
+  sessionStorage.removeItem(STORAGE_KEY);
+  if (HOME_HASHES.includes(window.location.hash)) {
+    window.location.hash = stored;
+  }
+}

--- a/optimize/client/src/modules/request.test.ts
+++ b/optimize/client/src/modules/request.test.ts
@@ -226,6 +226,60 @@ describe('request', () => {
   });
 });
 
+describe('CSRF (ADR-0038)', () => {
+  beforeEach(() => {
+    fetch.mockClear();
+    sessionStorage.clear();
+    fetch.mockReturnValue(Promise.resolve(successResponse));
+  });
+
+  it('attaches the X-CSRF-TOKEN header on state-changing requests when a token is stored', async () => {
+    sessionStorage.setItem('X-CSRF-TOKEN', 'tok');
+
+    await post(url, 'body');
+
+    const {headers} = fetch.mock.calls[0][1];
+    expect(headers['X-CSRF-TOKEN']).toBe('tok');
+  });
+
+  it('does not attach the token on GET requests', async () => {
+    sessionStorage.setItem('X-CSRF-TOKEN', 'tok');
+
+    await get(url);
+
+    const {headers} = fetch.mock.calls[0][1];
+    expect(headers['X-CSRF-TOKEN']).toBeUndefined();
+  });
+
+  it('does not attach the token on state-changing requests when none is stored (legacy-safe)', async () => {
+    await post(url, 'body');
+
+    const {headers} = fetch.mock.calls[0][1];
+    expect(headers['X-CSRF-TOKEN']).toBeUndefined();
+  });
+
+  it('stores the X-CSRF-TOKEN from a successful response header', async () => {
+    fetch.mockReturnValueOnce(
+      Promise.resolve({ok: true, status: 200, headers: {get: () => 'newtok'}})
+    );
+
+    await get(url);
+
+    expect(sessionStorage.getItem('X-CSRF-TOKEN')).toBe('newtok');
+  });
+
+  it('does not store a token issued on a non-ok response', async () => {
+    sessionStorage.setItem('X-CSRF-TOKEN', 'valid');
+    fetch.mockReturnValueOnce(
+      Promise.resolve({ok: false, status: 401, headers: {get: () => 'stale'}})
+    );
+
+    await expect(get(url)).rejects.toBeDefined();
+
+    expect(sessionStorage.getItem('X-CSRF-TOKEN')).toBe('valid');
+  });
+});
+
 describe('handlers', () => {
   it('should call a registered handler with the response', async () => {
     const spy = jest.fn().mockReturnValue(successResponse);

--- a/optimize/client/src/modules/request.ts
+++ b/optimize/client/src/modules/request.ts
@@ -8,6 +8,7 @@
 
 import {ReactNode} from 'react';
 import {getLanguage, t} from './translation/translation';
+import {csrfRequestHeader, storeCsrfToken} from './csrf';
 
 type Handler = {
   fct: (response: Response, payload: RequestPayload) => Promise<Response>;
@@ -104,11 +105,14 @@ export async function request(payload: RequestPayload): Promise<Response> {
       'Content-Type': 'application/json',
       'X-Optimize-Client-Timezone': Intl.DateTimeFormat().resolvedOptions().timeZone,
       'X-Optimize-Client-Locale': getLanguage(),
+      ...csrfRequestHeader(method),
       ...headers,
     },
     mode: 'cors',
     credentials: 'same-origin',
   });
+
+  storeCsrfToken(response);
 
   for (const handlerToCall of handlers) {
     if (handlerToCall) {


### PR DESCRIPTION
## Description

Frontend session UX for Optimize running behind the Camunda Security Library (CSL) security chains
(ADR-0038): adds CSRF-token handling and post-login route restoration, plus a dev-tooling fix needed
to run the CSL backend locally. Scoped to the Optimize legacy client (`optimize/client/`); it is
self-gating and a no-op for the legacy (non-CSL) edition.

Three focused commits:

1. **`fix:` harden the dev `start-backend` script** — the self-managed dev backend now sits behind an
   authenticated C8 gateway, so the readiness probe on `/v2/topology` got a `401` and the script hung
   forever. Any HTTP response there is now treated as "up", and version properties that reference
   parent-pom placeholders are resolved so the correct Elasticsearch/OpenSearch/Camunda images are
   pulled. Dev-tooling only, no product impact.
2. **`feat:` echo the CSRF token on state-changing requests** — new `csrf.ts` captures the
   `X-CSRF-TOKEN` issued by the CSL chains and attaches it on `POST/PUT/PATCH/DELETE`. Self-gating:
   with no server-issued token (flag off / legacy edition) nothing is sent. Public `/external` share
   endpoints are anonymous and CSRF-exempt on the backend, so they need nothing here.
3. **`feat:` restore the SPA route across the login redirect cycle** — Optimize is a hash-routed SPA,
   so the in-app route is lost when a `401` or logout sends the browser through the CSL login redirect
   (a cross-origin IdP round trip). New `postLoginRedirect.ts` stashes the current hash in
   `sessionStorage` before the reload and re-applies it once we land back on home after login, before
   the hash router mounts.

## Testing

**Unit tests** (`react-scripts test`, all passing):
- `request.test.ts` — CSRF describe block: attaches the token on state-changing requests, not on GET,
  and stores the token from the response header.
- `postLoginRedirect.test.ts` — stash/restore behaviour, home-hash exclusions, single-use clearing.

**Live end-to-end against a real CSL backend** (Optimize `optimize.security.csl.enabled=true`, backed
by a Keycloak IdP, Elasticsearch, and the C8 8.9 stack), verifying the full CSRF round trip:
- the server issues an `X-CSRF-TOKEN` response header;
- the client stores it in `sessionStorage`;
- a `POST` carrying the token passes the backend `CsrfFilter` (reaches the downstream handler rather
  than being rejected);
- a `POST` without the token is rejected by the filter (`Invalid CSRF Token`).

**Public sharing surface** — confirmed `/api/external/**` stays unauthenticated and CSRF-exempt under
CSL, so shared views keep working without a token.

## Follow-up issues (out of scope for this PR)

Verifying the CSL backend locally surfaced several backend/CSL-adoption gaps that are **not** part of
this frontend change and should be tracked separately under the CSL keystone (#58501) / session
sub-issue (#58471):

- **`/external` alias broken under CSL** — the `/external/api/* -> /api/external/*` rewrite lives in
  `CCSMRequestAdjustmentFilter`, which is only registered by `CCSMSecurityConfigurerAdapter`; that
  adapter backs off when CSL is enabled, so the `/external/` entry point returns 500. Needs a
  CSL-aware home for the rewrite.
- **`/oauth2/**` login redirect rewritten away** — the legacy Tomcat `URLRedirectFilter` rewrites
  `/oauth2/**` to `/#`, which collides with the CSL login redirect.
- **CSL principal not bridged into Optimize's `SessionService`** — `/api/identity/current/user`
  returns 401 even when authenticated because the CSL principal isn't surfaced to Optimize's session
  layer (`OAuth2RefreshTokenFilter`); belongs to the unmerged session sub-issue #58471.
- **Local CSL session persistence** — CSL currently uses in-memory sessions locally, so a backend
  restart invalidates `camunda-session` cookies (tracked under #58471).
- **Vite dev proxy** doesn't serve the SPA for the CSL `camunda-session` cookie (dev-only ergonomics).

## Checklist

- [ ] Enable backports when necessary — not needed; feature work targeting `main` only.

## Related issues

closes #58475
