### PR TITLE
ci: add workflow to build docker image via PR labels

### DIFF
--- a/.github/workflows/build-camunda-image.yml
+++ b/.github/workflows/build-camunda-image.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
+      # Keep action definitions on the trusted base commit; the checkout above may be PR code.
       - uses: camunda/camunda/.github/actions/setup-build@02078341e06bc5f8d76da410fcb3d9ff38e96716
         with:
           dockerhub-readonly: true

--- a/.github/workflows/build-camunda-image.yml
+++ b/.github/workflows/build-camunda-image.yml
@@ -1,0 +1,142 @@
+# type: CI Helper - Reusable
+# owner: @camunda/engineering-operations
+#
+# Reusable workflow that builds and pushes the Camunda (orchestration cluster) and,
+# optionally, the Optimize Docker image to the internal Harbor registry.
+# Called by camunda-load-test.yml and pr-docker-build.yml so image building lives in
+# one place.
+---
+name: Build Camunda image
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref (branch, tag or commit SHA) to build'
+        required: true
+        type: string
+      image-tag:
+        description: 'Tag to publish the image(s) under'
+        required: true
+        type: string
+      image-repository:
+        description: 'Registry prefix, e.g. registry.camunda.cloud/team-zeebe. Images are pushed to <prefix>/camunda and <prefix>/optimize.'
+        required: false
+        default: registry.camunda.cloud/team-zeebe
+        type: string
+      enable-optimize:
+        description: 'Also build and push the Optimize image'
+        required: false
+        default: true
+        type: boolean
+      build-frontend:
+        description: 'Build frontend assets as part of the image build'
+        required: false
+        default: false
+        type: boolean
+      report-build-status:
+        description: 'Report build status via the observe-build-status action'
+        required: false
+        default: false
+        type: boolean
+      runs-on:
+        description: 'Runner label for the build job'
+        required: false
+        default: ubuntu-latest
+        type: string
+      platforms:
+        description: 'Target Docker platforms'
+        required: false
+        default: linux/amd64
+        type: string
+
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+jobs:
+  build-camunda-image:
+    name: Build Camunda
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+      - uses: ./.github/actions/setup-build
+        with:
+          dockerhub-readonly: true
+          harbor: true
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
+      - uses: ./.github/actions/build-frontend
+        name: Build Operate Frontend
+        id: build-operate-fe
+        if: ${{ inputs.build-frontend }}
+        with:
+          directory: ./operate/client
+          package-manager: "npm"
+      - uses: ./.github/actions/build-frontend
+        name: Build Tasklist Frontend
+        id: build-tasklist-fe
+        if: ${{ inputs.build-frontend }}
+        with:
+          directory: ./tasklist/client
+          package-manager: "npm"
+      - uses: ./.github/actions/build-frontend
+        name: Build Identity Frontend
+        id: build-identity-fe
+        if: ${{ inputs.build-frontend }}
+        with:
+          directory: ./identity/client
+          package-manager: "npm"
+      - uses: ./.github/actions/build-frontend
+        name: Build Optimize Frontend
+        id: build-optimize-fe
+        if: ${{ inputs.build-frontend && inputs.enable-optimize }}
+        with:
+          directory: ./optimize/client
+          package-manager: "yarn"
+      - uses: ./.github/actions/build-zeebe
+        name: Build Camunda Platform
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild ${{ inputs.enable-optimize && '-Pinclude-optimize' || '-P\!include-optimize' }}
+      - uses: ./.github/actions/build-platform-docker
+        name: Build Camunda Docker Image
+        with:
+          repository: '${{ inputs.image-repository }}/camunda'
+          revision: ${{ inputs.ref }}
+          push: true
+          version: ${{ inputs.image-tag }}
+          distball: ${{ steps.build-camunda.outputs.distball }}
+          platforms: ${{ inputs.platforms }}
+          dockerfile: 'camunda.Dockerfile'
+      - uses: ./.github/actions/build-platform-docker
+        name: Build Optimize Docker Image
+        if: ${{ inputs.enable-optimize }}
+        with:
+          repository: '${{ inputs.image-repository }}/optimize'
+          revision: ${{ inputs.ref }}
+          push: true
+          version: ${{ inputs.image-tag }}
+          distball: 'optimize-distro/target/camunda-optimize-*.tar.gz'
+          platforms: ${{ inputs.platforms }}
+          dockerfile: 'optimize.Dockerfile'
+      - name: Observe build status
+        if: ${{ always() && inputs.report-build-status }}
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/build-camunda-image.yml
+++ b/.github/workflows/build-camunda-image.yml
@@ -5,6 +5,8 @@
 # optionally, the Optimize Docker image to the internal Harbor registry.
 # Called by camunda-load-test.yml and pr-docker-build.yml so image building lives in
 # one place.
+# Action implementations are pinned to the pre-PR base commit to keep PR checkouts
+# from changing the secret-consuming actions.
 ---
 name: Build Camunda image
 

--- a/.github/workflows/build-camunda-image.yml
+++ b/.github/workflows/build-camunda-image.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
-      - uses: ./.github/actions/setup-build
+      - uses: camunda/camunda/.github/actions/setup-build@02078341e06bc5f8d76da410fcb3d9ff38e96716
         with:
           dockerhub-readonly: true
           harbor: true
@@ -77,40 +77,40 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
-      - uses: ./.github/actions/build-frontend
+      - uses: camunda/camunda/.github/actions/build-frontend@02078341e06bc5f8d76da410fcb3d9ff38e96716
         name: Build Operate Frontend
         id: build-operate-fe
         if: ${{ inputs.build-frontend }}
         with:
           directory: ./operate/client
           package-manager: "npm"
-      - uses: ./.github/actions/build-frontend
+      - uses: camunda/camunda/.github/actions/build-frontend@02078341e06bc5f8d76da410fcb3d9ff38e96716
         name: Build Tasklist Frontend
         id: build-tasklist-fe
         if: ${{ inputs.build-frontend }}
         with:
           directory: ./tasklist/client
           package-manager: "npm"
-      - uses: ./.github/actions/build-frontend
+      - uses: camunda/camunda/.github/actions/build-frontend@02078341e06bc5f8d76da410fcb3d9ff38e96716
         name: Build Identity Frontend
         id: build-identity-fe
         if: ${{ inputs.build-frontend }}
         with:
           directory: ./identity/client
           package-manager: "npm"
-      - uses: ./.github/actions/build-frontend
+      - uses: camunda/camunda/.github/actions/build-frontend@02078341e06bc5f8d76da410fcb3d9ff38e96716
         name: Build Optimize Frontend
         id: build-optimize-fe
         if: ${{ inputs.build-frontend && inputs.enable-optimize }}
         with:
           directory: ./optimize/client
           package-manager: "yarn"
-      - uses: ./.github/actions/build-zeebe
+      - uses: camunda/camunda/.github/actions/build-zeebe@02078341e06bc5f8d76da410fcb3d9ff38e96716
         name: Build Camunda Platform
         id: build-camunda
         with:
           maven-extra-args: -PskipFrontendBuild ${{ inputs.enable-optimize && '-Pinclude-optimize' || '-P\!include-optimize' }}
-      - uses: ./.github/actions/build-platform-docker
+      - uses: camunda/camunda/.github/actions/build-platform-docker@02078341e06bc5f8d76da410fcb3d9ff38e96716
         name: Build Camunda Docker Image
         with:
           repository: '${{ inputs.image-repository }}/camunda'
@@ -120,7 +120,7 @@ jobs:
           distball: ${{ steps.build-camunda.outputs.distball }}
           platforms: ${{ inputs.platforms }}
           dockerfile: 'camunda.Dockerfile'
-      - uses: ./.github/actions/build-platform-docker
+      - uses: camunda/camunda/.github/actions/build-platform-docker@02078341e06bc5f8d76da410fcb3d9ff38e96716
         name: Build Optimize Docker Image
         if: ${{ inputs.enable-optimize }}
         with:
@@ -134,7 +134,7 @@ jobs:
       - name: Observe build status
         if: ${{ always() && inputs.report-build-status }}
         continue-on-error: true
-        uses: ./.github/actions/observe-build-status
+        uses: camunda/camunda/.github/actions/observe-build-status@02078341e06bc5f8d76da410fcb3d9ff38e96716
         with:
           build_status: ${{ job.status }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -391,85 +391,18 @@ jobs:
     name: Build Camunda
     needs: calculate-image-tag
     if: ${{ inputs.reuse-tag == '' && inputs.orchestration-tag == '' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+    uses: ./.github/workflows/build-camunda-image.yml
     permissions:
       contents: 'read'
       id-token: 'write'
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ inputs.ref }}
-          persist-credentials: false
-      - uses: ./.github/actions/setup-build
-        with:
-          dockerhub-readonly: true
-          harbor: true
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-          minimus: true
-      - uses: ./.github/actions/build-frontend
-        name: Build Operate Frontend
-        id: build-operate-fe
-        if: ${{ inputs.build-frontend }}
-        with:
-          directory: ./operate/client
-          package-manager: "npm"
-      - uses: ./.github/actions/build-frontend
-        name: Build Tasklist Frontend
-        id: build-tasklist-fe
-        if: ${{ inputs.build-frontend }}
-        with:
-          directory: ./tasklist/client
-          package-manager: "npm"
-      - uses: ./.github/actions/build-frontend
-        name: Build Identity Frontend
-        id: build-identity-fe
-        if: ${{ inputs.build-frontend }}
-        with:
-          directory: ./identity/client
-          package-manager: "npm"
-      - uses: ./.github/actions/build-frontend
-        name: Build Optimize Frontend
-        id: build-optimize-fe
-        if: ${{ inputs.build-frontend && inputs.enable-optimize }}
-        with:
-          directory: ./optimize/client
-          package-manager: "yarn"
-      - uses: ./.github/actions/build-zeebe
-        name: Build Camunda Platform
-        id: build-camunda
-        with:
-          maven-extra-args: -PskipFrontendBuild ${{ inputs.enable-optimize && '-Pinclude-optimize' || '-P\!include-optimize' }}
-      - uses: ./.github/actions/build-platform-docker
-        name: Build Camunda Docker Image
-        with:
-          repository: '${{ env.IMAGE_REPOSITORY }}/camunda'
-          revision: ${{ inputs.ref }}
-          push: true
-          version: ${{ needs.calculate-image-tag.outputs.image-tag }}
-          distball: ${{ steps.build-camunda.outputs.distball }}
-          dockerfile: 'camunda.Dockerfile'
-      - uses: ./.github/actions/build-platform-docker
-        name: Build Optimize Docker Image
-        if: ${{ inputs.enable-optimize }}
-        with:
-          repository: '${{ env.IMAGE_REPOSITORY }}/optimize'
-          revision: ${{ inputs.ref }}
-          push: true
-          version: ${{ needs.calculate-image-tag.outputs.image-tag }}
-          distball: 'optimize-distro/target/camunda-optimize-*.tar.gz'
-          dockerfile: 'optimize.Dockerfile'
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+    with:
+      ref: ${{ inputs.ref }}
+      image-tag: ${{ needs.calculate-image-tag.outputs.image-tag }}
+      image-repository: registry.camunda.cloud/team-zeebe
+      enable-optimize: ${{ inputs.enable-optimize }}
+      build-frontend: ${{ inputs.build-frontend }}
+      report-build-status: true
+    secrets: inherit
 
   build-load-test-images:
     name: Build Starter and Worker

--- a/.github/workflows/pr-docker-build.yml
+++ b/.github/workflows/pr-docker-build.yml
@@ -34,7 +34,8 @@ jobs:
   calculate-image-tag:
     name: Calculate image tag
     # Run when a build label is added, or on new pushes while a build label is present.
-    # Only allow same-repository PRs so fork code cannot enter the secret-consuming build.
+    # Only allow same-repository PRs so fork code cannot enter the secret-consuming build;
+    # fork PRs with these labels are silently skipped.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
       ((github.event.action == 'labeled' && (github.event.label.name == 'build-docker-image' || github.event.label.name == 'build-docker-image-oc')) ||

--- a/.github/workflows/pr-docker-build.yml
+++ b/.github/workflows/pr-docker-build.yml
@@ -18,6 +18,8 @@ on:
   pull_request:
     types: [labeled, synchronize]
 
+permissions: {}
+
 defaults:
   run:
     # use bash shell by default to ensure pipefail behavior is the default
@@ -33,8 +35,9 @@ jobs:
     name: Calculate image tag
     # Run when a build label is added, or on new pushes while a build label is present.
     if: >-
-      (github.event.action == 'labeled' && (github.event.label.name == 'build-docker-image' || github.event.label.name == 'build-docker-image-oc')) ||
-      (github.event.action == 'synchronize' && (contains(github.event.pull_request.labels.*.name, 'build-docker-image') || contains(github.event.pull_request.labels.*.name, 'build-docker-image-oc')))
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      ((github.event.action == 'labeled' && (github.event.label.name == 'build-docker-image' || github.event.label.name == 'build-docker-image-oc')) ||
+      (github.event.action == 'synchronize' && (contains(github.event.pull_request.labels.*.name, 'build-docker-image') || contains(github.event.pull_request.labels.*.name, 'build-docker-image-oc'))))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}

--- a/.github/workflows/pr-docker-build.yml
+++ b/.github/workflows/pr-docker-build.yml
@@ -34,6 +34,7 @@ jobs:
   calculate-image-tag:
     name: Calculate image tag
     # Run when a build label is added, or on new pushes while a build label is present.
+    # Only allow same-repository PRs so fork code cannot enter the secret-consuming build.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
       ((github.event.action == 'labeled' && (github.event.label.name == 'build-docker-image' || github.event.label.name == 'build-docker-image-oc')) ||

--- a/.github/workflows/pr-docker-build.yml
+++ b/.github/workflows/pr-docker-build.yml
@@ -1,0 +1,66 @@
+# type: CI Helper - PR
+# owner: @camunda/engineering-operations
+#
+# Builds and pushes the Camunda (orchestration cluster) and, optionally, the Optimize
+# Docker image to the internal Harbor registry when a build label is present on a PR.
+# The image is tagged with the PR number only, e.g. pr-1234. The tag is mutable: each
+# push to the PR overwrites it, so only one tag per PR ever exists (no registry bloat).
+# Consumers MUST use imagePullPolicy: Always to avoid pulling a stale cached image.
+# Labels:
+#   - build-docker-image     -> build everything (backend + frontend + Optimize)
+#   - build-docker-image-oc  -> build only the orchestration cluster backend
+#                               (no frontend, no Optimize)
+# The actual build is delegated to the reusable build-camunda-image.yml workflow.
+---
+name: PR Docker build
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+concurrency:
+  group: pr-docker-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  calculate-image-tag:
+    name: Calculate image tag
+    # Run when a build label is added, or on new pushes while a build label is present.
+    if: >-
+      (github.event.action == 'labeled' && (github.event.label.name == 'build-docker-image' || github.event.label.name == 'build-docker-image-oc')) ||
+      (github.event.action == 'synchronize' && (contains(github.event.pull_request.labels.*.name, 'build-docker-image') || contains(github.event.pull_request.labels.*.name, 'build-docker-image-oc')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    outputs:
+      image-tag: ${{ steps.image-tag.outputs.image-tag }}
+    steps:
+      - id: image-tag
+        name: Calculate image tag
+        run: |
+          image_tag="pr-${PR_NUMBER}"
+          echo "image-tag=${image_tag}" >> "$GITHUB_OUTPUT"
+          echo "**Built image tag:** \`${image_tag}\` (mutable — overwritten on each push; use imagePullPolicy: Always)" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
+  build-camunda-image:
+    name: Build & push Camunda Docker images
+    needs: calculate-image-tag
+    uses: ./.github/workflows/build-camunda-image.yml
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+      image-tag: ${{ needs.calculate-image-tag.outputs.image-tag }}
+      # "build-docker-image" builds everything; "build-docker-image-oc" backend only.
+      enable-optimize: ${{ contains(github.event.pull_request.labels.*.name, 'build-docker-image') }}
+      build-frontend: ${{ contains(github.event.pull_request.labels.*.name, 'build-docker-image') }}
+    secrets: inherit


### PR DESCRIPTION
## Description
Extracts from the camunda-load-test workflow the steps to build an image.
Adds new labels to build a docker image.
This is useful when you need to test an image and you need it in the registry, for example when testing a ECS deployment.  

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
