### PR TITLE
feat: support two-phase Raft reconfiguration with promotable members

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -293,17 +293,34 @@ public interface RaftServer {
   }
 
   /**
-   * Starts this raft server by joining an existing replication group. A {@link
-   * io.atomix.raft.protocol.JoinRequest} is sent to an arbitrary member of the cluster.
+   * Starts this raft server by joining an existing replication group as an {@link
+   * RaftMember.Type#ACTIVE} member. A {@link io.atomix.raft.protocol.JoinRequest} is sent to an
+   * arbitrary member of the cluster.
    *
    * @param cluster a list of member ids that are part of the cluster and assist in joining.
    * @return A completable future to be completed once the server has joined the cluster.
    */
-  CompletableFuture<RaftServer> join(Collection<MemberId> cluster);
+  default CompletableFuture<RaftServer> join(final Collection<MemberId> cluster) {
+    return join(Type.ACTIVE, cluster);
+  }
 
   /**
-   * Starts this raft server by joining an existing replication group. A {@link
-   * io.atomix.raft.protocol.JoinRequest} is sent to an arbitrary member of the cluster.
+   * Starts this raft server by joining an existing replication group as a member of the given type.
+   * A {@link io.atomix.raft.protocol.JoinRequest} is sent to an arbitrary member of the cluster.
+   *
+   * @param type the type the member joins as: {@link RaftMember.Type#ACTIVE} for a one-shot voting
+   *     join (current production behavior), {@link RaftMember.Type#PROMOTABLE} for the two-phase
+   *     learner flow where the member is caught up first and promoted to ACTIVE in a second
+   *     configuration change. {@link RaftMember.Type#INACTIVE} is rejected.
+   * @param cluster a list of member ids that are part of the cluster and assist in joining.
+   * @return A completable future to be completed once the server has joined the cluster.
+   */
+  CompletableFuture<RaftServer> join(Type type, Collection<MemberId> cluster);
+
+  /**
+   * Starts this raft server by joining an existing replication group as an {@link
+   * RaftMember.Type#ACTIVE} member. A {@link io.atomix.raft.protocol.JoinRequest} is sent to an
+   * arbitrary member of the cluster.
    *
    * @param cluster a list of member ids that are part of the cluster and assist in joining.
    * @return A completable future to be completed once the server has joined the cluster.

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -33,7 +33,6 @@ import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.raft.zeebe.EntryValidator.NoopEntryValidator;
-import io.atomix.utils.Builder;
 import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.util.health.FailureListener;
@@ -339,11 +338,11 @@ public interface RaftServer {
   CompletableFuture<RaftServer> leave();
 
   /**
-   * Promotes the server to leader if possible.
+   * Anoints the server to be leader if possible.
    *
-   * @return a future to be completed once the server has been promoted
+   * @return a future to be completed once the server has been anointed
    */
-  CompletableFuture<RaftServer> promote();
+  CompletableFuture<RaftServer> anoint();
 
   /**
    * Force configure the partition to remove all members which are not part of the given

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/RaftCluster.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/RaftCluster.java
@@ -135,7 +135,27 @@ public interface RaftCluster {
    */
   CompletableFuture<Void> bootstrap(Collection<MemberId> cluster);
 
-  CompletableFuture<Void> join(Collection<MemberId> cluster);
+  /**
+   * Joins the cluster as an {@link RaftMember.Type#ACTIVE} member.
+   *
+   * @param cluster a list of member ids that are part of the cluster and assist in joining.
+   * @return A completable future to be completed once the server has joined the cluster.
+   */
+  default CompletableFuture<Void> join(final Collection<MemberId> cluster) {
+    return join(RaftMember.Type.ACTIVE, cluster);
+  }
+
+  /**
+   * Joins the cluster as a member of the given type.
+   *
+   * @param type the type the member joins as: {@link RaftMember.Type#ACTIVE} for a one-shot voting
+   *     join (current production behavior), {@link RaftMember.Type#PROMOTABLE} for the two-phase
+   *     learner flow where the member is caught up first and promoted to ACTIVE in a second
+   *     configuration change. {@link RaftMember.Type#INACTIVE} is rejected.
+   * @param cluster a list of member ids that are part of the cluster and assist in joining.
+   * @return A completable future to be completed once the server has joined the cluster.
+   */
+  CompletableFuture<Void> join(RaftMember.Type type, Collection<MemberId> cluster);
 
   /**
    * Returns a member by ID.

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/DefaultRaftMember.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/DefaultRaftMember.java
@@ -22,16 +22,19 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.hash.Hashing;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftError;
+import io.atomix.raft.RaftException;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.protocol.RaftResponse;
 import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.storage.system.Configuration;
 import io.atomix.utils.concurrent.Scheduled;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 /** Cluster member. */
@@ -136,34 +139,61 @@ public final class DefaultRaftMember implements RaftMember, AutoCloseable {
 
   /** Demotes the server to the given type. */
   private CompletableFuture<Void> configure(final RaftMember.Type type) {
-    if (type == this.type) {
-      return CompletableFuture.completedFuture(null);
-    }
+    // Deliberately no short-circuit when the requested type equals the locally known one: this
+    // member's view of its own type can be stale or outright wrong - a member that restarted
+    // without a stored configuration falls back to the fabricated all-ACTIVE initial configuration
+    // - and answering from it would report a promotion or demotion as successful without anything
+    // ever reaching the leader. The leader is the authority: a request that does not change its
+    // configuration is answered OK by the equal-membership branch of LeaderRole#onReconfigure, and
+    // one built from a stale view is rejected as a stale configuration for the caller to retry.
     final CompletableFuture<Void> future = new CompletableFuture<>();
-    cluster.getContext().getThreadContext().execute(() -> configure(type, future));
+    // The retry timer is owned by this operation, not by the member: a stale response for an
+    // earlier, already completed operation must never cancel a newer operation's timer - the only
+    // thing that would drive that operation forward - and would otherwise hang its future
+    // forever. At the same time there is at most one live timer per operation: every reschedule
+    // replaces (and cancels) the previous one, so duplicated in-flight attempts of the same
+    // operation cannot multiply timers.
+    final var retryTimer = new AtomicReference<Scheduled>();
+    cluster.getContext().getThreadContext().execute(() -> configure(type, future, retryTimer));
     return future;
   }
 
   /** Recursively reconfigures the cluster. */
-  private void configure(final RaftMember.Type type, final CompletableFuture<Void> future) {
-    // Set a timer to retry the attempt to leave the cluster.
-    configureTimeout =
-        cluster
-            .getContext()
-            .getThreadContext()
-            .schedule(cluster.getContext().getElectionTimeout(), () -> configure(type, future));
+  private void configure(
+      final RaftMember.Type type,
+      final CompletableFuture<Void> future,
+      final AtomicReference<Scheduled> retryTimer) {
+    if (future.isDone()) {
+      // The operation already completed, e.g. the retry timer fired while the response that
+      // completed the future was still in flight. Don't send another request or re-arm the timer.
+      return;
+    }
+    final var currentConfiguration = cluster.getConfiguration();
+    if (currentConfiguration == null) {
+      // The local member does not know a configuration yet, for example a PROMOTABLE member whose
+      // join completed before the leader disseminated the configuration to it. The request is
+      // built from the local configuration view, so fail fast - like a stale-view
+      // CONFIGURATION_ERROR - and let the caller retry once a configuration is known.
+      cancelRetryTimer(retryTimer);
+      future.completeExceptionally(
+          new RaftException.ConfigurationException(
+              null, "Cannot change type of member %s to %s: no known configuration", id, type));
+      return;
+    }
 
-    // Attempt to leave the cluster by submitting a LeaveRequest directly to the server state.
+    // Set a timer to retry the attempt in case the response is lost.
+    scheduleRetry(cluster.getContext().getElectionTimeout(), type, future, retryTimer);
+
+    // Attempt to reconfigure by submitting a ReconfigureRequest directly to the server state.
     // Non-leader states should forward the request to the leader if there is one. Leader states
     // will log, replicate, and commit the reconfiguration.
-    final var currentConfiguration = cluster.getConfiguration();
     cluster
         .getContext()
         .getRaftRole()
         .onReconfigure(
             ReconfigureRequest.builder()
                 .withIndex(currentConfiguration.index())
-                .withTerm(currentConfiguration.term())
+                .withTerm(cluster.getConfigurationTerm())
                 .withMembers(currentConfiguration.newMembers())
                 // Override local member with the new type.
                 .withMember(new DefaultRaftMember(id, type, updated))
@@ -171,36 +201,76 @@ public final class DefaultRaftMember implements RaftMember, AutoCloseable {
                 .build())
         .whenComplete(
             (response, error) -> {
+              if (future.isDone()) {
+                // A late response for an already completed operation must not touch any timer:
+                // the caller may have observed the completion and started a new operation, whose
+                // timer must stay armed.
+                return;
+              }
               if (error == null) {
                 if (response.status() == RaftResponse.Status.OK) {
-                  cancelConfigureTimer();
-                  cluster.configure(
-                      new Configuration(
-                          response.index(),
-                          response.term(),
-                          response.timestamp(),
-                          response.members()));
-                  future.complete(null);
+                  cancelRetryTimer(retryTimer);
+                  // Complete the future even if applying the new configuration fails: the
+                  // exception would otherwise be swallowed by this callback and, with the retry
+                  // timer already cancelled, hang the future forever.
+                  try {
+                    cluster.configure(
+                        new Configuration(
+                            response.index(),
+                            response.term(),
+                            response.timestamp(),
+                            response.members()));
+                    future.complete(null);
+                  } catch (final Exception e) {
+                    future.completeExceptionally(e);
+                  }
                 } else if (response.error() == null
                     || response.error().type() == RaftError.Type.UNAVAILABLE
                     || response.error().type() == RaftError.Type.PROTOCOL_ERROR
                     || response.error().type() == RaftError.Type.NO_LEADER) {
-                  cancelConfigureTimer();
-                  configureTimeout =
-                      cluster
-                          .getContext()
-                          .getThreadContext()
-                          .schedule(
-                              cluster.getContext().getElectionTimeout().multipliedBy(2),
-                              () -> configure(type, future));
+                  scheduleRetry(
+                      cluster.getContext().getElectionTimeout().multipliedBy(2),
+                      type,
+                      future,
+                      retryTimer);
                 } else {
-                  cancelConfigureTimer();
+                  cancelRetryTimer(retryTimer);
                   future.completeExceptionally(response.error().createException());
                 }
               } else {
+                cancelRetryTimer(retryTimer);
                 future.completeExceptionally(error);
               }
             });
+  }
+
+  /**
+   * Replaces the operation's retry timer with a new one, so that at most one timer is live per
+   * operation. The member-level configureTimeout field tracks the newest timer solely so that
+   * {@link #close()} can cancel it.
+   */
+  private void scheduleRetry(
+      final Duration delay,
+      final RaftMember.Type type,
+      final CompletableFuture<Void> future,
+      final AtomicReference<Scheduled> retryTimer) {
+    final var timer =
+        cluster
+            .getContext()
+            .getThreadContext()
+            .schedule(delay, () -> configure(type, future, retryTimer));
+    final var previous = retryTimer.getAndSet(timer);
+    if (previous != null) {
+      previous.cancel();
+    }
+    configureTimeout = timer;
+  }
+
+  private void cancelRetryTimer(final AtomicReference<Scheduled> retryTimer) {
+    final var timer = retryTimer.getAndSet(null);
+    if (timer != null) {
+      timer.cancel();
+    }
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/DefaultRaftMember.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/DefaultRaftMember.java
@@ -22,9 +22,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.hash.Hashing;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftError;
+import io.atomix.raft.RaftException;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.protocol.RaftResponse;
 import io.atomix.raft.protocol.ReconfigureRequest;
+import io.atomix.raft.storage.log.entry.ConfigurationEntry;
 import io.atomix.raft.storage.system.Configuration;
 import io.atomix.utils.concurrent.Scheduled;
 import java.time.Instant;
@@ -146,6 +148,18 @@ public final class DefaultRaftMember implements RaftMember, AutoCloseable {
 
   /** Recursively reconfigures the cluster. */
   private void configure(final RaftMember.Type type, final CompletableFuture<Void> future) {
+    final var currentConfiguration = cluster.getConfiguration();
+    if (currentConfiguration == null) {
+      // The local member does not know a configuration yet, for example a PROMOTABLE member whose
+      // join completed before the leader disseminated the configuration to it. The request is
+      // built from the local configuration view, so fail fast - like a stale-view
+      // CONFIGURATION_ERROR - and let the caller retry once a configuration is known.
+      future.completeExceptionally(
+          new RaftException.ConfigurationException(
+              null, "Cannot change type of member %s to %s: no known configuration", id, type));
+      return;
+    }
+
     // Set a timer to retry the attempt to leave the cluster.
     configureTimeout =
         cluster
@@ -156,14 +170,13 @@ public final class DefaultRaftMember implements RaftMember, AutoCloseable {
     // Attempt to leave the cluster by submitting a LeaveRequest directly to the server state.
     // Non-leader states should forward the request to the leader if there is one. Leader states
     // will log, replicate, and commit the reconfiguration.
-    final var currentConfiguration = cluster.getConfiguration();
     cluster
         .getContext()
         .getRaftRole()
         .onReconfigure(
             ReconfigureRequest.builder()
                 .withIndex(currentConfiguration.index())
-                .withTerm(currentConfiguration.term())
+                .withTerm(configurationTerm(currentConfiguration))
                 .withMembers(currentConfiguration.newMembers())
                 // Override local member with the new type.
                 .withMember(new DefaultRaftMember(id, type, updated))
@@ -201,6 +214,33 @@ public final class DefaultRaftMember implements RaftMember, AutoCloseable {
                 future.completeExceptionally(error);
               }
             });
+  }
+
+  /**
+   * Returns the term identifying the given configuration towards the leader.
+   *
+   * <p>The locally stored configuration term is not reliable for this: followers store the
+   * leadership term under which the configuration was disseminated ({@code ConfigureRequest}
+   * carries the leader's then-current term), while the leader's own configuration - which {@code
+   * LeaderRole#onReconfigure} validates reconfigure requests against - keeps the term at which the
+   * configuration entry was appended. Whenever an election happened between appending and
+   * disseminating a configuration, the two terms differ and a request built from the stored term
+   * would be rejected as stale forever. Prefer the actual term of the local log's configuration
+   * entry, falling back to the stored term when the entry is not in the log (e.g. for the initial
+   * configuration, which has no entry, or when this member has not received the entry yet - the
+   * possibly-rejected request is safe to retry).
+   */
+  private long configurationTerm(final Configuration configuration) {
+    try (final var reader = cluster.getContext().getLog().openUncommittedReader()) {
+      reader.seek(configuration.index());
+      if (reader.hasNext()) {
+        final var entry = reader.next();
+        if (entry.index() == configuration.index() && entry.entry() instanceof ConfigurationEntry) {
+          return entry.term();
+        }
+      }
+    }
+    return configuration.term();
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/DefaultRaftMember.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/DefaultRaftMember.java
@@ -29,11 +29,13 @@ import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.storage.log.entry.ConfigurationEntry;
 import io.atomix.raft.storage.system.Configuration;
 import io.atomix.utils.concurrent.Scheduled;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 /** Cluster member. */
@@ -142,32 +144,44 @@ public final class DefaultRaftMember implements RaftMember, AutoCloseable {
       return CompletableFuture.completedFuture(null);
     }
     final CompletableFuture<Void> future = new CompletableFuture<>();
-    cluster.getContext().getThreadContext().execute(() -> configure(type, future));
+    // The retry timer is owned by this operation, not by the member: a stale response for an
+    // earlier, already completed operation must never cancel a newer operation's timer - the only
+    // thing that would drive that operation forward - and would otherwise hang its future
+    // forever. At the same time there is at most one live timer per operation: every reschedule
+    // replaces (and cancels) the previous one, so duplicated in-flight attempts of the same
+    // operation cannot multiply timers.
+    final var retryTimer = new AtomicReference<Scheduled>();
+    cluster.getContext().getThreadContext().execute(() -> configure(type, future, retryTimer));
     return future;
   }
 
   /** Recursively reconfigures the cluster. */
-  private void configure(final RaftMember.Type type, final CompletableFuture<Void> future) {
+  private void configure(
+      final RaftMember.Type type,
+      final CompletableFuture<Void> future,
+      final AtomicReference<Scheduled> retryTimer) {
+    if (future.isDone()) {
+      // The operation already completed, e.g. the retry timer fired while the response that
+      // completed the future was still in flight. Don't send another request or re-arm the timer.
+      return;
+    }
     final var currentConfiguration = cluster.getConfiguration();
     if (currentConfiguration == null) {
       // The local member does not know a configuration yet, for example a PROMOTABLE member whose
       // join completed before the leader disseminated the configuration to it. The request is
       // built from the local configuration view, so fail fast - like a stale-view
       // CONFIGURATION_ERROR - and let the caller retry once a configuration is known.
+      cancelRetryTimer(retryTimer);
       future.completeExceptionally(
           new RaftException.ConfigurationException(
               null, "Cannot change type of member %s to %s: no known configuration", id, type));
       return;
     }
 
-    // Set a timer to retry the attempt to leave the cluster.
-    configureTimeout =
-        cluster
-            .getContext()
-            .getThreadContext()
-            .schedule(cluster.getContext().getElectionTimeout(), () -> configure(type, future));
+    // Set a timer to retry the attempt in case the response is lost.
+    scheduleRetry(cluster.getContext().getElectionTimeout(), type, future, retryTimer);
 
-    // Attempt to leave the cluster by submitting a LeaveRequest directly to the server state.
+    // Attempt to reconfigure by submitting a ReconfigureRequest directly to the server state.
     // Non-leader states should forward the request to the leader if there is one. Leader states
     // will log, replicate, and commit the reconfiguration.
     cluster
@@ -184,36 +198,76 @@ public final class DefaultRaftMember implements RaftMember, AutoCloseable {
                 .build())
         .whenComplete(
             (response, error) -> {
+              if (future.isDone()) {
+                // A late response for an already completed operation must not touch any timer:
+                // the caller may have observed the completion and started a new operation, whose
+                // timer must stay armed.
+                return;
+              }
               if (error == null) {
                 if (response.status() == RaftResponse.Status.OK) {
-                  cancelConfigureTimer();
-                  cluster.configure(
-                      new Configuration(
-                          response.index(),
-                          response.term(),
-                          response.timestamp(),
-                          response.members()));
-                  future.complete(null);
+                  cancelRetryTimer(retryTimer);
+                  // Complete the future even if applying the new configuration fails: the
+                  // exception would otherwise be swallowed by this callback and, with the retry
+                  // timer already cancelled, hang the future forever.
+                  try {
+                    cluster.configure(
+                        new Configuration(
+                            response.index(),
+                            response.term(),
+                            response.timestamp(),
+                            response.members()));
+                    future.complete(null);
+                  } catch (final Exception e) {
+                    future.completeExceptionally(e);
+                  }
                 } else if (response.error() == null
                     || response.error().type() == RaftError.Type.UNAVAILABLE
                     || response.error().type() == RaftError.Type.PROTOCOL_ERROR
                     || response.error().type() == RaftError.Type.NO_LEADER) {
-                  cancelConfigureTimer();
-                  configureTimeout =
-                      cluster
-                          .getContext()
-                          .getThreadContext()
-                          .schedule(
-                              cluster.getContext().getElectionTimeout().multipliedBy(2),
-                              () -> configure(type, future));
+                  scheduleRetry(
+                      cluster.getContext().getElectionTimeout().multipliedBy(2),
+                      type,
+                      future,
+                      retryTimer);
                 } else {
-                  cancelConfigureTimer();
+                  cancelRetryTimer(retryTimer);
                   future.completeExceptionally(response.error().createException());
                 }
               } else {
+                cancelRetryTimer(retryTimer);
                 future.completeExceptionally(error);
               }
             });
+  }
+
+  /**
+   * Replaces the operation's retry timer with a new one, so that at most one timer is live per
+   * operation. The member-level configureTimeout field tracks the newest timer solely so that
+   * {@link #close()} can cancel it.
+   */
+  private void scheduleRetry(
+      final Duration delay,
+      final RaftMember.Type type,
+      final CompletableFuture<Void> future,
+      final AtomicReference<Scheduled> retryTimer) {
+    final var timer =
+        cluster
+            .getContext()
+            .getThreadContext()
+            .schedule(delay, () -> configure(type, future, retryTimer));
+    final var previous = retryTimer.getAndSet(timer);
+    if (previous != null) {
+      previous.cancel();
+    }
+    configureTimeout = timer;
+  }
+
+  private void cancelRetryTimer(final AtomicReference<Scheduled> retryTimer) {
+    final var timer = retryTimer.getAndSet(null);
+    if (timer != null) {
+      timer.cancel();
+    }
   }
 
   /**

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -100,9 +100,9 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
   }
 
   @Override
-  public CompletableFuture<Void> join(final Collection<MemberId> cluster) {
+  public CompletableFuture<Void> join(final Type type, final Collection<MemberId> cluster) {
     return new ReconfigurationHelper(raft)
-        .join(cluster)
+        .join(type, cluster)
         // Usually the transition is triggered by `onConfigure` when the leader sends the updated
         // configuration. If the join is attempted again, it can be accepted without a configuration
         // change and nothing triggers the transition.

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -265,6 +265,44 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
     return configuration;
   }
 
+  /**
+   * Returns the term that identifies the current configuration in a {@code ReconfigureRequest},
+   * which {@code LeaderRole#onReconfigure} validates against the leader's own view of it.
+   *
+   * <p>{@link Configuration#term()} alone is ambiguous: a member that appended or recovered the
+   * configuration entry stores the term the entry was appended in, while a member that learned the
+   * configuration from a {@code ConfigureRequest} stores the leadership term it was disseminated
+   * under - {@code ConfigureRequest} carries the leader's then-current term, which is also what
+   * tracks the leader. Whenever an election happened between appending and disseminating a
+   * configuration, the two differ, and a requester and a leader that learned the same configuration
+   * in different ways would never agree on its term, so every reconfiguration would be rejected as
+   * stale forever. Both sides therefore derive the term from the configuration entry in their own
+   * log, which is unambiguous, and only fall back to the stored term when that entry is not
+   * available - for the initial configuration, which has no entry, or before the entry arrived.
+   * Such a mismatch is still possible, but it is transient and the rejected request is safe to
+   * retry.
+   */
+  public long getConfigurationTerm() {
+    final var currentConfiguration = configuration;
+    try (final var reader = raft.getLog().openUncommittedReader()) {
+      reader.seek(currentConfiguration.index());
+      if (reader.hasNext()) {
+        final var entry = reader.next();
+        if (entry.index() == currentConfiguration.index()
+            && entry.entry() instanceof ConfigurationEntry) {
+          return entry.term();
+        }
+      }
+    } catch (final Exception e) {
+      LOGGER.warn(
+          "Failed to read the term of the configuration entry at index {}, falling back to the stored term {}",
+          currentConfiguration.index(),
+          currentConfiguration.term(),
+          e);
+    }
+    return currentConfiguration.term();
+  }
+
   public RaftContext getContext() {
     return raft;
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -223,7 +223,15 @@ public final class RaftMemberContext {
 
   /** Completes an append request to the member. */
   public void completeAppend() {
-    inFlightAppendCount--;
+    // Floor at zero: resetState() zeroes the in-flight count - necessarily so, because it must
+    // recover slots stranded by a previous leader's closed appender, whose response callbacks
+    // never run - but responses to appends started before a reset within the same leadership
+    // still arrive here. For example, a member's type change (such as a promotion) resets its
+    // state while heartbeats to it are in flight. Without the floor, such a response makes the
+    // count negative, and canAppend()/canHeartbeat() - both testing for == 0 - may never hold
+    // again, permanently silencing the leader towards this member. With the floor, the worst
+    // case is a transiently over-permissive count, i.e. one extra concurrent append.
+    inFlightAppendCount = Math.max(0, inFlightAppendCount - 1);
   }
 
   /**

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -218,7 +218,15 @@ public final class RaftMemberContext {
 
   /** Completes an append request to the member. */
   public void completeAppend() {
-    inFlightAppendCount--;
+    // Floor at zero: resetState() zeroes the in-flight count - necessarily so, because it must
+    // recover slots stranded by a previous leader's closed appender, whose response callbacks
+    // never run - but responses to appends started before a reset within the same leadership
+    // still arrive here. For example, a member's type change (such as a promotion) resets its
+    // state while heartbeats to it are in flight. Without the floor, such a response makes the
+    // count negative, and canAppend()/canHeartbeat() - both testing for == 0 - may never hold
+    // again, permanently silencing the leader towards this member. With the floor, the worst
+    // case is a transiently over-permissive count, i.e. one extra concurrent append.
+    inFlightAppendCount = Math.max(0, inFlightAppendCount - 1);
   }
 
   /**

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -108,7 +108,7 @@ public class DefaultRaftServer implements RaftServer {
   }
 
   @Override
-  public CompletableFuture<RaftServer> promote() {
+  public CompletableFuture<RaftServer> anoint() {
     return new ReconfigurationHelper(context).anoint().thenApply(v -> this);
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -98,8 +98,8 @@ public class DefaultRaftServer implements RaftServer {
   }
 
   @Override
-  public CompletableFuture<RaftServer> join(final Collection<MemberId> cluster) {
-    return start(() -> cluster().join(cluster));
+  public CompletableFuture<RaftServer> join(final Type type, final Collection<MemberId> cluster) {
+    return start(() -> cluster().join(type, cluster));
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -1400,6 +1400,10 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     return partitionConfig.getPreferSnapshotReplicationThreshold();
   }
 
+  public long getPromotionLagThreshold() {
+    return partitionConfig.getPromotionLagThreshold();
+  }
+
   public void setPreferSnapshotReplicationThreshold(final int snapshotReplicationThreshold) {
     partitionConfig.setPreferSnapshotReplicationThreshold(snapshotReplicationThreshold);
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -981,6 +981,15 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   }
 
   /**
+   * Returns the join catch-up timeout.
+   *
+   * @return The join catch-up timeout.
+   */
+  public Duration getJoinCatchUpTimeout() {
+    return partitionConfig.getJoinCatchUpTimeout();
+  }
+
+  /**
    * Returns the first commit index.
    *
    * @return The first commit index.

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -1318,6 +1318,10 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     return partitionConfig.getPreferSnapshotReplicationThreshold();
   }
 
+  public long getPromotionLagThreshold() {
+    return partitionConfig.getPromotionLagThreshold();
+  }
+
   public void setPreferSnapshotReplicationThreshold(final int snapshotReplicationThreshold) {
     partitionConfig.setPreferSnapshotReplicationThreshold(snapshotReplicationThreshold);
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -10,6 +10,7 @@ package io.atomix.raft.impl;
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.MessagingException.NoRemoteHandler;
 import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
+import io.atomix.raft.RaftCommitListener;
 import io.atomix.raft.RaftError;
 import io.atomix.raft.RaftException.ProtocolException;
 import io.atomix.raft.RaftServer.Role;
@@ -24,8 +25,10 @@ import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.raft.protocol.TransferRequest;
 import io.atomix.raft.storage.system.Configuration;
 import io.atomix.raft.utils.ForceConfigureQuorum;
+import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.concurrent.ThreadContext;
 import java.net.ConnectException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
@@ -194,8 +197,22 @@ public final class ReconfigurationHelper {
                   result.completeExceptionally(error);
                 }
               } else if (response.status() == Status.OK) {
-                LOGGER.debug("Join request accepted");
-                result.complete(null);
+                // The leader may have committed the configuration entry admitting this member
+                // without this member's participation at all - e.g. a PROMOTABLE joiner is in no
+                // quorum, so the old side of a joint configuration can commit on the strength of
+                // the existing members alone. Wait for this node's own commit index to reach the
+                // entry before declaring the join done: RaftContext#setCommitIndex clamps to what
+                // this node has itself persisted, so reaching the index implies the entry is
+                // already durable here too - exactly what a restart needs, see
+                // RaftClusterContext#reloadConfigurationFromLog - and it recovers this join's
+                // outcome instead of falling back to treating this node as a fresh, unconfigured
+                // one. A crash before that needs no special handling: the join future then never
+                // completes, so the caller retries it.
+                LOGGER.debug(
+                    "Join request accepted at index {}, waiting for the configuration entry to"
+                        + " commit locally",
+                    response.index());
+                awaitLocalCommit(response.index(), result, deadline);
               } else if (response.error().type() == RaftError.Type.NO_LEADER
                   || response.error().type() == RaftError.Type.CONFIGURATION_ERROR) {
                 if (Instant.now().isBefore(deadline)) {
@@ -237,6 +254,63 @@ public final class ReconfigurationHelper {
               }
             },
             threadContext);
+  }
+
+  /**
+   * Completes {@code result} once this node's own commit index reaches {@code index}, using {@link
+   * RaftContext#addCommitListener} rather than polling. {@link RaftContext#setCommitIndex} clamps
+   * to what this node has itself persisted, so waiting for the local commit index - not the
+   * leader's - is what guarantees the entry is durable here too.
+   *
+   * @param index the index of the configuration entry admitting this member
+   * @param result the future to complete once the entry commits locally
+   * @param deadline until when to wait before failing {@code result}
+   */
+  private void awaitLocalCommit(
+      final long index, final CompletableFuture<Void> result, final Instant deadline) {
+    if (raftContext.getCommitIndex() >= index) {
+      LOGGER.debug("Configuration entry at index {} is already committed locally", index);
+      result.complete(null);
+      return;
+    }
+    if (!Instant.now().isBefore(deadline)) {
+      result.completeExceptionally(
+          new TimeoutException(
+              "Join request was accepted at index %d, but that configuration entry did not commit"
+                  + " locally within the configuration change timeout".formatted(index)));
+      return;
+    }
+
+    // Self-removing: whichever of the commit notification or the timeout fires first cancels the
+    // other. Needs a mutable field for the timeout handle because the listener has to be
+    // registered before that handle exists.
+    final var listener =
+        new RaftCommitListener() {
+          Scheduled timeout;
+
+          @Override
+          public void onCommit(final long committedIndex) {
+            if (committedIndex < index) {
+              return;
+            }
+            raftContext.removeCommitListener(this);
+            timeout.cancel();
+            LOGGER.debug("Configuration entry at index {} committed locally", index);
+            result.complete(null);
+          }
+        };
+    listener.timeout =
+        threadContext.schedule(
+            Duration.between(Instant.now(), deadline),
+            () -> {
+              raftContext.removeCommitListener(listener);
+              result.completeExceptionally(
+                  new TimeoutException(
+                      "Join request was accepted at index %d, but that configuration entry did"
+                          + " not commit locally within the configuration change timeout"
+                              .formatted(index)));
+            });
+    raftContext.addCommitListener(listener);
   }
 
   public CompletableFuture<Void> leave() {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -28,7 +28,6 @@ import io.atomix.raft.utils.ForceConfigureQuorum;
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.concurrent.ThreadContext;
 import java.net.ConnectException;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
@@ -212,7 +211,7 @@ public final class ReconfigurationHelper {
                     "Join request accepted at index {}, waiting for the configuration entry to"
                         + " commit locally",
                     response.index());
-                awaitLocalCommit(response.index(), result, deadline);
+                awaitLocalCommit(response.index(), result);
               } else if (response.error().type() == RaftError.Type.NO_LEADER
                   || response.error().type() == RaftError.Type.CONFIGURATION_ERROR) {
                 if (Instant.now().isBefore(deadline)) {
@@ -262,28 +261,24 @@ public final class ReconfigurationHelper {
    * to what this node has itself persisted, so waiting for the local commit index - not the
    * leader's - is what guarantees the entry is durable here too.
    *
+   * <p>The wait runs on its own {@link RaftContext#getJoinCatchUpTimeout()} budget rather than what
+   * remains of the join-request deadline, which may be mostly spent on retries by the time the join
+   * is accepted: reaching the accepted index is paced by replication - potentially a snapshot
+   * install plus a log replay - not by request round-trips.
+   *
    * @param index the index of the configuration entry admitting this member
    * @param result the future to complete once the entry commits locally
-   * @param deadline until when to wait before failing {@code result}
    */
-  private void awaitLocalCommit(
-      final long index, final CompletableFuture<Void> result, final Instant deadline) {
+  private void awaitLocalCommit(final long index, final CompletableFuture<Void> result) {
     if (raftContext.getCommitIndex() >= index) {
       LOGGER.debug("Configuration entry at index {} is already committed locally", index);
       result.complete(null);
       return;
     }
-    if (!Instant.now().isBefore(deadline)) {
-      result.completeExceptionally(
-          new TimeoutException(
-              "Join request was accepted at index %d, but that configuration entry did not commit"
-                  + " locally within the configuration change timeout".formatted(index)));
-      return;
-    }
 
     // Self-removing: whichever of the commit notification or the timeout fires first cancels the
-    // other. Needs a mutable field for the timeout handle because the listener has to be
-    // registered before that handle exists.
+    // other. Needs a mutable field for the timeout handle because the timeout's callback captures
+    // the listener, so the listener must exist before the handle does.
     final var listener =
         new RaftCommitListener() {
           Scheduled timeout;
@@ -301,14 +296,14 @@ public final class ReconfigurationHelper {
         };
     listener.timeout =
         threadContext.schedule(
-            Duration.between(Instant.now(), deadline),
+            raftContext.getJoinCatchUpTimeout(),
             () -> {
               raftContext.removeCommitListener(listener);
               result.completeExceptionally(
                   new TimeoutException(
                       "Join request was accepted at index %d, but that configuration entry did"
-                          + " not commit locally within the configuration change timeout"
-                              .formatted(index)));
+                          + " not commit locally within the join catch-up timeout of %s"
+                              .formatted(index, raftContext.getJoinCatchUpTimeout())));
             });
     raftContext.addCommitListener(listener);
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -52,8 +52,15 @@ public final class ReconfigurationHelper {
     this.raftContext = raftContext;
   }
 
-  public CompletableFuture<Void> join(final Collection<MemberId> clusterMembers) {
+  public CompletableFuture<Void> join(final Type type, final Collection<MemberId> clusterMembers) {
     final var result = new CompletableFuture<Void>();
+    if (type == Type.INACTIVE) {
+      result.completeExceptionally(
+          new IllegalArgumentException(
+              "Cannot join cluster as %s, must join as %s, %s or %s"
+                  .formatted(type, Type.PASSIVE, Type.PROMOTABLE, Type.ACTIVE)));
+      return result;
+    }
     threadContext.execute(
         () -> {
           // If the previous join was partially or fully completed, i.e. committed the first
@@ -89,7 +96,7 @@ public final class ReconfigurationHelper {
           // retry join any way.
           final var joining =
               new DefaultRaftMember(
-                  raftContext.getCluster().getLocalMember().memberId(), Type.ACTIVE, Instant.now());
+                  raftContext.getCluster().getLocalMember().memberId(), type, Instant.now());
           final var knownAssistingMembers =
               clusterMembers.stream()
                   .filter(memberId -> !memberId.equals(joining.memberId()))

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -28,7 +28,9 @@ import io.atomix.utils.concurrent.ThreadContext;
 import java.net.ConnectException;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
@@ -78,19 +80,27 @@ public final class ReconfigurationHelper {
             return;
           }
 
-          // Always transition to PASSIVE or the last member type as found by
-          // `reloadConfigurationFromLog`.
-          // This ensures that the member trying to join is not stuck in `INACTIVE` which would
-          // prevent the joining from completing, particularly when joining a single-member cluster
-          // where this new node is already required for quorum.
-          switch (raftContext.getCluster().getLocalMember().getType()) {
-            // The last configuration entry is probably old and has the local member as INACTIVE.
-            // Ignore this and become PASSIVE instead.
-            case INACTIVE -> raftContext.transition(Type.PASSIVE);
-            // The last configuration entry has the local member as PASSIVE or ACTIVE, we can
-            // directly transition to that.
-            case final Type memberType -> raftContext.transition(memberType);
-          }
+          final var storedType = raftContext.getCluster().getLocalMember().getType();
+          final var startType =
+              switch (storedType) {
+                // No configuration at all: the member may replicate and catch up but must not
+                // enter the voting follower role, and it must not stay INACTIVE either, which
+                // accepts no appends and would prevent the join from completing, particularly
+                // when joining a single-member cluster where this new node is already required
+                // for quorum. ACTIVE joins keep starting as PASSIVE: starting them as PROMOTABLE
+                // would satisfy both constraints too, but would surface the PROMOTABLE role on
+                // the production one-shot join path before the dynamic-config orchestration
+                // adopts two-phase joins (#57392); the leader's configuration promotes them
+                // either way.
+                case INACTIVE -> type == Type.ACTIVE ? Type.PASSIVE : type;
+                // Never start above the requested type: non-voting members persist the leader's
+                // uncommitted tail, so the stored type may come from a configuration entry that a
+                // later leader has since truncated - a PROMOTABLE joiner must not enter the
+                // voting follower role on the strength of such an entry while the leader still
+                // counts it as non-voting.
+                default -> Collections.min(List.of(storedType, type));
+              };
+          raftContext.transition(startType);
 
           // We don't know if the latest configuration loaded from the log is valid. So we will
           // retry join any way.

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -78,15 +78,18 @@ public final class ReconfigurationHelper {
             return;
           }
 
-          // Always transition to PASSIVE or the last member type as found by
+          // Always transition to the requested type or the last member type as found by
           // `reloadConfigurationFromLog`.
           // This ensures that the member trying to join is not stuck in `INACTIVE` which would
           // prevent the joining from completing, particularly when joining a single-member cluster
           // where this new node is already required for quorum.
           switch (raftContext.getCluster().getLocalMember().getType()) {
             // The last configuration entry is probably old and has the local member as INACTIVE.
-            // Ignore this and become PASSIVE instead.
-            case INACTIVE -> raftContext.transition(Type.PASSIVE);
+            // Ignore this and start in the requested type instead, so that e.g. a PROMOTABLE
+            // joiner accepts the uncommitted tail from the very first append. ACTIVE joins keep
+            // starting as PASSIVE: a member without a configuration must not enter the follower
+            // role, and it is promoted by the configuration disseminated by the leader anyway.
+            case INACTIVE -> raftContext.transition(type == Type.ACTIVE ? Type.PASSIVE : type);
             // The last configuration entry has the local member as PASSIVE or ACTIVE, we can
             // directly transition to that.
             case final Type memberType -> raftContext.transition(memberType);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -52,8 +52,15 @@ public final class ReconfigurationHelper {
     this.raftContext = raftContext;
   }
 
-  public CompletableFuture<Void> join(final Collection<MemberId> clusterMembers) {
+  public CompletableFuture<Void> join(final Type type, final Collection<MemberId> clusterMembers) {
     final var result = new CompletableFuture<Void>();
+    if (type == Type.INACTIVE) {
+      result.completeExceptionally(
+          new IllegalArgumentException(
+              "Cannot join cluster as %s, must join as %s, %s or %s"
+                  .formatted(type, Type.PASSIVE, Type.PROMOTABLE, Type.ACTIVE)));
+      return result;
+    }
     threadContext.execute(
         () -> {
           // If the previous join was partially or fully completed, i.e. committed the first
@@ -89,7 +96,7 @@ public final class ReconfigurationHelper {
           // retry join any way.
           final var joining =
               new DefaultRaftMember(
-                  raftContext.getCluster().getLocalMember().memberId(), Type.ACTIVE, Instant.now());
+                  raftContext.getCluster().getLocalMember().memberId(), type, Instant.now());
           final var assistingMembers =
               clusterMembers.stream()
                   .filter(memberId -> !memberId.equals(joining.memberId()))

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -115,6 +115,27 @@ public final class RaftPartition implements Partition, HealthMonitorable {
     return server.leave().thenApply(v -> this);
   }
 
+  /**
+   * Promotes the local member to an ACTIVE voting member via a leader-forwarded reconfiguration -
+   * the second phase of a two-phase join for members that joined as PROMOTABLE and have caught up.
+   * Not to be confused with {@link RaftPartitionServer#promote()}, which transfers leadership
+   * (anoint). See {@link RaftPartitionServer#promoteMember()} for the retry semantics.
+   */
+  public CompletableFuture<RaftPartition> promoteMember() {
+    return server.promoteMember().thenApply(v -> this);
+  }
+
+  /**
+   * Demotes the local member to a PASSIVE, non-voting member via a leader-forwarded reconfiguration
+   * - the first phase of a two-phase leave, so that the subsequent {@link #leave()} commits without
+   * the departing member's participation. Not to be confused with {@link
+   * RaftPartitionServer#promote()}, which transfers leadership (anoint). See {@link
+   * RaftPartitionServer#demoteMember()} for the retry semantics.
+   */
+  public CompletableFuture<RaftPartition> demoteMember() {
+    return server.demoteMember().thenApply(v -> this);
+  }
+
   private void initServer(
       final PartitionManagementService managementService,
       final ReceivableSnapshotStore snapshotStore) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -118,8 +118,7 @@ public final class RaftPartition implements Partition, HealthMonitorable {
   /**
    * Promotes the local member to an ACTIVE voting member via a leader-forwarded reconfiguration -
    * the second phase of a two-phase join for members that joined as PROMOTABLE and have caught up.
-   * Not to be confused with {@link RaftPartitionServer#promote()}, which transfers leadership
-   * (anoint). See {@link RaftPartitionServer#promoteMember()} for the retry semantics.
+   * See {@link RaftPartitionServer#promoteMember()} for the retry semantics.
    */
   public CompletableFuture<RaftPartition> promoteMember() {
     return server.promoteMember().thenApply(v -> this);
@@ -128,9 +127,8 @@ public final class RaftPartition implements Partition, HealthMonitorable {
   /**
    * Demotes the local member to a PASSIVE, non-voting member via a leader-forwarded reconfiguration
    * - the first phase of a two-phase leave, so that the subsequent {@link #leave()} commits without
-   * the departing member's participation. Not to be confused with {@link
-   * RaftPartitionServer#promote()}, which transfers leadership (anoint). See {@link
-   * RaftPartitionServer#demoteMember()} for the retry semantics.
+   * the departing member's participation. See {@link RaftPartitionServer#demoteMember()} for the
+   * retry semantics.
    */
   public CompletableFuture<RaftPartition> demoteMember() {
     return server.demoteMember().thenApply(v -> this);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -37,6 +37,10 @@ public class RaftPartitionConfig {
   private static final long DEFAULT_REBALANCE_REPLICATION_LAG_THRESHOLD = 8L * 1024 * 1024;
   private static final Duration DEFAULT_REBALANCE_REPLICATION_TIMEOUT = Duration.ofSeconds(10);
   private static final int DEFAULT_REBALANCE_MAX_TRANSFER_ATTEMPTS = 3;
+  // 16 MiB: at a conservative 20 MB/s of replication bandwidth this bounds the commit-stall
+  // window of a promotion to well under a second, while the in-flight replication lag of a
+  // healthy, caught-up member stays orders of magnitude below it even under sustained load.
+  private static final long DEFAULT_PROMOTION_LAG_THRESHOLD = 16 * 1024 * 1024L;
 
   private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
   private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
@@ -56,6 +60,7 @@ public class RaftPartitionConfig {
   private Duration configurationChangeTimeout = DEFAULT_CONFIGURATION_CHANGE_TIMEOUT;
   private int snapshotChunkSize = DEFAULT_SNAPSHOT_CHUNK_SIZE;
   private boolean receiveOnLegacySubject = DEFAULT_RECEIVE_ON_LEGACY_SUBJECT;
+  private long promotionLagThreshold = DEFAULT_PROMOTION_LAG_THRESHOLD;
 
   /**
    * Returns the Raft leader election timeout.
@@ -276,6 +281,23 @@ public class RaftPartitionConfig {
     this.receiveOnLegacySubject = receiveOnLegacySubject;
   }
 
+  public long getPromotionLagThreshold() {
+    return promotionLagThreshold;
+  }
+
+  /**
+   * Sets the maximum replication lag, in bytes, up to which a member may be promoted to ACTIVE. The
+   * lag is the byte-exact amount of data the leader still has to replicate to the member - the
+   * unreplicated log tail plus any pending snapshot install - and bounds how long commits can stall
+   * once the promoted member joins the commit quorum. Internal for now; not exposed via broker
+   * configuration.
+   *
+   * @param promotionLagThreshold the maximum replication lag in bytes for promotions
+   */
+  public void setPromotionLagThreshold(final long promotionLagThreshold) {
+    this.promotionLagThreshold = promotionLagThreshold;
+  }
+
   @Override
   public String toString() {
     return "RaftPartitionConfig{"
@@ -311,6 +333,8 @@ public class RaftPartitionConfig {
         + rebalanceMaxTransferAttempts
         + ", receiveOnLegacySubject="
         + receiveOnLegacySubject
+        + ", promotionLagThreshold="
+        + promotionLagThreshold
         + '}';
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -33,6 +33,10 @@ public class RaftPartitionConfig {
   private static final boolean DEFAULT_RECEIVE_ON_LEGACY_SUBJECT = true;
   // Keep in sync with the defaults in ExperimentalRaftCfg, which usually override these.
   private static final Duration DEFAULT_CONFIGURATION_CHANGE_TIMEOUT = Duration.ofSeconds(10);
+  // 60s: well above the RPC-scale configurationChangeTimeout, since catching up to the admitting
+  // entry may include a snapshot install and a log replay. Still bounded, so a join whose entry a
+  // newer leader truncated eventually fails and is retried with a fresh request.
+  private static final Duration DEFAULT_JOIN_CATCH_UP_TIMEOUT = Duration.ofSeconds(60);
   private static final int DEFAULT_SNAPSHOT_CHUNK_SIZE = 8 * 1024 * 1024;
   private static final long DEFAULT_REBALANCE_REPLICATION_LAG_THRESHOLD = 8L * 1024 * 1024;
   private static final Duration DEFAULT_REBALANCE_REPLICATION_TIMEOUT = Duration.ofSeconds(10);
@@ -58,6 +62,7 @@ public class RaftPartitionConfig {
   private RaftStorageConfig storageConfig;
   private EntryValidator entryValidator;
   private Duration configurationChangeTimeout = DEFAULT_CONFIGURATION_CHANGE_TIMEOUT;
+  private Duration joinCatchUpTimeout = DEFAULT_JOIN_CATCH_UP_TIMEOUT;
   private int snapshotChunkSize = DEFAULT_SNAPSHOT_CHUNK_SIZE;
   private boolean receiveOnLegacySubject = DEFAULT_RECEIVE_ON_LEGACY_SUBJECT;
   private long promotionLagThreshold = DEFAULT_PROMOTION_LAG_THRESHOLD;
@@ -166,6 +171,22 @@ public class RaftPartitionConfig {
 
   public void setConfigurationChangeTimeout(final Duration configurationChangeTimeout) {
     this.configurationChangeTimeout = configurationChangeTimeout;
+  }
+
+  /**
+   * The maximum time to wait, once a join request was accepted, for this node's own commit index to
+   * catch up to the index it was admitted at. Unlike {@link #getConfigurationChangeTimeout()},
+   * which bounds request round-trips, this bounds a replication-paced wait, so it defaults to a
+   * longer duration.
+   *
+   * @return the join catch-up timeout
+   */
+  public Duration getJoinCatchUpTimeout() {
+    return joinCatchUpTimeout;
+  }
+
+  public void setJoinCatchUpTimeout(final Duration joinCatchUpTimeout) {
+    this.joinCatchUpTimeout = joinCatchUpTimeout;
   }
 
   public int getMinStepDownFailureCount() {
@@ -289,8 +310,7 @@ public class RaftPartitionConfig {
    * Sets the maximum replication lag, in bytes, up to which a member may be promoted to ACTIVE. The
    * lag is the byte-exact amount of data the leader still has to replicate to the member - the
    * unreplicated log tail plus any pending snapshot install - and bounds how long commits can stall
-   * once the promoted member joins the commit quorum. Internal for now; not exposed via broker
-   * configuration.
+   * once the promoted member joins the commit quorum.
    *
    * @param promotionLagThreshold the maximum replication lag in bytes for promotions
    */
@@ -319,6 +339,8 @@ public class RaftPartitionConfig {
         + snapshotChunkSize
         + ", configurationChangeTimeout="
         + configurationChangeTimeout
+        + ", joinCatchUpTimeout="
+        + joinCatchUpTimeout
         + ", minStepDownFailureCount="
         + minStepDownFailureCount
         + ", maxQuorumResponseTimeout="

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -33,6 +33,10 @@ public class RaftPartitionConfig {
   private static final boolean DEFAULT_RECEIVE_ON_LEGACY_SUBJECT = true;
   // Keep in sync with the default in ExperimentalRaftCfg, which usually overrides this.
   private static final Duration DEFAULT_CONFIGURATION_CHANGE_TIMEOUT = Duration.ofSeconds(10);
+  // 16 MiB: at a conservative 20 MB/s of replication bandwidth this bounds the commit-stall
+  // window of a promotion to well under a second, while the in-flight replication lag of a
+  // healthy, caught-up member stays orders of magnitude below it even under sustained load.
+  private static final long DEFAULT_PROMOTION_LAG_THRESHOLD = 16 * 1024 * 1024L;
 
   private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
   private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
@@ -49,6 +53,7 @@ public class RaftPartitionConfig {
   private Duration configurationChangeTimeout = DEFAULT_CONFIGURATION_CHANGE_TIMEOUT;
   private int snapshotChunkSize;
   private boolean receiveOnLegacySubject = DEFAULT_RECEIVE_ON_LEGACY_SUBJECT;
+  private long promotionLagThreshold = DEFAULT_PROMOTION_LAG_THRESHOLD;
 
   /**
    * Returns the Raft leader election timeout.
@@ -221,6 +226,23 @@ public class RaftPartitionConfig {
     this.receiveOnLegacySubject = receiveOnLegacySubject;
   }
 
+  public long getPromotionLagThreshold() {
+    return promotionLagThreshold;
+  }
+
+  /**
+   * Sets the maximum replication lag, in bytes, up to which a member may be promoted to ACTIVE. The
+   * lag is the byte-exact amount of data the leader still has to replicate to the member - the
+   * unreplicated log tail plus any pending snapshot install - and bounds how long commits can stall
+   * once the promoted member joins the commit quorum. Internal for now; not exposed via broker
+   * configuration.
+   *
+   * @param promotionLagThreshold the maximum replication lag in bytes for promotions
+   */
+  public void setPromotionLagThreshold(final long promotionLagThreshold) {
+    this.promotionLagThreshold = promotionLagThreshold;
+  }
+
   @Override
   public String toString() {
     return "RaftPartitionConfig{"
@@ -250,6 +272,8 @@ public class RaftPartitionConfig {
         + preferSnapshotReplicationThreshold
         + ", receiveOnLegacySubject="
         + receiveOnLegacySubject
+        + ", promotionLagThreshold="
+        + promotionLagThreshold
         + '}';
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -154,6 +154,51 @@ public class RaftPartitionServer implements HealthMonitorable {
     return server.leave().thenApply(v -> this);
   }
 
+  /**
+   * Promotes the local member to {@link Type#ACTIVE} via a reconfiguration that is forwarded to the
+   * current leader, making it a full voting member. This is the second phase of the two-phase join
+   * flow for members that joined as {@link Type#PROMOTABLE} and have caught up to the leader's log.
+   *
+   * <p>Not to be confused with {@link #promote()}, which transfers <em>leadership</em> to this
+   * member (anoint) and is unrelated to member types.
+   *
+   * <p>{@code NO_LEADER}, {@code UNAVAILABLE} and {@code PROTOCOL_ERROR} responses are retried
+   * internally without a deadline. A {@code CONFIGURATION_ERROR} - the member is not caught up yet,
+   * another configuration change is in progress, or the request was built from a stale
+   * configuration view - fails the returned future and the caller is expected to retry. There is no
+   * production caller yet; this supports the dynamic-config orchestration of two-phase joins
+   * (#57392).
+   *
+   * @return a future to be completed once the local member is an ACTIVE part of the committed
+   *     configuration
+   */
+  public CompletableFuture<RaftPartitionServer> promoteMember() {
+    return server.cluster().getLocalMember().promote(Type.ACTIVE).thenApply(v -> this);
+  }
+
+  /**
+   * Demotes the local member to {@link Type#PASSIVE} via a reconfiguration that is forwarded to the
+   * current leader, removing it from all quorums. This is the first phase of a two-phase leave:
+   * demote, then {@link #leave()}, so that the removal can commit without the departing member's
+   * participation. The target is PASSIVE rather than PROMOTABLE because a departing member has no
+   * promotion intent and must not be shipped the leader's uncommitted tail.
+   *
+   * <p>Not to be confused with {@link #promote()}, which transfers <em>leadership</em> (anoint) and
+   * is unrelated to member types.
+   *
+   * <p>{@code NO_LEADER}, {@code UNAVAILABLE} and {@code PROTOCOL_ERROR} responses are retried
+   * internally without a deadline. A {@code CONFIGURATION_ERROR} - e.g. another configuration
+   * change is in progress or the request was built from a stale configuration view - fails the
+   * returned future and the caller is expected to retry. There is no production caller yet; this
+   * supports the dynamic-config orchestration of two-phase leaves (#57392).
+   *
+   * @return a future to be completed once the local member is a PASSIVE part of the committed
+   *     configuration
+   */
+  public CompletableFuture<RaftPartitionServer> demoteMember() {
+    return server.cluster().getLocalMember().demote(Type.PASSIVE).thenApply(v -> this);
+  }
+
   public CompletableFuture<RaftPartitionServer> forceReconfigure(
       final Map<MemberId, Type> members) {
     return server.forceConfigure(members).thenApply(v -> this);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -159,9 +159,6 @@ public class RaftPartitionServer implements HealthMonitorable {
    * current leader, making it a full voting member. This is the second phase of the two-phase join
    * flow for members that joined as {@link Type#PROMOTABLE} and have caught up to the leader's log.
    *
-   * <p>Not to be confused with {@link #promote()}, which transfers <em>leadership</em> to this
-   * member (anoint) and is unrelated to member types.
-   *
    * <p>{@code NO_LEADER}, {@code UNAVAILABLE} and {@code PROTOCOL_ERROR} responses are retried
    * internally without a deadline. A {@code CONFIGURATION_ERROR} - the member is not caught up yet,
    * another configuration change is in progress, or the request was built from a stale
@@ -182,9 +179,6 @@ public class RaftPartitionServer implements HealthMonitorable {
    * demote, then {@link #leave()}, so that the removal can commit without the departing member's
    * participation. The target is PASSIVE rather than PROMOTABLE because a departing member has no
    * promotion intent and must not be shipped the leader's uncommitted tail.
-   *
-   * <p>Not to be confused with {@link #promote()}, which transfers <em>leadership</em> (anoint) and
-   * is unrelated to member types.
    *
    * <p>{@code NO_LEADER}, {@code UNAVAILABLE} and {@code PROTOCOL_ERROR} responses are retried
    * internally without a deadline. A {@code CONFIGURATION_ERROR} - e.g. another configuration
@@ -415,8 +409,8 @@ public class RaftPartitionServer implements HealthMonitorable {
     return server.stepDown();
   }
 
-  public CompletableFuture<RaftServer> promote() {
-    return server.promote();
+  public CompletableFuture<RaftServer> anoint() {
+    return server.anoint();
   }
 
   public Collection<RaftMember> getMembers() {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ConfigureRequest.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ConfigureRequest.java
@@ -39,6 +39,16 @@ public class ConfigureRequest extends AbstractRaftRequest {
   private final String leader;
   private final long index;
   private final long timestamp;
+
+  /**
+   * The term of the configuration entry at {@link #index}, which together with the index identifies
+   * the configuration - as opposed to {@link #term}, the leader's current term, which only says who
+   * is disseminating it. Absent (zero) from requests built by members that predate this field; a
+   * receiver then has to fall back to {@link #term}, which is what made {@code
+   * Configuration#term()} ambiguous in the first place.
+   */
+  private final long configurationTerm;
+
   private final Collection<RaftMember> members;
   private final Collection<RaftMember> oldMembers;
 
@@ -48,18 +58,20 @@ public class ConfigureRequest extends AbstractRaftRequest {
       final long index,
       final long timestamp,
       final Collection<RaftMember> newMembers,
-      final Collection<RaftMember> oldMembers) {
+      final Collection<RaftMember> oldMembers,
+      final long configurationTerm) {
     this.term = term;
     this.leader = leader;
     this.index = index;
     this.timestamp = timestamp;
     members = newMembers;
     this.oldMembers = oldMembers;
+    this.configurationTerm = configurationTerm;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(term, leader, index, timestamp, members, oldMembers);
+    return Objects.hash(term, leader, index, timestamp, members, oldMembers, configurationTerm);
   }
 
   @Override
@@ -74,6 +86,7 @@ public class ConfigureRequest extends AbstractRaftRequest {
     return term == that.term
         && index == that.index
         && timestamp == that.timestamp
+        && configurationTerm == that.configurationTerm
         && Objects.equals(leader, that.leader)
         && Objects.equals(members, that.members)
         && Objects.equals(oldMembers, that.oldMembers);
@@ -95,6 +108,8 @@ public class ConfigureRequest extends AbstractRaftRequest {
         + members
         + ", oldMembers="
         + oldMembers
+        + ", configurationTerm="
+        + configurationTerm
         + '}';
   }
 
@@ -135,6 +150,16 @@ public class ConfigureRequest extends AbstractRaftRequest {
   }
 
   /**
+   * Returns the term of the configuration entry at {@link #index()}, or {@code 0} when the sender
+   * does not provide it.
+   *
+   * @return The configuration's term, or {@code 0} if unknown.
+   */
+  public long configurationTerm() {
+    return configurationTerm;
+  }
+
+  /**
    * Returns the configuration timestamp.
    *
    * @return The configuration timestamp.
@@ -170,6 +195,7 @@ public class ConfigureRequest extends AbstractRaftRequest {
   public static class Builder extends AbstractRaftRequest.Builder<Builder, ConfigureRequest> {
 
     private long term;
+    private long configurationTerm;
     private String leader;
     private long index;
     private long timestamp;
@@ -210,6 +236,18 @@ public class ConfigureRequest extends AbstractRaftRequest {
     public Builder withIndex(final long index) {
       checkArgument(index >= 0, "index must be positive");
       this.index = index;
+      return this;
+    }
+
+    /**
+     * Sets the term of the configuration entry at the request index.
+     *
+     * @param configurationTerm The configuration entry's term.
+     * @return The request builder.
+     */
+    public Builder withConfigurationTerm(final long configurationTerm) {
+      checkArgument(configurationTerm >= 0, "configurationTerm must not be negative");
+      this.configurationTerm = configurationTerm;
       return this;
     }
 
@@ -255,7 +293,8 @@ public class ConfigureRequest extends AbstractRaftRequest {
     @Override
     public ConfigureRequest build() {
       validate();
-      return new ConfigureRequest(term, leader, index, timestamp, newMembers, oldMembers);
+      return new ConfigureRequest(
+          term, leader, index, timestamp, newMembers, oldMembers, configurationTerm);
     }
 
     @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/JoinResponse.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/JoinResponse.java
@@ -11,21 +11,39 @@ import io.atomix.raft.RaftError;
 
 public final class JoinResponse extends AbstractRaftResponse {
 
-  private JoinResponse(final Status status, final RaftError error) {
+  // The index of the configuration entry that admits the joining member, or 0 on error. The
+  // joiner waits for this entry to be durably present in its own log before considering the join
+  // complete - see ReconfigurationHelper#join - since the leader may commit it without the
+  // joiner's participation, e.g. a PROMOTABLE joiner is in no quorum.
+  private final long index;
+
+  private JoinResponse(final Status status, final RaftError error, final long index) {
     super(status, error);
+    this.index = index;
   }
 
   public static Builder builder() {
     return new Builder();
   }
 
+  public long index() {
+    return index;
+  }
+
   public static final class Builder extends AbstractRaftResponse.Builder<Builder, JoinResponse> {
+    private long index;
+
     private Builder() {}
+
+    public Builder withIndex(final long index) {
+      this.index = index;
+      return this;
+    }
 
     @Override
     public JoinResponse build() {
       validate();
-      return new JoinResponse(status, error);
+      return new JoinResponse(status, error, index);
     }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/InactiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/InactiveRole.java
@@ -68,10 +68,16 @@ public class InactiveRole extends AbstractRole {
     logRequest(request);
     updateTermAndLeader(request.term(), request.leader());
 
+    // Store the term that identifies the configuration, not the term it was disseminated under, so
+    // that Configuration#term() means the same thing here as on the member that appended the entry.
+    // A leader that predates the configurationTerm field sends 0; fall back to its current term,
+    // which is the ambiguous value this member would have stored before.
+    final var configurationTerm =
+        request.configurationTerm() > 0 ? request.configurationTerm() : request.term();
     final Configuration configuration =
         new Configuration(
             request.index(),
-            request.term(),
+            configurationTerm,
             request.timestamp(),
             request.newMembers(),
             request.oldMembers() != null ? request.oldMembers() : List.of());

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -308,7 +308,13 @@ final class LeaderAppender {
     final var leader = raft.getLeader();
     final var configuration = raft.getCluster().getConfiguration();
     return ConfigureRequest.builder()
+        // The leader's current term, which the receiver uses to update its own term and leader.
         .withTerm(raft.getTerm())
+        // The term that identifies the configuration, which is a different thing: it belongs to the
+        // configuration entry, not to whoever disseminates it. Sending only the leader's term is
+        // what made a member label the same configuration differently depending on whether it
+        // appended the entry or learned it from here.
+        .withConfigurationTerm(raft.getCluster().getConfigurationTerm())
         .withLeader(leader.memberId())
         .withIndex(configuration.index())
         .withTime(configuration.time())

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -221,13 +221,31 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     // the leader, fail the request to ensure servers can't reconfigure an old configuration.
     final var configuration = raft.getCluster().getConfiguration();
     final var configurationTerm = raft.getCluster().getConfigurationTerm();
-    if (request.index() > 0 && request.index() < configuration.index()
-        || request.term() != configurationTerm) {
+    // Report which half is stale. Both mean "you are not amending the configuration I have", but
+    // they need different reactions: a stale index means the requester has to be configured up to
+    // the current one first, while a matching index with a different term means the two disagree
+    // about which configuration sits at that index, which no amount of retrying resolves on its
+    // own.
+    if (request.index() > 0 && request.index() < configuration.index()) {
       return CompletableFuture.completedFuture(
           logResponse(
               ReconfigureResponse.builder()
                   .withStatus(RaftResponse.Status.ERROR)
-                  .withError(RaftError.Type.CONFIGURATION_ERROR, "Stale configuration")
+                  .withError(
+                      RaftError.Type.CONFIGURATION_ERROR,
+                      "Stale configuration index %d, expected at least %d"
+                          .formatted(request.index(), configuration.index()))
+                  .build()));
+    }
+    if (request.term() != configurationTerm) {
+      return CompletableFuture.completedFuture(
+          logResponse(
+              ReconfigureResponse.builder()
+                  .withStatus(RaftResponse.Status.ERROR)
+                  .withError(
+                      RaftError.Type.CONFIGURATION_ERROR,
+                      "Stale configuration term %d at index %d, expected %d"
+                          .formatted(request.term(), request.index(), configurationTerm))
                   .build()));
     }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -199,8 +199,13 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
        joining member receives an error, it may shut down the Raft partition and restart. In such
        cases, the reconfiguration request cannot complete because the joining member might already
        be part of the quorum and must be active to commit the configuration change.
+
+       There is no future to return when the configuration change was not requested from this
+       leader role: a leader that recovered a joint configuration resumes its exit from a task
+       queued in start(), and until that task runs there is nothing to hook onto. Reject the
+       request as retriable instead of returning null.
       */
-      if (isDuplicateReconfigureRequest(request)) {
+      if (isDuplicateReconfigureRequest(request) && ongoingReconfigurationRequestFuture != null) {
         return ongoingReconfigurationRequestFuture;
       }
       return CompletableFuture.completedFuture(

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -403,7 +403,11 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
         && !configuring()
         && !jointConsensus()) {
       return CompletableFuture.completedFuture(
-          logResponse(JoinResponse.builder().withStatus(Status.OK).build()));
+          logResponse(
+              JoinResponse.builder()
+                  .withStatus(Status.OK)
+                  .withIndex(currentConfiguration.index())
+                  .build()));
     }
 
     return onReconfigure(
@@ -427,7 +431,10 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
                     .build();
               }
               if (reconfigureResponse.status() == Status.OK) {
-                return JoinResponse.builder().withStatus(Status.OK).build();
+                return JoinResponse.builder()
+                    .withStatus(Status.OK)
+                    .withIndex(reconfigureResponse.index())
+                    .build();
               } else {
                 return JoinResponse.builder()
                     .withStatus(Status.ERROR)

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -117,8 +117,9 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     // Reset state for the leader.
     takeLeadership();
 
-    // Append initial entries to the log, including an initial no-op entry and the server's
-    // configuration.
+    // Append an initial no-op entry to the log, so that the leader can commit its log prefix.
+    // Note this does not append a configuration entry: the current configuration keeps the term of
+    // whichever entry introduced it, across any number of elections.
     appendInitialEntries();
     commitInitialEntriesFuture = commitInitialEntries();
     lastZbEntry = findLastZeebeEntry();
@@ -214,8 +215,9 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     // If the configuration request index is less than the last known configuration index for
     // the leader, fail the request to ensure servers can't reconfigure an old configuration.
     final var configuration = raft.getCluster().getConfiguration();
+    final var configurationTerm = raft.getCluster().getConfigurationTerm();
     if (request.index() > 0 && request.index() < configuration.index()
-        || request.term() != configuration.term()) {
+        || request.term() != configurationTerm) {
       return CompletableFuture.completedFuture(
           logResponse(
               ReconfigureResponse.builder()
@@ -292,7 +294,10 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     return onReconfigure(
             ReconfigureRequest.builder()
                 .withIndex(currentConfiguration.index())
-                .withTerm(currentConfiguration.term())
+                // The same term the validation in onReconfigure expects, see
+                // RaftClusterContext#getConfigurationTerm: this request is built from the leader's
+                // own configuration, so it must never be rejected as stale.
+                .withTerm(raft.getCluster().getConfigurationTerm())
                 .withMembers(currentConfiguration.newMembers())
                 // Override local member with the new type.
                 .withMember(request.joiningMember())
@@ -329,7 +334,8 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     return onReconfigure(
             ReconfigureRequest.builder()
                 .withIndex(currentConfiguration.index())
-                .withTerm(currentConfiguration.term())
+                // See onJoin: the leader's own request must not be rejected as stale.
+                .withTerm(raft.getCluster().getConfigurationTerm())
                 .withMembers(updatedMembers)
                 .from(raft.getCluster().getLocalMember().memberId().id())
                 .build())

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -259,6 +259,70 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
                   .build()));
     }
 
+    // Gate promotions of existing members to ACTIVE on the member being caught up: it joins the
+    // commit quorum as soon as the joint configuration is appended, so a promoted member lagging
+    // far behind would stall commits until it caught up. The gate bounds that stall window with
+    // the byte-exact replication lag rather than an entry count: the stall is bytes divided by
+    // replication bandwidth (entries range from tens of bytes to full batches, and entry counts
+    // are blind to a pending snapshot install, which the byte lag includes - a member
+    // mid-install is rejected by construction). Only in-configuration non-ACTIVE -> ACTIVE type
+    // changes are gated; members that are not part of the current configuration at all -
+    // brand-new one-shot ACTIVE joiners, the current production join path - are unaffected.
+    // CONFIGURATION_ERROR makes the requester fail fast and retry the whole promotion (see
+    // DefaultRaftMember#configure), unlike the internally retried NO_LEADER/UNAVAILABLE/
+    // PROTOCOL_ERROR responses.
+    for (final var updatedMember : updatedMembers) {
+      if (updatedMember.getType() != RaftMember.Type.ACTIVE) {
+        continue;
+      }
+      final var currentMember =
+          configuration.newMembers().stream()
+              .filter(member -> member.memberId().equals(updatedMember.memberId()))
+              .findAny();
+      if (currentMember.isEmpty() || currentMember.get().getType() == RaftMember.Type.ACTIVE) {
+        continue;
+      }
+      final var memberContext = raft.getCluster().getMemberContext(updatedMember.memberId());
+      // Requiring a positive match index closes an optimism window right after a leadership
+      // change: resetState zeroes the replication lag and opens the replication reader at the
+      // end of the log, so a far-behind member briefly reads as lag 0 until its first probe
+      // response repositions the reader and recalculates the lag from its actual position
+      // (RaftMemberContext#reset). The match index is also per-leadership and only ever set by a
+      // real acknowledgement, so a rejection here has already made the lag exact for the retry.
+      //
+      // A member that acknowledged everything committed is caught up regardless of its byte lag:
+      // what is left to ship is the leader's uncommitted tail, which flow control keeps small. The
+      // byte lag alone would not do here, because for a PASSIVE member it counts that whole
+      // uncommitted tail - the leader replicates to it from a committed reader, whose
+      // bytesUntilEnd() measures to the end of the journal - so a fully caught-up PASSIVE member
+      // could never work its lag off and its promotion would be rejected forever.
+      final var caughtUp =
+          memberContext != null
+              && memberContext.getMatchIndex() > 0
+              && (memberContext.getMatchIndex() >= raft.getCommitIndex()
+                  || memberContext.getReplicationLagBytes() <= raft.getPromotionLagThreshold());
+      if (!caughtUp) {
+        return CompletableFuture.completedFuture(
+            logResponse(
+                ReconfigureResponse.builder()
+                    .withStatus(RaftResponse.Status.ERROR)
+                    .withError(
+                        Type.CONFIGURATION_ERROR,
+                        "Cannot promote %s to ACTIVE because it is not caught up (match index %s, commit index %d, replication lag %s bytes, threshold %d bytes)"
+                            .formatted(
+                                updatedMember.memberId(),
+                                memberContext == null
+                                    ? "unknown"
+                                    : String.valueOf(memberContext.getMatchIndex()),
+                                raft.getCommitIndex(),
+                                memberContext == null
+                                    ? "unknown"
+                                    : String.valueOf(memberContext.getReplicationLagBytes()),
+                                raft.getPromotionLagThreshold()))
+                    .build()));
+      }
+    }
+
     ongoingReconfigurationRequestFuture = new CompletableFuture<>();
     configure(updatedMembers, currentMembers)
         .whenComplete(
@@ -291,6 +355,34 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
   public CompletableFuture<JoinResponse> onJoin(final JoinRequest request) {
     raft.checkThread();
     final var currentConfiguration = raft.getCluster().getConfiguration();
+
+    // Joining must never demote a member that is already part of the configuration: for example,
+    // a crash-recovery retry of join(PROMOTABLE) must not downgrade a member that was promoted to
+    // ACTIVE in the meantime. Strictly greater is deliberate: an equal-type duplicate must keep
+    // falling through to onReconfigure's duplicate handling, which returns the ongoing
+    // reconfiguration future and completes the join only when the configuration commits -
+    // acknowledging it here would weaken the join's completion semantics while the member's own
+    // first join is still an in-flight joint configuration.
+    //
+    // Only a stable, committed configuration may be acknowledged from here: configurations take
+    // effect as soon as they are appended, so this view also reflects entries a later leader can
+    // still truncate, and this response - unlike a rejection - is final for the joiner. While a
+    // configuration change is in flight, or while this leader has not committed its initial entry
+    // yet, fall through to onReconfigure, which returns the ongoing reconfiguration future for a
+    // duplicate and otherwise rejects with a retriable CONFIGURATION_ERROR.
+    final var existingMember =
+        currentConfiguration.newMembers().stream()
+            .filter(member -> member.memberId().equals(request.joiningMember().memberId()))
+            .findAny();
+    if (existingMember.isPresent()
+        && existingMember.get().getType().ordinal() > request.joiningMember().getType().ordinal()
+        && !initializing()
+        && !configuring()
+        && !jointConsensus()) {
+      return CompletableFuture.completedFuture(
+          logResponse(JoinResponse.builder().withStatus(Status.OK).build()));
+    }
+
     return onReconfigure(
             ReconfigureRequest.builder()
                 .withIndex(currentConfiguration.index())

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -473,6 +473,20 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
 
   private void leaveJointConsensus(
       final Collection<RaftMember> updatedMembers, final Configuration configuration) {
+    if (!isRunning() || !raft.isRunning()) {
+      // This runs deferred - from the completion of the joint configuration's commit or from a
+      // task scheduled in start() - so the role may have stopped or the server may have shut down
+      // in the meantime. Do not append as an ex-leader; the next elected leader resumes the exit
+      // from joint consensus (see start()). Both checks are needed: stepping down stops the role
+      // but a closing server does not stop it before closing the log.
+      ongoingReconfigurationRequestFuture.complete(
+          logResponse(
+              ReconfigureResponse.builder()
+                  .withStatus(Status.ERROR)
+                  .withError(Type.NO_LEADER, "Leader stopped before leaving joint consensus")
+                  .build()));
+      return;
+    }
     configure(updatedMembers, List.of())
         .whenComplete(
             (leftJointConsensusIndex, leftJointConsensusError) -> {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -243,6 +243,59 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
                   .build()));
     }
 
+    // Gate promotions of existing members to ACTIVE on the member being caught up: it joins the
+    // commit quorum as soon as the joint configuration is appended, so a promoted member lagging
+    // far behind would stall commits until it caught up. The gate bounds that stall window with
+    // the byte-exact replication lag rather than an entry count: the stall is bytes divided by
+    // replication bandwidth (entries range from tens of bytes to full batches, and entry counts
+    // are blind to a pending snapshot install, which the byte lag includes - a member
+    // mid-install is rejected by construction). Only in-configuration non-ACTIVE -> ACTIVE type
+    // changes are gated; members that are not part of the current configuration at all -
+    // brand-new one-shot ACTIVE joiners, the current production join path - are unaffected.
+    // CONFIGURATION_ERROR makes the requester fail fast and retry the whole promotion (see
+    // DefaultRaftMember#configure), unlike the internally retried NO_LEADER/UNAVAILABLE/
+    // PROTOCOL_ERROR responses.
+    for (final var updatedMember : updatedMembers) {
+      if (updatedMember.getType() != RaftMember.Type.ACTIVE) {
+        continue;
+      }
+      final var currentMember =
+          configuration.newMembers().stream()
+              .filter(member -> member.memberId().equals(updatedMember.memberId()))
+              .findAny();
+      if (currentMember.isEmpty() || currentMember.get().getType() == RaftMember.Type.ACTIVE) {
+        continue;
+      }
+      final var memberContext = raft.getCluster().getMemberContext(updatedMember.memberId());
+      // Requiring a positive match index closes an optimism window right after a leadership
+      // change: resetState zeroes the replication lag and opens the replication reader at the
+      // end of the log, so a far-behind member briefly reads as lag 0 until its first probe
+      // response repositions the reader and recalculates the lag from its actual position
+      // (RaftMemberContext#reset). The match index is also per-leadership and only ever set by a
+      // real acknowledgement, so a rejection here has already made the lag exact for the retry.
+      if (memberContext == null
+          || memberContext.getMatchIndex() <= 0
+          || memberContext.getReplicationLagBytes() > raft.getPromotionLagThreshold()) {
+        return CompletableFuture.completedFuture(
+            logResponse(
+                ReconfigureResponse.builder()
+                    .withStatus(RaftResponse.Status.ERROR)
+                    .withError(
+                        Type.CONFIGURATION_ERROR,
+                        "Cannot promote %s to ACTIVE because it is not caught up (match index %s, replication lag %s bytes, threshold %d bytes)"
+                            .formatted(
+                                updatedMember.memberId(),
+                                memberContext == null
+                                    ? "unknown"
+                                    : String.valueOf(memberContext.getMatchIndex()),
+                                memberContext == null
+                                    ? "unknown"
+                                    : String.valueOf(memberContext.getReplicationLagBytes()),
+                                raft.getPromotionLagThreshold()))
+                    .build()));
+      }
+    }
+
     ongoingReconfigurationRequestFuture = new CompletableFuture<>();
     configure(updatedMembers, currentMembers)
         .whenComplete(
@@ -275,6 +328,24 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
   public CompletableFuture<JoinResponse> onJoin(final JoinRequest request) {
     raft.checkThread();
     final var currentConfiguration = raft.getCluster().getConfiguration();
+
+    // Joining must never demote a member that is already part of the configuration: for example,
+    // a crash-recovery retry of join(PROMOTABLE) must not downgrade a member that was promoted to
+    // ACTIVE in the meantime. Strictly greater is deliberate: an equal-type duplicate must keep
+    // falling through to onReconfigure's duplicate handling, which returns the ongoing
+    // reconfiguration future and completes the join only when the configuration commits -
+    // acknowledging it here would weaken the join's completion semantics while the member's own
+    // first join is still an in-flight joint configuration.
+    final var existingMember =
+        currentConfiguration.newMembers().stream()
+            .filter(member -> member.memberId().equals(request.joiningMember().memberId()))
+            .findAny();
+    if (existingMember.isPresent()
+        && existingMember.get().getType().ordinal() > request.joiningMember().getType().ordinal()) {
+      return CompletableFuture.completedFuture(
+          logResponse(JoinResponse.builder().withStatus(Status.OK).build()));
+    }
+
     return onReconfigure(
             ReconfigureRequest.builder()
                 .withIndex(currentConfiguration.index())

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -432,6 +432,20 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
 
   private void leaveJointConsensus(
       final Collection<RaftMember> updatedMembers, final Configuration configuration) {
+    if (!isRunning() || !raft.isRunning()) {
+      // This runs deferred - from the completion of the joint configuration's commit or from a
+      // task scheduled in start() - so the role may have stopped or the server may have shut down
+      // in the meantime. Do not append as an ex-leader; the next elected leader resumes the exit
+      // from joint consensus (see start()). Both checks are needed: stepping down stops the role
+      // but a closing server does not stop it before closing the log.
+      ongoingReconfigurationRequestFuture.complete(
+          logResponse(
+              ReconfigureResponse.builder()
+                  .withStatus(Status.ERROR)
+                  .withError(Type.NO_LEADER, "Leader stopped before leaving joint consensus")
+                  .build()));
+      return;
+    }
     configure(updatedMembers, List.of())
         .whenComplete(
             (leftJointConsensusIndex, leftJointConsensusError) -> {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -893,9 +893,17 @@ public class PassiveRole extends InactiveRole {
           return;
         }
 
-        // If the last log index meets the commitIndex, break the append loop to avoid appending
-        // uncommitted entries.
-        if (!role().active() && index == commitIndex) {
+        // A PASSIVE member is a committed-only replica by design - the leader ships entries to it
+        // through a committed reader (see RaftMemberContext#newReader) - so it stops appending
+        // when a batch straddles the request's commit index, to avoid persisting uncommitted
+        // entries. A PROMOTABLE member, by contrast, must accept the uncommitted tail that the
+        // leader ships via an uncommitted reader, so it can catch up to the leader's last index
+        // for promotion. Note that this break only fires for batches straddling the commit index:
+        // batches lying entirely beyond it are appended in full by every role, and a dropped
+        // straddle-tail is recovered by the leader's reject/rewind handling - so for PROMOTABLE
+        // this saves the extra probe/rewind round trips at each commit boundary during catch-up
+        // rather than gating it.
+        if (role() == RaftServer.Role.PASSIVE && index == commitIndex) {
           break;
         }
       }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -909,8 +909,22 @@ public class PassiveRole extends InactiveRole {
       }
     }
 
-    // Set the first commit index.
-    raft.setFirstCommitIndex(request.commitIndex(), lastLogIndex);
+    // Set the first commit index. Its second argument is the index up to which the leader and this
+    // node agree on persisted data: request.prevLogIndex() is what the leader vouches for holding
+    // itself, extended by the entries appended above.
+    //
+    // For a PASSIVE member that agreement is unknowable from the request: the leader replicates to
+    // it through a committed reader (see RaftMemberContext#newReader), so prevLogIndex is capped at
+    // the leader's commit index and understates the leader's log. Right after an election that
+    // commit index lags, so an ex-leader demoted to PASSIVE - whose own persisted commit index is
+    // higher - tripped the data-loss check spuriously. Pass the local log end instead, which by
+    // construction never lies below the persisted commit index (setCommitIndex clamps to the log
+    // end, and truncation refuses to go below the commit index) and therefore never trips. The
+    // check stays armed for every other role, where the leader's prevLogIndex is exact because it
+    // replicates from an uncommitted reader.
+    final long agreedPersistedIndex =
+        role() == RaftServer.Role.PASSIVE ? raft.getLog().getLastIndex() : lastLogIndex;
+    raft.setFirstCommitIndex(request.commitIndex(), agreedPersistedIndex);
 
     try {
       //     Make sure all entries are flushed before ack to ensure we have persisted what we

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -909,8 +909,15 @@ public class PassiveRole extends InactiveRole {
       }
     }
 
-    // Set the first commit index.
-    raft.setFirstCommitIndex(request.commitIndex(), lastLogIndex);
+    // Set the first commit index. The data-loss check compares against the node's actual log end
+    // rather than the request-relative lastLogIndex: for an empty heartbeat, lastLogIndex is just
+    // the request's prevLogIndex, which can lie before this node's own commit index even though
+    // its log is fully intact - e.g. the position of the leader's committed reader for a PASSIVE
+    // member is the leader's commit index, which lags behind right after an election. An
+    // ex-leader that is demoted to PASSIVE and receives its first-ever append then tripped the
+    // check spuriously. Real data loss still trips it: a truncated log ends before the persisted
+    // commit index, and lastLogIndex never exceeds the log end.
+    raft.setFirstCommitIndex(request.commitIndex(), raft.getLog().getLastIndex());
 
     try {
       //     Make sure all entries are flushed before ack to ensure we have persisted what we

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -468,7 +468,7 @@ public final class ControllableRaftContexts {
 
   public void restart(final MemberId memberId) {
     final var raftcontext = raftServers.get(memberId);
-    raftcontext.getThreadContext().execute(raftcontext::close);
+    raftcontext.getThreadContext().execute(() -> closeRaftContext(raftcontext));
     runUntilDone(memberId);
     deterministicExecutors.remove(memberId).close();
     snapshotStores.get(memberId).close();
@@ -500,7 +500,7 @@ public final class ControllableRaftContexts {
   public CompletableFuture<Void> join(
       final MemberId memberId, final Collection<MemberId> otherMembers) {
     final var raftcontext = raftServers.get(memberId);
-    raftcontext.getThreadContext().execute(raftcontext::close);
+    raftcontext.getThreadContext().execute(() -> closeRaftContext(raftcontext));
     runUntilDone(memberId);
 
     deterministicExecutors.remove(memberId).close();
@@ -512,6 +512,18 @@ public final class ControllableRaftContexts {
     return future;
   }
 
+  /**
+   * Mirrors {@link io.atomix.raft.impl.DefaultRaftServer#shutdown()}: transition to INACTIVE before
+   * closing so that the current role - in particular a leader's appender - is stopped first. Tasks
+   * already queued behind the close (append callbacks, reconfiguration completions) then no-op on
+   * the stopped role instead of touching the closed, unmapped journal, which crashed with "journal
+   * not open" or a SIGSEGV in the memory-mapped segment.
+   */
+  private static void closeRaftContext(final RaftContext raftContext) {
+    raftContext.transition(RaftServer.Role.INACTIVE);
+    raftContext.close();
+  }
+
   // This is a different from other operations, as it restarts the node and force operations on
   // other
   // nodes to wait until this node is ready. This is required because we can only tolerate data loss
@@ -520,7 +532,7 @@ public final class ControllableRaftContexts {
     LOG.info("Shutting down member {}", memberId.id());
     {
       final var raftContext = raftServers.get(memberId);
-      raftContext.getThreadContext().execute(raftContext::close);
+      raftContext.getThreadContext().execute(() -> closeRaftContext(raftContext));
       runUntilDone(memberId);
     }
     deterministicExecutors.remove(memberId).close();

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -26,7 +26,9 @@ import static org.mockito.Mockito.withSettings;
 
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.MemberId;
+import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.impl.RaftContext;
+import io.atomix.raft.impl.ReconfigurationHelper;
 import io.atomix.raft.partition.RaftElectionConfig;
 import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.protocol.ControllableRaftServerProtocol;
@@ -91,6 +93,10 @@ public final class ControllableRaftContexts {
   private final Map<MemberId, DeterministicSingleThreadContext> deterministicExecutors =
       new HashMap<>();
   private final Map<MemberId, CompletableFuture<?>> futuresToFailOnClose = new HashMap<>();
+  // Pending promote/demote/leave futures per member. Unlike futuresToFailOnClose, these carry no
+  // membership bookkeeping; they are only failed when the member's context is torn down, because
+  // their internal retries run on the closed context's scheduler and would never complete.
+  private final Map<MemberId, CompletableFuture<?>> pendingMemberOperations = new HashMap<>();
 
   private Path directory;
   private Random random;
@@ -181,6 +187,7 @@ public final class ControllableRaftContexts {
     leadersAtTerms.clear();
     votesAtTerms.clear();
     futuresToFailOnClose.clear();
+    pendingMemberOperations.clear();
     bootstrappedMembers.clear();
     directory = null;
     MicrometerUtil.close(meterRegistry);
@@ -484,6 +491,7 @@ public final class ControllableRaftContexts {
         pendingJoin.completeExceptionally(new RuntimeException("Shutting down"));
       }
     }
+    failPendingMemberOperation(memberId);
 
     final var newContext = createRaftContextForMember(random, Integer.parseInt(memberId.id()));
     // Only members that are part of the cluster restart via bootstrap. A member whose join did
@@ -499,6 +507,13 @@ public final class ControllableRaftContexts {
 
   public CompletableFuture<Void> join(
       final MemberId memberId, final Collection<MemberId> otherMembers) {
+    return join(memberId, RaftMember.Type.ACTIVE, otherMembers);
+  }
+
+  public CompletableFuture<Void> join(
+      final MemberId memberId,
+      final RaftMember.Type type,
+      final Collection<MemberId> otherMembers) {
     final var raftcontext = raftServers.get(memberId);
     raftcontext.getThreadContext().execute(() -> closeRaftContext(raftcontext));
     runUntilDone(memberId);
@@ -506,9 +521,37 @@ public final class ControllableRaftContexts {
     deterministicExecutors.remove(memberId).close();
     snapshotStores.get(memberId).close();
     MicrometerUtil.close(meterRegistries.get(memberId));
+    failPendingMemberOperation(memberId);
     createRaftContextForMember(random, Integer.parseInt(memberId.id()));
-    final var future = raftServers.get(memberId).getCluster().join(otherMembers);
+    final var future = raftServers.get(memberId).getCluster().join(type, otherMembers);
     futuresToFailOnClose.put(memberId, future);
+    return future;
+  }
+
+  // Promote, demote and leave are deliberately not part of the random RaftOperation streams:
+  // randomly changing arbitrary members' types would make the properties' goals meaningless.
+  // Properties drive them explicitly and retry on failure, like they do with join.
+
+  /** Requests the promotion of the given member's local member to ACTIVE. */
+  public CompletableFuture<Void> promote(final MemberId memberId) {
+    final var future =
+        raftServers.get(memberId).getCluster().getLocalMember().promote(RaftMember.Type.ACTIVE);
+    pendingMemberOperations.put(memberId, future);
+    return future;
+  }
+
+  /** Requests the demotion of the given member's local member to PASSIVE. */
+  public CompletableFuture<Void> demote(final MemberId memberId) {
+    final var future =
+        raftServers.get(memberId).getCluster().getLocalMember().demote(RaftMember.Type.PASSIVE);
+    pendingMemberOperations.put(memberId, future);
+    return future;
+  }
+
+  /** Requests that the given member leaves the cluster. */
+  public CompletableFuture<Void> leave(final MemberId memberId) {
+    final var future = new ReconfigurationHelper(raftServers.get(memberId)).leave();
+    pendingMemberOperations.put(memberId, future);
     return future;
   }
 
@@ -522,6 +565,16 @@ public final class ControllableRaftContexts {
   private static void closeRaftContext(final RaftContext raftContext) {
     raftContext.transition(RaftServer.Role.INACTIVE);
     raftContext.close();
+  }
+
+  private void failPendingMemberOperation(final MemberId memberId) {
+    final var pendingOperation = pendingMemberOperations.remove(memberId);
+    if (pendingOperation != null && !pendingOperation.isDone()) {
+      // The operation's internal retries are driven by timers on the closed context's scheduler
+      // and would never complete; fail the future so that properties retry the operation on the
+      // new context.
+      pendingOperation.completeExceptionally(new RuntimeException("Shutting down"));
+    }
   }
 
   // This is a different from other operations, as it restarts the node and force operations on
@@ -608,21 +661,20 @@ public final class ControllableRaftContexts {
 
   // Verify that committed entries in all logs are equal
   public void assertAllLogsEqual() {
+    assertAllLogsEqual(raftServers.keySet());
+  }
+
+  // Verify that committed entries in the given members' logs are equal
+  public void assertAllLogsEqual(final Collection<MemberId> members) {
+    final var contexts = members.stream().map(raftServers::get).toList();
     final var readers =
-        raftServers.values().stream()
+        contexts.stream()
             .collect(Collectors.toMap(Function.identity(), s -> s.getLog().openCommittedReader()));
     long index =
-        raftServers.values().stream()
-                .map(s -> s.getLog().getFirstIndex())
-                .min(Long::compareTo)
-                .orElse(1L)
-            - 1;
+        contexts.stream().map(s -> s.getLog().getFirstIndex()).min(Long::compareTo).orElse(1L) - 1;
 
     final long commitIndexOnLeader =
-        raftServers.values().stream()
-            .map(RaftContext::getCommitIndex)
-            .max(Long::compareTo)
-            .orElseThrow();
+        contexts.stream().map(RaftContext::getCommitIndex).max(Long::compareTo).orElseThrow();
 
     while (index < commitIndexOnLeader) {
       final var nextIndex = index + 1;
@@ -800,7 +852,16 @@ public final class ControllableRaftContexts {
   }
 
   public boolean allMembersAreReady() {
-    return raftServers.values().stream()
+    return allMembersAreReady(raftServers.keySet());
+  }
+
+  /**
+   * Like {@link #allMembersAreReady()}, but only for the given members. Useful when a member left
+   * the cluster and is thus never READY again.
+   */
+  public boolean allMembersAreReady(final Collection<MemberId> members) {
+    return members.stream()
+        .map(raftServers::get)
         .map(RaftContext::getState)
         .filter(state -> !READY.equals(state))
         .findAny()

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -26,7 +26,9 @@ import static org.mockito.Mockito.withSettings;
 
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.MemberId;
+import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.impl.RaftContext;
+import io.atomix.raft.impl.ReconfigurationHelper;
 import io.atomix.raft.partition.RaftElectionConfig;
 import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.protocol.ControllableRaftServerProtocol;
@@ -91,6 +93,10 @@ public final class ControllableRaftContexts {
   private final Map<MemberId, DeterministicSingleThreadContext> deterministicExecutors =
       new HashMap<>();
   private final Map<MemberId, CompletableFuture<?>> futuresToFailOnClose = new HashMap<>();
+  // Pending promote/demote/leave futures per member. Unlike futuresToFailOnClose, these carry no
+  // membership bookkeeping; they are only failed when the member's context is torn down, because
+  // their internal retries run on the closed context's scheduler and would never complete.
+  private final Map<MemberId, CompletableFuture<?>> pendingMemberOperations = new HashMap<>();
 
   private Path directory;
   private Random random;
@@ -180,6 +186,7 @@ public final class ControllableRaftContexts {
     leadersAtTerms.clear();
     votesAtTerms.clear();
     futuresToFailOnClose.clear();
+    pendingMemberOperations.clear();
     bootstrappedMembers.clear();
     directory = null;
     MicrometerUtil.close(meterRegistry);
@@ -467,7 +474,7 @@ public final class ControllableRaftContexts {
 
   public void restart(final MemberId memberId) {
     final var raftcontext = raftServers.get(memberId);
-    raftcontext.getThreadContext().execute(raftcontext::close);
+    raftcontext.getThreadContext().execute(() -> closeRaftContext(raftcontext));
     runUntilDone(memberId);
     deterministicExecutors.remove(memberId).close();
     snapshotStores.get(memberId).close();
@@ -483,6 +490,7 @@ public final class ControllableRaftContexts {
         pendingJoin.completeExceptionally(new RuntimeException("Shutting down"));
       }
     }
+    failPendingMemberOperation(memberId);
 
     final var newContext = createRaftContextForMember(random, Integer.parseInt(memberId.id()));
     // Only members that are part of the cluster restart via bootstrap. A member whose join did
@@ -498,17 +506,74 @@ public final class ControllableRaftContexts {
 
   public CompletableFuture<Void> join(
       final MemberId memberId, final Collection<MemberId> otherMembers) {
+    return join(memberId, RaftMember.Type.ACTIVE, otherMembers);
+  }
+
+  public CompletableFuture<Void> join(
+      final MemberId memberId,
+      final RaftMember.Type type,
+      final Collection<MemberId> otherMembers) {
     final var raftcontext = raftServers.get(memberId);
-    raftcontext.getThreadContext().execute(raftcontext::close);
+    raftcontext.getThreadContext().execute(() -> closeRaftContext(raftcontext));
     runUntilDone(memberId);
 
     deterministicExecutors.remove(memberId).close();
     snapshotStores.get(memberId).close();
     MicrometerUtil.close(meterRegistries.get(memberId));
+    failPendingMemberOperation(memberId);
     createRaftContextForMember(random, Integer.parseInt(memberId.id()));
-    final var future = raftServers.get(memberId).getCluster().join(otherMembers);
+    final var future = raftServers.get(memberId).getCluster().join(type, otherMembers);
     futuresToFailOnClose.put(memberId, future);
     return future;
+  }
+
+  // Promote, demote and leave are deliberately not part of the random RaftOperation streams:
+  // randomly changing arbitrary members' types would make the properties' goals meaningless.
+  // Properties drive them explicitly and retry on failure, like they do with join.
+
+  /** Requests the promotion of the given member's local member to ACTIVE. */
+  public CompletableFuture<Void> promote(final MemberId memberId) {
+    final var future =
+        raftServers.get(memberId).getCluster().getLocalMember().promote(RaftMember.Type.ACTIVE);
+    pendingMemberOperations.put(memberId, future);
+    return future;
+  }
+
+  /** Requests the demotion of the given member's local member to PASSIVE. */
+  public CompletableFuture<Void> demote(final MemberId memberId) {
+    final var future =
+        raftServers.get(memberId).getCluster().getLocalMember().demote(RaftMember.Type.PASSIVE);
+    pendingMemberOperations.put(memberId, future);
+    return future;
+  }
+
+  /** Requests that the given member leaves the cluster. */
+  public CompletableFuture<Void> leave(final MemberId memberId) {
+    final var future = new ReconfigurationHelper(raftServers.get(memberId)).leave();
+    pendingMemberOperations.put(memberId, future);
+    return future;
+  }
+
+  /**
+   * Mirrors {@link io.atomix.raft.impl.DefaultRaftServer#shutdown()}: transition to INACTIVE before
+   * closing so that the current role - in particular a leader's appender - is stopped first. Tasks
+   * already queued behind the close (append callbacks, reconfiguration completions) then no-op on
+   * the stopped role instead of touching the closed, unmapped journal, which crashed with "journal
+   * not open" or a SIGSEGV in the memory-mapped segment.
+   */
+  private static void closeRaftContext(final RaftContext raftContext) {
+    raftContext.transition(RaftServer.Role.INACTIVE);
+    raftContext.close();
+  }
+
+  private void failPendingMemberOperation(final MemberId memberId) {
+    final var pendingOperation = pendingMemberOperations.remove(memberId);
+    if (pendingOperation != null && !pendingOperation.isDone()) {
+      // The operation's internal retries are driven by timers on the closed context's scheduler
+      // and would never complete; fail the future so that properties retry the operation on the
+      // new context.
+      pendingOperation.completeExceptionally(new RuntimeException("Shutting down"));
+    }
   }
 
   // This is a different from other operations, as it restarts the node and force operations on
@@ -519,7 +584,7 @@ public final class ControllableRaftContexts {
     LOG.info("Shutting down member {}", memberId.id());
     {
       final var raftContext = raftServers.get(memberId);
-      raftContext.getThreadContext().execute(raftContext::close);
+      raftContext.getThreadContext().execute(() -> closeRaftContext(raftContext));
       runUntilDone(memberId);
     }
     deterministicExecutors.remove(memberId).close();
@@ -595,21 +660,20 @@ public final class ControllableRaftContexts {
 
   // Verify that committed entries in all logs are equal
   public void assertAllLogsEqual() {
+    assertAllLogsEqual(raftServers.keySet());
+  }
+
+  // Verify that committed entries in the given members' logs are equal
+  public void assertAllLogsEqual(final Collection<MemberId> members) {
+    final var contexts = members.stream().map(raftServers::get).toList();
     final var readers =
-        raftServers.values().stream()
+        contexts.stream()
             .collect(Collectors.toMap(Function.identity(), s -> s.getLog().openCommittedReader()));
     long index =
-        raftServers.values().stream()
-                .map(s -> s.getLog().getFirstIndex())
-                .min(Long::compareTo)
-                .orElse(1L)
-            - 1;
+        contexts.stream().map(s -> s.getLog().getFirstIndex()).min(Long::compareTo).orElse(1L) - 1;
 
     final long commitIndexOnLeader =
-        raftServers.values().stream()
-            .map(RaftContext::getCommitIndex)
-            .max(Long::compareTo)
-            .orElseThrow();
+        contexts.stream().map(RaftContext::getCommitIndex).max(Long::compareTo).orElseThrow();
 
     while (index < commitIndexOnLeader) {
       final var nextIndex = index + 1;
@@ -787,7 +851,16 @@ public final class ControllableRaftContexts {
   }
 
   public boolean allMembersAreReady() {
-    return raftServers.values().stream()
+    return allMembersAreReady(raftServers.keySet());
+  }
+
+  /**
+   * Like {@link #allMembersAreReady()}, but only for the given members. Useful when a member left
+   * the cluster and is thus never READY again.
+   */
+  public boolean allMembersAreReady(final Collection<MemberId> members) {
+    return members.stream()
+        .map(raftServers::get)
         .map(RaftContext::getState)
         .filter(state -> !READY.equals(state))
         .findAny()

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftOperation.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftOperation.java
@@ -76,6 +76,10 @@ public final class RaftOperation {
     return operations;
   }
 
+  // Reconfiguration operations (join, promote, demote, leave) are deliberately not part of these
+  // random operation lists: randomly reconfiguring arbitrary members would make the properties'
+  // goals meaningless. Properties drive them explicitly and retry on failure, see
+  // RandomizedRaftJoinTest and RandomizedRaftScaleDownTest.
   public static List<RaftOperation> getDefaultRaftOperations() {
     final List<RaftOperation> defaultRaftOperation = new ArrayList<>();
     defaultRaftOperation.add(

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -218,7 +218,7 @@ public class RaftTest extends ConcurrentTestCase {
     final var leader = getLeader(servers).orElseThrow();
     awaitAppendEntries(leader, 1000);
     final RaftServer follower = servers.stream().filter(RaftServer::isFollower).findFirst().get();
-    follower.promote().thenRun(this::resume);
+    follower.anoint().thenRun(this::resume);
     await(15000, 1001);
     assertThat(follower.isLeader()).isTrue();
   }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftJoinTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftJoinTest.java
@@ -137,24 +137,14 @@ public class RandomizedRaftJoinTest {
         raftContexts.join(member1, RaftMember.Type.PROMOTABLE, Set.of(member0, member1));
     CompletableFuture<Void> promoteFuture = null;
 
-    // given - when there are failures such as message loss
+    // given - when there are failures such as message loss, including restarts of the joined
+    // member: the join future only completes once the admitting configuration entry is durably
+    // in this node's own log (see ReconfigurationHelper#awaitLocalDurability), so a restart right
+    // after completion always finds that entry via reloadConfigurationFromLog and never falls
+    // back to treating this node as a fresh, unconfigured one.
     final var memberIter = raftMembers.iterator();
     for (final RaftOperation operation : raftOperations) {
       final MemberId member = memberIter.next();
-      if ("Restart member".equals(operation.toString())
-          && member.equals(member1)
-          && joinFuture.isDone()
-          && !joinFuture.isCompletedExceptionally()) {
-        // Known pre-existing residual, outside this task's scope: a PROMOTABLE join can complete
-        // before the joiner received any log entry or configuration, because the joiner is in no
-        // quorum. If the joiner then restarts, it falls back to the all-ACTIVE initial
-        // configuration at index 0 and reports configuration index 0 in its append responses,
-        // which the leader ignores as "no information" (LeaderAppender#updateConfigurationIndex)
-        // while its own bookkeeping still holds the joiner's pre-restart configuration index - so
-        // the joiner is never re-configured, considers itself ACTIVE, and its local promote()
-        // no-ops forever. Skip restarts of the joined member instead of fighting this here.
-        continue;
-      }
       LOG.info("{} on {}", operation, member);
       operation.run(raftContexts, member);
       // sample the safety invariant on every step: it records the vote of each member at the

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftJoinTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftJoinTest.java
@@ -10,6 +10,8 @@ package io.atomix.raft;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
+import io.atomix.raft.cluster.RaftMember;
+import io.atomix.raft.impl.RaftContext;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -18,6 +20,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.EdgeCasesMode;
@@ -48,13 +51,6 @@ public class RandomizedRaftJoinTest {
     // Initialize the two member IDs for the 2-node cluster
     member0 = MemberId.from("0");
     member1 = MemberId.from("1");
-    // Create ControllableRaftContexts with 2 nodes. Reduce the quorum response timeout to make
-    // the wall-clock gated leader step-down reachable under the deterministic scheduler: a leader
-    // then steps down after minStepDownFailureCount consecutive failures to reach the joining
-    // member, as it does in production when the joiner is unreachable for two election timeouts.
-    raftContexts =
-        new ControllableRaftContexts(
-            2, config -> config.setMaxQuorumResponseTimeout(Duration.ofMillis(1)));
     operationsWithRestarts = RaftOperation.getRaftOperationsWithRestarts();
   }
 
@@ -129,9 +125,143 @@ public class RandomizedRaftJoinTest {
     raftContexts.assertAtMostOneVotePerMemberAndTerm();
   }
 
+  @Property
+  void joinThenPromoteCompletes(
+      @ForAll("raftOperations") final List<RaftOperation> raftOperations,
+      @ForAll("raftMembers") final List<MemberId> raftMembers,
+      @ForAll("seeds") final long seed)
+      throws Exception {
+    setUpRaftNodes(new Random(seed));
+
+    var joinFuture =
+        raftContexts.join(member1, RaftMember.Type.PROMOTABLE, Set.of(member0, member1));
+    CompletableFuture<Void> promoteFuture = null;
+
+    // given - when there are failures such as message loss
+    final var memberIter = raftMembers.iterator();
+    for (final RaftOperation operation : raftOperations) {
+      final MemberId member = memberIter.next();
+      if ("Restart member".equals(operation.toString())
+          && member.equals(member1)
+          && joinFuture.isDone()
+          && !joinFuture.isCompletedExceptionally()) {
+        // Known pre-existing residual, outside this task's scope: a PROMOTABLE join can complete
+        // before the joiner received any log entry or configuration, because the joiner is in no
+        // quorum. If the joiner then restarts, it falls back to the all-ACTIVE initial
+        // configuration at index 0 and reports configuration index 0 in its append responses,
+        // which the leader ignores as "no information" (LeaderAppender#updateConfigurationIndex)
+        // while its own bookkeeping still holds the joiner's pre-restart configuration index - so
+        // the joiner is never re-configured, considers itself ACTIVE, and its local promote()
+        // no-ops forever. Skip restarts of the joined member instead of fighting this here.
+        continue;
+      }
+      LOG.info("{} on {}", operation, member);
+      operation.run(raftContexts, member);
+      // sample the safety invariant on every step: it records the vote of each member at the
+      // term it is currently in, so a vote that is overwritten between two steps is only
+      // observable while it is still recorded
+      raftContexts.assertAtMostOneVotePerMemberAndTerm();
+      if (joinFuture.isCompletedExceptionally()) {
+        // retry join
+        LOG.info("Join failed. Retrying...");
+        joinFuture =
+            raftContexts.join(member1, RaftMember.Type.PROMOTABLE, Set.of(member0, member1));
+      } else if (joinFuture.isDone() && shouldRetryPromote(promoteFuture)) {
+        LOG.info("Promoting member 1...");
+        promoteFuture = raftContexts.promote(member1);
+      }
+    }
+
+    raftContexts.runUntilDone();
+    raftContexts.processAllMessage();
+    raftContexts.tickHeartbeatTimeout();
+
+    // when - no more message loss or restarts
+
+    LOG.info("Stopping failures, waiting for join and promotion to complete");
+
+    int maxStepsToReplicateEntries = 10100;
+    while (!(joinFuture.isDone()
+            && !joinFuture.isCompletedExceptionally()
+            && promoteFuture != null
+            && promoteFuture.isDone()
+            && !promoteFuture.isCompletedExceptionally()
+            && member1IsActiveInLeadersConfiguration()
+            && raftContexts.allMembersAreReady()
+            && raftContexts.hasLeaderAtTheLatestTerm())
+        && maxStepsToReplicateEntries-- > 0) {
+
+      if (joinFuture.isCompletedExceptionally()) {
+        // retry join
+        LOG.info("Join failed. Retrying...");
+        joinFuture =
+            raftContexts.join(member1, RaftMember.Type.PROMOTABLE, Set.of(member0, member1));
+      } else if (joinFuture.isDone() && shouldRetryPromote(promoteFuture)) {
+        LOG.info("Promoting member 1...");
+        promoteFuture = raftContexts.promote(member1);
+      }
+
+      raftContexts.runUntilDone();
+      raftContexts.processAllMessage();
+      raftContexts.tickHeartbeatTimeout();
+    }
+
+    // then
+    assertThat(joinFuture).describedAs("Join of member 1 should be completed").isCompleted();
+    assertThat(promoteFuture)
+        .describedAs("Promotion of member 1 should be completed")
+        .isCompleted();
+    assertThat(raftContexts.hasLeaderAtTheLatestTerm()).describedAs("There is a leader").isTrue();
+    assertThat(member1IsActiveInLeadersConfiguration())
+        .describedAs("Member 1 is ACTIVE in the leader's configuration")
+        .isTrue();
+    raftContexts.assertAllMembersAreReady();
+  }
+
+  /**
+   * The promotion fails fast on CONFIGURATION_ERROR - not caught up yet, another change in
+   * progress, or a stale configuration view - so it is simply re-issued until it completes. A
+   * promotion can also complete trivially without effect: after a restart with an empty log, the
+   * member falls back to the initial all-ACTIVE configuration and already considers itself ACTIVE
+   * until the leader's next configure request corrects it. Such a completed promotion is retried as
+   * long as the leader's configuration does not have member 1 as ACTIVE.
+   */
+  private boolean shouldRetryPromote(final CompletableFuture<Void> promoteFuture) {
+    return promoteFuture == null
+        || promoteFuture.isCompletedExceptionally()
+        || (promoteFuture.isDone() && !member1IsActiveInLeadersConfiguration());
+  }
+
+  private boolean member1IsActiveInLeadersConfiguration() {
+    return raftContexts.getRaftServers().values().stream()
+        .filter(RaftContext::isLeader)
+        .findAny()
+        .map(leader -> leader.getCluster().getConfiguration())
+        .map(
+            configuration ->
+                configuration.newMembers().stream()
+                    .anyMatch(
+                        member ->
+                            member.memberId().equals(member1)
+                                && member.getType() == RaftMember.Type.ACTIVE))
+        .orElse(false);
+  }
+
   private void setUpRaftNodes(final Random random) throws Exception {
     // Create temporary directory for raft data
     raftDataDirectory = Files.createTempDirectory(null);
+
+    // Create ControllableRaftContexts with 2 nodes. Reduce the quorum response timeout to make
+    // the wall-clock gated leader step-down reachable under the deterministic scheduler: a leader
+    // then steps down after minStepDownFailureCount consecutive failures to reach the joining
+    // member, as it does in production when the joiner is unreachable for two election timeouts.
+    //
+    // Per try, not per property: shutdown() runs after every try and closes the harness' meter
+    // registry, so a reused instance would register the next try's contexts into a closed registry
+    // and carry its predecessor's data-loss bookkeeping over into an unrelated cluster.
+    raftContexts =
+        new ControllableRaftContexts(
+            2, config -> config.setMaxQuorumResponseTimeout(Duration.ofMillis(1)));
 
     // Bootstrap only with member 0 (single node cluster initially)
     raftContexts.setup(raftDataDirectory, random, Set.of(0));

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftJoinTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftJoinTest.java
@@ -10,6 +10,8 @@ package io.atomix.raft;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
+import io.atomix.raft.cluster.RaftMember;
+import io.atomix.raft.impl.RaftContext;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -18,6 +20,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.EdgeCasesMode;
@@ -122,6 +125,124 @@ public class RandomizedRaftJoinTest {
     assertThat(joinFuture).describedAs("Join of member 1 should be completed").isCompleted();
     assertThat(raftContexts.hasLeaderAtTheLatestTerm()).describedAs("There is a leader").isTrue();
     raftContexts.assertAllMembersAreReady();
+  }
+
+  @Property
+  void joinThenPromoteCompletes(
+      @ForAll("raftOperations") final List<RaftOperation> raftOperations,
+      @ForAll("raftMembers") final List<MemberId> raftMembers,
+      @ForAll("seeds") final long seed)
+      throws Exception {
+    setUpRaftNodes(new Random(seed));
+
+    var joinFuture =
+        raftContexts.join(member1, RaftMember.Type.PROMOTABLE, Set.of(member0, member1));
+    CompletableFuture<Void> promoteFuture = null;
+
+    // given - when there are failures such as message loss
+    final var memberIter = raftMembers.iterator();
+    for (final RaftOperation operation : raftOperations) {
+      final MemberId member = memberIter.next();
+      if ("Restart member".equals(operation.toString())
+          && member.equals(member1)
+          && joinFuture.isDone()
+          && !joinFuture.isCompletedExceptionally()) {
+        // Known pre-existing residual, outside this task's scope: a PROMOTABLE join can complete
+        // before the joiner received any log entry or configuration, because the joiner is in no
+        // quorum. If the joiner then restarts, it falls back to the all-ACTIVE initial
+        // configuration at index 0 and reports configuration index 0 in its append responses,
+        // which the leader ignores as "no information" (LeaderAppender#updateConfigurationIndex)
+        // while its own bookkeeping still holds the joiner's pre-restart configuration index - so
+        // the joiner is never re-configured, considers itself ACTIVE, and its local promote()
+        // no-ops forever. Skip restarts of the joined member instead of fighting this here.
+        continue;
+      }
+      LOG.info("{} on {}", operation, member);
+      operation.run(raftContexts, member);
+      if (joinFuture.isCompletedExceptionally()) {
+        // retry join
+        LOG.info("Join failed. Retrying...");
+        joinFuture =
+            raftContexts.join(member1, RaftMember.Type.PROMOTABLE, Set.of(member0, member1));
+      } else if (joinFuture.isDone() && shouldRetryPromote(promoteFuture)) {
+        LOG.info("Promoting member 1...");
+        promoteFuture = raftContexts.promote(member1);
+      }
+    }
+
+    raftContexts.runUntilDone();
+    raftContexts.processAllMessage();
+    raftContexts.tickHeartbeatTimeout();
+
+    // when - no more message loss or restarts
+
+    LOG.info("Stopping failures, waiting for join and promotion to complete");
+
+    int maxStepsToReplicateEntries = 10100;
+    while (!(joinFuture.isDone()
+            && !joinFuture.isCompletedExceptionally()
+            && promoteFuture != null
+            && promoteFuture.isDone()
+            && !promoteFuture.isCompletedExceptionally()
+            && member1IsActiveInLeadersConfiguration()
+            && raftContexts.allMembersAreReady()
+            && raftContexts.hasLeaderAtTheLatestTerm())
+        && maxStepsToReplicateEntries-- > 0) {
+
+      if (joinFuture.isCompletedExceptionally()) {
+        // retry join
+        LOG.info("Join failed. Retrying...");
+        joinFuture =
+            raftContexts.join(member1, RaftMember.Type.PROMOTABLE, Set.of(member0, member1));
+      } else if (joinFuture.isDone() && shouldRetryPromote(promoteFuture)) {
+        LOG.info("Promoting member 1...");
+        promoteFuture = raftContexts.promote(member1);
+      }
+
+      raftContexts.runUntilDone();
+      raftContexts.processAllMessage();
+      raftContexts.tickHeartbeatTimeout();
+    }
+
+    // then
+    assertThat(joinFuture).describedAs("Join of member 1 should be completed").isCompleted();
+    assertThat(promoteFuture)
+        .describedAs("Promotion of member 1 should be completed")
+        .isCompleted();
+    assertThat(raftContexts.hasLeaderAtTheLatestTerm()).describedAs("There is a leader").isTrue();
+    assertThat(member1IsActiveInLeadersConfiguration())
+        .describedAs("Member 1 is ACTIVE in the leader's configuration")
+        .isTrue();
+    raftContexts.assertAllMembersAreReady();
+  }
+
+  /**
+   * The promotion fails fast on CONFIGURATION_ERROR - not caught up yet, another change in
+   * progress, or a stale configuration view - so it is simply re-issued until it completes. A
+   * promotion can also complete trivially without effect: after a restart with an empty log, the
+   * member falls back to the initial all-ACTIVE configuration and already considers itself ACTIVE
+   * until the leader's next configure request corrects it. Such a completed promotion is retried as
+   * long as the leader's configuration does not have member 1 as ACTIVE.
+   */
+  private boolean shouldRetryPromote(final CompletableFuture<Void> promoteFuture) {
+    return promoteFuture == null
+        || promoteFuture.isCompletedExceptionally()
+        || (promoteFuture.isDone() && !member1IsActiveInLeadersConfiguration());
+  }
+
+  private boolean member1IsActiveInLeadersConfiguration() {
+    return raftContexts.getRaftServers().values().stream()
+        .filter(RaftContext::isLeader)
+        .findAny()
+        .map(leader -> leader.getCluster().getConfiguration())
+        .map(
+            configuration ->
+                configuration.newMembers().stream()
+                    .anyMatch(
+                        member ->
+                            member.memberId().equals(member1)
+                                && member.getType() == RaftMember.Type.ACTIVE))
+        .orElse(false);
   }
 
   private void setUpRaftNodes(final Random random) throws Exception {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftScaleDownTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftScaleDownTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.cluster.RaftMember;
+import io.atomix.raft.impl.RaftContext;
+import io.camunda.zeebe.util.FileUtil;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.EdgeCasesMode;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.PropertyDefaults;
+import net.jqwik.api.Provide;
+import net.jqwik.api.ShrinkingMode;
+import net.jqwik.api.lifecycle.AfterTry;
+import net.jqwik.api.lifecycle.BeforeProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Randomized test for the two-phase scale down: a member demotes itself to PASSIVE and then leaves,
+ * so that its removal commits without its own participation. Mirrors the structure of {@link
+ * RandomizedRaftJoinTest}, but with three bootstrapped ACTIVE members.
+ */
+@PropertyDefaults(tries = 10, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
+public class RandomizedRaftScaleDownTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RandomizedRaftScaleDownTest.class);
+  private static final int OPERATION_SIZE = 1000;
+
+  private ControllableRaftContexts raftContexts;
+  private Path raftDataDirectory;
+  private MemberId member0;
+  private MemberId member1;
+  private MemberId member2;
+  private List<RaftOperation> operationsWithRestarts;
+
+  @BeforeProperty
+  public void initMembers() {
+    member0 = MemberId.from("0");
+    member1 = MemberId.from("1");
+    member2 = MemberId.from("2");
+    operationsWithRestarts = RaftOperation.getRaftOperationsWithRestarts();
+  }
+
+  @AfterTry
+  public void shutDownRaftNodes() throws IOException {
+    if (raftContexts != null) {
+      raftContexts.shutdown();
+    }
+    if (raftDataDirectory != null) {
+      FileUtil.deleteFolder(raftDataDirectory);
+      raftDataDirectory = null;
+    }
+  }
+
+  @Property
+  void scaleDownCompletes(
+      @ForAll("raftOperations") final List<RaftOperation> raftOperations,
+      @ForAll("raftMembers") final List<MemberId> raftMembers,
+      @ForAll("seeds") final long seed)
+      throws Exception {
+    setUpRaftNodes(new Random(seed));
+
+    // Both operations fail fast on CONFIGURATION_ERROR or when the member restarts while they are
+    // pending, so they are simply re-issued until they complete: first the demotion, then the
+    // leave.
+    var demoteFuture = raftContexts.demote(member2);
+    CompletableFuture<Void> leaveFuture = null;
+
+    // given - when there are failures such as message loss
+    final var memberIter = raftMembers.iterator();
+    for (final RaftOperation operation : raftOperations) {
+      final MemberId member = memberIter.next();
+      if ("Restart member".equals(operation.toString()) && member.equals(member2)) {
+        // Known pre-existing residuals, outside this task's scope: a member that restarts during
+        // the demote/leave window can miss the corresponding configuration entries and fall back
+        // to a stale or initial configuration whose index the leader ignores as "no information"
+        // (LeaderAppender#updateConfigurationIndex), so it is never re-configured and its local
+        // demote() runs against a wrong self-view; a removed member restarting during the
+        // append-to-commit window additionally transitions itself INACTIVE at bootstrap. Skip
+        // restarts of the leaving member instead of fighting these here.
+        continue;
+      }
+      LOG.info("{} on {}", operation, member);
+      operation.run(raftContexts, member);
+      // sample the safety invariant on every step: it records the vote of each member at the
+      // term it is currently in, so a vote that is overwritten between two steps is only
+      // observable while it is still recorded
+      raftContexts.assertAtMostOneVotePerMemberAndTerm();
+      if (leaveFuture == null) {
+        if (shouldRetryDemote(demoteFuture)) {
+          LOG.info("Demoting member 2...");
+          demoteFuture = raftContexts.demote(member2);
+        } else if (demoteFuture.isDone()) {
+          LOG.info("Demote completed. Leaving...");
+          leaveFuture = raftContexts.leave(member2);
+        }
+      } else if (leaveFuture.isCompletedExceptionally()) {
+        LOG.info("Leave failed. Retrying...");
+        leaveFuture = raftContexts.leave(member2);
+      }
+    }
+
+    raftContexts.runUntilDone();
+    raftContexts.processAllMessage();
+    raftContexts.tickHeartbeatTimeout();
+
+    // when - no more message loss or restarts
+
+    LOG.info("Stopping failures, waiting for demote and leave to complete");
+
+    final var remainingMembers = Set.of(member0, member1);
+    int maxStepsToReplicateEntries = 10100;
+    while (!(leaveFuture != null
+            && leaveFuture.isDone()
+            && !leaveFuture.isCompletedExceptionally()
+            && raftContexts.allMembersAreReady(remainingMembers)
+            && raftContexts.hasLeaderAtTheLatestTerm())
+        && maxStepsToReplicateEntries-- > 0) {
+
+      if (leaveFuture == null) {
+        if (shouldRetryDemote(demoteFuture)) {
+          LOG.info("Demoting member 2...");
+          demoteFuture = raftContexts.demote(member2);
+        } else if (demoteFuture.isDone()) {
+          LOG.info("Demote completed. Leaving...");
+          leaveFuture = raftContexts.leave(member2);
+        }
+      } else if (leaveFuture.isCompletedExceptionally()) {
+        LOG.info("Leave failed. Retrying...");
+        leaveFuture = raftContexts.leave(member2);
+      }
+
+      raftContexts.runUntilDone();
+      raftContexts.processAllMessage();
+      raftContexts.tickHeartbeatTimeout();
+    }
+
+    // then - the leave is only ever issued once the leader's configuration has member 2 as
+    // PASSIVE, so a completed leave also witnesses that the demotion phase took effect
+    assertThat(demoteFuture).describedAs("Demotion of member 2 should be completed").isCompleted();
+    assertThat(leaveFuture).describedAs("Leave of member 2 should be completed").isCompleted();
+    assertThat(raftContexts.hasLeaderAtTheLatestTerm()).describedAs("There is a leader").isTrue();
+    assertThat(raftContexts.allMembersAreReady(remainingMembers))
+        .describedAs("The remaining members are ready")
+        .isTrue();
+    raftContexts.assertAllLogsEqual(remainingMembers);
+  }
+
+  /**
+   * The demotion fails fast on CONFIGURATION_ERROR - another change in progress or a stale
+   * configuration view - so it is simply re-issued until it completes. A demotion can also complete
+   * without effect on the leader's configuration, for example when it is answered from a stale
+   * local self-view or as a duplicate of the current membership, so it is retried as long as the
+   * leader's configuration does not have member 2 as PASSIVE. Without this, the property would pass
+   * on a demotion that never happened, and what it asserts would reduce to a plain one-phase leave.
+   */
+  private boolean shouldRetryDemote(final CompletableFuture<Void> demoteFuture) {
+    return demoteFuture.isCompletedExceptionally()
+        || (demoteFuture.isDone() && !member2IsPassiveInLeadersConfiguration());
+  }
+
+  private boolean member2IsPassiveInLeadersConfiguration() {
+    return raftContexts.getRaftServers().values().stream()
+        .filter(RaftContext::isLeader)
+        .findAny()
+        .map(leader -> leader.getCluster().getConfiguration())
+        .map(
+            configuration ->
+                configuration.newMembers().stream()
+                    .anyMatch(
+                        member ->
+                            member.memberId().equals(member2)
+                                && member.getType() == RaftMember.Type.PASSIVE))
+        .orElse(false);
+  }
+
+  private void setUpRaftNodes(final Random random) throws Exception {
+    // Create temporary directory for raft data
+    raftDataDirectory = Files.createTempDirectory(null);
+
+    // Create ControllableRaftContexts with 3 nodes. Reduce the quorum response timeout to make
+    // the wall-clock gated leader step-down reachable under the deterministic scheduler, see
+    // RandomizedRaftJoinTest. Created per try because shutdown() runs after every try, see
+    // RandomizedRaftJoinTest#setUpRaftNodes.
+    raftContexts =
+        new ControllableRaftContexts(
+            3, config -> config.setMaxQuorumResponseTimeout(Duration.ofMillis(1)));
+
+    // Bootstrap all three members
+    raftContexts.setup(raftDataDirectory, random);
+
+    LOG.info("Set up 3-node raft cluster");
+  }
+
+  @Provide
+  Arbitrary<List<RaftOperation>> raftOperations() {
+    final var operation = Arbitraries.of(operationsWithRestarts);
+    return operation.list().ofSize(OPERATION_SIZE);
+  }
+
+  @Provide
+  Arbitrary<List<MemberId>> raftMembers() {
+    final var members = Arbitraries.of(member0, member1, member2);
+    return members.list().ofSize(OPERATION_SIZE);
+  }
+
+  @Provide
+  Arbitrary<Long> seeds() {
+    return Arbitraries.longs();
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftScaleDownTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftScaleDownTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.util.FileUtil;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.EdgeCasesMode;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.PropertyDefaults;
+import net.jqwik.api.Provide;
+import net.jqwik.api.ShrinkingMode;
+import net.jqwik.api.lifecycle.AfterTry;
+import net.jqwik.api.lifecycle.BeforeProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Randomized test for the two-phase scale down: a member demotes itself to PASSIVE and then leaves,
+ * so that its removal commits without its own participation. Mirrors the structure of {@link
+ * RandomizedRaftJoinTest}, but with three bootstrapped ACTIVE members.
+ */
+@PropertyDefaults(tries = 10, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
+public class RandomizedRaftScaleDownTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RandomizedRaftScaleDownTest.class);
+  private static final int OPERATION_SIZE = 1000;
+
+  private ControllableRaftContexts raftContexts;
+  private Path raftDataDirectory;
+  private MemberId member0;
+  private MemberId member1;
+  private MemberId member2;
+  private List<RaftOperation> operationsWithRestarts;
+
+  @BeforeProperty
+  public void initMembers() {
+    member0 = MemberId.from("0");
+    member1 = MemberId.from("1");
+    member2 = MemberId.from("2");
+    // Create ControllableRaftContexts with 3 nodes. Reduce the quorum response timeout to make
+    // the wall-clock gated leader step-down reachable under the deterministic scheduler, see
+    // RandomizedRaftJoinTest.
+    raftContexts =
+        new ControllableRaftContexts(
+            3, config -> config.setMaxQuorumResponseTimeout(Duration.ofMillis(1)));
+    operationsWithRestarts = RaftOperation.getRaftOperationsWithRestarts();
+  }
+
+  @AfterTry
+  public void shutDownRaftNodes() throws IOException {
+    if (raftContexts != null) {
+      raftContexts.shutdown();
+    }
+    if (raftDataDirectory != null) {
+      FileUtil.deleteFolder(raftDataDirectory);
+      raftDataDirectory = null;
+    }
+  }
+
+  @Property
+  void scaleDownCompletes(
+      @ForAll("raftOperations") final List<RaftOperation> raftOperations,
+      @ForAll("raftMembers") final List<MemberId> raftMembers,
+      @ForAll("seeds") final long seed)
+      throws Exception {
+    setUpRaftNodes(new Random(seed));
+
+    // Both operations fail fast on CONFIGURATION_ERROR or when the member restarts while they are
+    // pending, so they are simply re-issued until they complete: first the demotion, then the
+    // leave.
+    var demoteFuture = raftContexts.demote(member2);
+    CompletableFuture<Void> leaveFuture = null;
+
+    // given - when there are failures such as message loss
+    final var memberIter = raftMembers.iterator();
+    for (final RaftOperation operation : raftOperations) {
+      final MemberId member = memberIter.next();
+      if ("Restart member".equals(operation.toString()) && member.equals(member2)) {
+        // Known pre-existing residuals, outside this task's scope: a member that restarts during
+        // the demote/leave window can miss the corresponding configuration entries and fall back
+        // to a stale or initial configuration whose index the leader ignores as "no information"
+        // (LeaderAppender#updateConfigurationIndex), so it is never re-configured and its local
+        // demote() runs against a wrong self-view; a removed member restarting during the
+        // append-to-commit window additionally transitions itself INACTIVE at bootstrap. Skip
+        // restarts of the leaving member instead of fighting these here.
+        continue;
+      }
+      LOG.info("{} on {}", operation, member);
+      operation.run(raftContexts, member);
+      if (leaveFuture == null) {
+        if (demoteFuture.isCompletedExceptionally()) {
+          LOG.info("Demote failed. Retrying...");
+          demoteFuture = raftContexts.demote(member2);
+        } else if (demoteFuture.isDone()) {
+          LOG.info("Demote completed. Leaving...");
+          leaveFuture = raftContexts.leave(member2);
+        }
+      } else if (leaveFuture.isCompletedExceptionally()) {
+        LOG.info("Leave failed. Retrying...");
+        leaveFuture = raftContexts.leave(member2);
+      }
+    }
+
+    raftContexts.runUntilDone();
+    raftContexts.processAllMessage();
+    raftContexts.tickHeartbeatTimeout();
+
+    // when - no more message loss or restarts
+
+    LOG.info("Stopping failures, waiting for demote and leave to complete");
+
+    final var remainingMembers = Set.of(member0, member1);
+    int maxStepsToReplicateEntries = 10100;
+    while (!(leaveFuture != null
+            && leaveFuture.isDone()
+            && !leaveFuture.isCompletedExceptionally()
+            && raftContexts.allMembersAreReady(remainingMembers)
+            && raftContexts.hasLeaderAtTheLatestTerm())
+        && maxStepsToReplicateEntries-- > 0) {
+
+      if (leaveFuture == null) {
+        if (demoteFuture.isCompletedExceptionally()) {
+          LOG.info("Demote failed. Retrying...");
+          demoteFuture = raftContexts.demote(member2);
+        } else if (demoteFuture.isDone()) {
+          LOG.info("Demote completed. Leaving...");
+          leaveFuture = raftContexts.leave(member2);
+        }
+      } else if (leaveFuture.isCompletedExceptionally()) {
+        LOG.info("Leave failed. Retrying...");
+        leaveFuture = raftContexts.leave(member2);
+      }
+
+      raftContexts.runUntilDone();
+      raftContexts.processAllMessage();
+      raftContexts.tickHeartbeatTimeout();
+    }
+
+    // then
+    assertThat(leaveFuture).describedAs("Leave of member 2 should be completed").isCompleted();
+    assertThat(raftContexts.hasLeaderAtTheLatestTerm()).describedAs("There is a leader").isTrue();
+    assertThat(raftContexts.allMembersAreReady(remainingMembers))
+        .describedAs("The remaining members are ready")
+        .isTrue();
+    raftContexts.assertAllLogsEqual(remainingMembers);
+  }
+
+  private void setUpRaftNodes(final Random random) throws Exception {
+    // Create temporary directory for raft data
+    raftDataDirectory = Files.createTempDirectory(null);
+
+    // Bootstrap all three members
+    raftContexts.setup(raftDataDirectory, random);
+
+    LOG.info("Set up 3-node raft cluster");
+  }
+
+  @Provide
+  Arbitrary<List<RaftOperation>> raftOperations() {
+    final var operation = Arbitraries.of(operationsWithRestarts);
+    return operation.list().ofSize(OPERATION_SIZE);
+  }
+
+  @Provide
+  Arbitrary<List<MemberId>> raftMembers() {
+    final var members = Arbitraries.of(member0, member1, member2);
+    return members.list().ofSize(OPERATION_SIZE);
+  }
+
+  @Provide
+  Arbitrary<Long> seeds() {
+    return Arbitraries.longs();
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -1466,6 +1466,97 @@ final class ReconfigurationTest {
     }
 
     /**
+     * The termination counterpart of {@link
+     * #shouldNotCommitPromotionWhilePromotedMemberUnreachable}: that test pins that an appended
+     * promotion does not commit without the promoted member, and deliberately keeps the step-down
+     * out of its observation window. This one pins that a promotion whose joint configuration can
+     * never commit does not leave the leader wedged either - it must not fall back to committing
+     * under the old configuration alone, which would apply the promotion without the promoted
+     * member ever having stored it, so instead it fails to reach a quorum and steps down. It uses
+     * the class's default timeouts for exactly that reason.
+     */
+    @Test
+    void shouldStepDownWhenPromotionCanNeverCommit(@TempDir final Path tmp) {
+      // given - a single-member cluster [1A] with a caught-up PROMOTABLE member 2
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+
+      final var m1 = createServer(tmp, StaticClusterMembershipService.of(id1, id2));
+      m1.bootstrap(id1).join();
+      assertThat(appendEntry(awaitLeader(m1)).commit()).succeedsWithin(Duration.ofSeconds(5));
+
+      final var m2 = createServer(tmp, StaticClusterMembershipService.of(id2, id1));
+      assertThat(m2.join(Type.PROMOTABLE, List.of(id1, id2)))
+          .succeedsWithin(Duration.ofSeconds(30));
+      awaitCaughtUp(m1, m2);
+      awaitSameConfiguration(m1, m2);
+
+      // when - m2 becomes unreachable in both directions, so it can neither acknowledge the joint
+      // configuration nor answer polls and votes: a member that still answered votes could
+      // re-elect the leader immediately after it stepped down. Blocking only entry-carrying
+      // appends, as the sibling test does, would leave exactly that hole. The promotion is then
+      // requested through a client rather than by m2 itself: an isolated m2 could not send it, and
+      // DefaultRaftMember#promote retries on NO_LEADER, so its future would never complete and
+      // there would be nothing deterministic to assert on. The leader's match index for m2 is
+      // untouched by the failing appends, so the request still passes the catch-up gate.
+      final var commitIndexBeforePromotion = m1.getContext().getCommitIndex();
+      final var configuration = m1.getContext().getCluster().getConfiguration();
+      final var client = protocolFactory.newServerProtocol(MemberId.from("test-client"));
+      protocolFactory.partition(id2);
+
+      final var promoted =
+          List.<RaftMember>of(
+              new DefaultRaftMember(id1, Type.ACTIVE, Instant.now()),
+              new DefaultRaftMember(id2, Type.ACTIVE, Instant.now()));
+      final var response =
+          client.reconfigure(
+              id1,
+              ReconfigureRequest.builder()
+                  .withIndex(configuration.index())
+                  .withTerm(m1.getContext().getCluster().getConfigurationTerm())
+                  .withMembers(promoted)
+                  .from(id1.id())
+                  .build());
+
+      // then - the joint configuration is appended
+      Awaitility.await("the joint configuration is appended")
+          .untilAsserted(
+              () ->
+                  assertThat(
+                          m1.getContext().getCluster().getConfiguration().requiresJointConsensus())
+                      .isTrue());
+      final var jointIndex = m1.getContext().getCluster().getConfiguration().index();
+      assertThat(jointIndex).isGreaterThan(commitIndexBeforePromotion);
+
+      // and - it never commits and the leader steps down instead of committing it under the old
+      // configuration [1A] alone. It also stays down: the joint vote quorum needs a majority of
+      // the new side [1A, 2A] too, which m2 is part of.
+      awaitNoLeader(m1);
+      Awaitility.await("the promotion never commits and the leader stays down")
+          .during(Duration.ofSeconds(1))
+          .untilAsserted(
+              () -> {
+                assertThat(m1.getContext().getCommitIndex())
+                    .isEqualTo(commitIndexBeforePromotion)
+                    .isLessThan(jointIndex);
+                assertThat(m1.isLeader()).isFalse();
+              });
+
+      // and - the promotion does not succeed. It terminates either with the error the stepping-down
+      // leader completes the pending reconfiguration with, or, if that response loses the race
+      // against the test protocol's request timeout, exceptionally. Both mean a failed promotion,
+      // and asserting only one of the two would be racy.
+      Awaitility.await("the promotion request completes")
+          .untilAsserted(() -> assertThat(response).isDone());
+      assertThat(response.isCompletedExceptionally() || response.join().status() == Status.ERROR)
+          .describedAs("the promotion must not succeed")
+          .isTrue();
+      assertThat(m1.getContext().getCluster().getConfiguration().requiresJointConsensus())
+          .describedAs("the promotion never took effect: the cluster is left in joint consensus")
+          .isTrue();
+    }
+
+    /**
      * A crash-recovery retry of join(PROMOTABLE) can arrive after the member was already promoted
      * to ACTIVE. Joining must never demote: the retry is acknowledged without a configuration
      * change.

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -1174,8 +1174,16 @@ final class ReconfigurationTest {
       assertThat(appendEntry(newLeader).commit()).succeedsWithin(Duration.ofSeconds(5));
     }
 
+    /**
+     * A member that never acknowledged an append has a match index of 0, so the promotion catch-up
+     * gate rejects promoting it before anything is appended: the leader's view of its replication
+     * lag cannot be trusted yet. The append-time protection - an appended promotion must not commit
+     * without the promoted member's acknowledgement - is pinned separately by {@link
+     * TwoPhaseReconfiguration#shouldNotCommitPromotionWhilePromotedMemberUnreachable}, where the
+     * member catches up before it becomes unreachable.
+     */
     @Test
-    void doesNotCommitConfigurationWhileVotingMemberIsUnreachable(@TempDir final Path tmp) {
+    void shouldRejectPromotingUnreachableMember(@TempDir final Path tmp) {
       // given - a single member cluster [1A] with an unreachable PASSIVE member 2
       final var id1 = MemberId.from("1");
       final var id2 = MemberId.from("2");
@@ -1206,8 +1214,8 @@ final class ReconfigurationTest {
           .satisfies(
               reconfigureResponse -> assertThat(reconfigureResponse.status()).isEqualTo(Status.OK));
 
-      // when - promoting the unreachable member to ACTIVE, making it a voting member of the new
-      // configuration
+      // when - promoting the unreachable member to ACTIVE, which would make it a voting member
+      // of the new configuration
       final var commitIndexBeforePromotion = m1.getContext().getCommitIndex();
       final var committedConfiguration = m1.getContext().getCluster().getConfiguration();
       final var promoted =
@@ -1224,18 +1232,20 @@ final class ReconfigurationTest {
                   .from(id1.id())
                   .build());
 
-      // then - the configuration does not commit without the new voting member's ack: the leader
-      // eventually steps down instead of committing governed solely by the old configuration
-      Awaitility.await("Leader steps down because the new configuration cannot commit")
-          .atMost(Duration.ofSeconds(30))
-          .until(() -> !m1.isLeader());
+      // then - the promotion is rejected outright because the member never acknowledged anything,
+      // nothing is appended, and the leader keeps leading and committing
+      assertThat(response)
+          .succeedsWithin(Duration.ofSeconds(10))
+          .satisfies(
+              reconfigureResponse -> {
+                assertThat(reconfigureResponse.status()).isEqualTo(Status.ERROR);
+                assertThat(reconfigureResponse.error().type())
+                    .isEqualTo(RaftError.Type.CONFIGURATION_ERROR);
+                assertThat(reconfigureResponse.error().message()).contains("not caught up");
+              });
       assertThat(m1.getContext().getCommitIndex()).isEqualTo(commitIndexBeforePromotion);
-      Awaitility.await("Reconfigure request completes")
-          .atMost(Duration.ofSeconds(30))
-          .until(response::isDone);
-      assertThat(response.isCompletedExceptionally() || response.join().status() == Status.ERROR)
-          .describedAs("Reconfigure request must not succeed")
-          .isTrue();
+      assertThat(m1.isLeader()).isTrue();
+      assertThat(appendEntry(awaitLeader(m1)).commit()).succeedsWithin(Duration.ofSeconds(5));
     }
   }
 
@@ -1301,6 +1311,248 @@ final class ReconfigurationTest {
           .isEqualTo(commitIndexBefore);
     }
 
+    @Test
+    void shouldJoinAsPromotableAndBecomeActiveAfterPromotion(@TempDir final Path tmp) {
+      // given - a single-member cluster
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+
+      final var m1 = createServer(tmp, StaticClusterMembershipService.of(id1, id2));
+      m1.bootstrap(id1).join();
+      // commit an entry to ensure that the leader is ready to accept new configurations
+      assertThat(appendEntry(awaitLeader(m1)).commit()).succeedsWithin(Duration.ofSeconds(5));
+
+      // when - m2 joins as PROMOTABLE
+      final var m2 = createServer(tmp, StaticClusterMembershipService.of(id2, id1));
+      assertThat(m2.join(Type.PROMOTABLE, List.of(id1, id2)))
+          .succeedsWithin(Duration.ofSeconds(30));
+
+      // then - the leader's configuration has m2 as a PROMOTABLE, non-voting member
+      assertThat(memberTypes(m1)).containsEntry(id2, Type.PROMOTABLE);
+
+      // when - m2 caught up to the leader and is promoted to ACTIVE
+      awaitCaughtUp(m1, m2);
+      awaitSameConfiguration(m1, m2);
+      assertThat(m2.cluster().getLocalMember().promote(Type.ACTIVE))
+          .succeedsWithin(Duration.ofSeconds(30));
+
+      // then - the leader's committed configuration has m2 as ACTIVE and the cluster still
+      // commits entries
+      Awaitility.await("the promotion is committed")
+          .untilAsserted(
+              () -> {
+                final var configuration = m1.getContext().getCluster().getConfiguration();
+                assertThat(configuration.requiresJointConsensus()).isFalse();
+                assertThat(memberTypes(m1)).containsEntry(id2, Type.ACTIVE);
+                assertThat(m1.getContext().getCommitIndex())
+                    .isGreaterThanOrEqualTo(configuration.index());
+              });
+      assertThat(appendEntry(awaitLeader(m1, m2)).commit()).succeedsWithin(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void shouldRejectPromotionUntilCaughtUp(@TempDir final Path tmp) {
+      // given - a single-member cluster with a caught-up PROMOTABLE member 2, a promotion lag
+      // threshold that any unreplicated entry exceeds, and generous timeouts so that blocking
+      // replication to m2 doesn't make the leader step down within this test's observation window
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+      final Consumer<RaftPartitionConfig> testConfig =
+          config -> {
+            config.setMaxQuorumResponseTimeout(Duration.ofSeconds(60));
+            config.setElectionTimeout(Duration.ofSeconds(3));
+            config.setPromotionLagThreshold(1);
+          };
+
+      final var m1 = createServer(tmp, StaticClusterMembershipService.of(id1, id2), testConfig);
+      m1.bootstrap(id1).join();
+      assertThat(appendEntry(awaitLeader(m1)).commit()).succeedsWithin(Duration.ofSeconds(5));
+
+      final var m2 = createServer(tmp, StaticClusterMembershipService.of(id2, id1), testConfig);
+      assertThat(m2.join(Type.PROMOTABLE, List.of(id1, id2)))
+          .succeedsWithin(Duration.ofSeconds(30));
+      awaitCaughtUp(m1, m2);
+      awaitSameConfiguration(m1, m2);
+
+      // when - m2 stops receiving entries while the leader commits a few more, so m2's
+      // replication lag exceeds the promotion lag threshold (the ACTIVE quorum is the leader
+      // alone, so commits don't need m2)
+      final var blockAppends = new AtomicBoolean(true);
+      interceptEntryAppends(m1, id2, blockAppends);
+      final var leaderRole = getLeader(m1).orElseThrow();
+      for (int i = 0; i < 3; i++) {
+        assertThat(appendEntry(leaderRole).commit()).succeedsWithin(Duration.ofSeconds(5));
+      }
+
+      // then - the promotion is rejected because m2 is not caught up
+      assertThat(m2.cluster().getLocalMember().promote(Type.ACTIVE))
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableOfType(ExecutionException.class)
+          .withMessageContaining("not caught up");
+      assertThat(memberTypes(m1)).containsEntry(id2, Type.PROMOTABLE);
+
+      // when - replication to m2 resumes and it catches up
+      blockAppends.set(false);
+      awaitCaughtUp(m1, m2);
+
+      // then - retrying the promotion succeeds. The first retries may still be rejected while
+      // the acknowledgement that clears m2's replication lag on the leader is in flight.
+      Awaitility.await("the promotion succeeds after catching up")
+          .untilAsserted(
+              () ->
+                  assertThat(m2.cluster().getLocalMember().promote(Type.ACTIVE))
+                      .succeedsWithin(Duration.ofSeconds(10)));
+      assertThat(memberTypes(m1)).containsEntry(id2, Type.ACTIVE);
+    }
+
+    /**
+     * Pins the quorum arithmetic protecting promotion durability: as soon as the joint
+     * configuration for a promotion is appended, the promoted member counts towards the new side's
+     * ACTIVE commit quorum, so the promotion cannot commit while the promoted member is
+     * unreachable.
+     */
+    @Test
+    void shouldNotCommitPromotionWhilePromotedMemberUnreachable(@TempDir final Path tmp) {
+      // given - a single-member cluster with a caught-up PROMOTABLE member 2, and generous
+      // timeouts so that blocking replication to m2 doesn't make the leader step down within
+      // this test's observation window
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+      final Consumer<RaftPartitionConfig> testTimeouts =
+          config -> {
+            config.setMaxQuorumResponseTimeout(Duration.ofSeconds(60));
+            config.setElectionTimeout(Duration.ofSeconds(3));
+          };
+
+      final var m1 = createServer(tmp, StaticClusterMembershipService.of(id1, id2), testTimeouts);
+      m1.bootstrap(id1).join();
+      assertThat(appendEntry(awaitLeader(m1)).commit()).succeedsWithin(Duration.ofSeconds(5));
+
+      final var m2 = createServer(tmp, StaticClusterMembershipService.of(id2, id1), testTimeouts);
+      assertThat(m2.join(Type.PROMOTABLE, List.of(id1, id2)))
+          .succeedsWithin(Duration.ofSeconds(30));
+      awaitCaughtUp(m1, m2);
+      awaitSameConfiguration(m1, m2);
+
+      // when - m2 stops receiving entries (its own requests still reach the leader, so the
+      // promotion request itself is forwarded and accepted) and m2 requests its promotion
+      final var blockAppends = new AtomicBoolean(true);
+      interceptEntryAppends(m1, id2, blockAppends);
+      final var promoteFuture = m2.cluster().getLocalMember().promote(Type.ACTIVE);
+
+      // then - the joint configuration is appended but does not commit: its new side [1A, 2A]
+      // needs m2's acknowledgement, which never arrives
+      Awaitility.await("the joint configuration is appended")
+          .untilAsserted(
+              () ->
+                  assertThat(
+                          m1.getContext().getCluster().getConfiguration().requiresJointConsensus())
+                      .isTrue());
+      final var jointIndex = m1.getContext().getCluster().getConfiguration().index();
+      Awaitility.await("the promotion does not commit while the promoted member is unreachable")
+          .during(Duration.ofSeconds(1))
+          .untilAsserted(
+              () -> {
+                assertThat(promoteFuture).isNotDone();
+                assertThat(m1.getContext().getCommitIndex()).isLessThan(jointIndex);
+              });
+
+      // when - replication to m2 resumes
+      blockAppends.set(false);
+
+      // then - the promotion completes
+      assertThat(promoteFuture).succeedsWithin(Duration.ofSeconds(30));
+      assertThat(memberTypes(m1)).containsEntry(id2, Type.ACTIVE);
+    }
+
+    /**
+     * A crash-recovery retry of join(PROMOTABLE) can arrive after the member was already promoted
+     * to ACTIVE. Joining must never demote: the retry is acknowledged without a configuration
+     * change.
+     */
+    @Test
+    void shouldNotDemoteActiveMemberWhenJoiningAsPromotable(@TempDir final Path tmp) {
+      // given - a two-member cluster where m2 joined as PROMOTABLE and was promoted to ACTIVE
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+
+      final var m1 = createServer(tmp, StaticClusterMembershipService.of(id1, id2));
+      m1.bootstrap(id1).join();
+      assertThat(appendEntry(awaitLeader(m1)).commit()).succeedsWithin(Duration.ofSeconds(5));
+
+      final var m2 = createServer(tmp, StaticClusterMembershipService.of(id2, id1));
+      assertThat(m2.join(Type.PROMOTABLE, List.of(id1, id2)))
+          .succeedsWithin(Duration.ofSeconds(30));
+      awaitCaughtUp(m1, m2);
+      awaitSameConfiguration(m1, m2);
+      assertThat(m2.cluster().getLocalMember().promote(Type.ACTIVE))
+          .succeedsWithin(Duration.ofSeconds(30));
+      assertThat(memberTypes(m1)).containsEntry(id2, Type.ACTIVE);
+
+      // when - a crash-recovery retry re-issues the join as PROMOTABLE
+      final var retriedJoin = m2.cluster().join(Type.PROMOTABLE, List.of(id1, id2));
+
+      // then - the join is acknowledged without demoting m2
+      assertThat(retriedJoin).succeedsWithin(Duration.ofSeconds(30));
+      assertThat(memberTypes(m1)).containsEntry(id2, Type.ACTIVE);
+      assertThat(appendEntry(awaitLeader(m1, m2)).commit()).succeedsWithin(Duration.ofSeconds(5));
+    }
+
+    /**
+     * The two-phase leave: a member that demoted itself to PASSIVE before leaving is in no quorum
+     * anymore, so its removal commits without any participation from the leaving member - both
+     * joint sides' ACTIVE quorums consist of the remaining members only.
+     */
+    @Test
+    void shouldRemoveDemotedMemberWithoutItsParticipation(@TempDir final Path tmp) {
+      // given - a cluster with 3 ACTIVE members
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+      final var id3 = MemberId.from("3");
+
+      final var m1 = createServer(tmp, StaticClusterMembershipService.of(id1, id2, id3));
+      final var m2 = createServer(tmp, StaticClusterMembershipService.of(id2, id1, id3));
+      final var m3 = createServer(tmp, StaticClusterMembershipService.of(id3, id1, id2));
+
+      CompletableFuture.allOf(
+              m1.bootstrap(id1, id2, id3), m2.bootstrap(id1, id2, id3), m3.bootstrap(id1, id2, id3))
+          .join();
+      // commit an entry to ensure that the leader is ready to accept new configurations
+      assertThat(appendEntry(awaitLeader(m1, m2, m3)).commit())
+          .succeedsWithin(Duration.ofSeconds(5));
+      final var leader = getLeaderServer(List.of(m1, m2, m3)).orElseThrow();
+      final var demoting = Stream.of(m1, m2, m3).filter(s -> s != leader).findAny().orElseThrow();
+      final var demotingId = MemberId.from(demoting.name());
+
+      // when - a follower demotes itself to PASSIVE, then all messages to it are blocked (its
+      // own requests still reach the leader), and it leaves
+      assertThat(demoting.cluster().getLocalMember().demote(Type.PASSIVE))
+          .succeedsWithin(Duration.ofSeconds(10));
+      assertThat(memberTypes(leader)).containsEntry(demotingId, Type.PASSIVE);
+      protocolFactory.blockMessagesTo(demotingId);
+      final var leaveFuture = demoting.leave();
+
+      // then - the leader commits the configuration without the demoted member even though it
+      // never acknowledged anything after the demotion
+      final var remaining = Stream.of(m1, m2, m3).filter(s -> s != demoting).toList();
+      final var expected =
+          remaining.stream().map(server -> server.cluster().getLocalMember()).toList();
+      Awaitility.await("the leader commits the configuration without the demoted member")
+          .untilAsserted(
+              () -> {
+                final var configuration = leader.getContext().getCluster().getConfiguration();
+                assertThat(configuration.requiresJointConsensus()).isFalse();
+                assertThat(configuration.allMembers())
+                    .containsExactlyInAnyOrderElementsOf(expected);
+                assertThat(leader.getContext().getCommitIndex())
+                    .isGreaterThanOrEqualTo(configuration.index());
+              });
+
+      // and - the leave completes once connectivity is restored
+      protocolFactory.heal(demotingId);
+      assertThat(leaveFuture).succeedsWithin(Duration.ofSeconds(30));
+    }
+
     /**
      * Blocks entry-carrying appends from {@code sender} to {@code receiver} while {@code blocked}
      * is true. Empty appends (heartbeats) keep flowing so the receiver is not falsely suspected
@@ -1328,6 +1580,17 @@ final class ReconfigurationTest {
           });
     }
 
+    private static Map<MemberId, Type> memberTypes(final RaftServer server) {
+      return server.cluster().getMembers().stream()
+          .collect(Collectors.toMap(RaftMember::memberId, RaftMember::getType));
+    }
+
+    private static void awaitCaughtUp(final RaftServer leader, final RaftServer member) {
+      Awaitility.await(
+              "%s caught up to the last index of %s".formatted(member.name(), leader.name()))
+          .untilAsserted(() -> assertThat(lastIndex(member)).isEqualTo(lastIndex(leader)));
+    }
+
     /**
      * Reads the server's last log index on its own raft thread. The journal is thread-confined:
      * reading it from the test thread races with the appending raft thread over the current segment
@@ -1339,6 +1602,19 @@ final class ReconfigurationTest {
       final var lastIndex = new CompletableFuture<Long>();
       context.getThreadContext().execute(() -> lastIndex.complete(context.getLog().getLastIndex()));
       return lastIndex.orTimeout(5, TimeUnit.SECONDS).join();
+    }
+
+    /**
+     * Waits until both servers hold the same configuration. Configuration changes are requested
+     * with the requester's local view of index and term; a request from a member that has not
+     * received the latest configuration yet is rejected as stale.
+     */
+    private static void awaitSameConfiguration(final RaftServer a, final RaftServer b) {
+      Awaitility.await("%s and %s hold the same configuration".formatted(a.name(), b.name()))
+          .untilAsserted(
+              () ->
+                  assertThat(a.getContext().getCluster().getConfiguration().index())
+                      .isEqualTo(b.getContext().getCluster().getConfiguration().index()));
     }
   }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -1240,6 +1240,109 @@ final class ReconfigurationTest {
   }
 
   @Nested
+  final class TwoPhaseReconfiguration {
+    /**
+     * Pins the PROMOTABLE catch-up contract: the leader ships its uncommitted tail to a PROMOTABLE
+     * member through an uncommitted reader (see {@link
+     * io.atomix.raft.cluster.impl.RaftMemberContext}), and the member appends and acknowledges that
+     * tail even though the entries are not committed, so it can reach the leader's last index and
+     * become eligible for promotion.
+     */
+    @Test
+    void shouldReplicateUncommittedEntriesToPromotableMember(@TempDir final Path tmp) {
+      // given - a cluster [1A, 2A] with a PROMOTABLE member 3, and generous timeouts so that
+      // holding back the ACTIVE follower's acks doesn't make the leader step down within this
+      // test's observation window (see removedLeaderStepsDownAtCommitNotAtAppend for why)
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+      final var id3 = MemberId.from("3");
+      final Consumer<RaftPartitionConfig> testTimeouts =
+          config -> {
+            config.setMaxQuorumResponseTimeout(Duration.ofSeconds(60));
+            config.setElectionTimeout(Duration.ofSeconds(3));
+          };
+
+      final var m1 =
+          createServer(tmp, StaticClusterMembershipService.of(id1, id2, id3), testTimeouts);
+      final var m2 =
+          createServer(tmp, StaticClusterMembershipService.of(id2, id1, id3), testTimeouts);
+
+      CompletableFuture.allOf(m1.bootstrap(id1, id2), m2.bootstrap(id1, id2)).join();
+      assertThat(appendEntry(awaitLeader(m1, m2)).commit()).succeedsWithin(Duration.ofSeconds(5));
+
+      final var m3 =
+          createServer(tmp, StaticClusterMembershipService.of(id3, id1, id2), testTimeouts);
+      assertThat(m3.join(Type.PROMOTABLE, List.of(id1, id2, id3)))
+          .succeedsWithin(Duration.ofSeconds(30));
+
+      final var leader = getLeaderServer(List.of(m1, m2)).orElseThrow();
+      final var follower = Stream.of(m1, m2).filter(s -> s != leader).findAny().orElseThrow();
+      final var followerId = MemberId.from(follower.name());
+
+      // when - nothing new can commit because entry-carrying appends to the only ACTIVE follower
+      // fail (the ACTIVE commit quorum is 2 out of 2, the PROMOTABLE member is in no quorum), and
+      // the leader appends several new entries
+      interceptEntryAppends(leader, followerId, new AtomicBoolean(true));
+
+      final var commitIndexBefore = leader.getContext().getCommitIndex();
+      final var leaderRole = getLeader(leader).orElseThrow();
+      for (int i = 0; i < 5; i++) {
+        appendEntry(leaderRole).write().join();
+      }
+      final var lastIndex = lastIndex(leader);
+      assertThat(lastIndex).isGreaterThan(commitIndexBefore);
+
+      // then - the PROMOTABLE member catches up to the leader's last index even though the
+      // leader's commit index stays behind it
+      Awaitility.await("the promotable member catches up to the leader's last uncommitted index")
+          .untilAsserted(() -> assertThat(lastIndex(m3)).isEqualTo(lastIndex));
+      assertThat(leader.getContext().getCommitIndex())
+          .describedAs("the appended entries must not have committed")
+          .isEqualTo(commitIndexBefore);
+    }
+
+    /**
+     * Blocks entry-carrying appends from {@code sender} to {@code receiver} while {@code blocked}
+     * is true. Empty appends (heartbeats) keep flowing so the receiver is not falsely suspected
+     * unreachable. Every append exchange is delayed by a few milliseconds to avoid busy-looping the
+     * raft actor thread with the in-memory test protocol (see
+     * removedLeaderStepsDownAtCommitNotAtAppend).
+     */
+    private static void interceptEntryAppends(
+        final RaftServer sender, final MemberId receiver, final AtomicBoolean blocked) {
+      final var protocol = (TestRaftServerProtocol) sender.getContext().getProtocol();
+      protocol.interceptDelivery(
+          VersionedAppendRequest.class,
+          (to, request) -> {
+            final var result = new CompletableFuture<Void>();
+            CompletableFuture.runAsync(
+                () -> {
+                  if (to.equals(receiver) && blocked.get() && !request.entries().isEmpty()) {
+                    result.completeExceptionally(new ConnectException());
+                  } else {
+                    result.complete(null);
+                  }
+                },
+                CompletableFuture.delayedExecutor(20, TimeUnit.MILLISECONDS));
+            return result;
+          });
+    }
+
+    /**
+     * Reads the server's last log index on its own raft thread. The journal is thread-confined:
+     * reading it from the test thread races with the appending raft thread over the current segment
+     * and its writer, both plain fields, so a poll could observe a retired writer indefinitely or
+     * trip over a half-published segment switch.
+     */
+    private static long lastIndex(final RaftServer server) {
+      final var context = server.getContext();
+      final var lastIndex = new CompletableFuture<Long>();
+      context.getThreadContext().execute(() -> lastIndex.complete(context.getLog().getLastIndex()));
+      return lastIndex.orTimeout(5, TimeUnit.SECONDS).join();
+    }
+  }
+
+  @Nested
   class ForceConfigureTest {
     final MemberId id1 = MemberId.from("1");
     final MemberId id2 = MemberId.from("2");

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -1134,8 +1134,16 @@ final class ReconfigurationTest {
       assertThat(appendEntry(newLeader).commit()).succeedsWithin(Duration.ofSeconds(5));
     }
 
+    /**
+     * A member that never acknowledged an append has a match index of 0, so the promotion catch-up
+     * gate rejects promoting it before anything is appended: the leader's view of its replication
+     * lag cannot be trusted yet. The append-time protection - an appended promotion must not commit
+     * without the promoted member's acknowledgement - is pinned separately by {@link
+     * TwoPhaseReconfiguration#shouldNotCommitPromotionWhilePromotedMemberUnreachable}, where the
+     * member catches up before it becomes unreachable.
+     */
     @Test
-    void doesNotCommitConfigurationWhileVotingMemberIsUnreachable(@TempDir final Path tmp) {
+    void shouldRejectPromotingUnreachableMember(@TempDir final Path tmp) {
       // given - a single member cluster [1A] with an unreachable PASSIVE member 2
       final var id1 = MemberId.from("1");
       final var id2 = MemberId.from("2");
@@ -1166,8 +1174,8 @@ final class ReconfigurationTest {
           .satisfies(
               reconfigureResponse -> assertThat(reconfigureResponse.status()).isEqualTo(Status.OK));
 
-      // when - promoting the unreachable member to ACTIVE, making it a voting member of the new
-      // configuration
+      // when - promoting the unreachable member to ACTIVE, which would make it a voting member
+      // of the new configuration
       final var commitIndexBeforePromotion = m1.getContext().getCommitIndex();
       final var committedConfiguration = m1.getContext().getCluster().getConfiguration();
       final var promoted =
@@ -1184,18 +1192,20 @@ final class ReconfigurationTest {
                   .from(id1.id())
                   .build());
 
-      // then - the configuration does not commit without the new voting member's ack: the leader
-      // eventually steps down instead of committing governed solely by the old configuration
-      Awaitility.await("Leader steps down because the new configuration cannot commit")
-          .atMost(Duration.ofSeconds(30))
-          .until(() -> !m1.isLeader());
+      // then - the promotion is rejected outright because the member never acknowledged anything,
+      // nothing is appended, and the leader keeps leading and committing
+      assertThat(response)
+          .succeedsWithin(Duration.ofSeconds(10))
+          .satisfies(
+              reconfigureResponse -> {
+                assertThat(reconfigureResponse.status()).isEqualTo(Status.ERROR);
+                assertThat(reconfigureResponse.error().type())
+                    .isEqualTo(RaftError.Type.CONFIGURATION_ERROR);
+                assertThat(reconfigureResponse.error().message()).contains("not caught up");
+              });
       assertThat(m1.getContext().getCommitIndex()).isEqualTo(commitIndexBeforePromotion);
-      Awaitility.await("Reconfigure request completes")
-          .atMost(Duration.ofSeconds(30))
-          .until(response::isDone);
-      assertThat(response.isCompletedExceptionally() || response.join().status() == Status.ERROR)
-          .describedAs("Reconfigure request must not succeed")
-          .isTrue();
+      assertThat(m1.isLeader()).isTrue();
+      assertThat(appendEntry(awaitLeader(m1)).commit()).succeedsWithin(Duration.ofSeconds(5));
     }
   }
 
@@ -1241,25 +1251,8 @@ final class ReconfigurationTest {
 
       // when - nothing new can commit because entry-carrying appends to the only ACTIVE follower
       // fail (the ACTIVE commit quorum is 2 out of 2, the PROMOTABLE member is in no quorum), and
-      // the leader appends several new entries. Every append exchange is delayed by a few
-      // milliseconds to avoid busy-looping the raft actor thread with the in-memory test protocol
-      // (see removedLeaderStepsDownAtCommitNotAtAppend).
-      final var leaderProtocol = (TestRaftServerProtocol) leader.getContext().getProtocol();
-      leaderProtocol.interceptDelivery(
-          VersionedAppendRequest.class,
-          (receiver, request) -> {
-            final var result = new CompletableFuture<Void>();
-            CompletableFuture.runAsync(
-                () -> {
-                  if (receiver.equals(followerId) && !request.entries().isEmpty()) {
-                    result.completeExceptionally(new ConnectException());
-                  } else {
-                    result.complete(null);
-                  }
-                },
-                CompletableFuture.delayedExecutor(20, TimeUnit.MILLISECONDS));
-            return result;
-          });
+      // the leader appends several new entries
+      interceptEntryAppends(leader, followerId, new AtomicBoolean(true));
 
       final var commitIndexBefore = leader.getContext().getCommitIndex();
       final var leaderRole = getLeader(leader).orElseThrow();
@@ -1277,6 +1270,302 @@ final class ReconfigurationTest {
       assertThat(leader.getContext().getCommitIndex())
           .describedAs("the appended entries must not have committed")
           .isEqualTo(commitIndexBefore);
+    }
+
+    @Test
+    void shouldJoinAsPromotableAndBecomeActiveAfterPromotion(@TempDir final Path tmp) {
+      // given - a single-member cluster
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+
+      final var m1 = createServer(tmp, StaticClusterMembershipService.of(id1, id2));
+      m1.bootstrap(id1).join();
+      // commit an entry to ensure that the leader is ready to accept new configurations
+      assertThat(appendEntry(awaitLeader(m1)).commit()).succeedsWithin(Duration.ofSeconds(5));
+
+      // when - m2 joins as PROMOTABLE
+      final var m2 = createServer(tmp, StaticClusterMembershipService.of(id2, id1));
+      assertThat(m2.join(Type.PROMOTABLE, List.of(id1, id2)))
+          .succeedsWithin(Duration.ofSeconds(30));
+
+      // then - the leader's configuration has m2 as a PROMOTABLE, non-voting member
+      assertThat(memberTypes(m1)).containsEntry(id2, Type.PROMOTABLE);
+
+      // when - m2 caught up to the leader and is promoted to ACTIVE
+      awaitCaughtUp(m1, m2);
+      awaitSameConfiguration(m1, m2);
+      assertThat(m2.cluster().getLocalMember().promote(Type.ACTIVE))
+          .succeedsWithin(Duration.ofSeconds(30));
+
+      // then - the leader's committed configuration has m2 as ACTIVE and the cluster still
+      // commits entries
+      Awaitility.await("the promotion is committed")
+          .untilAsserted(
+              () -> {
+                final var configuration = m1.getContext().getCluster().getConfiguration();
+                assertThat(configuration.requiresJointConsensus()).isFalse();
+                assertThat(memberTypes(m1)).containsEntry(id2, Type.ACTIVE);
+                assertThat(m1.getContext().getCommitIndex())
+                    .isGreaterThanOrEqualTo(configuration.index());
+              });
+      assertThat(appendEntry(awaitLeader(m1, m2)).commit()).succeedsWithin(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void shouldRejectPromotionUntilCaughtUp(@TempDir final Path tmp) {
+      // given - a single-member cluster with a caught-up PROMOTABLE member 2, a promotion lag
+      // threshold that any unreplicated entry exceeds, and generous timeouts so that blocking
+      // replication to m2 doesn't make the leader step down within this test's observation window
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+      final Consumer<RaftPartitionConfig> testConfig =
+          config -> {
+            config.setMaxQuorumResponseTimeout(Duration.ofSeconds(60));
+            config.setElectionTimeout(Duration.ofSeconds(3));
+            config.setPromotionLagThreshold(1);
+          };
+
+      final var m1 = createServer(tmp, StaticClusterMembershipService.of(id1, id2), testConfig);
+      m1.bootstrap(id1).join();
+      assertThat(appendEntry(awaitLeader(m1)).commit()).succeedsWithin(Duration.ofSeconds(5));
+
+      final var m2 = createServer(tmp, StaticClusterMembershipService.of(id2, id1), testConfig);
+      assertThat(m2.join(Type.PROMOTABLE, List.of(id1, id2)))
+          .succeedsWithin(Duration.ofSeconds(30));
+      awaitCaughtUp(m1, m2);
+      awaitSameConfiguration(m1, m2);
+
+      // when - m2 stops receiving entries while the leader commits a few more, so m2's
+      // replication lag exceeds the promotion lag threshold (the ACTIVE quorum is the leader
+      // alone, so commits don't need m2)
+      final var blockAppends = new AtomicBoolean(true);
+      interceptEntryAppends(m1, id2, blockAppends);
+      final var leaderRole = getLeader(m1).orElseThrow();
+      for (int i = 0; i < 3; i++) {
+        assertThat(appendEntry(leaderRole).commit()).succeedsWithin(Duration.ofSeconds(5));
+      }
+
+      // then - the promotion is rejected because m2 is not caught up
+      assertThat(m2.cluster().getLocalMember().promote(Type.ACTIVE))
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableOfType(ExecutionException.class)
+          .withMessageContaining("not caught up");
+      assertThat(memberTypes(m1)).containsEntry(id2, Type.PROMOTABLE);
+
+      // when - replication to m2 resumes and it catches up
+      blockAppends.set(false);
+      awaitCaughtUp(m1, m2);
+
+      // then - retrying the promotion succeeds. The first retries may still be rejected while
+      // the acknowledgement that clears m2's replication lag on the leader is in flight.
+      Awaitility.await("the promotion succeeds after catching up")
+          .untilAsserted(
+              () ->
+                  assertThat(m2.cluster().getLocalMember().promote(Type.ACTIVE))
+                      .succeedsWithin(Duration.ofSeconds(10)));
+      assertThat(memberTypes(m1)).containsEntry(id2, Type.ACTIVE);
+    }
+
+    /**
+     * Pins the quorum arithmetic protecting promotion durability: as soon as the joint
+     * configuration for a promotion is appended, the promoted member counts towards the new side's
+     * ACTIVE commit quorum, so the promotion cannot commit while the promoted member is
+     * unreachable.
+     */
+    @Test
+    void shouldNotCommitPromotionWhilePromotedMemberUnreachable(@TempDir final Path tmp) {
+      // given - a single-member cluster with a caught-up PROMOTABLE member 2, and generous
+      // timeouts so that blocking replication to m2 doesn't make the leader step down within
+      // this test's observation window
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+      final Consumer<RaftPartitionConfig> testTimeouts =
+          config -> {
+            config.setMaxQuorumResponseTimeout(Duration.ofSeconds(60));
+            config.setElectionTimeout(Duration.ofSeconds(3));
+          };
+
+      final var m1 = createServer(tmp, StaticClusterMembershipService.of(id1, id2), testTimeouts);
+      m1.bootstrap(id1).join();
+      assertThat(appendEntry(awaitLeader(m1)).commit()).succeedsWithin(Duration.ofSeconds(5));
+
+      final var m2 = createServer(tmp, StaticClusterMembershipService.of(id2, id1), testTimeouts);
+      assertThat(m2.join(Type.PROMOTABLE, List.of(id1, id2)))
+          .succeedsWithin(Duration.ofSeconds(30));
+      awaitCaughtUp(m1, m2);
+      awaitSameConfiguration(m1, m2);
+
+      // when - m2 stops receiving entries (its own requests still reach the leader, so the
+      // promotion request itself is forwarded and accepted) and m2 requests its promotion
+      final var blockAppends = new AtomicBoolean(true);
+      interceptEntryAppends(m1, id2, blockAppends);
+      final var promoteFuture = m2.cluster().getLocalMember().promote(Type.ACTIVE);
+
+      // then - the joint configuration is appended but does not commit: its new side [1A, 2A]
+      // needs m2's acknowledgement, which never arrives
+      Awaitility.await("the joint configuration is appended")
+          .untilAsserted(
+              () ->
+                  assertThat(
+                          m1.getContext().getCluster().getConfiguration().requiresJointConsensus())
+                      .isTrue());
+      final var jointIndex = m1.getContext().getCluster().getConfiguration().index();
+      Awaitility.await("the promotion does not commit while the promoted member is unreachable")
+          .during(Duration.ofSeconds(1))
+          .untilAsserted(
+              () -> {
+                assertThat(promoteFuture).isNotDone();
+                assertThat(m1.getContext().getCommitIndex()).isLessThan(jointIndex);
+              });
+
+      // when - replication to m2 resumes
+      blockAppends.set(false);
+
+      // then - the promotion completes
+      assertThat(promoteFuture).succeedsWithin(Duration.ofSeconds(30));
+      assertThat(memberTypes(m1)).containsEntry(id2, Type.ACTIVE);
+    }
+
+    /**
+     * A crash-recovery retry of join(PROMOTABLE) can arrive after the member was already promoted
+     * to ACTIVE. Joining must never demote: the retry is acknowledged without a configuration
+     * change.
+     */
+    @Test
+    void shouldNotDemoteActiveMemberWhenJoiningAsPromotable(@TempDir final Path tmp) {
+      // given - a two-member cluster where m2 joined as PROMOTABLE and was promoted to ACTIVE
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+
+      final var m1 = createServer(tmp, StaticClusterMembershipService.of(id1, id2));
+      m1.bootstrap(id1).join();
+      assertThat(appendEntry(awaitLeader(m1)).commit()).succeedsWithin(Duration.ofSeconds(5));
+
+      final var m2 = createServer(tmp, StaticClusterMembershipService.of(id2, id1));
+      assertThat(m2.join(Type.PROMOTABLE, List.of(id1, id2)))
+          .succeedsWithin(Duration.ofSeconds(30));
+      awaitCaughtUp(m1, m2);
+      awaitSameConfiguration(m1, m2);
+      assertThat(m2.cluster().getLocalMember().promote(Type.ACTIVE))
+          .succeedsWithin(Duration.ofSeconds(30));
+      assertThat(memberTypes(m1)).containsEntry(id2, Type.ACTIVE);
+
+      // when - a crash-recovery retry re-issues the join as PROMOTABLE
+      final var retriedJoin = m2.cluster().join(Type.PROMOTABLE, List.of(id1, id2));
+
+      // then - the join is acknowledged without demoting m2
+      assertThat(retriedJoin).succeedsWithin(Duration.ofSeconds(30));
+      assertThat(memberTypes(m1)).containsEntry(id2, Type.ACTIVE);
+      assertThat(appendEntry(awaitLeader(m1, m2)).commit()).succeedsWithin(Duration.ofSeconds(5));
+    }
+
+    /**
+     * The two-phase leave: a member that demoted itself to PASSIVE before leaving is in no quorum
+     * anymore, so its removal commits without any participation from the leaving member - both
+     * joint sides' ACTIVE quorums consist of the remaining members only.
+     */
+    @Test
+    void shouldRemoveDemotedMemberWithoutItsParticipation(@TempDir final Path tmp) {
+      // given - a cluster with 3 ACTIVE members
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+      final var id3 = MemberId.from("3");
+
+      final var m1 = createServer(tmp, StaticClusterMembershipService.of(id1, id2, id3));
+      final var m2 = createServer(tmp, StaticClusterMembershipService.of(id2, id1, id3));
+      final var m3 = createServer(tmp, StaticClusterMembershipService.of(id3, id1, id2));
+
+      CompletableFuture.allOf(
+              m1.bootstrap(id1, id2, id3), m2.bootstrap(id1, id2, id3), m3.bootstrap(id1, id2, id3))
+          .join();
+      // commit an entry to ensure that the leader is ready to accept new configurations
+      assertThat(appendEntry(awaitLeader(m1, m2, m3)).commit())
+          .succeedsWithin(Duration.ofSeconds(5));
+      final var leader = getLeaderServer(List.of(m1, m2, m3)).orElseThrow();
+      final var demoting = Stream.of(m1, m2, m3).filter(s -> s != leader).findAny().orElseThrow();
+      final var demotingId = MemberId.from(demoting.name());
+
+      // when - a follower demotes itself to PASSIVE, then all messages to it are blocked (its
+      // own requests still reach the leader), and it leaves
+      assertThat(demoting.cluster().getLocalMember().demote(Type.PASSIVE))
+          .succeedsWithin(Duration.ofSeconds(10));
+      assertThat(memberTypes(leader)).containsEntry(demotingId, Type.PASSIVE);
+      protocolFactory.blockMessagesTo(demotingId);
+      final var leaveFuture = demoting.leave();
+
+      // then - the leader commits the configuration without the demoted member even though it
+      // never acknowledged anything after the demotion
+      final var remaining = Stream.of(m1, m2, m3).filter(s -> s != demoting).toList();
+      final var expected =
+          remaining.stream().map(server -> server.cluster().getLocalMember()).toList();
+      Awaitility.await("the leader commits the configuration without the demoted member")
+          .untilAsserted(
+              () -> {
+                final var configuration = leader.getContext().getCluster().getConfiguration();
+                assertThat(configuration.requiresJointConsensus()).isFalse();
+                assertThat(configuration.allMembers())
+                    .containsExactlyInAnyOrderElementsOf(expected);
+                assertThat(leader.getContext().getCommitIndex())
+                    .isGreaterThanOrEqualTo(configuration.index());
+              });
+
+      // and - the leave completes once connectivity is restored
+      protocolFactory.heal(demotingId);
+      assertThat(leaveFuture).succeedsWithin(Duration.ofSeconds(30));
+    }
+
+    /**
+     * Blocks entry-carrying appends from {@code sender} to {@code receiver} while {@code blocked}
+     * is true. Empty appends (heartbeats) keep flowing so the receiver is not falsely suspected
+     * unreachable. Every append exchange is delayed by a few milliseconds to avoid busy-looping the
+     * raft actor thread with the in-memory test protocol (see
+     * removedLeaderStepsDownAtCommitNotAtAppend).
+     */
+    private static void interceptEntryAppends(
+        final RaftServer sender, final MemberId receiver, final AtomicBoolean blocked) {
+      final var protocol = (TestRaftServerProtocol) sender.getContext().getProtocol();
+      protocol.interceptDelivery(
+          VersionedAppendRequest.class,
+          (to, request) -> {
+            final var result = new CompletableFuture<Void>();
+            CompletableFuture.runAsync(
+                () -> {
+                  if (to.equals(receiver) && blocked.get() && !request.entries().isEmpty()) {
+                    result.completeExceptionally(new ConnectException());
+                  } else {
+                    result.complete(null);
+                  }
+                },
+                CompletableFuture.delayedExecutor(20, TimeUnit.MILLISECONDS));
+            return result;
+          });
+    }
+
+    private static Map<MemberId, Type> memberTypes(final RaftServer server) {
+      return server.cluster().getMembers().stream()
+          .collect(Collectors.toMap(RaftMember::memberId, RaftMember::getType));
+    }
+
+    private static void awaitCaughtUp(final RaftServer leader, final RaftServer member) {
+      Awaitility.await(
+              "%s caught up to the last index of %s".formatted(member.name(), leader.name()))
+          .untilAsserted(
+              () ->
+                  assertThat(member.getContext().getLog().getLastIndex())
+                      .isEqualTo(leader.getContext().getLog().getLastIndex()));
+    }
+
+    /**
+     * Waits until both servers hold the same configuration. Configuration changes are requested
+     * with the requester's local view of index and term; a request from a member that has not
+     * received the latest configuration yet is rejected as stale.
+     */
+    private static void awaitSameConfiguration(final RaftServer a, final RaftServer b) {
+      Awaitility.await("%s and %s hold the same configuration".formatted(a.name(), b.name()))
+          .untilAsserted(
+              () ->
+                  assertThat(a.getContext().getCluster().getConfiguration().index())
+                      .isEqualTo(b.getContext().getCluster().getConfiguration().index()));
     }
   }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -1200,6 +1200,87 @@ final class ReconfigurationTest {
   }
 
   @Nested
+  final class TwoPhaseReconfiguration {
+    /**
+     * Pins the PROMOTABLE catch-up contract: the leader ships its uncommitted tail to a PROMOTABLE
+     * member through an uncommitted reader (see {@link
+     * io.atomix.raft.cluster.impl.RaftMemberContext}), and the member appends and acknowledges that
+     * tail even though the entries are not committed, so it can reach the leader's last index and
+     * become eligible for promotion.
+     */
+    @Test
+    void shouldReplicateUncommittedEntriesToPromotableMember(@TempDir final Path tmp) {
+      // given - a cluster [1A, 2A] with a PROMOTABLE member 3, and generous timeouts so that
+      // holding back the ACTIVE follower's acks doesn't make the leader step down within this
+      // test's observation window (see removedLeaderStepsDownAtCommitNotAtAppend for why)
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+      final var id3 = MemberId.from("3");
+      final Consumer<RaftPartitionConfig> testTimeouts =
+          config -> {
+            config.setMaxQuorumResponseTimeout(Duration.ofSeconds(60));
+            config.setElectionTimeout(Duration.ofSeconds(3));
+          };
+
+      final var m1 =
+          createServer(tmp, StaticClusterMembershipService.of(id1, id2, id3), testTimeouts);
+      final var m2 =
+          createServer(tmp, StaticClusterMembershipService.of(id2, id1, id3), testTimeouts);
+
+      CompletableFuture.allOf(m1.bootstrap(id1, id2), m2.bootstrap(id1, id2)).join();
+      assertThat(appendEntry(awaitLeader(m1, m2)).commit()).succeedsWithin(Duration.ofSeconds(5));
+
+      final var m3 =
+          createServer(tmp, StaticClusterMembershipService.of(id3, id1, id2), testTimeouts);
+      assertThat(m3.join(Type.PROMOTABLE, List.of(id1, id2, id3)))
+          .succeedsWithin(Duration.ofSeconds(30));
+
+      final var leader = getLeaderServer(List.of(m1, m2)).orElseThrow();
+      final var follower = Stream.of(m1, m2).filter(s -> s != leader).findAny().orElseThrow();
+      final var followerId = MemberId.from(follower.name());
+
+      // when - nothing new can commit because entry-carrying appends to the only ACTIVE follower
+      // fail (the ACTIVE commit quorum is 2 out of 2, the PROMOTABLE member is in no quorum), and
+      // the leader appends several new entries. Every append exchange is delayed by a few
+      // milliseconds to avoid busy-looping the raft actor thread with the in-memory test protocol
+      // (see removedLeaderStepsDownAtCommitNotAtAppend).
+      final var leaderProtocol = (TestRaftServerProtocol) leader.getContext().getProtocol();
+      leaderProtocol.interceptDelivery(
+          VersionedAppendRequest.class,
+          (receiver, request) -> {
+            final var result = new CompletableFuture<Void>();
+            CompletableFuture.runAsync(
+                () -> {
+                  if (receiver.equals(followerId) && !request.entries().isEmpty()) {
+                    result.completeExceptionally(new ConnectException());
+                  } else {
+                    result.complete(null);
+                  }
+                },
+                CompletableFuture.delayedExecutor(20, TimeUnit.MILLISECONDS));
+            return result;
+          });
+
+      final var commitIndexBefore = leader.getContext().getCommitIndex();
+      final var leaderRole = getLeader(leader).orElseThrow();
+      for (int i = 0; i < 5; i++) {
+        appendEntry(leaderRole).write().join();
+      }
+      final var lastIndex = leader.getContext().getLog().getLastIndex();
+      assertThat(lastIndex).isGreaterThan(commitIndexBefore);
+
+      // then - the PROMOTABLE member catches up to the leader's last index even though the
+      // leader's commit index stays behind it
+      Awaitility.await("the promotable member catches up to the leader's last uncommitted index")
+          .untilAsserted(
+              () -> assertThat(m3.getContext().getLog().getLastIndex()).isEqualTo(lastIndex));
+      assertThat(leader.getContext().getCommitIndex())
+          .describedAs("the appended entries must not have committed")
+          .isEqualTo(commitIndexBefore);
+    }
+  }
+
+  @Nested
   class ForceConfigureTest {
     final MemberId id1 = MemberId.from("1");
     final MemberId id2 = MemberId.from("2");

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftMemberContextTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftMemberContextTest.java
@@ -298,6 +298,24 @@ final class RaftMemberContextTest {
   }
 
   @Test
+  void shouldAllowAppendsAfterStateResetWithInFlightAppends() {
+    // given - an append in flight while the member state is reset, e.g. because the member's type
+    // changed when a configuration promoting it was appended
+    final var log = mock(RaftLog.class);
+    final var context = newContext();
+    context.startAppend();
+    context.resetState(log);
+
+    // when - the response to the pre-reset append arrives
+    context.completeAppend();
+
+    // then - the in-flight bookkeeping has not gone negative and the member can still receive
+    // heartbeats and appends
+    assertThat(context.canHeartbeat()).isTrue();
+    assertThat(context.canAppend()).isTrue();
+  }
+
+  @Test
   void shouldCloseSnapshotChunkReaderOnClose() {
     // given
     final var context = newContext();

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerSenderSubjectsTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerSenderSubjectsTest.java
@@ -139,7 +139,8 @@ public class RaftServerSenderSubjectsTest {
     return p ->
         p.configure(
             MEMBER_ID,
-            new ConfigureRequest(1, "b", 0, 0, Collections.emptyList(), Collections.emptyList()));
+            new ConfigureRequest(
+                1, "b", 0, 0, Collections.emptyList(), Collections.emptyList(), 1));
   }
 
   static Consumer<RaftServerProtocol> forceConfigureRequest() {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -318,6 +318,67 @@ public class PassiveRoleTest {
     assertThat(getPendingSnapshot()).as("pending snapshot should be cleared").isNull();
   }
 
+  @Test
+  public void shouldCheckForDataLossWithTheIndexTheLeaderAgreesOn() throws CheckedJournalException {
+    // given - a promotable member whose log ends far beyond what this append covers
+    final var promotableRole = new PromotableRole(ctx);
+    when(log.getLastIndex()).thenReturn(120L);
+    final var entries =
+        List.of(
+            new ReplicatableJournalRecord(1, 1, 1, new byte[1]),
+            new ReplicatableJournalRecord(1, 2, 1, new byte[1]));
+    final VersionedAppendRequest request =
+        VersionedAppendRequest.builder()
+            .withTerm(1)
+            .withLeader(MemberId.anonymous())
+            .withPrevLogTerm(0)
+            .withPrevLogIndex(0)
+            .withEntries(entries)
+            .withCommitIndex(2)
+            .build();
+    when(log.append(any(ReplicatableJournalRecord.class)))
+        .thenReturn(mock(IndexedRaftLogEntry.class))
+        .thenReturn(mock(IndexedRaftLogEntry.class));
+
+    // when
+    promotableRole.handleAppend(ProtocolVersionHandler.transform(request)).join();
+
+    // then - the data-loss check gets the index up to which this node and the leader agree on
+    // persisted data. The local log end must not be used here: it can never lie below this node's
+    // own commit index, which would make the majority-data-loss check unsatisfiable.
+    verify(ctx).setFirstCommitIndex(2, 2);
+  }
+
+  @Test
+  public void shouldCheckForDataLossWithTheLocalLogEndWhenPassive() throws CheckedJournalException {
+    // given - a passive member whose log ends far beyond what this append covers
+    when(log.getLastIndex()).thenReturn(120L);
+    final var entries =
+        List.of(
+            new ReplicatableJournalRecord(1, 1, 1, new byte[1]),
+            new ReplicatableJournalRecord(1, 2, 1, new byte[1]));
+    final VersionedAppendRequest request =
+        VersionedAppendRequest.builder()
+            .withTerm(1)
+            .withLeader(MemberId.anonymous())
+            .withPrevLogTerm(0)
+            .withPrevLogIndex(0)
+            .withEntries(entries)
+            .withCommitIndex(2)
+            .build();
+    when(log.append(any(ReplicatableJournalRecord.class)))
+        .thenReturn(mock(IndexedRaftLogEntry.class))
+        .thenReturn(mock(IndexedRaftLogEntry.class));
+
+    // when
+    role.handleAppend(ProtocolVersionHandler.transform(request)).join();
+
+    // then - the leader replicates to a PASSIVE member from a committed reader, so the request
+    // understates the leader's log and cannot be used to detect data loss. The local log end never
+    // trips the check, which is the point: an ex-leader demoted to PASSIVE tripped it spuriously.
+    verify(ctx).setFirstCommitIndex(2, 120);
+  }
+
   private void setPendingSnapshot(final ReceivedSnapshot snapshot) throws Exception {
     final var field = PassiveRole.class.getDeclaredField("pendingSnapshot");
     field.setAccessible(true);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -24,10 +24,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.MemberId;
+import io.atomix.raft.cluster.impl.RaftClusterContext;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.metrics.RaftReplicationMetrics;
 import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
+import io.atomix.raft.protocol.ConfigureRequest;
 import io.atomix.raft.protocol.PersistedRaftRecord;
 import io.atomix.raft.protocol.ProtocolVersionHandler;
 import io.atomix.raft.protocol.ReplicatableJournalRecord;
@@ -35,6 +37,7 @@ import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLog;
+import io.atomix.raft.storage.system.Configuration;
 import io.camunda.zeebe.journal.CheckedJournalException;
 import io.camunda.zeebe.journal.JournalException;
 import io.camunda.zeebe.journal.JournalException.InvalidChecksum;
@@ -52,6 +55,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.rules.Timeout;
+import org.mockito.ArgumentCaptor;
 
 public class PassiveRoleTest {
 
@@ -324,5 +328,41 @@ public class PassiveRoleTest {
     final var field = PassiveRole.class.getDeclaredField("pendingSnapshot");
     field.setAccessible(true);
     return field.get(role);
+  }
+
+  /**
+   * A configuration is identified by its index and the term of the entry that introduced it, so a
+   * member configured by a leader has to store that term - not the leader's current term, which
+   * only says who disseminated it. Storing the latter made {@code Configuration#term()} mean one
+   * thing on a member that appended the entry and another on a member that was configured, which
+   * the leader then rejected as a stale configuration.
+   */
+  @Test
+  public void shouldStoreTheConfigurationsOwnTerm() {
+    // given
+    final var cluster = mock(RaftClusterContext.class);
+    when(ctx.getCluster()).thenReturn(cluster);
+    // the commit check at the end of onConfigure reads it back; any older configuration will do
+    when(cluster.getConfiguration()).thenReturn(new Configuration(1, 1, 1, List.of(), List.of()));
+
+    // when - a leader in term 5 disseminates a configuration whose entry was appended in term 2
+    role.onConfigure(
+            ConfigureRequest.builder()
+                .withTerm(5)
+                .withConfigurationTerm(2)
+                .withLeader(MemberId.from("1"))
+                .withIndex(7)
+                .withTime(1)
+                .withNewMembers(List.of())
+                .build())
+        .join();
+
+    // then
+    final var configuration = ArgumentCaptor.forClass(Configuration.class);
+    verify(cluster).configure(configuration.capture());
+    assertThat(configuration.getValue().term())
+        .describedAs("the term of the configuration entry, not of its dissemination")
+        .isEqualTo(2);
+    assertThat(configuration.getValue().index()).isEqualTo(7);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -106,6 +106,10 @@ public final class RaftPartitionFactory {
         (int) brokerCfg.getExperimental().getRaft().getSnapshotChunkSize().toBytes());
     partitionConfig.setConfigurationChangeTimeout(
         brokerCfg.getExperimental().getRaft().getConfigurationChangeTimeout());
+    partitionConfig.setJoinCatchUpTimeout(
+        brokerCfg.getExperimental().getRaft().getJoinCatchUpTimeout());
+    partitionConfig.setPromotionLagThreshold(
+        brokerCfg.getExperimental().getRaft().getPromotionLagThreshold().toBytes());
     partitionConfig.setMaxQuorumResponseTimeout(
         brokerCfg.getExperimental().getRaft().getMaxQuorumResponseTimeout());
     partitionConfig.setMinStepDownFailureCount(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
@@ -18,6 +18,9 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
   public static final Duration DEFAULT_SNAPSHOT_REQUEST_TIMEOUT = Duration.ofMillis(2500);
   public static final DataSize DEFAULT_SNAPSHOT_CHUNK_SIZE = DataSize.ofMegabytes(8);
   private static final Duration DEFAULT_CONFIGURATION_CHANGE_TIMEOUT = Duration.ofSeconds(10);
+  // Keep in sync with the defaults in RaftPartitionConfig, which these override on startup.
+  private static final Duration DEFAULT_JOIN_CATCH_UP_TIMEOUT = Duration.ofSeconds(60);
+  private static final DataSize DEFAULT_PROMOTION_LAG_THRESHOLD = DataSize.ofMegabytes(16);
   // Requests should time out faster than the election timeout to ensure that a single missed
   // heartbeat does not cause immediate re-election.
   private static final Duration DEFAULT_REQUEST_TIMEOUT = DEFAULT_ELECTION_TIMEOUT;
@@ -31,6 +34,8 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
   private Duration snapshotRequestTimeout = DEFAULT_SNAPSHOT_REQUEST_TIMEOUT;
   private DataSize snapshotChunkSize = DEFAULT_SNAPSHOT_CHUNK_SIZE;
   private Duration configurationChangeTimeout = DEFAULT_CONFIGURATION_CHANGE_TIMEOUT;
+  private Duration joinCatchUpTimeout = DEFAULT_JOIN_CATCH_UP_TIMEOUT;
+  private DataSize promotionLagThreshold = DEFAULT_PROMOTION_LAG_THRESHOLD;
   private Duration maxQuorumResponseTimeout = DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT;
   private int minStepDownFailureCount = DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT;
   private int preferSnapshotReplicationThreshold = DEFAULT_PREFER_SNAPSHOT_REPLICATION_THRESHOLD;
@@ -68,6 +73,22 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
 
   public void setConfigurationChangeTimeout(final Duration configurationChangeTimeout) {
     this.configurationChangeTimeout = configurationChangeTimeout;
+  }
+
+  public Duration getJoinCatchUpTimeout() {
+    return joinCatchUpTimeout;
+  }
+
+  public void setJoinCatchUpTimeout(final Duration joinCatchUpTimeout) {
+    this.joinCatchUpTimeout = joinCatchUpTimeout;
+  }
+
+  public DataSize getPromotionLagThreshold() {
+    return promotionLagThreshold;
+  }
+
+  public void setPromotionLagThreshold(final DataSize promotionLagThreshold) {
+    this.promotionLagThreshold = promotionLagThreshold;
   }
 
   public Duration getMaxQuorumResponseTimeout() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
@@ -752,8 +752,8 @@ public class ClusteringRule extends ExternalResource {
         .ignoreExceptions()
         .untilAsserted(
             () -> {
-              assertThat(serverOfExpectedLeader.promote())
-                  .describedAs("Promote request is successful")
+              assertThat(serverOfExpectedLeader.anoint())
+                  .describedAs("Anoint request is successful")
                   .succeedsWithin(Duration.ofSeconds(15));
               final int currentLeaderId = getLeaderForPartition(partitionId).getNodeId();
               assertThat(currentLeaderId)


### PR DESCRIPTION
Raft-layer support for two-phase reconfiguration, following the learner pattern: a member joins as PROMOTABLE (replicated to, in no quorum), catches up, and is promoted to ACTIVE in a second configuration change. Symmetrically, a member demotes itself to PASSIVE before leaving, so the removal commits without it. This removes the window where a quorum depends on an empty-log member — the root of the #56808 deadlock class.

**Production behavior is unchanged.** Brokers still join one-shot as ACTIVE. The switch-over is #57392, which will drive the new `promoteMember()`/`demoteMember()` on `RaftPartition`/`RaftPartitionServer`.

The commits are ordered for one-by-one review; details live in the commit messages.

### Where review judgment matters most

- **The promotion catch-up gate** ([`LeaderRole#onReconfigure`](https://github.com/camunda/camunda/blob/0e795765b1a2872704c96ecc9d3e43410e66c72c/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java#L284-L347)): a promotion is rejected unless the member acked everything committed, or its replication lag is under 16 MiB (new internal `promotionLagThreshold`). The byte lag bounds how long commits can stall once the member joins the new quorum; the acked-everything clause is what makes caught-up PASSIVE members promotable at all, since the leader replicates to them from a committed reader and their lag therefore always includes the whole uncommitted tail. A positive match index is also required because lag reads 0 right after an election, before the first probe response. The gate is availability-only — safety stays with joint consensus, pinned by `shouldNotCommitPromotionWhilePromotedMemberUnreachable` and `shouldStepDownWhenPromotionCanNeverCommit`.
- **The data-loss tripwire is disarmed for PASSIVE members.** Because the leader replicates to them from a committed reader, the request understates the leader's log, and a demoted ex-leader tripped the check spuriously right after an election. PASSIVE members now check against their own log end (which never trips); every other role keeps the exact check. Both behaviors are pinned in `PassiveRoleTest`.
- **`ConfigureRequest` gains a `configurationTerm` field.** The existing term doubled as the configuration's identity, so a member that learned a configuration from dissemination labeled it with the leader's then-current term — and after any election, its promote/demote was rejected as "Stale configuration" forever. Old senders omit the field and receivers fall back to today's behavior, so mixed versions are unaffected.
- **[`onJoin` never demotes an existing member](https://github.com/camunda/camunda/blob/0e795765b1a2872704c96ecc9d3e43410e66c72c/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java#L381-L406)**, so a crash-recovery retry of `join(PROMOTABLE)` after promotion no-ops — and it acknowledges the redundant join only from a committed configuration, since an appended one can still be truncated and this answer, unlike a rejection, is final for the joiner.

### Latent bugs this surfaced

All pre-existing, each fixed in its own commit (or in the feature commit for the member-side ones):

- `completeAppend` drove the in-flight count negative when a type change reset member state mid-append, permanently silencing the leader towards that member.
- `leaveJointConsensus` could append the final configuration after the role had stopped — the long-standing rare SIGSEGV flake in the randomized raft properties.
- A duplicate reconfigure was answered with a null future when the leader had recovered the joint configuration instead of starting the change itself.
- The promote/demote retry timer was member-level, so a late duplicate response could cancel the next operation's timer and hang its future forever.
- `DefaultRaftMember#configure` crashed without a known configuration, and short-circuited on the member's own type view — which can be wrong, so the leader is now always asked.

Closes #57391
Closes #60087