### PR TITLE
pg/sigsegv-stop-raft-role-preemptively

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -886,6 +886,19 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     // Unregister protocol listeners.
     unregisterHandlers(protocol);
 
+    // Stop the current role before closing the log. A running role may have queued tasks on the
+    // thread context that append to the log, for example a leader coming out of joint consensus.
+    // Such tasks bail out once the role is no longer running, but if they run against a closed
+    // journal, they write into unmapped memory and crash the JVM.
+    try {
+      role.stop().get();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOGGER.error("Interrupted while stopping role {} on close", role.role(), e);
+    } catch (final Exception e) {
+      LOGGER.error("Failed to stop role {} on close", role.role(), e);
+    }
+
     // Close the log.
     try {
       raftLog.close();

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -171,7 +171,8 @@ public final class ControllableRaftContexts {
   public void shutdown() throws IOException {
     snapshotStores.forEach((m, store) -> store.close());
     snapshotStores.clear();
-    raftServers.forEach((m, c) -> c.close());
+    raftServers.forEach((m, c) -> c.getThreadContext().execute(c::close));
+    raftServers.keySet().forEach(this::runUntilDone);
     raftServers.clear();
     serverProtocols.clear();
     deterministicExecutors.forEach((m, e) -> e.close());

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -81,6 +81,7 @@ public final class SegmentedJournal implements Journal {
 
   @Override
   public JournalRecord append(final long asqn, final BufferWriter recordDataWriter) {
+    assertOpen();
     try (final var ignored = journalMetrics.observeAppendLatency()) {
       return writer.append(asqn, recordDataWriter);
     }
@@ -88,6 +89,7 @@ public final class SegmentedJournal implements Journal {
 
   @Override
   public void append(final JournalRecord record) {
+    assertOpen();
     try (final var ignored = journalMetrics.observeAppendLatency()) {
       writer.append(record);
     }
@@ -95,6 +97,7 @@ public final class SegmentedJournal implements Journal {
 
   @Override
   public JournalRecord append(final long checksum, final byte[] serializedRecord) {
+    assertOpen();
     try (final var ignored = journalMetrics.observeAppendLatency()) {
       return writer.append(checksum, serializedRecord);
     }

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -1080,6 +1080,26 @@ class SegmentedJournalTest {
     assertThat(closed).succeedsWithin(Duration.ofSeconds(5));
   }
 
+  @Test
+  void shouldRejectAppendAfterClose() {
+    // given
+    journalFactory = new TestJournalFactory("test", 2);
+    journal = journalFactory.journal(journalFactory.segmentsManager(directory));
+    journal.append(1, journalFactory.entry());
+    journal.close();
+
+    // when - then
+    assertThatThrownBy(() -> journal.append(2, journalFactory.entry()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("journal not open");
+    assertThatThrownBy(() -> journal.append(journalFactory.entry()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("journal not open");
+    assertThatThrownBy(() -> journal.append(1L, "data".getBytes(StandardCharsets.UTF_8)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("journal not open");
+  }
+
   private SegmentedJournal openJournal(final int entriesPerSegment) {
     return openJournal("test", entriesPerSegment);
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Preemptively close the `RaftRole` before proceeding to close the journal, this is done to terminate any infligth appends queued by the role. Fixes a possible SIGSEGV that was observed in the `RandomizedRaftJoinTest` both over CI and locally reproducible.

```text
13:18:32.268 [raft-server-1 0] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Closing segment: Segment{id=1, index=1}
  13:18:32.268 [raft-server-1 0] DEBUG io.atomix.raft.impl.RaftContext - Raft context closed
  #
  # A fatal error has been detected by the Java Runtime Environment:
  #
  #  SIGSEGV (0xb) at pc=0x00007f49ca601f4a, pid=140344, tid=140345
  #
  # JRE version: OpenJDK Runtime Environment Temurin-25.0.3+9 (25.0.3+9) (build 25.0.3+9-LTS)
  # Java VM: OpenJDK 64-Bit Server VM Temurin-25.0.3+9 (25.0.3+9-LTS, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
  # Problematic frame:
  # J 12089 c2 io.camunda.zeebe.journal.file.SegmentedJournalWriter.appendInCurrentSegmentOrNext(Ljava/util/function/Function;)Lio/camunda/zeebe/journal/JournalRecord; (117 bytes) @ 0x00007f49ca601f4a [0x00007f49ca600620+0x000000000000192a]
  #
  # Core dump will be written. Default location: Determined by the following: "/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h %d %F" (alternatively, falling back to /home/pgoutis/repos/camunda-review/zeebe/atomix/cluster/core.140344)
  #
  # An error report file with more information is saved as:
  # /home/pgoutis/repos/camunda-review/zeebe/atomix/cluster/hs_err_pid140344.log
  [95.494s][warning][os] Loading hsdis library failed
  #
  # If you would like to submit a bug report, please visit:
  #   https://github.com/adoptium/adoptium-support/issues
  #

  Process finished with exit code 134 (interrupted by signal 6:SIGABRT)
```

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
