### PR TITLE
feat: add batch operation status handlers for process instance suspend/resume

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
@@ -12,7 +12,6 @@ import static io.camunda.it.auditlog.AuditLogUtils.TENANT_A;
 import static io.camunda.it.util.TestHelper.deployProcessForTenantAndWaitForIt;
 import static io.camunda.it.util.TestHelper.startProcessInstanceWithMessageForTenant;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationCompleted;
-import static io.camunda.it.util.TestHelper.waitForBatchOperationStatus;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationWithCorrectTotalCount;
 import static io.camunda.it.util.TestHelper.waitForDecisionsToBeDeployed;
 import static io.camunda.it.util.TestHelper.waitForJobs;
@@ -35,7 +34,6 @@ import io.camunda.client.api.search.enums.AuditLogCategoryEnum;
 import io.camunda.client.api.search.enums.AuditLogEntityTypeEnum;
 import io.camunda.client.api.search.enums.AuditLogOperationTypeEnum;
 import io.camunda.client.api.search.enums.AuditLogResultEnum;
-import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.filter.AuditLogFilter;
 import io.camunda.client.api.search.response.AuditLogResult;
@@ -1083,7 +1081,7 @@ public class AuditLogProcessOperationsIT {
 
     final var batchOperationKey = batchResult.getBatchOperationKey();
     waitForBatchOperationWithCorrectTotalCount(client, batchOperationKey, 2);
-    waitForBatchOperationStatus(client, batchOperationKey, BatchOperationState.COMPLETED);
+    waitForBatchOperationCompleted(client, batchOperationKey, 2, 0);
 
     final var batchAuditLogs =
         awaitAuditLogEntry(
@@ -1146,7 +1144,7 @@ public class AuditLogProcessOperationsIT {
 
     final var batchOperationKey = batchResult.getBatchOperationKey();
     waitForBatchOperationWithCorrectTotalCount(client, batchOperationKey, 2);
-    waitForBatchOperationStatus(client, batchOperationKey, BatchOperationState.COMPLETED);
+    waitForBatchOperationCompleted(client, batchOperationKey, 2, 0);
 
     final var batchAuditLogs =
         awaitAuditLogEntry(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
@@ -12,11 +12,13 @@ import static io.camunda.it.auditlog.AuditLogUtils.TENANT_A;
 import static io.camunda.it.util.TestHelper.deployProcessForTenantAndWaitForIt;
 import static io.camunda.it.util.TestHelper.startProcessInstanceWithMessageForTenant;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationCompleted;
+import static io.camunda.it.util.TestHelper.waitForBatchOperationStatus;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationWithCorrectTotalCount;
 import static io.camunda.it.util.TestHelper.waitForDecisionsToBeDeployed;
 import static io.camunda.it.util.TestHelper.waitForJobs;
 import static io.camunda.it.util.TestHelper.waitForProcessInstances;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeCompleted;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeSuspended;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
 import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreResolved;
@@ -33,6 +35,7 @@ import io.camunda.client.api.search.enums.AuditLogCategoryEnum;
 import io.camunda.client.api.search.enums.AuditLogEntityTypeEnum;
 import io.camunda.client.api.search.enums.AuditLogOperationTypeEnum;
 import io.camunda.client.api.search.enums.AuditLogResultEnum;
+import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.filter.AuditLogFilter;
 import io.camunda.client.api.search.response.AuditLogResult;
@@ -1051,6 +1054,128 @@ public class AuditLogProcessOperationsIT {
     assertThat(batchAuditLogs).isNotEmpty();
     final var batchAuditLog = batchAuditLogs.stream().findFirst().orElseThrow();
     assertBatchAuditLog(batchAuditLog, AuditLogOperationTypeEnum.CREATE, batchOperationKey);
+  }
+
+  @Test
+  void shouldTrackBatchProcessInstanceSuspend(
+      @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
+    final var instance1 =
+        createProcessInstance(
+            client, SERVICE_TASKS_PROCESS_ID, Map.of("batchSuspendAll", "value1"));
+    final var instance2 =
+        createProcessInstance(
+            client, SERVICE_TASKS_PROCESS_ID, Map.of("batchSuspendAll", "value2"));
+    final long instance1Key = instance1.getProcessInstanceKey();
+    final long instance2Key = instance2.getProcessInstanceKey();
+
+    waitForProcessInstancesToStart(
+        client, f -> f.processInstanceKey(instance1Key).tenantId(TENANT_A), 1);
+    waitForProcessInstancesToStart(
+        client, f -> f.processInstanceKey(instance2Key).tenantId(TENANT_A), 1);
+
+    final var batchResult =
+        client
+            .newCreateBatchOperationCommand()
+            .processInstanceSuspend()
+            .filter(f -> f.processInstanceKey(k -> k.in(List.of(instance1Key, instance2Key))))
+            .send()
+            .join();
+
+    final var batchOperationKey = batchResult.getBatchOperationKey();
+    waitForBatchOperationWithCorrectTotalCount(client, batchOperationKey, 2);
+    waitForBatchOperationStatus(client, batchOperationKey, BatchOperationState.COMPLETED);
+
+    final var batchAuditLogs =
+        awaitAuditLogEntry(
+            client,
+            AuditLogEntityTypeEnum.BATCH,
+            AuditLogOperationTypeEnum.CREATE,
+            batchOperationKey);
+    assertThat(batchAuditLogs).isNotEmpty();
+    assertBatchAuditLog(
+        batchAuditLogs.getFirst(), AuditLogOperationTypeEnum.CREATE, batchOperationKey);
+
+    for (final var instance : List.of(instance1, instance2)) {
+      final var suspendAuditLogs =
+          awaitAuditLogEntry(
+              client,
+              AuditLogEntityTypeEnum.PROCESS_INSTANCE,
+              AuditLogOperationTypeEnum.SUSPEND,
+              String.valueOf(instance.getProcessInstanceKey()));
+      assertThat(suspendAuditLogs).hasSize(1);
+      final var suspendAuditLog = suspendAuditLogs.getFirst();
+      assertProcessInstanceAuditLog(
+          suspendAuditLog,
+          AuditLogEntityTypeEnum.PROCESS_INSTANCE,
+          AuditLogOperationTypeEnum.SUSPEND,
+          instance.getProcessInstanceKey(),
+          instance.getProcessDefinitionKey(),
+          SERVICE_TASKS_PROCESS_ID);
+      assertThat(suspendAuditLog.getBatchOperationKey()).isEqualTo(batchOperationKey);
+    }
+  }
+
+  @Test
+  void shouldTrackBatchProcessInstanceResume(
+      @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
+    final var instance1 =
+        createProcessInstance(client, SERVICE_TASKS_PROCESS_ID, Map.of("batchResumeAll", "value1"));
+    final var instance2 =
+        createProcessInstance(client, SERVICE_TASKS_PROCESS_ID, Map.of("batchResumeAll", "value2"));
+    final long instance1Key = instance1.getProcessInstanceKey();
+    final long instance2Key = instance2.getProcessInstanceKey();
+
+    waitForProcessInstancesToStart(
+        client, f -> f.processInstanceKey(instance1Key).tenantId(TENANT_A), 1);
+    waitForProcessInstancesToStart(
+        client, f -> f.processInstanceKey(instance2Key).tenantId(TENANT_A), 1);
+
+    client.newSuspendProcessInstanceCommand(instance1Key).send().join();
+    client.newSuspendProcessInstanceCommand(instance2Key).send().join();
+
+    waitForProcessInstancesToBeSuspended(
+        client, f -> f.processInstanceKey(k -> k.in(List.of(instance1Key, instance2Key))), 2);
+
+    final var batchResult =
+        client
+            .newCreateBatchOperationCommand()
+            .processInstanceResume()
+            .filter(f -> f.processInstanceKey(k -> k.in(List.of(instance1Key, instance2Key))))
+            .send()
+            .join();
+
+    final var batchOperationKey = batchResult.getBatchOperationKey();
+    waitForBatchOperationWithCorrectTotalCount(client, batchOperationKey, 2);
+    waitForBatchOperationStatus(client, batchOperationKey, BatchOperationState.COMPLETED);
+
+    final var batchAuditLogs =
+        awaitAuditLogEntry(
+            client,
+            AuditLogEntityTypeEnum.BATCH,
+            AuditLogOperationTypeEnum.CREATE,
+            batchOperationKey);
+    assertThat(batchAuditLogs).isNotEmpty();
+    assertBatchAuditLog(
+        batchAuditLogs.getFirst(), AuditLogOperationTypeEnum.CREATE, batchOperationKey);
+
+    for (final var instance : List.of(instance1, instance2)) {
+      final var resumeAuditLogs =
+          awaitAuditLogEntry(
+              client,
+              AuditLogEntityTypeEnum.PROCESS_INSTANCE,
+              AuditLogOperationTypeEnum.RESUME,
+              String.valueOf(instance.getProcessInstanceKey()));
+      assertThat(resumeAuditLogs).hasSize(1);
+      final var resumeAuditLog = resumeAuditLogs.getFirst();
+      assertProcessInstanceAuditLog(
+          resumeAuditLog,
+          AuditLogEntityTypeEnum.PROCESS_INSTANCE,
+          AuditLogOperationTypeEnum.RESUME,
+          instance.getProcessInstanceKey(),
+          instance.getProcessDefinitionKey(),
+          SERVICE_TASKS_PROCESS_ID);
+      assertThat(resumeAuditLog.getBatchOperationKey()).isEqualTo(batchOperationKey);
+    }
   }
 
   // ========================================================================================

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -739,6 +739,21 @@ public final class TestHelper {
                 .execute());
   }
 
+  public static void waitForProcessInstancesToBeSuspended(
+      final CamundaClient camundaClient,
+      final Consumer<ProcessInstanceFilter> fn,
+      final int expectedCount) {
+    waitForItemsPaginated(
+        "should wait for process instances to be suspended",
+        expectedCount,
+        page ->
+            camundaClient
+                .newProcessInstanceSearchRequest()
+                .page(page)
+                .filter(fn.andThen(f -> f.state(ProcessInstanceState.SUSPENDED)))
+                .execute());
+  }
+
   public static void waitForProcessInstance(
       final CamundaClient client,
       final Consumer<ProcessInstanceFilter> filter,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -88,6 +88,8 @@ import io.camunda.exporter.handlers.batchoperation.ProcessInstanceCancellationOp
 import io.camunda.exporter.handlers.batchoperation.ProcessInstanceHistoryDeletionOperationHandler;
 import io.camunda.exporter.handlers.batchoperation.ProcessInstanceMigrationOperationHandler;
 import io.camunda.exporter.handlers.batchoperation.ProcessInstanceModificationOperationHandler;
+import io.camunda.exporter.handlers.batchoperation.ProcessInstanceResumptionOperationHandler;
+import io.camunda.exporter.handlers.batchoperation.ProcessInstanceSuspensionOperationHandler;
 import io.camunda.exporter.handlers.batchoperation.ResolveIncidentOperationHandler;
 import io.camunda.exporter.handlers.batchoperation.UpdateJobOperationHandler;
 import io.camunda.exporter.handlers.batchoperation.listview.ListViewFromChunkItemHandler;
@@ -377,6 +379,12 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(OperationTemplate.class).getFullQualifiedName(),
                 batchOperationCache),
             new ProcessInstanceModificationOperationHandler(
+                indexDescriptors.get(OperationTemplate.class).getFullQualifiedName(),
+                batchOperationCache),
+            new ProcessInstanceSuspensionOperationHandler(
+                indexDescriptors.get(OperationTemplate.class).getFullQualifiedName(),
+                batchOperationCache),
+            new ProcessInstanceResumptionOperationHandler(
                 indexDescriptors.get(OperationTemplate.class).getFullQualifiedName(),
                 batchOperationCache),
             new ResolveIncidentOperationHandler(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceResumptionOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceResumptionOperationHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation;
+
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+
+/**
+ * This handles the batch operation item status of batch operations of type RESUME_PROCESS_INSTANCE.
+ * It tracks the resumption of process instances by updating the corresponding batch operation item
+ * entity.
+ */
+public class ProcessInstanceResumptionOperationHandler
+    extends AbstractOperationStatusHandler<ProcessInstanceRecordValue> {
+
+  public ProcessInstanceResumptionOperationHandler(
+      final String indexName,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+    super(
+        indexName,
+        ValueType.PROCESS_INSTANCE,
+        OperationType.RESUME_PROCESS_INSTANCE,
+        batchOperationCache);
+  }
+
+  @Override
+  long getRootProcessInstanceKey(final Record<ProcessInstanceRecordValue> record) {
+    return record.getValue().getRootProcessInstanceKey();
+  }
+
+  @Override
+  long getItemKey(final Record<ProcessInstanceRecordValue> record) {
+    return record.getValue().getProcessInstanceKey();
+  }
+
+  @Override
+  long getProcessInstanceKey(final Record<ProcessInstanceRecordValue> record) {
+    return record.getValue().getProcessInstanceKey();
+  }
+
+  @Override
+  boolean isCompleted(final Record<ProcessInstanceRecordValue> record) {
+    return record.getIntent().equals(ProcessInstanceIntent.RESUMED);
+  }
+
+  @Override
+  boolean isFailed(final Record<ProcessInstanceRecordValue> record) {
+    return record.getIntent().equals(ProcessInstanceIntent.RESUME)
+        && record.getRejectionType() != RejectionType.NULL_VAL;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceSuspensionOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceSuspensionOperationHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation;
+
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+
+/**
+ * This handles the batch operation item status of batch operations of type
+ * SUSPEND_PROCESS_INSTANCE. It tracks the suspension of process instances by updating the
+ * corresponding batch operation item entity.
+ */
+public class ProcessInstanceSuspensionOperationHandler
+    extends AbstractOperationStatusHandler<ProcessInstanceRecordValue> {
+
+  public ProcessInstanceSuspensionOperationHandler(
+      final String indexName,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+    super(
+        indexName,
+        ValueType.PROCESS_INSTANCE,
+        OperationType.SUSPEND_PROCESS_INSTANCE,
+        batchOperationCache);
+  }
+
+  @Override
+  long getRootProcessInstanceKey(final Record<ProcessInstanceRecordValue> record) {
+    return record.getValue().getRootProcessInstanceKey();
+  }
+
+  @Override
+  long getItemKey(final Record<ProcessInstanceRecordValue> record) {
+    return record.getValue().getProcessInstanceKey();
+  }
+
+  @Override
+  long getProcessInstanceKey(final Record<ProcessInstanceRecordValue> record) {
+    return record.getValue().getProcessInstanceKey();
+  }
+
+  @Override
+  boolean isCompleted(final Record<ProcessInstanceRecordValue> record) {
+    return record.getIntent().equals(ProcessInstanceIntent.SUSPENDED);
+  }
+
+  @Override
+  boolean isFailed(final Record<ProcessInstanceRecordValue> record) {
+    return record.getIntent().equals(ProcessInstanceIntent.SUSPEND)
+        && record.getRejectionType() != RejectionType.NULL_VAL;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceResumptionOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceResumptionOperationHandlerTest.java
@@ -153,6 +153,29 @@ class ProcessInstanceResumptionOperationHandlerTest {
   }
 
   @Test
+  void shouldNotHandleSuspendSuccessRecord() {
+    final Record<ProcessInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            b ->
+                b.withIntent(ProcessInstanceIntent.SUSPENDED)
+                    .withBatchOperationReference(batchOperationKey));
+    assertThat(handler.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleSuspendFailureRecord() {
+    final Record<ProcessInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            b ->
+                b.withRejectionType(RejectionType.INVALID_STATE)
+                    .withIntent(ProcessInstanceIntent.SUSPEND)
+                    .withBatchOperationReference(batchOperationKey));
+    assertThat(handler.handlesRecord(record)).isFalse();
+  }
+
+  @Test
   void shouldUpdateEntityOnSuccess() {
     final var record = createSuccessRecord();
     final var entity = new OperationEntity();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceResumptionOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceResumptionOperationHandlerTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation;
+
+import static io.camunda.exporter.utils.ExporterUtil.map;
+import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperationReferenceNullValue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
+import io.camunda.webapps.schema.entities.operation.OperationEntity;
+import io.camunda.webapps.schema.entities.operation.OperationState;
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.protocol.record.ImmutableRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class ProcessInstanceResumptionOperationHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-index";
+  private final long batchOperationKey = 42L;
+
+  private final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache =
+      mock(ExporterEntityCache.class);
+
+  private ProcessInstanceResumptionOperationHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new ProcessInstanceResumptionOperationHandler(indexName, batchOperationCache);
+    Mockito.reset(batchOperationCache);
+    when(batchOperationCache.get(Mockito.anyString()))
+        .thenReturn(
+            Optional.of(
+                new CachedBatchOperationEntity(
+                    String.valueOf(batchOperationKey), map(handler.getRelevantOperationType()))));
+  }
+
+  private Record<ProcessInstanceRecordValue> createSuccessRecord() {
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE,
+        b ->
+            b.withIntent(ProcessInstanceIntent.RESUMED)
+                .withBatchOperationReference(batchOperationKey));
+  }
+
+  private Record<ProcessInstanceRecordValue> createFailureRecord() {
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE,
+        b ->
+            b.withRejectionType(RejectionType.INVALID_STATE)
+                .withIntent(ProcessInstanceIntent.RESUME)
+                .withBatchOperationReference(batchOperationKey));
+  }
+
+  @Test
+  void shouldHandleSuccessRecord() {
+    assertThat(handler.handlesRecord(createSuccessRecord())).isTrue();
+  }
+
+  @Test
+  void shouldNotHandleSuccessRecordWithoutBatchOperationKeyInMetadata() {
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createSuccessRecord())
+            .withBatchOperationReference(batchOperationReferenceNullValue())
+            .build();
+    assertThat(handler.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleSuccessRecordWhenNotRelevantType() {
+    Mockito.reset(batchOperationCache);
+    final var otherOperationType =
+        Arrays.stream(OperationType.values())
+            .filter(t -> !t.equals(handler.getRelevantOperationType()))
+            .findAny()
+            .get();
+    when(batchOperationCache.get(Mockito.anyString()))
+        .thenReturn(
+            Optional.of(
+                new CachedBatchOperationEntity(
+                    String.valueOf(batchOperationKey), map(otherOperationType))));
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createSuccessRecord())
+            .withBatchOperationReference(batchOperationKey)
+            .build();
+    assertThat(handler.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldHandleFailureRecord() {
+    assertThat(handler.handlesRecord(createFailureRecord())).isTrue();
+  }
+
+  @Test
+  void shouldNotHandleFailureRecordWithoutBatchOperationKeyInMetadata() {
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createFailureRecord())
+            .withBatchOperationReference(batchOperationReferenceNullValue())
+            .build();
+    assertThat(handler.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleFailureRecordWhenNotRelevantType() {
+    Mockito.reset(batchOperationCache);
+    final var otherOperationType =
+        Arrays.stream(OperationType.values())
+            .filter(t -> !t.equals(handler.getRelevantOperationType()))
+            .findAny()
+            .get();
+    when(batchOperationCache.get(Mockito.anyString()))
+        .thenReturn(
+            Optional.of(
+                new CachedBatchOperationEntity(
+                    String.valueOf(batchOperationKey), map(otherOperationType))));
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createFailureRecord())
+            .withBatchOperationReference(batchOperationKey)
+            .build();
+    assertThat(handler.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleOtherRecord() {
+    assertThat(handler.handlesRecord(factory.generateRecord(ValueType.VARIABLE))).isFalse();
+  }
+
+  @Test
+  void shouldUpdateEntityOnSuccess() {
+    final var record = createSuccessRecord();
+    final var entity = new OperationEntity();
+    handler.updateEntity(record, entity);
+    assertThat(entity.getState()).isEqualTo(OperationState.COMPLETED);
+    assertThat(entity.getCompletedDate()).isNotNull();
+    assertThat(entity.getErrorMessage()).isNull();
+  }
+
+  @Test
+  void shouldUpdateEntityOnFailure() {
+    final var record = createFailureRecord();
+    final var entity = new OperationEntity();
+    handler.updateEntity(record, entity);
+    assertThat(entity.getState()).isEqualTo(OperationState.FAILED);
+    assertThat(entity.getErrorMessage())
+        .isEqualTo(record.getRejectionType() + ": " + record.getRejectionReason());
+    assertThat(entity.getCompletedDate()).isNull();
+  }
+
+  @Test
+  void shouldUpdateEntityOnNotFound() {
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createFailureRecord())
+            .withRejectionType(RejectionType.NOT_FOUND)
+            .build();
+    final var entity = new OperationEntity();
+    handler.updateEntity(record, entity);
+    assertThat(entity.getState()).isEqualTo(OperationState.SKIPPED);
+    assertThat(entity.getErrorMessage()).isNull();
+    assertThat(entity.getCompletedDate()).isNull();
+  }
+
+  @Test
+  void shouldFlushEntityFields() {
+    final var entity = new OperationEntity();
+    entity.setState(OperationState.COMPLETED);
+    entity.setType(handler.getRelevantOperationType());
+    entity.setBatchOperationId(String.valueOf(batchOperationKey));
+    entity.setItemKey(123L);
+    entity.setProcessInstanceKey(456L);
+    entity.setCompletedDate(OffsetDateTime.now());
+    entity.setErrorMessage("error message");
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
+    final var mockRequest = mock(BatchRequest.class);
+    handler.flush(index, entity, mockRequest);
+    verify(mockRequest, times(1))
+        .upsert(
+            index,
+            entity.getId(),
+            entity,
+            Map.of(
+                OperationTemplate.STATE, entity.getState(),
+                OperationTemplate.TYPE, entity.getType(),
+                OperationTemplate.BATCH_OPERATION_ID, entity.getBatchOperationId(),
+                OperationTemplate.ITEM_KEY, entity.getItemKey(),
+                OperationTemplate.PROCESS_INSTANCE_KEY, entity.getProcessInstanceKey(),
+                OperationTemplate.COMPLETED_DATE, entity.getCompletedDate(),
+                OperationTemplate.ERROR_MSG, entity.getErrorMessage()));
+  }
+
+  @Test
+  void shouldGenerateCorrectId() {
+    final var record = createSuccessRecord();
+    assertThat(handler.generateIds(record))
+        .containsExactly(batchOperationKey + "_" + handler.getItemKey(record));
+  }
+
+  @Test
+  void shouldUpdateEntitySetRootProcessInstanceKeyOnSuccess() {
+    final var record = createSuccessRecord();
+    final var entity = new OperationEntity();
+    handler.updateEntity(record, entity);
+    assertThat(entity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(handler.getRootProcessInstanceKey(record));
+  }
+
+  @Test
+  void shouldUpdateEntitySetRootProcessInstanceKeyOnFailure() {
+    final var record = createFailureRecord();
+    final var entity = new OperationEntity();
+    handler.updateEntity(record, entity);
+    assertThat(entity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(handler.getRootProcessInstanceKey(record));
+  }
+
+  @Test
+  void shouldExtractCorrectItemKey() {
+    final var record = createSuccessRecord();
+    assertThat(handler.getItemKey(record)).isEqualTo(record.getValue().getProcessInstanceKey());
+  }
+
+  @Test
+  void shouldExtractCorrectProcessInstanceKey() {
+    final var record = createSuccessRecord();
+    assertThat(handler.getProcessInstanceKey(record))
+        .isEqualTo(record.getValue().getProcessInstanceKey());
+  }
+
+  @Test
+  void shouldNotSetRootProcessInstanceKeyWhenDefault() {
+    final Record<ProcessInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            b ->
+                b.withRejectionType(RejectionType.INVALID_STATE)
+                    .withIntent(ProcessInstanceIntent.RESUME)
+                    .withValue(
+                        ImmutableProcessInstanceRecordValue.builder()
+                            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+                            .withRootProcessInstanceKey(-1L)
+                            .build())
+                    .withBatchOperationReference(batchOperationKey));
+    final var entity = new OperationEntity();
+    handler.updateEntity(record, entity);
+    assertThat(entity.getRootProcessInstanceKey()).isNull();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceSuspensionOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceSuspensionOperationHandlerTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation;
+
+import static io.camunda.exporter.utils.ExporterUtil.map;
+import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperationReferenceNullValue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
+import io.camunda.webapps.schema.entities.operation.OperationEntity;
+import io.camunda.webapps.schema.entities.operation.OperationState;
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.protocol.record.ImmutableRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class ProcessInstanceSuspensionOperationHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-index";
+  private final long batchOperationKey = 42L;
+
+  private final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache =
+      mock(ExporterEntityCache.class);
+
+  private ProcessInstanceSuspensionOperationHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new ProcessInstanceSuspensionOperationHandler(indexName, batchOperationCache);
+    Mockito.reset(batchOperationCache);
+    when(batchOperationCache.get(Mockito.anyString()))
+        .thenReturn(
+            Optional.of(
+                new CachedBatchOperationEntity(
+                    String.valueOf(batchOperationKey), map(handler.getRelevantOperationType()))));
+  }
+
+  private Record<ProcessInstanceRecordValue> createSuccessRecord() {
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE,
+        b ->
+            b.withIntent(ProcessInstanceIntent.SUSPENDED)
+                .withBatchOperationReference(batchOperationKey));
+  }
+
+  private Record<ProcessInstanceRecordValue> createFailureRecord() {
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE,
+        b ->
+            b.withRejectionType(RejectionType.INVALID_STATE)
+                .withIntent(ProcessInstanceIntent.SUSPEND)
+                .withBatchOperationReference(batchOperationKey));
+  }
+
+  @Test
+  void shouldHandleSuccessRecord() {
+    assertThat(handler.handlesRecord(createSuccessRecord())).isTrue();
+  }
+
+  @Test
+  void shouldNotHandleSuccessRecordWithoutBatchOperationKeyInMetadata() {
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createSuccessRecord())
+            .withBatchOperationReference(batchOperationReferenceNullValue())
+            .build();
+    assertThat(handler.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleSuccessRecordWhenNotRelevantType() {
+    Mockito.reset(batchOperationCache);
+    final var otherOperationType =
+        Arrays.stream(OperationType.values())
+            .filter(t -> !t.equals(handler.getRelevantOperationType()))
+            .findAny()
+            .get();
+    when(batchOperationCache.get(Mockito.anyString()))
+        .thenReturn(
+            Optional.of(
+                new CachedBatchOperationEntity(
+                    String.valueOf(batchOperationKey), map(otherOperationType))));
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createSuccessRecord())
+            .withBatchOperationReference(batchOperationKey)
+            .build();
+    assertThat(handler.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldHandleFailureRecord() {
+    assertThat(handler.handlesRecord(createFailureRecord())).isTrue();
+  }
+
+  @Test
+  void shouldNotHandleFailureRecordWithoutBatchOperationKeyInMetadata() {
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createFailureRecord())
+            .withBatchOperationReference(batchOperationReferenceNullValue())
+            .build();
+    assertThat(handler.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleFailureRecordWhenNotRelevantType() {
+    Mockito.reset(batchOperationCache);
+    final var otherOperationType =
+        Arrays.stream(OperationType.values())
+            .filter(t -> !t.equals(handler.getRelevantOperationType()))
+            .findAny()
+            .get();
+    when(batchOperationCache.get(Mockito.anyString()))
+        .thenReturn(
+            Optional.of(
+                new CachedBatchOperationEntity(
+                    String.valueOf(batchOperationKey), map(otherOperationType))));
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createFailureRecord())
+            .withBatchOperationReference(batchOperationKey)
+            .build();
+    assertThat(handler.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleOtherRecord() {
+    assertThat(handler.handlesRecord(factory.generateRecord(ValueType.VARIABLE))).isFalse();
+  }
+
+  @Test
+  void shouldUpdateEntityOnSuccess() {
+    final var record = createSuccessRecord();
+    final var entity = new OperationEntity();
+    handler.updateEntity(record, entity);
+    assertThat(entity.getState()).isEqualTo(OperationState.COMPLETED);
+    assertThat(entity.getCompletedDate()).isNotNull();
+    assertThat(entity.getErrorMessage()).isNull();
+  }
+
+  @Test
+  void shouldUpdateEntityOnFailure() {
+    final var record = createFailureRecord();
+    final var entity = new OperationEntity();
+    handler.updateEntity(record, entity);
+    assertThat(entity.getState()).isEqualTo(OperationState.FAILED);
+    assertThat(entity.getErrorMessage())
+        .isEqualTo(record.getRejectionType() + ": " + record.getRejectionReason());
+    assertThat(entity.getCompletedDate()).isNull();
+  }
+
+  @Test
+  void shouldUpdateEntityOnNotFound() {
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createFailureRecord())
+            .withRejectionType(RejectionType.NOT_FOUND)
+            .build();
+    final var entity = new OperationEntity();
+    handler.updateEntity(record, entity);
+    assertThat(entity.getState()).isEqualTo(OperationState.SKIPPED);
+    assertThat(entity.getErrorMessage()).isNull();
+    assertThat(entity.getCompletedDate()).isNull();
+  }
+
+  @Test
+  void shouldFlushEntityFields() {
+    final var entity = new OperationEntity();
+    entity.setState(OperationState.COMPLETED);
+    entity.setType(handler.getRelevantOperationType());
+    entity.setBatchOperationId(String.valueOf(batchOperationKey));
+    entity.setItemKey(123L);
+    entity.setProcessInstanceKey(456L);
+    entity.setCompletedDate(OffsetDateTime.now());
+    entity.setErrorMessage("error message");
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
+    final var mockRequest = mock(BatchRequest.class);
+    handler.flush(index, entity, mockRequest);
+    verify(mockRequest, times(1))
+        .upsert(
+            index,
+            entity.getId(),
+            entity,
+            Map.of(
+                OperationTemplate.STATE, entity.getState(),
+                OperationTemplate.TYPE, entity.getType(),
+                OperationTemplate.BATCH_OPERATION_ID, entity.getBatchOperationId(),
+                OperationTemplate.ITEM_KEY, entity.getItemKey(),
+                OperationTemplate.PROCESS_INSTANCE_KEY, entity.getProcessInstanceKey(),
+                OperationTemplate.COMPLETED_DATE, entity.getCompletedDate(),
+                OperationTemplate.ERROR_MSG, entity.getErrorMessage()));
+  }
+
+  @Test
+  void shouldGenerateCorrectId() {
+    final var record = createSuccessRecord();
+    assertThat(handler.generateIds(record))
+        .containsExactly(batchOperationKey + "_" + handler.getItemKey(record));
+  }
+
+  @Test
+  void shouldUpdateEntitySetRootProcessInstanceKeyOnSuccess() {
+    final var record = createSuccessRecord();
+    final var entity = new OperationEntity();
+    handler.updateEntity(record, entity);
+    assertThat(entity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(handler.getRootProcessInstanceKey(record));
+  }
+
+  @Test
+  void shouldUpdateEntitySetRootProcessInstanceKeyOnFailure() {
+    final var record = createFailureRecord();
+    final var entity = new OperationEntity();
+    handler.updateEntity(record, entity);
+    assertThat(entity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(handler.getRootProcessInstanceKey(record));
+  }
+
+  @Test
+  void shouldExtractCorrectItemKey() {
+    final var record = createSuccessRecord();
+    assertThat(handler.getItemKey(record)).isEqualTo(record.getValue().getProcessInstanceKey());
+  }
+
+  @Test
+  void shouldExtractCorrectProcessInstanceKey() {
+    final var record = createSuccessRecord();
+    assertThat(handler.getProcessInstanceKey(record))
+        .isEqualTo(record.getValue().getProcessInstanceKey());
+  }
+
+  @Test
+  void shouldNotSetRootProcessInstanceKeyWhenDefault() {
+    final Record<ProcessInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            b ->
+                b.withRejectionType(RejectionType.INVALID_STATE)
+                    .withIntent(ProcessInstanceIntent.SUSPEND)
+                    .withValue(
+                        ImmutableProcessInstanceRecordValue.builder()
+                            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+                            .withRootProcessInstanceKey(-1L)
+                            .build())
+                    .withBatchOperationReference(batchOperationKey));
+    final var entity = new OperationEntity();
+    handler.updateEntity(record, entity);
+    assertThat(entity.getRootProcessInstanceKey()).isNull();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceSuspensionOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceSuspensionOperationHandlerTest.java
@@ -153,6 +153,29 @@ class ProcessInstanceSuspensionOperationHandlerTest {
   }
 
   @Test
+  void shouldNotHandleResumeSuccessRecord() {
+    final Record<ProcessInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            b ->
+                b.withIntent(ProcessInstanceIntent.RESUMED)
+                    .withBatchOperationReference(batchOperationKey));
+    assertThat(handler.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleResumeFailureRecord() {
+    final Record<ProcessInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            b ->
+                b.withRejectionType(RejectionType.INVALID_STATE)
+                    .withIntent(ProcessInstanceIntent.RESUME)
+                    .withBatchOperationReference(batchOperationKey));
+    assertThat(handler.handlesRecord(record)).isFalse();
+  }
+
+  @Test
   void shouldUpdateEntityOnSuccess() {
     final var record = createSuccessRecord();
     final var entity = new OperationEntity();

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -61,6 +61,8 @@ import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceCancella
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceHistoryDeletionBatchOperationExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceMigrationBatchOperationExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceModificationBatchOperationExportHandler;
+import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceResumptionBatchOperationExportHandler;
+import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceSuspensionBatchOperationExportHandler;
 import io.camunda.exporter.rdbms.handlers.waitstate.WaitStateAddUpdateHandler;
 import io.camunda.exporter.rdbms.handlers.waitstate.WaitStateRemoveHandler;
 import io.camunda.exporter.rdbms.replication.DelayReplicationControllerFactory;
@@ -367,6 +369,14 @@ public class RdbmsExporterWrapper implements Exporter {
     builder.withHandler(
         ValueType.PROCESS_INSTANCE,
         new ProcessInstanceCancellationBatchOperationExportHandler(
+            rdbmsWriters.getBatchOperationWriter(), cacheRegistry.batchOperationCache()));
+    builder.withHandler(
+        ValueType.PROCESS_INSTANCE,
+        new ProcessInstanceSuspensionBatchOperationExportHandler(
+            rdbmsWriters.getBatchOperationWriter(), cacheRegistry.batchOperationCache()));
+    builder.withHandler(
+        ValueType.PROCESS_INSTANCE,
+        new ProcessInstanceResumptionBatchOperationExportHandler(
             rdbmsWriters.getBatchOperationWriter(), cacheRegistry.batchOperationCache()));
     builder.withHandler(
         ValueType.INCIDENT,

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceResumptionBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceResumptionBatchOperationExportHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.batchoperation;
+
+import io.camunda.db.rdbms.write.service.BatchOperationWriter;
+import io.camunda.search.entities.BatchOperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import java.util.Optional;
+
+/**
+ * This handles the batch operation item status of batch operations of type RESUME_PROCESS_INSTANCE.
+ * It tracks the resumption of process instances by updating the corresponding batch operation item
+ * entity.
+ */
+public class ProcessInstanceResumptionBatchOperationExportHandler
+    extends RdbmsBatchOperationStatusExportHandler<ProcessInstanceRecordValue> {
+
+  public ProcessInstanceResumptionBatchOperationExportHandler(
+      final BatchOperationWriter batchOperationWriter,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+    super(batchOperationWriter, batchOperationCache, BatchOperationType.RESUME_PROCESS_INSTANCE);
+  }
+
+  @Override
+  long getItemKey(final Record<ProcessInstanceRecordValue> record) {
+    return record.getValue().getProcessInstanceKey();
+  }
+
+  @Override
+  Optional<Long> getProcessInstanceKey(final Record<ProcessInstanceRecordValue> record) {
+    return Optional.of(record.getValue().getProcessInstanceKey());
+  }
+
+  @Override
+  Optional<Long> getRootProcessInstanceKey(final Record<ProcessInstanceRecordValue> record) {
+    return Optional.of(record.getValue().getRootProcessInstanceKey());
+  }
+
+  @Override
+  boolean isCompleted(final Record<ProcessInstanceRecordValue> record) {
+    return record.getIntent().equals(ProcessInstanceIntent.RESUMED);
+  }
+
+  @Override
+  boolean isFailed(final Record<ProcessInstanceRecordValue> record) {
+    return record.getIntent().equals(ProcessInstanceIntent.RESUME)
+        && record.getRejectionType() != RejectionType.NULL_VAL;
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceSuspensionBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceSuspensionBatchOperationExportHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.batchoperation;
+
+import io.camunda.db.rdbms.write.service.BatchOperationWriter;
+import io.camunda.search.entities.BatchOperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import java.util.Optional;
+
+/**
+ * This handles the batch operation item status of batch operations of type
+ * SUSPEND_PROCESS_INSTANCE. It tracks the suspension of process instances by updating the
+ * corresponding batch operation item entity.
+ */
+public class ProcessInstanceSuspensionBatchOperationExportHandler
+    extends RdbmsBatchOperationStatusExportHandler<ProcessInstanceRecordValue> {
+
+  public ProcessInstanceSuspensionBatchOperationExportHandler(
+      final BatchOperationWriter batchOperationWriter,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+    super(batchOperationWriter, batchOperationCache, BatchOperationType.SUSPEND_PROCESS_INSTANCE);
+  }
+
+  @Override
+  long getItemKey(final Record<ProcessInstanceRecordValue> record) {
+    return record.getValue().getProcessInstanceKey();
+  }
+
+  @Override
+  Optional<Long> getProcessInstanceKey(final Record<ProcessInstanceRecordValue> record) {
+    return Optional.of(record.getValue().getProcessInstanceKey());
+  }
+
+  @Override
+  Optional<Long> getRootProcessInstanceKey(final Record<ProcessInstanceRecordValue> record) {
+    return Optional.of(record.getValue().getRootProcessInstanceKey());
+  }
+
+  @Override
+  boolean isCompleted(final Record<ProcessInstanceRecordValue> record) {
+    return record.getIntent().equals(ProcessInstanceIntent.SUSPENDED);
+  }
+
+  @Override
+  boolean isFailed(final Record<ProcessInstanceRecordValue> record) {
+    return record.getIntent().equals(ProcessInstanceIntent.SUSPEND)
+        && record.getRejectionType() != RejectionType.NULL_VAL;
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceResumptionBatchOperationExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceResumptionBatchOperationExportHandlerTest.java
@@ -145,6 +145,29 @@ class ProcessInstanceResumptionBatchOperationExportHandlerTest {
   }
 
   @Test
+  void shouldNotHandleSuspendSuccessRecord() {
+    final Record<ProcessInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            b ->
+                b.withIntent(ProcessInstanceIntent.SUSPENDED)
+                    .withBatchOperationReference(batchOperationKey));
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleSuspendFailureRecord() {
+    final Record<ProcessInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            b ->
+                b.withRejectionType(RejectionType.INVALID_STATE)
+                    .withIntent(ProcessInstanceIntent.SUSPEND)
+                    .withBatchOperationReference(batchOperationKey));
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
   void shouldUpdateEntityOnSuccess() {
     handler.export(createSuccessRecord());
 

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceResumptionBatchOperationExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceResumptionBatchOperationExportHandlerTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.batchoperation;
+
+import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperationReferenceNullValue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
+import io.camunda.db.rdbms.write.service.BatchOperationWriter;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import io.camunda.search.entities.BatchOperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.protocol.record.ImmutableRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.Arrays;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+class ProcessInstanceResumptionBatchOperationExportHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final long batchOperationKey = 42L;
+
+  private final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache =
+      mock(ExporterEntityCache.class);
+  private final BatchOperationWriter batchOperationWriter = mock(BatchOperationWriter.class);
+
+  private ProcessInstanceResumptionBatchOperationExportHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler =
+        new ProcessInstanceResumptionBatchOperationExportHandler(
+            batchOperationWriter, batchOperationCache);
+    Mockito.reset(batchOperationCache);
+    when(batchOperationCache.get(Mockito.anyString()))
+        .thenReturn(
+            Optional.of(
+                new CachedBatchOperationEntity(
+                    String.valueOf(batchOperationKey), handler.relevantOperationType)));
+  }
+
+  private Record<ProcessInstanceRecordValue> createSuccessRecord() {
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE,
+        b ->
+            b.withIntent(ProcessInstanceIntent.RESUMED)
+                .withBatchOperationReference(batchOperationKey));
+  }
+
+  private Record<ProcessInstanceRecordValue> createFailureRecord() {
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE,
+        b ->
+            b.withRejectionType(RejectionType.INVALID_STATE)
+                .withIntent(ProcessInstanceIntent.RESUME)
+                .withBatchOperationReference(batchOperationKey));
+  }
+
+  @Test
+  void shouldHandleSuccessRecord() {
+    assertThat(handler.canExport(createSuccessRecord())).isTrue();
+  }
+
+  @Test
+  void shouldNotHandleSuccessRecordWithoutBatchOperationKeyInMetadata() {
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createSuccessRecord())
+            .withBatchOperationReference(batchOperationReferenceNullValue())
+            .build();
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleSuccessRecordWhenNotRelevantType() {
+    Mockito.reset(batchOperationCache);
+    final var otherOperationType =
+        Arrays.stream(BatchOperationType.values())
+            .filter(t -> !t.equals(handler.relevantOperationType))
+            .findAny()
+            .get();
+    when(batchOperationCache.get(Mockito.anyString()))
+        .thenReturn(
+            Optional.of(
+                new CachedBatchOperationEntity(
+                    String.valueOf(batchOperationKey), otherOperationType)));
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createSuccessRecord())
+            .withBatchOperationReference(batchOperationKey)
+            .build();
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
+  void shouldHandleFailureRecord() {
+    assertThat(handler.canExport(createFailureRecord())).isTrue();
+  }
+
+  @Test
+  void shouldNotHandleFailureRecordWithoutBatchOperationKeyInMetadata() {
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createFailureRecord())
+            .withBatchOperationReference(batchOperationReferenceNullValue())
+            .build();
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleFailureRecordWhenNotRelevantType() {
+    Mockito.reset(batchOperationCache);
+    final var otherOperationType =
+        Arrays.stream(BatchOperationType.values())
+            .filter(t -> !t.equals(handler.relevantOperationType))
+            .findAny()
+            .get();
+    when(batchOperationCache.get(Mockito.anyString()))
+        .thenReturn(
+            Optional.of(
+                new CachedBatchOperationEntity(
+                    String.valueOf(batchOperationKey), otherOperationType)));
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createFailureRecord())
+            .withBatchOperationReference(batchOperationKey)
+            .build();
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
+  void shouldUpdateEntityOnSuccess() {
+    handler.export(createSuccessRecord());
+
+    final var itemCaptor = ArgumentCaptor.forClass(BatchOperationItemDbModel.class);
+    verify(batchOperationWriter).updateItem(itemCaptor.capture());
+
+    assertThat(itemCaptor.getValue().state()).isEqualTo(BatchOperationItemState.COMPLETED);
+    assertThat(itemCaptor.getValue().processedDate()).isNotNull();
+    assertThat(itemCaptor.getValue().errorMessage()).isNull();
+  }
+
+  @Test
+  void shouldUpdateEntityOnFailure() {
+    handler.export(createFailureRecord());
+
+    final var itemCaptor = ArgumentCaptor.forClass(BatchOperationItemDbModel.class);
+    verify(batchOperationWriter).updateItem(itemCaptor.capture());
+
+    assertThat(itemCaptor.getValue().state()).isEqualTo(BatchOperationItemState.FAILED);
+    assertThat(itemCaptor.getValue().processedDate()).isNotNull();
+    assertThat(itemCaptor.getValue().errorMessage()).isNotNull();
+  }
+
+  @Test
+  void shouldUpdateEntityAsSkippedOnNotFound() {
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createFailureRecord())
+            .withRejectionType(RejectionType.NOT_FOUND)
+            .build();
+
+    handler.export(record);
+
+    final var itemCaptor = ArgumentCaptor.forClass(BatchOperationItemDbModel.class);
+    verify(batchOperationWriter).updateItem(itemCaptor.capture());
+
+    assertThat(itemCaptor.getValue().state()).isEqualTo(BatchOperationItemState.SKIPPED);
+    assertThat(itemCaptor.getValue().processedDate()).isNotNull();
+    assertThat(itemCaptor.getValue().errorMessage()).isNull();
+  }
+
+  @Test
+  void shouldExtractCorrectItemKey() {
+    final var record = createSuccessRecord();
+    assertThat(handler.getItemKey(record)).isEqualTo(record.getValue().getProcessInstanceKey());
+  }
+
+  @Test
+  void shouldExtractCorrectProcessInstanceKey() {
+    final var record = createSuccessRecord();
+    assertThat(handler.getProcessInstanceKey(record))
+        .isPresent()
+        .get()
+        .isEqualTo(record.getValue().getProcessInstanceKey());
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceSuspensionBatchOperationExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceSuspensionBatchOperationExportHandlerTest.java
@@ -145,6 +145,29 @@ class ProcessInstanceSuspensionBatchOperationExportHandlerTest {
   }
 
   @Test
+  void shouldNotHandleResumeSuccessRecord() {
+    final Record<ProcessInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            b ->
+                b.withIntent(ProcessInstanceIntent.RESUMED)
+                    .withBatchOperationReference(batchOperationKey));
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleResumeFailureRecord() {
+    final Record<ProcessInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            b ->
+                b.withRejectionType(RejectionType.INVALID_STATE)
+                    .withIntent(ProcessInstanceIntent.RESUME)
+                    .withBatchOperationReference(batchOperationKey));
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
   void shouldUpdateEntityOnSuccess() {
     handler.export(createSuccessRecord());
 

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceSuspensionBatchOperationExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceSuspensionBatchOperationExportHandlerTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.batchoperation;
+
+import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperationReferenceNullValue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
+import io.camunda.db.rdbms.write.service.BatchOperationWriter;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import io.camunda.search.entities.BatchOperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.protocol.record.ImmutableRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.Arrays;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+class ProcessInstanceSuspensionBatchOperationExportHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final long batchOperationKey = 42L;
+
+  private final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache =
+      mock(ExporterEntityCache.class);
+  private final BatchOperationWriter batchOperationWriter = mock(BatchOperationWriter.class);
+
+  private ProcessInstanceSuspensionBatchOperationExportHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler =
+        new ProcessInstanceSuspensionBatchOperationExportHandler(
+            batchOperationWriter, batchOperationCache);
+    Mockito.reset(batchOperationCache);
+    when(batchOperationCache.get(Mockito.anyString()))
+        .thenReturn(
+            Optional.of(
+                new CachedBatchOperationEntity(
+                    String.valueOf(batchOperationKey), handler.relevantOperationType)));
+  }
+
+  private Record<ProcessInstanceRecordValue> createSuccessRecord() {
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE,
+        b ->
+            b.withIntent(ProcessInstanceIntent.SUSPENDED)
+                .withBatchOperationReference(batchOperationKey));
+  }
+
+  private Record<ProcessInstanceRecordValue> createFailureRecord() {
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE,
+        b ->
+            b.withRejectionType(RejectionType.INVALID_STATE)
+                .withIntent(ProcessInstanceIntent.SUSPEND)
+                .withBatchOperationReference(batchOperationKey));
+  }
+
+  @Test
+  void shouldHandleSuccessRecord() {
+    assertThat(handler.canExport(createSuccessRecord())).isTrue();
+  }
+
+  @Test
+  void shouldNotHandleSuccessRecordWithoutBatchOperationKeyInMetadata() {
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createSuccessRecord())
+            .withBatchOperationReference(batchOperationReferenceNullValue())
+            .build();
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleSuccessRecordWhenNotRelevantType() {
+    Mockito.reset(batchOperationCache);
+    final var otherOperationType =
+        Arrays.stream(BatchOperationType.values())
+            .filter(t -> !t.equals(handler.relevantOperationType))
+            .findAny()
+            .get();
+    when(batchOperationCache.get(Mockito.anyString()))
+        .thenReturn(
+            Optional.of(
+                new CachedBatchOperationEntity(
+                    String.valueOf(batchOperationKey), otherOperationType)));
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createSuccessRecord())
+            .withBatchOperationReference(batchOperationKey)
+            .build();
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
+  void shouldHandleFailureRecord() {
+    assertThat(handler.canExport(createFailureRecord())).isTrue();
+  }
+
+  @Test
+  void shouldNotHandleFailureRecordWithoutBatchOperationKeyInMetadata() {
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createFailureRecord())
+            .withBatchOperationReference(batchOperationReferenceNullValue())
+            .build();
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleFailureRecordWhenNotRelevantType() {
+    Mockito.reset(batchOperationCache);
+    final var otherOperationType =
+        Arrays.stream(BatchOperationType.values())
+            .filter(t -> !t.equals(handler.relevantOperationType))
+            .findAny()
+            .get();
+    when(batchOperationCache.get(Mockito.anyString()))
+        .thenReturn(
+            Optional.of(
+                new CachedBatchOperationEntity(
+                    String.valueOf(batchOperationKey), otherOperationType)));
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createFailureRecord())
+            .withBatchOperationReference(batchOperationKey)
+            .build();
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
+  void shouldUpdateEntityOnSuccess() {
+    handler.export(createSuccessRecord());
+
+    final var itemCaptor = ArgumentCaptor.forClass(BatchOperationItemDbModel.class);
+    verify(batchOperationWriter).updateItem(itemCaptor.capture());
+
+    assertThat(itemCaptor.getValue().state()).isEqualTo(BatchOperationItemState.COMPLETED);
+    assertThat(itemCaptor.getValue().processedDate()).isNotNull();
+    assertThat(itemCaptor.getValue().errorMessage()).isNull();
+  }
+
+  @Test
+  void shouldUpdateEntityOnFailure() {
+    handler.export(createFailureRecord());
+
+    final var itemCaptor = ArgumentCaptor.forClass(BatchOperationItemDbModel.class);
+    verify(batchOperationWriter).updateItem(itemCaptor.capture());
+
+    assertThat(itemCaptor.getValue().state()).isEqualTo(BatchOperationItemState.FAILED);
+    assertThat(itemCaptor.getValue().processedDate()).isNotNull();
+    assertThat(itemCaptor.getValue().errorMessage()).isNotNull();
+  }
+
+  @Test
+  void shouldUpdateEntityAsSkippedOnNotFound() {
+    final var record =
+        ImmutableRecord.<ProcessInstanceRecordValue>builder()
+            .from(createFailureRecord())
+            .withRejectionType(RejectionType.NOT_FOUND)
+            .build();
+
+    handler.export(record);
+
+    final var itemCaptor = ArgumentCaptor.forClass(BatchOperationItemDbModel.class);
+    verify(batchOperationWriter).updateItem(itemCaptor.capture());
+
+    assertThat(itemCaptor.getValue().state()).isEqualTo(BatchOperationItemState.SKIPPED);
+    assertThat(itemCaptor.getValue().processedDate()).isNotNull();
+    assertThat(itemCaptor.getValue().errorMessage()).isNull();
+  }
+
+  @Test
+  void shouldExtractCorrectItemKey() {
+    final var record = createSuccessRecord();
+    assertThat(handler.getItemKey(record)).isEqualTo(record.getValue().getProcessInstanceKey());
+  }
+
+  @Test
+  void shouldExtractCorrectProcessInstanceKey() {
+    final var record = createSuccessRecord();
+    assertThat(handler.getProcessInstanceKey(record))
+        .isPresent()
+        .get()
+        .isEqualTo(record.getValue().getProcessInstanceKey());
+  }
+}


### PR DESCRIPTION
## Description

`SUSPEND_PROCESS_INSTANCE`/`RESUME_PROCESS_INSTANCE` batch operations had no per-item status export handler, so individual item completion/failure was never tracked in the operation history — a batch could be marked `COMPLETED` at the aggregate level even if every single SUSPEND/RESUME command was rejected.

Adds `ProcessInstanceSuspensionOperationHandler`/`ProcessInstanceResumptionOperationHandler` (camunda-exporter) and their rdbms-exporter counterparts, mirroring the existing `ProcessInstanceModificationOperationHandler` pattern, and registers them alongside the other per-item batch operation handlers.

## Tests

Two acceptance tests were added to `AuditLogProcessOperationsIT`, verifying that process instances suspended or resumed via the batch endpoint (`processInstanceSuspend()` / `processInstanceResume()`) carry the batch correlation into the audit log:

- `shouldTrackBatchProcessInstanceSuspend` — suspends two instances via a batch operation, then asserts the batch `CREATE` audit entry plus one per-instance `SUSPEND` entry whose `batchOperationKey` equals the batch operation key.
- `shouldTrackBatchProcessInstanceResume` — suspends then batch-resumes two instances, asserting the same batch correlation on the per-instance `RESUME` entries.

Both run under `@MultiDbTest`, covering the `CamundaExporter` (ES/OS) and `RdbmsExporterWrapper` (RDBMS) backends, and both use `waitForBatchOperationCompleted(client, batchOperationKey, 2, 0)` to assert the completed/failed item counts, matching every other batch test in the class — now possible thanks to the new handlers.

## Notes

- #57610 already landed the `ProcessInstanceSuspendResumeAuditLogTransformer` (fires on `SUSPENDED`/`RESUMED`), so batch correlation works out-of-the-box.

Closes #58037