### PR TITLE
ci: publish flattened POMs for snapshot deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2611,7 +2611,11 @@ jobs:
       # compile and generate-sources to ensure that the Javadoc can be properly generated; compile is
       # necessary when using annotation preprocessors for code generation, as otherwise the symbols are
       # not resolve-able by the Javadoc generator
-      - run: ./mvnw -B -T1C -D skipTests -D skipChecks -PskipFrontendBuild compile generate-sources source:jar javadoc:jar deploy
+      # -Dflatten.updatePomFile=true swaps in the flattened POM for the deployed snapshot artifacts,
+      # matching the central-sonatype-publish release path. Without it, snapshots ship the raw reactor
+      # POM whose parent chain (zeebe-parent) must be resolved by external consumers to build the
+      # effective model; the flattened POM is self-contained, exactly as published releases are.
+      - run: ./mvnw -B -T1C -D skipTests -D skipChecks -PskipFrontendBuild -Dflatten.updatePomFile=true compile generate-sources source:jar javadoc:jar deploy
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Description

The `Deploy snapshot artifacts` job published the **raw reactor `pom.xml`**: `flatten.updatePomFile` defaults to `false` and only the `central-sonatype-publish` (release) profile flips it to `true`. The raw POM keeps its `<parent>zeebe-parent</parent>`, so an external consumer building the effective model must resolve `zeebe-parent` and its import-scoped BOMs instead of reading a self-contained descriptor.

Setting `-Dflatten.updatePomFile=true` on the snapshot deploy publishes the flattened, self-contained POM (no parent, no `dependencyManagement` imports) — exactly as releases already do — so snapshot and release resolution behave consistently for downstream consumers (e.g. `zeebe-process-test`).

Ports the same fix already merged on the stable branches:
- stable/8.7: #58660
- stable/8.8: #58659

There it also resolved a hard failure, since those branches' `zeebe-parent` imports HeroDevs NES Spring BOMs that only resolve from Camunda's internal Nexus. On `main`/`8.9` `zeebe-parent` uses OSS Spring, so this is a consistency/self-containment improvement rather than a break fix.