### PR TITLE
fix: support OAuth resource parameters for Hub ping

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
@@ -175,6 +175,11 @@ public class PingConsoleRunner implements ApplicationRunner, BrokerTopologyListe
         || pingConfiguration.credentials().clientSecret().isBlank()) {
       return Either.left("M2M client secret must not be null or empty.");
     }
+    final var tokenRequestParametersError =
+        pingConfiguration.credentials().tokenRequestParametersValidationError();
+    if (tokenRequestParametersError.isPresent()) {
+      return Either.left(tokenRequestParametersError.get());
+    }
     if (licensePayload.isLeft()) {
       return Either.left(
           "Failed to parse license payload for Console ping task: "

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MCredentials.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MCredentials.java
@@ -8,7 +8,10 @@
 package io.camunda.application.commons.hub.ping;
 
 import java.net.URI;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 public record M2MCredentials(
@@ -21,8 +24,23 @@ public record M2MCredentials(
 
   public M2MCredentials {
     tokenRequestParameters =
-        tokenRequestParameters == null ? Map.of() : Map.copyOf(tokenRequestParameters);
-    tokenRequestParameters.keySet().forEach(M2MCredentials::validateTokenRequestParameterName);
+        tokenRequestParameters == null
+            ? Map.of()
+            : Collections.unmodifiableMap(new LinkedHashMap<>(tokenRequestParameters));
+  }
+
+  public Optional<String> tokenRequestParametersValidationError() {
+    for (final String name : tokenRequestParameters.keySet()) {
+      if (name == null || name.isBlank()) {
+        return Optional.of("Token request parameter names must not be blank.");
+      }
+      if (RESERVED_PARAMETERS.contains(name)) {
+        return Optional.of(
+            "Token request parameter '%s' is managed by Camunda and cannot be overridden."
+                .formatted(name));
+      }
+    }
+    return Optional.empty();
   }
 
   @Override
@@ -34,16 +52,5 @@ public record M2MCredentials(
         + ", clientSecret=***, tokenRequestParameterNames="
         + tokenRequestParameters.keySet()
         + "]";
-  }
-
-  private static void validateTokenRequestParameterName(final String name) {
-    if (name.isBlank()) {
-      throw new IllegalArgumentException("Token request parameter names must not be blank.");
-    }
-    if (RESERVED_PARAMETERS.contains(name)) {
-      throw new IllegalArgumentException(
-          "Token request parameter '%s' is managed by Camunda and cannot be overridden."
-              .formatted(name));
-    }
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MCredentials.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MCredentials.java
@@ -8,14 +8,21 @@
 package io.camunda.application.commons.hub.ping;
 
 import java.net.URI;
+import java.util.Map;
 
-public record M2MCredentials(URI tokenEndpoint, String clientId, String clientSecret) {
+public record M2MCredentials(
+    URI tokenEndpoint,
+    String clientId,
+    String clientSecret,
+    Map<String, String> tokenRequestParameters) {
   @Override
   public String toString() {
     return "M2MCredentials[tokenEndpoint="
         + tokenEndpoint
         + ", clientId="
         + clientId
-        + ", clientSecret=***]";
+        + ", clientSecret=***, tokenRequestParameterNames="
+        + (tokenRequestParameters == null ? null : tokenRequestParameters.keySet())
+        + "]";
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MCredentials.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MCredentials.java
@@ -9,12 +9,22 @@ package io.camunda.application.commons.hub.ping;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Set;
 
 public record M2MCredentials(
     URI tokenEndpoint,
     String clientId,
     String clientSecret,
     Map<String, String> tokenRequestParameters) {
+  private static final Set<String> RESERVED_PARAMETERS =
+      Set.of("grant_type", "client_id", "client_secret");
+
+  public M2MCredentials {
+    tokenRequestParameters =
+        tokenRequestParameters == null ? Map.of() : Map.copyOf(tokenRequestParameters);
+    tokenRequestParameters.keySet().forEach(M2MCredentials::validateTokenRequestParameterName);
+  }
+
   @Override
   public String toString() {
     return "M2MCredentials[tokenEndpoint="
@@ -22,7 +32,18 @@ public record M2MCredentials(
         + ", clientId="
         + clientId
         + ", clientSecret=***, tokenRequestParameterNames="
-        + (tokenRequestParameters == null ? null : tokenRequestParameters.keySet())
+        + tokenRequestParameters.keySet()
         + "]";
+  }
+
+  private static void validateTokenRequestParameterName(final String name) {
+    if (name.isBlank()) {
+      throw new IllegalArgumentException("Token request parameter names must not be blank.");
+    }
+    if (RESERVED_PARAMETERS.contains(name)) {
+      throw new IllegalArgumentException(
+          "Token request parameter '%s' is managed by Camunda and cannot be overridden."
+              .formatted(name));
+    }
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MTokenProvider.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MTokenProvider.java
@@ -17,6 +17,8 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +28,8 @@ public class M2MTokenProvider {
   private static final int TOKEN_EXPIRY_BUFFER_SECONDS = 30;
   private static final int MAX_RESPONSE_LOG_LENGTH = 500;
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final Set<String> RESERVED_PARAMETERS =
+      Set.of("grant_type", "client_id", "client_secret");
 
   private final HttpClient httpClient;
   private final M2MCredentials credentials;
@@ -40,6 +44,7 @@ public class M2MTokenProvider {
   public M2MTokenProvider(final M2MCredentials credentials, final HttpClient httpClient) {
     this.credentials = credentials;
     this.httpClient = httpClient;
+    validateTokenRequestParameters(credentials.tokenRequestParameters());
   }
 
   public synchronized String getToken() throws IOException, InterruptedException {
@@ -51,18 +56,23 @@ public class M2MTokenProvider {
 
   private void refreshToken() throws IOException, InterruptedException {
     LOGGER.debug("Fetching M2M token from {}", credentials.tokenEndpoint());
-    final String requestBody =
-        "grant_type=client_credentials"
-            + "&client_id="
-            + URLEncoder.encode(credentials.clientId(), StandardCharsets.UTF_8)
-            + "&client_secret="
-            + URLEncoder.encode(credentials.clientSecret(), StandardCharsets.UTF_8);
+    final StringBuilder requestBody =
+        new StringBuilder("grant_type=client_credentials")
+            .append("&client_id=")
+            .append(encode(credentials.clientId()))
+            .append("&client_secret=")
+            .append(encode(credentials.clientSecret()));
+    if (credentials.tokenRequestParameters() != null) {
+      credentials.tokenRequestParameters().entrySet().stream()
+          .sorted(Map.Entry.comparingByKey())
+          .forEach(entry -> appendParameter(requestBody, entry.getKey(), entry.getValue()));
+    }
 
     final HttpRequest request =
         HttpRequest.newBuilder()
             .uri(credentials.tokenEndpoint())
             .header("Content-Type", "application/x-www-form-urlencoded")
-            .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+            .POST(HttpRequest.BodyPublishers.ofString(requestBody.toString()))
             .build();
 
     final HttpResponse<String> response =
@@ -91,5 +101,36 @@ public class M2MTokenProvider {
     return s.length() <= MAX_RESPONSE_LOG_LENGTH
         ? s
         : s.substring(0, MAX_RESPONSE_LOG_LENGTH) + "... [truncated]";
+  }
+
+  private static void appendParameter(
+      final StringBuilder requestBody, final String name, final String value) {
+    if (value != null && !value.isBlank()) {
+      requestBody.append('&').append(encode(name)).append('=').append(encode(value));
+    }
+  }
+
+  private static void validateTokenRequestParameters(final Map<String, String> parameters) {
+    if (parameters == null) {
+      return;
+    }
+    parameters
+        .keySet()
+        .forEach(
+            name -> {
+              if (name == null || name.isBlank()) {
+                throw new IllegalArgumentException(
+                    "Token request parameter names must not be blank.");
+              }
+              if (RESERVED_PARAMETERS.contains(name)) {
+                throw new IllegalArgumentException(
+                    "Token request parameter '%s' is managed by Camunda and cannot be overridden."
+                        .formatted(name));
+              }
+            });
+  }
+
+  private static String encode(final String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8);
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MTokenProvider.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MTokenProvider.java
@@ -18,7 +18,6 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Map;
-import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,9 +27,6 @@ public class M2MTokenProvider {
   private static final int TOKEN_EXPIRY_BUFFER_SECONDS = 30;
   private static final int MAX_RESPONSE_LOG_LENGTH = 500;
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-  private static final Set<String> RESERVED_PARAMETERS =
-      Set.of("grant_type", "client_id", "client_secret");
-
   private final HttpClient httpClient;
   private final M2MCredentials credentials;
   private volatile String cachedToken;
@@ -44,7 +40,6 @@ public class M2MTokenProvider {
   public M2MTokenProvider(final M2MCredentials credentials, final HttpClient httpClient) {
     this.credentials = credentials;
     this.httpClient = httpClient;
-    validateTokenRequestParameters(credentials.tokenRequestParameters());
   }
 
   public synchronized String getToken() throws IOException, InterruptedException {
@@ -62,11 +57,9 @@ public class M2MTokenProvider {
             .append(encode(credentials.clientId()))
             .append("&client_secret=")
             .append(encode(credentials.clientSecret()));
-    if (credentials.tokenRequestParameters() != null) {
-      credentials.tokenRequestParameters().entrySet().stream()
-          .sorted(Map.Entry.comparingByKey())
-          .forEach(entry -> appendParameter(requestBody, entry.getKey(), entry.getValue()));
-    }
+    credentials.tokenRequestParameters().entrySet().stream()
+        .sorted(Map.Entry.comparingByKey())
+        .forEach(entry -> appendParameter(requestBody, entry.getKey(), entry.getValue()));
 
     final HttpRequest request =
         HttpRequest.newBuilder()
@@ -108,26 +101,6 @@ public class M2MTokenProvider {
     if (value != null && !value.isBlank()) {
       requestBody.append('&').append(encode(name)).append('=').append(encode(value));
     }
-  }
-
-  private static void validateTokenRequestParameters(final Map<String, String> parameters) {
-    if (parameters == null) {
-      return;
-    }
-    parameters
-        .keySet()
-        .forEach(
-            name -> {
-              if (name == null || name.isBlank()) {
-                throw new IllegalArgumentException(
-                    "Token request parameter names must not be blank.");
-              }
-              if (RESERVED_PARAMETERS.contains(name)) {
-                throw new IllegalArgumentException(
-                    "Token request parameter '%s' is managed by Camunda and cannot be overridden."
-                        .formatted(name));
-              }
-            });
   }
 
   private static String encode(final String value) {

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubRunner.java
@@ -157,6 +157,11 @@ public class PingHubRunner implements ApplicationRunner, BrokerTopologyListener 
         || pingConfiguration.credentials().clientSecret().isBlank()) {
       return Either.left("M2M client secret must not be null or empty.");
     }
+    final var tokenRequestParametersError =
+        pingConfiguration.credentials().tokenRequestParametersValidationError();
+    if (tokenRequestParametersError.isPresent()) {
+      return Either.left(tokenRequestParametersError.get());
+    }
     if (licensePayload.isLeft()) {
       return Either.left(
           "Failed to parse license payload for Hub ping task: "

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
@@ -52,7 +52,7 @@ class PingConsoleConfigurationTest {
       mock(ClusterConfiguration.class);
   private static final M2MCredentials VALID_CREDENTIALS =
       new M2MCredentials(
-          URI.create("http://auth-server.com/token"), "test-client-id", "test-client-secret");
+          URI.create("http://auth-server.com/token"), "test-client-id", "test-client-secret", null);
 
   private final ConsolePingConfiguration pingConfiguration =
       new ConsolePingConfiguration(
@@ -412,7 +412,7 @@ class PingConsoleConfigurationTest {
             Duration.ofMillis(5000),
             new RetryConfiguration(),
             null,
-            new M2MCredentials(null, "clientId", "secret"));
+            new M2MCredentials(null, "clientId", "secret", null));
 
     final PingConsoleRunner runner =
         new PingConsoleRunner(
@@ -440,7 +440,7 @@ class PingConsoleConfigurationTest {
             Duration.ofMillis(5000),
             new RetryConfiguration(),
             null,
-            new M2MCredentials(URI.create("not-a-valid-uri"), "clientId", "secret"));
+            new M2MCredentials(URI.create("not-a-valid-uri"), "clientId", "secret", null));
 
     final PingConsoleRunner runner =
         new PingConsoleRunner(
@@ -469,7 +469,7 @@ class PingConsoleConfigurationTest {
             Duration.ofMillis(5000),
             new RetryConfiguration(),
             null,
-            new M2MCredentials(URI.create("http://auth-server.com/token"), "", "secret"));
+            new M2MCredentials(URI.create("http://auth-server.com/token"), "", "secret", null));
 
     final PingConsoleRunner runner =
         new PingConsoleRunner(
@@ -497,7 +497,7 @@ class PingConsoleConfigurationTest {
             Duration.ofMillis(5000),
             new RetryConfiguration(),
             null,
-            new M2MCredentials(URI.create("http://auth-server.com/token"), "clientId", ""));
+            new M2MCredentials(URI.create("http://auth-server.com/token"), "clientId", "", null));
 
     final PingConsoleRunner runner =
         new PingConsoleRunner(

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
@@ -29,6 +29,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -512,6 +513,39 @@ class PingConsoleConfigurationTest {
     // then
     assertThat(result.isLeft()).isTrue();
     assertThat(result.getLeft()).isEqualTo("M2M client secret must not be null or empty.");
+  }
+
+  @Test
+  void reservedTokenRequestParametersMustBeRejectedGracefully() {
+    // given
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(),
+            null,
+            new M2MCredentials(
+                URI.create("http://auth-server.com/token"),
+                "clientId",
+                "secret",
+                Map.of("client_secret", "override")));
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft())
+        .isEqualTo(
+            "Token request parameter 'client_secret' is managed by Camunda and cannot be overridden.");
   }
 
   @Test

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
@@ -107,7 +107,8 @@ public class PingConsoleRunnerIT {
         .thenReturn(new String[] {"gateway", "broker", "identity"});
 
     final M2MCredentials credentials =
-        new M2MCredentials(URI.create(baseUrl + "/token"), "test-client-id", "test-client-secret");
+        new M2MCredentials(
+            URI.create(baseUrl + "/token"), "test-client-id", "test-client-secret", null);
     final ConsolePingConfiguration config =
         new ConsolePingConfiguration(
             true,
@@ -153,7 +154,8 @@ public class PingConsoleRunnerIT {
     when(environment.getActiveProfiles()).thenReturn(new String[] {"broker"});
 
     final M2MCredentials credentials =
-        new M2MCredentials(URI.create(baseUrl + "/token"), "test-client-id", "test-client-secret");
+        new M2MCredentials(
+            URI.create(baseUrl + "/token"), "test-client-id", "test-client-secret", null);
     final ConsolePingConfiguration config =
         new ConsolePingConfiguration(
             true,

--- a/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubConfigurationTest.java
@@ -27,6 +27,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -35,8 +36,11 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
+import org.springframework.mock.env.MockEnvironment;
 
 @ExtendWith(MockitoExtension.class)
 class PingHubConfigurationTest {
@@ -50,7 +54,7 @@ class PingHubConfigurationTest {
       mock(ClusterConfiguration.class);
   private static final M2MCredentials VALID_CREDENTIALS =
       new M2MCredentials(
-          URI.create("http://auth-server.com/token"), "test-client-id", "test-client-secret");
+          URI.create("http://auth-server.com/token"), "test-client-id", "test-client-secret", null);
 
   private final HubPingConfiguration pingConfiguration =
       new HubPingConfiguration(
@@ -76,6 +80,36 @@ class PingHubConfigurationTest {
     when(BROKER_TOPOLOGY_MANAGER.getClusterConfiguration())
         .thenReturn(BROKER_CLUSTER_CONFIGURATION);
     when(BROKER_CLUSTER_CONFIGURATION.clusterId()).thenReturn(Optional.of("clusterId"));
+  }
+
+  @Test
+  void shouldBindM2MCredentialsWithTokenRequestTargetParameters() {
+    // given
+    final MockEnvironment environment =
+        new MockEnvironment()
+            .withProperty("camunda.hub.ping.credentials.token-endpoint", "https://idp/token")
+            .withProperty("camunda.hub.ping.credentials.client-id", "client")
+            .withProperty("camunda.hub.ping.credentials.client-secret", "secret")
+            .withProperty(
+                "camunda.hub.ping.credentials.token-request-parameters.audience", "https://hub/api")
+            .withProperty(
+                "camunda.hub.ping.credentials.token-request-parameters.scope",
+                "api://hub/.default");
+
+    // when
+    final M2MCredentials credentials =
+        Binder.get(environment)
+            .bind("camunda.hub.ping.credentials", Bindable.of(M2MCredentials.class))
+            .orElseThrow(() -> new AssertionError("M2M credentials were not bound"));
+
+    // then
+    assertThat(credentials)
+        .isEqualTo(
+            new M2MCredentials(
+                URI.create("https://idp/token"),
+                "client",
+                "secret",
+                Map.of("audience", "https://hub/api", "scope", "api://hub/.default")));
   }
 
   @Test
@@ -377,7 +411,7 @@ class PingHubConfigurationTest {
             Duration.ofMillis(5000),
             new RetryConfiguration(),
             null,
-            new M2MCredentials(null, "clientId", "secret"));
+            new M2MCredentials(null, "clientId", "secret", null));
 
     final PingHubRunner runner =
         new PingHubRunner(
@@ -402,7 +436,7 @@ class PingHubConfigurationTest {
             Duration.ofMillis(5000),
             new RetryConfiguration(),
             null,
-            new M2MCredentials(URI.create("not-a-valid-uri"), "clientId", "secret"));
+            new M2MCredentials(URI.create("not-a-valid-uri"), "clientId", "secret", null));
 
     final PingHubRunner runner =
         new PingHubRunner(
@@ -428,7 +462,7 @@ class PingHubConfigurationTest {
             Duration.ofMillis(5000),
             new RetryConfiguration(),
             null,
-            new M2MCredentials(URI.create("http://auth-server.com/token"), "", "secret"));
+            new M2MCredentials(URI.create("http://auth-server.com/token"), "", "secret", null));
 
     final PingHubRunner runner =
         new PingHubRunner(
@@ -453,7 +487,7 @@ class PingHubConfigurationTest {
             Duration.ofMillis(5000),
             new RetryConfiguration(),
             null,
-            new M2MCredentials(URI.create("http://auth-server.com/token"), "clientId", ""));
+            new M2MCredentials(URI.create("http://auth-server.com/token"), "clientId", "", null));
 
     final PingHubRunner runner =
         new PingHubRunner(

--- a/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubConfigurationTest.java
@@ -502,6 +502,36 @@ class PingHubConfigurationTest {
   }
 
   @Test
+  void reservedTokenRequestParametersMustBeRejectedGracefully() {
+    // given
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(),
+            null,
+            new M2MCredentials(
+                URI.create("http://auth-server.com/token"),
+                "clientId",
+                "secret",
+                Map.of("client_secret", "override")));
+    final PingHubRunner runner =
+        new PingHubRunner(
+            config, MANAGEMENT_SERVICES, APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft())
+        .isEqualTo(
+            "Token request parameter 'client_secret' is managed by Camunda and cannot be overridden.");
+  }
+
+  @Test
   void shouldSucceedToStartHubPingForValidConfig() {
     // given
     final HubPingConfiguration config =

--- a/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubRunnerIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubRunnerIT.java
@@ -13,6 +13,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -31,6 +32,7 @@ import io.camunda.zeebe.util.retry.RetryConfiguration;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
@@ -106,7 +108,8 @@ public class PingHubRunnerIT {
         .thenReturn(new String[] {"gateway", "broker", "identity"});
 
     final M2MCredentials credentials =
-        new M2MCredentials(URI.create(baseUrl + "/token"), "test-client-id", "test-client-secret");
+        new M2MCredentials(
+            URI.create(baseUrl + "/token"), "test-client-id", "test-client-secret", null);
     final HubPingConfiguration config =
         new HubPingConfiguration(
             true,
@@ -153,7 +156,8 @@ public class PingHubRunnerIT {
     when(environment.getActiveProfiles()).thenReturn(new String[] {"broker"});
 
     final M2MCredentials credentials =
-        new M2MCredentials(URI.create(baseUrl + "/token"), "test-client-id", "test-client-secret");
+        new M2MCredentials(
+            URI.create(baseUrl + "/token"), "test-client-id", "test-client-secret", null);
     final HubPingConfiguration config =
         new HubPingConfiguration(
             true,
@@ -179,6 +183,67 @@ public class PingHubRunnerIT {
         .isEqualTo("Bearer test-m2m-token");
   }
 
+  @Test
+  void shouldSendConfiguredTokenRequestTargetParameters() throws Exception {
+    // given
+    final String baseUrl = "http://localhost:" + wireMockServer.port();
+    final M2MCredentials credentials =
+        new M2MCredentials(
+            URI.create(baseUrl + "/token"),
+            "test-client-id",
+            "test-client-secret",
+            Map.of(
+                "audience", "https://hub.example/api",
+                "scope", "api://hub/.default",
+                "resource indicator", "hub resource"));
+    final M2MTokenProvider tokenProvider = new M2MTokenProvider(credentials);
+
+    // when
+    tokenProvider.getToken();
+
+    // then
+    final String requestBody = tokenServeEvents().getFirst().getRequest().getBodyAsString();
+    assertThat(requestBody)
+        .contains("audience=https%3A%2F%2Fhub.example%2Fapi")
+        .contains("scope=api%3A%2F%2Fhub%2F.default")
+        .contains("resource+indicator=hub+resource");
+  }
+
+  @Test
+  void shouldOmitUnconfiguredTokenRequestTargetParameters() throws Exception {
+    // given
+    final String baseUrl = "http://localhost:" + wireMockServer.port();
+    final M2MCredentials credentials =
+        new M2MCredentials(
+            URI.create(baseUrl + "/token"), "test-client-id", "test-client-secret", null);
+    final M2MTokenProvider tokenProvider = new M2MTokenProvider(credentials);
+
+    // when
+    tokenProvider.getToken();
+
+    // then
+    final String requestBody = tokenServeEvents().getFirst().getRequest().getBodyAsString();
+    assertThat(requestBody).doesNotContain("audience=").doesNotContain("scope=");
+  }
+
+  @Test
+  void shouldRejectReservedTokenRequestParameters() {
+    // given
+    final String baseUrl = "http://localhost:" + wireMockServer.port();
+    final M2MCredentials credentials =
+        new M2MCredentials(
+            URI.create(baseUrl + "/token"),
+            "test-client-id",
+            "test-client-secret",
+            Map.of("client_secret", "override"));
+
+    // when - then
+    assertThatThrownBy(() -> new M2MTokenProvider(credentials))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("client_secret")
+        .hasMessageContaining("cannot be overridden");
+  }
+
   private long pingEventsCount() {
     return wireMockServer.getAllServeEvents().stream()
         .filter(e -> e.getRequest().getUrl().equals("/ping"))
@@ -188,6 +253,12 @@ public class PingHubRunnerIT {
   private List<ServeEvent> pingServeEvents() {
     return wireMockServer.getAllServeEvents().stream()
         .filter(e -> e.getRequest().getUrl().equals("/ping"))
+        .toList();
+  }
+
+  private List<ServeEvent> tokenServeEvents() {
+    return wireMockServer.getAllServeEvents().stream()
+        .filter(e -> e.getRequest().getUrl().equals("/token"))
         .toList();
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubRunnerIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubRunnerIT.java
@@ -13,7 +13,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -224,24 +223,6 @@ public class PingHubRunnerIT {
     // then
     final String requestBody = tokenServeEvents().getFirst().getRequest().getBodyAsString();
     assertThat(requestBody).doesNotContain("audience=").doesNotContain("scope=");
-  }
-
-  @Test
-  void shouldRejectReservedTokenRequestParameters() {
-    // given
-    final String baseUrl = "http://localhost:" + wireMockServer.port();
-
-    // when - then
-    assertThatThrownBy(
-            () ->
-                new M2MCredentials(
-                    URI.create(baseUrl + "/token"),
-                    "test-client-id",
-                    "test-client-secret",
-                    Map.of("client_secret", "override")))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("client_secret")
-        .hasMessageContaining("cannot be overridden");
   }
 
   private long pingEventsCount() {

--- a/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubRunnerIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubRunnerIT.java
@@ -230,15 +230,15 @@ public class PingHubRunnerIT {
   void shouldRejectReservedTokenRequestParameters() {
     // given
     final String baseUrl = "http://localhost:" + wireMockServer.port();
-    final M2MCredentials credentials =
-        new M2MCredentials(
-            URI.create(baseUrl + "/token"),
-            "test-client-id",
-            "test-client-secret",
-            Map.of("client_secret", "override"));
 
     // when - then
-    assertThatThrownBy(() -> new M2MTokenProvider(credentials))
+    assertThatThrownBy(
+            () ->
+                new M2MCredentials(
+                    URI.create(baseUrl + "/token"),
+                    "test-client-id",
+                    "test-client-secret",
+                    Map.of("client_secret", "override")))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("client_secret")
         .hasMessageContaining("cannot be overridden");


### PR DESCRIPTION
## Summary

- allow Hub ping client-credentials requests to include provider-specific form parameters
- URL-encode custom parameter names and values while protecting Camunda-managed OAuth fields
- preserve existing Keycloak requests when no custom parameters are configured

Auth0 requires an `audience` parameter, while Microsoft Entra requires `scope=<resource>/.default`. The previous implementation sent neither and therefore only worked with providers such as Keycloak that infer the target resource from assigned client roles.

## Validation

- `./mvnw verify -pl dist -Dtest=PingHubConfigurationTest,PingHubRunnerIT,PingConsoleConfigurationTest,PingConsoleRunnerIT -DskipTests=false -DskipITs -Dquickly -T1C`
- `./mvnw install -Dquickly -T1C`
- **Full Helm chart workflow: success** ([run 30356943939](https://github.com/camunda/camunda-platform-helm/actions/runs/30356943939), Helm commit `722413d995095800af4a69753eff0d2e0f0f293c`)
- **Auth0 GKE install: success** ([job 90267802092](https://github.com/camunda/camunda-platform-helm/actions/runs/30356943939/job/90267802092))
- **Microsoft Entra GKE install: success** ([job 90267808095](https://github.com/camunda/camunda-platform-helm/actions/runs/30356943939/job/90267808095))

The complete workflow finished successfully with no failed or cancelled jobs. Both provider jobs ran the authenticated Hub ping post-deploy check, obtained provider tokens, passed Identity role mapping and Hub authorization, and verified the expected cluster and discovery property in Hub's PostgreSQL database.

Related Helm chart PR: https://github.com/camunda/camunda-platform-helm/pull/6655

Related issue: https://github.com/camunda/camunda-platform-helm/issues/6660