### PR TITLE
Restore multi-tenancy test coverage for CreateProcessInstanceWithResult

### DIFF
--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceWithResultTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceWithResultTest.java
@@ -27,7 +27,6 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.util.HashSet;
 import java.util.List;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public final class CreateProcessInstanceWithResultTest extends GatewayTest {
@@ -161,33 +160,5 @@ public final class CreateProcessInstanceWithResultTest extends GatewayTest {
             Status.Code.ALREADY_EXISTS,
             "Command 'CREATE_WITH_AWAITING_RESULT' rejected with code 'ALREADY_EXISTS': "
                 + rejectionReason);
-  }
-
-  @Test
-  @Ignore("https://github.com/camunda/camunda/issues/14041")
-  public void shouldMapRequestAndResponseWithCustomTenant() {
-    // given
-    final String tenantId = "test-tenant";
-    final CreateProcessInstanceWithResultStub stub = new CreateProcessInstanceWithResultStub();
-    stub.registerWith(brokerClient);
-
-    final CreateProcessInstanceWithResultRequest request =
-        CreateProcessInstanceWithResultRequest.newBuilder()
-            .setRequest(
-                CreateProcessInstanceRequest.newBuilder()
-                    .setProcessDefinitionKey(stub.getProcessDefinitionKey())
-                    .setTenantId(tenantId))
-            .build();
-
-    // when
-    final CreateProcessInstanceWithResultResponse response =
-        client.createProcessInstanceWithResult(request);
-
-    // then
-    assertThat(response.getTenantId()).isEqualTo(tenantId);
-
-    final ProcessInstanceCreationRecord brokerRequestValue =
-        (ProcessInstanceCreationRecord) brokerClient.getSingleBrokerRequest().getRequestWriter();
-    assertThat(brokerRequestValue.getTenantId()).isEqualTo(tenantId);
   }
 }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.gateway.api.deployment.DeployResourceStub;
 import io.camunda.zeebe.gateway.api.job.ActivateJobsStub;
 import io.camunda.zeebe.gateway.api.job.TestStreamObserver;
 import io.camunda.zeebe.gateway.api.process.CreateProcessInstanceStub;
+import io.camunda.zeebe.gateway.api.process.CreateProcessInstanceWithResultStub;
 import io.camunda.zeebe.gateway.api.signal.BroadcastSignalStub;
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
@@ -27,6 +28,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalReques
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionMetadata;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionRequirementsMetadata;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
@@ -58,6 +61,7 @@ public class MultiTenancyEnabledTest extends GatewayTest {
   public void setup() {
     new DeployResourceStub().registerWith(brokerClient);
     new CreateProcessInstanceStub().registerWith(brokerClient);
+    new CreateProcessInstanceWithResultStub().registerWith(brokerClient);
     new TenantAwareEvaluateDecisionStub().registerWith(brokerClient);
     new BroadcastSignalStub().registerWith(brokerClient);
     new EvaluateConditionalStub().registerWith(brokerClient);
@@ -163,6 +167,34 @@ public class MultiTenancyEnabledTest extends GatewayTest {
     final CreateProcessInstanceResponse response =
         client.createProcessInstance(
             CreateProcessInstanceRequest.newBuilder().setTenantId("tenant-b").build());
+    assertThat(response).isNotNull();
+
+    // then
+    assertThat(response.getTenantId()).isEqualTo("tenant-b");
+  }
+
+  @Test
+  public void createProcessInstanceWithResultRequestShouldContainAuthorizedTenants() {
+    // when
+    final CreateProcessInstanceWithResultResponse response =
+        client.createProcessInstanceWithResult(
+            CreateProcessInstanceWithResultRequest.newBuilder()
+                .setRequest(CreateProcessInstanceRequest.newBuilder().setTenantId("tenant-b"))
+                .build());
+    assertThat(response).isNotNull();
+
+    // then
+    assertThatTenantIdsSet("tenant-b");
+  }
+
+  @Test
+  public void createProcessInstanceWithResultResponseHasTenantId() {
+    // when
+    final CreateProcessInstanceWithResultResponse response =
+        client.createProcessInstanceWithResult(
+            CreateProcessInstanceWithResultRequest.newBuilder()
+                .setRequest(CreateProcessInstanceRequest.newBuilder().setTenantId("tenant-b"))
+                .build());
     assertThat(response).isNotNull();
 
     // then

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
@@ -188,6 +188,16 @@ public class MultiTenancyEnabledTest extends GatewayTest {
   }
 
   @Test
+  public void createProcessInstanceWithResultRequestRequiresTenantId() {
+    // given
+    final var request = CreateProcessInstanceWithResultRequest.newBuilder().build();
+
+    // when/then
+    assertThatRejectsRequestMissingTenantId(
+        () -> client.createProcessInstanceWithResult(request), "CreateProcessInstanceWithResult");
+  }
+
+  @Test
   public void createProcessInstanceWithResultResponseHasTenantId() {
     // when
     final CreateProcessInstanceWithResultResponse response =


### PR DESCRIPTION
## Description

`createProcessInstanceWithResult` had no multi-tenancy coverage in `MultiTenancyEnabledTest`: no stub registered, no test referencing it. A test for this once existed (`shouldMapRequestAndResponseWithCustomTenant`), but it was `@Ignore`d against #14041 and never reactivated after that issue closed via #14281, even though multi-tenancy enforcement was later built out for real.

This PR:
- Adds two focused tests to `MultiTenancyEnabledTest` covering what the old disabled test asserted (broker command carries the tenant id, response echoes it back), matching the split-per-behavior pattern already used for the sibling `createProcessInstance` RPC.
- Removes the stale disabled test, now fully superseded.
- Adds a third test for the missing-tenant-id rejection case, which the old test never covered, for parity with every other tenant-aware RPC in this file.

No production code changes: the underlying mapping already works correctly via the same `RequestMapper`/`TenantOwned` plumbing the sibling RPC's tests already exercise. All three new tests pass immediately.

**Out of scope:** the REST equivalent of this RPC (`gateway-rest`), downstream layers (`clients/java`, `gateways/gateway-mcp`, `service/`), and broker-side physical tenant routing (covered by `BrokerRequestPhysicalTenantRoutingTest`) — this PR only covers the gRPC gateway's request/response mapping.

## Related issues

closes #58902
