### PR TITLE
test: set testForkNumber in the default surefire config

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2567,6 +2567,12 @@
             <failIfNoTests>false</failIfNoTests>
             <trimStackTrace>false</trimStackTrace>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
+            <systemPropertyVariables>
+              <!-- use two dollar signs to prevent maven properties resolution, surefire will resolve
+              the property later. If only ${surefire.forkNumber} is used maven will fail to resolve it
+              and don't set the system property -->
+              <testForkNumber>$${surefire.forkNumber}</testForkNumber>
+            </systemPropertyVariables>
             <properties>
               <property>
                 <name>listener</name>
@@ -2604,6 +2610,12 @@
             <failIfNoTests>false</failIfNoTests>
             <trimStackTrace>false</trimStackTrace>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
+            <systemPropertyVariables>
+              <!-- use two dollar signs to prevent maven properties resolution, surefire will resolve
+              the property later. If only ${surefire.forkNumber} is used maven will fail to resolve it
+              and don't set the system property -->
+              <testForkNumber>$${surefire.forkNumber}</testForkNumber>
+            </systemPropertyVariables>
             <properties>
               <property>
                 <name>listener</name>
@@ -3203,12 +3215,6 @@
             <configuration>
               <forkCount>${forkCount}</forkCount>
               <reuseForks>true</reuseForks>
-              <systemPropertyVariables>
-                <!-- use two dollar signs to prevent maven properties resolution, surefire will resolve
-                the property later. If only ${surefire.forkNumber} is used maven will fail to resolve it
-                and don't set the system property -->
-                <testForkNumber>$${surefire.forkNumber}</testForkNumber>
-              </systemPropertyVariables>
               <properties>
                 <configurationParameters>${junitConfigurationParameters}</configurationParameters>
               </properties>
@@ -3220,12 +3226,6 @@
             <configuration>
               <forkCount>${forkCount}</forkCount>
               <reuseForks>true</reuseForks>
-              <systemPropertyVariables>
-                <!-- use two dollar signs to prevent maven properties resolution, surefire will resolve
-                the property later. If only ${surefire.forkNumber} is used maven will fail to resolve it
-                and don't set the system property -->
-                <testForkNumber>$${surefire.forkNumber}</testForkNumber>
-              </systemPropertyVariables>
               <properties>
                 <configurationParameters>${junitConfigurationParameters}</configurationParameters>
               </properties>


### PR DESCRIPTION
SocketUtil partitions TCP ports per fork using the `testForkNumber` system property, but that property was only set inside the `parallel-tests` profile.

Setting it in the default surefire and failsafe configuration keeps the `parallel-tests` behaviour unchanged and also resolves port clashes on plain `mvn -T1C` builds, improving the local dev experience a little.