### PR TITLE
fix: restart usage metric reindex when its task is lost or failed

### DIFF
--- a/migration/usage-metric-migration/pom.xml
+++ b/migration/usage-metric-migration/pom.xml
@@ -127,6 +127,11 @@
       <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/migration/usage-metric-migration/src/main/java/io/camunda/migration/usagemetric/MetricMigrator.java
+++ b/migration/usage-metric-migration/src/main/java/io/camunda/migration/usagemetric/MetricMigrator.java
@@ -19,6 +19,7 @@ import io.camunda.migration.commons.storage.MigrationRepositoryIndex;
 import io.camunda.migration.commons.storage.ProcessorStep;
 import io.camunda.migration.commons.utils.ExceptionFilter;
 import io.camunda.migration.usagemetric.client.UsageMetricMigrationClient;
+import io.camunda.migration.usagemetric.client.UsageMetricMigrationClient.TaskStatus;
 import io.camunda.migration.usagemetric.client.es.ElasticsearchUsageMetricMigrationClient;
 import io.camunda.migration.usagemetric.client.os.OpensearchUsageMetricMigrationClient;
 import io.camunda.migration.usagemetric.util.MetricRegistry;
@@ -31,6 +32,7 @@ import io.camunda.webapps.schema.entities.ImportPositionEntity;
 import io.camunda.zeebe.util.retry.RetryDecorator;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,22 +86,15 @@ public abstract class MetricMigrator implements Migrator {
         } else {
           final var status = client.getTask(taskId);
           log.info("{} migration step exists status {}", getShortName(), status);
-          if (status.found()) {
-            if (status.completed()) {
-              log.info(
-                  "{} migration job {} already completed, nothing to do", getShortName(), taskId);
-              persistStatus(status.taskId(), true);
-              return null;
-            } else {
-              log.info("{} migration job already running {}", getShortName(), status);
-            }
-          } else {
+          if (status.isCompleted()) {
             log.info(
-                "{} migration job {}, is not present, restarting migration",
-                getShortName(),
-                taskId);
-            taskId = reindex();
-            persistStatus(taskId, false);
+                "{} migration job {} already completed, nothing to do", getShortName(), taskId);
+            persistStatus(status.taskId(), true);
+            return null;
+          } else if (status.needsRestart()) {
+            taskId = restartReindex(taskId, status);
+          } else {
+            log.info("{} migration job already running {}", getShortName(), status);
           }
         }
       }
@@ -159,26 +154,49 @@ public abstract class MetricMigrator implements Migrator {
   }
 
   private void monitorReindexTask(final String taskId) throws Exception {
-    final var retryDecorator = busyRetryDecorator();
+    final var currentTaskId = new AtomicReference<>(taskId);
+    final var retryDecorator =
+        busyRetryDecorator().withRetryOnException(p -> !(p instanceof MigrationTimeoutException));
     metricRegistry.measureReindexTask(
         getMeterReindexTaskTimerName(),
         () ->
             retryDecorator.decorate(
-                "Wait for reindex to be completed", () -> pollReindexTask(taskId), done -> !done));
+                "Wait for reindex to be completed",
+                () -> pollReindexTask(currentTaskId),
+                done -> !done));
   }
 
-  private boolean pollReindexTask(final String taskId) {
+  private boolean pollReindexTask(final AtomicReference<String> taskId) {
     try {
-      final var status = client.getTask(taskId);
-      if (status.completed()) {
-        log.info("Reindex task {} completed successfully", taskId);
+      final var status = client.getTask(taskId.get());
+      if (status.isCompleted()) {
+        log.info("Reindex task {} completed successfully", taskId.get());
         persistStatus(status.taskId(), true);
         return true;
+      }
+      if (status.needsRestart()) {
+        taskId.set(restartReindex(taskId.get(), status));
       }
     } catch (final Exception e) {
       log.error("Failed to acquire status of reindexing task", e);
     }
+    if (Instant.now().isAfter(timeout)) {
+      throw new MigrationTimeoutException(
+          "Reindex did not complete within the timeout of %s".formatted(configuration.getTimeout()),
+          false);
+    }
     return false;
+  }
+
+  private String restartReindex(final String previousTaskId, final TaskStatus status) {
+    log.info(
+        "{} migration job {} is {}, restarting reindex",
+        getShortName(),
+        previousTaskId,
+        status.state());
+    final var newTaskId = reindex();
+    persistStatus(newTaskId, false);
+    return newTaskId;
   }
 
   private RetryDecorator busyRetryDecorator() {

--- a/migration/usage-metric-migration/src/main/java/io/camunda/migration/usagemetric/client/UsageMetricMigrationClient.java
+++ b/migration/usage-metric-migration/src/main/java/io/camunda/migration/usagemetric/client/UsageMetricMigrationClient.java
@@ -66,18 +66,37 @@ public interface UsageMetricMigrationClient {
     return step;
   }
 
-  record TaskStatus(
-      String taskId,
-      boolean found,
-      boolean completed,
-      String description,
-      long total,
-      long created,
-      long updated,
-      long deleted) {
+  record TaskStatus(String taskId, State state) {
+
+    enum State {
+      NOT_FOUND,
+      RUNNING,
+      COMPLETED,
+      FAILED
+    }
 
     public static TaskStatus notFound() {
-      return new TaskStatus("", false, false, "", 0, 0, 0, 0);
+      return new TaskStatus("", State.NOT_FOUND);
+    }
+
+    public static TaskStatus running(final String taskId) {
+      return new TaskStatus(taskId, State.RUNNING);
+    }
+
+    public static TaskStatus completed(final String taskId) {
+      return new TaskStatus(taskId, State.COMPLETED);
+    }
+
+    public static TaskStatus failed(final String taskId) {
+      return new TaskStatus(taskId, State.FAILED);
+    }
+
+    public boolean isCompleted() {
+      return state == State.COMPLETED;
+    }
+
+    public boolean needsRestart() {
+      return state == State.NOT_FOUND || state == State.FAILED;
     }
   }
 }

--- a/migration/usage-metric-migration/src/main/java/io/camunda/migration/usagemetric/client/es/ElasticsearchUsageMetricMigrationClient.java
+++ b/migration/usage-metric-migration/src/main/java/io/camunda/migration/usagemetric/client/es/ElasticsearchUsageMetricMigrationClient.java
@@ -186,16 +186,23 @@ public final class ElasticsearchUsageMetricMigrationClient implements UsageMetri
     final int conflicts = status.getInt("version_conflicts");
     final var failures = status.getJsonArray("failures");
     final int total = status.getInt("total");
-    final boolean completed =
-        res.completed()
-            && (failures == null || failures.isEmpty())
+    final boolean successful =
+        (failures == null || failures.isEmpty())
             && res.error() == null
             && (created + updated + deleted + conflicts) >= total;
-    final var taskStatus =
-        new TaskStatus(
-            taskId, true, completed, res.task().description(), total, created, updated, deleted);
-    LOG.debug("Retrieved TaskStatus {}", taskStatus);
-    return taskStatus;
+    LOG.debug(
+        "Task {} completed {}, successful {}, total {}, created {}, updated {}, deleted {}",
+        taskId,
+        res.completed(),
+        successful,
+        total,
+        created,
+        updated,
+        deleted);
+    if (!res.completed()) {
+      return TaskStatus.running(taskId);
+    }
+    return successful ? TaskStatus.completed(taskId) : TaskStatus.failed(taskId);
   }
 
   @Override

--- a/migration/usage-metric-migration/src/main/java/io/camunda/migration/usagemetric/client/os/OpensearchUsageMetricMigrationClient.java
+++ b/migration/usage-metric-migration/src/main/java/io/camunda/migration/usagemetric/client/os/OpensearchUsageMetricMigrationClient.java
@@ -177,24 +177,24 @@ public final class OpensearchUsageMetricMigrationClient implements UsageMetricMi
         return TaskStatus.notFound();
       }
 
-      final boolean completed =
-          res.completed()
-              && res.error() == null
+      final boolean successful =
+          res.error() == null
               && (status.failures() == null || status.failures().isEmpty())
               && (status.created() + status.updated() + status.deleted() + status.versionConflicts()
                   >= status.total());
-      final var taskStatus =
-          new TaskStatus(
-              taskId,
-              true,
-              completed,
-              res.task().description(),
-              status.total(),
-              status.created(),
-              status.updated(),
-              status.deleted());
-      LOG.debug("Retrieved TaskStatus {}", taskStatus);
-      return taskStatus;
+      LOG.debug(
+          "Task {} completed {}, successful {}, total {}, created {}, updated {}, deleted {}",
+          taskId,
+          res.completed(),
+          successful,
+          status.total(),
+          status.created(),
+          status.updated(),
+          status.deleted());
+      if (!res.completed()) {
+        return TaskStatus.running(taskId);
+      }
+      return successful ? TaskStatus.completed(taskId) : TaskStatus.failed(taskId);
     } catch (final Exception e) {
       throw new MigrationException(e);
     }

--- a/migration/usage-metric-migration/src/test/java/io/camunda/migration/usagemetrics/TasklistMetricMigratorIT.java
+++ b/migration/usage-metric-migration/src/test/java/io/camunda/migration/usagemetrics/TasklistMetricMigratorIT.java
@@ -11,6 +11,14 @@ import static io.camunda.migration.usagemetric.client.UsageMetricMigrationClient
 import static io.camunda.search.clients.query.SearchQueryBuilders.ids;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import co.elastic.clients.elasticsearch.core.BulkRequest;
 import com.google.common.hash.Hashing;
@@ -23,7 +31,10 @@ import io.camunda.migration.commons.configuration.MigrationConfiguration;
 import io.camunda.migration.commons.configuration.MigrationProperties;
 import io.camunda.migration.commons.storage.ProcessorStep;
 import io.camunda.migration.commons.storage.TasklistMigrationRepositoryIndex;
+import io.camunda.migration.usagemetric.MetricMigrator;
 import io.camunda.migration.usagemetric.TasklistMetricMigrator;
+import io.camunda.migration.usagemetric.client.UsageMetricMigrationClient;
+import io.camunda.migration.usagemetric.client.UsageMetricMigrationClient.TaskStatus;
 import io.camunda.migration.usagemetric.client.es.ElasticsearchUsageMetricMigrationClient;
 import io.camunda.migration.usagemetric.client.os.OpensearchUsageMetricMigrationClient;
 import io.camunda.search.clients.query.SearchQuery;
@@ -45,14 +56,19 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.invocation.InvocationOnMock;
 
 public class TasklistMetricMigratorIT extends MigrationTest {
+  private static final String FAILING_SCRIPT = "ctx._source.injectedFailure.value = 1";
   private final ThreadLocalRandom rnd = ThreadLocalRandom.current();
   private final List<String> assignees = new ArrayList<>();
   private final Map<String, Long> documentCountPerAssignee = new HashMap<>();
@@ -99,6 +115,43 @@ public class TasklistMetricMigratorIT extends MigrationTest {
     // then
     assertDataMigrated();
 
+    assertProcessorStep(retrieveProcessorStep(), true);
+  }
+
+  @ParameterizedTest(name = "{1} task on {0}")
+  @CsvSource({"true, LOST", "true, FAILED", "false, LOST", "false, FAILED"})
+  void shouldRestartReindexWhenTaskCannotComplete(
+      final boolean isElasticsearch, final ReindexFault fault) throws Exception {
+    // given - metrics that are ready to be migrated and an importer that has finished
+    this.isElasticsearch = isElasticsearch;
+    prepareMetricsReadyForMigration();
+
+    // and - a first reindex task that can never report completion
+    final var migrator =
+        supplyMigrator(
+            isElasticsearch ? ES_CONFIGURATION : OS_CONFIGURATION, properties, meterRegistry);
+    final var client = injectFirstTaskFault(migrator, fault);
+
+    // when - the migration runs
+    final var migration =
+        CompletableFuture.runAsync(
+            () -> {
+              try {
+                migrator.call();
+              } catch (final Exception e) {
+                throw new CompletionException(e);
+              }
+            });
+
+    // then - it restarts the reindex instead of polling the unusable task forever
+    assertThat(migration)
+        .as("migration polled a %s reindex task instead of restarting it (#57988)", fault)
+        .succeedsWithin(Duration.ofSeconds(60));
+
+    // and - the reindex was submitted a second time and all the data was migrated
+    verify(client, times(2)).reindex(any(), any(), any(), any(), any());
+    refreshIndices();
+    assertDataMigrated();
     assertProcessorStep(retrieveProcessorStep(), true);
   }
 
@@ -469,5 +522,58 @@ public class TasklistMetricMigratorIT extends MigrationTest {
 
   private SearchQuery tasklistMigratorStepQuery() {
     return ids(TASKLIST_MIGRATOR_STEP_ID);
+  }
+
+  private void prepareMetricsReadyForMigration() throws Exception {
+    properties.getRetry().setMinRetryDelay(Duration.ofMillis(200));
+    properties.getRetry().setMaxRetryDelay(Duration.ofMillis(200));
+    properties.getRetry().setRetryDelayMultiplier(1);
+
+    generateAssignees(20);
+    generateMetricDocuments(2000);
+    writeImportPositionToIndex(
+        indexFqnForClass(TasklistImportPositionIndex.class), importPosition(true, 1));
+    awaitRecordsArePresent(MetricEntity.class, indexFqnForClass(TasklistMetricIndex.class), 2000);
+  }
+
+  enum ReindexFault {
+    LOST,
+    FAILED
+  }
+
+  private static UsageMetricMigrationClient injectFirstTaskFault(
+      final Migrator migrator, final ReindexFault fault) throws Exception {
+    final var field = MetricMigrator.class.getDeclaredField("client");
+    field.setAccessible(true);
+    final var real = (UsageMetricMigrationClient) field.get(migrator);
+    final var client = mock(UsageMetricMigrationClient.class, delegatesTo(real));
+
+    if (fault == ReindexFault.LOST) {
+      doReturn(TaskStatus.notFound())
+          .doAnswer(invocation -> real.getTask(invocation.getArgument(0)))
+          .when(client)
+          .getTask(anyString());
+    }
+    if (fault == ReindexFault.FAILED) {
+      doAnswer(invocation -> reindexWithScript(real, invocation, FAILING_SCRIPT))
+          .doAnswer(invocation -> reindexWithScript(real, invocation, invocation.getArgument(3)))
+          .when(client)
+          .reindex(any(), any(), any(), any(), any());
+    }
+
+    field.set(migrator, client);
+    return client;
+  }
+
+  private static String reindexWithScript(
+      final UsageMetricMigrationClient real,
+      final InvocationOnMock invocation,
+      final String script) {
+    return real.reindex(
+        invocation.getArgument(0),
+        invocation.getArgument(1),
+        invocation.getArgument(2),
+        script,
+        invocation.getArgument(4));
   }
 }


### PR DESCRIPTION
## Description

The usage metric migrator polls its reindex task until it reports `completed`, retrying with `maxRetries=Integer.MAX_VALUE`. Two states never satisfy that, so the migration hangs forever and raises `DataMigrationStuck`:

1. **The task is gone** — Elasticsearch/OpenSearch was restarted mid-reindex, and in-flight task ids do not survive a restart. `getTask` returns 404.
2. **The task failed** — both clients reported a terminally failed task as `found=true, completed=false`, which is indistinguishable from a task that is still running.

`call()` already recreated a lost reindex on startup, but that only runs between migrator runs, never while the monitor loop is polling. The two places that inspect task status had drifted apart, so only one of them was resilient.

## Fix

- `TaskStatus` carries an explicit state (`NOT_FOUND`, `RUNNING`, `COMPLETED`, `FAILED`) instead of collapsing "done" and "successful" into one flag, so a failed task is distinguishable from a running one. Classification lives in one factory rather than being duplicated per client.
- The monitor loop resubmits the reindex for any state that can never complete and follows the new task id. Resubmitting is safe: the reindex runs with `conflicts=proceed` onto a `create`-only destination, so already migrated documents are untouched.
- `restartReindex` is shared by `call()` and the monitor loop, so the two paths cannot drift again.
- Polling is bounded by the configured migration timeout (default 2h), so a reindex that cannot recover fails the migration instead of retrying invisibly.

Fixes both Elasticsearch and OpenSearch — the change is in the shared base class.

## Tests

Two integration tests in `TasklistMetricMigratorIT`, each run against both Elasticsearch and OpenSearch. Both fail before the fix (the migration never returns) and pass after:

- `shouldRestartReindexWhenInFlightTaskIsLostAfterStorageRestart` — the client reports the in-flight task as gone.
- `shouldRestartReindexWhenTaskFailed` — the first reindex is submitted with a script that throws for every document, so the task genuinely fails and the real client classification is exercised.

Verified locally: 4/4 failures before the fix, 18/18 green after (including the pre-existing tests).

## Review hints

The timeout bound is a behaviour change: a reindex legitimately running longer than the configured timeout now fails the migration instead of waiting. It guards against the new restart path retrying an unrecoverable reindex indefinitely. Happy to drop it if you would rather keep the previous unbounded wait.

Closes #57988
