### PR TITLE
ci: remove agentic-ai from MCP codeowners (.codeowners file)

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -138,13 +138,6 @@ mwnw*                       @camunda/engineering-operations
 /.github/workflows/camunda-client-compatibility-test* @camunda/clients-sdks-ai-first-tooling
 
 ################################
-## @camunda/connectors-agentic-ai
-################################
-
-# MCP gateway
-/gateways/gateway-mcp/      @camunda/connectors-agentic-ai
-
-################################
 ## @camunda/identity
 ################################
 

--- a/.codeowners
+++ b/.codeowners
@@ -280,6 +280,7 @@ optimize.Dockerfile         @camunda/core-features
 
 # Gateways
 /gateways/gateway-mapping-http/ @camunda/core-features
+/gateways/gateway-mcp/      @camunda/core-features
 /gateways/gateway-model/    @camunda/core-features
 
 # Acceptance tests


### PR DESCRIPTION
## Description

Remove @camunda/connectors-agentic-ai as codeowner of the MCP module in the `.codeowners` file as it was missed in https://github.com/camunda/camunda/pull/58862.

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
