### PR TITLE
fix: do not update lastExportedPosition when opening RdbmsExporter

### DIFF
--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -7,6 +7,11 @@
  */
 package io.camunda.exporter.rdbms;
 
+import static org.slf4j.event.Level.DEBUG;
+import static org.slf4j.event.Level.INFO;
+import static org.slf4j.event.Level.TRACE;
+import static org.slf4j.event.Level.WARN;
+
 import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
 import io.camunda.db.rdbms.exception.ExporterPositionMismatchException;
 import io.camunda.db.rdbms.write.RdbmsWriterMetrics.FlushTrigger;
@@ -32,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 /** https://docs.camunda.io/docs/next/components/zeebe/technical-concepts/process-lifecycles/ */
 public final class RdbmsExporter {
@@ -90,7 +96,8 @@ public final class RdbmsExporter {
     this.historyDeletionService = historyDeletionService;
     this.replicationControllerFactory = replicationControllerFactory;
 
-    logInfo(
+    log(
+        INFO,
         "RdbmsExporter created with Configuration: flushInterval={}, queueSize={}",
         flushInterval,
         queueSize);
@@ -99,13 +106,14 @@ public final class RdbmsExporter {
   public void open(final Controller controller) {
     this.controller = controller;
     rdbmsWriters.getExecutionQueue().reset();
-    logInfo(
+    log(
+        INFO,
         "Opening exporter with broker position {}, last flushed position {}",
         controller.getLastExportedRecordPosition(),
         lastFlushedPosition);
 
     if (!rdbmsSchemaManagerRegistry.isInitialized(physicalTenantId)) {
-      logWarn("Schema is not yet ready for use");
+      log(WARN, "Schema is not yet ready for use");
       throw new ExporterException("Schema is not ready for use");
     }
 
@@ -122,7 +130,8 @@ public final class RdbmsExporter {
       if (lastPosition < exporterRdbmsPosition.lastExportedPosition()) {
         // This is needed since the brokers last exported position is from its last snapshot and can
         // be different from ours.
-        logInfo(
+        log(
+            INFO,
             "Updating broker position {} to last exported position in rdbms {}",
             lastPosition,
             exporterRdbmsPosition.lastExportedPosition());
@@ -135,7 +144,8 @@ public final class RdbmsExporter {
         // LSN).
         replicationController.onFlush(lastPosition);
       } else if (lastPosition > exporterRdbmsPosition.lastExportedPosition()) {
-        logInfo(
+        log(
+            INFO,
             "Broker position {} is more advanced than rdbms position {}. Requesting replay from {}",
             lastPosition,
             exporterRdbmsPosition.lastExportedPosition(),
@@ -179,7 +189,7 @@ public final class RdbmsExporter {
             partitionId, historyCleanupService, historyDeletionService, LOG);
     backgroundTaskManager.start();
 
-    logInfo("Exporter opened with last exported position {}", lastPosition);
+    log(INFO, "Exporter opened with last exported position {}", lastPosition);
   }
 
   public void close() {
@@ -195,7 +205,7 @@ public final class RdbmsExporter {
       try {
         rdbmsWriters.flush(true);
       } catch (final Exception e) {
-        logWarn("Failed to execute final flush on close for partition {}", partitionId);
+        log(WARN, "Failed to execute final flush on close for partition {}", partitionId);
         throw e;
       }
 
@@ -206,10 +216,11 @@ public final class RdbmsExporter {
         replicationController = null;
       }
     } catch (final Exception e) {
-      logWarn("Failed to flush records before closing exporter.", e);
+      log(WARN, "Failed to flush records before closing exporter.", e);
     }
 
-    logInfo(
+    log(
+        INFO,
         "Exporter closed at positions Broker {}, RDBMS {}",
         lastPosition,
         exporterRdbmsPosition == null ? null : exporterRdbmsPosition.lastExportedPosition());
@@ -223,7 +234,8 @@ public final class RdbmsExporter {
               partitionId));
     }
 
-    logTrace(
+    log(
+        TRACE,
         "Process record {}-{} - {}:{}",
         record.getPartitionId(),
         record.getPosition(),
@@ -240,17 +252,20 @@ public final class RdbmsExporter {
     if (!alreadyProcessed && registeredHandlers.containsKey(record.getValueType())) {
       for (final var handler : registeredHandlers.get(record.getValueType())) {
         if (handler.canExport(record)) {
-          logTrace("Exporting record {} with handler {}", record.getValue(), handler.getClass());
+          log(TRACE, "Exporting record {} with handler {}", record.getValue(), handler.getClass());
           handler.export(record);
           exported = true;
           shouldFlushAfterRecordProcessed |= handler.shouldFlushAfterRecordProcessed();
         } else {
-          logTrace(
-              "Handler {} can not export record {}", handler.getClass(), record.getValueType());
+          log(
+              TRACE,
+              "Handler {} can not export record {}",
+              handler.getClass(),
+              record.getValueType());
         }
       }
     } else if (!alreadyProcessed) {
-      logTrace("No registered handler found for {}", record.getValueType());
+      log(TRACE, "No registered handler found for {}", record.getValueType());
     }
 
     if (!alreadyProcessed) {
@@ -277,7 +292,8 @@ public final class RdbmsExporter {
           resetIntervalFlush();
         }
       } catch (final ExporterPositionMismatchException e) {
-        logWarn(
+        log(
+            WARN,
             "Exporter position conflict detected during flush — requesting reopen to re-sync from DB position.");
         throw new ExporterException(
             String.format(
@@ -287,14 +303,16 @@ public final class RdbmsExporter {
             e,
             ExporterException.Compensation.REOPEN);
       } catch (final Exception e) {
-        logWarn(
+        log(
+            WARN,
             "Failed to flush record for positions {} to {} to the database.",
             lastFlushedPosition + 1,
             lastPosition);
         throw e;
       }
     } else {
-      logTrace(
+      log(
+          TRACE,
           "Record with key {} and original partitionId {} could not be exported {}.",
           record.getKey(),
           Protocol.decodePartitionId(record.getKey()),
@@ -328,7 +346,7 @@ public final class RdbmsExporter {
 
   private void updatePositionInRdbms() {
     if (lastPosition > exporterRdbmsPosition.lastExportedPosition()) {
-      logTrace("Updating position to {} in rdbms", lastPosition);
+      log(TRACE, "Updating position to {} in rdbms", lastPosition);
       exporterRdbmsPosition =
           new ExporterPositionModel(
               exporterRdbmsPosition.partitionId(),
@@ -353,7 +371,8 @@ public final class RdbmsExporter {
     try {
       exporterRdbmsPosition = rdbmsWriters.getExporterPositionService().findOne(partitionId);
     } catch (final Exception e) {
-      logWarn(
+      log(
+          WARN,
           "Failed to initialize exporter position because Database is not ready, retrying ... {}",
           e.getMessage());
       throw e;
@@ -368,9 +387,9 @@ public final class RdbmsExporter {
               LocalDateTime.now(),
               LocalDateTime.now());
       rdbmsWriters.getExporterPositionService().createWithoutQueue(exporterRdbmsPosition);
-      logDebug("Initialize position in rdbms");
+      log(DEBUG, "Initialize position in rdbms");
     } else {
-      logDebug("Found position in rdbms for this exporter: {}", exporterRdbmsPosition);
+      log(DEBUG, "Found position in rdbms for this exporter: {}", exporterRdbmsPosition);
     }
   }
 
@@ -383,7 +402,8 @@ public final class RdbmsExporter {
     try {
       flushExecutionQueue();
     } catch (final Exception e) {
-      logWarn(
+      log(
+          WARN,
           "Failed to flush records for positions {} to {} to the database",
           lastFlushedPosition + 1,
           lastPosition);
@@ -397,27 +417,17 @@ public final class RdbmsExporter {
       "Each exporter creates it's own executionQueue, so we need an accessible flush method for tests")
   public void flushExecutionQueue() {
     if (flushAfterEachRecord()) {
-      logWarn("Unnecessary flush called, since flush interval is zero or max queue size is zero");
+      log(WARN, "Unnecessary flush called, since flush interval is zero or max queue size is zero");
       return;
     }
     rdbmsWriters.getMetrics().recordQueueFlush(FlushTrigger.FLUSH_INTERVAL);
     rdbmsWriters.flush(true);
   }
 
-  private void logTrace(final String message, final Object... args) {
-    LOG.trace(withLogContext(message), withLogContextArgs(args));
-  }
-
-  private void logDebug(final String message, final Object... args) {
-    LOG.debug(withLogContext(message), withLogContextArgs(args));
-  }
-
-  private void logInfo(final String message, final Object... args) {
-    LOG.info(withLogContext(message), withLogContextArgs(args));
-  }
-
-  private void logWarn(final String message, final Object... args) {
-    LOG.warn(withLogContext(message), withLogContextArgs(args));
+  private void log(final Level level, final String message, final Object... args) {
+    if (LOG.isEnabledForLevel(level)) {
+      LOG.atLevel(level).log(withLogContext(message), withLogContextArgs(args));
+    }
   }
 
   private String withLogContext(final String message) {

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -117,6 +117,7 @@ public final class RdbmsExporter {
     // further than what's been acknowledged - e.g. under async LSN-based replication
     // (LsnReplicationController), acking is intentionally delayed until replication is confirmed.
     lastPosition = Math.max(controller.getLastExportedRecordPosition(), lastFlushedPosition);
+    replicationController = replicationControllerFactory.createReplicationController(controller);
     if (exporterRdbmsPosition.lastExportedPosition() > -1) {
       if (lastPosition < exporterRdbmsPosition.lastExportedPosition()) {
         // This is needed since the brokers last exported position is from its last snapshot and can
@@ -126,7 +127,13 @@ public final class RdbmsExporter {
             lastPosition,
             exporterRdbmsPosition.lastExportedPosition());
         lastPosition = exporterRdbmsPosition.lastExportedPosition();
-        updatePositionInBroker();
+        // Advance the broker through the replication controller instead of acking it directly: the
+        // RDBMS position only reflects what was flushed to the primary DB, not what replicas have
+        // confirmed. Under async replication acking the broker straight to this position would let
+        // the journal drop records that were never replicated (see #51588). The controller acks the
+        // broker according to its replication policy (immediately for NONE, once confirmed for
+        // LSN).
+        replicationController.onFlush(lastPosition);
       } else if (lastPosition > exporterRdbmsPosition.lastExportedPosition()) {
         logInfo(
             "Broker position {} is more advanced than rdbms position {}. Requesting replay from {}",
@@ -147,7 +154,6 @@ public final class RdbmsExporter {
     }
     lastFlushedPosition = lastPosition;
 
-    replicationController = replicationControllerFactory.createReplicationController(controller);
     rdbmsWriters
         .getExporterPositionService()
         .registerLockPositionHook(partitionId, () -> lastFlushedPosition);
@@ -318,11 +324,6 @@ public final class RdbmsExporter {
     }
 
     rdbmsWriters.getRdbmsPurger().purgeRdbms();
-  }
-
-  private void updatePositionInBroker() {
-    logTrace("Updating position to {} in broker", lastPosition);
-    controller.updateLastExportedRecordPosition(lastPosition);
   }
 
   private void updatePositionInRdbms() {

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -281,9 +281,11 @@ public final class RdbmsExporter {
         }
       }
       // causes a flush check after each processed record. Depending on the queue size and
-      // configuration, the writers ExecutionQueue may or may not flush here. When retrying an
-      // already-processed record we force the flush so the queue that failed to flush before is
-      // drained instead of lingering.
+      // configuration, the writers ExecutionQueue may or may not flush here. When a flush fails
+      // transiently, lastPosition has already advanced, so the broker redelivers the same record as
+      // a retry (alreadyProcessed). We force the flush to drain the batch that failed before,
+      // instead of letting it linger until the next interval flush. For re-deliveries with an empty
+      // queue this is a harmless no-op.
       try {
         final boolean shouldFlush =
             alreadyProcessed || flushAfterEachRecord() || shouldFlushAfterRecordProcessed;

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
 import io.camunda.db.rdbms.exception.ExporterPositionMismatchException;
+import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProvider;
 import io.camunda.db.rdbms.write.RdbmsWriterMetrics;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.ExporterPositionModel;
@@ -37,6 +38,7 @@ import io.camunda.db.rdbms.write.service.ExporterPositionService;
 import io.camunda.db.rdbms.write.service.HistoryCleanupService;
 import io.camunda.db.rdbms.write.service.HistoryDeletionService;
 import io.camunda.db.rdbms.write.service.RdbmsPurger;
+import io.camunda.exporter.rdbms.replication.LsnReplicationController;
 import io.camunda.exporter.rdbms.replication.ReplicationController;
 import io.camunda.exporter.rdbms.replication.ReplicationControllerFactory;
 import io.camunda.zeebe.exporter.api.ExporterException;
@@ -45,6 +47,7 @@ import io.camunda.zeebe.exporter.api.context.ScheduledTask;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import java.time.Duration;
+import java.time.InstantSource;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -563,6 +566,60 @@ class RdbmsExporterTest {
 
     // then - no replay should be requested
     verify(controller, never()).requestReplay(Mockito.anyLong());
+  }
+
+  @Test
+  void shouldNotAckBrokerDirectlyWhenBrokerBehindRdbmsOnOpen() {
+    // given - broker position (100) is behind the RDBMS position (150). Under async replication the
+    // RDBMS position reflects what is flushed to the primary DB, not what the replicas have
+    // confirmed. Acking the broker straight to the RDBMS position would let the journal drop
+    // records that were never replicated (see #51588).
+    final long brokerPosition = 100L;
+    final long rdbmsPosition = 150L;
+    createExporterWithRdbmsPosition(brokerPosition, rdbmsPosition);
+
+    // when
+    exporter.open(controller);
+
+    // then - the broker ack is delegated to the replication controller, which only advances the
+    // broker once replication is confirmed; the exporter must not ack the broker directly
+    verify(controller, never()).updateLastExportedRecordPosition(anyLong());
+    verify(replicationController).onFlush(rdbmsPosition);
+  }
+
+  @Test
+  void shouldNotAckBrokerPastUnconfirmedReplicationWithRealLsnControllerOnOpen() {
+    // given - broker (100) is behind the RDBMS position (150) and a REAL LsnReplicationController
+    // is
+    // wired in instead of a mock. Its replicas report no confirmed LSN, so nothing is replication-
+    // confirmed. This exercises the end-to-end #51588 guard: mocking the controller only proves the
+    // exporter delegates to onFlush; this proves the LSN controller then holds the broker back.
+    final long brokerPosition = 100L;
+    final long rdbmsPosition = 150L;
+    createExporterWithRdbmsPosition(brokerPosition, rdbmsPosition);
+
+    final var lsnProvider = mock(ReplicationLogStatusProvider.class);
+    when(lsnProvider.getCurrent()).thenReturn(200L);
+    when(lsnProvider.getReplicationStatuses()).thenReturn(List.of());
+    final var replicationConfig = new ExporterConfiguration.ReplicationConfiguration();
+    replicationConfig.setPollingInterval(Duration.ofSeconds(5));
+    replicationConfig.setMaxLag(Duration.ofSeconds(10));
+    replicationConfig.setMinSyncReplicas(1);
+    final var clock = mock(InstantSource.class);
+    when(clock.millis()).thenReturn(0L);
+    final var realLsnController =
+        new LsnReplicationController(controller, lsnProvider, replicationConfig, 0, clock, metrics);
+    when(replicationControllerFactory.createReplicationController(any()))
+        .thenReturn(realLsnController);
+
+    // when
+    exporter.open(controller);
+
+    // then - the RDBMS position is only enqueued in the LSN controller, never acked to the broker.
+    // The periodic replication check never runs (its scheduled task is mocked and never fires) and
+    // no replica has confirmed the LSN, so the broker must not be advanced past the unreplicated
+    // position (see #51588).
+    verify(controller, never()).updateLastExportedRecordPosition(anyLong());
   }
 
   @Test


### PR DESCRIPTION
## Description
When the RdbmsExporter is opened and detects a mismatch between acknowledged position & exportedPosition, then it automatically bumps the exportedPosition. This is wrong when using async replication as we're at risk of data loss if replication is not working during that time.
Bug found when restarting the cluster after a replica was removed from a global Aurora cluster.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates #58941
