### PR TITLE
test: add e2e coverage for DMN version tag FEEL expressions

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/decideUpgradeEligibility.dmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/decideUpgradeEligibility.dmn
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="{{DRD_ID}}" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.49.0-rc.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.10.0">
+  <decision id="{{DECISION_ID}}" name="Decide Upgrade Eligibility">
+    <extensionElements>
+      <zeebe:versionTag value="{{VERSION_TAG}}" />
+    </extensionElements>
+    <decisionTable id="DecisionTable_159uxo7" hitPolicy="FIRST">
+      <input id="InputClause_1bnwsvl" label="User Status">
+        <inputExpression id="LiteralExpression_081uqdf" typeRef="string">
+          <text>userStatus</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_0vy6xfo">
+          <text>"VIP","Regular"</text>
+        </inputValues>
+      </input>
+      <input id="InputClause_0adc4dq" label="Engagement Score">
+        <inputExpression id="LiteralExpression_15gdlmw" typeRef="number">
+          <text>CalculateEngagementScore</text>
+        </inputExpression>
+      </input>
+      <input id="Input_1" label="Is User under 18">
+        <inputExpression id="InputExpression_1" typeRef="boolean">
+          <text>under18</text>
+        </inputExpression>
+      </input>
+      <input id="InputClause_0nktm14" label="Student">
+        <inputExpression id="LiteralExpression_01f7vye" typeRef="boolean">
+          <text>isStudent</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Is Eligible for Upgrade" name="eligibleForUpgrade" typeRef="boolean" />
+      <rule id="DecisionRule_0zglss8">
+        <inputEntry id="UnaryTests_0egfog0">
+          <text>"VIP"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kr2l2z">
+          <text>&gt;= 25</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_10aaazw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hcbm8g">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1u0rlpd">
+          <text>{{VIP_ELIGIBLE}}</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0b2bzdh">
+        <inputEntry id="UnaryTests_1e9n3cs">
+          <text>"Regular"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0v86nfq">
+          <text>&lt;= 50</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_077hm7f">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0dzlice">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1j4if3w">
+          <text>false</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0jfpyox">
+        <inputEntry id="UnaryTests_0o1ddky">
+          <text>"New"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0y6895z">
+          <text>30</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0yp2sdb">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_08kvyy9">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1fze4qm">
+          <text>true</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_12fjlpy">
+        <inputEntry id="UnaryTests_1cbrb1t">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1g1canf">
+          <text>&gt;= 20</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mo4mz1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05zdqni">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0jc0p85">
+          <text>false</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_00u4fbr">
+        <inputEntry id="UnaryTests_1rr48dd">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ck4fzk">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qjpgnd">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1otucf9">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0rxnqop">
+          <text>false</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1sf1hjh">
+        <inputEntry id="UnaryTests_1huw4sj">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1fpql5y">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1xp5pr9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1nbz77t">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_157lys4">
+          <text>false</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="{{DECISION_ID}}">
+        <dc:Bounds height="80" width="180" x="160" y="80" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/decideUpgradeEligibilityCheck.form
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/decideUpgradeEligibilityCheck.form
@@ -1,0 +1,127 @@
+{
+  "components": [
+    {
+      "text": "## Application Review\n\nReview the details submitted for this upgrade eligibility request.",
+      "type": "text",
+      "id": "heading_applicant"
+    },
+    {
+      "type": "separator",
+      "id": "sep_1"
+    },
+    {
+      "text": "### Applicant Details",
+      "type": "text",
+      "id": "label_inputs"
+    },
+    {
+      "label": "User Status",
+      "type": "textfield",
+      "id": "field_userStatus",
+      "key": "userStatus",
+      "disabled": true,
+      "validate": {}
+    },
+    {
+      "label": "Engagement Score",
+      "type": "number",
+      "id": "field_engagementScore",
+      "key": "CalculateEngagementScore",
+      "disabled": true,
+      "validate": {}
+    },
+    {
+      "label": "Is User Under 18",
+      "type": "checkbox",
+      "id": "field_under18",
+      "key": "under18",
+      "disabled": true
+    },
+    {
+      "label": "Is Student",
+      "type": "checkbox",
+      "id": "field_isStudent",
+      "key": "isStudent",
+      "disabled": true
+    },
+    {
+      "type": "separator",
+      "id": "sep_2"
+    },
+    {
+      "text": "### Decision Result",
+      "type": "text",
+      "id": "label_decision"
+    },
+    {
+      "label": "DMN Version Tag Used",
+      "type": "textfield",
+      "id": "field_decisionVersion",
+      "key": "decisionVersion",
+      "disabled": true,
+      "validate": {}
+    },
+    {
+      "label": "Eligible for Upgrade",
+      "type": "checkbox",
+      "id": "field_decided",
+      "key": "decided",
+      "disabled": true
+    },
+    {
+      "type": "separator",
+      "id": "sep_3"
+    },
+    {
+      "text": "### Reviewer Action",
+      "type": "text",
+      "id": "label_action"
+    },
+    {
+      "label": "Review Notes",
+      "type": "textarea",
+      "id": "field_reviewNotes",
+      "key": "reviewNotes",
+      "description": "Optional: add notes about this eligibility decision.",
+      "validate": {}
+    },
+    {
+      "label": "Outcome",
+      "values": [
+        {
+          "label": "Confirmed — Proceed with Upgrade",
+          "value": "confirmed"
+        },
+        {
+          "label": "Override — Reject Despite Eligibility",
+          "value": "override_reject"
+        },
+        {
+          "label": "Escalate for Further Review",
+          "value": "escalate"
+        }
+      ],
+      "type": "select",
+      "id": "field_reviewOutcome",
+      "key": "reviewOutcome",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "label": "Submit Review",
+      "action": "submit",
+      "type": "button",
+      "id": "btn_submit"
+    }
+  ],
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "8.10.0",
+  "exporter": {
+    "name": "Camunda Modeler",
+    "version": "5.49.0-rc.0"
+  },
+  "schemaVersion": 19,
+  "id": "check-0ctwsr8",
+  "type": "default"
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/decideUpgradeEligibilityProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/decideUpgradeEligibilityProcess.bpmn
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.49.0-rc.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="{{PROCESS_ID}}" name="Decide Upgrade Eligibility" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Upgrade Eligibility&#10;Check Started">
+      <bpmn:outgoing>Flow_0prr2iv</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0prr2iv" sourceRef="StartEvent_1" targetRef="Activity_1wwz77k" />
+    <bpmn:businessRuleTask id="Activity_1wwz77k" name="Decide Upgrade Eligibility">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision decisionId="{{DECISION_ID}}" resultVariable="decided" bindingType="versionTag" versionTag="{{VERSION_TAG}}" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0prr2iv</bpmn:incoming>
+      <bpmn:outgoing>Flow_0bs05oi</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+    <bpmn:sequenceFlow id="Flow_0bs05oi" sourceRef="Activity_1wwz77k" targetRef="Gateway_1rcmuq9" />
+    <bpmn:exclusiveGateway id="Gateway_1rcmuq9" name="Eligible for Upgrade?">
+      <bpmn:incoming>Flow_0bs05oi</bpmn:incoming>
+      <bpmn:outgoing>Flow_0a6p43k</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0sx2m7g</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0a6p43k" name="eligible" sourceRef="Gateway_1rcmuq9" targetRef="Activity_1851bui">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">= decided</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:userTask id="Activity_1851bui" name="Review Application Details">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:formDefinition formId="check-0ctwsr8" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0a6p43k</bpmn:incoming>
+      <bpmn:outgoing>Flow_05yp6kv</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_05yp6kv" sourceRef="Activity_1851bui" targetRef="Event_015ftbd" />
+    <bpmn:sequenceFlow id="Flow_0sx2m7g" name="not eligible" sourceRef="Gateway_1rcmuq9" targetRef="Activity_sendemail">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">= not(decided)</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1yat3g3" sourceRef="Activity_sendemail" targetRef="Event_015ftbd" />
+    <bpmn:endEvent id="Event_015ftbd" name="Process Completed">
+      <bpmn:incoming>Flow_05yp6kv</bpmn:incoming>
+      <bpmn:incoming>Flow_1yat3g3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="Activity_sendemail" name="Send Rejection Email">
+      <bpmn:incoming>Flow_0sx2m7g</bpmn:incoming>
+      <bpmn:outgoing>Flow_1yat3g3</bpmn:outgoing>
+    </bpmn:task>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="{{PROCESS_ID}}">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="142" y="202" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="116" y="245" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1070lzr_di" bpmnElement="Activity_1wwz77k">
+        <dc:Bounds x="240" y="180" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1xnbyl9_di" bpmnElement="Gateway_1rcmuq9" isMarkerVisible="true">
+        <dc:Bounds x="395" y="195" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="454" y="206" width="52" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_13givrx_di" bpmnElement="Activity_1851bui">
+        <dc:Bounds x="520" y="60" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_015ftbd_di" bpmnElement="Event_015ftbd">
+        <dc:Bounds x="782" y="202" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="718" y="206" width="54" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x46dsh_di" bpmnElement="Activity_sendemail">
+        <dc:Bounds x="520" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0prr2iv_di" bpmnElement="Flow_0prr2iv">
+        <di:waypoint x="178" y="220" />
+        <di:waypoint x="240" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bs05oi_di" bpmnElement="Flow_0bs05oi">
+        <di:waypoint x="340" y="220" />
+        <di:waypoint x="395" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0a6p43k_di" bpmnElement="Flow_0a6p43k">
+        <di:waypoint x="420" y="195" />
+        <di:waypoint x="420" y="100" />
+        <di:waypoint x="520" y="100" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="429" y="144" width="35" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05yp6kv_di" bpmnElement="Flow_05yp6kv">
+        <di:waypoint x="620" y="100" />
+        <di:waypoint x="800" y="100" />
+        <di:waypoint x="800" y="202" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0sx2m7g_di" bpmnElement="Flow_0sx2m7g">
+        <di:waypoint x="420" y="245" />
+        <di:waypoint x="420" y="380" />
+        <di:waypoint x="520" y="380" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="428" y="304" width="53" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yat3g3_di" bpmnElement="Flow_1yat3g3">
+        <di:waypoint x="620" y="380" />
+        <di:waypoint x="800" y="380" />
+        <di:waypoint x="800" y="238" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/business-rule-task-version-tag-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/business-rule-task-version-tag-api.spec.ts
@@ -1,0 +1,214 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  createEligibilityIds,
+  deployEligibilityForm,
+  deployEligibilityProcess,
+  deployTaggedDecision,
+  expectEvaluatedDecisionVersion,
+  findUserTask,
+  resolveIncident,
+  REVIEW_USER_TASK_ID,
+  startEligibilityInstance,
+  VIP_INPUT,
+  waitForVersionTagIncident,
+  expectProcessState,
+  expectNoUserTask,
+} from '@requestHelpers';
+import {setVariables} from '../../../../utils/zeebeClient';
+
+/**
+ * Regression coverage for calling a specific DMN version from a business rule
+ * task through a FEEL version tag expression (product-hub#3501, eng#52338).
+ *
+ * The deployed decision versions differ only in the output of rule 1 (VIP with
+ * an engagement score >= 25). With the same VIP input, the version that was
+ * actually evaluated therefore decides which branch the process takes:
+ *   eligible     -> user task "Review Application Details" is created
+ *   not eligible -> pass-through rejection task, process completes
+ * Each test asserts both the routed branch and the evaluated decision version.
+ */
+test.describe
+  .parallel('Business rule task - FEEL version tag expression', () => {
+  test.beforeAll(async () => {
+    await deployEligibilityForm();
+  });
+
+  test('resolves the decision version tag from a process variable', async ({
+    request,
+  }) => {
+    const ids = createEligibilityIds('varRef');
+    const v1 = await deployTaggedDecision(ids, 'v1', true);
+    await deployTaggedDecision(ids, 'v2', false);
+    await deployEligibilityProcess(ids, '= decisionVersion');
+
+    const processInstanceKey = await startEligibilityInstance(ids, {
+      ...VIP_INPUT,
+      decisionVersion: 'v1',
+    });
+
+    await expectEvaluatedDecisionVersion(request, processInstanceKey, v1);
+    const userTaskKey = await findUserTask(
+      request,
+      processInstanceKey,
+      'CREATED',
+      REVIEW_USER_TASK_ID,
+    );
+    expect(
+      userTaskKey,
+      'the eligible branch must create the review user task',
+    ).toBeDefined();
+  });
+
+  test('routes two instances to different decision versions without redeployment', async ({
+    request,
+  }) => {
+    const ids = createEligibilityIds('twoInstances');
+    const v1 = await deployTaggedDecision(ids, 'v1', true);
+    const v2 = await deployTaggedDecision(ids, 'v2', false);
+    await deployEligibilityProcess(ids, '= decisionVersion');
+
+    const eligibleInstanceKey = await startEligibilityInstance(ids, {
+      ...VIP_INPUT,
+      decisionVersion: 'v1',
+    });
+    const notEligibleInstanceKey = await startEligibilityInstance(ids, {
+      ...VIP_INPUT,
+      decisionVersion: 'v2',
+    });
+
+    expect(
+      eligibleInstanceKey,
+      'both instances must come from the same deployed process',
+    ).not.toBe(notEligibleInstanceKey);
+
+    await test.step('instance with decisionVersion=v1 evaluates v1 and reaches the review task', async () => {
+      await expectEvaluatedDecisionVersion(request, eligibleInstanceKey, v1);
+      await findUserTask(
+        request,
+        eligibleInstanceKey,
+        'CREATED',
+        REVIEW_USER_TASK_ID,
+      );
+    });
+
+    await test.step('instance with decisionVersion=v2 evaluates v2 and takes the rejection branch', async () => {
+      await expectEvaluatedDecisionVersion(request, notEligibleInstanceKey, v2);
+      await expectProcessState(request, notEligibleInstanceKey, 'COMPLETED');
+      await expectNoUserTask(request, notEligibleInstanceKey);
+    });
+  });
+
+  test('resolves the decision version tag from a conditional FEEL expression', async ({
+    request,
+  }) => {
+    const ids = createEligibilityIds('conditional');
+    const v1 = await deployTaggedDecision(ids, 'v1', true);
+    const v2 = await deployTaggedDecision(ids, 'v2', false);
+    const v3 = await deployTaggedDecision(ids, 'v3', true);
+    await deployEligibilityProcess(
+      ids,
+      '= if productLine = "legacy" then "v1" else if productLine = "current" then "v2" else "v3"',
+    );
+
+    const expectEligibleBranch = async (processInstanceKey: string) => {
+      await findUserTask(
+        request,
+        processInstanceKey,
+        'CREATED',
+        REVIEW_USER_TASK_ID,
+      );
+    };
+    const expectRejectionBranch = async (processInstanceKey: string) => {
+      await expectProcessState(request, processInstanceKey, 'COMPLETED');
+      await expectNoUserTask(request, processInstanceKey);
+    };
+
+    const cases = [
+      {productLine: 'legacy', expected: v1, expectBranch: expectEligibleBranch},
+      {
+        productLine: 'current',
+        expected: v2,
+        expectBranch: expectRejectionBranch,
+      },
+      {productLine: 'other', expected: v3, expectBranch: expectEligibleBranch},
+    ];
+
+    for (const {productLine, expected, expectBranch} of cases) {
+      await test.step(`productLine=${productLine} evaluates ${expected.versionTag}`, async () => {
+        const processInstanceKey = await startEligibilityInstance(ids, {
+          ...VIP_INPUT,
+          productLine,
+        });
+
+        await expectEvaluatedDecisionVersion(
+          request,
+          processInstanceKey,
+          expected,
+        );
+        await expectBranch(processInstanceKey);
+      });
+    }
+  });
+
+  test('raises an incident naming the evaluated value when the version tag does not exist', async ({
+    request,
+  }) => {
+    const ids = createEligibilityIds('unknownTag');
+    await deployTaggedDecision(ids, 'v1', true);
+    await deployEligibilityProcess(ids, '= decisionVersion');
+
+    const processInstanceKey = await startEligibilityInstance(ids, {
+      ...VIP_INPUT,
+      decisionVersion: 'v99',
+    });
+
+    const incident = await waitForVersionTagIncident(
+      request,
+      processInstanceKey,
+    );
+    expect(incident.errorType).toBe('CALLED_DECISION_ERROR');
+    expect(
+      incident.errorMessage,
+      'the evaluated version tag must be diagnosable from the incident message',
+    ).toContain('v99');
+    expect(incident.errorMessage).toContain(ids.decisionId);
+  });
+
+  test('raises a resolvable incident when the version tag expression evaluates to null', async ({
+    request,
+  }) => {
+    const ids = createEligibilityIds('nullTag');
+    await deployTaggedDecision(ids, 'v1', true);
+    const v2 = await deployTaggedDecision(ids, 'v2', false);
+    await deployEligibilityProcess(ids, '= decisionVersion');
+
+    // decisionVersion is deliberately absent from the start variables
+    const processInstanceKey = await startEligibilityInstance(ids, {
+      ...VIP_INPUT,
+    });
+
+    const incident = await waitForVersionTagIncident(
+      request,
+      processInstanceKey,
+    );
+    expect(incident.errorType).toBe('CALLED_DECISION_ERROR');
+    expect(incident.errorMessage).toContain('decisionVersion');
+    expect(incident.errorMessage).toContain('NULL');
+
+    await test.step('setting the variable and resolving the incident evaluates the requested version', async () => {
+      await setVariables(processInstanceKey, {decisionVersion: 'v2'});
+      await resolveIncident(request, incident.incidentKey);
+
+      await expectEvaluatedDecisionVersion(request, processInstanceKey, v2);
+      await expectProcessState(request, processInstanceKey, 'COMPLETED');
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/business-rule-task-version-tag-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/business-rule-task-version-tag-api.spec.ts
@@ -13,6 +13,7 @@ import {
   deployEligibilityProcess,
   deployTaggedDecision,
   expectEvaluatedDecisionVersion,
+  expectRejectionTaskCompleted,
   findUserTask,
   resolveIncident,
   REVIEW_USER_TASK_ID,
@@ -20,7 +21,6 @@ import {
   VIP_INPUT,
   waitForVersionTagIncident,
   expectProcessState,
-  expectNoUserTask,
 } from '@requestHelpers';
 import {setVariables} from '../../../../utils/zeebeClient';
 
@@ -99,7 +99,7 @@ test.describe
     await test.step('instance with decisionVersion=v2 evaluates v2 and takes the rejection branch', async () => {
       await expectEvaluatedDecisionVersion(request, notEligibleInstanceKey, v2);
       await expectProcessState(request, notEligibleInstanceKey, 'COMPLETED');
-      await expectNoUserTask(request, notEligibleInstanceKey);
+      await expectRejectionTaskCompleted(request, notEligibleInstanceKey);
     });
   });
 
@@ -125,7 +125,7 @@ test.describe
     };
     const expectRejectionBranch = async (processInstanceKey: string) => {
       await expectProcessState(request, processInstanceKey, 'COMPLETED');
-      await expectNoUserTask(request, processInstanceKey);
+      await expectRejectionTaskCompleted(request, processInstanceKey);
     };
 
     const cases = [

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/business-rule-task-version-tag-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/business-rule-task-version-tag-api.spec.ts
@@ -25,15 +25,12 @@ import {
 import {setVariables} from '../../../../utils/zeebeClient';
 
 /**
- * Regression coverage for calling a specific DMN version from a business rule
- * task through a FEEL version tag expression (product-hub#3501, eng#52338).
+ * Calling a specific DMN version from a business rule task through a FEEL
+ * version tag expression (product-hub#3501).
  *
- * The deployed decision versions differ only in the output of rule 1 (VIP with
- * an engagement score >= 25). With the same VIP input, the version that was
- * actually evaluated therefore decides which branch the process takes:
- *   eligible     -> user task "Review Application Details" is created
- *   not eligible -> pass-through rejection task, process completes
- * Each test asserts both the routed branch and the evaluated decision version.
+ * Versions differ only in rule 1's output, so with identical inputs the branch
+ * taken reveals which version ran: eligible -> review user task, not eligible
+ * -> process completes.
  */
 test.describe
   .parallel('Business rule task - FEEL version tag expression', () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
@@ -138,9 +138,13 @@ test.describe('Decision Instances', () => {
 
   /**
    * Operate must show the decision version that a FEEL version tag expression
-   * resolved to at runtime (product-hub#3501). The two deployed versions differ
-   * only in the output of rule 1, so the version shown in the header is the
-   * version whose rules produced the result.
+   * resolved to at runtime (product-hub#3501).
+   *
+   * The instance deliberately asks for the *older* version tag while a newer
+   * one is deployed. Targeting the newest version would make this pass even if
+   * the engine ignored the version tag and fell back to latest-version
+   * binding; requiring the older version means only genuine tag resolution can
+   * satisfy it.
    */
   test('Decision version resolved by a FEEL version tag expression is shown in Operate', async ({
     page,
@@ -152,18 +156,25 @@ test.describe('Decision Instances', () => {
     let expectedVersion: number;
     let decisionEvaluationInstanceKey: string;
 
+    let latestVersion: number;
+
     await test.step('Deploy two tagged decision versions and a process binding by FEEL expression', async () => {
       await deployEligibilityForm();
-      await deployTaggedDecision(ids, 'v1', true);
+      const v1 = await deployTaggedDecision(ids, 'v1', true);
       const v2 = await deployTaggedDecision(ids, 'v2', false);
-      expectedVersion = v2.version;
+      expectedVersion = v1.version;
+      latestVersion = v2.version;
+      expect(
+        latestVersion,
+        'v2 must be the newer deployment for this test to prove tag resolution',
+      ).toBeGreaterThan(expectedVersion);
       await deployEligibilityProcess(ids, '= decisionVersion');
     });
 
-    await test.step('Start an instance that requests version tag v2', async () => {
+    await test.step('Start an instance that requests the older version tag v1', async () => {
       processInstanceKey = await startEligibilityInstance(ids, {
         ...VIP_INPUT,
-        decisionVersion: 'v2',
+        decisionVersion: 'v1',
       });
       const decisionInstance = await getEvaluatedDecisionInstance(
         request,
@@ -181,12 +192,17 @@ test.describe('Decision Instances', () => {
       await expect(operateDecisionInstancePage.instanceHeader).toBeVisible();
     });
 
-    await test.step('Header shows the version the expression resolved to', async () => {
+    await test.step('Header shows the version the expression resolved to, not the latest', async () => {
       await expect(
         operateDecisionInstancePage.instanceHeader.getByRole('link', {
           name: `View decision "Decide Upgrade Eligibility version ${expectedVersion}" instances`,
         }),
       ).toBeVisible();
+      await expect(
+        operateDecisionInstancePage.instanceHeader.getByRole('link', {
+          name: `View decision "Decide Upgrade Eligibility version ${latestVersion}" instances`,
+        }),
+      ).toBeHidden();
       await expect(
         operateDecisionInstancePage.instanceHeader.getByRole('link', {
           name: `View process instance ${processInstanceKey}`,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
@@ -17,7 +17,7 @@ import {
   deployEligibilityForm,
   deployEligibilityProcess,
   deployTaggedDecision,
-  getEvaluatedDecisionInstance,
+  searchDecisionInstancesByProcessInstanceKey,
   startEligibilityInstance,
   VIP_INPUT,
 } from '@requestHelpers';
@@ -171,10 +171,11 @@ test.describe('Decision Instances', () => {
         ...VIP_INPUT,
         decisionVersion: 'v1',
       });
-      const decisionInstance = await getEvaluatedDecisionInstance(
-        request,
-        processInstanceKey,
-      );
+      const [decisionInstance] =
+        await searchDecisionInstancesByProcessInstanceKey(
+          processInstanceKey,
+          request,
+        );
       decisionEvaluationInstanceKey =
         decisionInstance.decisionEvaluationInstanceKey;
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
@@ -12,6 +12,15 @@ import {captureScreenshot, captureFailureVideo} from '@setup';
 import {deploy} from 'utils/zeebeClient';
 import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
+import {
+  createEligibilityIds,
+  deployEligibilityForm,
+  deployEligibilityProcess,
+  deployTaggedDecision,
+  getEvaluatedDecisionInstance,
+  startEligibilityInstance,
+  VIP_INPUT,
+} from '@requestHelpers';
 
 interface DecisionInfo {
   key: string;
@@ -123,6 +132,72 @@ test.describe('Decision Instances', () => {
       ).toBeVisible();
       await expect(
         operateDecisionsPage.decisionViewer.getByText('Version 2'),
+      ).toBeVisible();
+    });
+  });
+
+  /**
+   * Operate must show the decision version that a FEEL version tag expression
+   * resolved to at runtime (product-hub#3501). The two deployed versions differ
+   * only in the output of rule 1, so the version shown in the header is the
+   * version whose rules produced the result.
+   */
+  test('Decision version resolved by a FEEL version tag expression is shown in Operate', async ({
+    page,
+    request,
+    operateDecisionInstancePage,
+  }) => {
+    const ids = createEligibilityIds('operateUi');
+    let processInstanceKey: string;
+    let expectedVersion: number;
+    let decisionEvaluationInstanceKey: string;
+
+    await test.step('Deploy two tagged decision versions and a process binding by FEEL expression', async () => {
+      await deployEligibilityForm();
+      await deployTaggedDecision(ids, 'v1', true);
+      const v2 = await deployTaggedDecision(ids, 'v2', false);
+      expectedVersion = v2.version;
+      await deployEligibilityProcess(ids, '= decisionVersion');
+    });
+
+    await test.step('Start an instance that requests version tag v2', async () => {
+      processInstanceKey = await startEligibilityInstance(ids, {
+        ...VIP_INPUT,
+        decisionVersion: 'v2',
+      });
+      const decisionInstance = await getEvaluatedDecisionInstance(
+        request,
+        processInstanceKey,
+      );
+      decisionEvaluationInstanceKey =
+        decisionInstance.decisionEvaluationInstanceKey;
+    });
+
+    await test.step('Open the decision instance in Operate', async () => {
+      await navigateToAppHome(page, 'operate');
+      await operateDecisionInstancePage.gotoDecisionInstancePage({
+        id: decisionEvaluationInstanceKey,
+      });
+      await expect(operateDecisionInstancePage.instanceHeader).toBeVisible();
+    });
+
+    await test.step('Header shows the version the expression resolved to', async () => {
+      await expect(
+        operateDecisionInstancePage.instanceHeader.getByRole('link', {
+          name: `View decision "Decide Upgrade Eligibility version ${expectedVersion}" instances`,
+        }),
+      ).toBeVisible();
+      await expect(
+        operateDecisionInstancePage.instanceHeader.getByRole('link', {
+          name: `View process instance ${processInstanceKey}`,
+        }),
+      ).toBeVisible();
+    });
+
+    await test.step('Evaluated decision table is rendered', async () => {
+      await expect(operateDecisionInstancePage.decisionPanel).toBeVisible();
+      await expect(
+        operateDecisionInstancePage.decisionPanel.getByText('User Status'),
       ).toBeVisible();
     });
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
@@ -137,14 +137,9 @@ test.describe('Decision Instances', () => {
   });
 
   /**
-   * Operate must show the decision version that a FEEL version tag expression
-   * resolved to at runtime (product-hub#3501).
-   *
-   * The instance deliberately asks for the *older* version tag while a newer
-   * one is deployed. Targeting the newest version would make this pass even if
-   * the engine ignored the version tag and fell back to latest-version
-   * binding; requiring the older version means only genuine tag resolution can
-   * satisfy it.
+   * Operate must show the version a FEEL version tag expression resolved to
+   * (product-hub#3501). Asks for the *older* tag while a newer one is deployed,
+   * so a latest-version fallback would fail this.
    */
   test('Decision version resolved by a FEEL version tag expression is shown in Operate', async ({
     page,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-version-tag-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-version-tag-requestHelpers.ts
@@ -23,7 +23,6 @@ const DMN_TEMPLATE = './resources/decideUpgradeEligibility.dmn';
 const PROCESS_TEMPLATE = './resources/decideUpgradeEligibilityProcess.bpmn';
 const FORM = './resources/decideUpgradeEligibilityCheck.form';
 
-export const BUSINESS_RULE_TASK_ID = 'Activity_1wwz77k';
 export const REVIEW_USER_TASK_ID = 'Activity_1851bui';
 
 /** Matches rule 1 (VIP, score >= 25) - the only rule that differs per version. */

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-version-tag-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-version-tag-requestHelpers.ts
@@ -8,12 +8,18 @@
 
 import {randomUUID} from 'node:crypto';
 import {expect, type APIRequestContext} from '@playwright/test';
+import {JSONDoc} from '@camunda8/sdk/dist/zeebe/types.js';
 import {
   createSingleInstance,
   deploy,
   deployWithSubstitutions,
 } from '../zeebeClient';
-import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
+import {
+  assertRequiredFields,
+  assertStatusCode,
+  buildUrl,
+  jsonHeaders,
+} from '../http';
 import {defaultAssertionOptions} from '../constants';
 
 const DMN_TEMPLATE = './resources/decideUpgradeEligibility.dmn';
@@ -141,7 +147,7 @@ export async function deployEligibilityProcess(
 
 export async function startEligibilityInstance(
   ids: EligibilityIds,
-  variables: Record<string, unknown>,
+  variables: JSONDoc,
 ): Promise<string> {
   const instance = await createSingleInstance(ids.processId, 1, variables);
   return instance.processInstanceKey;
@@ -153,6 +159,13 @@ export type EvaluatedDecisionInstance = {
   decisionDefinitionVersion: number;
   decisionDefinitionName: string;
 };
+
+const DECISION_INSTANCE_FIELDS = [
+  'decisionEvaluationInstanceKey',
+  'decisionDefinitionKey',
+  'decisionDefinitionVersion',
+  'decisionDefinitionName',
+];
 
 /**
  * Waits until the single decision instance of the process instance is indexed
@@ -172,6 +185,8 @@ export async function getEvaluatedDecisionInstance(
     const body = await res.json();
     expect(body.items).toHaveLength(1);
     expect(body.items[0].state).toBe('EVALUATED');
+    // Fail loudly on API shape drift rather than returning silent undefineds.
+    assertRequiredFields(body.items[0], DECISION_INSTANCE_FIELDS);
     Object.assign(found, body.items[0]);
   }).toPass(defaultAssertionOptions);
   return found as EvaluatedDecisionInstance;
@@ -219,6 +234,8 @@ export type IncidentSummary = {
   errorMessage: string;
 };
 
+const INCIDENT_FIELDS = ['incidentKey', 'errorType', 'errorMessage'];
+
 export async function waitForVersionTagIncident(
   request: APIRequestContext,
   processInstanceKey: string,
@@ -232,6 +249,7 @@ export async function waitForVersionTagIncident(
     await assertStatusCode(res, 200);
     const body = await res.json();
     expect(body.items).toHaveLength(1);
+    assertRequiredFields(body.items[0], INCIDENT_FIELDS);
     Object.assign(found, body.items[0]);
   }).toPass(defaultAssertionOptions);
   return found as IncidentSummary;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-version-tag-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-version-tag-requestHelpers.ts
@@ -29,12 +29,7 @@ const FORM = './resources/decideUpgradeEligibilityCheck.form';
 export const BUSINESS_RULE_TASK_ID = 'Activity_1wwz77k';
 export const REVIEW_USER_TASK_ID = 'Activity_1851bui';
 
-/**
- * Inputs that match rule 1 of the decision table (VIP with an engagement score
- * of at least 25). Rule 1 is the only rule whose output differs between the
- * deployed version tags, so the branch the process takes after the gateway
- * reveals which DMN version was evaluated.
- */
+/** Matches rule 1 (VIP, score >= 25) - the only rule that differs per version. */
 export const VIP_INPUT = {
   userStatus: 'VIP',
   CalculateEngagementScore: 30,
@@ -54,11 +49,7 @@ export type DeployedDecisionVersion = {
   decisionDefinitionKey: string;
 };
 
-/**
- * Every test deploys its own decision and process definitions. Decision
- * resolution by version tag is scoped to a decision ID, so unique IDs keep
- * parallel specs from resolving each other's tags.
- */
+/** Unique IDs per test - tag lookup is scoped to a decision ID. */
 export function createEligibilityIds(label: string): EligibilityIds {
   const suffix = `${label}_${randomUUID().slice(0, 8)}`;
   return {
@@ -101,11 +92,7 @@ export async function deployEligibilityForm(): Promise<void> {
   await deploy([FORM]);
 }
 
-/**
- * Deploys one version of the decision under the given version tag. `vipEligible`
- * controls the output of rule 1, which is what makes the versions behave
- * differently at runtime.
- */
+/** Deploys one version under the given tag; `vipEligible` sets rule 1's output. */
 export async function deployTaggedDecision(
   ids: EligibilityIds,
   versionTag: string,
@@ -129,12 +116,7 @@ export async function deployTaggedDecision(
   };
 }
 
-/**
- * Deploys the process whose business rule task binds the decision by version
- * tag. `versionTagExpression` is written verbatim into the `versionTag`
- * attribute, so it can be a FEEL expression (`= decisionVersion`) or a static
- * tag.
- */
+/** `versionTagExpression` goes verbatim into the BPMN `versionTag` attribute. */
 export async function deployEligibilityProcess(
   ids: EligibilityIds,
   versionTagExpression: string,
@@ -167,10 +149,7 @@ const DECISION_INSTANCE_FIELDS = [
   'decisionDefinitionName',
 ];
 
-/**
- * Waits until the single decision instance of the process instance is indexed
- * and returns it.
- */
+/** Waits for the instance's single decision instance to be indexed. */
 export async function getEvaluatedDecisionInstance(
   request: APIRequestContext,
   processInstanceKey: string,
@@ -185,17 +164,13 @@ export async function getEvaluatedDecisionInstance(
     const body = await res.json();
     expect(body.items).toHaveLength(1);
     expect(body.items[0].state).toBe('EVALUATED');
-    // Fail loudly on API shape drift rather than returning silent undefineds.
     assertRequiredFields(body.items[0], DECISION_INSTANCE_FIELDS);
     Object.assign(found, body.items[0]);
   }).toPass(defaultAssertionOptions);
   return found as EvaluatedDecisionInstance;
 }
 
-/**
- * Asserts which deployed decision version the engine actually evaluated for the
- * given process instance.
- */
+/** Asserts which deployed version the engine actually evaluated. */
 export async function expectEvaluatedDecisionVersion(
   request: APIRequestContext,
   processInstanceKey: string,
@@ -211,10 +186,7 @@ export async function expectEvaluatedDecisionVersion(
   );
 }
 
-/**
- * Asserts the process instance never created a user task, i.e. the gateway took
- * the "not eligible" branch.
- */
+/** No user task means the gateway took the "not eligible" branch. */
 export async function expectNoUserTask(
   request: APIRequestContext,
   processInstanceKey: string,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-version-tag-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-version-tag-requestHelpers.ts
@@ -14,13 +14,10 @@ import {
   deploy,
   deployWithSubstitutions,
 } from '../zeebeClient';
-import {
-  assertRequiredFields,
-  assertStatusCode,
-  buildUrl,
-  jsonHeaders,
-} from '../http';
-import {defaultAssertionOptions} from '../constants';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
+import {searchDecisionInstancesByProcessInstanceKey} from './decision-instance-requestHelpers';
+import {searchElementInstanceByElementIdAndState} from './element-instance-requestHelpers';
+import {searchIncidentByPIK} from './incident-requestHelpers';
 
 const DMN_TEMPLATE = './resources/decideUpgradeEligibility.dmn';
 const PROCESS_TEMPLATE = './resources/decideUpgradeEligibilityProcess.bpmn';
@@ -53,9 +50,9 @@ export type DeployedDecisionVersion = {
 export function createEligibilityIds(label: string): EligibilityIds {
   const suffix = `${label}_${randomUUID().slice(0, 8)}`;
   return {
-    processId: `versionTagProcess_${suffix}`,
-    decisionId: `versionTagDecision_${suffix}`,
-    drdId: `versionTagDrd_${suffix}`,
+    processId: `dmnTagProcess_${suffix}`,
+    decisionId: `dmnTagDecision_${suffix}`,
+    drdId: `dmnTagDrd_${suffix}`,
   };
 }
 
@@ -105,14 +102,15 @@ export async function deployTaggedDecision(
   const decision = response.decisions.find(
     (d) => d.decisionDefinitionId === ids.decisionId,
   );
-  expect(
-    decision,
-    `Decision ${ids.decisionId} missing from deployment response`,
-  ).toBeDefined();
+  if (!decision) {
+    throw new Error(
+      `Decision ${ids.decisionId} missing from deployment response`,
+    );
+  }
   return {
     versionTag,
-    version: decision!.version,
-    decisionDefinitionKey: decision!.decisionDefinitionKey,
+    version: decision.version,
+    decisionDefinitionKey: decision.decisionDefinitionKey,
   };
 }
 
@@ -135,69 +133,34 @@ export async function startEligibilityInstance(
   return instance.processInstanceKey;
 }
 
-export type EvaluatedDecisionInstance = {
-  decisionEvaluationInstanceKey: string;
-  decisionDefinitionKey: string;
-  decisionDefinitionVersion: number;
-  decisionDefinitionName: string;
-};
-
-const DECISION_INSTANCE_FIELDS = [
-  'decisionEvaluationInstanceKey',
-  'decisionDefinitionKey',
-  'decisionDefinitionVersion',
-  'decisionDefinitionName',
-];
-
-/** Waits for the instance's single decision instance to be indexed. */
-export async function getEvaluatedDecisionInstance(
-  request: APIRequestContext,
-  processInstanceKey: string,
-): Promise<EvaluatedDecisionInstance> {
-  const found: Partial<EvaluatedDecisionInstance> = {};
-  await expect(async () => {
-    const res = await request.post(buildUrl('/decision-instances/search'), {
-      headers: jsonHeaders(),
-      data: {filter: {processInstanceKey}},
-    });
-    await assertStatusCode(res, 200);
-    const body = await res.json();
-    expect(body.items).toHaveLength(1);
-    expect(body.items[0].state).toBe('EVALUATED');
-    assertRequiredFields(body.items[0], DECISION_INSTANCE_FIELDS);
-    Object.assign(found, body.items[0]);
-  }).toPass(defaultAssertionOptions);
-  return found as EvaluatedDecisionInstance;
-}
-
 /** Asserts which deployed version the engine actually evaluated. */
 export async function expectEvaluatedDecisionVersion(
   request: APIRequestContext,
   processInstanceKey: string,
   expected: DeployedDecisionVersion,
 ): Promise<void> {
-  const decisionInstance = await getEvaluatedDecisionInstance(
-    request,
+  const [instance] = await searchDecisionInstancesByProcessInstanceKey(
     processInstanceKey,
+    request,
   );
-  expect(decisionInstance.decisionDefinitionVersion).toBe(expected.version);
-  expect(decisionInstance.decisionDefinitionKey).toBe(
-    expected.decisionDefinitionKey,
-  );
+  expect(instance.decisionDefinitionVersion).toBe(expected.version);
+  expect(instance.decisionDefinitionKey).toBe(expected.decisionDefinitionKey);
 }
 
-/** No user task means the gateway took the "not eligible" branch. */
-export async function expectNoUserTask(
+/**
+ * The "not eligible" branch's only outcome is the rejection task, so its
+ * completion is a positive witness that branch was taken.
+ */
+export async function expectRejectionTaskCompleted(
   request: APIRequestContext,
   processInstanceKey: string,
 ): Promise<void> {
-  const res = await request.post(buildUrl('/user-tasks/search'), {
-    headers: jsonHeaders(),
-    data: {filter: {processInstanceKey}},
-  });
-  await assertStatusCode(res, 200);
-  const body = await res.json();
-  expect(body.page.totalItems).toBe(0);
+  await searchElementInstanceByElementIdAndState(
+    request,
+    processInstanceKey,
+    'Activity_sendemail',
+    'COMPLETED',
+  );
 }
 
 export type IncidentSummary = {
@@ -206,25 +169,21 @@ export type IncidentSummary = {
   errorMessage: string;
 };
 
-const INCIDENT_FIELDS = ['incidentKey', 'errorType', 'errorMessage'];
-
+/** Filters for the CALLED_DECISION_ERROR incident raised by version tag resolution. */
 export async function waitForVersionTagIncident(
   request: APIRequestContext,
   processInstanceKey: string,
 ): Promise<IncidentSummary> {
-  const found: Partial<IncidentSummary> = {};
-  await expect(async () => {
-    const res = await request.post(
-      buildUrl(`/process-instances/${processInstanceKey}/incidents/search`),
-      {headers: jsonHeaders(), data: {filter: {state: 'ACTIVE'}}},
+  const incidents = await searchIncidentByPIK(request, {processInstanceKey});
+  const incident = (incidents as unknown as IncidentSummary[]).find(
+    (i) => i.errorType === 'CALLED_DECISION_ERROR',
+  );
+  if (!incident) {
+    throw new Error(
+      `No CALLED_DECISION_ERROR incident found for process instance ${processInstanceKey}`,
     );
-    await assertStatusCode(res, 200);
-    const body = await res.json();
-    expect(body.items).toHaveLength(1);
-    assertRequiredFields(body.items[0], INCIDENT_FIELDS);
-    Object.assign(found, body.items[0]);
-  }).toPass(defaultAssertionOptions);
-  return found as IncidentSummary;
+  }
+  return incident;
 }
 
 export async function resolveIncident(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-version-tag-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-version-tag-requestHelpers.ts
@@ -1,0 +1,249 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {randomUUID} from 'node:crypto';
+import {expect, type APIRequestContext} from '@playwright/test';
+import {
+  createSingleInstance,
+  deploy,
+  deployWithSubstitutions,
+} from '../zeebeClient';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
+import {defaultAssertionOptions} from '../constants';
+
+const DMN_TEMPLATE = './resources/decideUpgradeEligibility.dmn';
+const PROCESS_TEMPLATE = './resources/decideUpgradeEligibilityProcess.bpmn';
+const FORM = './resources/decideUpgradeEligibilityCheck.form';
+
+export const BUSINESS_RULE_TASK_ID = 'Activity_1wwz77k';
+export const REVIEW_USER_TASK_ID = 'Activity_1851bui';
+
+/**
+ * Inputs that match rule 1 of the decision table (VIP with an engagement score
+ * of at least 25). Rule 1 is the only rule whose output differs between the
+ * deployed version tags, so the branch the process takes after the gateway
+ * reveals which DMN version was evaluated.
+ */
+export const VIP_INPUT = {
+  userStatus: 'VIP',
+  CalculateEngagementScore: 30,
+  under18: false,
+  isStudent: false,
+} as const;
+
+export type EligibilityIds = {
+  processId: string;
+  decisionId: string;
+  drdId: string;
+};
+
+export type DeployedDecisionVersion = {
+  versionTag: string;
+  version: number;
+  decisionDefinitionKey: string;
+};
+
+/**
+ * Every test deploys its own decision and process definitions. Decision
+ * resolution by version tag is scoped to a decision ID, so unique IDs keep
+ * parallel specs from resolving each other's tags.
+ */
+export function createEligibilityIds(label: string): EligibilityIds {
+  const suffix = `${label}_${randomUUID().slice(0, 8)}`;
+  return {
+    processId: `versionTagProcess_${suffix}`,
+    decisionId: `versionTagDecision_${suffix}`,
+    drdId: `versionTagDrd_${suffix}`,
+  };
+}
+
+function escapeXmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function decisionSubstitutions(
+  ids: EligibilityIds,
+  versionTag: string,
+  vipEligible: boolean,
+) {
+  return {
+    '{{DRD_ID}}': ids.drdId,
+    '{{DECISION_ID}}': ids.decisionId,
+    '{{VERSION_TAG}}': escapeXmlAttribute(versionTag),
+    '{{VIP_ELIGIBLE}}': String(vipEligible),
+  };
+}
+
+function processSubstitutions(ids: EligibilityIds, versionTag: string) {
+  return {
+    '{{PROCESS_ID}}': ids.processId,
+    '{{DECISION_ID}}': ids.decisionId,
+    '{{VERSION_TAG}}': escapeXmlAttribute(versionTag),
+  };
+}
+
+export async function deployEligibilityForm(): Promise<void> {
+  await deploy([FORM]);
+}
+
+/**
+ * Deploys one version of the decision under the given version tag. `vipEligible`
+ * controls the output of rule 1, which is what makes the versions behave
+ * differently at runtime.
+ */
+export async function deployTaggedDecision(
+  ids: EligibilityIds,
+  versionTag: string,
+  vipEligible: boolean,
+): Promise<DeployedDecisionVersion> {
+  const response = await deployWithSubstitutions(
+    DMN_TEMPLATE,
+    decisionSubstitutions(ids, versionTag, vipEligible),
+  );
+  const decision = response.decisions.find(
+    (d) => d.decisionDefinitionId === ids.decisionId,
+  );
+  expect(
+    decision,
+    `Decision ${ids.decisionId} missing from deployment response`,
+  ).toBeDefined();
+  return {
+    versionTag,
+    version: decision!.version,
+    decisionDefinitionKey: decision!.decisionDefinitionKey,
+  };
+}
+
+/**
+ * Deploys the process whose business rule task binds the decision by version
+ * tag. `versionTagExpression` is written verbatim into the `versionTag`
+ * attribute, so it can be a FEEL expression (`= decisionVersion`) or a static
+ * tag.
+ */
+export async function deployEligibilityProcess(
+  ids: EligibilityIds,
+  versionTagExpression: string,
+): Promise<void> {
+  await deployWithSubstitutions(
+    PROCESS_TEMPLATE,
+    processSubstitutions(ids, versionTagExpression),
+  );
+}
+
+export async function startEligibilityInstance(
+  ids: EligibilityIds,
+  variables: Record<string, unknown>,
+): Promise<string> {
+  const instance = await createSingleInstance(ids.processId, 1, variables);
+  return instance.processInstanceKey;
+}
+
+export type EvaluatedDecisionInstance = {
+  decisionEvaluationInstanceKey: string;
+  decisionDefinitionKey: string;
+  decisionDefinitionVersion: number;
+  decisionDefinitionName: string;
+};
+
+/**
+ * Waits until the single decision instance of the process instance is indexed
+ * and returns it.
+ */
+export async function getEvaluatedDecisionInstance(
+  request: APIRequestContext,
+  processInstanceKey: string,
+): Promise<EvaluatedDecisionInstance> {
+  const found: Partial<EvaluatedDecisionInstance> = {};
+  await expect(async () => {
+    const res = await request.post(buildUrl('/decision-instances/search'), {
+      headers: jsonHeaders(),
+      data: {filter: {processInstanceKey}},
+    });
+    await assertStatusCode(res, 200);
+    const body = await res.json();
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0].state).toBe('EVALUATED');
+    Object.assign(found, body.items[0]);
+  }).toPass(defaultAssertionOptions);
+  return found as EvaluatedDecisionInstance;
+}
+
+/**
+ * Asserts which deployed decision version the engine actually evaluated for the
+ * given process instance.
+ */
+export async function expectEvaluatedDecisionVersion(
+  request: APIRequestContext,
+  processInstanceKey: string,
+  expected: DeployedDecisionVersion,
+): Promise<void> {
+  const decisionInstance = await getEvaluatedDecisionInstance(
+    request,
+    processInstanceKey,
+  );
+  expect(decisionInstance.decisionDefinitionVersion).toBe(expected.version);
+  expect(decisionInstance.decisionDefinitionKey).toBe(
+    expected.decisionDefinitionKey,
+  );
+}
+
+/**
+ * Asserts the process instance never created a user task, i.e. the gateway took
+ * the "not eligible" branch.
+ */
+export async function expectNoUserTask(
+  request: APIRequestContext,
+  processInstanceKey: string,
+): Promise<void> {
+  const res = await request.post(buildUrl('/user-tasks/search'), {
+    headers: jsonHeaders(),
+    data: {filter: {processInstanceKey}},
+  });
+  await assertStatusCode(res, 200);
+  const body = await res.json();
+  expect(body.page.totalItems).toBe(0);
+}
+
+export type IncidentSummary = {
+  incidentKey: string;
+  errorType: string;
+  errorMessage: string;
+};
+
+export async function waitForVersionTagIncident(
+  request: APIRequestContext,
+  processInstanceKey: string,
+): Promise<IncidentSummary> {
+  const found: Partial<IncidentSummary> = {};
+  await expect(async () => {
+    const res = await request.post(
+      buildUrl(`/process-instances/${processInstanceKey}/incidents/search`),
+      {headers: jsonHeaders(), data: {filter: {state: 'ACTIVE'}}},
+    );
+    await assertStatusCode(res, 200);
+    const body = await res.json();
+    expect(body.items).toHaveLength(1);
+    Object.assign(found, body.items[0]);
+  }).toPass(defaultAssertionOptions);
+  return found as IncidentSummary;
+}
+
+export async function resolveIncident(
+  request: APIRequestContext,
+  incidentKey: string,
+): Promise<void> {
+  const res = await request.post(
+    buildUrl(`/incidents/${incidentKey}/resolution`),
+    {headers: jsonHeaders()},
+  );
+  await assertStatusCode(res, 204);
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-version-tag-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-version-tag-requestHelpers.ts
@@ -175,7 +175,7 @@ export async function waitForVersionTagIncident(
   processInstanceKey: string,
 ): Promise<IncidentSummary> {
   const incidents = await searchIncidentByPIK(request, {processInstanceKey});
-  const incident = (incidents as unknown as IncidentSummary[]).find(
+  const incident = incidents.find(
     (i) => i.errorType === 'CALLED_DECISION_ERROR',
   );
   if (!incident) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/incident-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/incident-requestHelpers.ts
@@ -51,6 +51,7 @@ export async function searchIncidentByPIK(
 
   return localState['incidents'] as {
     incidentKey: string;
+    errorType: string;
     errorMessage: string;
     processDefinitionId: string;
     processDefinitionKey: string;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -90,6 +90,7 @@ export {
 } from './decision-requirement-requestHelper';
 export {
   createMammalProcessInstanceAndDeployMammalDecision,
+  searchDecisionInstancesByProcessInstanceKey,
   type DecisionInstance,
 } from './decision-instance-requestHelpers';
 export {createProcessInstanceAndRetrieveTimeStamp} from './clock-requestHelpers';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -7,6 +7,7 @@
  */
 
 export * from './element-instance-requestHelpers';
+export * from './decision-version-tag-requestHelpers';
 export * from './resource-requestHelpers';
 export * from './user-task-requestHelpers';
 export * from './process-instance-requestHelpers';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
@@ -14,7 +14,12 @@ import {sleep} from './sleep';
 
 const c8 = new Camunda8({
   CAMUNDA_AUTH_STRATEGY: process.env.CAMUNDA_AUTH_STRATEGY as
-    'BASIC' | 'OAUTH' | 'BEARER' | 'COOKIE' | 'NONE' | undefined,
+    | 'BASIC'
+    | 'OAUTH'
+    | 'BEARER'
+    | 'COOKIE'
+    | 'NONE'
+    | undefined,
   CAMUNDA_BASIC_AUTH_USERNAME: process.env.CAMUNDA_BASIC_AUTH_USERNAME,
   CAMUNDA_BASIC_AUTH_PASSWORD: process.env.CAMUNDA_BASIC_AUTH_PASSWORD,
   ZEEBE_REST_ADDRESS: process.env.ZEEBE_REST_ADDRESS,
@@ -54,7 +59,7 @@ const deploy = async (processFilePaths: string[]) => {
 const deployWithSubstitutions = async (
   filePath: string,
   substitutions: Record<string, string>,
-): Promise<void> => {
+) => {
   let content = readFileSync(filePath, 'utf-8');
   for (const [placeholder, replacement] of Object.entries(substitutions)) {
     if (!content.includes(placeholder)) {
@@ -66,7 +71,7 @@ const deployWithSubstitutions = async (
   }
   const name = basename(filePath);
   try {
-    await zeebe.deployResources([{content, name}]);
+    return await zeebe.deployResources([{content, name}]);
   } catch (error) {
     console.error('Deployment failed:', error);
     throw error;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
@@ -64,7 +64,7 @@ const deployWithSubstitutions = async (
   for (const [placeholder, replacement] of Object.entries(substitutions)) {
     if (!content.includes(placeholder)) {
       throw new Error(
-        `Placeholder '${placeholder}' not found in BPMN file '${filePath}'`,
+        `Placeholder '${placeholder}' not found in resource file '${filePath}'`,
       );
     }
     content = content.split(placeholder).join(replacement);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
@@ -14,12 +14,7 @@ import {sleep} from './sleep';
 
 const c8 = new Camunda8({
   CAMUNDA_AUTH_STRATEGY: process.env.CAMUNDA_AUTH_STRATEGY as
-    | 'BASIC'
-    | 'OAUTH'
-    | 'BEARER'
-    | 'COOKIE'
-    | 'NONE'
-    | undefined,
+    'BASIC' | 'OAUTH' | 'BEARER' | 'COOKIE' | 'NONE' | undefined,
   CAMUNDA_BASIC_AUTH_USERNAME: process.env.CAMUNDA_BASIC_AUTH_USERNAME,
   CAMUNDA_BASIC_AUTH_PASSWORD: process.env.CAMUNDA_BASIC_AUTH_PASSWORD,
   ZEEBE_REST_ADDRESS: process.env.ZEEBE_REST_ADDRESS,


### PR DESCRIPTION
## Description

A business rule task can now resolve the called DMN version tag from a FEEL expression, but the feature was only covered by engine-level tests. This adds end-to-end coverage through the REST API and Operate.

The three deployed decision versions differ only in the output of one rule, so the branch the process takes after the gateway reveals which version the engine actually evaluated. Every test asserts both the routed branch and the evaluated decision version, rather than the version number alone.

## Tests added

`tests/api/v2/decision-definition/business-rule-task-version-tag-api.spec.ts`

- version tag resolved from a process variable
- two instances of the same process routed to different versions, no redeployment
- conditional FEEL expression (`if ... then ... else`), three branches
- non-existent version tag raises an incident naming the evaluated value
- expression evaluating to null raises an incident that is resolved and retried successfully

`tests/operate/decisionInstances.spec.ts`

- Operate shows the decision version the expression resolved to

## Notes

- The BPMN, DMN and form come from the manual test session and are templated with placeholders, so each test deploys its own uniquely-named decision. Version tag lookup is scoped per decision ID, so parallel specs never resolve each other's tags.
- `deployWithSubstitutions` now returns the deploy response, needed to map a version tag to its assigned version number. Additive: all existing callers ignored the return value.
- Modeler authoring cases are out of scope here; they belong in the cross-component suite.

## Testing

All 6 tests pass locally against an 8.10.0-SNAPSHOT cluster (Elasticsearch). The pre-existing `usage-metrics` failure on `main` (`[MISSING] /suspendedDate` on `GET /process-instances/{key}`) is unrelated to this change.

Relates to https://github.com/camunda/product-hub/issues/3668
