### PR TITLE
Reapply ad-hoc inner instance naming with same-batch NPE fix

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AdHocSubProcessInnerInstanceNameIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AdHocSubProcessInnerInstanceNameIT.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.search.enums.ElementInstanceState;
+import io.camunda.client.api.search.response.ElementInstance;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+/**
+ * Pins the behaviour that the synthetic <em>inner instance</em> of an ad-hoc subprocess surfaces in
+ * the instance history named after the element that was activated inside it (its entry element),
+ * rather than the generic synthetic id {@code <ahspId>#innerInstance}.
+ *
+ * <p>Activating "listUsers" (name "List users") makes the inner instance's {@code elementName} read
+ * "List users". The name must also survive completion of the inner instance / process instance
+ * (guarding the null-clobber regression where a later write could overwrite the resolved name).
+ *
+ * <p>Disabled on RDBMS: the naming lives only in the camunda-exporter (Elasticsearch/OpenSearch).
+ * The RDBMS exporter has no equivalent handler, so the inner instance name stays null there and
+ * this test's await would time out. RDBMS parity is out of scope for 8.10.
+ */
+@MultiDbTest
+@CompatibilityTest
+@DisabledIfSystemProperty(
+    named = "test.integration.camunda.database.type",
+    matches = "rdbms.*$",
+    disabledReason =
+        "Inner-instance naming is implemented only in the camunda-exporter (ES/OS); "
+            + "the RDBMS exporter has no equivalent, so the name stays null on RDBMS.")
+public class AdHocSubProcessInnerInstanceNameIT {
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldNameInnerInstanceAfterActivatedEntryElementAndRetainItAfterCompletion() {
+    // given
+    final var processModel =
+        Bpmn.createExecutableProcess("adHocInnerInstanceNameProcess")
+            .startEvent()
+            .adHocSubProcess(
+                "adHocSubProcess",
+                ahsp ->
+                    ahsp.serviceTask("listUsers", t -> t.zeebeJobType("listUsersJob"))
+                        .name("List users"))
+            .endEvent("end")
+            .done();
+
+    final var process =
+        deployProcessAndWaitForIt(camundaClient, processModel, "adhoc-inner-instance-name.bpmn");
+
+    // when
+    final long processInstanceKey =
+        startProcessInstance(camundaClient, process.getBpmnProcessId()).getProcessInstanceKey();
+
+    waitForElementInstances(
+        camundaClient,
+        f -> f.elementId("adHocSubProcess").processInstanceKey(processInstanceKey),
+        1);
+
+    final long adHocSubProcessInstanceKey =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.elementId("adHocSubProcess").processInstanceKey(processInstanceKey))
+            .execute()
+            .items()
+            .getFirst()
+            .getElementInstanceKey();
+
+    camundaClient
+        .newActivateAdHocSubProcessActivitiesCommand(String.valueOf(adHocSubProcessInstanceKey))
+        .activateElements("listUsers")
+        .send()
+        .join();
+
+    waitForElementInstances(
+        camundaClient,
+        f -> f.elementId("adHocSubProcess#innerInstance").processInstanceKey(processInstanceKey),
+        1);
+
+    final long jobKey = awaitEntryElementJobKey("listUsersJob");
+
+    // the name is written by the entry child's ELEMENT_ACTIVATING record, which may be exported
+    // after the inner-instance doc itself, so await the name before asserting on it.
+    final var activeInnerInstance =
+        Awaitility.await("inner instance is named")
+            .atMost(Duration.ofSeconds(60))
+            .ignoreExceptions()
+            .until(
+                () -> queryInnerInstance(processInstanceKey, "adHocSubProcess#innerInstance"),
+                instance -> instance.getElementName() != null);
+
+    // then
+    assertThat(activeInnerInstance.getElementName())
+        .describedAs("inner instance should be named after the activated entry element")
+        .isEqualTo("List users");
+    assertThat(activeInnerInstance.getElementName())
+        .describedAs("inner instance name should not fall back to the synthetic id")
+        .isNotEqualTo("adHocSubProcess#innerInstance");
+
+    // when
+    camundaClient.newCompleteCommand(jobKey).send().join();
+
+    Awaitility.await("inner instance completed")
+        .atMost(Duration.ofSeconds(60))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        queryInnerInstance(processInstanceKey, "adHocSubProcess#innerInstance")
+                            .getState())
+                    .isEqualTo(ElementInstanceState.COMPLETED));
+
+    // then
+    final var completedInnerInstance =
+        queryInnerInstance(processInstanceKey, "adHocSubProcess#innerInstance");
+    assertThat(completedInnerInstance.getElementName())
+        .describedAs("inner instance name should survive completion")
+        .isEqualTo("List users");
+    assertThat(completedInnerInstance.getElementName())
+        .describedAs("completed inner instance name should not fall back to the synthetic id")
+        .isNotEqualTo("adHocSubProcess#innerInstance");
+  }
+
+  private static long awaitEntryElementJobKey(final String jobType) {
+    return Awaitility.await("job for entry element is created")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .until(
+            () ->
+                camundaClient
+                    .newActivateJobsCommand()
+                    .jobType(jobType)
+                    .maxJobsToActivate(1)
+                    .timeout(Duration.ofMinutes(5))
+                    .send()
+                    .join()
+                    .getJobs()
+                    .stream()
+                    .findFirst()
+                    .map(ActivatedJob::getKey)
+                    .orElse(null),
+            key -> key != null);
+  }
+
+  private static ElementInstance queryInnerInstance(
+      final long processInstanceKey, final String innerInstanceElementId) {
+    return camundaClient
+        .newElementInstanceSearchRequest()
+        .filter(f -> f.elementId(innerInstanceElementId).processInstanceKey(processInstanceKey))
+        .execute()
+        .items()
+        .getFirst();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AdHocSubProcessInnerInstanceNameSameBatchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AdHocSubProcessInnerInstanceNameSameBatchIT.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.ElementInstanceState;
+import io.camunda.client.api.search.response.ElementInstance;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+/**
+ * Reproduces the production bug (#58803): if two exporter handlers touch the same cached entity
+ * within one flush batch — {@code FlowNodeInstanceNameFromAdHocActivityHandler}, which resolves an
+ * ad-hoc inner instance's name, and {@code FlowNodeInstanceFromProcessInstanceHandler}, which
+ * always nulls that field back out for the inner instance's own lifecycle records — the second
+ * handler's null-write can clobber the first handler's resolved name right before its {@code
+ * flush()} runs, throwing a {@code NullPointerException}. See {@code
+ * ExporterBatchWriterFlowNodeInstanceNameClobberTest} (camunda-exporter module) for this mechanism
+ * pinned in isolation; this test additionally proves the fix survives the real broker -&gt;
+ * exporter -&gt; search-index path.
+ *
+ * <p>{@code @MultiDbTest}'s managed default ({@code bulk.size=1}) flushes after every record, so
+ * two records can never share a batch. This test instead runs its own {@link TestStandaloneBroker}
+ * with {@code bulk.size=5000}/{@code bulk.delay=5s} so the entry child's activation and the inner
+ * instance's completion have room to land in the same flush batch — the condition this bug
+ * requires, and which the sibling {@code AdHocSubProcessInnerInstanceNameIT} structurally cannot
+ * reach.
+ *
+ * <p>Disabled on RDBMS: the naming lives only in the camunda-exporter (Elasticsearch/OpenSearch).
+ * The RDBMS exporter has no equivalent handler, so the inner instance name stays null there and
+ * this test's await would time out for an unrelated reason.
+ */
+@MultiDbTest
+@DisabledIfSystemProperty(
+    named = "test.integration.camunda.database.type",
+    matches = "rdbms.*$",
+    disabledReason =
+        "Inner-instance naming is implemented only in the camunda-exporter (ES/OS); "
+            + "the RDBMS exporter has no equivalent, so the name stays null on RDBMS.")
+public class AdHocSubProcessInnerInstanceNameSameBatchIT {
+
+  @MultiDbTestApplication(managedLifecycle = false)
+  private static final TestStandaloneBroker STANDALONE_CAMUNDA = new TestStandaloneBroker();
+
+  @BeforeAll
+  static void setUp() {
+    STANDALONE_CAMUNDA.withUnifiedConfig(
+        c -> {
+          // See class javadoc for why these specific values reproduce the bug.
+          final var bulk = c.getData().getSecondaryStorage().getDocumentBasedDatabase().getBulk();
+          bulk.setSize(5000);
+          bulk.setDelay(Duration.ofSeconds(5));
+        });
+
+    STANDALONE_CAMUNDA.start();
+    STANDALONE_CAMUNDA.awaitCompleteTopology();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    STANDALONE_CAMUNDA.stop();
+  }
+
+  @Test
+  void shouldRetainNameWhenEntryElementCompletesInSameBatch() {
+    try (final var camundaClient = STANDALONE_CAMUNDA.newClientBuilder().build()) {
+      // given - an ad-hoc subprocess whose entry element is a plain/undefined task: no job type
+      // and no outgoing sequence flow, so it auto-completes immediately once activated, which in
+      // turn immediately completes the inner instance in the same exporter flush batch.
+      final var processModel =
+          Bpmn.createExecutableProcess("adHocInnerInstanceNameSameBatchProcess")
+              .startEvent()
+              .adHocSubProcess(
+                  "adHocSubProcess",
+                  ahsp -> ahsp.task("autoCompleteTask").name("Auto complete task"))
+              .endEvent("end")
+              .done();
+
+      final var process =
+          deployProcessAndWaitForIt(
+              camundaClient, processModel, "adhoc-inner-instance-name-same-batch.bpmn");
+
+      // when
+      final long processInstanceKey =
+          startProcessInstance(camundaClient, process.getBpmnProcessId()).getProcessInstanceKey();
+
+      waitForElementInstances(
+          camundaClient,
+          f -> f.elementId("adHocSubProcess").processInstanceKey(processInstanceKey),
+          1);
+
+      final long adHocSubProcessInstanceKey =
+          camundaClient
+              .newElementInstanceSearchRequest()
+              .filter(f -> f.elementId("adHocSubProcess").processInstanceKey(processInstanceKey))
+              .execute()
+              .items()
+              .getFirst()
+              .getElementInstanceKey();
+
+      camundaClient
+          .newActivateAdHocSubProcessActivitiesCommand(String.valueOf(adHocSubProcessInstanceKey))
+          .activateElements("autoCompleteTask")
+          .send()
+          .join();
+
+      // then - the entry element auto-completes and the ad-hoc subprocess has no active elements
+      // left, so the inner instance completes right away. With the bug present, the exporter
+      // throws internally and gets stuck retrying the batch, so COMPLETED never becomes visible
+      // within the await window.
+      Awaitility.await("inner instance completes")
+          .atMost(Duration.ofSeconds(60))
+          .ignoreExceptions()
+          .untilAsserted(
+              () ->
+                  assertThat(
+                          queryInnerInstance(
+                                  camundaClient,
+                                  processInstanceKey,
+                                  "adHocSubProcess#innerInstance")
+                              .getState())
+                      .isEqualTo(ElementInstanceState.COMPLETED));
+
+      final var completedInnerInstance =
+          queryInnerInstance(camundaClient, processInstanceKey, "adHocSubProcess#innerInstance");
+      assertThat(completedInnerInstance.getElementName())
+          .describedAs(
+              "inner instance should be named after the activated entry element even though "
+                  + "activation and completion landed in the same exporter flush batch")
+          .isEqualTo("Auto complete task");
+      assertThat(completedInnerInstance.getElementName())
+          .describedAs("inner instance name should not fall back to the synthetic id")
+          .isNotEqualTo("adHocSubProcess#innerInstance");
+    }
+  }
+
+  private static ElementInstance queryInnerInstance(
+      final CamundaClient camundaClient,
+      final long processInstanceKey,
+      final String innerInstanceElementId) {
+    return camundaClient
+        .newElementInstanceSearchRequest()
+        .filter(f -> f.elementId(innerInstanceElementId).processInstanceKey(processInstanceKey))
+        .execute()
+        .items()
+        .getFirst();
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/process/CachedProcessEntity.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/process/CachedProcessEntity.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.exporter.common.cache.process;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public record CachedProcessEntity(
     String name,
@@ -17,4 +18,29 @@ public record CachedProcessEntity(
     List<String> callElementIds,
     Map<String, String> flowNodesMap,
     boolean hasUserTasks,
-    Map<String, Map<String, String>> elementExtensionProperties) {}
+    Map<String, Map<String, String>> elementExtensionProperties,
+    Set<String> adHocActivityIds) {
+
+  /**
+   * Backwards-compatible constructor that defaults {@code adHocActivityIds} to an empty set, so
+   * existing call sites that do not compute the ad-hoc activity set keep compiling.
+   */
+  public CachedProcessEntity(
+      final String name,
+      final int version,
+      final String versionTag,
+      final List<String> callElementIds,
+      final Map<String, String> flowNodesMap,
+      final boolean hasUserTasks,
+      final Map<String, Map<String, String>> elementExtensionProperties) {
+    this(
+        name,
+        version,
+        versionTag,
+        callElementIds,
+        flowNodesMap,
+        hasUserTasks,
+        elementExtensionProperties,
+        Set.of());
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
@@ -115,6 +115,7 @@ public final class ProcessCacheUtil {
       final var extensionProperties =
           ProcessModelReader.extractExtensionProperties(
               flowNodes, extensionPropertiesConfiguration.extensionPropertyFilter());
+      final var adHocActivityIds = reader.extractAdHocActivityIds();
       return new CachedProcessEntity(
           name,
           version,
@@ -122,7 +123,8 @@ public final class ProcessCacheUtil {
           callActivityIds,
           flowNodesMap,
           hasUserTasks,
-          extensionProperties);
+          extensionProperties,
+          adHocActivityIds);
     }
     return new CachedProcessEntity(name, version, versionTag, List.of(), Map.of(), true, Map.of());
   }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtilTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtilTest.java
@@ -66,6 +66,45 @@ public class ProcessCacheUtilTest {
   }
 
   @Test
+  void shouldExtractOnlyDirectlyActivatableAdHocActivityIds() {
+    // given — an ad-hoc subprocess with an internal flow: listUsers -> sortTask.
+    // Only listUsers is directly activatable; sortTask has an incoming sequence flow and is
+    // reached by flow, not by the ActivateAdHocSubProcessActivities command (see the engine's
+    // AdHocSubProcessTransformer, which filters activatable activities to getIncoming().isEmpty()).
+    final String processId = "adHocProcess";
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .adHocSubProcess(
+                "adHocSubProcess",
+                ahsp ->
+                    ahsp.serviceTask("listUsers", t -> t.zeebeJobType("listUsersJob"))
+                        .serviceTask("sortTask", t -> t.zeebeJobType("sortJob")))
+            .endEvent()
+            .done();
+
+    // when
+    final var adHocActivityIds =
+        ProcessCacheUtil.createCachedProcessEntity(
+                null,
+                0,
+                null,
+                Bpmn.convertToString(model),
+                processId,
+                new ExtensionPropertyConfiguration())
+            .adHocActivityIds();
+
+    // then
+    assertThat(adHocActivityIds)
+        .describedAs("only the directly-activatable (no-incoming-edge) ad-hoc activity is included")
+        .containsExactly("listUsers");
+    assertThat(adHocActivityIds)
+        .describedAs(
+            "a downstream sequence-flow target is not directly activatable and is excluded")
+        .doesNotContain("sortTask");
+  }
+
+  @Test
   void shouldOnlyRetainKnownToolPropertiesInProcessCache() {
     // given — a service task with both tool-related and unrelated zeebe:properties
     final String processId = "mixedPropsProcess";

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -31,6 +31,7 @@ import io.camunda.exporter.handlers.EmbeddedFormHandler;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.handlers.FlowNodeInstanceFromIncidentHandler;
 import io.camunda.exporter.handlers.FlowNodeInstanceFromProcessInstanceHandler;
+import io.camunda.exporter.handlers.FlowNodeInstanceNameFromAdHocActivityHandler;
 import io.camunda.exporter.handlers.FormHandler;
 import io.camunda.exporter.handlers.GlobalListenerCreatedUpdatedHandler;
 import io.camunda.exporter.handlers.GlobalListenerDeletedHandler;
@@ -285,6 +286,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new FlowNodeInstanceFromIncidentHandler(
                 indexDescriptors.get(FlowNodeInstanceTemplate.class).getFullQualifiedName()),
             new FlowNodeInstanceFromProcessInstanceHandler(
+                indexDescriptors.get(FlowNodeInstanceTemplate.class).getFullQualifiedName(),
+                processCache),
+            new FlowNodeInstanceNameFromAdHocActivityHandler(
                 indexDescriptors.get(FlowNodeInstanceTemplate.class).getFullQualifiedName(),
                 processCache),
             new IncidentHandler(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
@@ -107,10 +107,17 @@ public class FlowNodeInstanceFromProcessInstanceHandler
     entity.setId(String.valueOf(record.getKey()));
     entity.setPartitionId(record.getPartitionId());
     entity.setFlowNodeId(recordValue.getElementId());
-    entity.setFlowNodeName(
+    entity.setType(
+        FlowNodeType.fromZeebeBpmnElementType(
+            recordValue.getBpmnElementType() == null
+                ? null
+                : recordValue.getBpmnElementType().name()));
+    final var resolvedFlowNodeName =
         ProcessCacheUtil.getFlowNodeName(
-                processCache, processDefinitionKey, recordValue.getElementId())
-            .orElse(null));
+            processCache, processDefinitionKey, recordValue.getElementId());
+    if (shouldWriteName(entity, resolvedFlowNodeName.isPresent())) {
+      entity.setFlowNodeName(resolvedFlowNodeName.orElse(null));
+    }
     entity.setProcessInstanceKey(recordValue.getProcessInstanceKey());
     entity.setProcessDefinitionKey(processDefinitionKey);
     entity.setBpmnProcessId(recordValue.getBpmnProcessId());
@@ -140,11 +147,6 @@ public class FlowNodeInstanceFromProcessInstanceHandler
       }
     }
 
-    entity.setType(
-        FlowNodeType.fromZeebeBpmnElementType(
-            recordValue.getBpmnElementType() == null
-                ? null
-                : recordValue.getBpmnElementType().name()));
     final long rootProcessInstanceKey = recordValue.getRootProcessInstanceKey();
     if (rootProcessInstanceKey > 0) {
       entity.setRootProcessInstanceKey(rootProcessInstanceKey);
@@ -166,17 +168,7 @@ public class FlowNodeInstanceFromProcessInstanceHandler
       updateFields.put(FlowNodeInstanceTemplate.LEVEL, entity.getLevel());
     }
     updateFields.put(FlowNodeInstanceTemplate.FLOW_NODE_ID, entity.getFlowNodeId());
-    // The ad-hoc subprocess inner instance has no name of its own: its synthetic id is absent from
-    // the BPMN, so the name resolves to null here. Its name is instead written by
-    // FlowNodeInstanceNameFromAdHocActivityHandler, derived from the activated entry element.
-    //
-    // We therefore skip writing a null name for the inner instance, so this handler's later
-    // lifecycle records (e.g. COMPLETED, TERMINATED) don't clobber that resolved name.
-    //
-    // Normal elements always write their name, including a null that must clear a name
-    // (e.g. migration to an unnamed target).
-    if (entity.getType() != FlowNodeType.AD_HOC_SUB_PROCESS_INNER_INSTANCE
-        || entity.getFlowNodeName() != null) {
+    if (shouldWriteName(entity, entity.getFlowNodeName() != null)) {
       updateFields.put(FlowNodeInstanceTemplate.FLOW_NODE_NAME, entity.getFlowNodeName());
     }
     updateFields.put(
@@ -197,6 +189,16 @@ public class FlowNodeInstanceFromProcessInstanceHandler
   @Override
   public String getIndexName() {
     return indexName;
+  }
+
+  /**
+   * The ad-hoc subprocess inner instance's synthetic id is absent from the BPMN, so this handler
+   * never resolves a name for it; FlowNodeInstanceNameFromAdHocActivityHandler writes that name
+   * instead, derived from the activated entry element.
+   */
+  private static boolean shouldWriteName(
+      final FlowNodeInstanceEntity entity, final boolean hasName) {
+    return entity.getType() != FlowNodeType.AD_HOC_SUB_PROCESS_INNER_INSTANCE || hasName;
   }
 
   /**

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
@@ -166,7 +166,19 @@ public class FlowNodeInstanceFromProcessInstanceHandler
       updateFields.put(FlowNodeInstanceTemplate.LEVEL, entity.getLevel());
     }
     updateFields.put(FlowNodeInstanceTemplate.FLOW_NODE_ID, entity.getFlowNodeId());
-    updateFields.put(FlowNodeInstanceTemplate.FLOW_NODE_NAME, entity.getFlowNodeName());
+    // The ad-hoc subprocess inner instance has no name of its own: its synthetic id is absent from
+    // the BPMN, so the name resolves to null here. Its name is instead written by
+    // FlowNodeInstanceNameFromAdHocActivityHandler, derived from the activated entry element.
+    //
+    // We therefore skip writing a null name for the inner instance, so this handler's later
+    // lifecycle records (e.g. COMPLETED, TERMINATED) don't clobber that resolved name.
+    //
+    // Normal elements always write their name, including a null that must clear a name
+    // (e.g. migration to an unnamed target).
+    if (entity.getType() != FlowNodeType.AD_HOC_SUB_PROCESS_INNER_INSTANCE
+        || entity.getFlowNodeName() != null) {
+      updateFields.put(FlowNodeInstanceTemplate.FLOW_NODE_NAME, entity.getFlowNodeName());
+    }
     updateFields.put(
         FlowNodeInstanceTemplate.PROCESS_DEFINITION_KEY, entity.getProcessDefinitionKey());
     updateFields.put(FlowNodeInstanceTemplate.BPMN_PROCESS_ID, entity.getBpmnProcessId());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandler.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import java.util.List;
+
+/**
+ * Names the inner instance of an ad-hoc subprocess after the element that was initially activated
+ * inside it (its entry element).
+ *
+ * <p>Activating an element inside an ad-hoc subprocess creates a synthetic <em>inner instance</em>:
+ * a scope that owns the activated element together with everything reachable from it (e.g. the
+ * elements targeted by its outgoing sequence flows), so variables and state persist across those
+ * elements for the lifetime of the activation. That inner instance has no name of its own — its
+ * element id is the synthetic {@code <ahspId>#innerInstance}, which is not present in the deployed
+ * BPMN — so in the instance history it surfaces with a generic label.
+ *
+ * <p>This handler reacts to the <em>entry child's</em> {@code ELEMENT_ACTIVATING} record and writes
+ * the child's resolved name onto the parent inner-instance document, so the inner instance reads as
+ * the element that was activated (e.g. {@code listUsers} → "List users").
+ *
+ * <p>NOTE: no-op stub; the naming behaviour is implemented in the green phase.
+ */
+public class FlowNodeInstanceNameFromAdHocActivityHandler
+    implements ExportHandler<FlowNodeInstanceEntity, ProcessInstanceRecordValue> {
+
+  /**
+   * Painless script that sets {@code flowNodeName} only when it is not already set, so that the
+   * first-activated child (the entry element) wins and later activations in the same inner instance
+   * cannot clobber the name.
+   */
+  public static final String SET_IF_NULL_NAME_SCRIPT =
+      """
+      if (ctx._source.flowNodeName == null) {
+          ctx._source.flowNodeName = params.flowNodeName;
+      }
+      """;
+
+  private final String indexName;
+  private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
+
+  public FlowNodeInstanceNameFromAdHocActivityHandler(
+      final String indexName, final ExporterEntityCache<Long, CachedProcessEntity> processCache) {
+    this.indexName = indexName;
+    this.processCache = processCache;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.PROCESS_INSTANCE;
+  }
+
+  @Override
+  public Class<FlowNodeInstanceEntity> getEntityType() {
+    return FlowNodeInstanceEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<ProcessInstanceRecordValue> record) {
+    // stub
+    return false;
+  }
+
+  @Override
+  public List<String> generateIds(final Record<ProcessInstanceRecordValue> record) {
+    // stub
+    return List.of();
+  }
+
+  @Override
+  public FlowNodeInstanceEntity createNewEntity(final String id) {
+    return new FlowNodeInstanceEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<ProcessInstanceRecordValue> record, final FlowNodeInstanceEntity entity) {
+    // stub
+  }
+
+  @Override
+  public void flush(
+      final TargetIndex index,
+      final FlowNodeInstanceEntity entity,
+      final BatchRequest batchRequest) {
+    // stub
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandler.java
@@ -9,13 +9,17 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Names the inner instance of an ad-hoc subprocess after the element that was initially activated
@@ -31,16 +35,13 @@ import java.util.List;
  * <p>This handler reacts to the <em>entry child's</em> {@code ELEMENT_ACTIVATING} record and writes
  * the child's resolved name onto the parent inner-instance document, so the inner instance reads as
  * the element that was activated (e.g. {@code listUsers} → "List users").
- *
- * <p>NOTE: no-op stub; the naming behaviour is implemented in the green phase.
  */
 public class FlowNodeInstanceNameFromAdHocActivityHandler
     implements ExportHandler<FlowNodeInstanceEntity, ProcessInstanceRecordValue> {
 
   /**
-   * Painless script that sets {@code flowNodeName} only when it is not already set, so that the
-   * first-activated child (the entry element) wins and later activations in the same inner instance
-   * cannot clobber the name.
+   * Painless script that sets {@code flowNodeName} only when it is not already set (first-writer
+   * wins), so re-processing the entry child's record can't overwrite the resolved name.
    */
   public static final String SET_IF_NULL_NAME_SCRIPT =
       """
@@ -70,14 +71,21 @@ public class FlowNodeInstanceNameFromAdHocActivityHandler
 
   @Override
   public boolean handlesRecord(final Record<ProcessInstanceRecordValue> record) {
-    // stub
-    return false;
+    if (!ProcessInstanceIntent.ELEMENT_ACTIVATING.equals(record.getIntent())) {
+      return false;
+    }
+    final var recordValue = record.getValue();
+    return processCache
+        .get(recordValue.getProcessDefinitionKey())
+        .map(CachedProcessEntity::adHocActivityIds)
+        .map(ids -> ids.contains(recordValue.getElementId()))
+        .orElse(false);
   }
 
   @Override
   public List<String> generateIds(final Record<ProcessInstanceRecordValue> record) {
-    // stub
-    return List.of();
+    // the child's flow scope is the parent inner-instance, whose document we want to name
+    return List.of(String.valueOf(record.getValue().getFlowScopeKey()));
   }
 
   @Override
@@ -88,7 +96,14 @@ public class FlowNodeInstanceNameFromAdHocActivityHandler
   @Override
   public void updateEntity(
       final Record<ProcessInstanceRecordValue> record, final FlowNodeInstanceEntity entity) {
-    // stub
+    // resolve the name from the entry child's element id; keep the parent inner-instance id that
+    // generateIds established on the entity, so flush writes onto the inner-instance document
+    final var recordValue = record.getValue();
+    final var elementId = recordValue.getElementId();
+    entity.setFlowNodeName(
+        ProcessCacheUtil.getFlowNodeName(
+                processCache, recordValue.getProcessDefinitionKey(), elementId)
+            .orElse(elementId));
   }
 
   @Override
@@ -96,7 +111,16 @@ public class FlowNodeInstanceNameFromAdHocActivityHandler
       final TargetIndex index,
       final FlowNodeInstanceEntity entity,
       final BatchRequest batchRequest) {
-    // stub
+    // Only sets the name. The inner-instance document (with its identifying fields) is normally
+    // inserted first by FlowNodeInstanceFromProcessInstanceHandler, since the engine writes the
+    // inner instance's own ELEMENT_ACTIVATING before the entry child's. The upsert here is a
+    // defensive fallback: it lets ES/OS create the document rather than fail if it is missing.
+    batchRequest.upsertWithScript(
+        index,
+        entity.getId(),
+        entity,
+        SET_IF_NULL_NAME_SCRIPT,
+        Map.of(FlowNodeInstanceTemplate.FLOW_NODE_NAME, entity.getFlowNodeName()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
@@ -19,6 +19,7 @@ import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeState;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
+import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -451,6 +452,49 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
     assertThat(flowNodeInstanceEntity.getEndDate()).isNull();
     assertThat(flowNodeInstanceEntity.getPosition()).isNull();
     assertThat(flowNodeInstanceEntity.getTreePath()).isEqualTo(defaultTreePath);
+  }
+
+  @Test
+  public void shouldRetainStaleNameWhenAdHocInnerInstanceIsMigrated() {
+    // given
+    final long targetProcessDefinitionKey = 222L;
+    processCache.put(
+        targetProcessDefinitionKey,
+        new CachedProcessEntity(
+            "targetProcess",
+            1,
+            null,
+            List.of(),
+            Map.of("targetAdHocSubProcess", "Target ad-hoc subprocess"),
+            false,
+            Map.of()));
+
+    final ProcessInstanceRecordValue processInstanceRecordValue =
+        ImmutableProcessInstanceRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+            .withBpmnElementType(BpmnElementType.AD_HOC_SUB_PROCESS_INNER_INSTANCE)
+            .withElementId("targetAdHocSubProcess#innerInstance")
+            .withProcessDefinitionKey(targetProcessDefinitionKey)
+            .build();
+    final Record<ProcessInstanceRecordValue> processInstanceRecord =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withIntent(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                    .withValue(processInstanceRecordValue));
+
+    final FlowNodeInstanceEntity flowNodeInstanceEntity =
+        new FlowNodeInstanceEntity().setFlowNodeName("List users");
+
+    // when
+    underTest.updateEntity(processInstanceRecord, flowNodeInstanceEntity);
+
+    // then
+    assertThat(flowNodeInstanceEntity.getFlowNodeName())
+        .describedAs(
+            "pre-migration inner-instance name survives migration, unresolved against the "
+                + "target process definition")
+        .isEqualTo("List users");
   }
 
   @ParameterizedTest

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
@@ -218,6 +218,7 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
             .setType(FlowNodeType.SERVICE_TASK)
             .setState(FlowNodeState.ACTIVE)
             .setFlowNodeId("flowNode1")
+            .setFlowNodeName(null)
             .setProcessDefinitionKey(222L)
             .setBpmnProcessId("bpmnId");
     final TargetIndex index = TargetIndex.mainIndex("test-index");
@@ -239,6 +240,40 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
     // when
     underTest.flush(index, inputEntity, mockRequest);
     // then
+    verify(mockRequest, times(1))
+        .upsert(index, inputEntity.getId(), inputEntity, expectedUpdateFields);
+  }
+
+  @Test
+  public void shouldOmitFlowNodeNameForInnerInstanceWhenNull() {
+    final FlowNodeInstanceEntity inputEntity =
+        new FlowNodeInstanceEntity()
+            .setId("111")
+            .setKey(111)
+            .setProcessInstanceKey(444L)
+            .setPartitionId(1)
+            .setType(FlowNodeType.AD_HOC_SUB_PROCESS_INNER_INSTANCE)
+            .setState(FlowNodeState.COMPLETED)
+            .setFlowNodeId("adHocSubProcess#innerInstance")
+            .setFlowNodeName(null)
+            .setProcessDefinitionKey(222L)
+            .setBpmnProcessId("bpmnId");
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    final Map<String, Object> expectedUpdateFields = new HashMap<>();
+    expectedUpdateFields.put(FlowNodeInstanceTemplate.ID, inputEntity.getId());
+    expectedUpdateFields.put(FlowNodeInstanceTemplate.PARTITION_ID, inputEntity.getPartitionId());
+    expectedUpdateFields.put(FlowNodeInstanceTemplate.TYPE, inputEntity.getType());
+    expectedUpdateFields.put(FlowNodeInstanceTemplate.STATE, inputEntity.getState());
+    expectedUpdateFields.put(FlowNodeInstanceTemplate.FLOW_NODE_ID, inputEntity.getFlowNodeId());
+    expectedUpdateFields.put(
+        FlowNodeInstanceTemplate.PROCESS_DEFINITION_KEY, inputEntity.getProcessDefinitionKey());
+    expectedUpdateFields.put(
+        FlowNodeInstanceTemplate.BPMN_PROCESS_ID, inputEntity.getBpmnProcessId());
+
+    underTest.flush(index, inputEntity, mockRequest);
+
     verify(mockRequest, times(1))
         .upsert(index, inputEntity.getId(), inputEntity, expectedUpdateFields);
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
@@ -209,7 +209,44 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
   }
 
   @Test
-  public void shouldNotUpsertNullFields() {
+  public void shouldOmitAbsentOptionalFieldsFromUpsert() {
+    final FlowNodeInstanceEntity inputEntity =
+        new FlowNodeInstanceEntity()
+            .setId("111")
+            .setKey(111)
+            .setProcessInstanceKey(444L)
+            .setPartitionId(1)
+            .setType(FlowNodeType.SERVICE_TASK)
+            .setState(FlowNodeState.ACTIVE)
+            .setFlowNodeId("flowNode1")
+            .setFlowNodeName("flowNodeName")
+            .setProcessDefinitionKey(222L)
+            .setBpmnProcessId("bpmnId");
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    final Map<String, Object> expectedUpdateFields = new HashMap<>();
+    expectedUpdateFields.put(FlowNodeInstanceTemplate.ID, inputEntity.getId());
+    expectedUpdateFields.put(FlowNodeInstanceTemplate.PARTITION_ID, inputEntity.getPartitionId());
+    expectedUpdateFields.put(FlowNodeInstanceTemplate.TYPE, inputEntity.getType());
+    expectedUpdateFields.put(FlowNodeInstanceTemplate.STATE, inputEntity.getState());
+    expectedUpdateFields.put(FlowNodeInstanceTemplate.FLOW_NODE_ID, inputEntity.getFlowNodeId());
+    expectedUpdateFields.put(
+        FlowNodeInstanceTemplate.FLOW_NODE_NAME, inputEntity.getFlowNodeName());
+    expectedUpdateFields.put(
+        FlowNodeInstanceTemplate.PROCESS_DEFINITION_KEY, inputEntity.getProcessDefinitionKey());
+    expectedUpdateFields.put(
+        FlowNodeInstanceTemplate.BPMN_PROCESS_ID, inputEntity.getBpmnProcessId());
+
+    // when
+    underTest.flush(index, inputEntity, mockRequest);
+    // then
+    verify(mockRequest, times(1))
+        .upsert(index, inputEntity.getId(), inputEntity, expectedUpdateFields);
+  }
+
+  @Test
+  public void shouldUpsertNullFlowNodeNameForNormalElement() {
     final FlowNodeInstanceEntity inputEntity =
         new FlowNodeInstanceEntity()
             .setId("111")

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandlerTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.cache.TestProcessCache;
+import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
+import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
+import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+public class FlowNodeInstanceNameFromAdHocActivityHandlerTest {
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-flow-node-instance";
+  private final TestProcessCache processCache = new TestProcessCache();
+  private final FlowNodeInstanceNameFromAdHocActivityHandler underTest =
+      new FlowNodeInstanceNameFromAdHocActivityHandler(indexName, processCache);
+
+  @Test
+  public void shouldHandleActivatingAdHocActivity() {
+    // given
+    processCache.put(
+        222L, cachedProcessEntity(Map.of("listUsers", "List users"), Set.of("listUsers")));
+    final Record<ProcessInstanceRecordValue> record =
+        createRecord(ProcessInstanceIntent.ELEMENT_ACTIVATING, "listUsers", 222L, 0L);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isTrue();
+  }
+
+  @Test
+  public void shouldNotHandleNonAdHocActivity() {
+    // given
+    processCache.put(
+        222L, cachedProcessEntity(Map.of("listUsers", "List users"), Set.of("listUsers")));
+    final Record<ProcessInstanceRecordValue> record =
+        createRecord(ProcessInstanceIntent.ELEMENT_ACTIVATING, "someTask", 222L, 0L);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  public void shouldNotHandleNonActivatingIntent() {
+    // given
+    processCache.put(
+        222L, cachedProcessEntity(Map.of("listUsers", "List users"), Set.of("listUsers")));
+    final Record<ProcessInstanceRecordValue> record =
+        createRecord(ProcessInstanceIntent.ELEMENT_COMPLETED, "listUsers", 222L, 0L);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  public void shouldNotHandleWhenProcessNotInCache() {
+    // given - no entry in the process cache for this process definition key
+    final Record<ProcessInstanceRecordValue> record =
+        createRecord(ProcessInstanceIntent.ELEMENT_ACTIVATING, "listUsers", 222L, 0L);
+
+    // when - then
+    // a cache miss must not be treated as a match (and must not NPE resolving adHocActivityIds)
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  public void shouldGenerateInnerInstanceIdFromFlowScopeKey() {
+    // given
+    final Record<ProcessInstanceRecordValue> record =
+        createRecord(ProcessInstanceIntent.ELEMENT_ACTIVATING, "listUsers", 222L, 999L);
+
+    // when
+    final var idList = underTest.generateIds(record);
+
+    // then
+    assertThat(idList).containsExactly("999");
+  }
+
+  @Test
+  public void shouldResolveEntryElementName() {
+    // given
+    processCache.put(
+        222L, cachedProcessEntity(Map.of("listUsers", "List users"), Set.of("listUsers")));
+    final Record<ProcessInstanceRecordValue> record =
+        createRecord(ProcessInstanceIntent.ELEMENT_ACTIVATING, "listUsers", 222L, 999L);
+
+    // when
+    // the entity is created by the exporter framework with the id from generateIds (the parent
+    // inner-instance key); updateEntity must only enrich it, never re-key it to the child.
+    final FlowNodeInstanceEntity entity = new FlowNodeInstanceEntity().setId("999");
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getFlowNodeName()).isEqualTo("List users");
+    assertThat(entity.getId())
+        .describedAs(
+            "updateEntity must keep the parent inner-instance id from generateIds; re-keying it to "
+                + "the child would make flush write the name onto the child doc instead")
+        .isEqualTo("999");
+  }
+
+  @Test
+  public void shouldFallbackToElementIdWhenEntryUnnamed() {
+    // given
+    final Map<String, String> flowNodesMap = new HashMap<>();
+    flowNodesMap.put("listUsers", null);
+    processCache.put(222L, cachedProcessEntity(flowNodesMap, Set.of("listUsers")));
+    final Record<ProcessInstanceRecordValue> record =
+        createRecord(ProcessInstanceIntent.ELEMENT_ACTIVATING, "listUsers", 222L, 999L);
+
+    // when
+    final FlowNodeInstanceEntity entity = new FlowNodeInstanceEntity();
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getFlowNodeName()).isEqualTo("listUsers");
+  }
+
+  @Test
+  public void shouldUpsertNameWithSetIfNullScriptOnFlush() {
+    // given
+    final FlowNodeInstanceEntity entity =
+        new FlowNodeInstanceEntity().setId("111").setFlowNodeName("List users");
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(index, entity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1))
+        .upsertWithScript(
+            eq(index),
+            eq("111"),
+            eq(entity),
+            eq(FlowNodeInstanceNameFromAdHocActivityHandler.SET_IF_NULL_NAME_SCRIPT),
+            eq(Map.of(FlowNodeInstanceTemplate.FLOW_NODE_NAME, "List users")));
+  }
+
+  private CachedProcessEntity cachedProcessEntity(
+      final Map<String, String> flowNodesMap, final Set<String> adHocActivityIds) {
+    return new CachedProcessEntity(
+        "process", 1, null, List.of(), flowNodesMap, false, Map.of(), adHocActivityIds);
+  }
+
+  private Record<ProcessInstanceRecordValue> createRecord(
+      final ProcessInstanceIntent intent,
+      final String elementId,
+      final long processDefinitionKey,
+      final long flowScopeKey) {
+    final ProcessInstanceRecordValue value =
+        ImmutableProcessInstanceRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+            .withElementId(elementId)
+            .withProcessDefinitionKey(processDefinitionKey)
+            .withFlowScopeKey(flowScopeKey)
+            .build();
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE, r -> r.withIntent(intent).withValue(value));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterFlowNodeInstanceNameClobberTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterFlowNodeInstanceNameClobberTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.store;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.exporter.cache.TestProcessCache;
+import io.camunda.exporter.handlers.FlowNodeInstanceFromProcessInstanceHandler;
+import io.camunda.exporter.handlers.FlowNodeInstanceNameFromAdHocActivityHandler;
+import io.camunda.exporter.store.ExporterBatchWriter.Builder;
+import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the shared-mutable-entity mechanism behind #58803, in isolation from a broker: {@link
+ * ExporterBatchWriter} caches one entity per {@code (id, entityType)} across all handlers that
+ * touch it within a single flush batch. {@link FlowNodeInstanceNameFromAdHocActivityHandler} and
+ * {@link FlowNodeInstanceFromProcessInstanceHandler} both target the ad-hoc inner instance's own id
+ * — the former via the entry child's {@code ELEMENT_ACTIVATING} record (its {@code flowScopeKey}),
+ * the latter via the inner instance's own lifecycle records (its {@code key}).
+ *
+ * <p>If the inner instance's own completion record is processed after the entry child's activation
+ * within the same batch, {@code FlowNodeInstanceFromProcessInstanceHandler#updateEntity} clobbers
+ * the shared entity's {@code flowNodeName} back to {@code null} — that synthetic id never resolves
+ * in the BPMN — right before {@code FlowNodeInstanceNameFromAdHocActivityHandler#flush}'s {@code
+ * Map.of(FLOW_NODE_NAME, entity.getFlowNodeName())} runs on it. This must not throw a {@link
+ * NullPointerException} (#58803).
+ */
+public class ExporterBatchWriterFlowNodeInstanceNameClobberTest {
+
+  private static final long PROCESS_DEFINITION_KEY = 222L;
+  private static final long INNER_INSTANCE_KEY = 999L;
+  private static final String ENTRY_ELEMENT_ID = "listUsers";
+  private static final String INNER_INSTANCE_ELEMENT_ID = "adHocSubProcess#innerInstance";
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final TestProcessCache processCache = new TestProcessCache();
+
+  @Test
+  public void shouldNotThrowWhenInnerInstanceCompletionClobbersNameInSameBatch() {
+    // given
+    processCache.put(
+        PROCESS_DEFINITION_KEY,
+        new CachedProcessEntity(
+            "process",
+            1,
+            null,
+            List.of(),
+            Map.of(ENTRY_ELEMENT_ID, "List users"),
+            false,
+            Map.of(),
+            Set.of(ENTRY_ELEMENT_ID)));
+    final var writer =
+        Builder.begin()
+            .withHandler(
+                new FlowNodeInstanceNameFromAdHocActivityHandler(
+                    "flow-node-instance", processCache))
+            .withHandler(
+                new FlowNodeInstanceFromProcessInstanceHandler("flow-node-instance", processCache))
+            .build();
+
+    // the entry child's activation resolves the name and caches it onto the inner instance entity
+    writer.addRecord(entryElementActivatingRecord());
+    // the inner instance's own completion, processed in the same batch, clobbers it back to null
+    writer.addRecord(innerInstanceCompletedRecord());
+
+    // when - then
+    assertThatCode(() -> writer.flush(mock(BatchRequest.class))).doesNotThrowAnyException();
+  }
+
+  private Record<ProcessInstanceRecordValue> entryElementActivatingRecord() {
+    final ProcessInstanceRecordValue value =
+        ImmutableProcessInstanceRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+            .withElementId(ENTRY_ELEMENT_ID)
+            .withProcessDefinitionKey(PROCESS_DEFINITION_KEY)
+            .withFlowScopeKey(INNER_INSTANCE_KEY)
+            .build();
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE,
+        r -> r.withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING).withValue(value));
+  }
+
+  private Record<ProcessInstanceRecordValue> innerInstanceCompletedRecord() {
+    final ProcessInstanceRecordValue value =
+        ImmutableProcessInstanceRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+            .withElementId(INNER_INSTANCE_ELEMENT_ID)
+            .withProcessDefinitionKey(PROCESS_DEFINITION_KEY)
+            .withBpmnElementType(BpmnElementType.AD_HOC_SUB_PROCESS_INNER_INSTANCE)
+            .build();
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE,
+        r ->
+            r.withKey(INNER_INSTANCE_KEY)
+                .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withValue(value));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterFlowNodeInstanceNameClobberTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterFlowNodeInstanceNameClobberTest.java
@@ -8,12 +8,16 @@
 package io.camunda.exporter.store;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.cache.TestProcessCache;
 import io.camunda.exporter.handlers.FlowNodeInstanceFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.FlowNodeInstanceNameFromAdHocActivityHandler;
 import io.camunda.exporter.store.ExporterBatchWriter.Builder;
+import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -79,9 +83,18 @@ public class ExporterBatchWriterFlowNodeInstanceNameClobberTest {
     writer.addRecord(entryElementActivatingRecord());
     // the inner instance's own completion, processed in the same batch, clobbers it back to null
     writer.addRecord(innerInstanceCompletedRecord());
+    final var batchRequest = mock(BatchRequest.class);
 
     // when - then
-    assertThatCode(() -> writer.flush(mock(BatchRequest.class))).doesNotThrowAnyException();
+    assertThatCode(() -> writer.flush(batchRequest)).doesNotThrowAnyException();
+    // the resolved name must reach the batch request, not just avoid the NPE
+    verify(batchRequest)
+        .upsertWithScript(
+            any(),
+            eq(String.valueOf(INNER_INSTANCE_KEY)),
+            any(),
+            eq(FlowNodeInstanceNameFromAdHocActivityHandler.SET_IF_NULL_NAME_SCRIPT),
+            eq(Map.of(FlowNodeInstanceTemplate.FLOW_NODE_NAME, "List users")));
   }
 
   private Record<ProcessInstanceRecordValue> entryElementActivatingRecord() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterMultipleHandlersTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterMultipleHandlersTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
-/** Integration test with actual exporter handlers */
+/** Tests generic multi-handler flush ordering using synthetic {@link TestExportHandler} fakes. */
 public class ExporterBatchWriterMultipleHandlersTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/modelreader/ProcessModelReader.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/modelreader/ProcessModelReader.java
@@ -9,8 +9,11 @@ package io.camunda.zeebe.util.modelreader;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.Query;
+import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
 import io.camunda.zeebe.model.bpmn.instance.BaseElement;
+import io.camunda.zeebe.model.bpmn.instance.BoundaryEvent;
 import io.camunda.zeebe.model.bpmn.instance.CallActivity;
+import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.FlowNode;
 import io.camunda.zeebe.model.bpmn.instance.Process;
@@ -27,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -90,6 +94,40 @@ public final class ProcessModelReader {
         .getChildElementsByType(FlowNode.class)
         .forEach(fn -> extractCallActivities(callActivities, fn));
     return callActivities;
+  }
+
+  /**
+   * Returns the ids of all directly-activatable ad-hoc activities across every ad-hoc subprocess in
+   * the process: the direct child flow nodes that can be activated via the {@code
+   * ActivateAdHocSubProcessActivities} command.
+   *
+   * <p>This mirrors the engine's {@code AdHocSubProcessTransformer}, which selects an activity as
+   * directly-activatable when it has no incoming sequence flow (i.e. it is an entry point, not
+   * reached by flow) and its type is activatable — excluding start, boundary and end events as well
+   * as event subprocesses.
+   */
+  public Set<String> extractAdHocActivityIds() {
+    return extractFlowNodes().stream()
+        .filter(AdHocSubProcess.class::isInstance)
+        .map(AdHocSubProcess.class::cast)
+        .flatMap(ahsp -> ahsp.getChildElementsByType(FlowNode.class).stream())
+        .filter(ProcessModelReader::isDirectlyActivatableAdHocActivity)
+        .map(FlowNode::getId)
+        .collect(Collectors.toSet());
+  }
+
+  private static boolean isDirectlyActivatableAdHocActivity(final FlowNode flowNode) {
+    return flowNode.getIncoming().isEmpty() && isActivatableActivity(flowNode);
+  }
+
+  private static boolean isActivatableActivity(final FlowNode flowNode) {
+    if (flowNode instanceof StartEvent
+        || flowNode instanceof BoundaryEvent
+        || flowNode instanceof EndEvent) {
+      return false;
+    }
+    // event subprocesses are not re-parented into the inner instance and are not activatable
+    return !(flowNode instanceof final SubProcess subProcess && subProcess.triggeredByEvent());
   }
 
   public static boolean hasUserTasks(final Collection<FlowNode> flowNodes) {


### PR DESCRIPTION
## Description

#58307 named an ad-hoc sub-process's synthetic inner instance after its entry element, but was reverted (#58865/#58867) after it caused #58803: a `NullPointerException` in `CamundaExporter` whenever the entry element's activation and the inner instance's own completion land in the same exporter flush batch (near-deterministic for plain/undefined tasks), which stalled export entirely and broke the nightly API tests.

Rather than leave the feature reverted, this PR re-lands it unchanged (the first five commits, same intent as #58307) together with the actual fix. The original guard sat at ES-write time, which missed the real problem: both handlers share one cached entity per id within a batch, and the sibling handler reset the resolved name back to `null` in memory before the upsert was ever built. The fix guards both write paths in `FlowNodeInstanceFromProcessInstanceHandler` — `updateEntity`, which mutates the shared entity, and `flush()`, which builds the upsert fields — behind a single named condition. The name handler's `flush()` deliberately keeps `Map.of`: with the clobber fixed at its source no null name can reach it, and `Map.of` fails loudly rather than silently writing null if that ever stops being true.

Reproduced at two levels before fixing: an IT that forces both records into one batch (production-realistic `bulk.size`/`bulk.delay` rather than a timing trick), and a unit test pinning the clobber directly on `ExporterBatchWriter`.

## Checklist

- [ ] Enable backports when necessary — not backporting; the reverted feature never shipped in a release, so there's nothing to reconcile on `stable/*`.
- [ ] C8 Orchestration Cluster E2E Test Suite — not touched by this PR.

## Related issues

closes #58803
