### PR TITLE
feat: push cross-partition holder completion to P_K, demote lock-release polling to reconciliation

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/ProcessInstanceCreation.java
+++ b/configuration/src/main/java/io/camunda/configuration/ProcessInstanceCreation.java
@@ -12,7 +12,6 @@ import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGE_START_
 import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGE_START_DEDUP_EXPIRATION_SWEEP_INTERVAL;
 import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_BATCH_LIMIT;
 import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_INTERVAL;
-import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_MAX_BACKOFF;
 
 import java.time.Duration;
 
@@ -56,20 +55,12 @@ public class ProcessInstanceCreation {
 
   /**
    * Base poll interval for the cross-partition correlation-key lock-release scheduler on {@code
-   * P_K}. {@code P_K} polls {@code P_B} for the completion of each remotely-created holder
-   * instance; this value drives the scheduler's tick frequency and the base interval before
-   * back-off applies.
+   * P_K}. {@code P_K} reconciles the completion of each remotely-created holder instance with
+   * {@code P_B}; this value drives the scheduler's tick frequency. It is only a slow-path backstop,
+   * since holder completion is normally pushed from {@code P_B} directly.
    */
   private Duration messageStartLockReleasePollInterval =
       DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_INTERVAL;
-
-  /**
-   * Upper bound on the per-lock exponential back-off of the cross-partition correlation-key
-   * lock-release poll on {@code P_K}, so a long-running holder is not polled at the base rate
-   * indefinitely.
-   */
-  private Duration messageStartLockReleasePollMaxBackoff =
-      DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_MAX_BACKOFF;
 
   /**
    * Upper bound on the number of holders batched into a single cross-partition correlation-key
@@ -120,15 +111,6 @@ public class ProcessInstanceCreation {
   public void setMessageStartLockReleasePollInterval(
       final Duration messageStartLockReleasePollInterval) {
     this.messageStartLockReleasePollInterval = messageStartLockReleasePollInterval;
-  }
-
-  public Duration getMessageStartLockReleasePollMaxBackoff() {
-    return messageStartLockReleasePollMaxBackoff;
-  }
-
-  public void setMessageStartLockReleasePollMaxBackoff(
-      final Duration messageStartLockReleasePollMaxBackoff) {
-    this.messageStartLockReleasePollMaxBackoff = messageStartLockReleasePollMaxBackoff;
   }
 
   public int getMessageStartLockReleasePollBatchLimit() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -1262,8 +1262,6 @@ public class BrokerBasedPropertiesOverride {
         processInstanceCreation.getMessageStartAskRetryInterval());
     processInstanceCreationCfg.setMessageStartLockReleasePollInterval(
         processInstanceCreation.getMessageStartLockReleasePollInterval());
-    processInstanceCreationCfg.setMessageStartLockReleasePollMaxBackoff(
-        processInstanceCreation.getMessageStartLockReleasePollMaxBackoff());
     processInstanceCreationCfg.setMessageStartLockReleasePollBatchLimit(
         processInstanceCreation.getMessageStartLockReleasePollBatchLimit());
   }

--- a/configuration/src/test/java/io/camunda/configuration/ProcessInstanceCreationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ProcessInstanceCreationTest.java
@@ -66,16 +66,8 @@ public class ProcessInstanceCreationTest {
     void shouldSetDefaultMessageStartLockReleasePollInterval() {
       assertThat(brokerCfg.getExperimental().getEngine().getProcessInstanceCreation())
           .returns(
-              Duration.ofSeconds(1),
-              ProcessInstanceCreationCfg::getMessageStartLockReleasePollInterval);
-    }
-
-    @Test
-    void shouldSetDefaultMessageStartLockReleasePollMaxBackoff() {
-      assertThat(brokerCfg.getExperimental().getEngine().getProcessInstanceCreation())
-          .returns(
               Duration.ofSeconds(30),
-              ProcessInstanceCreationCfg::getMessageStartLockReleasePollMaxBackoff);
+              ProcessInstanceCreationCfg::getMessageStartLockReleasePollInterval);
     }
 
     @Test
@@ -93,7 +85,6 @@ public class ProcessInstanceCreationTest {
         "camunda.process-instance-creation.message-start-dedup-expiration-sweep-batch-limit=250",
         "camunda.process-instance-creation.message-start-ask-retry-interval=5s",
         "camunda.process-instance-creation.message-start-lock-release-poll-interval=2s",
-        "camunda.process-instance-creation.message-start-lock-release-poll-max-backoff=45s",
         "camunda.process-instance-creation.message-start-lock-release-poll-batch-limit=128",
       })
   class WithOnlyUnifiedConfigSet {
@@ -116,9 +107,6 @@ public class ProcessInstanceCreationTest {
           .returns(
               Duration.ofSeconds(2),
               ProcessInstanceCreationCfg::getMessageStartLockReleasePollInterval)
-          .returns(
-              Duration.ofSeconds(45),
-              ProcessInstanceCreationCfg::getMessageStartLockReleasePollMaxBackoff)
           .returns(128, ProcessInstanceCreationCfg::getMessageStartLockReleasePollBatchLimit);
     }
   }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -257,7 +257,6 @@ process-instance-creation.message-start-dedup-expiration-sweep-batch-limit
 process-instance-creation.message-start-dedup-expiration-sweep-interval
 process-instance-creation.message-start-lock-release-poll-batch-limit
 process-instance-creation.message-start-lock-release-poll-interval
-process-instance-creation.message-start-lock-release-poll-max-backoff
 processing.enable-async-message-ttl-checker
 processing.enable-async-timer-duedate-checker
 processing.enable-foreign-key-checks

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -243,8 +243,6 @@ public final class EngineCfg implements ConfigurationEntry {
         .setMessageStartAskRetryInterval(processInstanceCreation.getMessageStartAskRetryInterval())
         .setMessageStartLockReleasePollInterval(
             processInstanceCreation.getMessageStartLockReleasePollInterval())
-        .setMessageStartLockReleasePollMaxBackoff(
-            processInstanceCreation.getMessageStartLockReleasePollMaxBackoff())
         .setMessageStartLockReleasePollBatchLimit(
             processInstanceCreation.getMessageStartLockReleasePollBatchLimit())
         .setIncludeVariablesInJobCompletedEvent(jobs.isIncludeVariablesInJobCompletedEvent())

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ProcessInstanceCreationCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ProcessInstanceCreationCfg.java
@@ -13,7 +13,6 @@ import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGE_START_
 import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGE_START_DEDUP_EXPIRATION_SWEEP_INTERVAL;
 import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_BATCH_LIMIT;
 import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_INTERVAL;
-import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_MAX_BACKOFF;
 
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
 import java.time.Duration;
@@ -28,8 +27,6 @@ public class ProcessInstanceCreationCfg implements ConfigurationEntry {
   private Duration messageStartAskRetryInterval = DEFAULT_MESSAGE_START_ASK_RETRY_INTERVAL;
   private Duration messageStartLockReleasePollInterval =
       DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_INTERVAL;
-  private Duration messageStartLockReleasePollMaxBackoff =
-      DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_MAX_BACKOFF;
   private int messageStartLockReleasePollBatchLimit =
       DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_BATCH_LIMIT;
 
@@ -76,15 +73,6 @@ public class ProcessInstanceCreationCfg implements ConfigurationEntry {
     this.messageStartLockReleasePollInterval = messageStartLockReleasePollInterval;
   }
 
-  public Duration getMessageStartLockReleasePollMaxBackoff() {
-    return messageStartLockReleasePollMaxBackoff;
-  }
-
-  public void setMessageStartLockReleasePollMaxBackoff(
-      final Duration messageStartLockReleasePollMaxBackoff) {
-    this.messageStartLockReleasePollMaxBackoff = messageStartLockReleasePollMaxBackoff;
-  }
-
   public int getMessageStartLockReleasePollBatchLimit() {
     return messageStartLockReleasePollBatchLimit;
   }
@@ -107,8 +95,6 @@ public class ProcessInstanceCreationCfg implements ConfigurationEntry {
         + messageStartAskRetryInterval
         + ", messageStartLockReleasePollInterval="
         + messageStartLockReleasePollInterval
-        + ", messageStartLockReleasePollMaxBackoff="
-        + messageStartLockReleasePollMaxBackoff
         + ", messageStartLockReleasePollBatchLimit="
         + messageStartLockReleasePollBatchLimit
         + '}';

--- a/zeebe/docs/adr/0001-810-message-correlation-business-id-cross-partition.md
+++ b/zeebe/docs/adr/0001-810-message-correlation-business-id-cross-partition.md
@@ -1,4 +1,4 @@
-# Business ID message correlation: P_K owns messages, P_B enforces uniqueness, P_K pulls for release
+# Business ID message correlation: P_K owns messages, P_B enforces uniqueness, P_B pushes lock release
 
 **DRI**: Mustafa Dagher
 
@@ -21,7 +21,8 @@ message and the instance it would create no longer co-locate.
 The outcome: message routing is unchanged; `P_K` remains the single owner of message state and
 `P_B` remains the single owner of Business ID uniqueness. Message-start events bridge the two
 partitions with a cross-partition ask; other message events filter locally; and the resulting
-cross-partition lock is released by `P_K` polling `P_B`.
+cross-partition lock is released by `P_B` pushing a release to `P_K` when the holder completes, with
+a coarse `P_K` reconciliation poll retained only as a backstop for lost pushes.
 
 ## Decision
 
@@ -48,7 +49,7 @@ businessId-bearing start would create its instance on a different `P_B`, `P_K` s
 subscription has not yet been distributed to `P_B`). On a rejection the message stays buffered on
 `P_K`.
 
-The pull-based release (D3), continuing from the `STARTED` reply above:
+The push-based release (D3), continuing from the `STARTED` reply above:
 
 ```mermaid
 sequenceDiagram
@@ -56,23 +57,33 @@ sequenceDiagram
     participant P_B as P_B = hash(businessId)
 
     Note over P_K: STARTED applied:<br/>correlation-key lock records holder on P_B
+    Note over P_B: remembers which lock to release when the holder ends
 
-    loop poll with back-off and batching, until holder completes (D3)
-        P_K->>P_B: is holder instance still active?
-        alt holder still active
-            P_B-->>P_K: yes
-        else holder completed or terminated
-            P_B-->>P_K: no
-            Note over P_K: release correlation-key lock,<br/>pick up next buffered message
+    alt holder completes or terminates on P_B (fast path, D3)
+        P_B->>P_K: RELEASE(holder)
+        Note over P_K: release correlation-key lock,<br/>pick up next buffered message
+    else push lost, or holder banned (reconciliation backstop, D3)
+        loop coarse poll, only while the lock is still held
+            P_K->>P_B: is holder instance still active?
+            P_B-->>P_K: RELEASE if the holder is gone
         end
     end
 ```
 
-**D3. The cross-partition correlation-key lock is released by pull, not push.** For a remotely
-created start, `P_K` records the holder instance and polls `P_B` (with back-off and batching) for
-that specific instance's completion, then releases the lock and picks up the next buffered message —
-keeping lock semantics identical to a single-partition start. Locally created starts use the
-existing local release path unchanged.
+**D3. The cross-partition correlation-key lock is released by a push from `P_B`, with polling
+demoted to a reconciliation backstop.** When the remotely-created holder completes or terminates,
+`P_B` pushes a `RELEASE` to `P_K`, which releases the lock and picks up the next buffered message —
+keeping lock semantics identical to a single-partition start, resolved at holder-completion latency
+rather than poll latency. The push and the reconciliation poll (below) resolve through the same
+`RELEASE` command rather than separate messages, and locally created starts keep their local release
+path unchanged.
+
+A coarse `P_K` poll is retained only as a self-healing backstop for what the push cannot cover — a
+`RELEASE` lost to dropped inter-partition traffic, or a holder banned with no completion transition
+to push from. It reconciles from `P_K`'s current lock state each tick and persists no coordination
+state, so it survives restarts and leadership changes. Because the `RELEASE` processor on `P_K` is
+idempotent — a redundant release is rejected — a push and a reconciling poll racing on the same
+holder cannot double-release.
 
 **D4. Cross-partition creates are idempotent via a dedup row on `P_B`.** `P_B` records
 `(processDefinitionKey, messageKey) → processInstanceKey` with a deletion deadline equal to the
@@ -147,10 +158,16 @@ sequenceDiagram
 - **`P_B` owns blocked starts; `P_K` forwards-and-forgets.** Moves the message itself to `P_B` on
   forward. Relocates cross-partition state rather than removing it, and breaks `messageId`
   deduplication and correlation to processes that listen for the same message without a Business ID.
-- **Push-based release notification from `P_B`.** `P_B` would track which partitions hold dependent
-  work and notify them on each completion. Rejected: it requires per-waiter bookkeeping and reliable
-  delivery on `P_B`, is not self-healing across restarts/leadership changes, and has no decisive
-  efficiency advantage over the pull (D3).
+- **Pure pull with exponential back-off (the original D3).** `P_K` alone drove release: it polled
+  `P_B` for each held lock on a short interval with per-lock exponential back-off, and `P_B` pushed
+  nothing. Superseded because it puts release latency on the poll interval for every cross-partition
+  start even though `P_B` knows the exact completion instant, and the back-off bookkeeping exists
+  only to dampen a steady-state poll the push removes. The original rejection of a push cited
+  per-waiter bookkeeping, reliable delivery, and restart self-healing — each addressed respectively
+  by the single holder-origin entry the `STARTED` applier already writes, the retained poll
+  backstop, and the poll's stateless reconciliation from current lock state. The push (D3) resolves
+  the common case at completion latency; the poll is kept, coarsened, and stripped of back-off as
+  the reconciliation backstop.
 
 ## Consequences
 
@@ -161,9 +178,14 @@ sequenceDiagram
 - A synchronous `correlate` to a cross-partition start is answered exactly once, when its remote
   outcome is known, by reusing the existing request-deferral state — so it never reports a spurious
   `NOT_FOUND` while the instance is being created (D6, closing camunda/camunda#58207).
-- The pull keeps all reaction-to-completion logic on the partition that owns the work and is
-  self-healing, at the cost of added latency on the release path (bounded by the poll interval and
-  back-off).
+- The push releases the lock at holder-completion latency, not poll latency, while the retained
+  reconciliation poll keeps release self-healing across lost pushes, restarts, and leadership
+  changes — the fast-path/safety-net pair (D3). Release logic stays on `P_K`, which owns the lock
+  and the buffer.
+- Operational signal: releases are normally push-driven, so a `RELEASE` preceded by a reconciliation
+  `QUERY` for the same holder means that holder's push was lost. A rising rate of query-preceded
+  `RELEASE`s is a symptom of inter-partition delivery loss (network/partition health), not a feature
+  regression — the lock is still released, just via the backstop rather than the fast path.
 - A start rejected purely on Business ID uniqueness stays buffered and relies on its TTL and existing
   buffered-message triggers, matching single-partition behaviour. Proactively retrying it when the
   Business ID frees is decided separately in

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -91,17 +91,13 @@ public final class EngineConfiguration {
   public static final Duration DEFAULT_MESSAGE_START_ASK_RETRY_INTERVAL = Duration.ofSeconds(10);
 
   /**
-   * Base cadence at which {@code P_K} polls {@code P_B} for the completion of a cross-partition
-   * message-start holder instance, and the interval at which a newly observed lock entry is first
-   * polled. Each lock entry then backs off exponentially up to {@link
-   * #DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_MAX_BACKOFF} so a long-running holder does not produce
-   * steady-state polling at the base rate.
+   * Coarse cadence at which {@code P_K} reconciles the correlation-key locks it holds for
+   * cross-partition message-start instances against {@code P_B}. This is only a slow-path backstop:
+   * on holder completion or termination {@code P_B} pushes the release to {@code P_K} directly, so
+   * a lock is normally released well before the next reconciliation tick. The poll only recovers
+   * locks whose push was lost, which is why it runs infrequently.
    */
   public static final Duration DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_INTERVAL =
-      Duration.ofSeconds(1);
-
-  /** Maximum back-off interval a single cross-partition lock entry's release poll grows to. */
-  public static final Duration DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_MAX_BACKOFF =
       Duration.ofSeconds(30);
 
   /** Maximum number of holder instances batched into a single release query to one partition. */
@@ -181,8 +177,6 @@ public final class EngineConfiguration {
   private Duration messageStartAskRetryInterval = DEFAULT_MESSAGE_START_ASK_RETRY_INTERVAL;
   private Duration messageStartLockReleasePollInterval =
       DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_INTERVAL;
-  private Duration messageStartLockReleasePollMaxBackoff =
-      DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_MAX_BACKOFF;
   private int messageStartLockReleasePollBatchLimit =
       DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_BATCH_LIMIT;
 
@@ -653,8 +647,9 @@ public final class EngineConfiguration {
   }
 
   /**
-   * Base cadence at which {@code P_K} polls {@code P_B} for a cross-partition message-start
-   * holder's completion, and the interval at which a newly observed lock entry is first polled.
+   * Coarse cadence at which {@code P_K} reconciles the correlation-key locks it holds for
+   * cross-partition message-start holders against {@code P_B}. A slow-path backstop only: holder
+   * completion is normally pushed from {@code P_B} to {@code P_K} directly.
    */
   public Duration getMessageStartLockReleasePollInterval() {
     return messageStartLockReleasePollInterval;
@@ -663,17 +658,6 @@ public final class EngineConfiguration {
   public EngineConfiguration setMessageStartLockReleasePollInterval(
       final Duration messageStartLockReleasePollInterval) {
     this.messageStartLockReleasePollInterval = messageStartLockReleasePollInterval;
-    return this;
-  }
-
-  /** Maximum back-off interval a single cross-partition lock entry's release poll grows to. */
-  public Duration getMessageStartLockReleasePollMaxBackoff() {
-    return messageStartLockReleasePollMaxBackoff;
-  }
-
-  public EngineConfiguration setMessageStartLockReleasePollMaxBackoff(
-      final Duration messageStartLockReleasePollMaxBackoff) {
-    this.messageStartLockReleasePollMaxBackoff = messageStartLockReleasePollMaxBackoff;
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.message.MessageCorrelateBehavior;
 import io.camunda.zeebe.engine.processing.message.MessageCorrelateBehavior.MessageData;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
@@ -24,7 +25,10 @@ import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.message.StoredMessage;
 import io.camunda.zeebe.engine.state.routing.RoutingInfo;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartCorrelationKeyLockReleaseRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
+import io.camunda.zeebe.protocol.record.intent.MessageStartCorrelationKeyLockReleaseIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.InstantSource;
@@ -43,6 +47,8 @@ public final class BpmnBufferedMessageStartEventBehavior {
 
   private final MessageCorrelateBehavior messageCorrelateBehavior;
   private final InstantSource clock;
+  private final StateWriter stateWriter;
+  private final SubscriptionCommandSender commandSender;
 
   public BpmnBufferedMessageStartEventBehavior(
       final ProcessingState processingState,
@@ -62,6 +68,8 @@ public final class BpmnBufferedMessageStartEventBehavior {
     messageStartProcessInstanceAskState = processingState.getMessageStartProcessInstanceAskState();
     this.businessIdUniquenessEnabled = businessIdUniquenessEnabled;
     this.clock = clock;
+    stateWriter = writers.state();
+    this.commandSender = commandSender;
 
     final var eventHandle =
         new EventHandle(
@@ -93,6 +101,50 @@ public final class BpmnBufferedMessageStartEventBehavior {
   public Optional<DirectBuffer> findCorrelationKey(final BpmnElementContext context) {
     final var processInstanceKey = context.getProcessInstanceKey();
     return Optional.ofNullable(messageState.getProcessInstanceCorrelationKey(processInstanceKey));
+  }
+
+  /**
+   * Pushes a cross-partition message-start holder's completion or termination to {@code P_K}: when
+   * the given root process instance was created as such a holder via the handshake — signalled by a
+   * holder-origin entry on {@code P_B} — this emits a {@link
+   * MessageStartCorrelationKeyLockReleaseIntent#PUSHED} event (which drops the origin entry) and
+   * sends the {@code RELEASE} to {@code P_K}, so {@code P_K} frees the correlation-key lock and
+   * picks up the next buffered message the moment the holder is gone, rather than waiting to be
+   * polled.
+   *
+   * <p>Driven purely by the origin entry's presence, and everything the {@code RELEASE} carries is
+   * read from it — never from the completing element's context, which may belong to a migrated
+   * version declaring a different process id (or no message start event at all). For every
+   * non-holder root instance the lookup is a single point read that misses via the column family's
+   * bloom filter.
+   */
+  public void pushCrossPartitionHolderCompletion(final long processInstanceKey) {
+    final var origin = messageState.getCrossPartitionStartHolderOrigin(processInstanceKey);
+    if (origin == null) {
+      return;
+    }
+
+    // the origin getters are backed by the shared read buffer: copy before appending the event
+    final var bpmnProcessId = BufferUtil.cloneBuffer(origin.getBpmnProcessIdBuffer());
+    final var correlationKey = BufferUtil.cloneBuffer(origin.getCorrelationKeyBuffer());
+    final var tenantId = BufferUtil.bufferAsString(origin.getTenantIdBuffer());
+    // the buffered message key's partition bits address P_K; synthesize the RELEASE's routing
+    // envelope from them (raw key 0: it is a partition address, not an event or request key)
+    final long requestKey =
+        Protocol.encodePartitionId(Protocol.decodePartitionId(origin.getMessageKey()), 0L);
+
+    final var record = new MessageStartCorrelationKeyLockReleaseRecord().setRequestKey(requestKey);
+    final var holder =
+        record
+            .addHolder()
+            .setProcessInstanceKey(processInstanceKey)
+            .setBpmnProcessId(bpmnProcessId)
+            .setCorrelationKey(correlationKey)
+            .setTenantId(tenantId);
+
+    stateWriter.appendFollowUpEvent(
+        processInstanceKey, MessageStartCorrelationKeyLockReleaseIntent.PUSHED, record);
+    commandSender.sendCorrelationKeyLockRelease(requestKey, holder);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -34,8 +34,6 @@ import java.util.function.Function;
 public final class ProcessProcessor
     implements BpmnElementContainerProcessor<ExecutableFlowElementContainer> {
 
-  private static final Consumer<BpmnElementContext> NOOP = context -> {};
-
   private final BpmnStateBehavior stateBehavior;
   private final BpmnStateTransitionBehavior stateTransitionBehavior;
   private final BpmnEventSubscriptionBehavior eventSubscriptionBehavior;
@@ -267,16 +265,27 @@ public final class ProcessProcessor
       // Business ID that blocks a message-start owned by the latest version. The re-drive resolves
       // the latest version, so it correctly finds (or finds nothing) regardless of the holder's own
       // version.
+      final var processInstanceKey = context.getProcessInstanceKey();
       final var correlationKey =
           bufferedMessageStartEventBehavior.findCorrelationKey(context).orElse(null);
       final var businessId = context.getBusinessId();
 
-      return postTransitionContext ->
-          bufferedMessageStartEventBehavior.correlateNextBufferedMessagesOnCompletion(
-              postTransitionContext, correlationKey, businessId);
+      return postTransitionContext -> {
+        bufferedMessageStartEventBehavior.correlateNextBufferedMessagesOnCompletion(
+            postTransitionContext, correlationKey, businessId);
+        // If this instance is a cross-partition message-start holder, push its completion to P_K so
+        // the correlation-key lock there is freed without waiting for a poll (a no-op point read
+        // for every non-holder instance).
+        bufferedMessageStartEventBehavior.pushCrossPartitionHolderCompletion(processInstanceKey);
+      };
 
     } else {
-      return NOOP;
+      // A plain root instance still has to push its completion when it is a cross-partition
+      // message-start holder whose current version lost the message start event through migration:
+      // the release must key off the origin entry captured at creation, not this version's context.
+      final var processInstanceKey = context.getProcessInstanceKey();
+      return postTransitionContext ->
+          bufferedMessageStartEventBehavior.pushCrossPartitionHolderCompletion(processInstanceKey);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseScheduler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import com.google.common.collect.Lists;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.protocol.Protocol;
@@ -37,11 +38,13 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Each tick it walks the cross-partition lock entries in local {@link MessageState}, groups them
  * by the target partition (derived from each holder instance key's partition bits, since every
- * Zeebe key encodes its generating partition), and dispatches one batched {@code QUERY} per target
- * partition, carrying up to {@code batchLimit} holders each. {@code P_B} replies {@code RELEASE}
- * for any holder that is gone; the RELEASE command processor on {@code P_K} then releases the
- * correlation-key lock and picks up the next buffered message for that key. Any holders beyond the
- * batch limit are reconciled on a later tick, as reaped locks drop out of local state.
+ * Zeebe key encodes its generating partition), and dispatches a {@code QUERY} per target partition.
+ * All of a partition's holders are reconciled on every tick; they are split into chunks of at most
+ * {@code batchLimit} holders per {@code QUERY} so each {@code QUERY}/{@code QUERIED} record stays
+ * well under the broker's max message size, no matter how many holders currently target that
+ * partition. {@code P_B} replies {@code RELEASE} for any holder that is gone; the RELEASE command
+ * processor on {@code P_K} then releases the correlation-key lock and picks up the next buffered
+ * message for that key.
  *
  * <p>The poll set is fully reconstructable from local lock state, so the scheduler keeps no
  * transient bookkeeping and no cross-partition coordination state is persisted: every tick
@@ -80,6 +83,17 @@ public final class CrossPartitionMessageStartLockReleaseScheduler
 
   @Override
   public void run() {
+    final int limit = batchLimit.getAsInt();
+    if (limit <= 0) {
+      // Defensive: a non-positive batch limit is a misconfiguration. Warn so it is diagnosable and
+      // skip the tick rather than emitting empty queries and pointless inter-partition traffic.
+      LOG.warn(
+          "Skipping cross-partition message-start lock reconciliation: batch limit is {} but must "
+              + "be positive; check the message-start lock-release poll batch-limit configuration.",
+          limit);
+      return;
+    }
+
     // Group every cross-partition lock entry by the partition its holder lives on. Buffers handed
     // to the visitor are only valid during the callback, so copy into immutable values here.
     final Map<Integer, List<Lock>> locksByPartition = new HashMap<>();
@@ -101,28 +115,26 @@ public final class CrossPartitionMessageStartLockReleaseScheduler
                       tenantId));
         });
 
-    locksByPartition.forEach(this::pollPartition);
+    locksByPartition.forEach(
+        (targetPartition, locks) -> pollPartition(targetPartition, locks, limit));
   }
 
-  private void pollPartition(final int targetPartition, final List<Lock> locks) {
-    final int limit = batchLimit.getAsInt();
-    if (limit <= 0) {
-      // Defensive: a non-positive batch limit is a misconfiguration. Skip rather than emit an
-      // empty query so we don't produce pointless inter-partition traffic and QUERIED events every
-      // tick. (locks is never empty here — a partition list is only created when a lock is added.)
-      return;
-    }
+  private void pollPartition(final int targetPartition, final List<Lock> locks, final int limit) {
+    // Reconcile every holder each tick, split into chunks of at most batchLimit so a single
+    // QUERY/QUERIED record stays well under the broker's max message size no matter how many
+    // cross-partition holders currently target this partition. Chunking (rather than a hard cap on
+    // the first batchLimit entries) guarantees a holder sorted past the limit is still queried on
+    // the same tick and cannot starve while the leading holders stay long-lived.
+    Lists.partition(locks, limit).forEach(chunk -> sendQuery(targetPartition, chunk));
+  }
 
-    // Cap each query at the batch limit; the remainder is reconciled on a later tick as reaped
-    // locks drop out of local state.
-    final var batch = locks.size() <= limit ? locks : locks.subList(0, limit);
-
+  private void sendQuery(final int targetPartition, final List<Lock> chunk) {
     final var query =
         new MessageStartCorrelationKeyLockReleaseRecord()
             // requestKey only needs to carry P_K in its partition bits so P_B can route the reply
             // back; it is never used as an event key.
             .setRequestKey(Protocol.encodePartitionId(partitionId, 0L));
-    for (final var lock : batch) {
+    for (final var lock : chunk) {
       query
           .addHolder()
           .setProcessInstanceKey(lock.holderProcessInstanceKey())
@@ -134,7 +146,7 @@ public final class CrossPartitionMessageStartLockReleaseScheduler
     LOG.trace(
         "Reconciling partition {} for {} cross-partition message-start holder(s)",
         targetPartition,
-        batch.size());
+        chunk.size());
     commandSender.sendDirectCorrelationKeyLockReleaseQuery(targetPartition, query);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseScheduler.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.Duration;
-import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -26,25 +25,28 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Scheduled task on {@code P_K} that releases the correlation-key locks held for message-start
- * instances created via the cross-partition handshake, by polling {@code P_B} for the completion of
- * each holder instance.
+ * Scheduled reconciliation task on {@code P_K} that is the slow-path backstop for releasing the
+ * correlation-key locks held for message-start instances created via the cross-partition handshake.
  *
  * <p>For a locally-started message-start instance the correlation-key lock is released when the
  * holder completes on the same partition. For a cross-partition start the holder lives on {@code
- * P_B}, which {@code P_K} cannot observe directly — so {@code P_K} polls. Each tick this scheduler
- * walks the cross-partition lock entries in local {@link MessageState}, groups them by the target
- * partition (derived from each holder instance key's partition bits, since every Zeebe key encodes
- * its generating partition), and dispatches one batched {@code QUERY} per target partition. {@code
- * P_B} replies {@code RELEASE} for any holder that is gone; the RELEASE command processor on {@code
- * P_K} then releases the correlation-key lock and picks up the next buffered message for that key.
+ * P_B}: on completion or termination {@code P_B} pushes a {@code RELEASE} straight to {@code P_K},
+ * which is the fast path. This scheduler exists only to recover locks whose push was lost — e.g.
+ * dropped inter-partition traffic — and therefore runs at a coarse cadence (see {@link
+ * io.camunda.zeebe.engine.EngineConfiguration#DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_INTERVAL}).
  *
- * <p>The poll set is fully reconstructable from local lock state, so no cross-partition
- * coordination state is persisted. The per-entry back-off bookkeeping is transient and rebuilt from
- * an empty map on recovery: a newly observed lock entry is polled immediately and then backs off
- * exponentially (×2) up to the configured maximum, so a long-running holder does not keep polling
- * at the base rate. Entries that disappear from local state (their lock was released elsewhere) are
- * dropped from the bookkeeping. When there is nothing to poll the tick is a no-op.
+ * <p>Each tick it walks the cross-partition lock entries in local {@link MessageState}, groups them
+ * by the target partition (derived from each holder instance key's partition bits, since every
+ * Zeebe key encodes its generating partition), and dispatches one batched {@code QUERY} per target
+ * partition, carrying up to {@code batchLimit} holders each. {@code P_B} replies {@code RELEASE}
+ * for any holder that is gone; the RELEASE command processor on {@code P_K} then releases the
+ * correlation-key lock and picks up the next buffered message for that key. Any holders beyond the
+ * batch limit are reconciled on a later tick, as reaped locks drop out of local state.
+ *
+ * <p>The poll set is fully reconstructable from local lock state, so the scheduler keeps no
+ * transient bookkeeping and no cross-partition coordination state is persisted: every tick
+ * reconciles purely from the current lock entries. When there is nothing to reconcile the tick is a
+ * no-op.
  */
 public final class CrossPartitionMessageStartLockReleaseScheduler
     implements Runnable, StreamProcessorLifecycleAware {
@@ -56,154 +58,89 @@ public final class CrossPartitionMessageStartLockReleaseScheduler
   private final SubscriptionCommandSender commandSender;
   private final MessageState messageState;
   private final Supplier<Duration> pollInterval;
-  private final Supplier<Duration> maxBackoff;
   private final IntSupplier batchLimit;
-
-  /**
-   * Transient per-lock back-off bookkeeping, rebuilt on recovery (mirrors the pending-ask state).
-   */
-  private final Map<LockKey, PollState> backoffByLock = new HashMap<>();
-
-  private InstantSource clock;
-
-  /**
-   * Monotonic tick counter used to sweep bookkeeping for locks that disappeared: every entry seen
-   * in a tick is stamped with the current value, and entries left unstamped afterwards are dropped.
-   */
-  private long pollEpoch;
 
   public CrossPartitionMessageStartLockReleaseScheduler(
       final int partitionId,
       final SubscriptionCommandSender commandSender,
       final MessageState messageState,
       final Supplier<Duration> pollInterval,
-      final Supplier<Duration> maxBackoff,
       final IntSupplier batchLimit) {
     this.partitionId = partitionId;
     this.commandSender = commandSender;
     this.messageState = messageState;
     this.pollInterval = pollInterval;
-    this.maxBackoff = maxBackoff;
     this.batchLimit = batchLimit;
   }
 
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
-    clock = context.getClock();
     context.getScheduleService().runAtFixedRate(pollInterval.get(), this);
   }
 
   @Override
   public void run() {
-    final long now = clock.millis();
-    final long epoch = ++pollEpoch;
-
-    // Single pass over the local lock entries: refresh/age the back-off bookkeeping, drop entries
-    // for locks that disappeared, and materialise only the entries that are actually due into the
-    // per-target-partition batches. Non-due entries (the common case under back-off) are not
-    // copied.
-    final Map<Integer, List<Lock>> dueByPartition = new HashMap<>();
+    // Group every cross-partition lock entry by the partition its holder lives on. Buffers handed
+    // to the visitor are only valid during the callback, so copy into immutable values here.
+    final Map<Integer, List<Lock>> locksByPartition = new HashMap<>();
     messageState.visitCrossPartitionStartLocks(
         (bpmnProcessId, correlationKey, holderProcessInstanceKey, tenantId) -> {
-          // buffers are only valid during the callback, so copy into immutable strings
-          final var key =
-              new LockKey(
-                  BufferUtil.bufferAsString(bpmnProcessId),
-                  BufferUtil.bufferAsString(correlationKey));
-          final var pollState =
-              backoffByLock.computeIfAbsent(
-                  key,
-                  // A newly observed lock is polled immediately; its back-off starts at the base.
-                  k -> new PollState(now, pollInterval.get().toMillis()));
-          pollState.epoch = epoch;
-
-          if (pollState.nextPollTime > now) {
-            return;
-          }
           final int targetPartition = Protocol.decodePartitionId(holderProcessInstanceKey);
           if (targetPartition == partitionId) {
             // Defensive: a cross-partition lock entry never targets the local partition. Skip
             // rather than poll ourselves.
             return;
           }
-          dueByPartition
+          locksByPartition
               .computeIfAbsent(targetPartition, p -> new ArrayList<>())
               .add(
                   new Lock(
-                      key.bpmnProcessId(),
-                      key.correlationKey(),
+                      BufferUtil.bufferAsString(bpmnProcessId),
+                      BufferUtil.bufferAsString(correlationKey),
                       holderProcessInstanceKey,
                       tenantId));
         });
 
-    // Drop bookkeeping for locks that are no longer present (released elsewhere): any entry not
-    // re-stamped in this tick is gone from local state.
-    backoffByLock.values().removeIf(pollState -> pollState.epoch != epoch);
-
-    dueByPartition.forEach((targetPartition, due) -> pollPartition(targetPartition, due, now));
+    locksByPartition.forEach(this::pollPartition);
   }
 
-  private void pollPartition(final int targetPartition, final List<Lock> due, final long now) {
+  private void pollPartition(final int targetPartition, final List<Lock> locks) {
     final int limit = batchLimit.getAsInt();
+    if (limit <= 0) {
+      // Defensive: a non-positive batch limit is a misconfiguration. Skip rather than emit an
+      // empty query so we don't produce pointless inter-partition traffic and QUERIED events every
+      // tick. (locks is never empty here — a partition list is only created when a lock is added.)
+      return;
+    }
+
+    // Cap each query at the batch limit; the remainder is reconciled on a later tick as reaped
+    // locks drop out of local state.
+    final var batch = locks.size() <= limit ? locks : locks.subList(0, limit);
+
     final var query =
         new MessageStartCorrelationKeyLockReleaseRecord()
             // requestKey only needs to carry P_K in its partition bits so P_B can route the reply
             // back; it is never used as an event key.
             .setRequestKey(Protocol.encodePartitionId(partitionId, 0L));
-
-    int batched = 0;
-    for (final var lock : due) {
-      if (batched == limit) {
-        // Remaining due entries keep their nextPollTime in the past and are picked up next tick.
-        break;
-      }
+    for (final var lock : batch) {
       query
           .addHolder()
           .setProcessInstanceKey(lock.holderProcessInstanceKey())
           .setBpmnProcessId(lock.bpmnProcessId())
           .setCorrelationKey(lock.correlationKey())
           .setTenantId(lock.tenantId());
-      advanceBackoff(lock.key(), now);
-      batched++;
-    }
-
-    if (batched == 0) {
-      // Nothing was batched (e.g. a non-positive batch limit). Skip the empty query so we don't
-      // emit pointless inter-partition traffic and QUERIED events every tick.
-      return;
     }
 
     LOG.trace(
-        "Polling partition {} for {} cross-partition message-start holder(s)",
+        "Reconciling partition {} for {} cross-partition message-start holder(s)",
         targetPartition,
-        batched);
+        batch.size());
     commandSender.sendDirectCorrelationKeyLockReleaseQuery(targetPartition, query);
   }
 
-  private void advanceBackoff(final LockKey key, final long now) {
-    final var pollState = backoffByLock.get(key);
-    pollState.nextPollTime = now + pollState.intervalMillis;
-    pollState.intervalMillis = Math.min(pollState.intervalMillis * 2, maxBackoff.get().toMillis());
-  }
-
   private record Lock(
-      String bpmnProcessId, String correlationKey, long holderProcessInstanceKey, String tenantId) {
-    LockKey key() {
-      return new LockKey(bpmnProcessId, correlationKey);
-    }
-  }
-
-  /** Identifies a cross-partition lock entry; mirrors the lock column family's composite key. */
-  private record LockKey(String bpmnProcessId, String correlationKey) {}
-
-  private static final class PollState {
-    private long nextPollTime;
-    private long intervalMillis;
-    private long epoch;
-
-    private PollState(final long nextPollTime, final long intervalMillis) {
-      this.nextPollTime = nextPollTime;
-      this.intervalMillis = intervalMillis;
-    }
-  }
+      String bpmnProcessId,
+      String correlationKey,
+      long holderProcessInstanceKey,
+      String tenantId) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -256,7 +256,6 @@ public final class MessageEventProcessors {
                 subscriptionCommandSender,
                 scheduledTaskStateFactory.get().getMessageState(),
                 config::getMessageStartLockReleasePollInterval,
-                config::getMessageStartLockReleasePollMaxBackoff,
                 config::getMessageStartLockReleasePollBatchLimit));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -219,7 +219,11 @@ public final class MessageEventProcessors {
             ValueType.MESSAGE_START_CORRELATION_KEY_LOCK_RELEASE,
             MessageStartCorrelationKeyLockReleaseIntent.QUERY,
             new MessageStartCorrelationKeyLockReleaseQueryProcessor(
-                elementInstanceState, bannedInstanceState, subscriptionCommandSender, writers))
+                elementInstanceState,
+                bannedInstanceState,
+                messageState,
+                subscriptionCommandSender,
+                writers))
         // Holder-completion release handler on P_K - on a RELEASE reply from P_B, releases the
         // correlation-key lock and picks up the next buffered message for that key.
         .onCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseQueryProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseQueryProcessor.java
@@ -25,19 +25,21 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
  * hash(businessId)}, the partition where a message-start instance created via the cross-partition
  * handshake actually runs.
  *
- * <p>{@code P_K} polls this processor to discover when such holder instances have completed, so it
- * can release the correlation-key locks it is holding for them. A query batches one holder per lock
- * entry {@code P_K} is polling for a given {@code P_B}; the processor answers per holder: a holder
- * is "still active" iff a local element instance exists for its key and the instance is not banned.
- * A banned holder is treated as gone, mirroring the banned-instance filter on the uniqueness check,
- * so a stuck holder does not block its correlation key forever.
+ * <p>This is the reconciliation backstop, not the primary release path: a cross-partition holder
+ * normally pushes a {@link MessageStartCorrelationKeyLockReleaseIntent#RELEASE} to {@code P_K} the
+ * moment it completes. {@code P_K}'s coarse reconciliation poll queries this processor only to
+ * recover locks whose push was lost, so it can still release them. A query batches one holder per
+ * lock entry {@code P_K} is reconciling for a given {@code P_B}; the processor answers per holder:
+ * a holder is "still active" iff a local element instance exists for its key and the instance is
+ * not banned. A banned holder is treated as gone, mirroring the banned-instance filter on the
+ * uniqueness check, so a stuck holder does not block its correlation key forever.
  *
  * <p>The processor always acknowledges with {@link
  * MessageStartCorrelationKeyLockReleaseIntent#QUERIED} for an observable trail, and replies {@link
  * MessageStartCorrelationKeyLockReleaseIntent#RELEASE} back to {@code P_K} for each holder that is
- * gone. Holders that are still active produce no reply — {@code P_K} keeps polling them with
- * back-off until completion. Each reply is routed back to {@code P_K} via the partition encoded in
- * the query's {@code requestKey}.
+ * gone. Holders that are still active produce no reply — {@code P_K} re-queries them on a later
+ * reconciliation tick until completion. Each reply is routed back to {@code P_K} via the partition
+ * encoded in the query's {@code requestKey}.
  *
  * <p>A gone holder that never ran the completion push (e.g. one that was banned, so it had no
  * transition to push) still has its holder-origin entry on this partition. For such a holder this

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseQueryProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseQueryProcessor.java
@@ -14,8 +14,10 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartCorrelationKeyLockReleaseRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageStartCorrelationKeyLockReleaseIntent;
+import io.camunda.zeebe.protocol.record.value.MessageStartCorrelationKeyLockReleaseRecordValue.MessageStartLockReleaseHolderValue;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 /**
@@ -36,6 +38,12 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
  * gone. Holders that are still active produce no reply — {@code P_K} keeps polling them with
  * back-off until completion. Each reply is routed back to {@code P_K} via the partition encoded in
  * the query's {@code requestKey}.
+ *
+ * <p>A gone holder that never ran the completion push (e.g. one that was banned, so it had no
+ * transition to push) still has its holder-origin entry on this partition. For such a holder this
+ * processor also appends a {@link MessageStartCorrelationKeyLockReleaseIntent#PUSHED} event, whose
+ * applier drops that entry, so a stuck cross-partition start does not leak one origin entry
+ * forever. The reconciliation itself never needs the entry, so the cleanup is order-independent.
  */
 @ExcludeAuthorizationCheck
 public final class MessageStartCorrelationKeyLockReleaseQueryProcessor
@@ -43,16 +51,19 @@ public final class MessageStartCorrelationKeyLockReleaseQueryProcessor
 
   private final ElementInstanceState elementInstanceState;
   private final BannedInstanceState bannedInstanceState;
+  private final MessageState messageState;
   private final SubscriptionCommandSender commandSender;
   private final StateWriter stateWriter;
 
   public MessageStartCorrelationKeyLockReleaseQueryProcessor(
       final ElementInstanceState elementInstanceState,
       final BannedInstanceState bannedInstanceState,
+      final MessageState messageState,
       final SubscriptionCommandSender commandSender,
       final Writers writers) {
     this.elementInstanceState = elementInstanceState;
     this.bannedInstanceState = bannedInstanceState;
+    this.messageState = messageState;
     this.commandSender = commandSender;
     stateWriter = writers.state();
   }
@@ -65,10 +76,35 @@ public final class MessageStartCorrelationKeyLockReleaseQueryProcessor
         record.getKey(), MessageStartCorrelationKeyLockReleaseIntent.QUERIED, query);
 
     for (final var holder : query.getHolders()) {
-      if (!isHolderActive(holder.getProcessInstanceKey())) {
-        commandSender.sendCorrelationKeyLockRelease(query.getRequestKey(), holder);
+      if (isHolderActive(holder.getProcessInstanceKey())) {
+        continue;
       }
+      commandSender.sendCorrelationKeyLockRelease(query.getRequestKey(), holder);
+      cleanUpOriginIfLeftover(holder);
     }
+  }
+
+  /**
+   * Drops the holder-origin entry left behind by a gone holder that never pushed its completion
+   * (its only remover otherwise). Appends {@link
+   * MessageStartCorrelationKeyLockReleaseIntent#PUSHED}, keyed by the holder process-instance key
+   * the entry is stored under; the same applier the push path uses removes it. Skipped when no
+   * entry exists, so holders that already pushed add no record.
+   */
+  private void cleanUpOriginIfLeftover(final MessageStartLockReleaseHolderValue holder) {
+    final long holderKey = holder.getProcessInstanceKey();
+    if (messageState.getCrossPartitionStartHolderOrigin(holderKey) == null) {
+      return;
+    }
+    final var pushed = new MessageStartCorrelationKeyLockReleaseRecord().setRequestKey(-1L);
+    pushed
+        .addHolder()
+        .setProcessInstanceKey(holderKey)
+        .setBpmnProcessId(holder.getBpmnProcessId())
+        .setCorrelationKey(holder.getCorrelationKey())
+        .setTenantId(holder.getTenantId());
+    stateWriter.appendFollowUpEvent(
+        holderKey, MessageStartCorrelationKeyLockReleaseIntent.PUSHED, pushed);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseReleaseProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseReleaseProcessor.java
@@ -11,9 +11,11 @@ import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBufferedMessageStartEventBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartCorrelationKeyLockReleaseRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MessageStartCorrelationKeyLockReleaseIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -33,8 +35,9 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
  * <em>different</em> instance for the same correlation key. The release therefore fires only while
  * the lock is still held by the exact instance the reply names ({@link
  * MessageState#getCrossPartitionStartLockHolder} matches the reply's holder key); otherwise the
- * holder is skipped and no {@code RELEASED} event is written. This guarantees a stale reply can
- * never release a successor's lock.
+ * holder is skipped. A reply whose holders are all skipped changes no state and is rejected as
+ * redundant rather than releasing anything. This guarantees a stale reply can never release a
+ * successor's lock.
  *
  * <p>The lock removal is applied as the state effect of the {@code RELEASED} event; the buffered
  * message pick-up runs in this processor immediately after, so it observes the freed lock and
@@ -44,9 +47,16 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 public final class MessageStartCorrelationKeyLockReleaseReleaseProcessor
     implements TypedRecordProcessor<MessageStartCorrelationKeyLockReleaseRecord> {
 
+  private static final String REDUNDANT_RELEASE_REJECTION_REASON =
+      """
+      Expected to release the correlation-key lock still held by the holder(s) named in the \
+      release reply, but none of them holds it anymore (already released or re-acquired by another \
+      instance)""";
+
   private final MessageState messageState;
   private final BpmnBufferedMessageStartEventBehavior bufferedMessageStartEventBehavior;
   private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
 
   public MessageStartCorrelationKeyLockReleaseReleaseProcessor(
       final MessageState messageState,
@@ -55,6 +65,7 @@ public final class MessageStartCorrelationKeyLockReleaseReleaseProcessor
     this.messageState = messageState;
     this.bufferedMessageStartEventBehavior = bufferedMessageStartEventBehavior;
     stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
   }
 
   @Override
@@ -78,7 +89,12 @@ public final class MessageStartCorrelationKeyLockReleaseReleaseProcessor
     }
 
     if (!releasable.hasHolders()) {
-      // every holder was already released (redelivered or superseded reply) — nothing to do
+      // Redundant reply: none of the reported holders still holds its correlation-key lock (already
+      // released, or the lock was re-acquired by a newer instance for the same key). Reject rather
+      // than silently returning, so the command is recorded as processed and cannot release a
+      // successor's lock.
+      rejectionWriter.appendRejection(
+          record, RejectionType.INVALID_STATE, REDUNDANT_RELEASE_REJECTION_REASON);
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor.java
@@ -25,8 +25,11 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
  *
  * <p>This processor writes the {@link
  * MessageStartProcessInstanceRequestIntent#NO_SUBSCRIPTION_REJECTED} follow-up event whose applier
- * does the bookkeeping cleanup (pending-ask state removal). The message stays buffered on {@code
- * P_K}, preserving the same semantics as when a local start-event subscription is missing.
+ * keeps the pending-ask entry and backs it off — incrementing its rejection count, never removing
+ * it. The message stays buffered on {@code P_K} and its ask is re-sent to {@code P_B} under capped
+ * exponential back-off by the pending-ask scheduler until the subscription reaches {@code P_B} (the
+ * reply then flips to {@code STARTED}) or the buffered message reaches its TTL (ADR 0002 D2/D3),
+ * preserving the same semantics as when a local start-event subscription is missing.
  *
  * <p>When the delegating command was a synchronous {@code correlate} (rather than a {@code
  * publish}), the client is still awaiting a response; this processor additionally flushes the

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectUniquenessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectUniquenessProcessor.java
@@ -25,9 +25,12 @@ import java.util.Set;
  * with the same {@code businessId} already exists.
  *
  * <p>This processor writes the {@link MessageStartProcessInstanceRequestIntent#UNIQUENESS_REJECTED}
- * follow-up event whose applier does the bookkeeping cleanup (pending-ask state removal). The
- * message stays buffered on {@code P_K}, waiting for the pull-based release mechanism in Increment
- * 4.
+ * follow-up event whose applier keeps the pending-ask entry and backs it off — incrementing its
+ * rejection count, never removing it. The message stays buffered on {@code P_K} and its ask is
+ * re-sent to {@code P_B} under capped exponential back-off by the pending-ask scheduler until the
+ * holder frees the {@code businessId} (the reply then flips to {@code STARTED}) or the buffered
+ * message reaches its TTL (ADR 0002 D2/D3). The cross-partition correlation-key lock release is a
+ * separate mechanism and does not retry a uniqueness rejection (ADR 0002 D4).
  *
  * <p>When the delegating command was a synchronous {@code correlate} (rather than a {@code
  * publish}), the client is still awaiting a response; this processor additionally flushes the

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestStartProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestStartProcessor.java
@@ -43,9 +43,11 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
  *   <li>{@link MessageStartProcessInstanceRequestIntent#STARTED} so the existing applier clears the
  *       pending-ask entry on {@code P_K} (stopping the retry scheduler) and, when the holder
  *       carries a non-empty {@code (correlationKey, businessId)}, additionally records the holder
- *       instance on a parallel CF. That holder-instance discriminator is what lets the pull-based
- *       release loop poll {@code P_B} (derived from the holder instance key) for the holder's
- *       completion, so the correlation-key lock can be released once the holder is gone.
+ *       instance on a parallel CF. That holder-instance discriminator is what lets {@code P_K}'s
+ *       reconciliation poll query {@code P_B} (derived from the holder instance key) for the
+ *       holder's completion as a backstop, so the correlation-key lock can still be released once
+ *       the holder is gone even if {@code P_B}'s completion push was lost. The primary release is
+ *       that push; the poll is only the safety net.
  *   <li>{@link MessageIntent#EXPIRED} for the buffered message itself. The cross-partition
  *       handshake consumed the publish; leaving it in the buffer would let the next polling cycle
  *       re-evaluate it, which is unnecessary work (correlation has already happened) and would
@@ -96,8 +98,8 @@ public final class MessageStartProcessInstanceRequestStartProcessor
     // it (CORRELATED writes a foreign-key reference into MESSAGE_KEY; EXPIRED removes the buffered
     // entry). A missing message can happen for two distinct reasons:
     //   1. The buffer TTL fired between the original publish and the (late) reply — legitimate
-    //      data loss inherent to the pull-based design; the PI on P_B is already created and the
-    //      pending-ask just needs to be cleared on P_K.
+    //      data loss inherent to the asynchronous cross-partition design; the PI on P_B is already
+    //      created and the pending-ask just needs to be cleared on P_K.
     //   2. The reply is a re-delivery: a previous reply's EXPIRED applier already removed the
     //      message; the CORRELATED applier has also run and the message correlation marker is
     //      present.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -469,7 +469,8 @@ public class SubscriptionCommandSender {
    * Sends the {@link MessageStartProcessInstanceRequestIntent#UNIQUENESS_REJECTED} reply from
    * {@code P_B} back to {@code P_K} after the businessId uniqueness check on {@code P_B} found an
    * active holder. {@code P_K} keeps the message buffered (TTL continues) and waits for the
-   * pull-based release introduced in a later increment.
+   * cross-partition lock release — pushed by {@code P_B} when the holder completes, reconciled by a
+   * coarse {@code P_K} poll as a backstop.
    */
   public boolean sendStartProcessInstanceUniquenessRejected(
       final MessageStartProcessInstanceRequestRecord request) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -637,9 +637,10 @@ public final class EventAppliers implements EventApplier {
   }
 
   /**
-   * Appliers for the pull-based correlation-key lock release lookup. Both event intents are
-   * introduced together with this feature and have no prior stream history, so a single V1 applier
-   * per intent is sufficient.
+   * Appliers for the cross-partition correlation-key lock release. The release is normally pushed
+   * by {@code P_B} on holder completion; these query/reconciliation intents are the backstop half.
+   * Both event intents are introduced together with this feature and have no prior stream history,
+   * so a single V1 applier per intent is sufficient.
    *
    * <ul>
    *   <li>{@code QUERIED}: acknowledgement event on {@code P_B} with no state effect.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -616,7 +616,8 @@ public final class EventAppliers implements EventApplier {
         new MessageStartProcessInstanceStartedV1Applier(
             state.getMessageStartProcessInstanceDedupState(),
             state.getMessageStartProcessInstanceAskState(),
-            state.getMessageState()));
+            state.getMessageState(),
+            state.getPartitionId()));
     register(
         MessageStartProcessInstanceRequestIntent.EXPIRED_DEDUP_DELETED,
         new MessageStartProcessInstanceExpiredDedupDeletedV1Applier(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -646,6 +646,9 @@ public final class EventAppliers implements EventApplier {
    *   <li>{@code RELEASED}: applied on {@code P_K} for each holder reported gone; removes the
    *       active process-instance lock and the cross-partition lock marker for that correlation
    *       key. The buffered-message pick-up is not done here but in the RELEASE command processor.
+   *   <li>{@code PUSHED}: applied on {@code P_B} when a holder completes/terminates and its {@code
+   *       RELEASE} was pushed to {@code P_K}; drops the holder-origin entry {@code P_B} kept for
+   *       it.
    * </ul>
    */
   private void registerMessageStartCorrelationKeyLockReleaseAppliers(
@@ -654,6 +657,9 @@ public final class EventAppliers implements EventApplier {
     register(
         MessageStartCorrelationKeyLockReleaseIntent.RELEASED,
         new MessageStartCorrelationKeyLockReleaseReleasedV1Applier(state.getMessageState()));
+    register(
+        MessageStartCorrelationKeyLockReleaseIntent.PUSHED,
+        new MessageStartCorrelationKeyLockReleasePushedV1Applier(state.getMessageState()));
   }
 
   private void registerIncidentEventAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartCorrelationKeyLockReleasePushedV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartCorrelationKeyLockReleasePushedV1Applier.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartCorrelationKeyLockReleaseRecord;
+import io.camunda.zeebe.protocol.record.intent.MessageStartCorrelationKeyLockReleaseIntent;
+
+/**
+ * Applier for {@link MessageStartCorrelationKeyLockReleaseIntent#PUSHED}.
+ *
+ * <p>Emitted on {@code P_B} when a cross-partition message-start holder instance completes or
+ * terminates and its {@code RELEASE} has been pushed straight to {@code P_K}. Its only state effect
+ * is to drop the holder-origin entry ({@link
+ * MutableMessageState#removeCrossPartitionStartHolderOrigin}) that {@code P_B} kept for this
+ * holder: the push has consumed it, so leaving it would leak one entry per cross-partition start.
+ *
+ * <p>The event key is the holder process-instance key, which is exactly the key the holder-origin
+ * entry is stored under, so the removal needs nothing from the record body. The removal is guarded
+ * against a missing entry (the underlying delete is a no-op if absent), tolerating a replayed
+ * {@code PUSHED} whose entry was already removed.
+ */
+final class MessageStartCorrelationKeyLockReleasePushedV1Applier
+    implements TypedEventApplier<
+        MessageStartCorrelationKeyLockReleaseIntent, MessageStartCorrelationKeyLockReleaseRecord> {
+
+  private final MutableMessageState messageState;
+
+  MessageStartCorrelationKeyLockReleasePushedV1Applier(final MutableMessageState messageState) {
+    this.messageState = messageState;
+  }
+
+  @Override
+  public void applyState(final long key, final MessageStartCorrelationKeyLockReleaseRecord value) {
+    // the event key is the holder process-instance key, which the origin entry is stored under
+    messageState.removeCrossPartitionStartHolderOrigin(key);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartCorrelationKeyLockReleaseReleasedV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartCorrelationKeyLockReleaseReleasedV1Applier.java
@@ -20,12 +20,13 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
  * a cross-partition message-start holder instance has completed. For each holder carried by the
  * event it drops the underlying correlation-key lock ({@link
  * MutableMessageState#removeActiveProcessInstance}) so the next buffered message for that key can
- * be picked up, removes the holder-instance discriminator that the pull-based release loop polls on
- * ({@link MutableMessageState#removeCrossPartitionStartLock}), and removes the process-instance ->
- * correlation-key row ({@link MutableMessageState#removeProcessInstanceCorrelationKey}) that {@code
- * P_K} wrote for the remote holder when it created it via the handshake — otherwise that row leaks
- * once per cross-partition start, since the completing element lives on {@code P_B} and never
- * reaches {@code P_K}'s local cleanup path.
+ * be picked up, removes the holder-instance discriminator that {@code P_K}'s reconciliation poll
+ * queries on ({@link MutableMessageState#removeCrossPartitionStartLock}), and removes the
+ * process-instance -> correlation-key row ({@link
+ * MutableMessageState#removeProcessInstanceCorrelationKey}) that {@code P_K} wrote for the remote
+ * holder when it created it via the handshake — otherwise that row leaks once per cross-partition
+ * start, since the completing element lives on {@code P_B} and never reaches {@code P_K}'s local
+ * cleanup path.
  *
  * <p>The release decision — including the idempotency guard that ensures the lock is still held by
  * the exact instance the reply names — lives in the {@code RELEASE} processor; the event is only

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartProcessInstanceStartedV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartProcessInstanceStartedV1Applier.java
@@ -74,8 +74,9 @@ import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceReques
  * io.camunda.zeebe.engine.processing.message.MessageCorrelateBehavior}: every active root PI with a
  * {@code businessId} lives on {@code P_B = hash(businessId)}, and {@code P_K} keeps a local
  * correlation-key lock so further triggers with the same correlation key are buffered regardless of
- * their {@code businessId}. The recorded holder instance is what the pull-based release loop polls
- * {@code P_B} for to decide when that lock can be released.
+ * their {@code businessId}. The recorded holder instance is what {@code P_K}'s reconciliation poll
+ * queries {@code P_B} for, as a backstop deciding when that lock can be released if the holder's
+ * completion push from {@code P_B} was lost.
  */
 final class MessageStartProcessInstanceStartedV1Applier
     implements TypedEventApplier<

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartProcessInstanceStartedV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartProcessInstanceStartedV1Applier.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartProcessInstanceAskState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartProcessInstanceDedupState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessInstanceRequestRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 
@@ -44,6 +45,19 @@ import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceReques
  *   <li><b>Pending-ask removal on {@code P_K}.</b> Always called; {@code remove} is a no-op when
  *       the entry is absent. On {@code P_B} there is no pending-ask, so this is also a harmless
  *       no-op.
+ *   <li><b>Holder-origin entry on {@code P_B}.</b> Records, keyed by the holder instance key, the
+ *       lock coordinates ({@code bpmnProcessId}, {@code correlationKey}, {@code tenantId}) plus the
+ *       {@code messageKey} whose partition bits address {@code P_K}, so that when the holder later
+ *       completes or terminates on {@code P_B} it can push a {@code RELEASE} to {@code P_K} without
+ *       re-deriving those coordinates from the completing element's context (the completing context
+ *       is unreliable under migration — the holder may since run a different process id).
+ *       Discriminated to {@code P_B} by the holder instance key's partition bits: the PI was
+ *       created on {@code P_B}, so {@code decodePartitionId(processInstanceKey) == partitionId}
+ *       there, whereas on {@code P_K} the same reply carries a PI key that decodes to {@code P_B}
+ *       and is skipped — the mirror of the discriminator used by the lock write below. Written only
+ *       when the holder carries a correlation key: without one there is no correlation-key lock on
+ *       {@code P_K} to release. The write is {@code upsert} and therefore idempotent under a
+ *       re-applied {@code STARTED} reply.
  *   <li><b>Cross-partition holder-instance discriminator on {@code P_K}.</b> Marks the local
  *       correlation-key lock entry that the {@link MessageStartEventSubscriptionCorrelatedApplier}
  *       wrote when the reply processor emitted {@code CORRELATED}, recording the holder instance's
@@ -70,14 +84,17 @@ final class MessageStartProcessInstanceStartedV1Applier
   private final MutableMessageStartProcessInstanceDedupState dedupState;
   private final MutableMessageStartProcessInstanceAskState askState;
   private final MutableMessageState messageState;
+  private final int partitionId;
 
   MessageStartProcessInstanceStartedV1Applier(
       final MutableMessageStartProcessInstanceDedupState dedupState,
       final MutableMessageStartProcessInstanceAskState askState,
-      final MutableMessageState messageState) {
+      final MutableMessageState messageState,
+      final int partitionId) {
     this.dedupState = dedupState;
     this.askState = askState;
     this.messageState = messageState;
+    this.partitionId = partitionId;
   }
 
   @Override
@@ -94,6 +111,20 @@ final class MessageStartProcessInstanceStartedV1Applier
 
     final var correlationKey = value.getCorrelationKeyBuffer();
     final var businessId = value.getBusinessIdBuffer();
+
+    // On P_B: record the holder-origin entry so the holder's completion can later push a RELEASE to
+    // P_K. Discriminated to P_B by the holder key's partition bits, and skipped without a
+    // correlation key (no lock to release). See the class javadoc for the full rationale.
+    if (correlationKey.capacity() > 0
+        && Protocol.decodePartitionId(value.getProcessInstanceKey()) == partitionId) {
+      messageState.putCrossPartitionStartHolderOrigin(
+          value.getProcessInstanceKey(),
+          value.getBpmnProcessIdBuffer(),
+          correlationKey,
+          value.getTenantId(),
+          value.getMessageKey());
+    }
+
     if (correlationKey.capacity() > 0
         && businessId.capacity() > 0
         && messageState.existActiveProcessInstance(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageState.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
+import io.camunda.zeebe.engine.state.message.CrossPartitionMessageStartHolderOrigin;
 import io.camunda.zeebe.engine.state.message.StoredMessage;
 import org.agrona.DirectBuffer;
 
@@ -87,6 +88,23 @@ public interface MessageState {
    * @return the recorded holder process-instance key, or {@code -1} when absent
    */
   long getCrossPartitionStartLockHolder(DirectBuffer bpmnProcessId, DirectBuffer correlationKey);
+
+  /**
+   * Returns the cross-partition message-start holder-origin entry for the holder instance {@code
+   * processInstanceKey}, or {@code null} when none exists. Present only on {@code P_B} (the
+   * buffering partition), the entry carries the lock coordinates ({@code bpmnProcessId}, {@code
+   * correlationKey}, {@code tenantId}) and the {@code messageKey} whose partition bits address
+   * {@code P_K}, so a completing/terminating holder can push a {@code RELEASE} without re-deriving
+   * anything from the completing element's context.
+   *
+   * <p>The returned value's buffers are backed by the shared column-family read buffer; copy them
+   * before appending events or performing further state reads.
+   *
+   * @param processInstanceKey the holder instance's process-instance key
+   * @return the origin entry, or {@code null} when absent
+   */
+  CrossPartitionMessageStartHolderOrigin getCrossPartitionStartHolderOrigin(
+      long processInstanceKey);
 
   /**
    * Index to point to a specific position in the messages with deadline column family.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/CrossPartitionMessageStartHolderOrigin.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/CrossPartitionMessageStartHolderOrigin.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.message;
+
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import org.agrona.DirectBuffer;
+
+/**
+ * Value of the cross-partition message-start holder-origin column family, written on {@code P_B}
+ * (the buffering partition) and keyed by the holder instance's process-instance key. It records
+ * everything {@code P_B} needs to push a {@code RELEASE} to {@code P_K} the moment the holder
+ * completes or terminates, without re-deriving anything from the completing element's context:
+ *
+ * <ul>
+ *   <li>the {@code bpmnProcessId} and {@code correlationKey} — together they identify the
+ *       correlation-key lock on {@code P_K} that must be released. The stored {@code bpmnProcessId}
+ *       is authoritative: a migrated holder's new version may declare a different process id (or no
+ *       message start event at all), so the lock must be keyed by the id captured at creation, not
+ *       by the completing instance's current definition;
+ *   <li>the {@code messageKey} — its partition bits address {@code P_K} (the partition that
+ *       buffered the message and holds the lock). The push path synthesizes the {@code RELEASE}'s
+ *       partition-addressing envelope from these bits;
+ *   <li>the {@code tenantId} — carried through to the {@code RELEASE} so the lock lookup on {@code
+ *       P_K} stays tenant-scoped.
+ * </ul>
+ *
+ * <p>The buffers returned by the getters are backed by the shared column-family read buffer; copy
+ * them before appending events or performing further state reads.
+ */
+public final class CrossPartitionMessageStartHolderOrigin extends UnpackedObject
+    implements DbValue {
+
+  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
+  private final StringProperty correlationKeyProp = new StringProperty("correlationKey", "");
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty messageKeyProp = new LongProperty("messageKey", -1L);
+
+  public CrossPartitionMessageStartHolderOrigin() {
+    super(4);
+    declareProperty(bpmnProcessIdProp)
+        .declareProperty(correlationKeyProp)
+        .declareProperty(tenantIdProp)
+        .declareProperty(messageKeyProp);
+  }
+
+  public DirectBuffer getBpmnProcessIdBuffer() {
+    return bpmnProcessIdProp.getValue();
+  }
+
+  public CrossPartitionMessageStartHolderOrigin setBpmnProcessId(final DirectBuffer bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  public DirectBuffer getCorrelationKeyBuffer() {
+    return correlationKeyProp.getValue();
+  }
+
+  public CrossPartitionMessageStartHolderOrigin setCorrelationKey(
+      final DirectBuffer correlationKey) {
+    correlationKeyProp.setValue(correlationKey);
+    return this;
+  }
+
+  public DirectBuffer getTenantIdBuffer() {
+    return tenantIdProp.getValue();
+  }
+
+  public CrossPartitionMessageStartHolderOrigin setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  public CrossPartitionMessageStartHolderOrigin setTenantId(final DirectBuffer tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  public long getMessageKey() {
+    return messageKeyProp.getValue();
+  }
+
+  public CrossPartitionMessageStartHolderOrigin setMessageKey(final long messageKey) {
+    messageKeyProp.setValue(messageKey);
+    return this;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
@@ -160,6 +160,19 @@ public final class DbMessageState implements MutableMessageState {
 
   private final ColumnFamily<DbLong, DbString> processInstanceCorrelationKeyColumnFamily;
 
+  /**
+   * <pre> holder process instance key -> (bpmnProcessId, correlationKey, tenantId, messageKey)
+   *
+   * Origin entry for a cross-partition message-start holder on {@code P_B}. Keyed by the holder
+   * instance key, it stores everything needed to push a {@code RELEASE} to {@code P_K} when the
+   * holder completes/terminates: the lock coordinates and the {@code messageKey} whose partition
+   * bits address {@code P_K}. Present only on {@code P_B}.
+   */
+  private final ColumnFamily<DbLong, CrossPartitionMessageStartHolderOrigin>
+      crossPartitionStartHolderOriginColumnFamily;
+
+  private final CrossPartitionMessageStartHolderOrigin crossPartitionStartHolderOrigin;
+
   private final BufferedMessagesMetrics bufferedMessagesMetrics;
 
   private Long localMessageDeadlineCount = 0L;
@@ -259,6 +272,14 @@ public final class DbMessageState implements MutableMessageState {
             transactionContext,
             processInstanceKey,
             correlationKey);
+
+    crossPartitionStartHolderOrigin = new CrossPartitionMessageStartHolderOrigin();
+    crossPartitionStartHolderOriginColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.CROSS_PARTITION_MESSAGE_START_HOLDER_ORIGIN,
+            transactionContext,
+            processInstanceKey,
+            crossPartitionStartHolderOrigin);
 
     bufferedMessagesMetrics = new BufferedMessagesMetrics(zeebeDb.getMeterRegistry());
   }
@@ -422,6 +443,47 @@ public final class DbMessageState implements MutableMessageState {
 
     this.processInstanceKey.wrapLong(processInstanceKey);
     processInstanceCorrelationKeyColumnFamily.deleteExisting(this.processInstanceKey);
+  }
+
+  @Override
+  public void putCrossPartitionStartHolderOrigin(
+      final long processInstanceKey,
+      final DirectBuffer bpmnProcessId,
+      final DirectBuffer correlationKey,
+      final String tenantId,
+      final long messageKey) {
+    ensureGreaterThan("process instance key", processInstanceKey, 0);
+    ensureNotNullOrEmpty("BPMN process id", bpmnProcessId);
+    ensureNotNullOrEmpty("correlation key", correlationKey);
+    ensureGreaterThan("message key", messageKey, 0);
+
+    this.processInstanceKey.wrapLong(processInstanceKey);
+    crossPartitionStartHolderOrigin
+        .setBpmnProcessId(bpmnProcessId)
+        .setCorrelationKey(correlationKey)
+        .setTenantId(tenantId)
+        .setMessageKey(messageKey);
+    // upsert because the cross-partition STARTED reply can be re-applied on retry; writing the same
+    // holder origin twice is a no-op overwrite rather than an error.
+    crossPartitionStartHolderOriginColumnFamily.upsert(
+        this.processInstanceKey, crossPartitionStartHolderOrigin);
+  }
+
+  @Override
+  public CrossPartitionMessageStartHolderOrigin getCrossPartitionStartHolderOrigin(
+      final long processInstanceKey) {
+    ensureGreaterThan("process instance key", processInstanceKey, 0);
+
+    this.processInstanceKey.wrapLong(processInstanceKey);
+    return crossPartitionStartHolderOriginColumnFamily.get(this.processInstanceKey);
+  }
+
+  @Override
+  public void removeCrossPartitionStartHolderOrigin(final long processInstanceKey) {
+    ensureGreaterThan("process instance key", processInstanceKey, 0);
+
+    this.processInstanceKey.wrapLong(processInstanceKey);
+    crossPartitionStartHolderOriginColumnFamily.deleteIfExists(this.processInstanceKey);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMessageState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMessageState.java
@@ -64,5 +64,40 @@ public interface MutableMessageState extends MessageState, StreamProcessorLifecy
 
   void removeProcessInstanceCorrelationKey(long processInstanceKey);
 
+  /**
+   * Writes the cross-partition message-start holder-origin entry for a holder instance on {@code
+   * P_B}, keyed by {@code processInstanceKey}. Called when {@code P_B} applies its local {@code
+   * STARTED} for an instance created via the cross-partition handshake, it captures the lock
+   * coordinates and the addressing {@code messageKey} so that a later completion/termination of the
+   * holder can push a {@code RELEASE} to {@code P_K} without re-deriving them from the completing
+   * element's context. The {@code bpmnProcessId} stored here is authoritative — a migrated holder's
+   * new version may declare a different process id, but the lock on {@code P_K} is keyed by the id
+   * captured at creation.
+   *
+   * <p>Idempotent: a repeated write for the same holder is a no-op overwrite (the {@code STARTED}
+   * reply can be re-applied on retry).
+   *
+   * @param processInstanceKey the holder instance's process-instance key (the entry's key)
+   * @param bpmnProcessId the process id of the lock to release on {@code P_K}
+   * @param correlationKey the correlation key of the lock to release on {@code P_K}
+   * @param tenantId tenant of the holder, carried through to the {@code RELEASE}
+   * @param messageKey the buffered message's key; its partition bits address {@code P_K}
+   */
+  void putCrossPartitionStartHolderOrigin(
+      long processInstanceKey,
+      DirectBuffer bpmnProcessId,
+      DirectBuffer correlationKey,
+      String tenantId,
+      long messageKey);
+
+  /**
+   * Removes the cross-partition message-start holder-origin entry for {@code processInstanceKey}. A
+   * no-op when the entry is absent, so the push path and a reconciliation-driven cleanup can both
+   * attempt removal without coordinating.
+   *
+   * @param processInstanceKey the holder instance's process-instance key
+   */
+  void removeCrossPartitionStartHolderOrigin(long processInstanceKey);
+
   void remove(long messageKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleasePushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleasePushTest.java
@@ -14,6 +14,8 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
@@ -21,9 +23,12 @@ import io.camunda.zeebe.protocol.record.intent.MessageStartCorrelationKeyLockRel
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -285,6 +290,65 @@ public final class CrossPartitionMessageStartLockReleasePushTest {
         .isZero();
   }
 
+  @Test
+  public void shouldCorrelateBufferedStreamWithoutPolling() {
+    // A throughput pin for the issue's core latency claim: a backlog of same-correlation-key,
+    // cross-partition starts drains end-to-end driven only by the completion push — no
+    // reconciliation timer is involved at all. The poll is disabled and the clock is never
+    // advanced, so if any hop depended on polling to make progress the stream would stall and this
+    // test would time out. The stronger form of "~N x holder-lifetime": zero timers.
+    deployAndAwaitStartSubscriptions(AUTO_PROCESS, AUTO_MESSAGE_NAME);
+
+    final int streamLength = 5;
+
+    // when a stream of same-correlation-key, cross-partition (businessId) starts is published, each
+    // hop only after the previous hop's lock is established on P_K (its terminal EXPIRED). That
+    // handshake fence is what keeps the stream deterministic without any collision: a follow-up
+    // published while the previous holder is still alive buffers behind the live lock, and one
+    // published after it has already completed starts cleanly on the freed businessId — it can
+    // never race a second concurrent holder onto the same businessId (which would be rejected on
+    // P_B and only retried by a timer the frozen clock never fires). Every hop is a cross-partition
+    // holder on P_B, so every lock release can come only from a completion push.
+    for (int hop = 1; hop <= streamLength; hop++) {
+      publishStart(AUTO_MESSAGE_NAME, CORRELATION_KEY, BUSINESS_ID);
+      awaitMessagesConsumedOnPK(AUTO_MESSAGE_NAME, hop);
+    }
+
+    // then every holder completes on P_B, purely push-driven, with the clock frozen and the poll
+    // disabled
+    final var completions =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+            .withBpmnProcessId(AUTO_PROCESS_ID)
+            .withElementType(BpmnElementType.PROCESS)
+            .limit(streamLength)
+            .asList();
+    assertThat(completions)
+        .as(
+            "all %d buffered cross-partition starts complete without any clock advancement",
+            streamLength)
+        .hasSize(streamLength);
+    assertThat(completions)
+        .allSatisfy(
+            r ->
+                assertThat(Protocol.decodePartitionId(r.getValue().getProcessInstanceKey()))
+                    .as("every hop is a cross-partition holder on P_B")
+                    .isEqualTo(partitionFor(BUSINESS_ID)));
+
+    // and not a single reconciliation QUERY was ever sent up to the last completion — the whole
+    // stream drained on the push fast path
+    final long queries =
+        RecordingExporter.records()
+            .limit(nthProcessCompleted(AUTO_PROCESS_ID, streamLength))
+            .filter(
+                r ->
+                    r.getValueType() == ValueType.MESSAGE_START_CORRELATION_KEY_LOCK_RELEASE
+                        && r.getIntent() == MessageStartCorrelationKeyLockReleaseIntent.QUERY)
+            .count();
+    assertThat(queries)
+        .as("a push-driven stream needs no reconciliation poll to make progress")
+        .isZero();
+  }
+
   private void deployAndAwaitStartSubscriptions(
       final BpmnModelInstance process, final String messageName) {
     engine.deployment().withXmlResource(process).deploy();
@@ -345,10 +409,42 @@ public final class CrossPartitionMessageStartLockReleasePushTest {
    * correlation-key lock on {@code P_K}.
    */
   private static void awaitMessageConsumedOnPK(final String messageName) {
+    awaitMessagesConsumedOnPK(messageName, 1);
+  }
+
+  /**
+   * Waits until {@code count} messages of the given name and correlation key have been consumed on
+   * {@code P_K} by the handshake (their terminal {@code EXPIRED}). Each such {@code EXPIRED} is
+   * written together with the correlation-key lock in the {@code STARTED}-reply processing, so the
+   * {@code n}-th {@code EXPIRED} fences the {@code n}-th hop's lock as established — the handshake
+   * fence that serialises the stream deterministically.
+   */
+  private static void awaitMessagesConsumedOnPK(final String messageName, final int count) {
     RecordingExporter.messageRecords(MessageIntent.EXPIRED)
         .withName(messageName)
         .withCorrelationKey(CORRELATION_KEY)
-        .getFirst();
+        .limit(count)
+        .asList();
+  }
+
+  /**
+   * A merged-stream bound that stops at the {@code n}-th PROCESS-level {@code ELEMENT_COMPLETED}
+   * for the given process. Each call returns a fresh stateful predicate, so it must not be shared
+   * across streams.
+   */
+  private static Predicate<Record<RecordValue>> nthProcessCompleted(
+      final String bpmnProcessId, final int n) {
+    final var seen = new AtomicInteger();
+    return r -> {
+      if (r.getValueType() != ValueType.PROCESS_INSTANCE
+          || r.getIntent() != ProcessInstanceIntent.ELEMENT_COMPLETED) {
+        return false;
+      }
+      final var value = (ProcessInstanceRecordValue) r.getValue();
+      return value.getBpmnElementType() == BpmnElementType.PROCESS
+          && bpmnProcessId.equals(value.getBpmnProcessId())
+          && seen.incrementAndGet() == n;
+    };
   }
 
   private static int partitionFor(final String key) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleasePushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleasePushTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartCorrelationKeyLockReleaseIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
@@ -70,6 +71,18 @@ public final class CrossPartitionMessageStartLockReleasePushTest {
       Bpmn.createExecutableProcess(AUTO_PROCESS_ID)
           .startEvent("autoStart")
           .message(AUTO_MESSAGE_NAME)
+          .endEvent()
+          .done();
+
+  // Message-start process with a service task: the holder parks on a job on P_B and stays active
+  // until it is cancelled, so the push can be exercised on the termination path.
+  private static final String SERVICE_PROCESS_ID = "wf-svc";
+  private static final String SERVICE_MESSAGE_NAME = "svc-start-msg";
+  private static final BpmnModelInstance SERVICE_PROCESS =
+      Bpmn.createExecutableProcess(SERVICE_PROCESS_ID)
+          .startEvent("svcStart")
+          .message(SERVICE_MESSAGE_NAME)
+          .serviceTask("task", t -> t.zeebeJobType("test"))
           .endEvent()
           .done();
 
@@ -137,6 +150,141 @@ public final class CrossPartitionMessageStartLockReleasePushTest {
     assertThat(queries).as("no reconciliation QUERY is needed on the push happy path").isZero();
   }
 
+  @Test
+  public void shouldEmitPushedAndDeleteHolderOriginOnHolderCompletion() {
+    // given a cross-partition start: holder created (and auto-completes) on P_B, lock on P_K and a
+    // holder-origin entry on P_B
+    deployAndAwaitStartSubscriptions(AUTO_PROCESS, AUTO_MESSAGE_NAME);
+    publishStart(AUTO_MESSAGE_NAME, CORRELATION_KEY, BUSINESS_ID);
+    final long holderKey = awaitHolderActivating(AUTO_PROCESS_ID);
+    awaitMessageConsumedOnPK(AUTO_MESSAGE_NAME);
+
+    // when the holder completes on P_B (the poll is disabled, so any release is push-driven)
+    awaitHolderCompleted(AUTO_PROCESS_ID);
+
+    // then P_B emits a PUSHED event carrying the holder's lock coordinates and a request key that
+    // addresses P_K
+    final var pushed =
+        RecordingExporter.messageStartCorrelationKeyLockReleaseRecords(
+                MessageStartCorrelationKeyLockReleaseIntent.PUSHED)
+            .getFirst();
+    assertThat(pushed.getPartitionId())
+        .as("the completion push is emitted on the holder partition P_B")
+        .isEqualTo(partitionFor(BUSINESS_ID));
+    assertThat(Protocol.decodePartitionId(pushed.getValue().getRequestKey()))
+        .as("the pushed request key addresses P_K")
+        .isEqualTo(partitionFor(CORRELATION_KEY));
+    final var holder = pushed.getValue().getHolders().get(0);
+    assertThat(holder.getProcessInstanceKey()).isEqualTo(holderKey);
+    assertThat(holder.getBpmnProcessId()).isEqualTo(AUTO_PROCESS_ID);
+    assertThat(holder.getCorrelationKey()).isEqualTo(CORRELATION_KEY);
+
+    // and the holder-origin entry on P_B is dropped by the PUSHED applier
+    assertThat(
+            engine
+                .getProcessingState(partitionFor(BUSINESS_ID))
+                .getMessageState()
+                .getCrossPartitionStartHolderOrigin(holderKey))
+        .as("the holder-origin entry is consumed by the push")
+        .isNull();
+
+    // and the RELEASE reply is delivered to P_K
+    final var release =
+        RecordingExporter.messageStartCorrelationKeyLockReleaseRecords(
+                MessageStartCorrelationKeyLockReleaseIntent.RELEASE)
+            .getFirst();
+    assertThat(release.getPartitionId())
+        .as("the RELEASE is routed to the lock partition P_K")
+        .isEqualTo(partitionFor(CORRELATION_KEY));
+  }
+
+  @Test
+  public void shouldReleaseLockOnHolderTerminationWithoutPolling() {
+    // given a cross-partition start whose holder parks on a service task on P_B, lock on P_K
+    deployAndAwaitStartSubscriptions(SERVICE_PROCESS, SERVICE_MESSAGE_NAME);
+    publishStart(SERVICE_MESSAGE_NAME, CORRELATION_KEY, BUSINESS_ID);
+    final long holderKey = awaitHolderActivating(SERVICE_PROCESS_ID);
+    awaitHolderJobCreated(holderKey);
+    awaitMessageConsumedOnPK(SERVICE_MESSAGE_NAME);
+
+    // and a second same-correlation-key publish buffered behind the lock
+    publishStart(SERVICE_MESSAGE_NAME, CORRELATION_KEY, null);
+
+    // when the holder is terminated (cancelled) on P_B — the poll is disabled
+    engine.processInstance().withInstanceKey(holderKey).cancel();
+
+    // then P_K releases the lock and starts the buffered message on P_K, driven by the termination
+    // push from P_B
+    final var pickedUp =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withBpmnProcessId(SERVICE_PROCESS_ID)
+            .withElementType(BpmnElementType.PROCESS)
+            .filter(r -> r.getValue().getProcessInstanceKey() != holderKey)
+            .getFirst();
+    assertThat(Protocol.decodePartitionId(pickedUp.getValue().getProcessInstanceKey()))
+        .as("the buffered message is picked up on P_K after the holder is cancelled")
+        .isEqualTo(partitionFor(CORRELATION_KEY));
+
+    // and no reconciliation QUERY was involved
+    final long queries =
+        RecordingExporter.records()
+            .limit(
+                r ->
+                    r.getValueType() == ValueType.PROCESS_INSTANCE
+                        && r.getIntent() == ProcessInstanceIntent.ELEMENT_ACTIVATING
+                        && r.getKey() == pickedUp.getValue().getProcessInstanceKey())
+            .filter(
+                r ->
+                    r.getValueType() == ValueType.MESSAGE_START_CORRELATION_KEY_LOCK_RELEASE
+                        && r.getIntent() == MessageStartCorrelationKeyLockReleaseIntent.QUERY)
+            .count();
+    assertThat(queries).as("no reconciliation QUERY is needed on the termination push").isZero();
+  }
+
+  @Test
+  public void shouldNotPushForLocalMessageStartHolder() {
+    // given a purely local message start (no businessId): the holder is created on P_K itself, so
+    // there is no cross-partition handshake and no holder-origin entry to push from
+    deployAndAwaitStartSubscriptions(AUTO_PROCESS, AUTO_MESSAGE_NAME);
+    publishStart(AUTO_MESSAGE_NAME, CORRELATION_KEY, null);
+    final long holderKey = awaitHolderActivating(AUTO_PROCESS_ID);
+
+    // and a second same-correlation-key publish buffered behind the local correlation-key lock
+    publishStart(AUTO_MESSAGE_NAME, CORRELATION_KEY, null);
+
+    // when the local holder completes (its lock is freed by the local path, not by a push)
+    awaitHolderCompleted(AUTO_PROCESS_ID);
+
+    // then the buffered message is still picked up on P_K
+    final var pickedUp =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withBpmnProcessId(AUTO_PROCESS_ID)
+            .withElementType(BpmnElementType.PROCESS)
+            .filter(r -> r.getValue().getProcessInstanceKey() != holderKey)
+            .getFirst();
+    assertThat(Protocol.decodePartitionId(pickedUp.getValue().getProcessInstanceKey()))
+        .isEqualTo(partitionFor(CORRELATION_KEY));
+
+    // and no PUSHED event and no RELEASE were produced up to that pick-up
+    final long pushOrRelease =
+        RecordingExporter.records()
+            .limit(
+                r ->
+                    r.getValueType() == ValueType.PROCESS_INSTANCE
+                        && r.getIntent() == ProcessInstanceIntent.ELEMENT_ACTIVATING
+                        && r.getKey() == pickedUp.getValue().getProcessInstanceKey())
+            .filter(
+                r ->
+                    r.getValueType() == ValueType.MESSAGE_START_CORRELATION_KEY_LOCK_RELEASE
+                        && (r.getIntent() == MessageStartCorrelationKeyLockReleaseIntent.PUSHED
+                            || r.getIntent()
+                                == MessageStartCorrelationKeyLockReleaseIntent.RELEASE))
+            .count();
+    assertThat(pushOrRelease)
+        .as("a local message-start holder neither pushes nor releases cross-partition")
+        .isZero();
+  }
+
   private void deployAndAwaitStartSubscriptions(
       final BpmnModelInstance process, final String messageName) {
     engine.deployment().withXmlResource(process).deploy();
@@ -179,6 +327,15 @@ public final class CrossPartitionMessageStartLockReleasePushTest {
     RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
         .withBpmnProcessId(bpmnProcessId)
         .withElementType(BpmnElementType.PROCESS)
+        .getFirst();
+  }
+
+  /**
+   * Waits for the holder's service-task {@code JOB:CREATED} — proof the holder is active on P_B.
+   */
+  private static void awaitHolderJobCreated(final long processInstanceKey) {
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .filter(r -> r.getValue().getProcessInstanceKey() == processInstanceKey)
         .getFirst();
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleasePushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleasePushTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageStartCorrelationKeyLockReleaseIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.Duration;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Multi-partition behavioral pin for the <em>push</em> half of the cross-partition correlation-key
+ * lock release (#57172): when the holder instance created via the handshake completes on {@code
+ * P_B}, {@code P_B} pushes that completion to {@code P_K}, which releases the lock and picks up the
+ * next buffered message — without the reconciliation poll being involved at all.
+ *
+ * <p>Unlike {@link CrossPartitionMessageStartLockReleaseTest}, whose scenarios drive the poll loop
+ * with an explicit {@code increaseTime}, this class deliberately runs with the reconciliation poll
+ * <em>disabled</em> (an interval far larger than any test's wall-clock runtime). The test harness's
+ * {@code ControlledActorClock} follows wall-clock time by default, so a short poll interval would
+ * fire on its own and race the push, making a "no QUERY" assertion flaky. Disabling the poll leaves
+ * the push as the only mechanism that can release the lock: the pick-up happening at all proves the
+ * push works, and the absence of any {@code QUERY} proves it was the push — not reconciliation —
+ * that did it.
+ *
+ * <p>The constants are chosen so {@code hash(correlationKey) != hash(businessId)}; an
+ * {@code @Before} precondition fails loudly if a future hash change degenerates the scenario into a
+ * single-partition path.
+ */
+public final class CrossPartitionMessageStartLockReleasePushTest {
+
+  private static final int PARTITION_COUNT = 3;
+
+  // hash("ck-1") → P_K=1 and hash("biz-1") → P_B=3 under PARTITION_COUNT=3, so the holder runs on a
+  // different partition than the lock. Re-asserted in @Before against hash drift.
+  private static final String CORRELATION_KEY = "ck-1";
+  private static final String BUSINESS_ID = "biz-1";
+
+  private static final long LONG_TTL = Duration.ofMinutes(5).toMillis();
+
+  // The reconciliation poll is disabled by making its interval far larger than any test's
+  // wall-clock runtime. The harness clock follows wall-clock, so this guarantees the poll never
+  // ticks during the test and the push is the sole releaser.
+  private static final Duration POLL_DISABLED = Duration.ofHours(1);
+
+  // Auto-completing message-start process: the holder completes on P_B on its own (the engine's job
+  // client writes to the primary partition and could not complete a job living on P_B).
+  private static final String AUTO_PROCESS_ID = "wf-auto";
+  private static final String AUTO_MESSAGE_NAME = "auto-start-msg";
+  private static final BpmnModelInstance AUTO_PROCESS =
+      Bpmn.createExecutableProcess(AUTO_PROCESS_ID)
+          .startEvent("autoStart")
+          .message(AUTO_MESSAGE_NAME)
+          .endEvent()
+          .done();
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.multiplePartition(PARTITION_COUNT)
+          .withEngineConfig(
+              config ->
+                  config
+                      .setBusinessIdUniquenessEnabled(true)
+                      .setMessageStartLockReleasePollInterval(POLL_DISABLED));
+
+  @Before
+  public void assertCrossPartitionRouting() {
+    assertThat(partitionFor(CORRELATION_KEY))
+        .as(
+            "CORRELATION_KEY (%s) and BUSINESS_ID (%s) must hash to different partitions so the"
+                + " cross-partition lock-release loop is actually exercised",
+            CORRELATION_KEY, BUSINESS_ID)
+        .isNotEqualTo(partitionFor(BUSINESS_ID));
+  }
+
+  @Test
+  public void shouldReleaseLockOnHolderCompletionWithoutPolling() {
+    // given a cross-partition start: holder created (and auto-completes) on P_B, lock on P_K
+    deployAndAwaitStartSubscriptions(AUTO_PROCESS, AUTO_MESSAGE_NAME);
+    publishStart(AUTO_MESSAGE_NAME, CORRELATION_KEY, BUSINESS_ID);
+    final long holderKey = awaitHolderActivating(AUTO_PROCESS_ID);
+    awaitMessageConsumedOnPK(AUTO_MESSAGE_NAME);
+
+    // and a second same-correlation-key publish buffered behind the lock
+    publishStart(AUTO_MESSAGE_NAME, CORRELATION_KEY, null);
+
+    // and the holder completes on P_B
+    awaitHolderCompleted(AUTO_PROCESS_ID);
+
+    // when the reconciliation poll never fires (disabled)
+
+    // then P_K releases the lock and starts the buffered message on P_K, driven purely by the
+    // completion push from P_B
+    final var pickedUp =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withBpmnProcessId(AUTO_PROCESS_ID)
+            .withElementType(BpmnElementType.PROCESS)
+            .filter(r -> r.getValue().getProcessInstanceKey() != holderKey)
+            .getFirst();
+    assertThat(Protocol.decodePartitionId(pickedUp.getValue().getProcessInstanceKey()))
+        .as("the buffered message is picked up on P_K without any poll tick")
+        .isEqualTo(partitionFor(CORRELATION_KEY));
+
+    // and not a single holder-liveness QUERY was ever sent up to that pick-up — the release was
+    // push-driven, not discovered by reconciliation
+    final long queries =
+        RecordingExporter.records()
+            .limit(
+                r ->
+                    r.getValueType() == ValueType.PROCESS_INSTANCE
+                        && r.getIntent() == ProcessInstanceIntent.ELEMENT_ACTIVATING
+                        && r.getKey() == pickedUp.getValue().getProcessInstanceKey())
+            .filter(
+                r ->
+                    r.getValueType() == ValueType.MESSAGE_START_CORRELATION_KEY_LOCK_RELEASE
+                        && r.getIntent() == MessageStartCorrelationKeyLockReleaseIntent.QUERY)
+            .count();
+    assertThat(queries).as("no reconciliation QUERY is needed on the push happy path").isZero();
+  }
+
+  private void deployAndAwaitStartSubscriptions(
+      final BpmnModelInstance process, final String messageName) {
+    engine.deployment().withXmlResource(process).deploy();
+    // deploy() waits for CommandDistribution:FINISHED; additionally wait until every partition has
+    // its MessageStartEventSubscription so the P_B ask handler sees its local subscription before
+    // the first cross-partition request arrives (otherwise it would reply
+    // NO_SUBSCRIPTION_REJECTED).
+    RecordingExporter.messageStartEventSubscriptionRecords(
+            MessageStartEventSubscriptionIntent.CREATED)
+        .withMessageName(messageName)
+        .limit(PARTITION_COUNT)
+        .asList();
+  }
+
+  private void publishStart(
+      final String messageName, final String correlationKey, final String businessId) {
+    var builder =
+        engine
+            .message()
+            .withName(messageName)
+            .withCorrelationKey(correlationKey)
+            .withTimeToLive(LONG_TTL);
+    if (businessId != null) {
+      builder = builder.withBusinessId(businessId);
+    }
+    builder.publish();
+  }
+
+  /** First PROCESS-level activation for the given process — the holder created on {@code P_B}. */
+  private static long awaitHolderActivating(final String bpmnProcessId) {
+    return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+        .withBpmnProcessId(bpmnProcessId)
+        .withElementType(BpmnElementType.PROCESS)
+        .getFirst()
+        .getValue()
+        .getProcessInstanceKey();
+  }
+
+  private static void awaitHolderCompleted(final String bpmnProcessId) {
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withBpmnProcessId(bpmnProcessId)
+        .withElementType(BpmnElementType.PROCESS)
+        .getFirst();
+  }
+
+  /**
+   * Waits for the buffered message to be consumed on {@code P_K} by the handshake (its terminal
+   * {@code EXPIRED}), which is written in the same {@code STARTED}-reply processing that writes the
+   * correlation-key lock on {@code P_K}.
+   */
+  private static void awaitMessageConsumedOnPK(final String messageName) {
+    RecordingExporter.messageRecords(MessageIntent.EXPIRED)
+        .withName(messageName)
+        .withCorrelationKey(CORRELATION_KEY)
+        .getFirst();
+  }
+
+  private static int partitionFor(final String key) {
+    return SubscriptionUtil.getSubscriptionPartitionId(BufferUtil.wrapString(key), PARTITION_COUNT);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseSchedulerTest.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.engine.state.immutable.MessageState.CrossPartitionStartL
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartCorrelationKeyLockReleaseRecord;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
-import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -34,23 +33,20 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 /**
- * Verifies the {@code P_K}-side release-poll scheduler in isolation: it walks the cross-partition
- * lock entries, groups them by the partition each holder lives on, batches one query per partition,
- * backs off per entry, and skips entries whose holder is local.
+ * Verifies the {@code P_K}-side release-reconciliation scheduler in isolation: it walks the
+ * cross-partition lock entries, groups them by the partition each holder lives on, batches one
+ * query per partition up to the batch limit, and skips entries whose holder is local. The scheduler
+ * holds no transient bookkeeping — every tick reconciles purely from the current lock state.
  */
 public final class CrossPartitionMessageStartLockReleaseSchedulerTest {
 
-  private static final Duration POLL_INTERVAL = Duration.ofSeconds(1);
-  private static final Duration MAX_BACKOFF = Duration.ofSeconds(30);
+  private static final Duration POLL_INTERVAL = Duration.ofSeconds(30);
   private static final int LOCAL_PARTITION = 1;
-  private static final long NOW = 100_000L;
 
   private SubscriptionCommandSender mockCommandSender;
   private MessageState mockMessageState;
   private ProcessingScheduleService mockScheduleService;
   private ReadonlyStreamProcessorContext mockContext;
-  private StreamClock mockClock;
-  private final long[] now = {NOW};
   private int batchLimit;
   private final List<Lock> locks = new ArrayList<>();
 
@@ -62,12 +58,9 @@ public final class CrossPartitionMessageStartLockReleaseSchedulerTest {
     mockMessageState = mock(MessageState.class);
     mockScheduleService = mock(ProcessingScheduleService.class);
     mockContext = mock(ReadonlyStreamProcessorContext.class);
-    mockClock = mock(StreamClock.class);
     batchLimit = 64;
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
-    when(mockContext.getClock()).thenReturn(mockClock);
-    when(mockClock.millis()).thenAnswer(invocation -> now[0]);
 
     // replay the configured locks to the visitor on every visit call
     doAnswer(
@@ -91,7 +84,6 @@ public final class CrossPartitionMessageStartLockReleaseSchedulerTest {
             mockCommandSender,
             mockMessageState,
             () -> POLL_INTERVAL,
-            () -> MAX_BACKOFF,
             () -> batchLimit);
     scheduler.onRecovered(mockContext);
   }
@@ -156,17 +148,21 @@ public final class CrossPartitionMessageStartLockReleaseSchedulerTest {
   }
 
   @Test
-  void shouldRespectBatchLimitAndPollRemainderOnNextTick() {
+  void shouldCapEachQueryAtBatchLimitAndReconcileRemainderOnNextTick() {
     // given two holders on the same partition but a batch limit of one
     batchLimit = 1;
     addLock("wf", "ck-a", holderKeyOnPartition(2, 1));
     addLock("wf", "ck-b", holderKeyOnPartition(2, 2));
 
-    // when the scheduler runs twice within the same tick
-    scheduler.run();
+    // when the first tick runs, only the first holder is batched
     scheduler.run();
 
-    // then each run dispatches a single-holder query and both holders are eventually polled
+    // and after its lock is reaped (its holder completed and the lock was released), the next tick
+    // reconciles the remainder
+    removeLock("ck-a");
+    scheduler.run();
+
+    // then each tick dispatched a single-holder query and both holders were eventually reconciled
     final var queryCaptor =
         ArgumentCaptor.forClass(MessageStartCorrelationKeyLockReleaseRecord.class);
     verify(mockCommandSender, org.mockito.Mockito.times(2))
@@ -177,7 +173,7 @@ public final class CrossPartitionMessageStartLockReleaseSchedulerTest {
             .peek(q -> assertThat(q.getHolders()).hasSize(1))
             .map(q -> q.getHolders().getFirst().getCorrelationKey())
             .toList();
-    assertThat(polledCorrelationKeys).containsExactlyInAnyOrder("ck-a", "ck-b");
+    assertThat(polledCorrelationKeys).containsExactly("ck-a", "ck-b");
   }
 
   @Test
@@ -194,61 +190,8 @@ public final class CrossPartitionMessageStartLockReleaseSchedulerTest {
   }
 
   @Test
-  void shouldBackOffEntryAfterPolling() {
-    // given a single lock
-    addLock("wf", "ck", holderKeyOnPartition(2, 1));
-
-    // when polled, then re-run within the back-off window
-    scheduler.run();
-    scheduler.run();
-
-    // then no second query is sent while the entry is still backing off
-    verify(mockCommandSender, org.mockito.Mockito.times(1))
-        .sendDirectCorrelationKeyLockReleaseQuery(eq(2), any());
-
-    // when the back-off interval elapses
-    now[0] += POLL_INTERVAL.toMillis();
-    scheduler.run();
-
-    // then the entry is polled again
-    verify(mockCommandSender, org.mockito.Mockito.times(2))
-        .sendDirectCorrelationKeyLockReleaseQuery(eq(2), any());
-  }
-
-  @Test
-  void shouldDoubleBackOffIntervalExponentiallyUpToMaxBackoff() {
-    // given a single lock whose holder stays alive across many polls
-    addLock("wf", "ck", holderKeyOnPartition(2, 1));
-
-    // the first poll happens immediately on the tick the lock is first observed
-    scheduler.run();
-    verify(mockCommandSender, org.mockito.Mockito.times(1))
-        .sendDirectCorrelationKeyLockReleaseQuery(eq(2), any());
-
-    // the wait before each subsequent poll doubles (1s, 2s, 4s, 8s, 16s) and then caps at the
-    // max back-off (30s, not 32s) and stays there
-    final long[] expectedGapsMillis = {1_000, 2_000, 4_000, 8_000, 16_000, 30_000, 30_000};
-
-    int expectedPolls = 1;
-    for (final long gap : expectedGapsMillis) {
-      // just before the gap elapses the entry is not yet eligible
-      now[0] += gap - 1;
-      scheduler.run();
-      verify(mockCommandSender, org.mockito.Mockito.times(expectedPolls))
-          .sendDirectCorrelationKeyLockReleaseQuery(eq(2), any());
-
-      // exactly at the gap boundary it is polled again
-      now[0] += 1;
-      scheduler.run();
-      expectedPolls++;
-      verify(mockCommandSender, org.mockito.Mockito.times(expectedPolls))
-          .sendDirectCorrelationKeyLockReleaseQuery(eq(2), any());
-    }
-  }
-
-  @Test
-  void shouldDropBackOffBookkeepingWhenLockDisappearsAndResetWhenItReappears() {
-    // given a lock that has been polled and is now backing off
+  void shouldReconcilePurelyFromCurrentLockStateEachTick() {
+    // given a lock that has been reconciled once
     addLock("wf", "ck", holderKeyOnPartition(2, 1));
     scheduler.run();
     verify(mockCommandSender, org.mockito.Mockito.times(1))
@@ -257,7 +200,7 @@ public final class CrossPartitionMessageStartLockReleaseSchedulerTest {
     // when the lock disappears (its holder completed and the lock was released elsewhere)
     locks.clear();
     scheduler.run();
-    // then nothing is polled and the back-off bookkeeping for it is dropped
+    // then nothing is reconciled — the scheduler keeps no memory of the vanished lock
     verify(mockCommandSender, org.mockito.Mockito.times(1))
         .sendDirectCorrelationKeyLockReleaseQuery(eq(2), any());
 
@@ -265,8 +208,8 @@ public final class CrossPartitionMessageStartLockReleaseSchedulerTest {
     addLock("wf", "ck", holderKeyOnPartition(2, 2));
     scheduler.run();
 
-    // then it is treated as newly observed and polled immediately without inheriting the earlier
-    // back-off, even though the clock has not advanced
+    // then it is reconciled again purely from the current state, without inheriting anything from
+    // the earlier entry
     verify(mockCommandSender, org.mockito.Mockito.times(2))
         .sendDirectCorrelationKeyLockReleaseQuery(eq(2), any());
   }
@@ -286,6 +229,10 @@ public final class CrossPartitionMessageStartLockReleaseSchedulerTest {
   private void addLock(
       final String bpmnProcessId, final String correlationKey, final long holderKey) {
     locks.add(new Lock(bpmnProcessId, correlationKey, holderKey, "<default>"));
+  }
+
+  private void removeLock(final String correlationKey) {
+    locks.removeIf(lock -> lock.correlationKey.equals(correlationKey));
   }
 
   private static long holderKeyOnPartition(final int partition, final long sequence) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseSchedulerTest.java
@@ -34,9 +34,10 @@ import org.mockito.ArgumentCaptor;
 
 /**
  * Verifies the {@code P_K}-side release-reconciliation scheduler in isolation: it walks the
- * cross-partition lock entries, groups them by the partition each holder lives on, batches one
- * query per partition up to the batch limit, and skips entries whose holder is local. The scheduler
- * holds no transient bookkeeping — every tick reconciles purely from the current lock state.
+ * cross-partition lock entries, groups them by the partition each holder lives on, chunks each
+ * partition's holders into one query per batch-limit slice, and skips entries whose holder is
+ * local. The scheduler holds no transient bookkeeping — every tick reconciles purely from the
+ * current lock state.
  */
 public final class CrossPartitionMessageStartLockReleaseSchedulerTest {
 
@@ -148,21 +149,17 @@ public final class CrossPartitionMessageStartLockReleaseSchedulerTest {
   }
 
   @Test
-  void shouldCapEachQueryAtBatchLimitAndReconcileRemainderOnNextTick() {
+  void shouldChunkHoldersExceedingBatchLimitIntoMultipleQueriesInSameTick() {
     // given two holders on the same partition but a batch limit of one
     batchLimit = 1;
     addLock("wf", "ck-a", holderKeyOnPartition(2, 1));
     addLock("wf", "ck-b", holderKeyOnPartition(2, 2));
 
-    // when the first tick runs, only the first holder is batched
+    // when a single tick runs
     scheduler.run();
 
-    // and after its lock is reaped (its holder completed and the lock was released), the next tick
-    // reconciles the remainder
-    removeLock("ck-a");
-    scheduler.run();
-
-    // then each tick dispatched a single-holder query and both holders were eventually reconciled
+    // then both holders are reconciled in that same tick, split into one single-holder query each,
+    // so a holder sorted past the batch limit never has to wait for a leading lock to be reaped
     final var queryCaptor =
         ArgumentCaptor.forClass(MessageStartCorrelationKeyLockReleaseRecord.class);
     verify(mockCommandSender, org.mockito.Mockito.times(2))
@@ -229,10 +226,6 @@ public final class CrossPartitionMessageStartLockReleaseSchedulerTest {
   private void addLock(
       final String bpmnProcessId, final String correlationKey, final long holderKey) {
     locks.add(new Lock(bpmnProcessId, correlationKey, holderKey, "<default>"));
-  }
-
-  private void removeLock(final String correlationKey) {
-    locks.removeIf(lock -> lock.correlationKey.equals(correlationKey));
   }
 
   private static long holderKeyOnPartition(final int partition, final long sequence) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseTest.java
@@ -24,9 +24,11 @@ import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionInte
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.MessageStartCorrelationKeyLockReleaseRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import org.junit.Before;
@@ -216,6 +218,57 @@ public final class CrossPartitionMessageStartLockReleaseTest {
     assertThat(Protocol.decodePartitionId(pickedUp.getValue().getProcessInstanceKey()))
         .as("the buffered message is picked up and started on P_K after the lock is released")
         .isEqualTo(partitionFor(CORRELATION_KEY));
+  }
+
+  @Test
+  public void shouldReleaseCompletedHolderExactlyOnceEvenThoughReconciliationPollAlsoRuns() {
+    // Idempotency pin for push × poll coexistence: with the poll enabled, a lock that the
+    // completion push has already released must not be released a second time when a later
+    // reconciliation poll runs. P_K must emit exactly one RELEASED for the holder and re-drive the
+    // buffered message exactly once; the holder-precise guard on the release handler makes the
+    // redundant poll a no-op.
+    deployAndAwaitStartSubscriptions(AUTO_PROCESS, AUTO_MESSAGE_NAME);
+
+    // given a cross-partition start — holder created (and auto-completing) on P_B, correlation-key
+    // lock on P_K — with a same-key message buffered behind that lock
+    publishStart(AUTO_MESSAGE_NAME, CORRELATION_KEY, BUSINESS_ID);
+    final long firstHolderKey = awaitHolderActivating(AUTO_PROCESS_ID);
+    awaitMessageConsumedOnPK(AUTO_MESSAGE_NAME);
+    publishStart(AUTO_MESSAGE_NAME, CORRELATION_KEY, null);
+
+    // and the completion push has already released the lock, so the poll can only ever act on an
+    // already-released lock
+    awaitLockReleasedFor(firstHolderKey);
+
+    // when the reconciliation poll then runs
+    engine.increaseTime(POLL_INTERVAL.multipliedBy(2));
+
+    // then, observed through a sentinel that bounds the record stream just past the poll tick (a
+    // second holder driven to completion; not part of the scenario — see the helper)
+    final var releasesThroughSentinel = awaitReleasesThroughPollSentinel();
+
+    // the first holder's lock is released exactly once — the poll did not release it again
+    final long releasesForFirstHolder =
+        releasesThroughSentinel.stream().filter(r -> holderHasKey(r, firstHolderKey)).count();
+    assertThat(releasesForFirstHolder)
+        .as("a completed holder's lock is released exactly once, even with the poll running")
+        .isEqualTo(1L);
+
+    // and the buffered message is re-driven exactly once: a single pick-up PI started on P_K within
+    // the same sentinel-bounded window (both holders live on P_B, so they are not pick-ups)
+    final long pickUps =
+        RecordingExporter.records()
+            .limit(nthReleased(2))
+            .processInstanceRecords()
+            .withBpmnProcessId(AUTO_PROCESS_ID)
+            .withElementType(BpmnElementType.PROCESS)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .filter(
+                r ->
+                    Protocol.decodePartitionId(r.getValue().getProcessInstanceKey())
+                        == partitionFor(CORRELATION_KEY))
+            .count();
+    assertThat(pickUps).as("the buffered message is re-driven exactly once").isEqualTo(1L);
   }
 
   @Test
@@ -516,6 +569,53 @@ public final class CrossPartitionMessageStartLockReleaseTest {
     return r ->
         r.getIntent() == MessageStartCorrelationKeyLockReleaseIntent.QUERIED
             && seen.incrementAndGet() == n;
+  }
+
+  /**
+   * A merged-stream bound that stops at the {@code n}-th RELEASED event. Each call returns a fresh
+   * stateful predicate, so it must not be shared across streams.
+   */
+  private static Predicate<Record<RecordValue>> nthReleased(final int n) {
+    final var seen = new AtomicInteger();
+    return r ->
+        r.getIntent() == MessageStartCorrelationKeyLockReleaseIntent.RELEASED
+            && seen.incrementAndGet() == n;
+  }
+
+  private static boolean holderHasKey(
+      final Record<MessageStartCorrelationKeyLockReleaseRecordValue> record, final long holderKey) {
+    return record.getValue().getHolders().stream()
+        .anyMatch(h -> h.getProcessInstanceKey() == holderKey);
+  }
+
+  /**
+   * Waits for the completion push to release the correlation-key lock held for {@code holderKey}.
+   */
+  private static void awaitLockReleasedFor(final long holderKey) {
+    RecordingExporter.messageStartCorrelationKeyLockReleaseRecords(
+            MessageStartCorrelationKeyLockReleaseIntent.RELEASED)
+        .filter(r -> holderHasKey(r, holderKey))
+        .getFirst();
+  }
+
+  /**
+   * Sentinel that makes the reconciliation poll's (in)action observable without waiting on the
+   * absence of a record. It is not part of the scenario under test: it drives a <em>second</em>
+   * cross-partition holder on the same correlation key to completion (its businessId is free again
+   * now that the first holder completed), whose push emits a second RELEASED. Because P_K applies
+   * release records in order, observing that second RELEASED proves the poll tick queued earlier
+   * has already been fully processed — so the returned window contains every effect the poll could
+   * have had on the first holder.
+   *
+   * @return the first two RELEASED records: the first holder's release, then the sentinel's
+   */
+  private List<Record<MessageStartCorrelationKeyLockReleaseRecordValue>>
+      awaitReleasesThroughPollSentinel() {
+    publishStart(AUTO_MESSAGE_NAME, CORRELATION_KEY, BUSINESS_ID);
+    return RecordingExporter.messageStartCorrelationKeyLockReleaseRecords(
+            MessageStartCorrelationKeyLockReleaseIntent.RELEASED)
+        .limit(2)
+        .asList();
   }
 
   private void deployAndAwaitStartSubscriptions(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseTest.java
@@ -144,6 +144,43 @@ public final class CrossPartitionMessageStartLockReleaseTest {
   }
 
   @Test
+  public void shouldWriteHolderOriginOnPBButNotOnPKForCrossPartitionStart() {
+    // given a cross-partition start whose holder stays active on P_B (service task) while the
+    // correlation-key lock lives on P_K
+    deployAndAwaitStartSubscriptions(SERVICE_PROCESS, SERVICE_MESSAGE_NAME);
+    publishStart(SERVICE_MESSAGE_NAME, CORRELATION_KEY, BUSINESS_ID);
+    final long holderKey = awaitHolderActivating(SERVICE_PROCESS_ID);
+    // holder active on P_B (its local STARTED applied) and the STARTED reply consumed on P_K
+    awaitHolderJobCreated(holderKey);
+    awaitMessageConsumedOnPK(SERVICE_MESSAGE_NAME);
+
+    // then the holder-origin entry exists on P_B (where the holder lives), keyed by the holder PI
+    // and carrying the lock coordinates plus a messageKey that addresses P_K
+    final var originOnPB =
+        engine
+            .getProcessingState(partitionFor(BUSINESS_ID))
+            .getMessageState()
+            .getCrossPartitionStartHolderOrigin(holderKey);
+    assertThat(originOnPB).as("the holder partition records the origin entry").isNotNull();
+    assertThat(BufferUtil.bufferAsString(originOnPB.getBpmnProcessIdBuffer()))
+        .isEqualTo(SERVICE_PROCESS_ID);
+    assertThat(BufferUtil.bufferAsString(originOnPB.getCorrelationKeyBuffer()))
+        .isEqualTo(CORRELATION_KEY);
+    assertThat(Protocol.decodePartitionId(originOnPB.getMessageKey()))
+        .as("the stored messageKey addresses P_K")
+        .isEqualTo(partitionFor(CORRELATION_KEY));
+
+    // and no entry is written on P_K, where the same STARTED reply is applied
+    assertThat(
+            engine
+                .getProcessingState(partitionFor(CORRELATION_KEY))
+                .getMessageState()
+                .getCrossPartitionStartHolderOrigin(holderKey))
+        .as("the lock partition never records a holder-origin entry")
+        .isNull();
+  }
+
+  @Test
   public void shouldReleaseLockAndStartBufferedMessageWhenHolderCompletesOnPB() {
     // given a cross-partition start: the holder is created (and auto-completes) on P_B and the
     // correlation-key lock is written on P_K

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseTest.java
@@ -104,12 +104,11 @@ public final class CrossPartitionMessageStartLockReleaseTest {
           .endEvent()
           .done();
 
-  // Dual-start process on a *single* bpmnProcessId: the message-start path auto-completes (the
-  // cross-partition holder), while the none-start path parks on a service task so a second instance
-  // of the SAME process definition can actively hold the businessId. Needed because businessId
-  // uniqueness is scoped per (businessId, processDefinitionId, tenantId) — a different process
-  // could
-  // not contend for the same businessId.
+  // Dual-start process on a *single* bpmnProcessId: the message-start path parks on a service task
+  // (the cross-partition holder stays active), while the none-start path parks on a service task so
+  // a second instance of the SAME process definition can actively hold the businessId. Needed
+  // because businessId uniqueness is scoped per (businessId, processDefinitionId, tenantId) — a
+  // different process could not contend for the same businessId.
   private static final String CONTENDED_PROCESS_ID = "wf-contended";
   private static final String CONTENDED_MESSAGE_NAME = "contended-start-msg";
   private static final BpmnModelInstance CONTENDED_PROCESS = contendedProcess();
@@ -125,7 +124,15 @@ public final class CrossPartitionMessageStartLockReleaseTest {
 
   private static BpmnModelInstance contendedProcess() {
     final var process = Bpmn.createExecutableProcess(CONTENDED_PROCESS_ID);
-    process.startEvent("contendedMsgStart").message(CONTENDED_MESSAGE_NAME).endEvent();
+    // the message-start holder parks on a job so it stays active: it must not auto-complete, which
+    // would push its own release immediately (before the contender exists), a separately covered
+    // path. Deferring the release to the poll (via ban) lets the contender take the businessId
+    // first.
+    process
+        .startEvent("contendedMsgStart")
+        .message(CONTENDED_MESSAGE_NAME)
+        .serviceTask("contendedMsgTask", t -> t.zeebeJobType("hold"))
+        .endEvent();
     process
         .startEvent("contendedNoneStart")
         .serviceTask("contendedTask", t -> t.zeebeJobType("hold"))
@@ -383,17 +390,28 @@ public final class CrossPartitionMessageStartLockReleaseTest {
     // leave two active root PIs sharing one businessId — the exact corruption the cross-partition
     // routing of the pick-up exists to prevent. Uses a dual-start process so the contender shares
     // the buffered message's process definition (uniqueness is scoped per process definition).
+    //
+    // The release is deferred to the reconciliation poll by *banning* the holder rather than
+    // completing it: a completing holder pushes its own release immediately — before the contender
+    // exists, while the businessId is free — which is a separately covered path. Banning frees the
+    // businessId (uniqueness excludes banned instances) while leaving the correlation-key lock for
+    // the poll to release, so the contender can take the businessId before the pick-up.
     deployAndAwaitStartSubscriptions(CONTENDED_PROCESS, CONTENDED_MESSAGE_NAME);
 
-    // the original holder starts on P_B via the message-start ask and auto-completes; lock on P_K
+    // the holder starts on P_B via the message-start ask and parks on a job (stays active); lock
+    // P_K
     publishStart(CONTENDED_MESSAGE_NAME, CORRELATION_KEY, BUSINESS_ID);
     final long holderKey = awaitHolderActivating(CONTENDED_PROCESS_ID);
+    awaitHolderJobCreated(holderKey);
     awaitMessageConsumedOnPK(CONTENDED_MESSAGE_NAME);
 
     // a second publish with the same correlation key AND the same businessId is buffered behind the
     // lock — it will have to be re-routed to P_B on pick-up
     publishStart(CONTENDED_MESSAGE_NAME, CORRELATION_KEY, BUSINESS_ID);
-    awaitHolderCompleted(CONTENDED_PROCESS_ID);
+
+    // ban the holder: frees the businessId without completing it, so no push fires and the
+    // correlation-key lock is left for the poll to release
+    engine.banInstanceInNewTransaction(partitionFor(BUSINESS_ID), holderKey);
 
     // a *different* instance of the same process now actively holds that businessId on P_B (via the
     // none-start path that parks on a service task), so the businessId is taken again before the

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseTest.java
@@ -38,21 +38,21 @@ import org.junit.Test;
 /**
  * Multi-partition behavioural pin for the pull-based correlation-key lock release. A message-start
  * instance created via the cross-partition handshake runs on {@code P_B = hash(businessId)} while
- * the correlation-key lock it holds lives on {@code P_K = hash(correlationKey)}; {@code P_K} cannot
- * observe that holder completing, so it polls {@code P_B} and releases the lock when the holder is
- * gone. These tests exercise that whole loop — scheduler on {@code P_K} → query handler on {@code
- * P_B} → release reply on {@code P_K} → buffered-message pick-up — through the real inter-partition
- * transport.
+ * the correlation-key lock it holds lives on {@code P_K = hash(correlationKey)}. On holder
+ * completion or termination {@code P_B} pushes a release straight to {@code P_K} (the fast path);
+ * {@code P_K} also reconciles periodically as a slow-path backstop for lost pushes. These tests
+ * exercise that whole loop — scheduler on {@code P_K} → query handler on {@code P_B} → release
+ * reply on {@code P_K} → buffered-message pick-up — through the real inter-partition transport.
  *
  * <p>Component-level behaviour that does not need the full transport is pinned with the code it
- * belongs to and is intentionally <em>not</em> re-tested here: the scheduler's back-off doubling /
- * cap and per-partition batching live in {@code
+ * belongs to and is intentionally <em>not</em> re-tested here: the scheduler's per-partition
+ * batching and stateless per-tick reconciliation live in {@code
  * CrossPartitionMessageStartLockReleaseSchedulerTest}; the {@code P_B} query outcomes (active /
  * gone / banned) live in {@code MessageStartCorrelationKeyLockReleaseQueryProcessorTest}; and the
  * {@code P_K} release handler's holder-precise idempotency guard lives in {@code
  * MessageStartCorrelationKeyLockReleaseReleaseProcessorTest}. Restart / leadership recovery is a
- * property of the transient back-off bookkeeping being rebuilt from local lock state (covered by
- * the scheduler unit test's reconcile case) and needs no dedicated multi-partition pin.
+ * property of the poll set being reconstructed from local lock state each tick (covered by the
+ * scheduler unit test's reconcile case) and needs no dedicated multi-partition pin.
  *
  * <p>The constants are chosen so {@code hash(correlationKey) != hash(businessId)}; an
  * {@code @Before} precondition fails loudly if a future hash change degenerates the scenario into a
@@ -70,9 +70,6 @@ public final class CrossPartitionMessageStartLockReleaseTest {
 
   private static final long LONG_TTL = Duration.ofMinutes(5).toMillis();
   private static final Duration POLL_INTERVAL = Duration.ofSeconds(1);
-  // Advanced well past a single lock's back-off so a second poll round is guaranteed to fire while
-  // the holder is still active (used as a "lock survived a full round" fence).
-  private static final Duration MAX_BACKOFF = Duration.ofSeconds(30);
 
   // Auto-completing message-start process: the holder completes on P_B on its own (the engine's job
   // client writes to the primary partition and could not complete a job living on P_B).
@@ -324,10 +321,10 @@ public final class CrossPartitionMessageStartLockReleaseTest {
     // and a second same-correlation-key publish buffered behind the lock
     publishStart(SERVICE_MESSAGE_NAME, CORRELATION_KEY, null);
 
-    // when the release poll fires, then fires again past the back-off
+    // when the reconciliation poll fires, then fires again on the next tick
     engine.increaseTime(POLL_INTERVAL.multipliedBy(2));
     awaitQueryRounds(1);
-    engine.increaseTime(MAX_BACKOFF);
+    engine.increaseTime(POLL_INTERVAL.multipliedBy(2));
 
     // then a SECOND query round is observed — which can only happen if the lock still exists, i.e.
     // round 1 did not release the still-active holder. This re-query is the fence that proves the

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseTest.java
@@ -392,6 +392,49 @@ public final class CrossPartitionMessageStartLockReleaseTest {
   }
 
   @Test
+  public void shouldDeleteHolderOriginDuringReconciliationWhenHolderBanned() {
+    // A holder that vanishes without completing — here, banned on P_B — never runs the completion
+    // push, so the push path never drops its holder-origin entry. The reconciliation poll, which
+    // releases the lock for such a gone holder, must also clean up the leftover origin entry, so a
+    // stuck cross-partition start does not leak one entry forever.
+    deployAndAwaitStartSubscriptions(SERVICE_PROCESS, SERVICE_MESSAGE_NAME);
+    publishStart(SERVICE_MESSAGE_NAME, CORRELATION_KEY, BUSINESS_ID);
+    final long holderKey = awaitHolderActivating(SERVICE_PROCESS_ID);
+    awaitHolderJobCreated(holderKey);
+    awaitMessageConsumedOnPK(SERVICE_MESSAGE_NAME);
+
+    // guard: the origin entry exists on P_B before the holder goes away, so the assertion below
+    // observes a deletion rather than an entry that was never written
+    final var pBMessageState =
+        engine.getProcessingState(partitionFor(BUSINESS_ID)).getMessageState();
+    assertThat(pBMessageState.getCrossPartitionStartHolderOrigin(holderKey))
+        .as("the holder-origin entry is written on P_B at holder creation")
+        .isNotNull();
+
+    // and the holder is banned on P_B — gone, but with no completion transition to push
+    engine.banInstanceInNewTransaction(partitionFor(BUSINESS_ID), holderKey);
+
+    // when the reconciliation poll fires
+    engine.increaseTime(POLL_INTERVAL.multipliedBy(2));
+
+    // then P_B appends a PUSHED for the gone holder (its applier drops the origin entry), on the
+    // holder's own partition
+    final var pushed =
+        RecordingExporter.messageStartCorrelationKeyLockReleaseRecords(
+                MessageStartCorrelationKeyLockReleaseIntent.PUSHED)
+            .filter(r -> r.getKey() == holderKey)
+            .getFirst();
+    assertThat(Protocol.decodePartitionId(pushed.getKey()))
+        .as("the origin cleanup is applied on P_B, the holder's partition")
+        .isEqualTo(partitionFor(BUSINESS_ID));
+
+    // and the leaked origin entry is gone
+    assertThat(pBMessageState.getCrossPartitionStartHolderOrigin(holderKey))
+        .as("reconciliation deletes the leftover holder-origin entry on P_B")
+        .isNull();
+  }
+
+  @Test
   public void shouldReleaseCompletedHolderLockEvenWhenBusinessIdWasReusedByAnotherInstance() {
     // Pins holder-instance precision: the release polls the *specific holder instance*, not
     // businessId availability, so the lock is released once the holder completes even if a

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseQueryProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseQueryProcessorTest.java
@@ -83,6 +83,17 @@ public final class MessageStartCorrelationKeyLockReleaseQueryProcessorTest {
             .getFirst();
     assertThat(release.getRecordType()).isEqualTo(RecordType.COMMAND);
     assertQueryPreserved(release.getValue(), ABSENT_HOLDER_KEY);
+
+    // and no PUSHED cleanup is appended: this gone holder has no leftover holder-origin entry, so
+    // the origin cleanup only fires for holders that actually left one behind (e.g. banned ones)
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    RecordingExporter.messageStartCorrelationKeyLockReleaseRecords(
+                            MessageStartCorrelationKeyLockReleaseIntent.PUSHED)
+                        .exists()))
+        .as("a gone holder with no origin entry produces no PUSHED cleanup")
+        .isFalse();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseReleaseProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseReleaseProcessorTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.message;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -19,10 +20,12 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBufferedMessageStartEventBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartCorrelationKeyLockReleaseRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MessageStartCorrelationKeyLockReleaseIntent;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -48,6 +51,7 @@ public final class MessageStartCorrelationKeyLockReleaseReleaseProcessorTest {
   private MessageState messageState;
   private BpmnBufferedMessageStartEventBehavior bufferedBehavior;
   private StateWriter stateWriter;
+  private TypedRejectionWriter rejectionWriter;
   private MessageStartCorrelationKeyLockReleaseReleaseProcessor processor;
 
   @BeforeEach
@@ -55,8 +59,10 @@ public final class MessageStartCorrelationKeyLockReleaseReleaseProcessorTest {
     messageState = mock(MessageState.class);
     bufferedBehavior = mock(BpmnBufferedMessageStartEventBehavior.class);
     stateWriter = mock(StateWriter.class);
+    rejectionWriter = mock(TypedRejectionWriter.class);
     final var writers = mock(Writers.class);
     when(writers.state()).thenReturn(stateWriter);
+    when(writers.rejection()).thenReturn(rejectionWriter);
     processor =
         new MessageStartCorrelationKeyLockReleaseReleaseProcessor(
             messageState, bufferedBehavior, writers);
@@ -91,30 +97,40 @@ public final class MessageStartCorrelationKeyLockReleaseReleaseProcessorTest {
             eq(BufferUtil.wrapString(PROCESS_ID)),
             eq(BufferUtil.wrapString(CORRELATION_KEY)),
             eq(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+
+    // and the reply is not rejected
+    verify(rejectionWriter, never()).appendRejection(any(), any(), anyString());
   }
 
   @Test
-  void shouldIgnoreReleaseWhenLockHeldByDifferentHolder() {
+  void shouldRejectRedundantReleaseWhenLockHeldByDifferentHolder() {
     // given the lock has since been re-acquired by a different instance for the same key
     when(messageState.getCrossPartitionStartLockHolder(any(), any())).thenReturn(HOLDER_KEY + 1);
 
     // when a stale/redelivered RELEASE for the old holder arrives
-    processor.processRecord(releaseRecord(HOLDER_KEY));
+    final var record = releaseRecord(HOLDER_KEY);
+    processor.processRecord(record);
 
-    // then the successor's lock is left untouched and nothing is picked up
+    // then the reply is rejected as redundant, the successor's lock is left untouched and nothing
+    // is picked up
+    verify(rejectionWriter)
+        .appendRejection(eq(record), eq(RejectionType.INVALID_STATE), anyString());
     verify(stateWriter, never()).appendFollowUpEvent(anyLong(), any(), any());
     verifyNoInteractions(bufferedBehavior);
   }
 
   @Test
-  void shouldIgnoreReleaseWhenLockAlreadyGone() {
+  void shouldRejectRedundantReleaseWhenLockAlreadyGone() {
     // given the lock has already been released (absent entry → -1)
     when(messageState.getCrossPartitionStartLockHolder(any(), any())).thenReturn(-1L);
 
     // when a redelivered RELEASE arrives
-    processor.processRecord(releaseRecord(HOLDER_KEY));
+    final var record = releaseRecord(HOLDER_KEY);
+    processor.processRecord(record);
 
-    // then it is a no-op
+    // then the reply is rejected as redundant and no state change or pick-up happens
+    verify(rejectionWriter)
+        .appendRejection(eq(record), eq(RejectionType.INVALID_STATE), anyString());
     verify(stateWriter, never()).appendFollowUpEvent(anyLong(), any(), any());
     verifyNoInteractions(bufferedBehavior);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MessageStartCorrelationKeyLockReleasePushedV1ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MessageStartCorrelationKeyLockReleasePushedV1ApplierTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartCorrelationKeyLockReleaseRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+final class MessageStartCorrelationKeyLockReleasePushedV1ApplierTest {
+  private static final long HOLDER_PROCESS_INSTANCE_KEY = 4503599627370497L;
+  private static final String BPMN_PROCESS_ID = "process";
+  private static final String CORRELATION_KEY = "ck-1";
+  private static final String TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+  private static final long MESSAGE_KEY = 2251799813685249L;
+
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  private MutableMessageState messageState;
+  private MessageStartCorrelationKeyLockReleasePushedV1Applier applier;
+
+  @BeforeEach
+  public void setUp() {
+    messageState = processingState.getMessageState();
+    applier = new MessageStartCorrelationKeyLockReleasePushedV1Applier(messageState);
+  }
+
+  @Test
+  public void shouldRemoveHolderOriginOnPushed() {
+    // given a holder-origin entry P_B kept for a cross-partition holder
+    seedOrigin();
+
+    // when the holder's completion is pushed
+    applier.applyState(HOLDER_PROCESS_INSTANCE_KEY, pushedRecord());
+
+    // then the holder-origin entry is dropped rather than leaked
+    assertThat(messageState.getCrossPartitionStartHolderOrigin(HOLDER_PROCESS_INSTANCE_KEY))
+        .isNull();
+  }
+
+  @Test
+  public void shouldNotFailWhenHolderOriginAbsent() {
+    // given no holder-origin entry (e.g. a PUSHED replayed after the entry was already removed)
+    // when the holder's completion is pushed
+    // then the removal is guarded and does not throw
+    assertThatCode(() -> applier.applyState(HOLDER_PROCESS_INSTANCE_KEY, pushedRecord()))
+        .doesNotThrowAnyException();
+  }
+
+  private void seedOrigin() {
+    messageState.putCrossPartitionStartHolderOrigin(
+        HOLDER_PROCESS_INSTANCE_KEY,
+        wrapString(BPMN_PROCESS_ID),
+        wrapString(CORRELATION_KEY),
+        TENANT,
+        MESSAGE_KEY);
+  }
+
+  private MessageStartCorrelationKeyLockReleaseRecord pushedRecord() {
+    final var record = new MessageStartCorrelationKeyLockReleaseRecord();
+    record
+        .addHolder()
+        .setProcessInstanceKey(HOLDER_PROCESS_INSTANCE_KEY)
+        .setBpmnProcessId(BPMN_PROCESS_ID)
+        .setCorrelationKey(CORRELATION_KEY)
+        .setTenantId(TENANT);
+    return record;
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MessageStartProcessInstanceReplyApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MessageStartProcessInstanceReplyApplierTest.java
@@ -40,6 +40,10 @@ public final class MessageStartProcessInstanceReplyApplierTest {
   private static final String BPMN_PROCESS_ID = "process";
   private static final String CORRELATION_KEY = "ck-1";
   private static final String BUSINESS_ID = "bid-1";
+  // PROCESS_INSTANCE_KEY (1000) decodes to partition 0; a different local partition keeps these
+  // mock-based tests off the holder-origin write (partition-gated), which is covered on real state
+  // by MessageStartProcessInstanceStartedV1ApplierTest. They pin dedup / pending-ask / lock only.
+  private static final int PARTITION_ID = 1;
 
   private MutableMessageStartProcessInstanceDedupState mockDedupState;
   private MutableMessageStartProcessInstanceAskState mockAskState;
@@ -140,7 +144,7 @@ public final class MessageStartProcessInstanceReplyApplierTest {
 
     private MessageStartProcessInstanceStartedV1Applier newApplier() {
       return new MessageStartProcessInstanceStartedV1Applier(
-          mockDedupState, mockAskState, mockMessageState);
+          mockDedupState, mockAskState, mockMessageState, PARTITION_ID);
     }
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MessageStartProcessInstanceStartedV1ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MessageStartProcessInstanceStartedV1ApplierTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessInstanceRequestRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+final class MessageStartProcessInstanceStartedV1ApplierTest {
+
+  private static final int P_B = 1;
+  private static final int P_K = 2;
+  private static final long RAW_HOLDER_KEY = 42L;
+  private static final long MESSAGE_KEY = Protocol.encodePartitionId(P_K, 7L);
+  private static final String BPMN_PROCESS_ID = "process";
+  private static final String CORRELATION_KEY = "ck-1";
+  private static final String BUSINESS_ID = "biz-1";
+  private static final String TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+  private static final long PROCESS_DEFINITION_KEY = 123L;
+
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  private MutableMessageState messageState;
+
+  @BeforeEach
+  public void setUp() {
+    messageState = processingState.getMessageState();
+  }
+
+  @Test
+  public void shouldWriteHolderOriginOnHolderPartition() {
+    // given the applier runs on P_B — the partition the holder instance was created on
+    final var applier = applierForPartition(P_B);
+    final long holderKey = Protocol.encodePartitionId(P_B, RAW_HOLDER_KEY);
+
+    // when the cross-partition STARTED is applied
+    applier.applyState(1L, startedRecord(holderKey, CORRELATION_KEY, BUSINESS_ID));
+
+    // then the holder-origin entry is written with the lock coordinates and addressing messageKey
+    final var origin = messageState.getCrossPartitionStartHolderOrigin(holderKey);
+    assertThat(origin).isNotNull();
+    assertThat(origin.getBpmnProcessIdBuffer()).isEqualTo(wrapString(BPMN_PROCESS_ID));
+    assertThat(origin.getCorrelationKeyBuffer()).isEqualTo(wrapString(CORRELATION_KEY));
+    assertThat(origin.getTenantIdBuffer()).isEqualTo(wrapString(TENANT));
+    assertThat(origin.getMessageKey()).isEqualTo(MESSAGE_KEY);
+  }
+
+  @Test
+  public void shouldNotWriteHolderOriginOnLockPartition() {
+    // given the applier runs on P_K — the lock partition, where the same STARTED reply is applied
+    // but the holder instance lives on another partition (its key encodes P_B)
+    final var applier = applierForPartition(P_K);
+    final long holderKey = Protocol.encodePartitionId(P_B, RAW_HOLDER_KEY);
+
+    // when the cross-partition STARTED is applied
+    applier.applyState(1L, startedRecord(holderKey, CORRELATION_KEY, BUSINESS_ID));
+
+    // then no holder-origin entry is written on P_K
+    assertThat(messageState.getCrossPartitionStartHolderOrigin(holderKey)).isNull();
+  }
+
+  @Test
+  public void shouldNotWriteHolderOriginWhenCorrelationKeyEmpty() {
+    // given the applier runs on P_B but the started holder carries no correlation key, so there is
+    // no correlation-key lock on any P_K to release
+    final var applier = applierForPartition(P_B);
+    final long holderKey = Protocol.encodePartitionId(P_B, RAW_HOLDER_KEY);
+
+    // when the STARTED is applied
+    applier.applyState(1L, startedRecord(holderKey, "", BUSINESS_ID));
+
+    // then no holder-origin entry is written
+    assertThat(messageState.getCrossPartitionStartHolderOrigin(holderKey)).isNull();
+  }
+
+  private MessageStartProcessInstanceStartedV1Applier applierForPartition(final int partitionId) {
+    return new MessageStartProcessInstanceStartedV1Applier(
+        processingState.getMessageStartProcessInstanceDedupState(),
+        processingState.getMessageStartProcessInstanceAskState(),
+        messageState,
+        partitionId);
+  }
+
+  private MessageStartProcessInstanceRequestRecord startedRecord(
+      final long processInstanceKey, final String correlationKey, final String businessId) {
+    return new MessageStartProcessInstanceRequestRecord()
+        .setProcessDefinitionKey(PROCESS_DEFINITION_KEY)
+        .setMessageKey(MESSAGE_KEY)
+        .setMessageName("start-msg")
+        .setCorrelationKey(correlationKey)
+        .setBusinessId(businessId)
+        .setBpmnProcessId(BPMN_PROCESS_ID)
+        .setTenantId(TENANT)
+        .setProcessInstanceKey(processInstanceKey);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStateTest.java
@@ -615,6 +615,73 @@ public final class MessageStateTest {
     assertThat(messageState.getProcessInstanceCorrelationKey(2L)).isEqualTo(wrapString("key-2"));
   }
 
+  @Test
+  public void shouldGetCrossPartitionStartHolderOrigin() {
+    // when
+    messageState.putCrossPartitionStartHolderOrigin(
+        1L, wrapString("process-1"), wrapString("key-1"), "tenant-1", 42L);
+
+    // then
+    final var origin = messageState.getCrossPartitionStartHolderOrigin(1L);
+    assertThat(origin).isNotNull();
+    assertThat(origin.getBpmnProcessIdBuffer()).isEqualTo(wrapString("process-1"));
+    assertThat(origin.getCorrelationKeyBuffer()).isEqualTo(wrapString("key-1"));
+    assertThat(origin.getTenantIdBuffer()).isEqualTo(wrapString("tenant-1"));
+    assertThat(origin.getMessageKey()).isEqualTo(42L);
+  }
+
+  @Test
+  public void shouldReturnNullForAbsentCrossPartitionStartHolderOrigin() {
+    // given
+    messageState.putCrossPartitionStartHolderOrigin(
+        1L, wrapString("process-1"), wrapString("key-1"), DEFAULT_TENANT, 42L);
+
+    // then
+    assertThat(messageState.getCrossPartitionStartHolderOrigin(2L)).isNull();
+  }
+
+  @Test
+  public void shouldRemoveCrossPartitionStartHolderOrigin() {
+    // given
+    messageState.putCrossPartitionStartHolderOrigin(
+        1L, wrapString("process-1"), wrapString("key-1"), "tenant-1", 42L);
+    messageState.putCrossPartitionStartHolderOrigin(
+        2L, wrapString("process-2"), wrapString("key-2"), "tenant-2", 43L);
+
+    // when
+    messageState.removeCrossPartitionStartHolderOrigin(1L);
+
+    // then
+    assertThat(messageState.getCrossPartitionStartHolderOrigin(1L)).isNull();
+    final var remaining = messageState.getCrossPartitionStartHolderOrigin(2L);
+    assertThat(remaining).isNotNull();
+    assertThat(remaining.getBpmnProcessIdBuffer()).isEqualTo(wrapString("process-2"));
+    assertThat(remaining.getMessageKey()).isEqualTo(43L);
+  }
+
+  @Test
+  public void shouldNotThrowWhenRemovingAbsentCrossPartitionStartHolderOrigin() {
+    // when - then (no exception)
+    messageState.removeCrossPartitionStartHolderOrigin(99L);
+    assertThat(messageState.getCrossPartitionStartHolderOrigin(99L)).isNull();
+  }
+
+  @Test
+  public void shouldOverwriteCrossPartitionStartHolderOrigin() {
+    // given
+    messageState.putCrossPartitionStartHolderOrigin(
+        1L, wrapString("process-1"), wrapString("key-1"), "tenant-1", 42L);
+
+    // when - re-applied STARTED reply writes the same holder again
+    messageState.putCrossPartitionStartHolderOrigin(
+        1L, wrapString("process-1"), wrapString("key-1"), "tenant-1", 42L);
+
+    // then
+    final var origin = messageState.getCrossPartitionStartHolderOrigin(1L);
+    assertThat(origin).isNotNull();
+    assertThat(origin.getMessageKey()).isEqualTo(42L);
+  }
+
   private MessageRecord createMessage(final String name, final String correlationKey) {
     return new MessageRecord()
         .setName(name)

--- a/zeebe/engine/src/test/resources/state/appliers/golden/MessageStartCorrelationKeyLockRelease_PUSHED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/MessageStartCorrelationKeyLockRelease_PUSHED_v1.golden
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartCorrelationKeyLockReleaseRecord;
+import io.camunda.zeebe.protocol.record.intent.MessageStartCorrelationKeyLockReleaseIntent;
+
+/**
+ * Applier for {@link MessageStartCorrelationKeyLockReleaseIntent#PUSHED}.
+ *
+ * <p>Emitted on {@code P_B} when a cross-partition message-start holder instance completes or
+ * terminates and its {@code RELEASE} has been pushed straight to {@code P_K}. Its only state effect
+ * is to drop the holder-origin entry ({@link
+ * MutableMessageState#removeCrossPartitionStartHolderOrigin}) that {@code P_B} kept for this
+ * holder: the push has consumed it, so leaving it would leak one entry per cross-partition start.
+ *
+ * <p>The event key is the holder process-instance key, which is exactly the key the holder-origin
+ * entry is stored under, so the removal needs nothing from the record body. The removal is guarded
+ * against a missing entry (the underlying delete is a no-op if absent), tolerating a replayed
+ * {@code PUSHED} whose entry was already removed.
+ */
+final class MessageStartCorrelationKeyLockReleasePushedV1Applier
+    implements TypedEventApplier<
+        MessageStartCorrelationKeyLockReleaseIntent, MessageStartCorrelationKeyLockReleaseRecord> {
+
+  private final MutableMessageState messageState;
+
+  MessageStartCorrelationKeyLockReleasePushedV1Applier(final MutableMessageState messageState) {
+    this.messageState = messageState;
+  }
+
+  @Override
+  public void applyState(final long key, final MessageStartCorrelationKeyLockReleaseRecord value) {
+    // the event key is the holder process-instance key, which the origin entry is stored under
+    messageState.removeCrossPartitionStartHolderOrigin(key);
+  }
+}

--- a/zeebe/engine/src/test/resources/state/appliers/golden/MessageStartCorrelationKeyLockRelease_RELEASED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/MessageStartCorrelationKeyLockRelease_RELEASED_v1.golden
@@ -20,12 +20,13 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
  * a cross-partition message-start holder instance has completed. For each holder carried by the
  * event it drops the underlying correlation-key lock ({@link
  * MutableMessageState#removeActiveProcessInstance}) so the next buffered message for that key can
- * be picked up, removes the holder-instance discriminator that the pull-based release loop polls on
- * ({@link MutableMessageState#removeCrossPartitionStartLock}), and removes the process-instance ->
- * correlation-key row ({@link MutableMessageState#removeProcessInstanceCorrelationKey}) that {@code
- * P_K} wrote for the remote holder when it created it via the handshake — otherwise that row leaks
- * once per cross-partition start, since the completing element lives on {@code P_B} and never
- * reaches {@code P_K}'s local cleanup path.
+ * be picked up, removes the holder-instance discriminator that {@code P_K}'s reconciliation poll
+ * queries on ({@link MutableMessageState#removeCrossPartitionStartLock}), and removes the
+ * process-instance -> correlation-key row ({@link
+ * MutableMessageState#removeProcessInstanceCorrelationKey}) that {@code P_K} wrote for the remote
+ * holder when it created it via the handshake — otherwise that row leaks once per cross-partition
+ * start, since the completing element lives on {@code P_B} and never reaches {@code P_K}'s local
+ * cleanup path.
  *
  * <p>The release decision — including the idempotency guard that ensures the lock is still held by
  * the exact instance the reply names — lives in the {@code RELEASE} processor; the event is only

--- a/zeebe/engine/src/test/resources/state/appliers/golden/MessageStartProcessInstanceRequest_STARTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/MessageStartProcessInstanceRequest_STARTED_v1.golden
@@ -74,8 +74,9 @@ import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceReques
  * io.camunda.zeebe.engine.processing.message.MessageCorrelateBehavior}: every active root PI with a
  * {@code businessId} lives on {@code P_B = hash(businessId)}, and {@code P_K} keeps a local
  * correlation-key lock so further triggers with the same correlation key are buffered regardless of
- * their {@code businessId}. The recorded holder instance is what the pull-based release loop polls
- * {@code P_B} for to decide when that lock can be released.
+ * their {@code businessId}. The recorded holder instance is what {@code P_K}'s reconciliation poll
+ * queries {@code P_B} for, as a backstop deciding when that lock can be released if the holder's
+ * completion push from {@code P_B} was lost.
  */
 final class MessageStartProcessInstanceStartedV1Applier
     implements TypedEventApplier<

--- a/zeebe/engine/src/test/resources/state/appliers/golden/MessageStartProcessInstanceRequest_STARTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/MessageStartProcessInstanceRequest_STARTED_v1.golden
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartProcessInstanceAskState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartProcessInstanceDedupState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessInstanceRequestRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 
@@ -44,6 +45,19 @@ import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceReques
  *   <li><b>Pending-ask removal on {@code P_K}.</b> Always called; {@code remove} is a no-op when
  *       the entry is absent. On {@code P_B} there is no pending-ask, so this is also a harmless
  *       no-op.
+ *   <li><b>Holder-origin entry on {@code P_B}.</b> Records, keyed by the holder instance key, the
+ *       lock coordinates ({@code bpmnProcessId}, {@code correlationKey}, {@code tenantId}) plus the
+ *       {@code messageKey} whose partition bits address {@code P_K}, so that when the holder later
+ *       completes or terminates on {@code P_B} it can push a {@code RELEASE} to {@code P_K} without
+ *       re-deriving those coordinates from the completing element's context (the completing context
+ *       is unreliable under migration — the holder may since run a different process id).
+ *       Discriminated to {@code P_B} by the holder instance key's partition bits: the PI was
+ *       created on {@code P_B}, so {@code decodePartitionId(processInstanceKey) == partitionId}
+ *       there, whereas on {@code P_K} the same reply carries a PI key that decodes to {@code P_B}
+ *       and is skipped — the mirror of the discriminator used by the lock write below. Written only
+ *       when the holder carries a correlation key: without one there is no correlation-key lock on
+ *       {@code P_K} to release. The write is {@code upsert} and therefore idempotent under a
+ *       re-applied {@code STARTED} reply.
  *   <li><b>Cross-partition holder-instance discriminator on {@code P_K}.</b> Marks the local
  *       correlation-key lock entry that the {@link MessageStartEventSubscriptionCorrelatedApplier}
  *       wrote when the reply processor emitted {@code CORRELATED}, recording the holder instance's
@@ -70,14 +84,17 @@ final class MessageStartProcessInstanceStartedV1Applier
   private final MutableMessageStartProcessInstanceDedupState dedupState;
   private final MutableMessageStartProcessInstanceAskState askState;
   private final MutableMessageState messageState;
+  private final int partitionId;
 
   MessageStartProcessInstanceStartedV1Applier(
       final MutableMessageStartProcessInstanceDedupState dedupState,
       final MutableMessageStartProcessInstanceAskState askState,
-      final MutableMessageState messageState) {
+      final MutableMessageState messageState,
+      final int partitionId) {
     this.dedupState = dedupState;
     this.askState = askState;
     this.messageState = messageState;
+    this.partitionId = partitionId;
   }
 
   @Override
@@ -94,6 +111,20 @@ final class MessageStartProcessInstanceStartedV1Applier
 
     final var correlationKey = value.getCorrelationKeyBuffer();
     final var businessId = value.getBusinessIdBuffer();
+
+    // On P_B: record the holder-origin entry so the holder's completion can later push a RELEASE to
+    // P_K. Discriminated to P_B by the holder key's partition bits, and skipped without a
+    // correlation key (no lock to release). See the class javadoc for the full rationale.
+    if (correlationKey.capacity() > 0
+        && Protocol.decodePartitionId(value.getProcessInstanceKey()) == partitionId) {
+      messageState.putCrossPartitionStartHolderOrigin(
+          value.getProcessInstanceKey(),
+          value.getBpmnProcessIdBuffer(),
+          correlationKey,
+          value.getTenantId(),
+          value.getMessageKey());
+    }
+
     if (correlationKey.capacity() > 0
         && businessId.capacity() > 0
         && messageState.existActiveProcessInstance(

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageStartCorrelationKeyLockReleaseRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageStartCorrelationKeyLockReleaseRecord.java
@@ -23,7 +23,15 @@ import java.util.List;
  * on a single partition in isolation: {@code P_K} sends a {@code QUERY} batching one {@link
  * MessageStartLockReleaseHolder holder} per lock entry to {@code P_B} (derived from each holder's
  * instance key); {@code P_B} replies {@code RELEASE} back to {@code P_K} (derived from {@link
- * #requestKeyProp the request key}) with the single gone holder.
+ * #requestKeyProp the request key}) with the single gone holder. On the {@code PUSHED} path {@code
+ * P_B} builds the same {@code RELEASE} itself, from the holder-origin entry, the moment the holder
+ * completes — so the release also flows without a preceding {@code QUERY}.
+ *
+ * <p>The {@link #requestKeyProp request key} is purely a partition-addressing envelope: the {@code
+ * RELEASE} is routed to the partition its bits encode. On the query path {@code P_K} stamps it so
+ * the reply comes back to itself; on the push path {@code P_B} synthesizes it from the buffered
+ * message key's partition bits to address {@code P_K}. It is never a request-correlation id and
+ * never an event key.
  */
 public final class MessageStartCorrelationKeyLockReleaseRecord extends UnifiedRecordValue
     implements MessageStartCorrelationKeyLockReleaseRecordValue {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -353,7 +353,15 @@ public enum ZbColumnFamilies implements EnumValue, ScopedColumnFamily {
 
   // (processDefinitionKey, partitionId) → ∅: partitions that still owe a drain report for a
   // definition being deleted while it has running instances. Lives on the aggregating partition.
-  PENDING_PROCESS_DELETIONS_PER_PARTITION(159, PARTITION_LOCAL);
+  PENDING_PROCESS_DELETIONS_PER_PARTITION(159, PARTITION_LOCAL),
+
+  // holder processInstanceKey -> (bpmnProcessId, correlationKey, tenantId, messageKey).
+  // Origin entry for a cross-partition message-start holder, written on P_B so it can push a
+  // RELEASE to P_K (addressed by messageKey's partition bits) when the holder completes/terminates.
+  // Present only on P_B — the symmetric STARTED on P_K writes nothing here. See
+  // CrossPartitionMessageStartHolderOrigin and the STARTED / PUSHED appliers for the full
+  // write/delete lifecycle and the migration rationale.
+  CROSS_PARTITION_MESSAGE_START_HOLDER_ORIGIN(160, PARTITION_LOCAL);
 
   private final int value;
   private final ColumnFamilyScope columnFamilyScope;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageStartCorrelationKeyLockReleaseIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageStartCorrelationKeyLockReleaseIntent.java
@@ -34,9 +34,16 @@ package io.camunda.zeebe.protocol.record.intent;
  * P_B} stays silent — {@code P_K} keeps polling with back-off until it observes completion — so
  * there is no "still active" reply intent.
  *
+ * <p>{@link #PUSHED} is the push counterpart, applied on {@code P_B} when a cross-partition holder
+ * completes or terminates: {@code P_B} pushes a {@link #RELEASE} straight to {@code P_K} instead of
+ * waiting to be polled, and drops the holder-origin bookkeeping it kept for that purpose. The query
+ * half above then only has to cover the rare cases the push cannot (e.g. a holder lost before it
+ * pushed), acting as a self-healing reconciliation fallback rather than the primary path.
+ *
  * <p>The target partition of a {@link #QUERY} is derived from the holder instance key (every Zeebe
  * key encodes its generating partition); the target partition of the {@link #RELEASE} reply is
- * derived from the {@code requestKey} generated on {@code P_K}.
+ * derived from the {@code requestKey} — stamped by {@code P_K} on the poll path, synthesized by
+ * {@code P_B} from the buffered message key's partition bits on the push path.
  */
 public enum MessageStartCorrelationKeyLockReleaseIntent implements Intent {
 
@@ -46,7 +53,11 @@ public enum MessageStartCorrelationKeyLockReleaseIntent implements Intent {
 
   // release reply half, applied on P_K only when the holder instance is no longer active on P_B
   RELEASE((short) 2, false),
-  RELEASED((short) 3, true);
+  RELEASED((short) 3, true),
+
+  // push half, applied on P_B when a cross-partition holder completes/terminates: it pushes a
+  // RELEASE to P_K without waiting to be polled and drops the holder-origin bookkeeping
+  PUSHED((short) 4, true);
 
   private final short value;
   private final boolean isEvent;
@@ -76,6 +87,8 @@ public enum MessageStartCorrelationKeyLockReleaseIntent implements Intent {
         return RELEASE;
       case 3:
         return RELEASED;
+      case 4:
+        return PUSHED;
       default:
         return Intent.UNKNOWN;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageStartCorrelationKeyLockReleaseIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageStartCorrelationKeyLockReleaseIntent.java
@@ -16,34 +16,38 @@
 package io.camunda.zeebe.protocol.record.intent;
 
 /**
- * Intents of the pull-based release lookup that lets {@code P_K} (the partition that owns a
- * correlation-key lock for a message-start instance created via the cross-partition handshake)
- * discover when its remote holder instance has completed on {@code P_B = hash(businessId)}, so the
- * lock can be released and the next buffered message for that correlation key picked up.
+ * Intents of the cross-partition correlation-key lock release: how {@code P_K} (the partition that
+ * owns a correlation-key lock for a message-start instance created via the cross-partition
+ * handshake) learns that its remote holder instance has completed on {@code P_B =
+ * hash(businessId)}, so the lock can be released and the next buffered message for that correlation
+ * key picked up.
  *
  * <p>For a message-start instance created locally the correlation-key lock is released when the
  * holder completes on the same partition. For one created via the cross-partition ask the holder
- * lives on {@code P_B}, which {@code P_K} cannot observe directly. Rather than {@code P_B} pushing
- * a completion notification, {@code P_K} polls: it asks {@code P_B} whether a specific holder
- * instance is still active, and acts on the reply. The lookup is reconstructable from {@code P_K}'s
- * local lock state and is self-healing — a dropped poll simply retries on the next tick.
+ * lives on {@code P_B}, which {@code P_K} cannot observe directly. The primary mechanism is a push:
+ * when the holder completes or terminates, {@code P_B} sends a {@link #RELEASE} straight to {@code
+ * P_K} (see {@link #PUSHED}), so the lock is released at completion latency without {@code P_K}
+ * having to poll.
  *
- * <p>The flow is split into a query half ({@link #QUERY} / {@link #QUERIED}) carried from {@code
- * P_K} to {@code P_B}, and a release reply ({@link #RELEASE} / {@link #RELEASED}) carried back from
- * {@code P_B} to {@code P_K} only when the holder is gone. While the holder is still active {@code
- * P_B} stays silent — {@code P_K} keeps polling with back-off until it observes completion — so
- * there is no "still active" reply intent.
+ * <p>{@link #PUSHED} is applied on {@code P_B} when a cross-partition holder completes or
+ * terminates: {@code P_B} pushes a {@link #RELEASE} to {@code P_K} and drops the holder-origin
+ * bookkeeping the {@code STARTED} applier kept for that purpose. The {@link #RELEASE} / {@link
+ * #RELEASED} reply half is applied on {@code P_K}: it releases the lock and picks up the next
+ * buffered message. The reply is idempotent — a redundant {@code RELEASE} for an already-released
+ * lock is rejected — so a push and a reconciling poll racing on the same holder cannot
+ * double-release.
  *
- * <p>{@link #PUSHED} is the push counterpart, applied on {@code P_B} when a cross-partition holder
- * completes or terminates: {@code P_B} pushes a {@link #RELEASE} straight to {@code P_K} instead of
- * waiting to be polled, and drops the holder-origin bookkeeping it kept for that purpose. The query
- * half above then only has to cover the rare cases the push cannot (e.g. a holder lost before it
- * pushed), acting as a self-healing reconciliation fallback rather than the primary path.
+ * <p>The query half ({@link #QUERY} / {@link #QUERIED}) is the reconciliation backstop, not the
+ * primary path: a coarse {@code P_K} poll asks {@code P_B} whether specific holders are still
+ * active and reconciles any whose push was lost (or that were banned, so had no transition to push
+ * from). It is reconstructable from {@code P_K}'s local lock state and self-healing — a lock still
+ * held is simply re-queried on a later tick. {@code P_B} replies {@link #RELEASE} for a holder that
+ * is gone and stays silent for one still active, so there is no "still active" reply intent.
  *
  * <p>The target partition of a {@link #QUERY} is derived from the holder instance key (every Zeebe
  * key encodes its generating partition); the target partition of the {@link #RELEASE} reply is
- * derived from the {@code requestKey} — stamped by {@code P_K} on the poll path, synthesized by
- * {@code P_B} from the buffered message key's partition bits on the push path.
+ * derived from the {@code requestKey} — synthesized by {@code P_B} from the buffered message key's
+ * partition bits on the push path, stamped by {@code P_K} on the reconciliation path.
  */
 public enum MessageStartCorrelationKeyLockReleaseIntent implements Intent {
 


### PR DESCRIPTION
## Description

For a message-start instance created via the cross-partition handshake, the holder process instance runs on `P_B = hash(businessId)` while the correlation-key lock it justifies lives on `P_K = hash(correlationKey)`. Until now, `P_K` discovered holder completion **only by polling** `P_B`, which put per-message release latency on the poll interval, generated steady-state chatter that scaled with live locks (not completions), and required three tuning knobs.

This PR flips the mechanism to the **fast-path / safety-net** pattern already used elsewhere in the handshake:

- **Fast path (new): completion push.** When a cross-partition holder completes or terminates on `P_B`, `P_B` pushes the existing `MessageStartCorrelationKeyLockReleaseIntent.RELEASE` command straight to `P_K`, which releases the lock and re-drives the next buffered message immediately — at holder-completion latency rather than poll latency.
- **Safety net (demoted): the poller becomes pure reconciliation.** A lost push is recovered by the next reconciliation tick. The poll interval default is much lazier (30s) and the per-lock exponential back-off is removed.

**The protocol does not change.** `RELEASE`/`RELEASED` already exist, and `P_K`'s release processor cannot distinguish a pushed `RELEASE` from a queried one, so a mixed-version cluster is safe by construction. No new cross-partition intents and no release-path schema change.

### Scope: why only the correlation-key lock release moves to push

This PR converts **correlation-key lock release** to the push model, but the **Business-ID uniqueness-rejection retry** arm deliberately stays poll-based.

The two look symmetric but aren't. A correlation-key lock lives on exactly one partition; the holder on `P_B` always knows the single `P_K` to push the release to, so a targeted push is cheap and stateless. A uniqueness-rejected start, by contrast, can have waiters on any number of partitions with no fixed relationship to the holder. Converting it to push would mean either broadcasting freed-Business-ID wake-ups to every partition or maintaining a per-waiter subscriber registry on `P_B`; meaning extra state, extra hot-path reads, and a larger replay/upgrade surface, for a latency win that only shows up under active uniqueness contention. The existing back-off poll already keeps that path correct (no duplicates, TTL-bounded, eventually starts).

So the poll-based uniqueness-retry is intentional here, not an oversight. The push-convergence idea is captured and, for now, deferred in the spike #58900.

### Key changes

- **New holder-origin state on `P_B`** (`CROSS_PARTITION_MESSAGE_START_HOLDER_ORIGIN` column family): written by the `STARTED` applier at holder creation, keyed by the holder PI key, carrying the lock coordinates (`bpmnProcessId`, `correlationKey`, `tenantId`) plus the `messageKey` whose partition bits address `P_K`. This makes the release independent of the completing element's context, which may be unreliable under migration.
- **Push hook** on the process completion/termination path (`ProcessProcessor` → `BpmnBufferedMessageStartEventBehavior.pushCrossPartitionHolderCompletion`): a single point read that hits only for cross-partition holders; on a hit it emits a new `PUSHED` event (whose applier drops the origin entry) and sends the `RELEASE` to `P_K`.
- **Reconciliation scheduler** (`CrossPartitionMessageStartLockReleaseScheduler`): stripped of per-lock back-off bookkeeping and now reconciles purely from current lock state each tick, chunking holders into `batchLimit`-sized queries per partition.
- **Idempotency**: the `RELEASE` processor now rejects a redundant reply (all holders already released/re-acquired) as `INVALID_STATE`, so a push × poll race cannot double-release.
- **Origin-entry cleanup for gone-but-never-pushed holders** (e.g. banned): the reconciliation query processor on `P_B` also appends `PUSHED` to drop the leftover origin entry, so a stuck cross-partition start cannot leak an entry.
- **Config**: `messageStartLockReleasePollMaxBackoff` removed; `messageStartLockReleasePollInterval` default relaxed to 30s; `messageStartLockReleasePollBatchLimit` retained.
- **ADR 0001 updated** to describe the push-based release with reconciliation backstop, and the alternatives section reworked.
- **Tests**: new `CrossPartitionMessageStartLockReleasePushTest` (push happy path with the poll disabled — zero-`QUERY` assertions, termination push, no push for local holders, buffered-stream throughput pin), plus updates to the scheduler, query-processor, release-processor and multi-partition tests.

## Related issues

closes #57172