### PR TITLE
fix: provide variables in process definition statistics filter queries

### DIFF
--- a/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
@@ -16,6 +16,7 @@ import {diagramOverlaysStore} from 'modules/stores/diagramOverlays';
 import {notificationsStore} from 'modules/stores/notifications';
 import {StateOverlay} from 'modules/components/StateOverlay';
 import {batchModificationStore} from 'modules/stores/batchModification';
+import {variableFilterStore} from 'modules/stores/variableFilter';
 import {isMoveModificationTarget} from 'modules/bpmn-js/utils/isMoveModificationTarget';
 import {ModificationBadgeOverlay} from 'modules/components/ModificationBadgeOverlay';
 import {BatchModificationNotification} from './BatchModificationNotification';
@@ -100,7 +101,9 @@ const DiagramPanel: React.FC = observer(() => {
 
   const {data: businessObjects} = useBusinessObjects();
 
-  const baseFilters = useProcessInstanceStatisticsFilters();
+  const baseFilters = useProcessInstanceStatisticsFilters(
+    variableFilterStore.conditions,
+  );
   const processInstanceKeyFilter = getSelectedProcessInstancesFilter();
 
   const {data: processInstanceOverlayData} = useProcessInstancesOverlayData(

--- a/operate/client/src/modules/hooks/useProcessInstanceStatisticsFilters.test.tsx
+++ b/operate/client/src/modules/hooks/useProcessInstanceStatisticsFilters.test.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {renderHook} from '@testing-library/react';
+import {MemoryRouter} from 'react-router-dom';
+import type {VariableCondition} from 'modules/stores/variableFilter';
+import {useProcessInstanceStatisticsFilters} from './useProcessInstanceStatisticsFilters';
+
+const getWrapper = (initialSearchParams?: Record<string, string>) => {
+  const Wrapper = ({children}: {children: React.ReactNode}) => {
+    const searchParams = new URLSearchParams(initialSearchParams);
+
+    return (
+      <MemoryRouter initialEntries={[`/processes?${searchParams.toString()}`]}>
+        {children}
+      </MemoryRouter>
+    );
+  };
+  return Wrapper;
+};
+
+describe('useProcessInstanceStatisticsFilters', () => {
+  it('should return an undefined filter when no base filter is present', () => {
+    const {result} = renderHook(() => useProcessInstanceStatisticsFilters(), {
+      wrapper: getWrapper(),
+    });
+
+    expect(result.current).toEqual({filter: undefined});
+  });
+
+  it('should not add variables when no conditions are provided', () => {
+    const {result} = renderHook(() => useProcessInstanceStatisticsFilters(), {
+      wrapper: getWrapper({active: 'true'}),
+    });
+
+    expect(result.current.filter).toEqual({
+      state: {$eq: 'ACTIVE'},
+      hasIncident: false,
+    });
+  });
+
+  it('should not add variables for an empty conditions array', () => {
+    const {result} = renderHook(() => useProcessInstanceStatisticsFilters([]), {
+      wrapper: getWrapper({active: 'true'}),
+    });
+
+    expect(result.current.filter).not.toHaveProperty('variables');
+  });
+
+  it('should map variable conditions into filter.variables', () => {
+    const conditions: VariableCondition[] = [
+      {name: 'status', operator: 'equals', value: 'active'},
+    ];
+
+    const {result} = renderHook(
+      () => useProcessInstanceStatisticsFilters(conditions),
+      {wrapper: getWrapper({active: 'true'})},
+    );
+
+    expect(result.current.filter?.variables).toEqual([
+      {name: 'status', value: {$eq: '"active"'}},
+    ]);
+  });
+
+  it('should map multiple conditions with mixed operators', () => {
+    const conditions: VariableCondition[] = [
+      {name: 'status', operator: 'equals', value: 'active'},
+      {name: 'region', operator: 'contains', value: 'eu'},
+      {name: 'priority', operator: 'exists', value: ''},
+    ];
+
+    const {result} = renderHook(
+      () => useProcessInstanceStatisticsFilters(conditions),
+      {wrapper: getWrapper({active: 'true'})},
+    );
+
+    expect(result.current.filter?.variables).toEqual([
+      {name: 'status', value: {$eq: '"active"'}},
+      {name: 'region', value: {$like: '*eu*'}},
+      {name: 'priority', value: {$exists: true}},
+    ]);
+  });
+
+  it('should drop unparseable conditions and keep valid ones', () => {
+    const conditions: VariableCondition[] = [
+      {name: 'broken', operator: 'equals', value: '"NEW'},
+      {name: 'status', operator: 'equals', value: 'active'},
+    ];
+
+    const {result} = renderHook(
+      () => useProcessInstanceStatisticsFilters(conditions),
+      {wrapper: getWrapper({active: 'true'})},
+    );
+
+    expect(result.current.filter?.variables).toEqual([
+      {name: 'status', value: {$eq: '"active"'}},
+    ]);
+  });
+
+  it('should strip process-definition fields while keeping variables', () => {
+    const conditions: VariableCondition[] = [
+      {name: 'status', operator: 'equals', value: 'active'},
+    ];
+
+    const {result} = renderHook(
+      () => useProcessInstanceStatisticsFilters(conditions),
+      {
+        wrapper: getWrapper({
+          active: 'true',
+          processDefinitionId: 'my-process',
+          processDefinitionVersion: '2',
+        }),
+      },
+    );
+
+    const filter = result.current.filter;
+    expect(filter).not.toHaveProperty('processDefinitionId');
+    expect(filter).not.toHaveProperty('processDefinitionVersion');
+    expect(filter?.variables).toEqual([
+      {name: 'status', value: {$eq: '"active"'}},
+    ]);
+  });
+});

--- a/operate/client/src/modules/hooks/useProcessInstanceStatisticsFilters.ts
+++ b/operate/client/src/modules/hooks/useProcessInstanceStatisticsFilters.ts
@@ -6,12 +6,15 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {useMemo} from 'react';
 import {useSearchParams} from 'react-router-dom';
 import {
   type GetProcessDefinitionStatisticsRequestBody,
   type QueryProcessInstancesRequestBody,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 import {parseProcessInstancesSearchFilter} from 'modules/utils/filter/processInstancesSearch';
+import type {VariableCondition} from 'modules/stores/variableFilter';
+import {buildVariableEntry} from 'modules/hooks/processInstancesSearch';
 
 type ProcessInstancesSearchFilter = NonNullable<
   QueryProcessInstancesRequestBody['filter']
@@ -35,18 +38,31 @@ const getValidStatisticsFilters = (
   return statisticsFilter;
 };
 
-const useProcessInstanceStatisticsFilters =
-  (): GetProcessDefinitionStatisticsRequestBody => {
-    const [searchParams] = useSearchParams();
+const useProcessInstanceStatisticsFilters = (
+  conditions?: VariableCondition[],
+): GetProcessDefinitionStatisticsRequestBody => {
+  const [searchParams] = useSearchParams();
+
+  return useMemo(() => {
     const fullFilter = parseProcessInstancesSearchFilter(searchParams);
 
     if (!fullFilter) {
       return {filter: undefined};
     }
 
+    if (conditions && conditions.length > 0) {
+      const entries = conditions
+        .map(buildVariableEntry)
+        .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+      if (entries.length > 0) {
+        fullFilter.variables = entries;
+      }
+    }
+
     return {
       filter: getValidStatisticsFilters(fullFilter),
     };
-  };
+  }, [searchParams, conditions]);
+};
 
 export {useProcessInstanceStatisticsFilters, getValidStatisticsFilters};


### PR DESCRIPTION
## Description

This PR extends the `useProcessInstanceStatisticsFilters` hook to include variables in the constructed filter.

## Checklist

<!--- Please delete options that are not relevant. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57384
