### PR TITLE
feat: define broker protocol for coordinated leadership transfer

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Raft.java
+++ b/configuration/src/main/java/io/camunda/configuration/Raft.java
@@ -156,6 +156,9 @@ public class Raft {
    */
   private int preferSnapshotReplicationThreshold = 100;
 
+  /** Coordinated leadership transfer (rebalancing) options. */
+  private final Rebalance rebalance = new Rebalance();
+
   /**
    * Defines whether segment files are pre-allocated to their full size on creation or not. If true,
    * when a new segment is created on demand, disk space will be reserved for its full maximum size.
@@ -370,6 +373,10 @@ public class Raft {
     this.preferSnapshotReplicationThreshold = preferSnapshotReplicationThreshold;
   }
 
+  public Rebalance getRebalance() {
+    return rebalance;
+  }
+
   public boolean isPreallocateSegmentFiles() {
     return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".preallocate-segment-files",
@@ -398,5 +405,45 @@ public class Raft {
   public void setSegmentPreallocationStrategy(
       final PreAllocationStrategy segmentPreallocationStrategy) {
     this.segmentPreallocationStrategy = segmentPreallocationStrategy;
+  }
+
+  /** Coordinated leadership transfer (rebalancing) options under {@code ....raft.rebalance}. */
+  public static class Rebalance {
+    /**
+     * The maximum replication lag a desired leader may have for the current leader to attempt a
+     * transfer. Above it the partition is skipped with {@code LAG_TOO_HIGH}. Lag is the remaining
+     * Raft entries to replicate plus any pending snapshot, in bytes.
+     */
+    private DataSize replicationLagThreshold = DataSize.ofMegabytes(8);
+
+    /**
+     * How long the current leader waits (paused, declining writes) for the desired leader to finish
+     * replicating. If exceeded, the transfer is cancelled with {@code REPLICATION_TIMED_OUT}.
+     */
+    private Duration replicationTimeout = Duration.ofSeconds(10);
+
+    public DataSize getReplicationLagThreshold() {
+      return replicationLagThreshold;
+    }
+
+    public void setReplicationLagThreshold(final DataSize replicationLagThreshold) {
+      if (replicationLagThreshold == null || replicationLagThreshold.toBytes() < 0) {
+        throw new IllegalArgumentException("replicationLagThreshold must be non-negative");
+      }
+      this.replicationLagThreshold = replicationLagThreshold;
+    }
+
+    public Duration getReplicationTimeout() {
+      return replicationTimeout;
+    }
+
+    public void setReplicationTimeout(final Duration replicationTimeout) {
+      if (replicationTimeout == null
+          || replicationTimeout.isNegative()
+          || replicationTimeout.isZero()) {
+        throw new IllegalArgumentException("replicationTimeout must be positive");
+      }
+      this.replicationTimeout = replicationTimeout;
+    }
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -619,6 +619,14 @@ public class BrokerBasedPropertiesOverride {
         .getRaft()
         .setPreferSnapshotReplicationThreshold(raft.getPreferSnapshotReplicationThreshold());
     override
+        .getCluster()
+        .getRaft()
+        .setRebalanceReplicationLagThreshold(raft.getRebalance().getReplicationLagThreshold());
+    override
+        .getCluster()
+        .getRaft()
+        .setRebalanceReplicationTimeout(raft.getRebalance().getReplicationTimeout());
+    override
         .getExperimental()
         .getRaft()
         .setPreallocateSegmentFiles(raft.isPreallocateSegmentFiles());

--- a/configuration/src/test/java/io/camunda/configuration/ClusterRaftTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterRaftTest.java
@@ -13,6 +13,7 @@ import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.zeebe.broker.system.configuration.ExperimentalCfg;
 import io.camunda.zeebe.broker.system.configuration.ExperimentalRaftCfg;
+import io.camunda.zeebe.broker.system.configuration.RaftCfg;
 import java.time.Duration;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,9 @@ public class ClusterRaftTest {
         "camunda.cluster.raft.max-quorum-response-timeout=10s",
         "camunda.cluster.raft.min-step-down-failure-count=5",
         "camunda.cluster.raft.prefer-snapshot-replication-threshold=110",
-        "camunda.cluster.raft.preallocate-segment-files=false"
+        "camunda.cluster.raft.preallocate-segment-files=false",
+        "camunda.cluster.raft.rebalance.replication-lag-threshold=16MB",
+        "camunda.cluster.raft.rebalance.replication-timeout=30s"
       })
   class WithOnlyUnifiedConfigSet {
     final BrokerBasedProperties brokerCfg;
@@ -99,6 +102,13 @@ public class ClusterRaftTest {
           .returns(5, ExperimentalRaftCfg::getMinStepDownFailureCount)
           .returns(110, ExperimentalRaftCfg::getPreferSnapshotReplicationThreshold)
           .returns(false, ExperimentalRaftCfg::isPreallocateSegmentFiles);
+    }
+
+    @Test
+    void shouldSetRebalance() {
+      assertThat(brokerCfg.getCluster().getRaft())
+          .returns(DataSize.ofMegabytes(16), RaftCfg::getRebalanceReplicationLagThreshold)
+          .returns(Duration.ofSeconds(30), RaftCfg::getRebalanceReplicationTimeout);
     }
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/RaftRebalanceValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/RaftRebalanceValidationTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.configuration.Raft.Rebalance;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.unit.DataSize;
+
+final class RaftRebalanceValidationTest {
+
+  @Test
+  void shouldRejectNegativeReplicationLagThreshold() {
+    // given
+    final var rebalance = new Rebalance();
+
+    // when / then
+    assertThatThrownBy(() -> rebalance.setReplicationLagThreshold(DataSize.ofBytes(-1)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldAcceptZeroReplicationLagThreshold() {
+    // given
+    final var rebalance = new Rebalance();
+
+    // when / then
+    assertThatCode(() -> rebalance.setReplicationLagThreshold(DataSize.ofBytes(0)))
+        .doesNotThrowAnyException();
+    assertThat(rebalance.getReplicationLagThreshold()).isEqualTo(DataSize.ofBytes(0));
+  }
+
+  @Test
+  void shouldRejectZeroReplicationTimeout() {
+    // given
+    final var rebalance = new Rebalance();
+
+    // when / then
+    assertThatThrownBy(() -> rebalance.setReplicationTimeout(Duration.ZERO))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldRejectNegativeReplicationTimeout() {
+    // given
+    final var rebalance = new Rebalance();
+
+    // when / then
+    assertThatThrownBy(() -> rebalance.setReplicationTimeout(Duration.ofSeconds(-1)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldAcceptValidValues() {
+    // given
+    final var rebalance = new Rebalance();
+
+    // when / then
+    assertThatCode(
+            () -> {
+              rebalance.setReplicationLagThreshold(DataSize.ofMegabytes(16));
+              rebalance.setReplicationTimeout(Duration.ofSeconds(30));
+            })
+        .doesNotThrowAnyException();
+  }
+}

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
@@ -61,6 +61,8 @@ cluster.raft.min-step-down-failure-count
 cluster.raft.preallocate-segment-files
 cluster.raft.prefer-snapshot-replication-threshold
 cluster.raft.priority-election-enabled
+cluster.raft.rebalance.replication-lag-threshold
+cluster.raft.rebalance.replication-timeout
 cluster.raft.request-timeout
 cluster.raft.segment-preallocation-strategy
 cluster.raft.snapshot-chunk-size

--- a/zeebe/atomix/cluster/spotbugs/spotbugs-exclude.xml
+++ b/zeebe/atomix/cluster/spotbugs/spotbugs-exclude.xml
@@ -19,10 +19,6 @@
     <Class name="io.atomix.raft.cluster.impl.RaftMemberContext"/>
     <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
   </Match>
-  <Match>
-    <Class name="io.atomix.raft.roles.LeaderRole"/>
-    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
-  </Match>
 
 
 </FindBugsFilter>

--- a/zeebe/atomix/cluster/spotbugs/spotbugs-exclude.xml
+++ b/zeebe/atomix/cluster/spotbugs/spotbugs-exclude.xml
@@ -19,6 +19,10 @@
     <Class name="io.atomix.raft.cluster.impl.RaftMemberContext"/>
     <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
   </Match>
+  <Match>
+    <Class name="io.atomix.raft.roles.LeaderRole"/>
+    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
+  </Match>
 
 
 </FindBugsFilter>

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/LeadershipTransferResult.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/LeadershipTransferResult.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+/**
+ * The terminal outcome of a per-partition coordinated leadership transfer, reported by the current
+ * leader to the rebalancing coordinator. Also used as the {@code result} label on the
+ * transfer-duration metric.
+ */
+public enum LeadershipTransferResult {
+  /** The desired leader was promoted and took over leadership. */
+  TRANSFERRED,
+  /** The desired leader is already the leader; nothing to do. */
+  ALREADY_LEADER,
+  /** The desired leader is offline or not a member of the partition. */
+  OFFLINE,
+  /**
+   * The request did not come from the current coordinator (the lowest-id member of the leader's
+   * committed configuration), or carried a stale configuration version.
+   */
+  INVALID_COORDINATOR,
+  /** This leader is already running a transfer. */
+  TRANSFER_IN_PROGRESS,
+  /** The desired leader's replication lag is above the configured threshold. */
+  LAG_TOO_HIGH,
+  /**
+   * A Raft configuration change is in progress, so the log head the desired leader would catch up
+   * to cannot be frozen.
+   */
+  CONFIGURATION_CHANGE_IN_PROGRESS,
+  /** The desired leader did not finish replicating within {@code replicationTimeout}. */
+  REPLICATION_TIMED_OUT,
+  /** TimeoutNow did not move leadership within {@code maxTransferAttempts}. */
+  TRANSFER_FAILED,
+  /**
+   * Leadership changed (this node stepped down or another node was elected) during the transfer.
+   */
+  LEADER_CHANGED
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/LeadershipTransferResult.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/LeadershipTransferResult.java
@@ -52,7 +52,7 @@ public enum LeadershipTransferResult {
   /** The desired leader did not finish replicating within {@code replicationTimeout}. */
   REPLICATION_TIMED_OUT,
   /** TimeoutNow did not move leadership within {@code maxTransferAttempts}. */
-  TRANSFER_FAILED,
+  TIMEOUT_NOW_EXHAUSTED,
   /**
    * Leadership changed (this node stepped down or another node was elected) during the transfer.
    */

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/LeadershipTransferResult.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/LeadershipTransferResult.java
@@ -29,7 +29,7 @@ public enum LeadershipTransferResult {
   OFFLINE,
   /**
    * The request did not come from the current coordinator (the lowest-id member of the leader's
-   * committed configuration), or carried a stale configuration version.
+   * committed configuration), or carried a stale Raft configuration index.
    */
   INVALID_COORDINATOR,
   /** This leader is already running a transfer. */

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/LeadershipTransferResult.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/LeadershipTransferResult.java
@@ -25,13 +25,21 @@ public enum LeadershipTransferResult {
   TRANSFERRED,
   /** The desired leader is already the leader; nothing to do. */
   ALREADY_LEADER,
-  /** The desired leader is offline or not a member of the partition. */
-  OFFLINE,
+  /** The desired leader is not a member of the partition. */
+  NOT_MEMBER,
   /**
-   * The request did not come from the current coordinator (the lowest-id member of the leader's
-   * committed configuration), or carried a stale Raft configuration index.
+   * The desired leader has not acknowledged an append in this term, so its log has not converged.
    */
-  INVALID_COORDINATOR,
+  NOT_REPLICATING,
+  /** The desired leader is out of contact with this leader. */
+  UNREACHABLE,
+  /**
+   * The request did not come from the current coordinator, the lowest-id member of the leader's
+   * committed configuration.
+   */
+  NOT_COORDINATOR,
+  /** The request carried a Raft configuration index older than the leader's. */
+  STALE_CONFIGURATION,
   /** This leader is already running a transfer. */
   TRANSFER_IN_PROGRESS,
   /** The desired leader's replication lag is above the configured threshold. */

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -197,6 +197,11 @@ public final class RaftMemberContext {
     appendSucceeded(true);
   }
 
+  /** Whether an append has been successfully replicated to this member during this term. */
+  public boolean hasAckedAppend() {
+    return appendSucceeded;
+  }
+
   /**
    * Sets whether the last append to the member succeeded.
    *

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -1323,6 +1323,14 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     return partitionConfig.getMinStepDownFailureCount();
   }
 
+  public long getRebalanceReplicationLagThreshold() {
+    return partitionConfig.getRebalanceReplicationLagThreshold();
+  }
+
+  public Duration getRebalanceReplicationTimeout() {
+    return partitionConfig.getRebalanceReplicationTimeout();
+  }
+
   public Duration getMaxQuorumResponseTimeout() {
     return partitionConfig.getMaxQuorumResponseTimeout();
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -33,6 +33,8 @@ public class RaftPartitionConfig {
   private static final boolean DEFAULT_RECEIVE_ON_LEGACY_SUBJECT = true;
   // Keep in sync with the default in ExperimentalRaftCfg, which usually overrides this.
   private static final Duration DEFAULT_CONFIGURATION_CHANGE_TIMEOUT = Duration.ofSeconds(10);
+  private static final long DEFAULT_REBALANCE_REPLICATION_LAG_THRESHOLD = 8L * 1024 * 1024;
+  private static final Duration DEFAULT_REBALANCE_REPLICATION_TIMEOUT = Duration.ofSeconds(10);
 
   private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
   private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
@@ -44,6 +46,8 @@ public class RaftPartitionConfig {
   private int minStepDownFailureCount = DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT;
   private Duration maxQuorumResponseTimeout = DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT;
   private int preferSnapshotReplicationThreshold = DEFAULT_SNAPSHOT_REPLICATION_THRESHOLD;
+  private long rebalanceReplicationLagThreshold = DEFAULT_REBALANCE_REPLICATION_LAG_THRESHOLD;
+  private Duration rebalanceReplicationTimeout = DEFAULT_REBALANCE_REPLICATION_TIMEOUT;
   private RaftStorageConfig storageConfig;
   private EntryValidator entryValidator;
   private Duration configurationChangeTimeout = DEFAULT_CONFIGURATION_CHANGE_TIMEOUT;
@@ -195,6 +199,32 @@ public class RaftPartitionConfig {
 
   public void setPreferSnapshotReplicationThreshold(final int preferSnapshotReplicationThreshold) {
     this.preferSnapshotReplicationThreshold = preferSnapshotReplicationThreshold;
+  }
+
+  /**
+   * The maximum replication lag, in bytes, that the desired leader may have for the current leader
+   * to attempt a coordinated leadership transfer. Above it the partition is skipped with {@code
+   * LAG_TOO_HIGH}. Maps to {@code camunda.cluster.raft.rebalance.replicationLagThreshold}.
+   */
+  public long getRebalanceReplicationLagThreshold() {
+    return rebalanceReplicationLagThreshold;
+  }
+
+  public void setRebalanceReplicationLagThreshold(final long rebalanceReplicationLagThreshold) {
+    this.rebalanceReplicationLagThreshold = rebalanceReplicationLagThreshold;
+  }
+
+  /**
+   * How long the current leader waits (paused, declining writes) for the desired leader to finish
+   * replicating during a coordinated leadership transfer before cancelling with {@code
+   * REPLICATION_TIMED_OUT}. Maps to {@code camunda.cluster.raft.rebalance.replicationTimeout}.
+   */
+  public Duration getRebalanceReplicationTimeout() {
+    return rebalanceReplicationTimeout;
+  }
+
+  public void setRebalanceReplicationTimeout(final Duration rebalanceReplicationTimeout) {
+    this.rebalanceReplicationTimeout = rebalanceReplicationTimeout;
   }
 
   public RaftStorageConfig getStorageConfig() {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
@@ -34,6 +34,8 @@ class RaftMessageContext {
   final String installSubject;
   final String transferSubject;
   final String timeoutNowSubject;
+  final String leadershipTransferInitiateSubject;
+  final String leadershipTransferResultSubject;
   final String pollSubject;
   final String voteSubject;
   final String appendV1subject;
@@ -56,6 +58,8 @@ class RaftMessageContext {
     installSubject = getSubject(prefix, "install");
     transferSubject = getSubject(prefix, "transfer");
     timeoutNowSubject = getSubject(prefix, "timeout-now");
+    leadershipTransferInitiateSubject = getSubject(prefix, "leadership-transfer-initiate");
+    leadershipTransferResultSubject = getSubject(prefix, "leadership-transfer-result");
     pollSubject = getSubject(prefix, "poll");
     voteSubject = getSubject(prefix, "vote");
     appendV1subject = getSubject(prefix, "append");
@@ -109,6 +113,14 @@ class RaftMessageContext {
 
   String getTimeoutNowSubject() {
     return timeoutNowSubject;
+  }
+
+  String getLeadershipTransferInitiateSubject() {
+    return leadershipTransferInitiateSubject;
+  }
+
+  String getLeadershipTransferResultSubject() {
+    return leadershipTransferResultSubject;
   }
 
   private static String getSubject(final String prefix, final String type) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
@@ -17,6 +17,7 @@
 package io.atomix.raft.partition.impl;
 
 import io.atomix.cluster.MemberId;
+import io.atomix.raft.LeadershipTransferResult;
 import io.atomix.raft.RaftError;
 import io.atomix.raft.RaftError.Type;
 import io.atomix.raft.cluster.RaftMember;
@@ -31,6 +32,10 @@ import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.JoinRequest;
 import io.atomix.raft.protocol.JoinResponse;
+import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
+import io.atomix.raft.protocol.LeadershipTransferInitiateResponse;
+import io.atomix.raft.protocol.LeadershipTransferResultRequest;
+import io.atomix.raft.protocol.LeadershipTransferResultResponse;
 import io.atomix.raft.protocol.LeaveRequest;
 import io.atomix.raft.protocol.LeaveResponse;
 import io.atomix.raft.protocol.PersistedRaftRecord;
@@ -102,6 +107,11 @@ public final class RaftNamespaces {
           .register(ForceConfigureResponse.class)
           .register(TimeoutNowRequest.class)
           .register(TimeoutNowResponse.class)
+          .register(LeadershipTransferInitiateRequest.class)
+          .register(LeadershipTransferInitiateResponse.class)
+          .register(LeadershipTransferResultRequest.class)
+          .register(LeadershipTransferResultResponse.class)
+          .register(LeadershipTransferResult.class)
           .name("RaftProtocol")
           .build();
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
@@ -30,6 +30,10 @@ import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.JoinRequest;
 import io.atomix.raft.protocol.JoinResponse;
+import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
+import io.atomix.raft.protocol.LeadershipTransferInitiateResponse;
+import io.atomix.raft.protocol.LeadershipTransferResultRequest;
+import io.atomix.raft.protocol.LeadershipTransferResultResponse;
 import io.atomix.raft.protocol.LeaveRequest;
 import io.atomix.raft.protocol.LeaveResponse;
 import io.atomix.raft.protocol.PollRequest;
@@ -138,6 +142,18 @@ public class RaftServerCommunicator implements RaftServerProtocol {
   }
 
   @Override
+  public CompletableFuture<LeadershipTransferInitiateResponse> leadershipTransferInitiate(
+      final MemberId memberId, final LeadershipTransferInitiateRequest request) {
+    return sendAndReceive(sendingSubject.getLeadershipTransferInitiateSubject(), request, memberId);
+  }
+
+  @Override
+  public CompletableFuture<LeadershipTransferResultResponse> leadershipTransferResult(
+      final MemberId memberId, final LeadershipTransferResultRequest request) {
+    return sendAndReceive(sendingSubject.getLeadershipTransferResultSubject(), request, memberId);
+  }
+
+  @Override
   public CompletableFuture<PollResponse> poll(final MemberId memberId, final PollRequest request) {
     return sendAndReceive(sendingSubject.getPollSubject(), request, memberId);
   }
@@ -179,6 +195,33 @@ public class RaftServerCommunicator implements RaftServerProtocol {
   @Override
   public void unregisterTimeoutNowHandler() {
     unregisterHandler(RaftMessageContext::getTimeoutNowSubject);
+  }
+
+  @Override
+  public void registerLeadershipTransferInitiateHandler(
+      final Function<
+              LeadershipTransferInitiateRequest,
+              CompletableFuture<LeadershipTransferInitiateResponse>>
+          handler) {
+    registerHandler(RaftMessageContext::getLeadershipTransferInitiateSubject, handler);
+  }
+
+  @Override
+  public void unregisterLeadershipTransferInitiateHandler() {
+    unregisterHandler(RaftMessageContext::getLeadershipTransferInitiateSubject);
+  }
+
+  @Override
+  public void registerLeadershipTransferResultHandler(
+      final Function<
+              LeadershipTransferResultRequest, CompletableFuture<LeadershipTransferResultResponse>>
+          handler) {
+    registerHandler(RaftMessageContext::getLeadershipTransferResultSubject, handler);
+  }
+
+  @Override
+  public void unregisterLeadershipTransferResultHandler() {
+    unregisterHandler(RaftMessageContext::getLeadershipTransferResultSubject);
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeadershipTransferInitiateRequest.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeadershipTransferInitiateRequest.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * immediately (returning a skip result in the {@link LeadershipTransferInitiateResponse}) or
  * accepts it and drives the transfer, reporting the terminal outcome asynchronously via a {@link
  * LeadershipTransferResultRequest} carrying the same {@code correlationId}. The {@code coordinator}
- * and {@code coordinatorConfigVersion} let the leader reject a request from a stale or
+ * and {@code coordinatorConfigIndex} let the leader reject a request from a stale or
  * non-coordinator node.
  *
  * <p>The two halves travel on separate subjects rather than as one request/response pair because a
@@ -42,17 +42,17 @@ public final class LeadershipTransferInitiateRequest extends AbstractRaftRequest
 
   private final MemberId desiredLeader;
   private final MemberId coordinator;
-  private final long coordinatorConfigVersion;
+  private final long coordinatorConfigIndex;
   private final long correlationId;
 
   private LeadershipTransferInitiateRequest(
       final MemberId desiredLeader,
       final MemberId coordinator,
-      final long coordinatorConfigVersion,
+      final long coordinatorConfigIndex,
       final long correlationId) {
     this.desiredLeader = desiredLeader;
     this.coordinator = coordinator;
-    this.coordinatorConfigVersion = coordinatorConfigVersion;
+    this.coordinatorConfigIndex = coordinatorConfigIndex;
     this.correlationId = correlationId;
   }
 
@@ -70,9 +70,9 @@ public final class LeadershipTransferInitiateRequest extends AbstractRaftRequest
     return coordinator;
   }
 
-  /** The configuration version the coordinator based its request on. */
-  public long coordinatorConfigVersion() {
-    return coordinatorConfigVersion;
+  /** The index of the Raft configuration the coordinator based its request on. */
+  public long coordinatorConfigIndex() {
+    return coordinatorConfigIndex;
   }
 
   /**
@@ -92,7 +92,7 @@ public final class LeadershipTransferInitiateRequest extends AbstractRaftRequest
   @Override
   public int hashCode() {
     return Objects.hash(
-        getClass(), desiredLeader, coordinator, coordinatorConfigVersion, correlationId);
+        getClass(), desiredLeader, coordinator, coordinatorConfigIndex, correlationId);
   }
 
   @Override
@@ -104,7 +104,7 @@ public final class LeadershipTransferInitiateRequest extends AbstractRaftRequest
       return false;
     }
     final LeadershipTransferInitiateRequest other = (LeadershipTransferInitiateRequest) object;
-    return coordinatorConfigVersion == other.coordinatorConfigVersion
+    return coordinatorConfigIndex == other.coordinatorConfigIndex
         && correlationId == other.correlationId
         && desiredLeader.equals(other.desiredLeader)
         && coordinator.equals(other.coordinator);
@@ -115,7 +115,7 @@ public final class LeadershipTransferInitiateRequest extends AbstractRaftRequest
     return toStringHelper(this)
         .add("desiredLeader", desiredLeader)
         .add("coordinator", coordinator)
-        .add("coordinatorConfigVersion", coordinatorConfigVersion)
+        .add("coordinatorConfigIndex", coordinatorConfigIndex)
         .add("correlationId", correlationId)
         .toString();
   }
@@ -126,7 +126,7 @@ public final class LeadershipTransferInitiateRequest extends AbstractRaftRequest
 
     private MemberId desiredLeader;
     private MemberId coordinator;
-    private long coordinatorConfigVersion;
+    private long coordinatorConfigIndex;
     private long correlationId;
 
     public Builder withDesiredLeader(final MemberId desiredLeader) {
@@ -139,8 +139,8 @@ public final class LeadershipTransferInitiateRequest extends AbstractRaftRequest
       return this;
     }
 
-    public Builder withCoordinatorConfigVersion(final long coordinatorConfigVersion) {
-      this.coordinatorConfigVersion = coordinatorConfigVersion;
+    public Builder withCoordinatorConfigIndex(final long coordinatorConfigIndex) {
+      this.coordinatorConfigIndex = coordinatorConfigIndex;
       return this;
     }
 
@@ -161,7 +161,7 @@ public final class LeadershipTransferInitiateRequest extends AbstractRaftRequest
     public LeadershipTransferInitiateRequest build() {
       validate();
       return new LeadershipTransferInitiateRequest(
-          desiredLeader, coordinator, coordinatorConfigVersion, correlationId);
+          desiredLeader, coordinator, coordinatorConfigIndex, correlationId);
     }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeadershipTransferInitiateRequest.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeadershipTransferInitiateRequest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.protocol;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import io.atomix.cluster.MemberId;
+import java.util.Objects;
+
+/**
+ * Initiate request for a coordinated leadership transfer.
+ *
+ * <p>Sent by the rebalancing coordinator to a partition's current leader to ask it to hand
+ * leadership to {@code desiredLeader}. The leader validates the request and either rejects it
+ * immediately (returning a skip result in the {@link LeadershipTransferInitiateResponse}) or
+ * accepts it and drives the transfer, reporting the terminal outcome asynchronously via a {@link
+ * LeadershipTransferResultRequest} carrying the same {@code correlationId}. The {@code coordinator}
+ * and {@code coordinatorConfigVersion} let the leader reject a request from a stale or
+ * non-coordinator node.
+ */
+public final class LeadershipTransferInitiateRequest extends AbstractRaftRequest {
+
+  private final MemberId desiredLeader;
+  private final MemberId coordinator;
+  private final long coordinatorConfigVersion;
+  private final long correlationId;
+
+  private LeadershipTransferInitiateRequest(
+      final MemberId desiredLeader,
+      final MemberId coordinator,
+      final long coordinatorConfigVersion,
+      final long correlationId) {
+    this.desiredLeader = desiredLeader;
+    this.coordinator = coordinator;
+    this.coordinatorConfigVersion = coordinatorConfigVersion;
+    this.correlationId = correlationId;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** The intended successor the coordinator wants leadership to move to. */
+  public MemberId desiredLeader() {
+    return desiredLeader;
+  }
+
+  /** The coordinator that requested the transfer. */
+  public MemberId coordinator() {
+    return coordinator;
+  }
+
+  /** The configuration version the coordinator based its request on. */
+  public long coordinatorConfigVersion() {
+    return coordinatorConfigVersion;
+  }
+
+  /**
+   * The coordinator-generated id of the rebalance operation this transfer belongs to. Echoed back
+   * in the {@link LeadershipTransferResultRequest} so the coordinator can tell the result of this
+   * operation apart from a delayed result of an earlier one.
+   */
+  public long correlationId() {
+    return correlationId;
+  }
+
+  @Override
+  public MemberId from() {
+    return coordinator;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        getClass(), desiredLeader, coordinator, coordinatorConfigVersion, correlationId);
+  }
+
+  @Override
+  public boolean equals(final Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (object == null || !getClass().isAssignableFrom(object.getClass())) {
+      return false;
+    }
+    final LeadershipTransferInitiateRequest other = (LeadershipTransferInitiateRequest) object;
+    return coordinatorConfigVersion == other.coordinatorConfigVersion
+        && correlationId == other.correlationId
+        && desiredLeader.equals(other.desiredLeader)
+        && coordinator.equals(other.coordinator);
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .add("desiredLeader", desiredLeader)
+        .add("coordinator", coordinator)
+        .add("coordinatorConfigVersion", coordinatorConfigVersion)
+        .add("correlationId", correlationId)
+        .toString();
+  }
+
+  /** Leadership-transfer initiate request builder. */
+  public static class Builder
+      extends AbstractRaftRequest.Builder<Builder, LeadershipTransferInitiateRequest> {
+
+    private MemberId desiredLeader;
+    private MemberId coordinator;
+    private long coordinatorConfigVersion;
+    private long correlationId;
+
+    public Builder withDesiredLeader(final MemberId desiredLeader) {
+      this.desiredLeader = checkNotNull(desiredLeader, "desiredLeader cannot be null");
+      return this;
+    }
+
+    public Builder withCoordinator(final MemberId coordinator) {
+      this.coordinator = checkNotNull(coordinator, "coordinator cannot be null");
+      return this;
+    }
+
+    public Builder withCoordinatorConfigVersion(final long coordinatorConfigVersion) {
+      this.coordinatorConfigVersion = coordinatorConfigVersion;
+      return this;
+    }
+
+    public Builder withCorrelationId(final long correlationId) {
+      this.correlationId = correlationId;
+      return this;
+    }
+
+    @Override
+    protected void validate() {
+      super.validate();
+      checkNotNull(desiredLeader, "desiredLeader cannot be null");
+      checkNotNull(coordinator, "coordinator cannot be null");
+      checkArgument(correlationId != 0, "correlationId must be set");
+    }
+
+    @Override
+    public LeadershipTransferInitiateRequest build() {
+      validate();
+      return new LeadershipTransferInitiateRequest(
+          desiredLeader, coordinator, coordinatorConfigVersion, correlationId);
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeadershipTransferInitiateRequest.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeadershipTransferInitiateRequest.java
@@ -32,6 +32,11 @@ import java.util.Objects;
  * LeadershipTransferResultRequest} carrying the same {@code correlationId}. The {@code coordinator}
  * and {@code coordinatorConfigVersion} let the leader reject a request from a stale or
  * non-coordinator node.
+ *
+ * <p>The two halves travel on separate subjects rather than as one request/response pair because a
+ * transfer takes far longer than the {@code requestTimeout} bounding a single round trip, and has
+ * to survive the leader it was sent to stepping down. The {@code correlationId} is what ties them
+ * back together.
  */
 public final class LeadershipTransferInitiateRequest extends AbstractRaftRequest {
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeadershipTransferInitiateResponse.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeadershipTransferInitiateResponse.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.protocol;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.LeadershipTransferResult;
+import io.atomix.raft.RaftError;
+import java.util.Objects;
+
+/**
+ * Immediate acknowledgement of a {@link LeadershipTransferInitiateRequest}.
+ *
+ * <p>If {@code accepted} is true the current leader has taken the transfer on and will report the
+ * terminal outcome later via a {@link LeadershipTransferResultRequest}. If {@code accepted} is
+ * false the transfer was resolved immediately: {@code result} carries the skip reason (a failed
+ * pre-check) and {@code leader} points to the node the receiver believes is the leader, so a
+ * request that reached a follower can be redirected.
+ */
+public class LeadershipTransferInitiateResponse extends AbstractRaftResponse {
+
+  private final boolean accepted;
+  private final LeadershipTransferResult result;
+  private final MemberId leader;
+
+  public LeadershipTransferInitiateResponse(
+      final Status status,
+      final RaftError error,
+      final boolean accepted,
+      final LeadershipTransferResult result,
+      final MemberId leader) {
+    super(status, error);
+    this.accepted = accepted;
+    this.result = result;
+    this.leader = leader;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Whether the leader accepted the transfer and will report the outcome asynchronously. */
+  public boolean accepted() {
+    return accepted;
+  }
+
+  /** The immediate skip result when the transfer was not accepted, or {@code null} otherwise. */
+  public LeadershipTransferResult result() {
+    return result;
+  }
+
+  /** The node the receiver believes is the leader, for redirecting a misrouted request. */
+  public MemberId leader() {
+    return leader;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), status, accepted, result, leader);
+  }
+
+  @Override
+  public boolean equals(final Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (object == null || !getClass().isAssignableFrom(object.getClass())) {
+      return false;
+    }
+    final LeadershipTransferInitiateResponse other = (LeadershipTransferInitiateResponse) object;
+    return status == other.status
+        && accepted == other.accepted
+        && result == other.result
+        && Objects.equals(leader, other.leader);
+  }
+
+  @Override
+  public String toString() {
+    if (status == Status.OK) {
+      return toStringHelper(this)
+          .add("status", status)
+          .add("accepted", accepted)
+          .add("result", result)
+          .add("leader", leader)
+          .toString();
+    }
+    return toStringHelper(this).add("status", status).add("error", error).toString();
+  }
+
+  /** Leadership-transfer initiate response builder. */
+  public static class Builder
+      extends AbstractRaftResponse.Builder<Builder, LeadershipTransferInitiateResponse> {
+
+    private boolean accepted;
+    private LeadershipTransferResult result;
+    private MemberId leader;
+
+    public Builder withAccepted(final boolean accepted) {
+      this.accepted = accepted;
+      return this;
+    }
+
+    public Builder withResult(final LeadershipTransferResult result) {
+      this.result = result;
+      return this;
+    }
+
+    public Builder withLeader(final MemberId leader) {
+      this.leader = leader;
+      return this;
+    }
+
+    @Override
+    public LeadershipTransferInitiateResponse build() {
+      validate();
+      return new LeadershipTransferInitiateResponse(status, error, accepted, result, leader);
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeadershipTransferInitiateResponse.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeadershipTransferInitiateResponse.java
@@ -17,7 +17,6 @@ package io.atomix.raft.protocol;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
-import io.atomix.cluster.MemberId;
 import io.atomix.raft.LeadershipTransferResult;
 import io.atomix.raft.RaftError;
 import java.util.Objects;
@@ -25,52 +24,44 @@ import java.util.Objects;
 /**
  * Immediate acknowledgement of a {@link LeadershipTransferInitiateRequest}.
  *
- * <p>If {@code accepted} is true the current leader has taken the transfer on and will report the
- * terminal outcome later via a {@link LeadershipTransferResultRequest}. If {@code accepted} is
- * false the transfer was resolved immediately: {@code result} carries the skip reason (a failed
- * pre-check) and {@code leader} points to the node the receiver believes is the leader, so a
- * request that reached a follower can be redirected.
+ * <p>An {@code OK} response comes from the leader. A null {@code rejectionReason} means it has
+ * accepted the transfer request and will report the terminal outcome later via a {@link
+ * LeadershipTransferResultRequest}; otherwise the rejection reason resolves the request
+ * immediately.
+ *
+ * <p>A receiver that is not the leader answers {@code ERROR} with {@link
+ * RaftError.Type#ILLEGAL_MEMBER_STATE}, like any other misrouted Raft request.
  */
 public class LeadershipTransferInitiateResponse extends AbstractRaftResponse {
 
-  private final boolean accepted;
-  private final LeadershipTransferResult result;
-  private final MemberId leader;
+  private final LeadershipTransferResult rejectionReason;
 
   public LeadershipTransferInitiateResponse(
-      final Status status,
-      final RaftError error,
-      final boolean accepted,
-      final LeadershipTransferResult result,
-      final MemberId leader) {
+      final Status status, final RaftError error, final LeadershipTransferResult rejectionReason) {
     super(status, error);
-    this.accepted = accepted;
-    this.result = result;
-    this.leader = leader;
+    this.rejectionReason = rejectionReason;
   }
 
   public static Builder builder() {
     return new Builder();
   }
 
-  /** Whether the leader accepted the transfer and will report the outcome asynchronously. */
+  /** Whether the leader took the transfer on and will report the outcome asynchronously. */
   public boolean accepted() {
-    return accepted;
+    return status == Status.OK && rejectionReason == null;
   }
 
-  /** The immediate skip result when the transfer was not accepted, or {@code null} otherwise. */
-  public LeadershipTransferResult result() {
-    return result;
-  }
-
-  /** The node the receiver believes is the leader, for redirecting a misrouted request. */
-  public MemberId leader() {
-    return leader;
+  /**
+   * The pre-check that resolved the transfer immediately, or {@code null} if the leader accepted
+   * it. Always {@code null} when {@code status} is not {@code OK}.
+   */
+  public LeadershipTransferResult rejectionReason() {
+    return rejectionReason;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getClass(), status, accepted, result, leader);
+    return Objects.hash(getClass(), status, rejectionReason);
   }
 
   @Override
@@ -83,9 +74,8 @@ public class LeadershipTransferInitiateResponse extends AbstractRaftResponse {
     }
     final LeadershipTransferInitiateResponse other = (LeadershipTransferInitiateResponse) object;
     return status == other.status
-        && accepted == other.accepted
-        && result == other.result
-        && Objects.equals(leader, other.leader);
+        && rejectionReason == other.rejectionReason
+        && Objects.equals(error, other.error);
   }
 
   @Override
@@ -93,9 +83,7 @@ public class LeadershipTransferInitiateResponse extends AbstractRaftResponse {
     if (status == Status.OK) {
       return toStringHelper(this)
           .add("status", status)
-          .add("accepted", accepted)
-          .add("result", result)
-          .add("leader", leader)
+          .add("rejectionReason", rejectionReason)
           .toString();
     }
     return toStringHelper(this).add("status", status).add("error", error).toString();
@@ -105,29 +93,17 @@ public class LeadershipTransferInitiateResponse extends AbstractRaftResponse {
   public static class Builder
       extends AbstractRaftResponse.Builder<Builder, LeadershipTransferInitiateResponse> {
 
-    private boolean accepted;
-    private LeadershipTransferResult result;
-    private MemberId leader;
+    private LeadershipTransferResult rejectionReason;
 
-    public Builder withAccepted(final boolean accepted) {
-      this.accepted = accepted;
-      return this;
-    }
-
-    public Builder withResult(final LeadershipTransferResult result) {
-      this.result = result;
-      return this;
-    }
-
-    public Builder withLeader(final MemberId leader) {
-      this.leader = leader;
+    public Builder withRejectionReason(final LeadershipTransferResult rejectionReason) {
+      this.rejectionReason = rejectionReason;
       return this;
     }
 
     @Override
     public LeadershipTransferInitiateResponse build() {
       validate();
-      return new LeadershipTransferInitiateResponse(status, error, accepted, result, leader);
+      return new LeadershipTransferInitiateResponse(status, error, rejectionReason);
     }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeadershipTransferResultRequest.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeadershipTransferResultRequest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.protocol;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.LeadershipTransferResult;
+import java.util.Objects;
+
+/**
+ * Reports the terminal outcome of a coordinated leadership transfer from the current leader back to
+ * the rebalancing coordinator that initiated it. Sent after an accepted {@link
+ * LeadershipTransferInitiateRequest} resolves.
+ *
+ * <p>The {@code correlationId} echoes the one from the initiate request this result belongs to, so
+ * the coordinator can reject a delayed or out-of-order result from another rebalance operation.
+ */
+public final class LeadershipTransferResultRequest extends AbstractRaftRequest {
+
+  private final MemberId leader;
+  private final MemberId desiredLeader;
+  private final LeadershipTransferResult result;
+  private final long correlationId;
+
+  private LeadershipTransferResultRequest(
+      final MemberId leader,
+      final MemberId desiredLeader,
+      final LeadershipTransferResult result,
+      final long correlationId) {
+    this.leader = leader;
+    this.desiredLeader = desiredLeader;
+    this.result = result;
+    this.correlationId = correlationId;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** The leader reporting the outcome. */
+  public MemberId leader() {
+    return leader;
+  }
+
+  /** The intended successor the transfer targeted. */
+  public MemberId desiredLeader() {
+    return desiredLeader;
+  }
+
+  /** The terminal outcome of the transfer. */
+  public LeadershipTransferResult result() {
+    return result;
+  }
+
+  /**
+   * The id carried by the {@link LeadershipTransferInitiateRequest} this result answers, echoed
+   * back unchanged.
+   */
+  public long correlationId() {
+    return correlationId;
+  }
+
+  @Override
+  public MemberId from() {
+    return leader;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), leader, desiredLeader, result, correlationId);
+  }
+
+  @Override
+  public boolean equals(final Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (object == null || !getClass().isAssignableFrom(object.getClass())) {
+      return false;
+    }
+    final LeadershipTransferResultRequest other = (LeadershipTransferResultRequest) object;
+    return result == other.result
+        && correlationId == other.correlationId
+        && leader.equals(other.leader)
+        && desiredLeader.equals(other.desiredLeader);
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .add("leader", leader)
+        .add("desiredLeader", desiredLeader)
+        .add("result", result)
+        .add("correlationId", correlationId)
+        .toString();
+  }
+
+  /** Leadership-transfer result request builder. */
+  public static class Builder
+      extends AbstractRaftRequest.Builder<Builder, LeadershipTransferResultRequest> {
+
+    private MemberId leader;
+    private MemberId desiredLeader;
+    private LeadershipTransferResult result;
+    private long correlationId;
+
+    public Builder withLeader(final MemberId leader) {
+      this.leader = checkNotNull(leader, "leader cannot be null");
+      return this;
+    }
+
+    public Builder withDesiredLeader(final MemberId desiredLeader) {
+      this.desiredLeader = checkNotNull(desiredLeader, "desiredLeader cannot be null");
+      return this;
+    }
+
+    public Builder withResult(final LeadershipTransferResult result) {
+      this.result = checkNotNull(result, "result cannot be null");
+      return this;
+    }
+
+    public Builder withCorrelationId(final long correlationId) {
+      this.correlationId = correlationId;
+      return this;
+    }
+
+    @Override
+    protected void validate() {
+      super.validate();
+      checkNotNull(leader, "leader cannot be null");
+      checkNotNull(desiredLeader, "desiredLeader cannot be null");
+      checkNotNull(result, "result cannot be null");
+      checkArgument(correlationId != 0, "correlationId must be set");
+    }
+
+    @Override
+    public LeadershipTransferResultRequest build() {
+      validate();
+      return new LeadershipTransferResultRequest(leader, desiredLeader, result, correlationId);
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeadershipTransferResultResponse.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeadershipTransferResultResponse.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.protocol;
+
+import io.atomix.raft.RaftError;
+
+/**
+ * A simple acknowledgement that the coordinator received a {@link LeadershipTransferResultRequest}.
+ */
+public class LeadershipTransferResultResponse extends AbstractRaftResponse {
+
+  public LeadershipTransferResultResponse(final Status status, final RaftError error) {
+    super(status, error);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Leadership-transfer result response builder. */
+  public static class Builder
+      extends AbstractRaftResponse.Builder<Builder, LeadershipTransferResultResponse> {
+
+    @Override
+    public LeadershipTransferResultResponse build() {
+      validate();
+      return new LeadershipTransferResultResponse(status, error);
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftServerProtocol.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftServerProtocol.java
@@ -97,6 +97,26 @@ public interface RaftServerProtocol {
   CompletableFuture<TimeoutNowResponse> timeoutNow(MemberId memberId, TimeoutNowRequest request);
 
   /**
+   * Sends a coordinated-leadership-transfer initiate request to the given node.
+   *
+   * @param memberId the node to which to send the request
+   * @param request the request to send
+   * @return a future to be completed with the response
+   */
+  CompletableFuture<LeadershipTransferInitiateResponse> leadershipTransferInitiate(
+      MemberId memberId, LeadershipTransferInitiateRequest request);
+
+  /**
+   * Reports the terminal outcome of a coordinated leadership transfer to the coordinator.
+   *
+   * @param memberId the coordinator to notify
+   * @param request the result to report
+   * @return a future to be completed with the acknowledgement
+   */
+  CompletableFuture<LeadershipTransferResultResponse> leadershipTransferResult(
+      MemberId memberId, LeadershipTransferResultRequest request);
+
+  /**
    * Sends a poll request to the given node.
    *
    * @param memberId the node to which to send the request
@@ -146,6 +166,32 @@ public interface RaftServerProtocol {
 
   /** Unregisters the timeout-now request handler. */
   void unregisterTimeoutNowHandler();
+
+  /**
+   * Registers a coordinated-leadership-transfer initiate request callback.
+   *
+   * @param handler the initiate request handler to register
+   */
+  void registerLeadershipTransferInitiateHandler(
+      Function<
+              LeadershipTransferInitiateRequest,
+              CompletableFuture<LeadershipTransferInitiateResponse>>
+          handler);
+
+  /** Unregisters the leadership-transfer initiate request handler. */
+  void unregisterLeadershipTransferInitiateHandler();
+
+  /**
+   * Registers a coordinated-leadership-transfer result callback on the coordinator.
+   *
+   * @param handler the result request handler to register
+   */
+  void registerLeadershipTransferResultHandler(
+      Function<LeadershipTransferResultRequest, CompletableFuture<LeadershipTransferResultResponse>>
+          handler);
+
+  /** Unregisters the leadership-transfer result request handler. */
+  void unregisterLeadershipTransferResultHandler();
 
   /**
    * Registers a configure request callback.

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -560,7 +560,11 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     if (!desiredContext.hasAckedAppend()) {
       return Optional.of(LeadershipTransferResult.NOT_REPLICATING);
     }
-    if (desiredContext.getFailureCount() > 0) {
+    // We tolerate missed appends here - only silence beyond an election timeout counts as out of
+    // contact (that being the earliest point at which the desired leader may start campaigning
+    // against us anyway).
+    final var silenceMs = System.currentTimeMillis() - desiredContext.getResponseTime();
+    if (silenceMs > raft.getElectionTimeout().toMillis()) {
       return Optional.of(LeadershipTransferResult.UNREACHABLE);
     }
     // Point-in-time lag sample: the threshold should be tuned so a passing desired leader reliably

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -530,12 +530,10 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
    *
    * @param desiredLeader the desired leader
    * @param coordinator the node that requested the transfer
-   * @param coordinatorConfigVersion the configuration version the coordinator based its request on
+   * @param coordinatorConfigIndex the Raft configuration index the coordinator based its request on
    */
   public Optional<LeadershipTransferResult> precheckTransfer(
-      final MemberId desiredLeader,
-      final MemberId coordinator,
-      final long coordinatorConfigVersion) {
+      final MemberId desiredLeader, final MemberId coordinator, final long coordinatorConfigIndex) {
     raft.checkThread();
     final var localMember = raft.getCluster().getLocalMember().memberId();
 
@@ -545,7 +543,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     if (transferInProgress) {
       return Optional.of(LeadershipTransferResult.TRANSFER_IN_PROGRESS);
     }
-    if (!isCurrentCoordinator(coordinator, coordinatorConfigVersion)) {
+    if (!isCurrentCoordinator(coordinator, coordinatorConfigIndex)) {
       return Optional.of(LeadershipTransferResult.INVALID_COORDINATOR);
     }
     // A configuration entry would move the frozen log head the desired leader has to catch up to,
@@ -571,16 +569,16 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
 
   /**
    * The coordinator is the lowest-id member of the leader's committed configuration. A request from
-   * any other member, or one carrying a configuration version older than the leader's, is rejected
-   * so a stale or non-coordinator node cannot request a transfer.
+   * any other member, or one carrying a Raft configuration index older than the leader's, is
+   * rejected so a stale or non-coordinator node cannot request a transfer.
    */
   private boolean isCurrentCoordinator(
-      final MemberId coordinator, final long coordinatorConfigVersion) {
+      final MemberId coordinator, final long coordinatorConfigIndex) {
     final var configuration = raft.getCluster().getConfiguration();
     if (configuration == null) {
       return false;
     }
-    if (coordinatorConfigVersion < configuration.index()) {
+    if (coordinatorConfigIndex < configuration.index()) {
       return false;
     }
     return configuration.newMembers().stream()

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -543,8 +543,9 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     if (transferInProgress) {
       return Optional.of(LeadershipTransferResult.TRANSFER_IN_PROGRESS);
     }
-    if (!isCurrentCoordinator(coordinator, coordinatorConfigIndex)) {
-      return Optional.of(LeadershipTransferResult.INVALID_COORDINATOR);
+    final var coordinatorRejection = validateCoordinator(coordinator, coordinatorConfigIndex);
+    if (coordinatorRejection.isPresent()) {
+      return coordinatorRejection;
     }
     // A configuration entry would move the frozen log head the desired leader has to catch up to,
     // and can drop the desired leader from the replica set altogether, so a transfer cannot start
@@ -553,11 +554,14 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
       return Optional.of(LeadershipTransferResult.CONFIGURATION_CHANGE_IN_PROGRESS);
     }
     final var desiredContext = raft.getCluster().getMemberContext(desiredLeader);
-    if (desiredContext == null
-        || !raft.getCluster().isMember(desiredLeader)
-        || !desiredContext.hasAckedAppend()
-        || desiredContext.getFailureCount() > 0) {
-      return Optional.of(LeadershipTransferResult.OFFLINE);
+    if (desiredContext == null || !raft.getCluster().isMember(desiredLeader)) {
+      return Optional.of(LeadershipTransferResult.NOT_MEMBER);
+    }
+    if (!desiredContext.hasAckedAppend()) {
+      return Optional.of(LeadershipTransferResult.NOT_REPLICATING);
+    }
+    if (desiredContext.getFailureCount() > 0) {
+      return Optional.of(LeadershipTransferResult.UNREACHABLE);
     }
     // Point-in-time lag sample: the threshold should be tuned so a passing desired leader reliably
     // catches up within replicationTimeout once the pause begins.
@@ -572,20 +576,19 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
    * any other member, or one carrying a Raft configuration index older than the leader's, is
    * rejected so a stale or non-coordinator node cannot request a transfer.
    */
-  private boolean isCurrentCoordinator(
+  private Optional<LeadershipTransferResult> validateCoordinator(
       final MemberId coordinator, final long coordinatorConfigIndex) {
     final var configuration = raft.getCluster().getConfiguration();
-    if (configuration == null) {
-      return false;
+    if (configuration == null || coordinatorConfigIndex < configuration.index()) {
+      return Optional.of(LeadershipTransferResult.STALE_CONFIGURATION);
     }
-    if (coordinatorConfigIndex < configuration.index()) {
-      return false;
-    }
-    return configuration.newMembers().stream()
-        .map(RaftMember::memberId)
-        .min(MemberId.ID_COMPARATOR)
-        .map(coordinator::equals)
-        .orElse(false);
+    final var isCoordinator =
+        configuration.newMembers().stream()
+            .map(RaftMember::memberId)
+            .min(MemberId.ID_COMPARATOR)
+            .map(coordinator::equals)
+            .orElse(false);
+    return isCoordinator ? Optional.empty() : Optional.of(LeadershipTransferResult.NOT_COORDINATOR);
   }
 
   /** Ensures the local server is not the leader. */

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -549,7 +549,8 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
       return Optional.of(LeadershipTransferResult.INVALID_COORDINATOR);
     }
     // A configuration entry would move the frozen log head the desired leader has to catch up to,
-    // so a transfer cannot start while one is in flight. We also check this again once paused.
+    // and can drop the desired leader from the replica set altogether, so a transfer cannot start
+    // while one is in flight. We also check this again once paused.
     if (configuring() || jointConsensus()) {
       return Optional.of(LeadershipTransferResult.CONFIGURATION_CHANGE_IN_PROGRESS);
     }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -91,7 +91,6 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
   private long transferPauseStartMs;
   private long transferPauseTargetIndex;
   private Scheduled transferPauseWatchdog;
-  private boolean transferInProgress;
 
   public LeaderRole(final RaftContext context) {
     super(context);
@@ -470,7 +469,6 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     final Duration remaining = resumeTimeout.minusMillis(elapsedMs);
 
     pausedForTransfer = true;
-    transferInProgress = true;
     transferPauseStartMs = pausedSinceMs;
 
     // Writes must already have been frozen and the processor drained before this runs, so the last
@@ -520,7 +518,6 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
           .observePauseDuration(
               Duration.ofMillis(System.currentTimeMillis() - transferPauseStartMs));
     }
-    transferInProgress = false;
   }
 
   /**
@@ -540,7 +537,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     if (desiredLeader.equals(localMember)) {
       return Optional.of(LeadershipTransferResult.ALREADY_LEADER);
     }
-    if (transferInProgress) {
+    if (pausedForTransfer) {
       return Optional.of(LeadershipTransferResult.TRANSFER_IN_PROGRESS);
     }
     final var coordinatorRejection = validateCoordinator(coordinator, coordinatorConfigIndex);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -18,6 +18,7 @@ package io.atomix.raft.roles;
 
 import com.google.common.base.Throwables;
 import io.atomix.cluster.MemberId;
+import io.atomix.raft.LeadershipTransferResult;
 import io.atomix.raft.RaftError;
 import io.atomix.raft.RaftError.Type;
 import io.atomix.raft.RaftException;
@@ -67,6 +68,7 @@ import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
@@ -89,6 +91,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
   private long transferPauseStartMs;
   private long transferPauseTargetIndex;
   private Scheduled transferPauseWatchdog;
+  private boolean transferInProgress;
 
   public LeaderRole(final RaftContext context) {
     super(context);
@@ -467,6 +470,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     final Duration remaining = resumeTimeout.minusMillis(elapsedMs);
 
     pausedForTransfer = true;
+    transferInProgress = true;
     transferPauseStartMs = pausedSinceMs;
 
     // Writes must already have been frozen and the processor drained before this runs, so the last
@@ -516,6 +520,73 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
           .observePauseDuration(
               Duration.ofMillis(System.currentTimeMillis() - transferPauseStartMs));
     }
+    transferInProgress = false;
+  }
+
+  /**
+   * Evaluates whether we should accept a leadership transfer for {@code desiredLeader} on behalf of
+   * {@code coordinator}. Returns the skip reason if any check fails, or empty if the transfer may
+   * proceed.
+   *
+   * @param desiredLeader the desired leader
+   * @param coordinator the node that requested the transfer
+   * @param coordinatorConfigVersion the configuration version the coordinator based its request on
+   */
+  public Optional<LeadershipTransferResult> precheckTransfer(
+      final MemberId desiredLeader,
+      final MemberId coordinator,
+      final long coordinatorConfigVersion) {
+    raft.checkThread();
+    final var localMember = raft.getCluster().getLocalMember().memberId();
+
+    if (desiredLeader.equals(localMember)) {
+      return Optional.of(LeadershipTransferResult.ALREADY_LEADER);
+    }
+    if (transferInProgress) {
+      return Optional.of(LeadershipTransferResult.TRANSFER_IN_PROGRESS);
+    }
+    if (!isCurrentCoordinator(coordinator, coordinatorConfigVersion)) {
+      return Optional.of(LeadershipTransferResult.INVALID_COORDINATOR);
+    }
+    // A configuration entry would move the frozen log head the desired leader has to catch up to,
+    // so a transfer cannot start while one is in flight. We also check this again once paused.
+    if (configuring() || jointConsensus()) {
+      return Optional.of(LeadershipTransferResult.CONFIGURATION_CHANGE_IN_PROGRESS);
+    }
+    final var desiredContext = raft.getCluster().getMemberContext(desiredLeader);
+    if (desiredContext == null
+        || !raft.getCluster().isMember(desiredLeader)
+        || !desiredContext.hasAckedAppend()
+        || desiredContext.getFailureCount() > 0) {
+      return Optional.of(LeadershipTransferResult.OFFLINE);
+    }
+    // Point-in-time lag sample: the threshold should be tuned so a passing desired leader reliably
+    // catches up within replicationTimeout once the pause begins.
+    if (desiredContext.getReplicationLagBytes() > raft.getRebalanceReplicationLagThreshold()) {
+      return Optional.of(LeadershipTransferResult.LAG_TOO_HIGH);
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * The coordinator is the lowest-id member of the leader's committed configuration. A request from
+   * any other member, or one carrying a configuration version older than the leader's, is rejected
+   * so a stale or non-coordinator node cannot request a transfer.
+   */
+  private boolean isCurrentCoordinator(
+      final MemberId coordinator, final long coordinatorConfigVersion) {
+    final var configuration = raft.getCluster().getConfiguration();
+    if (configuration == null) {
+      return false;
+    }
+    if (coordinatorConfigVersion < configuration.index()) {
+      return false;
+    }
+    return configuration.newMembers().stream()
+        .map(RaftMember::memberId)
+        .min(MemberId.ID_COMPARATOR)
+        .map(coordinator::equals)
+        .orElse(false);
   }
 
   /** Ensures the local server is not the leader. */

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCoordinatedLeadershipTransferTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCoordinatedLeadershipTransferTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.partition.impl.RaftNamespaces;
+import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
+import io.atomix.raft.protocol.LeadershipTransferInitiateResponse;
+import io.atomix.raft.protocol.LeadershipTransferResultRequest;
+import io.atomix.raft.protocol.RaftResponse.Status;
+import org.junit.Test;
+
+public class RaftCoordinatedLeadershipTransferTest {
+
+  @Test
+  public void shouldRoundTripTransferMessagesThroughRaftNamespace() {
+    // given
+    final var initiateRequest = initiate(MemberId.from("2"), MemberId.from("1"), 7, 0x5eed_0005L);
+    final var initiateResponse =
+        LeadershipTransferInitiateResponse.builder()
+            .withStatus(Status.OK)
+            .withAccepted(false)
+            .withResult(LeadershipTransferResult.LAG_TOO_HIGH)
+            .withLeader(MemberId.from("3"))
+            .build();
+    final var resultRequest =
+        result(
+            MemberId.from("3"),
+            MemberId.from("2"),
+            LeadershipTransferResult.TRANSFERRED,
+            0x5eed_0005L);
+
+    // when / then
+    assertThat(roundTrip(initiateRequest)).isEqualTo(initiateRequest);
+    assertThat(roundTrip(initiateRequest).correlationId()).isEqualTo(0x5eed_0005L);
+    final LeadershipTransferInitiateResponse deserializedResponse = roundTrip(initiateResponse);
+    assertThat(deserializedResponse.accepted()).isFalse();
+    assertThat(deserializedResponse.result()).isEqualTo(LeadershipTransferResult.LAG_TOO_HIGH);
+    assertThat(deserializedResponse.leader()).isEqualTo(MemberId.from("3"));
+    assertThat(roundTrip(resultRequest)).isEqualTo(resultRequest);
+    assertThat(roundTrip(resultRequest).correlationId()).isEqualTo(0x5eed_0005L);
+  }
+
+  @Test
+  public void shouldTellRequestsApartByCorrelationId() {
+    // given
+    final var initiateRequest = initiate(MemberId.from("2"), MemberId.from("1"), 7, 0x5eed_0006L);
+    final var sameInitiateRequest =
+        initiate(MemberId.from("2"), MemberId.from("1"), 7, 0x5eed_0006L);
+    final var otherInitiateRequest =
+        initiate(MemberId.from("2"), MemberId.from("1"), 7, 0x5eed_0007L);
+    final var resultRequest =
+        result(
+            MemberId.from("3"),
+            MemberId.from("2"),
+            LeadershipTransferResult.TRANSFERRED,
+            0x5eed_0006L);
+    final var sameResultRequest =
+        result(
+            MemberId.from("3"),
+            MemberId.from("2"),
+            LeadershipTransferResult.TRANSFERRED,
+            0x5eed_0006L);
+    final var otherResultRequest =
+        result(
+            MemberId.from("3"),
+            MemberId.from("2"),
+            LeadershipTransferResult.TRANSFERRED,
+            0x5eed_0007L);
+
+    // then
+    assertThat(initiateRequest.correlationId()).isEqualTo(0x5eed_0006L);
+    assertThat(initiateRequest)
+        .isEqualTo(sameInitiateRequest)
+        .hasSameHashCodeAs(sameInitiateRequest)
+        .isNotEqualTo(otherInitiateRequest);
+    assertThat(resultRequest.correlationId()).isEqualTo(0x5eed_0006L);
+    assertThat(resultRequest)
+        .isEqualTo(sameResultRequest)
+        .hasSameHashCodeAs(sameResultRequest)
+        .isNotEqualTo(otherResultRequest);
+  }
+
+  @Test
+  public void shouldRejectRequestsBuiltWithoutACorrelationId() {
+    // given
+    final var initiateBuilder =
+        LeadershipTransferInitiateRequest.builder()
+            .withDesiredLeader(MemberId.from("2"))
+            .withCoordinator(MemberId.from("1"))
+            .withCoordinatorConfigVersion(7);
+    final var resultBuilder =
+        LeadershipTransferResultRequest.builder()
+            .withLeader(MemberId.from("3"))
+            .withDesiredLeader(MemberId.from("2"))
+            .withResult(LeadershipTransferResult.TRANSFERRED);
+
+    // when / then
+    assertThatThrownBy(initiateBuilder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("correlationId");
+    assertThatThrownBy(resultBuilder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("correlationId");
+  }
+
+  private static <T> T roundTrip(final T message) {
+    return RaftNamespaces.RAFT_PROTOCOL.deserialize(
+        RaftNamespaces.RAFT_PROTOCOL.serialize(message));
+  }
+
+  private LeadershipTransferInitiateRequest initiate(
+      final MemberId desiredLeader,
+      final MemberId coordinator,
+      final long configVersion,
+      final long correlationId) {
+    return LeadershipTransferInitiateRequest.builder()
+        .withDesiredLeader(desiredLeader)
+        .withCoordinator(coordinator)
+        .withCoordinatorConfigVersion(configVersion)
+        .withCorrelationId(correlationId)
+        .build();
+  }
+
+  private static LeadershipTransferResultRequest result(
+      final MemberId leader,
+      final MemberId desiredLeader,
+      final LeadershipTransferResult result,
+      final long correlationId) {
+    return LeadershipTransferResultRequest.builder()
+        .withLeader(leader)
+        .withDesiredLeader(desiredLeader)
+        .withResult(result)
+        .withCorrelationId(correlationId)
+        .build();
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCoordinatedLeadershipTransferTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCoordinatedLeadershipTransferTest.java
@@ -104,7 +104,7 @@ public class RaftCoordinatedLeadershipTransferTest {
         LeadershipTransferInitiateRequest.builder()
             .withDesiredLeader(MemberId.from("2"))
             .withCoordinator(MemberId.from("1"))
-            .withCoordinatorConfigVersion(7);
+            .withCoordinatorConfigIndex(7);
     final var resultBuilder =
         LeadershipTransferResultRequest.builder()
             .withLeader(MemberId.from("3"))
@@ -128,12 +128,12 @@ public class RaftCoordinatedLeadershipTransferTest {
   private LeadershipTransferInitiateRequest initiate(
       final MemberId desiredLeader,
       final MemberId coordinator,
-      final long configVersion,
+      final long configIndex,
       final long correlationId) {
     return LeadershipTransferInitiateRequest.builder()
         .withDesiredLeader(desiredLeader)
         .withCoordinator(coordinator)
-        .withCoordinatorConfigVersion(configVersion)
+        .withCoordinatorConfigIndex(configIndex)
         .withCorrelationId(correlationId)
         .build();
   }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCoordinatedLeadershipTransferTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCoordinatedLeadershipTransferTest.java
@@ -32,12 +32,17 @@ public class RaftCoordinatedLeadershipTransferTest {
   public void shouldRoundTripTransferMessagesThroughRaftNamespace() {
     // given
     final var initiateRequest = initiate(MemberId.from("2"), MemberId.from("1"), 7, 0x5eed_0005L);
-    final var initiateResponse =
+    final var acceptedResponse =
+        LeadershipTransferInitiateResponse.builder().withStatus(Status.OK).build();
+    final var rejectedResponse =
         LeadershipTransferInitiateResponse.builder()
             .withStatus(Status.OK)
-            .withAccepted(false)
-            .withResult(LeadershipTransferResult.LAG_TOO_HIGH)
-            .withLeader(MemberId.from("3"))
+            .withRejectionReason(LeadershipTransferResult.LAG_TOO_HIGH)
+            .build();
+    final var notLeaderResponse =
+        LeadershipTransferInitiateResponse.builder()
+            .withStatus(Status.ERROR)
+            .withError(RaftError.Type.ILLEGAL_MEMBER_STATE)
             .build();
     final var resultRequest =
         result(
@@ -49,10 +54,14 @@ public class RaftCoordinatedLeadershipTransferTest {
     // when / then
     assertThat(roundTrip(initiateRequest)).isEqualTo(initiateRequest);
     assertThat(roundTrip(initiateRequest).correlationId()).isEqualTo(0x5eed_0005L);
-    final LeadershipTransferInitiateResponse deserializedResponse = roundTrip(initiateResponse);
-    assertThat(deserializedResponse.accepted()).isFalse();
-    assertThat(deserializedResponse.result()).isEqualTo(LeadershipTransferResult.LAG_TOO_HIGH);
-    assertThat(deserializedResponse.leader()).isEqualTo(MemberId.from("3"));
+    assertThat(roundTrip(acceptedResponse).accepted()).isTrue();
+    final LeadershipTransferInitiateResponse deserializedRejection = roundTrip(rejectedResponse);
+    assertThat(deserializedRejection.accepted()).isFalse();
+    assertThat(deserializedRejection.rejectionReason())
+        .isEqualTo(LeadershipTransferResult.LAG_TOO_HIGH);
+    final LeadershipTransferInitiateResponse deserializedNotLeader = roundTrip(notLeaderResponse);
+    assertThat(deserializedNotLeader.accepted()).isFalse();
+    assertThat(deserializedNotLeader.error().type()).isEqualTo(RaftError.Type.ILLEGAL_MEMBER_STATE);
     assertThat(roundTrip(resultRequest)).isEqualTo(resultRequest);
     assertThat(roundTrip(resultRequest).correlationId()).isEqualTo(0x5eed_0005L);
   }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferInitiateTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferInitiateTest.java
@@ -22,6 +22,7 @@ import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.roles.LeaderRole;
 import java.time.Duration;
 import java.util.Comparator;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import org.awaitility.Awaitility;
@@ -154,31 +155,43 @@ public class RaftLeadershipTransferInitiateTest {
     final var leader = raftRule.getLeader().orElseThrow();
     final var target = raftRule.getFollower().orElseThrow();
     final var targetId = memberId(target);
+
+    // when
     raftRule.partition(target);
 
-    Awaitility.await("leader records contact failures to the partitioned follower")
+    // then
+    Awaitility.await("the leader stops treating the partitioned follower as reachable")
         .atMost(Duration.ofSeconds(15))
         .until(
             () ->
                 onRaftThread(
                         leader,
                         () ->
-                            leader
-                                .getContext()
-                                .getCluster()
-                                .getMemberContext(targetId)
-                                .getFailureCount())
-                    > 0);
+                            leaderRole(leader)
+                                .precheckTransfer(targetId, coordinator(leader), index(leader)))
+                    .equals(Optional.of(LeadershipTransferResult.UNREACHABLE)));
+  }
+
+  @Test
+  public void shouldTolerateASingleMissedAppendToTheDesiredLeader() throws Exception {
+    // given
+    raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+    final var targetId = memberId(target);
 
     // when
     final var result =
         onRaftThread(
             leader,
-            () ->
-                leaderRole(leader).precheckTransfer(targetId, coordinator(leader), index(leader)));
+            () -> {
+              leader.getContext().getCluster().getMemberContext(targetId).incrementFailureCount();
+              return leaderRole(leader)
+                  .precheckTransfer(targetId, coordinator(leader), index(leader));
+            });
 
     // then
-    assertThat(result).contains(LeadershipTransferResult.UNREACHABLE);
+    assertThat(result).as("a member that is still answering stays eligible").isEmpty();
   }
 
   @Test

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferInitiateTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferInitiateTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.protocol.ReconfigureRequest;
+import io.atomix.raft.roles.LeaderRole;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+import org.awaitility.Awaitility;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class RaftLeadershipTransferInitiateTest {
+
+  @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);
+
+  @Test
+  public void shouldRejectTransferToCurrentLeader() throws Exception {
+    // given
+    raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var leaderId = memberId(leader);
+
+    // when
+    final var result =
+        onRaftThread(
+            leader, () -> leaderRole(leader).precheckTransfer(leaderId, leaderId, index(leader)));
+
+    // then
+    assertThat(result).contains(LeadershipTransferResult.ALREADY_LEADER);
+  }
+
+  @Test
+  public void shouldRejectTransferToNonMember() throws Exception {
+    // given
+    raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+
+    // when
+    final var result =
+        onRaftThread(
+            leader,
+            () ->
+                leaderRole(leader)
+                    .precheckTransfer(
+                        MemberId.from("nonmember"), coordinator(leader), index(leader)));
+
+    // then
+    assertThat(result).contains(LeadershipTransferResult.OFFLINE);
+  }
+
+  @Test
+  public void shouldRejectTransferFromNonCoordinator() throws Exception {
+    // given
+    raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+
+    // when
+    final var result =
+        onRaftThread(
+            leader,
+            () ->
+                leaderRole(leader)
+                    .precheckTransfer(
+                        memberId(target), MemberId.from("not-the-coordinator"), index(leader)));
+
+    // then
+    assertThat(result).contains(LeadershipTransferResult.INVALID_COORDINATOR);
+  }
+
+  @Test
+  public void shouldPassPrecheckForCaughtUpFollower() throws Exception {
+    // given
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+    final var targetId = memberId(target);
+
+    // when
+    final var result =
+        onRaftThread(
+            leader,
+            () ->
+                leaderRole(leader).precheckTransfer(targetId, coordinator(leader), index(leader)));
+
+    // then
+    assertThat(result).as("pre-checks pass for a caught-up follower").isEmpty();
+  }
+
+  @Test
+  public void shouldRejectTransferToUnreachableMember() throws Exception {
+    // given
+    raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+    final var targetId = memberId(target);
+    raftRule.partition(target);
+
+    Awaitility.await("leader records contact failures to the partitioned follower")
+        .atMost(Duration.ofSeconds(15))
+        .until(
+            () ->
+                onRaftThread(
+                        leader,
+                        () ->
+                            leader
+                                .getContext()
+                                .getCluster()
+                                .getMemberContext(targetId)
+                                .getFailureCount())
+                    > 0);
+
+    // when
+    final var result =
+        onRaftThread(
+            leader,
+            () ->
+                leaderRole(leader).precheckTransfer(targetId, coordinator(leader), index(leader)));
+
+    // then
+    assertThat(result).contains(LeadershipTransferResult.OFFLINE);
+  }
+
+  @Test
+  public void shouldRejectTransferWhenLagTooHigh() throws Exception {
+    // given
+    raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+    final var targetId = memberId(target);
+
+    // when
+    final var result =
+        onRaftThread(
+            leader,
+            () -> {
+              leader
+                  .getContext()
+                  .getCluster()
+                  .getMemberContext(targetId)
+                  .setSnapshotReplicationLag(
+                      leader.getContext().getRebalanceReplicationLagThreshold() + 1);
+              return leaderRole(leader)
+                  .precheckTransfer(targetId, coordinator(leader), index(leader));
+            });
+
+    // then
+    assertThat(result).contains(LeadershipTransferResult.LAG_TOO_HIGH);
+  }
+
+  @Test
+  public void shouldRejectTransferWhileReconfiguring() throws Exception {
+    // given
+    raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var followers =
+        raftRule.getServers().stream()
+            .filter(server -> server.getRole() == RaftServer.Role.FOLLOWER)
+            .toList();
+    final var leavingFollower = followers.get(0);
+    final var targetId = memberId(followers.get(1));
+
+    // when
+    final var result =
+        onRaftThread(
+            leader,
+            () -> {
+              leaderRole(leader).onReconfigure(removeFollowerRequest(leader, leavingFollower));
+              return leaderRole(leader)
+                  .precheckTransfer(targetId, coordinator(leader), index(leader));
+            });
+
+    // then
+    assertThat(result).contains(LeadershipTransferResult.CONFIGURATION_CHANGE_IN_PROGRESS);
+  }
+
+  @Test
+  public void shouldRejectTransferWhileAnotherTransferIsPaused() throws Exception {
+    // given
+    raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+    final var targetId = memberId(target);
+
+    // when
+    final var result =
+        onRaftThread(
+            leader,
+            () -> {
+              leaderRole(leader)
+                  .pauseForTransfer(Duration.ofSeconds(30), System.currentTimeMillis());
+              return leaderRole(leader)
+                  .precheckTransfer(targetId, coordinator(leader), index(leader));
+            });
+
+    // then
+    assertThat(result).contains(LeadershipTransferResult.TRANSFER_IN_PROGRESS);
+  }
+
+  /** Builds a membership change that removes {@code follower}, so it is not a no-op. */
+  private static ReconfigureRequest removeFollowerRequest(
+      final RaftServer leader, final RaftServer follower) {
+    final var leavingId = memberId(follower);
+    final var configuration = leader.getContext().getCluster().getConfiguration();
+    final var remainingMembers =
+        configuration.newMembers().stream()
+            .filter(member -> !member.memberId().equals(leavingId))
+            .toList();
+    return ReconfigureRequest.builder()
+        .withIndex(configuration.index())
+        .withTerm(configuration.term())
+        .withMembers(remainingMembers)
+        .from(memberId(leader).id())
+        .build();
+  }
+
+  private static LeaderRole leaderRole(final RaftServer leader) {
+    return (LeaderRole) leader.getContext().getRaftRole();
+  }
+
+  private static MemberId memberId(final RaftServer server) {
+    return server.getContext().getCluster().getLocalMember().memberId();
+  }
+
+  private static long index(final RaftServer leader) {
+    return leader.getContext().getCluster().getConfiguration().index();
+  }
+
+  private static MemberId coordinator(final RaftServer leader) {
+    return leader.getContext().getCluster().getConfiguration().newMembers().stream()
+        .map(io.atomix.raft.cluster.RaftMember::memberId)
+        .min(Comparator.comparing(MemberId::id))
+        .orElseThrow();
+  }
+
+  private static <T> T onRaftThread(final RaftServer leader, final Supplier<T> action)
+      throws Exception {
+    final var future = new CompletableFuture<T>();
+    leader
+        .getContext()
+        .getThreadContext()
+        .execute(
+            () -> {
+              try {
+                future.complete(action.get());
+              } catch (final Exception e) {
+                future.completeExceptionally(e);
+              }
+            });
+    return future.get();
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferInitiateTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferInitiateTest.java
@@ -64,7 +64,29 @@ public class RaftLeadershipTransferInitiateTest {
                         MemberId.from("nonmember"), coordinator(leader), index(leader)));
 
     // then
-    assertThat(result).contains(LeadershipTransferResult.OFFLINE);
+    assertThat(result).contains(LeadershipTransferResult.NOT_MEMBER);
+  }
+
+  @Test
+  public void shouldRejectTransferToMemberWithUnconvergedLog() throws Exception {
+    // given
+    raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+    final var targetId = memberId(target);
+
+    // when
+    final var result =
+        onRaftThread(
+            leader,
+            () -> {
+              leader.getContext().getCluster().getMemberContext(targetId).appendFailed();
+              return leaderRole(leader)
+                  .precheckTransfer(targetId, coordinator(leader), index(leader));
+            });
+
+    // then
+    assertThat(result).contains(LeadershipTransferResult.NOT_REPLICATING);
   }
 
   @Test
@@ -84,7 +106,26 @@ public class RaftLeadershipTransferInitiateTest {
                         memberId(target), MemberId.from("not-the-coordinator"), index(leader)));
 
     // then
-    assertThat(result).contains(LeadershipTransferResult.INVALID_COORDINATOR);
+    assertThat(result).contains(LeadershipTransferResult.NOT_COORDINATOR);
+  }
+
+  @Test
+  public void shouldRejectTransferOnAStaleConfiguration() throws Exception {
+    // given
+    raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+
+    // when
+    final var result =
+        onRaftThread(
+            leader,
+            () ->
+                leaderRole(leader)
+                    .precheckTransfer(memberId(target), coordinator(leader), index(leader) - 1));
+
+    // then
+    assertThat(result).contains(LeadershipTransferResult.STALE_CONFIGURATION);
   }
 
   @Test
@@ -137,7 +178,7 @@ public class RaftLeadershipTransferInitiateTest {
                 leaderRole(leader).precheckTransfer(targetId, coordinator(leader), index(leader)));
 
     // then
-    assertThat(result).contains(LeadershipTransferResult.OFFLINE);
+    assertThat(result).contains(LeadershipTransferResult.UNREACHABLE);
   }
 
   @Test

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftMemberContextTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftMemberContextTest.java
@@ -311,6 +311,52 @@ final class RaftMemberContextTest {
     verify(snapshotChunkReader).close();
   }
 
+  @Test
+  void shouldNotHaveAckedAppendBeforeFirstSuccess() {
+    // given / then
+    assertThat(newContext().hasAckedAppend()).isFalse();
+  }
+
+  @Test
+  void shouldMarkAckedAppendOnSuccess() {
+    // given
+    final var context = newContext();
+
+    // when
+    context.appendSucceeded();
+
+    // then
+    assertThat(context.hasAckedAppend()).isTrue();
+  }
+
+  @Test
+  void shouldClearAckedAppendOnFailure() {
+    // given
+    final var context = newContext();
+    context.appendSucceeded();
+
+    // when
+    context.appendFailed();
+
+    // then
+    assertThat(context.hasAckedAppend()).isFalse();
+  }
+
+  @Test
+  void shouldClearAckedAppendWhenReplicationContextReopens() {
+    // given
+    final var log = mock(RaftLog.class);
+    when(log.openUncommittedReader()).thenReturn(mock(RaftLogReader.class));
+    final var context = newContext();
+    context.appendSucceeded();
+
+    // when
+    context.openReplicationContext(log);
+
+    // then
+    assertThat(context.hasAckedAppend()).isFalse();
+  }
+
   private RaftMemberContext newContext() {
     final var member = new DefaultRaftMember(MemberId.from("1"), Type.ACTIVE, Instant.now());
     return new RaftMemberContext(member, mock(RaftClusterContext.class), 1);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/ControllableRaftServerProtocol.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/ControllableRaftServerProtocol.java
@@ -48,6 +48,12 @@ public class ControllableRaftServerProtocol implements RaftServerProtocol {
   private Function<InstallRequest, CompletableFuture<InstallResponse>> installHandler;
   private Function<TransferRequest, CompletableFuture<TransferResponse>> transferHandler;
   private Function<TimeoutNowRequest, CompletableFuture<TimeoutNowResponse>> timeoutNowHandler;
+  private Function<
+          LeadershipTransferInitiateRequest, CompletableFuture<LeadershipTransferInitiateResponse>>
+      leadershipTransferInitiateHandler;
+  private Function<
+          LeadershipTransferResultRequest, CompletableFuture<LeadershipTransferResultResponse>>
+      leadershipTransferResultHandler;
   private Function<PollRequest, CompletableFuture<PollResponse>> pollHandler;
   private Function<VoteRequest, CompletableFuture<VoteResponse>> voteHandler;
   private Function<VersionedAppendRequest, CompletableFuture<AppendResponse>> appendHandler;
@@ -266,6 +272,36 @@ public class ControllableRaftServerProtocol implements RaftServerProtocol {
   }
 
   @Override
+  public CompletableFuture<LeadershipTransferInitiateResponse> leadershipTransferInitiate(
+      final MemberId memberId, final LeadershipTransferInitiateRequest request) {
+    final var responseFuture = new CompletableFuture<LeadershipTransferInitiateResponse>();
+    send(
+        memberId,
+        () ->
+            getServer(memberId)
+                .thenCompose(listener -> listener.leadershipTransferInitiate(request))
+                .thenAccept(
+                    response -> send(localMemberId, () -> responseFuture.complete(response), null)),
+        responseFuture);
+    return responseFuture;
+  }
+
+  @Override
+  public CompletableFuture<LeadershipTransferResultResponse> leadershipTransferResult(
+      final MemberId memberId, final LeadershipTransferResultRequest request) {
+    final var responseFuture = new CompletableFuture<LeadershipTransferResultResponse>();
+    send(
+        memberId,
+        () ->
+            getServer(memberId)
+                .thenCompose(listener -> listener.leadershipTransferResult(request))
+                .thenAccept(
+                    response -> send(localMemberId, () -> responseFuture.complete(response), null)),
+        responseFuture);
+    return responseFuture;
+  }
+
+  @Override
   public CompletableFuture<PollResponse> poll(final MemberId memberId, final PollRequest request) {
     final var responseFuture = new CompletableFuture<PollResponse>();
     send(
@@ -334,6 +370,33 @@ public class ControllableRaftServerProtocol implements RaftServerProtocol {
   @Override
   public void unregisterTimeoutNowHandler() {
     timeoutNowHandler = null;
+  }
+
+  @Override
+  public void registerLeadershipTransferInitiateHandler(
+      final Function<
+              LeadershipTransferInitiateRequest,
+              CompletableFuture<LeadershipTransferInitiateResponse>>
+          handler) {
+    leadershipTransferInitiateHandler = handler;
+  }
+
+  @Override
+  public void unregisterLeadershipTransferInitiateHandler() {
+    leadershipTransferInitiateHandler = null;
+  }
+
+  @Override
+  public void registerLeadershipTransferResultHandler(
+      final Function<
+              LeadershipTransferResultRequest, CompletableFuture<LeadershipTransferResultResponse>>
+          handler) {
+    leadershipTransferResultHandler = handler;
+  }
+
+  @Override
+  public void unregisterLeadershipTransferResultHandler() {
+    leadershipTransferResultHandler = null;
   }
 
   @Override
@@ -483,6 +546,24 @@ public class ControllableRaftServerProtocol implements RaftServerProtocol {
   CompletableFuture<TimeoutNowResponse> timeoutNow(final TimeoutNowRequest request) {
     if (timeoutNowHandler != null) {
       return timeoutNowHandler.apply(request);
+    } else {
+      return CompletableFuture.failedFuture(new ConnectException());
+    }
+  }
+
+  CompletableFuture<LeadershipTransferInitiateResponse> leadershipTransferInitiate(
+      final LeadershipTransferInitiateRequest request) {
+    if (leadershipTransferInitiateHandler != null) {
+      return leadershipTransferInitiateHandler.apply(request);
+    } else {
+      return CompletableFuture.failedFuture(new ConnectException());
+    }
+  }
+
+  CompletableFuture<LeadershipTransferResultResponse> leadershipTransferResult(
+      final LeadershipTransferResultRequest request) {
+    if (leadershipTransferResultHandler != null) {
+      return leadershipTransferResultHandler.apply(request);
     } else {
       return CompletableFuture.failedFuture(new ConnectException());
     }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
@@ -44,6 +44,12 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
   private Function<InstallRequest, CompletableFuture<InstallResponse>> installHandler;
   private Function<TransferRequest, CompletableFuture<TransferResponse>> transferHandler;
   private Function<TimeoutNowRequest, CompletableFuture<TimeoutNowResponse>> timeoutNowHandler;
+  private Function<
+          LeadershipTransferInitiateRequest, CompletableFuture<LeadershipTransferInitiateResponse>>
+      leadershipTransferInitiateHandler;
+  private Function<
+          LeadershipTransferResultRequest, CompletableFuture<LeadershipTransferResultResponse>>
+      leadershipTransferResultHandler;
   private Function<PollRequest, CompletableFuture<PollResponse>> pollHandler;
   private Function<VoteRequest, CompletableFuture<VoteResponse>> voteHandler;
   private Function<VersionedAppendRequest, CompletableFuture<AppendResponse>> appendHandler;
@@ -160,6 +166,30 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
   }
 
   @Override
+  public CompletableFuture<LeadershipTransferInitiateResponse> leadershipTransferInitiate(
+      final MemberId memberId, final LeadershipTransferInitiateRequest request) {
+    return getServer(memberId)
+        .thenCompose(
+            listener -> intercept(listener, request, LeadershipTransferInitiateRequest.class))
+        .thenCompose(listener -> listener.leadershipTransferInitiate(request))
+        .thenCompose(
+            response -> transformResponse(response, LeadershipTransferInitiateResponse.class))
+        .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  public CompletableFuture<LeadershipTransferResultResponse> leadershipTransferResult(
+      final MemberId memberId, final LeadershipTransferResultRequest request) {
+    return getServer(memberId)
+        .thenCompose(
+            listener -> intercept(listener, request, LeadershipTransferResultRequest.class))
+        .thenCompose(listener -> listener.leadershipTransferResult(request))
+        .thenCompose(
+            response -> transformResponse(response, LeadershipTransferResultResponse.class))
+        .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+  }
+
+  @Override
   public CompletableFuture<PollResponse> poll(final MemberId memberId, final PollRequest request) {
     return getServer(memberId)
         .thenCompose(listener -> intercept(listener, request, PollRequest.class))
@@ -213,6 +243,33 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
   @Override
   public void unregisterTimeoutNowHandler() {
     timeoutNowHandler = null;
+  }
+
+  @Override
+  public void registerLeadershipTransferInitiateHandler(
+      final Function<
+              LeadershipTransferInitiateRequest,
+              CompletableFuture<LeadershipTransferInitiateResponse>>
+          handler) {
+    leadershipTransferInitiateHandler = handler;
+  }
+
+  @Override
+  public void unregisterLeadershipTransferInitiateHandler() {
+    leadershipTransferInitiateHandler = null;
+  }
+
+  @Override
+  public void registerLeadershipTransferResultHandler(
+      final Function<
+              LeadershipTransferResultRequest, CompletableFuture<LeadershipTransferResultResponse>>
+          handler) {
+    leadershipTransferResultHandler = handler;
+  }
+
+  @Override
+  public void unregisterLeadershipTransferResultHandler() {
+    leadershipTransferResultHandler = null;
   }
 
   @Override
@@ -365,6 +422,24 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
   CompletableFuture<TimeoutNowResponse> timeoutNow(final TimeoutNowRequest request) {
     if (timeoutNowHandler != null) {
       return timeoutNowHandler.apply(request);
+    } else {
+      return CompletableFuture.failedFuture(new ConnectException());
+    }
+  }
+
+  CompletableFuture<LeadershipTransferInitiateResponse> leadershipTransferInitiate(
+      final LeadershipTransferInitiateRequest request) {
+    if (leadershipTransferInitiateHandler != null) {
+      return leadershipTransferInitiateHandler.apply(request);
+    } else {
+      return CompletableFuture.failedFuture(new ConnectException());
+    }
+  }
+
+  CompletableFuture<LeadershipTransferResultResponse> leadershipTransferResult(
+      final LeadershipTransferResultRequest request) {
+    if (leadershipTransferResultHandler != null) {
+      return leadershipTransferResultHandler.apply(request);
     } else {
       return CompletableFuture.failedFuture(new ConnectException());
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -112,6 +112,10 @@ public final class RaftPartitionFactory {
         brokerCfg.getExperimental().getRaft().getMinStepDownFailureCount());
     partitionConfig.setPreferSnapshotReplicationThreshold(
         brokerCfg.getExperimental().getRaft().getPreferSnapshotReplicationThreshold());
+    partitionConfig.setRebalanceReplicationLagThreshold(
+        brokerCfg.getCluster().getRaft().getRebalanceReplicationLagThreshold().toBytes());
+    partitionConfig.setRebalanceReplicationTimeout(
+        brokerCfg.getCluster().getRaft().getRebalanceReplicationTimeout());
 
     partitionConfig.setReceiveOnLegacySubject(
         brokerCfg.getExperimental().isReceiveOnLegacySubject());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
@@ -8,14 +8,20 @@
 package io.camunda.zeebe.broker.system.configuration;
 
 import java.time.Duration;
+import org.springframework.util.unit.DataSize;
 
 public final class RaftCfg implements ConfigurationEntry {
   public static final boolean DEFAULT_ENABLE_PRIORITY_ELECTION = true;
+  public static final DataSize DEFAULT_REBALANCE_REPLICATION_LAG_THRESHOLD =
+      DataSize.ofMegabytes(8);
+  public static final Duration DEFAULT_REBALANCE_REPLICATION_TIMEOUT = Duration.ofSeconds(10);
   private static final FlushConfig DEFAULT_FLUSH_CONFIG = new FlushConfig(true, Duration.ZERO);
 
   private boolean enablePriorityElection = DEFAULT_ENABLE_PRIORITY_ELECTION;
 
   private FlushConfig flush = DEFAULT_FLUSH_CONFIG;
+  private DataSize rebalanceReplicationLagThreshold = DEFAULT_REBALANCE_REPLICATION_LAG_THRESHOLD;
+  private Duration rebalanceReplicationTimeout = DEFAULT_REBALANCE_REPLICATION_TIMEOUT;
 
   public boolean isEnablePriorityElection() {
     return enablePriorityElection;
@@ -33,6 +39,22 @@ public final class RaftCfg implements ConfigurationEntry {
     this.flush = flush;
   }
 
+  public DataSize getRebalanceReplicationLagThreshold() {
+    return rebalanceReplicationLagThreshold;
+  }
+
+  public void setRebalanceReplicationLagThreshold(final DataSize rebalanceReplicationLagThreshold) {
+    this.rebalanceReplicationLagThreshold = rebalanceReplicationLagThreshold;
+  }
+
+  public Duration getRebalanceReplicationTimeout() {
+    return rebalanceReplicationTimeout;
+  }
+
+  public void setRebalanceReplicationTimeout(final Duration rebalanceReplicationTimeout) {
+    this.rebalanceReplicationTimeout = rebalanceReplicationTimeout;
+  }
+
   @Override
   public String toString() {
     return "RaftCfg{"
@@ -40,6 +62,10 @@ public final class RaftCfg implements ConfigurationEntry {
         + enablePriorityElection
         + ", flushConfig="
         + flush
+        + ", rebalanceReplicationLagThreshold="
+        + rebalanceReplicationLagThreshold
+        + ", rebalanceReplicationTimeout="
+        + rebalanceReplicationTimeout
         + '}';
   }
 


### PR DESCRIPTION
Introduces the new inter-broker messages to be used for coordinated leadership transfer, along with related configuration and validation. For the moment, this is just wired up in tests.

The coordinator will send an initiate request to the current leader, specifying the desired leader for the transfer. The recipient validates the request comes from the current coordinator, and that the desired leader is in a suitable state for a transfer to be attempted (including checking that it's reachable, and that its replication lag is below the specified threshold).

The response will either be a skip reason (if the request failed validation), or an acknowledgement that the request was accepted. In the latter case, the actual result will be reported asynchronously via another request/response pair.

Requests and responses also include correlation IDs, so that e.g. a coordinator can validate that the asynchronous response it received was in fact related to the request it had sent.

Notably, the new configs introduced here are static, though we plan for them to be overridden on a per-rebalance basis - I've split out https://github.com/camunda/camunda/issues/58913 to cover support for that.

Closes #58908.