### PR TITLE
Snapshot metadata changes before emitting

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -229,14 +229,24 @@ public class SwimMembershipProtocol
 
   /** Checks the local member metadata for changes. */
   private void checkMetadata() {
-    if (!localMember.properties().equals(localProperties)) {
-      localProperties = new Properties();
-      localProperties.putAll(localMember.properties());
-      LOGGER.debug("{} - Detected local properties change {}", localMember.id(), localProperties);
-      localMember.setIncarnationNumber(localMember.getIncarnationNumber() + 1);
-      post(new GroupMembershipEvent(GroupMembershipEvent.Type.METADATA_CHANGED, localMember));
-      recordUpdate(localMember.copy());
+    final var currentProperties = new Properties();
+    currentProperties.putAll(localMember.properties());
+    if (currentProperties.equals(localProperties)) {
+      return;
     }
+
+    localProperties = currentProperties;
+    LOGGER.debug("{} - Detected local properties change {}", localMember.id(), currentProperties);
+    localMember.setIncarnationNumber(localMember.getIncarnationNumber() + 1);
+
+    // The properties of the local member are mutated in place by other components, e.g. to publish
+    // partition roles and health. Listeners are notified asynchronously, so they must observe
+    // exactly the properties we diffed against here: if they read the live properties instead, a
+    // change applied and reverted before the next check is observed but never published again,
+    // leaving those listeners permanently stale.
+    final var snapshot = localMember.copy(currentProperties);
+    post(new GroupMembershipEvent(GroupMembershipEvent.Type.METADATA_CHANGED, snapshot));
+    recordUpdate(snapshot);
   }
 
   /**
@@ -1150,11 +1160,24 @@ public class SwimMembershipProtocol
     }
 
     /**
-     * Copies the member's state to a new object.
+     * Copies the member's state to a new object. The copy shares the properties instance with this
+     * member, so it observes any later mutation of them. Use {@link #copy(Properties)} to copy with
+     * a stable set of properties.
      *
      * @return the copied object
      */
     ImmutableMember copy() {
+      return copy(properties());
+    }
+
+    /**
+     * Copies the member's state to a new object, using the given properties instead of this
+     * member's own, mutable ones.
+     *
+     * @param properties the properties the copy should report
+     * @return the copied object
+     */
+    ImmutableMember copy(final Properties properties) {
       return new ImmutableMember(
           id(),
           nodeVersion(),
@@ -1162,7 +1185,7 @@ public class SwimMembershipProtocol
           zone(),
           rack(),
           host(),
-          properties(),
+          properties,
           version(),
           timestamp(),
           state,

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -229,12 +229,12 @@ public class SwimMembershipProtocol
 
   /** Checks the local member metadata for changes. */
   private void checkMetadata() {
-    final var currentProperties = new Properties();
-    currentProperties.putAll(localMember.properties());
-    if (currentProperties.equals(localProperties)) {
+    final var liveProperties = localMember.properties();
+    if (liveProperties.equals(localProperties)) {
       return;
     }
 
+    final var currentProperties = (Properties) liveProperties.clone();
     localProperties = currentProperties;
     LOGGER.debug("{} - Detected local properties change {}", localMember.id(), currentProperties);
     localMember.setIncarnationNumber(localMember.getIncarnationNumber() + 1);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
@@ -181,7 +181,7 @@ public class SwimProtocolTest extends ConcurrentTestCase {
         });
 
     // when - the property changes to a new value while the listener is notified of the first
-    // change, and is then reverted to the value the protocol last published
+    // change
     member1.properties().setProperty("foo", "published");
     assertThat(notifying.await(30, TimeUnit.SECONDS)).isTrue();
     member1.properties().setProperty("foo", "changed");
@@ -189,7 +189,6 @@ public class SwimProtocolTest extends ConcurrentTestCase {
     Awaitility.await("until the listener was notified")
         .atMost(Duration.ofSeconds(30))
         .until(() -> !notifiedValues.isEmpty());
-    member1.properties().setProperty("foo", "published");
 
     // then - the listener ends up knowing the member's current property value
     Awaitility.await("until the listener knows the current property value")

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
@@ -46,9 +46,12 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.function.UnaryOperator;
@@ -137,6 +140,61 @@ public class SwimProtocolTest extends ConcurrentTestCase {
     // then
     checkEvent(member1, MEMBER_ADDED, member1);
     checkMembers(member1, member1);
+  }
+
+  /**
+   * The properties of the local member are mutated in place by other components, e.g. by the broker
+   * to publish partition roles and health, while listeners are notified asynchronously. A change
+   * that is applied and reverted while a listener is being notified of the previous change must
+   * still leave that listener with the member's current properties.
+   */
+  @Test
+  public void shouldNotifyListenersOfPropertyChangedWithCorrectValue() throws Exception {
+    // given - a listener that is blocked while being notified of a first property change; the
+    // gossip interval is long enough that no further metadata check runs while the test changes the
+    // properties below
+    reset(false);
+    final var protocol =
+        startProtocol(
+            member1,
+            config -> config.setGossipInterval(Duration.ofSeconds(5)),
+            member1.id().toString());
+    checkEvent(member1, MEMBER_ADDED, member1);
+
+    final var notifying = new CountDownLatch(1);
+    final var resumeNotifying = new CountDownLatch(1);
+    final List<String> notifiedValues = new CopyOnWriteArrayList<>();
+    protocol.addListener(
+        event -> {
+          if (event.type() != METADATA_CHANGED) {
+            return;
+          }
+
+          notifying.countDown();
+          try {
+            resumeNotifying.await(30, TimeUnit.SECONDS);
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+          }
+          notifiedValues.add(event.member().properties().getProperty("foo"));
+        });
+
+    // when - the property changes to a new value while the listener is notified of the first
+    // change, and is then reverted to the value the protocol last published
+    member1.properties().setProperty("foo", "published");
+    assertThat(notifying.await(30, TimeUnit.SECONDS)).isTrue();
+    member1.properties().setProperty("foo", "changed");
+    resumeNotifying.countDown();
+    Awaitility.await("until the listener was notified")
+        .atMost(Duration.ofSeconds(30))
+        .until(() -> !notifiedValues.isEmpty());
+    member1.properties().setProperty("foo", "published");
+
+    // then - the listener ends up knowing the member's current property value
+    Awaitility.await("until the listener knows the current property value")
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(() -> assertThat(notifiedValues.getLast()).isEqualTo("published"));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

On metadata changed, emit the snapshot of the properties changed instead of the live state. The live state can be mutated by the time the properties are gossiped.

The final outcome of the gossiped property changes should remain the same, however skipping property changes can result to inconsistencies being detected in CI such as the health check failing during startup which is evidently present.

_Reverting the code and running the new added test fails_

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #58906 
