### PR TITLE
test: cover role-guard and multi-org cases in the CCSaaS org validator

### DIFF
--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeCloudOrganizationValidatorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeCloudOrganizationValidatorTest.java
@@ -57,6 +57,51 @@ class OptimizeCloudOrganizationValidatorTest {
     assertThat(validator.validate(token).hasErrors()).isTrue();
   }
 
+  @Test
+  void shouldRejectWhenConfiguredOrgCarriesNoRolesEntry() {
+    // Membership alone does not grant access: Optimize requires an allowed role.
+    final Jwt token = jwtWithOrgs(List.of(Map.of("id", "org-1")));
+
+    assertThat(validator.validate(token).hasErrors()).isTrue();
+  }
+
+  @Test
+  void shouldRejectWhenConfiguredOrgRolesIsNotACollection() {
+    final Jwt token = jwtWithOrgs(List.of(Map.of("id", "org-1", "roles", "admin")));
+
+    assertThat(validator.validate(token).hasErrors()).isTrue();
+  }
+
+  @Test
+  void shouldRejectWhenConfiguredOrgRolesIsEmpty() {
+    final Jwt token = jwtWithOrgs(List.of(Map.of("id", "org-1", "roles", List.of())));
+
+    assertThat(validator.validate(token).hasErrors()).isTrue();
+  }
+
+  @Test
+  void shouldAcceptWhenOnlyOneOfSeveralOrgsIsTheConfiguredOne() {
+    final Jwt token =
+        jwtWithOrgs(
+            List.of(
+                Map.of("id", "org-2", "roles", List.of("viewer")),
+                Map.of("id", "org-1", "roles", List.of("owner"))));
+
+    assertThat(validator.validate(token).hasErrors()).isFalse();
+  }
+
+  @Test
+  void shouldRejectWhenAnotherOrgGrantsAnAllowedRoleButTheConfiguredOneDoesNot() {
+    // Roles must not leak across organizations: only the configured org's entry counts.
+    final Jwt token =
+        jwtWithOrgs(
+            List.of(
+                Map.of("id", "org-1", "roles", List.of("viewer")),
+                Map.of("id", "org-2", "roles", List.of("admin"))));
+
+    assertThat(validator.validate(token).hasErrors()).isTrue();
+  }
+
   private static Jwt jwtWithOrgs(final List<Map<String, Object>> orgs) {
     return baseJwt().claim(OptimizeCloudOrganizationValidator.ORGANIZATIONS_CLAIM, orgs).build();
   }


### PR DESCRIPTION
## Description

Follow-up to #58638 for review feedback that landed after it merged: https://github.com/camunda/camunda/pull/58638#discussion_r3666153197

`OptimizeCloudOrganizationValidator.grantsAllowedRole` guards on the org's `roles` entry actually being a `Collection`, and filters entries on the configured organization id. Neither guard was pinned by a test, so both could have regressed silently. Test-only change.

Added cases:

- Configured org present with no `roles` entry, with `roles` not a collection, and with an empty `roles` list. All rejected, since membership alone does not grant access.
- Multi-org claim where only one entry is the configured org. Accepted.
- Multi-org claim where another org grants an allowed role but the configured one does not. Rejected, so roles cannot leak across organizations.

## Notes for reviewers

Both guards are now mutation-checked. Replacing the role check with `anyMatch(org -> true)` fails 5 cases; dropping the `organizationId.equals(org.get("id"))` filter fails 2, including the cross-org leak case.

`OptimizeCloudOrganizationValidatorTest` goes from 5 to 10 cases. Full `optimize/backend` suite green.

## Related issues

Origin PR: #58638
Origin task: #58476
Parent epic: #58403
Related: camunda/camunda-security-library#576 will promote this validator into CSL, so these cases move with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
