### PR TITLE
feat: wire the secret store into the gateway service layer

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.application.commons.service;
 
 import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabled;
 import io.camunda.application.commons.document.CamundaDocumentStoreConfigurationLoader;
+import io.camunda.application.commons.secrets.SecretStoreRegistries;
 import io.camunda.application.commons.security.AuthorizationCheckerProvider;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.UnifiedConfiguration;
@@ -129,7 +130,8 @@ public class CamundaServicesConfiguration {
       final MeterRegistry meterRegistry,
       final Environment environment,
       final ManagementServices managementServices,
-      final ApiServicesExecutorProvider executor) {
+      final ApiServicesExecutorProvider executor,
+      final SecretStoreRegistries secretStoreRegistries) {
 
     final int maxNameFieldLength = gatewayRestConfiguration.getMaxNameFieldLength();
     final boolean secondaryStorageEnabled =
@@ -443,6 +445,7 @@ public class CamundaServicesConfiguration {
                           securityContextProvider,
                           authorizationChecker,
                           tenantSecurity.getAuthorizations(),
+                          secretStoreRegistries.forPhysicalTenant(tenantId),
                           executor,
                           converter))
                   .signalServices(

--- a/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
@@ -16,10 +16,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.camunda.application.commons.secrets.SecretStoreRegistries;
 import io.camunda.application.commons.security.AuthorizationCheckerProvider;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.api.model.authz.AuthorizationScope;
 import io.camunda.security.api.model.authz.PermissionType;
@@ -241,6 +243,41 @@ class CamundaServicesConfigurationTest {
   }
 
   @Test
+  void shouldWireDistinctSecretStoreRegistryPerPhysicalTenantIntoSecretServices() {
+    // given: each physical tenant has its own store registry, keyed by tenant ID
+    final var registryA = new SecretStoreRegistry(Map.of());
+    final var registryB = new SecretStoreRegistry(Map.of());
+    final var registry =
+        buildRegistry(
+            twoTenants(),
+            new AuthorizationCheckerProvider(sharedAuthorizationChecker, Map.of()),
+            new SecretStoreRegistries(Map.of(TENANT_A, registryA, TENANT_B, registryB)));
+
+    // then: each tenant's SecretServices holds exactly its own tenant's registry, so the
+    // store-backed resolve/list (#58497) can never read another tenant's stores
+    assertThat(registry.secretServices(TENANT_A).getSecretStoreRegistry()).isSameAs(registryA);
+    assertThat(registry.secretServices(TENANT_B).getSecretStoreRegistry()).isSameAs(registryB);
+  }
+
+  @Test
+  void shouldFallBackToEmptySecretStoreRegistryWhenTenantAbsentFromRegistries() {
+    // given: the registries hold no entry for any tenant (a tenant with no configured stores
+    // still gets a noop-store registry from SecretStoreConfiguration, so absence only happens
+    // when the secrets bean saw a different tenant set than this wiring)
+    final var registry =
+        buildRegistry(
+            twoTenants(),
+            new AuthorizationCheckerProvider(sharedAuthorizationChecker, Map.of()),
+            new SecretStoreRegistries(Map.of()));
+
+    // then: SecretServices still receives a (store-less) registry instead of null, mirroring the
+    // fallback of SecretStoreRegistries#forPhysicalTenant
+    final var fallback = registry.secretServices(TENANT_A).getSecretStoreRegistry();
+    assertThat(fallback).isNotNull();
+    assertThat(fallback.getStores()).isEmpty();
+  }
+
+  @Test
   void shouldWireExactlyOneEntryWhenOnlyTheDefaultPhysicalTenantExists() {
     // given: a single-PT/default-only deployment
     final var defaultChecker = mock(AuthorizationChecker.class);
@@ -320,6 +357,14 @@ class CamundaServicesConfigurationTest {
   private ServiceRegistry buildRegistry(
       final Map<String, Camunda> tenants,
       final AuthorizationCheckerProvider authorizationCheckerProvider) {
+    return buildRegistry(
+        tenants, authorizationCheckerProvider, new SecretStoreRegistries(Map.of()));
+  }
+
+  private ServiceRegistry buildRegistry(
+      final Map<String, Camunda> tenants,
+      final AuthorizationCheckerProvider authorizationCheckerProvider,
+      final SecretStoreRegistries secretStoreRegistries) {
     final var physicalTenantResolver = mock(PhysicalTenantResolver.class);
     when(physicalTenantResolver.getAll()).thenReturn(tenants);
 
@@ -336,7 +381,8 @@ class CamundaServicesConfigurationTest {
         new SimpleMeterRegistry(),
         new MockEnvironment(),
         new ManagementServices(new CamundaLicense(null)),
-        new ApiServicesExecutorProvider(Executors.newSingleThreadExecutor()));
+        new ApiServicesExecutorProvider(Executors.newSingleThreadExecutor()),
+        secretStoreRegistries);
   }
 
   /** A physical tenant config with {@code security.authorizations.enabled} set as given. */

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -84,6 +84,10 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-secret-store-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>camunda-security-core</artifactId>
     </dependency>
     <dependency>

--- a/service/src/main/java/io/camunda/service/SecretServices.java
+++ b/service/src/main/java/io/camunda/service/SecretServices.java
@@ -21,6 +21,7 @@ import io.camunda.security.core.authz.AuthorizationChecker;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -105,8 +106,12 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
 
   /**
    * Returns the secret stores and caches of this service's physical tenant. Not consulted by the
-   * mocked backend yet; the store-backed resolve/list lands with #58497.
+   * mocked backend yet; the store-backed resolve/list lands with #58497, and reads the field
+   * directly. Exposed only so the wiring can be asserted, deliberately not a production read path:
+   * a caller holding the registry could read a value without the per-reference {@code
+   * SECRET:REVEAL} check {@link #resolve} applies.
    */
+  @VisibleForTesting
   public SecretStoreRegistry getSecretStoreRegistry() {
     return secretStoreRegistry;
   }

--- a/service/src/main/java/io/camunda/service/SecretServices.java
+++ b/service/src/main/java/io/camunda/service/SecretServices.java
@@ -10,6 +10,7 @@ package io.camunda.service;
 import static io.camunda.service.authorization.Authorizations.SECRET_READ_AUTHORIZATION;
 import static io.camunda.service.authorization.Authorizations.SECRET_REVEAL_AUTHORIZATION;
 
+import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.api.model.authz.AuthorizationResourceMatcher;
 import io.camunda.security.api.model.authz.AuthorizationScope;
@@ -41,11 +42,9 @@ import org.slf4j.LoggerFactory;
  *
  * <p><b>Phase 1 scope (#56567, #56568):</b> the per-reference authorization, deduplication,
  * reference validation and per-reference outcome routing are real. The secret backend itself is
- * <b>mocked</b> ({@link #mockResolve}, {@link #mockListReferences}); neither endpoint yet uses the
- * {@code SecretStore} wiring. That wiring needs the physical-tenant {@code SecretStoreRegistry} to
- * be reachable from this module, but the registry currently lives in {@code dist}, which this
- * module cannot depend on without a cycle — resolving that dependency direction is tracked
- * alongside #56561 / #57199.
+ * <b>mocked</b> ({@link #mockResolve}, {@link #mockListReferences}). The physical tenant's {@link
+ * SecretStoreRegistry} is wired in (#58784) but not read yet; replacing the mocks with real store
+ * reads is tracked in #58497.
  */
 @NullMarked
 public class SecretServices extends PhysicalTenantScopedApiServices<SecretServices> {
@@ -76,12 +75,13 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
   // Phase 1 only: the references the mocked backend pretends to know, shared by mockResolve and
   // mockListReferences so a caller who lists then resolves sees consistent references. Any other
   // authorized, valid reference resolves to NOT_FOUND and is absent from the listing. Removed once
-  // a real SecretStore is wired (#56561/#57199).
+  // the wired secret stores replace the mocks (#58497).
   private static final Set<String> MOCK_RESOLVABLE_REFERENCES =
       Set.of("camunda.secrets.token", "camunda.secrets.a", "camunda.secrets.b");
 
   private final AuthorizationChecker authorizationChecker;
   private final AuthorizationsConfiguration authorizationsConfig;
+  private final SecretStoreRegistry secretStoreRegistry;
 
   public SecretServices(
       final String physicalTenantId,
@@ -89,6 +89,7 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
       final SecurityContextProvider securityContextProvider,
       final AuthorizationChecker authorizationChecker,
       final AuthorizationsConfiguration authorizationsConfig,
+      final SecretStoreRegistry secretStoreRegistry,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
@@ -99,6 +100,15 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
         brokerRequestAuthorizationConverter);
     this.authorizationChecker = authorizationChecker;
     this.authorizationsConfig = authorizationsConfig;
+    this.secretStoreRegistry = secretStoreRegistry;
+  }
+
+  /**
+   * Returns the secret stores and caches of this service's physical tenant. Not consulted by the
+   * mocked backend yet; the store-backed resolve/list lands with #58497.
+   */
+  public SecretStoreRegistry getSecretStoreRegistry() {
+    return secretStoreRegistry;
   }
 
   /**
@@ -108,8 +118,7 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
    *
    * <p>Synchronous today (no broker round-trip while the backend is mocked), but returns a future
    * like every other action method on this base class so the signature does not have to break once
-   * the real, likely I/O-bound {@code SecretStore} lookup replaces {@link #mockResolve}
-   * (#56561/#57199).
+   * the real, likely I/O-bound {@code SecretStore} lookup replaces {@link #mockResolve} (#58497).
    */
   public CompletableFuture<SecretResolution> resolve(
       final List<String> references, final CamundaAuthentication authentication) {
@@ -248,8 +257,8 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
    * live endpoint; every other authorized, valid reference yields {@code NOT_FOUND}, exercising the
    * real not-found path rather than fabricating a value for an arbitrary reference. The value is
    * scoped by physical tenant so the mock cannot mask a cross-tenant leak once the real {@code
-   * SecretStore} (which is itself registered per physical tenant) replaces it. TODO(#56561/#57199):
-   * replace with {@code SecretStore.resolve(...)} once store is configured.
+   * SecretStore} (which is itself registered per physical tenant) replaces it. TODO(#58497):
+   * replace with a lookup through {@link #secretStoreRegistry}.
    */
   private Optional<String> mockResolve(final String reference) {
     if (!MOCK_RESOLVABLE_REFERENCES.contains(reference)) {
@@ -263,8 +272,7 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
    * Mocked reference enumeration for Phase 1, sharing {@link #MOCK_RESOLVABLE_REFERENCES} with
    * {@link #mockResolve} so a caller who lists then resolves sees consistent references. Sorted for
    * a deterministic response, since the backing {@link Set} has no defined iteration order.
-   * TODO(#56561/#57199): replace with {@code SecretStore.list(...)} once store wiring is reachable
-   * from this module (see the class Javadoc for why it is not yet).
+   * TODO(#58497): replace with an enumeration through {@link #secretStoreRegistry}.
    */
   private List<String> mockListReferences() {
     return MOCK_RESOLVABLE_REFERENCES.stream().sorted().toList();
@@ -309,8 +317,8 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
 
   /**
    * The typed reason a reference could not be resolved. Mirrors the {@code secret-store} SPI's
-   * {@code SecretErrorCode}; kept independent so the service module does not depend on the store
-   * SPI while the backend is mocked.
+   * {@code SecretErrorCode}; kept independent so the API-facing error contract does not couple to
+   * the SPI's enum and can evolve with the endpoint instead.
    */
   public enum SecretErrorCode {
     NOT_FOUND,

--- a/service/src/test/java/io/camunda/service/SecretServicesAuthorizationCheckerDelegationTest.java
+++ b/service/src/test/java/io/camunda/service/SecretServicesAuthorizationCheckerDelegationTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.api.model.authz.AuthorizationScope;
 import io.camunda.security.api.model.config.AuthorizationsConfiguration;
@@ -25,6 +26,7 @@ import io.camunda.service.SecretServices.SecretResolutionError;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -102,6 +104,7 @@ class SecretServicesAuthorizationCheckerDelegationTest {
         mock(SecurityContextProvider.class),
         authorizationChecker,
         authorizationsConfig,
+        new SecretStoreRegistry(Map.of()),
         mock(ApiServicesExecutorProvider.class),
         null);
   }

--- a/service/src/test/java/io/camunda/service/SecretServicesTest.java
+++ b/service/src/test/java/io/camunda/service/SecretServicesTest.java
@@ -18,6 +18,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.secretstore.NoopSecretStore;
+import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.api.model.authz.AuthorizationScope;
 import io.camunda.security.api.model.config.AuthorizationsConfiguration;
@@ -28,6 +30,7 @@ import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -48,12 +51,18 @@ public class SecretServicesTest {
   }
 
   private SecretServices newSecretServices(final String physicalTenantId) {
+    return newSecretServices(physicalTenantId, new SecretStoreRegistry(Map.of()));
+  }
+
+  private SecretServices newSecretServices(
+      final String physicalTenantId, final SecretStoreRegistry secretStoreRegistry) {
     return new SecretServices(
         physicalTenantId,
         mock(BrokerClient.class),
         mock(SecurityContextProvider.class),
         authorizationChecker,
         authorizationsConfig,
+        secretStoreRegistry,
         mock(ApiServicesExecutorProvider.class),
         null);
   }
@@ -92,6 +101,18 @@ public class SecretServicesTest {
     when(authorizationChecker.retrieveAuthorizedAuthorizationScopes(
             any(), eq(SECRET_READ_AUTHORIZATION)))
         .thenReturn(List.of());
+  }
+
+  @Test
+  void shouldExposeTheSecretStoreRegistryItWasConstructedWith() {
+    // given the per-physical-tenant registry handed in by the dist wiring (#58784)
+    final var registry = new SecretStoreRegistry(Map.of("main", new NoopSecretStore()));
+
+    // when
+    final var services = newSecretServices(PHYSICAL_TENANT_ID, registry);
+
+    // then the same registry is exposed for the store-backed resolve/list (#58497)
+    assertThat(services.getSecretStoreRegistry()).isSameAs(registry);
   }
 
   @Test


### PR DESCRIPTION
## Description

Structural plumbing only, no endpoint behavior change: makes the configured secret stores reachable from the gateway service layer so #58497 can replace the mocked resolve/list backends with real store reads.

- `service` now depends on `camunda-secret-store-api`, and `SecretServices` receives its physical tenant's `SecretStoreRegistry` (stores + caches) at construction, exposed via `getSecretStoreRegistry()`.
- `CamundaServicesConfiguration` injects the `SecretStoreRegistries` bean (the same per-tenant source the broker wiring consumes) and hands each tenant's registry to its `SecretServices`, falling back to an empty registry for tenants without configured stores.
- Resolve/list responses are unchanged; the mock backend stays until #58497.

Notes on the issue's acceptance criteria, which predate the recent store-API refactorings:

- "`SecretStoreRegistry` lives in `dist`" no longer holds: it was moved to `secret-store-api` in https://github.com/camunda/camunda/commit/014e557c33070a354065ae4e2cd73bf112dd02b1, which is what makes this dependency direction legal (`service` -> `secret-store-api`, no cycle).
- "`SecretReference` exposes `name()`" is superseded: `SecretStore`/`SecretCache` became string-keyed by bare secret name and `SecretReference` was removed from the store API in https://github.com/camunda/camunda/commit/db96ba27c6673f333b0e4eaacb77344cb3a4082d. The service layer derives the bare name by stripping the `camunda.secrets.` prefix once #58497 wires the real lookups.

Closes #58784

