### PR TITLE
test: widen wait-state search validation poll window to 90s

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-search-validation-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-search-validation-api.spec.ts
@@ -16,7 +16,10 @@ import {
   assertUnauthorizedRequest,
 } from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
-import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  defaultAssertionOptions,
+  extendedAssertionOptions,
+} from '../../../../utils/constants';
 import {
   WAIT_STATES_SEARCH_ENDPOINT,
   createProcessInstanceWaitingOnJob,
@@ -62,7 +65,7 @@ test.describe.parallel('Wait State Search Validation', () => {
         instance.processInstanceKey,
       );
       expect(body.items[0].details.waitStateType).toBe('JOB');
-    }).toPass(defaultAssertionOptions);
+    }).toPass(extendedAssertionOptions);
   });
 
   test('rejects an unknown filter field with 400', async ({request}) => {


### PR DESCRIPTION
## Description

Hardens the flaky nightly test **"finds a wait state by processInstanceKey with sort and pagination applied"** (`qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-search-validation-api.spec.ts`).

**Symptom:** In the RDBMS API nightly (run [30322679625](https://github.com/camunda/camunda/actions/runs/30322679625)), this test failed only on **MySQL 8.4/9.7** and **MSSQL 2022** (Postgres/MariaDB/Oracle passed). The search returned `{items: [], totalItems: 0}` and the assertion timed out.

**Root cause (investigated, not a product bug):**
- `totalItems` comes from a **count** query that does **not** use sorting, so the `sort` in the request is not the cause.
- The product is correct on these engines: `WaitStateJobIT` (the same single-JOB scenario, no sort) **passed on MySQL/MSSQL** in the RDBMS integration suite the same day.
- **Local reproduction** against a real MySQL 9.7 container, issuing this test's exact request (`filter(processInstanceKey)` + `sort(elementId)` + `page.limit(10)`), returned the row in **~2s**, with sorted and unsorted results identical.
- The failing assertion used `defaultAssertionOptions` (**30s**). Under the loaded shared nightly cluster the secondary-storage export for the wait state can exceed 30s on the slower RDBMS engines, so the poll timed out. The sibling wait-state cap tests already use `extendedAssertionOptions` (**90s**), and the Java ITs allow 120s.

**Fix:** switch this data-propagation assertion to `extendedAssertionOptions` (90s) — the option documented for "data that has to propagate through the secondary-storage indexer on a loaded shared cluster." This is a waiting-strategy fix for eventual consistency, not a masked assertion: the assertion itself is unchanged. The pure request-validation cases (400/401) keep the 30s window.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

> Note: verified via local MySQL 9.7 reproduction (row visible in ~2s, sorted==unsorted). The on-demand E2E workflow has **not** been run yet — recommended before marking ready.

## Related issues

Nightly failure: https://github.com/camunda/camunda/actions/runs/30322679625

🤖 Generated with [Claude Code](https://claude.com/claude-code)
