### PR TITLE
fix: release RdbmsExporter resources when open fails

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
@@ -72,8 +72,11 @@ import io.camunda.db.rdbms.write.service.WaitStateWriter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class RdbmsWriters {
+public class RdbmsWriters implements AutoCloseable {
+  private static final Logger LOG = LoggerFactory.getLogger(RdbmsWriters.class);
 
   private final RdbmsPurger rdbmsPurger;
   private final ExecutionQueue executionQueue;
@@ -378,5 +381,17 @@ public class RdbmsWriters {
    */
   public int getErrorMessageSize() {
     return vendorDatabaseProperties.errorMessageSize();
+  }
+
+  @Override
+  public void close() throws Exception {
+    try {
+      flush(true);
+    } catch (final Exception e) {
+      LOG.warn("Failed to execute final flush on close");
+      throw e;
+    } finally {
+      getExecutionQueue().reset();
+    }
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/RdbmsWritersTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/RdbmsWritersTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+class RdbmsWritersTest {
+
+  private ExecutionQueue executionQueue;
+  private RdbmsWriters rdbmsWriters;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    // The RdbmsWriters constructor wires ~30 writers and mappers; close() only interacts with the
+    // execution queue, so we drive the real close() on a partial mock and stub the two
+    // collaborators
+    // it touches (flush and the execution queue) instead of building the full object graph.
+    executionQueue = mock(ExecutionQueue.class);
+    rdbmsWriters = mock(RdbmsWriters.class);
+    when(rdbmsWriters.getExecutionQueue()).thenReturn(executionQueue);
+    doCallRealMethod().when(rdbmsWriters).close();
+  }
+
+  @Test
+  void shouldFlushThenResetOnClose() throws Exception {
+    // when
+    rdbmsWriters.close();
+
+    // then
+    final InOrder inOrder = inOrder(rdbmsWriters, executionQueue);
+    inOrder.verify(rdbmsWriters).flush(true);
+    inOrder.verify(executionQueue).reset();
+  }
+
+  @Test
+  void shouldResetEvenWhenFlushThrows() {
+    // given
+    doThrow(new RuntimeException("flush failed")).when(rdbmsWriters).flush(true);
+
+    // when
+    assertThatThrownBy(() -> rdbmsWriters.close())
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("flush failed");
+
+    // then - the execution queue is reset regardless of the flush failure, so a retried open starts
+    // from a clean state
+    verify(executionQueue).reset();
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/pom.xml
+++ b/zeebe/exporters/rdbms-exporter/pom.xml
@@ -59,6 +59,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -104,6 +104,18 @@ public final class RdbmsExporter {
   }
 
   public void open(final Controller controller) {
+    try {
+      doOpen(controller);
+    } catch (final RuntimeException e) {
+      // open() may fail after allocating resources (replication controller, scheduled flush task,
+      // background task manager). Release them via close() before propagating so a retried open
+      // starts from a clean state instead of leaking the partial allocation.
+      close();
+      throw e;
+    }
+  }
+
+  private void doOpen(final Controller controller) {
     this.controller = controller;
     rdbmsWriters.getExecutionQueue().reset();
     log(

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import org.agrona.CloseHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -206,27 +207,15 @@ public final class RdbmsExporter {
 
   public void close() {
     try {
-      if (currentFlushTask != null) {
-        currentFlushTask.cancel();
-      }
-      if (backgroundTaskManager != null) {
-        backgroundTaskManager.close();
-        backgroundTaskManager = null;
-      }
-
-      try {
-        rdbmsWriters.flush(true);
-      } catch (final Exception e) {
-        log(WARN, "Failed to execute final flush on close for partition {}", partitionId);
-        throw e;
-      }
-
-      rdbmsWriters.getExecutionQueue().reset();
-
-      if (replicationController != null) {
-        replicationController.close();
-        replicationController = null;
-      }
+      CloseHelper.closeAll(
+          () -> {
+            if (currentFlushTask != null) {
+              currentFlushTask.cancel();
+            }
+          },
+          backgroundTaskManager,
+          rdbmsWriters,
+          replicationController);
     } catch (final Exception e) {
       log(WARN, "Failed to flush records before closing exporter.", e);
     }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
@@ -572,7 +572,7 @@ class RdbmsExporterTest {
     // flushed. The flush task and background task manager are allocated only after the failing
     // step, so there is nothing to release for those here.
     verify(replicationController).close();
-    verify(rdbmsWriters).flush(true);
+    verify(rdbmsWriters).close();
     // reset() runs twice, and that is expected: once at the start of open() (so re-registering
     // listeners/hooks on a reopen never duplicates them) and once again inside close() as part of
     // teardown. reset() is idempotent, so running it on both the open and close paths is harmless;
@@ -897,6 +897,23 @@ class RdbmsExporterTest {
         .when(rdbmsWriters)
         .flush(true);
     doAnswer((invocation) -> executionQueue.checkQueueForFlush()).when(rdbmsWriters).flush(false);
+
+    // mirror the real RdbmsWriters.close(): final flush followed by an execution-queue reset
+    try {
+      doAnswer(
+              (invocation) -> {
+                try {
+                  executionQueue.flush();
+                } finally {
+                  executionQueue.reset();
+                }
+                return null;
+              })
+          .when(rdbmsWriters)
+          .close();
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
 
     final var builder =
         new RdbmsExporter.Builder()

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
@@ -556,6 +556,31 @@ class RdbmsExporterTest {
   }
 
   @Test
+  void shouldReleaseAllocatedResourcesWhenOpenFails() throws Exception {
+    // given - open() allocates the replication controller (which schedules a background poll task)
+    // and only afterwards schedules the flush task; make that scheduling fail so open() throws
+    // after the controller and the execution-queue listeners have already been allocated
+    createExporter(b -> b, true, false, null);
+    when(controller.scheduleCancellableTask(any(), any()))
+        .thenThrow(new RuntimeException("scheduling failed"));
+
+    // when
+    assertThatThrownBy(() -> exporter.open(controller)).isInstanceOf(RuntimeException.class);
+
+    // then - close() must run its full cleanup so a retried open starts from a clean state: the
+    // replication controller (and its background poll task) is released and the pending writes are
+    // flushed. The flush task and background task manager are allocated only after the failing
+    // step, so there is nothing to release for those here.
+    verify(replicationController).close();
+    verify(rdbmsWriters).flush(true);
+    // reset() runs twice, and that is expected: once at the start of open() (so re-registering
+    // listeners/hooks on a reopen never duplicates them) and once again inside close() as part of
+    // teardown. reset() is idempotent, so running it on both the open and close paths is harmless;
+    // we pin the count only to document the two distinct call sites.
+    verify(executionQueue, times(2)).reset();
+  }
+
+  @Test
   void shouldNotRequestReplayWhenBrokerAndRdbmsPositionAreEqual() {
     // given - broker position equals RDBMS position
     final long position = 1000L;


### PR DESCRIPTION
## Description
RdbmsExporter.open() allocates resources incrementally: the replication controller (which schedules a background poll task), a scheduled flush task, and a background task manager. Several code paths after those allocations can throw - notably the replay-unavailable path, reachable once createReplicationController was moved ahead of it.

The exporter SPI states close() is called exactly once at the end of the lifecycle, so ExporterContainer does not (and must not) close an exporter whose open() threw - doing so would break third-party exporters. That leaves each exporter responsible for releasing its own partial state on a failed open. RdbmsExporter did not, so a failed open leaked the replication controller's scheduled task; the surrounding retry loop then created a fresh controller on every attempt, stacking leaked tasks.

Wrap open() so any failure runs close() before propagating. close() is already null-guarded and idempotent, and open() resets the execution queue up front, so a retried open starts from a clean state.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates #58894
