### PR TITLE
feat: resolve and list gateway secrets from the configured store

### DIFF
--- a/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
@@ -22,6 +22,8 @@ import io.camunda.cluster.SecondaryStorageReadiness;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.secretstore.SecretResolutionResult;
+import io.camunda.secretstore.SecretStore;
 import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.api.model.authz.AuthorizationScope;
@@ -46,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.mock.env.MockEnvironment;
@@ -108,7 +111,9 @@ class CamundaServicesConfigurationTest {
         buildRegistry(
             twoTenants(),
             new AuthorizationCheckerProvider(
-                sharedAuthorizationChecker, Map.of(TENANT_A, checkerA, TENANT_B, checkerB)));
+                sharedAuthorizationChecker, Map.of(TENANT_A, checkerA, TENANT_B, checkerB)),
+            new SecretStoreRegistries(
+                Map.of(TENANT_A, registryHolding("token"), TENANT_B, registryHolding("token"))));
 
     // when / then: tenant A's checker grants REVEAL -- the reference resolves, using only tenant
     // A's checker.
@@ -354,6 +359,34 @@ class CamundaServicesConfigurationTest {
     tenants.put(TENANT_A, tenantWithAuthorizations(true));
     tenants.put(TENANT_B, tenantWithAuthorizations(true));
     return tenants;
+  }
+
+  /** A store registry whose single store holds the given secret names, each with a dummy value. */
+  private static SecretStoreRegistry registryHolding(final String... names) {
+    final var held = Set.of(names);
+    final var store =
+        new SecretStore() {
+          @Override
+          public Map<String, SecretResolutionResult> resolve(final Set<String> requested) {
+            return requested.stream()
+                .collect(
+                    Collectors.toMap(
+                        name -> name,
+                        name ->
+                            held.contains(name)
+                                ? new SecretResolutionResult.Resolved("value-of-" + name)
+                                : new SecretResolutionResult.Failed(
+                                    io.camunda.secretstore.SecretErrorCode.NOT_FOUND,
+                                    "unknown",
+                                    null)));
+          }
+
+          @Override
+          public List<String> list() {
+            return List.copyOf(held);
+          }
+        };
+    return new SecretStoreRegistry(Map.of("main", store));
   }
 
   private ServiceRegistry buildRegistry(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -705,6 +705,7 @@ public final class ResponseMapper {
       case NOT_FOUND -> SecretErrorCode.NOT_FOUND;
       case ACCESS_DENIED -> SecretErrorCode.ACCESS_DENIED;
       case INVALID_REFERENCE -> SecretErrorCode.INVALID_REFERENCE;
+      case UNREADABLE -> SecretErrorCode.UNREADABLE;
     };
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/SecretAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/SecretAuthorizationIT.java
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
-import io.camunda.configuration.Secrets.FileStore;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
@@ -24,8 +23,6 @@ import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
@@ -35,13 +32,10 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Base64;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.StreamSupport;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -64,20 +58,23 @@ class SecretAuthorizationIT {
   private static final String TOKEN_VALUE = "token-file-value";
   private static final String OTHER_VALUE = "a-file-value";
 
-  // Written before the broker starts, since the broker's store is configured to read this
-  // directory. Declared above BROKER so its initializer runs first.
-  private static final Path SECRETS_DIRECTORY = createSecretsDirectory();
-
+  /**
+   * The broker reads a real file-based store. {@code tls.crt} is deliberately among the secrets:
+   * the file store accepts that name but it cannot form a {@code camunda.secrets.<name>} reference,
+   * so the listing has to leave it out.
+   */
   @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker()
           .withBasicAuth()
           .withAuthorizationsEnabled()
-          .withUnifiedConfig(
-              config -> {
-                final var store = new FileStore();
-                store.setPath(SECRETS_DIRECTORY.toString());
-                config.getSecrets().getStores().getFile().put("it", store);
+          .withFileBasedSecretStore(
+              directory -> {
+                Files.writeString(directory.resolve("token"), TOKEN_VALUE, StandardCharsets.UTF_8);
+                Files.writeString(directory.resolve("a"), OTHER_VALUE, StandardCharsets.UTF_8);
+                Files.writeString(directory.resolve("b"), "b-file-value", StandardCharsets.UTF_8);
+                Files.writeString(
+                    directory.resolve("tls.crt"), "certificate", StandardCharsets.UTF_8);
               });
 
   private static final ObjectMapper JSON =
@@ -141,39 +138,6 @@ class SecretAuthorizationIT {
           "password",
           // Granted READ on all references via the "*" wildcard.
           List.of(new Permissions(SECRET, READ, List.of("*"))));
-
-  /**
-   * Creates the store's directory and writes one file per secret. {@code tls.crt} is deliberately
-   * among them: the file store accepts that name but it cannot form a {@code
-   * camunda.secrets.<name>} reference, so the listing has to leave it out.
-   */
-  private static Path createSecretsDirectory() {
-    try {
-      final var directory = Files.createTempDirectory("secret-authorization-it-");
-      Files.writeString(directory.resolve("token"), TOKEN_VALUE, StandardCharsets.UTF_8);
-      Files.writeString(directory.resolve("a"), OTHER_VALUE, StandardCharsets.UTF_8);
-      Files.writeString(directory.resolve("b"), "b-file-value", StandardCharsets.UTF_8);
-      Files.writeString(directory.resolve("tls.crt"), "certificate", StandardCharsets.UTF_8);
-      return directory;
-    } catch (final IOException e) {
-      throw new UncheckedIOException("Failed to create the secrets directory", e);
-    }
-  }
-
-  @AfterAll
-  static void deleteSecretsDirectory() throws IOException {
-    try (final var entries = Files.walk(SECRETS_DIRECTORY)) {
-      entries.sorted(Comparator.reverseOrder()).forEach(SecretAuthorizationIT::delete);
-    }
-  }
-
-  private static void delete(final Path path) {
-    try {
-      Files.deleteIfExists(path);
-    } catch (final IOException e) {
-      throw new UncheckedIOException("Failed to delete " + path, e);
-    }
-  }
 
   @Test
   @DisabledIfSystemProperty(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/SecretAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/SecretAuthorizationIT.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
+import io.camunda.configuration.Secrets.FileStore;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
@@ -23,6 +24,8 @@ import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
@@ -31,10 +34,14 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Base64;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.StreamSupport;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -45,25 +52,41 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
  * exercises the real per-reference {@code SECRET:REVEAL} / {@code SECRET:READ} checks so the
  * security guarantee is proven, not assumed.
  *
- * <p>The secret backend is mocked in Phase 1 (#56567, #56568): references in the service's mock
- * allow-list ({@code camunda.secrets.token} etc.) resolve to a placeholder value or are listed;
- * authorization is real.
+ * <p>The broker runs with a real file-based secret store (#58497), so a resolved reference carries
+ * the value that is actually on disk and the listing is the store's own enumeration. The gateway
+ * path answers without a broker round-trip, so no resolved value can reach state or exported
+ * records; the response body is the only place a value appears, which the tests below pin down.
  */
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 class SecretAuthorizationIT {
 
+  private static final String TOKEN_VALUE = "token-file-value";
+  private static final String OTHER_VALUE = "a-file-value";
+
+  // Written before the broker starts, since the broker's store is configured to read this
+  // directory. Declared above BROKER so its initializer runs first.
+  private static final Path SECRETS_DIRECTORY = createSecretsDirectory();
+
   @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
-      new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withAuthorizationsEnabled()
+          .withUnifiedConfig(
+              config -> {
+                final var store = new FileStore();
+                store.setPath(SECRETS_DIRECTORY.toString());
+                config.getSecrets().getStores().getFile().put("it", store);
+              });
 
   private static final ObjectMapper JSON =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-  // Resolvable by the mock backend (see SecretServices#MOCK_RESOLVABLE_REFERENCES).
+  // Held by the store (one file per secret, the file name being the bare secret name).
   private static final String GRANTED_REFERENCE = "camunda.secrets.token";
   private static final String OTHER_REFERENCE = "camunda.secrets.a";
-  // Not in SecretServices#MOCK_RESOLVABLE_REFERENCES, so a wildcard-authorized lookup misses.
+  // No file of that name exists, so a wildcard-authorized lookup misses.
   private static final String UNKNOWN_REFERENCE = "camunda.secrets.doesnotexist";
 
   // Under a physical tenant, secret authorization is resolved against root storage, so grants
@@ -119,6 +142,39 @@ class SecretAuthorizationIT {
           // Granted READ on all references via the "*" wildcard.
           List.of(new Permissions(SECRET, READ, List.of("*"))));
 
+  /**
+   * Creates the store's directory and writes one file per secret. {@code tls.crt} is deliberately
+   * among them: the file store accepts that name but it cannot form a {@code
+   * camunda.secrets.<name>} reference, so the listing has to leave it out.
+   */
+  private static Path createSecretsDirectory() {
+    try {
+      final var directory = Files.createTempDirectory("secret-authorization-it-");
+      Files.writeString(directory.resolve("token"), TOKEN_VALUE, StandardCharsets.UTF_8);
+      Files.writeString(directory.resolve("a"), OTHER_VALUE, StandardCharsets.UTF_8);
+      Files.writeString(directory.resolve("b"), "b-file-value", StandardCharsets.UTF_8);
+      Files.writeString(directory.resolve("tls.crt"), "certificate", StandardCharsets.UTF_8);
+      return directory;
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to create the secrets directory", e);
+    }
+  }
+
+  @AfterAll
+  static void deleteSecretsDirectory() throws IOException {
+    try (final var entries = Files.walk(SECRETS_DIRECTORY)) {
+      entries.sorted(Comparator.reverseOrder()).forEach(SecretAuthorizationIT::delete);
+    }
+  }
+
+  private static void delete(final Path path) {
+    try {
+      Files.deleteIfExists(path);
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to delete " + path, e);
+    }
+  }
+
   @Test
   @DisabledIfSystemProperty(
       named = PHYSICAL_TENANT_PROPERTY,
@@ -129,10 +185,11 @@ class SecretAuthorizationIT {
     // when a user with SECRET:REVEAL on the reference resolves it
     final var response = resolve(client, REVEAL_USER, List.of(GRANTED_REFERENCE));
 
-    // then it succeeds with the (mocked) value and no errors
+    // then it succeeds with the value the store holds on disk, and no errors
     assertThat(response.statusCode()).isEqualTo(200);
     final var body = read(response.body());
     assertThat(references(body.get("resolved"))).containsExactly(GRANTED_REFERENCE);
+    assertThat(body.get("resolved").get(0).get("value").asText()).isEqualTo(TOKEN_VALUE);
     assertThat(body.get("errors")).isEmpty();
   }
 
@@ -180,10 +237,11 @@ class SecretAuthorizationIT {
     // when a user granted SECRET:REVEAL:* resolves a reference it was not explicitly granted
     final var response = resolve(client, WILDCARD_USER, List.of(OTHER_REFERENCE));
 
-    // then the wildcard grant authorizes it and it resolves with no errors
+    // then the wildcard grant authorizes it and it resolves to that secret's own stored value
     assertThat(response.statusCode()).isEqualTo(200);
     final var body = read(response.body());
     assertThat(references(body.get("resolved"))).containsExactly(OTHER_REFERENCE);
+    assertThat(body.get("resolved").get(0).get("value").asText()).isEqualTo(OTHER_VALUE);
     assertThat(body.get("errors")).isEmpty();
   }
 
@@ -194,11 +252,11 @@ class SecretAuthorizationIT {
       disabledReason = PHYSICAL_TENANT_DISABLED_REASON)
   void shouldReportNotFoundForAuthorizedUnknownReference(
       @Authenticated(WILDCARD_USER) final CamundaClient client) throws Exception {
-    // when a wildcard-authorized user resolves a reference the mock backend does not know
+    // when a wildcard-authorized user resolves a reference the store does not hold
     final var response = resolve(client, WILDCARD_USER, List.of(UNKNOWN_REFERENCE));
 
     // then it is NOT_FOUND rather than ACCESS_DENIED, exercising the third error code through the
-    // full stack (authorization granted, mock lookup misses)
+    // full stack (authorization granted, store lookup misses)
     assertThat(response.statusCode()).isEqualTo(200);
     final var body = read(response.body());
     assertThat(body.get("resolved")).isEmpty();
@@ -251,7 +309,9 @@ class SecretAuthorizationIT {
     // when a user granted SECRET:READ:* lists references
     final var response = list(client, WILDCARD_READ_USER);
 
-    // then every reference the mock backend knows is returned, names only
+    // then every secret the store holds is returned as a reference, names only. The store's
+    // tls.crt is left out: it cannot form a valid reference, so it would only offer the caller
+    // something resolve() and any BPMN expression reject.
     assertThat(response.statusCode()).isEqualTo(200);
     final var body = read(response.body());
     assertThat(referenceNames(body.get("references")))

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/CachingSecretStore.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/CachingSecretStore.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A {@link SecretStore} that serves what its {@link SecretCache} holds and caches what the store
+ * answers, so a caller resolves secrets through a single call instead of driving store and cache
+ * itself.
+ *
+ * <p>Only a resolved value is cached: a failure has to stay retryable, or a secret that was briefly
+ * unreadable would stay unresolvable until the process restarts. {@link #list()} goes straight to
+ * the store, since a cache holds the values read so far rather than the store's set of secrets.
+ *
+ * <p>Does not close the store it wraps: whoever configured that store owns its lifecycle.
+ */
+@NullMarked
+public final class CachingSecretStore implements SecretStore {
+
+  private final SecretStore store;
+  private final SecretCache cache;
+
+  public CachingSecretStore(final SecretStore store, final SecretCache cache) {
+    this.store = store;
+    this.cache = cache;
+  }
+
+  /**
+   * Resolves the given names, serving the cached ones and asking the store only for the rest.
+   *
+   * <p>A name the store answers without a result for is left out of the returned map, exactly as
+   * the store left it out, so a caller can still tell an unanswered name apart from a failed one.
+   */
+  @Override
+  public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
+    final Map<String, SecretResolutionResult> results = new LinkedHashMap<>();
+    final Set<String> misses = new LinkedHashSet<>();
+    for (final var name : names) {
+      final var cached = cache.get(name).orElse(null);
+      if (cached == null) {
+        misses.add(name);
+      } else {
+        results.put(name, new SecretResolutionResult.Resolved(cached));
+      }
+    }
+    if (misses.isEmpty()) {
+      return results;
+    }
+
+    store
+        .resolve(misses)
+        .forEach(
+            (name, result) -> {
+              if (result instanceof final SecretResolutionResult.Resolved resolved) {
+                cache.put(name, resolved.value());
+              }
+              results.put(name, result);
+            });
+    return results;
+  }
+
+  @Override
+  public List<String> list() {
+    return store.list();
+  }
+}

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretErrorCode.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretErrorCode.java
@@ -10,9 +10,10 @@ package io.camunda.secretstore;
 /**
  * Typed error categories for {@link SecretResolutionResult.Failed}.
  *
- * <p>New codes may be added in future minor versions as additional store implementations are
- * introduced. Callers performing exhaustive switches should include a {@code default} branch to
- * handle unrecognized codes gracefully.
+ * <p>New codes may be added as additional store implementations are introduced. Callers switch over
+ * them exhaustively and without a {@code default} branch: every store and every caller ships from
+ * this repository in the same release, so a code added here has to be mapped at every caller in the
+ * same change, and the compiler is what enforces that.
  */
 public enum SecretErrorCode {
   NOT_FOUND,

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStoreRegistry.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStoreRegistry.java
@@ -7,12 +7,17 @@
  */
 package io.camunda.secretstore;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Provides the configured {@link SecretStore}s for the current physical tenant, keyed by store ID.
+ * Provides the configured {@link SecretStore}s for the current physical tenant, keyed by store ID,
+ * along with the {@link SecretCache} in front of each of them.
+ *
+ * <p>Every configured store has a cache: a caller may look one up by store ID without handling a
+ * missing entry.
  */
 @NullMarked
 public final class SecretStoreRegistry {
@@ -21,21 +26,18 @@ public final class SecretStoreRegistry {
   private final Map<String, SecretCache> caches;
 
   public SecretStoreRegistry(final Map<String, SecretStore> stores) {
-    this(
-        stores,
-        stores.keySet().stream()
-            .collect(
-                Collectors.toUnmodifiableMap(name -> name, name -> new InMemorySecretCache())));
+    this(stores, Map.of());
   }
 
   /**
-   * Creates a registry with the given caches instead of one in-memory cache per store. Primarily
-   * for tests that need custom cache behavior.
+   * Creates a registry with the given caches instead of the default in-memory one. A store the
+   * caches do not cover still gets an in-memory cache, so the one-cache-per-store invariant holds
+   * whichever constructor is used. Primarily for tests that need custom cache behavior.
    */
   public SecretStoreRegistry(
       final Map<String, SecretStore> stores, final Map<String, SecretCache> caches) {
     this.stores = stores;
-    this.caches = caches;
+    this.caches = withACachePerStore(stores, caches);
   }
 
   /** Returns all configured secret stores, keyed by store ID. */
@@ -46,5 +48,15 @@ public final class SecretStoreRegistry {
   /** Returns one cache per configured store, keyed by store ID. */
   public Map<String, SecretCache> getCaches() {
     return caches;
+  }
+
+  private static Map<String, SecretCache> withACachePerStore(
+      final Map<String, SecretStore> stores, final Map<String, SecretCache> caches) {
+    final Map<String, SecretCache> perStore = new LinkedHashMap<>(caches);
+    stores
+        .keySet()
+        .forEach(
+            storeId -> perStore.computeIfAbsent(storeId, ignored -> new InMemorySecretCache()));
+    return Collections.unmodifiableMap(perStore);
   }
 }

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStoreRegistry.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStoreRegistry.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.secretstore;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -24,6 +26,7 @@ public final class SecretStoreRegistry {
 
   private final Map<String, SecretStore> stores;
   private final Map<String, SecretCache> caches;
+  private final Map<String, SecretStore> cachingStores;
 
   public SecretStoreRegistry(final Map<String, SecretStore> stores) {
     this(stores, Map.of());
@@ -38,6 +41,7 @@ public final class SecretStoreRegistry {
       final Map<String, SecretStore> stores, final Map<String, SecretCache> caches) {
     this.stores = stores;
     this.caches = withACachePerStore(stores, caches);
+    cachingStores = cachingStores(stores, this.caches);
   }
 
   /** Returns all configured secret stores, keyed by store ID. */
@@ -48,6 +52,28 @@ public final class SecretStoreRegistry {
   /** Returns one cache per configured store, keyed by store ID. */
   public Map<String, SecretCache> getCaches() {
     return caches;
+  }
+
+  /**
+   * Returns each configured store wrapped so that resolving goes through the store's cache, keyed
+   * by store ID. This is what a caller that only wants to resolve secrets uses, rather than pairing
+   * a store with its cache itself; {@link #getStores()} and {@link #getCaches()} stay for the
+   * callers that drive the two apart, such as the engine writing a value into the cache without
+   * revealing it.
+   */
+  public Map<String, SecretStore> getCachingStores() {
+    return cachingStores;
+  }
+
+  private static Map<String, SecretStore> cachingStores(
+      final Map<String, SecretStore> stores, final Map<String, SecretCache> caches) {
+    final Map<String, SecretStore> caching = new LinkedHashMap<>();
+    stores.forEach(
+        (storeId, store) ->
+            // non-null by the one-cache-per-store invariant withACachePerStore establishes
+            caching.put(
+                storeId, new CachingSecretStore(store, requireNonNull(caches.get(storeId)))));
+    return Collections.unmodifiableMap(caching);
   }
 
   private static Map<String, SecretCache> withACachePerStore(

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CachingSecretStoreTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CachingSecretStoreTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.secretstore.SecretResolutionResult.Failed;
+import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class CachingSecretStoreTest {
+
+  private final RecordingSecretStore store = new RecordingSecretStore();
+  private final InMemorySecretCache cache = new InMemorySecretCache();
+  private final CachingSecretStore cachingStore = new CachingSecretStore(store, cache);
+
+  @Test
+  void shouldServeACachedNameWithoutAskingTheStore() {
+    // given
+    cache.put("token", "cached-value");
+
+    // when
+    final var results = cachingStore.resolve(Set.of("token"));
+
+    // then
+    assertThat(results.get("token")).isEqualTo(new Resolved("cached-value"));
+    assertThat(store.resolveCalls).isEmpty();
+  }
+
+  @Test
+  void shouldOnlyAskTheStoreForUncachedNames() {
+    // given one of two names is cached
+    store.holds("b", "b-value");
+    cache.put("a", "cached-a-value");
+
+    // when
+    final var results = cachingStore.resolve(Set.of("a", "b"));
+
+    // then only the miss reaches the store, and both names are still answered
+    assertThat(store.resolveCalls).containsExactly(Set.of("b"));
+    assertThat(results)
+        .containsEntry("a", new Resolved("cached-a-value"))
+        .containsEntry("b", new Resolved("b-value"));
+  }
+
+  @Test
+  void shouldCacheAValueReadFromTheStore() {
+    // given
+    store.holds("token", "token-value");
+
+    // when the same name is resolved twice
+    cachingStore.resolve(Set.of("token"));
+    final var second = cachingStore.resolve(Set.of("token"));
+
+    // then the store was read once and the cached value answers the second call
+    assertThat(store.resolveCalls).containsExactly(Set.of("token"));
+    assertThat(second.get("token")).isEqualTo(new Resolved("token-value"));
+    assertThat(cache.get("token")).contains("token-value");
+  }
+
+  @Test
+  void shouldNotCacheAFailure() {
+    // given a name the store cannot read
+    store.fails("token", SecretErrorCode.UNREADABLE);
+
+    // when the same name is resolved twice
+    cachingStore.resolve(Set.of("token"));
+    cachingStore.resolve(Set.of("token"));
+
+    // then the store is asked again: caching the failure would keep the secret unresolvable until
+    // the process restarts
+    assertThat(store.resolveCalls).containsExactly(Set.of("token"), Set.of("token"));
+    assertThat(cache.get("token")).isEmpty();
+  }
+
+  @Test
+  void shouldLeaveOutANameTheStoreDidNotAnswerFor() {
+    // given a store that answers without a result for the name it was asked for
+    store.omitsResults();
+
+    // when
+    final var results = cachingStore.resolve(Set.of("token"));
+
+    // then the name is absent rather than made up into a failure, so a caller can still tell an
+    // unanswered name apart from a failed one
+    assertThat(results).doesNotContainKey("token");
+  }
+
+  @Test
+  void shouldListFromTheStoreRatherThanTheCache() {
+    // given a cached value the store no longer holds
+    store.holds("token", "token-value");
+    cache.put("ghost", "cached-value");
+
+    // when
+    final var names = cachingStore.list();
+
+    // then the listing is the store's own: a cache holds the values read so far, not the store's
+    // set of secrets
+    assertThat(names).containsExactly("token");
+  }
+
+  private static final class RecordingSecretStore implements SecretStore {
+
+    private final Map<String, String> values = new LinkedHashMap<>();
+    private final Map<String, SecretErrorCode> failures = new LinkedHashMap<>();
+    private final List<Set<String>> resolveCalls = new ArrayList<>();
+    private boolean omitResults;
+
+    @Override
+    public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
+      resolveCalls.add(Set.copyOf(names));
+      final Map<String, SecretResolutionResult> results = new LinkedHashMap<>();
+      if (omitResults) {
+        return results;
+      }
+      names.forEach(name -> results.put(name, resultFor(name)));
+      return results;
+    }
+
+    @Override
+    public List<String> list() {
+      return List.copyOf(values.keySet());
+    }
+
+    void holds(final String name, final String value) {
+      values.put(name, value);
+    }
+
+    void fails(final String name, final SecretErrorCode code) {
+      failures.put(name, code);
+    }
+
+    void omitsResults() {
+      omitResults = true;
+    }
+
+    private SecretResolutionResult resultFor(final String name) {
+      final var failure = failures.get(name);
+      if (failure != null) {
+        return new Failed(failure, "failed: " + name, null);
+      }
+      final var value = values.get(name);
+      return value == null
+          ? new Failed(SecretErrorCode.NOT_FOUND, "no secret found: " + name, null)
+          : new Resolved(value);
+    }
+  }
+}

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretStoreRegistryTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretStoreRegistryTest.java
@@ -8,6 +8,7 @@
 package io.camunda.secretstore;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -80,5 +81,30 @@ class SecretStoreRegistryTest {
 
     // then - one cache per store, keyed by the same ID
     assertThat(caches).containsKeys("store-a", "store-b");
+  }
+
+  @Test
+  void shouldCacheAStoreTheProvidedCachesDoNotCover() {
+    // given caches covering only one of the two configured stores
+    final var cache = new InMemorySecretCache();
+
+    // when
+    final var registry =
+        new SecretStoreRegistry(
+            Map.of("store-a", NOOP, "store-b", new NoopSecretStore()), Map.of("store-a", cache));
+
+    // then the uncovered store is cached too, so a caller never has to handle a missing cache
+    assertThat(registry.getCaches().get("store-a")).isSameAs(cache);
+    assertThat(registry.getCaches().get("store-b")).isNotNull();
+  }
+
+  @Test
+  void shouldNotAllowTheCachesToBeModified() {
+    // given
+    final var registry = new SecretStoreRegistry(Map.of("default", NOOP));
+
+    // when / then the one-cache-per-store invariant cannot be broken from the outside
+    assertThatThrownBy(() -> registry.getCaches().remove("default"))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 }

--- a/service/src/main/java/io/camunda/service/SecretServices.java
+++ b/service/src/main/java/io/camunda/service/SecretServices.java
@@ -192,6 +192,11 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
    * SecretStoreConfiguration}), so the loop below sees a single store and there is no second store
    * to fall back to. Lifting that cap has to revisit this, since a store's {@code NOT_FOUND} counts
    * as an answer here and would have to become "ask the next store" instead.
+   *
+   * <p>It also has to revisit the sequential loop itself: every store read is blocking I/O (a file
+   * read, an AWS Secrets Manager call), so several stores have to be read concurrently rather than
+   * one after another, which costs the sum of their latencies. Sequential is only free while a
+   * single store is all there is.
    */
   private SecretResolution readFromStores(
       final List<String> references,

--- a/service/src/main/java/io/camunda/service/SecretServices.java
+++ b/service/src/main/java/io/camunda/service/SecretServices.java
@@ -27,7 +27,6 @@ import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -185,15 +184,14 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
    * Asks each configured store for the authorized references, adding every outcome to {@code
    * resolved} or {@code errors}. The stores are the registry's caching ones, so a reference already
    * cached for a store never reaches it and every value it answers with is cached; this method only
-   * decides what each outcome means to the API. A reference no store could resolve is reported with
-   * the reason of the last store that failed on it, or {@code NOT_FOUND} if no store knew it at
-   * all.
+   * decides what each outcome means to the API. A reference nothing answered for is reported as
+   * {@code NOT_FOUND}.
    *
-   * <p>A physical tenant is capped at one configured store in this release (enforced at startup by
-   * {@code SecretStoreConfiguration}), so the loop below sees a single store today. The
-   * multiple-store wording above describes how it behaves once that cap is lifted: which store wins
-   * a reference both hold is then decided by iteration order, which the registry does not currently
-   * promise, so a precedence order has to be defined along with the cap.
+   * <p>The first store to answer for a reference decides it, a failure included. A physical tenant
+   * is capped at one configured store in this release (enforced at startup by {@code
+   * SecretStoreConfiguration}), so the loop below sees a single store and there is no second store
+   * to fall back to. Lifting that cap has to revisit this, since a store's {@code NOT_FOUND} counts
+   * as an answer here and would have to become "ask the next store" instead.
    */
   private SecretResolution readFromStores(
       final List<String> references,
@@ -203,15 +201,13 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
     // the references still to be resolved, in a stable order so the outcomes do not come out in
     // whatever order a hash map happens to iterate in
     final Set<String> pending = new LinkedHashSet<>(references);
-    final Map<String, SecretErrorCode> failures = new HashMap<>();
 
     try {
       for (final var store : secretStoreRegistry.getCachingStores().entrySet()) {
         if (pending.isEmpty()) {
           break;
         }
-        readFromStore(
-            store.getKey(), store.getValue(), pending, failures, resolved, authentication);
+        readFromStore(store.getKey(), store.getValue(), pending, resolved, errors, authentication);
       }
     } catch (final SecretStoreException e) {
       // a store that cannot be read at all fails the whole request rather than reporting every
@@ -221,26 +217,23 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
           "Failed to read the configured secret store.", ServiceException.Status.UNAVAILABLE);
     }
 
-    pending.forEach(
-        reference -> {
-          final var code = failures.getOrDefault(reference, SecretErrorCode.NOT_FOUND);
-          errors.add(new SecretResolutionError(reference, code, messageFor(code)));
-        });
+    // nothing answered for these: either no store is configured, or a store left the name out of
+    // the results it answered with
+    pending.forEach(reference -> errors.add(errorFor(reference, SecretErrorCode.NOT_FOUND)));
     return new SecretResolution(resolved, errors);
   }
 
   /**
    * Asks one store for every reference still {@code pending}, revealing the ones it resolves and
-   * taking those out of {@code pending}. A reference the store fails on is recorded in {@code
-   * failures} and left pending, so a later store can still resolve it; only if none does is the
-   * recorded reason reported.
+   * reporting the ones it fails on, taking both out of {@code pending}. A reference the store
+   * answers without a result for stays pending, since an absent entry is not an answer.
    */
   private void readFromStore(
       final String storeId,
       final SecretStore store,
       final Set<String> pending,
-      final Map<String, SecretErrorCode> failures,
       final List<ResolvedSecret> resolved,
+      final List<SecretResolutionError> errors,
       final CamundaAuthentication authentication) {
     // the references to ask this store for, keyed by the bare name the stores are keyed by. A
     // separate map, since resolving a reference takes it out of the pending ones.
@@ -262,11 +255,12 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
                   reference,
                   failure.code(),
                   failure.message());
-              failures.put(reference, toApiErrorCode(failure.code()));
+              errors.add(errorFor(reference, toApiErrorCode(failure.code())));
+              pending.remove(reference);
             }
             // a store that answers without an entry for a requested name is treated as not knowing
             // it, rather than dropping the reference from the response entirely
-            case null -> failures.putIfAbsent(reference, SecretErrorCode.NOT_FOUND);
+            case null -> {}
           }
         });
   }
@@ -296,6 +290,11 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
       case INVALID_REF -> SecretErrorCode.INVALID_REFERENCE;
       case ACCESS_DENIED, UNREADABLE -> SecretErrorCode.UNREADABLE;
     };
+  }
+
+  private static SecretResolutionError errorFor(
+      final String reference, final SecretErrorCode code) {
+    return new SecretResolutionError(reference, code, messageFor(code));
   }
 
   /**

--- a/service/src/main/java/io/camunda/service/SecretServices.java
+++ b/service/src/main/java/io/camunda/service/SecretServices.java
@@ -450,7 +450,19 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
   public record SecretResolution(
       List<ResolvedSecret> resolved, List<SecretResolutionError> errors) {}
 
-  public record ResolvedSecret(String reference, String value) {}
+  /**
+   * A revealed secret. {@code toString} masks the value, mirroring the {@code secret-store} SPI's
+   * {@code SecretResolutionResult.Resolved}: a resolved value must never reach a log line, and the
+   * record's generated {@code toString} would print it in any log statement, exception message or
+   * test failure dump this ever lands in.
+   */
+  public record ResolvedSecret(String reference, String value) {
+
+    @Override
+    public String toString() {
+      return "ResolvedSecret[reference=" + reference + ", value=***]";
+    }
+  }
 
   public record SecretResolutionError(String reference, SecretErrorCode code, String message) {}
 

--- a/service/src/main/java/io/camunda/service/SecretServices.java
+++ b/service/src/main/java/io/camunda/service/SecretServices.java
@@ -187,6 +187,12 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
    * that store in a single batched call, and every value read is cached. A reference no store could
    * resolve is reported with the reason of the last store that failed on it, or {@code NOT_FOUND}
    * if no store knew it at all.
+   *
+   * <p>A physical tenant is capped at one configured store in this release (enforced at startup by
+   * {@code SecretStoreConfiguration}), so the loop below sees a single store today. The
+   * multiple-store wording above describes how it behaves once that cap is lifted: which store wins
+   * a reference both hold is then decided by iteration order, which the registry does not currently
+   * promise, so a precedence order has to be defined along with the cap.
    */
   private SecretResolution readFromStores(
       final List<String> references,

--- a/service/src/main/java/io/camunda/service/SecretServices.java
+++ b/service/src/main/java/io/camunda/service/SecretServices.java
@@ -287,14 +287,16 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
    * cluster's own store credentials being rejected, not the caller lacking {@code SECRET:REVEAL},
    * so it must not surface as this API's {@code ACCESS_DENIED}, which always refers to the caller's
    * permission.
+   *
+   * <p>Deliberately without a {@code default} branch: the SPI and this gateway ship from the same
+   * repository in the same release, so a code added to the SPI has to be mapped here in that same
+   * change, and an unhandled one is a compile error rather than a silent {@code UNREADABLE}.
    */
   private static SecretErrorCode toApiErrorCode(final io.camunda.secretstore.SecretErrorCode code) {
     return switch (code) {
       case NOT_FOUND -> SecretErrorCode.NOT_FOUND;
       case INVALID_REF -> SecretErrorCode.INVALID_REFERENCE;
       case ACCESS_DENIED, UNREADABLE -> SecretErrorCode.UNREADABLE;
-      // the SPI may add codes in a minor version; an unknown one is still a value we cannot read
-      default -> SecretErrorCode.UNREADABLE;
     };
   }
 

--- a/service/src/main/java/io/camunda/service/SecretServices.java
+++ b/service/src/main/java/io/camunda/service/SecretServices.java
@@ -408,8 +408,16 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
     return AuthorizedScopes.only(authorizedResourceIds);
   }
 
+  /**
+   * Whether the caller's reference is one this service accepts.
+   *
+   * <p>The length is bounded before {@link #bareNameOf} takes the name out, so an over-long
+   * reference is rejected without copying it. Bounding the whole reference is the same test {@link
+   * #isResolvableName} applies to the name, since a reference that reached it carries the prefix.
+   */
   private static boolean isValidReference(final String reference) {
     return reference != null
+        && reference.length() <= MAX_REFERENCE_LENGTH
         && reference.startsWith(REFERENCE_PREFIX)
         && isResolvableName(bareNameOf(reference));
   }

--- a/service/src/main/java/io/camunda/service/SecretServices.java
+++ b/service/src/main/java/io/camunda/service/SecretServices.java
@@ -10,8 +10,8 @@ package io.camunda.service;
 import static io.camunda.service.authorization.Authorizations.SECRET_READ_AUTHORIZATION;
 import static io.camunda.service.authorization.Authorizations.SECRET_REVEAL_AUTHORIZATION;
 
-import io.camunda.secretstore.SecretCache;
 import io.camunda.secretstore.SecretResolutionResult;
+import io.camunda.secretstore.SecretStore;
 import io.camunda.secretstore.SecretStoreException;
 import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.security.api.model.CamundaAuthentication;
@@ -182,11 +182,12 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
   }
 
   /**
-   * Reads the authorized references cache-first, adding each outcome to {@code resolved} or {@code
-   * errors}: a reference cached for a store is served from there, the remaining ones are read from
-   * that store in a single batched call, and every value read is cached. A reference no store could
-   * resolve is reported with the reason of the last store that failed on it, or {@code NOT_FOUND}
-   * if no store knew it at all.
+   * Asks each configured store for the authorized references, adding every outcome to {@code
+   * resolved} or {@code errors}. The stores are the registry's caching ones, so a reference already
+   * cached for a store never reaches it and every value it answers with is cached; this method only
+   * decides what each outcome means to the API. A reference no store could resolve is reported with
+   * the reason of the last store that failed on it, or {@code NOT_FOUND} if no store knew it at
+   * all.
    *
    * <p>A physical tenant is capped at one configured store in this release (enforced at startup by
    * {@code SecretStoreConfiguration}), so the loop below sees a single store today. The
@@ -205,40 +206,52 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
     final Map<String, SecretErrorCode> failures = new HashMap<>();
 
     try {
-      final var caches = secretStoreRegistry.getCaches();
-      for (final var store : secretStoreRegistry.getStores().entrySet()) {
+      for (final var store : secretStoreRegistry.getCachingStores().entrySet()) {
         if (pending.isEmpty()) {
           break;
         }
-        final var storeId = store.getKey();
-        final SecretCache cache = caches.get(storeId);
+        readFromStore(
+            store.getKey(), store.getValue(), pending, failures, resolved, authentication);
+      }
+    } catch (final SecretStoreException e) {
+      // a store that cannot be read at all fails the whole request rather than reporting every
+      // reference as missing, which a caller could not tell apart from a genuinely empty store
+      LOG.warn("Failed to read a configured secret store while resolving secret references", e);
+      throw new ServiceException(
+          "Failed to read the configured secret store.", ServiceException.Status.UNAVAILABLE);
+    }
 
-        // the references this store still has to be asked for, keyed by their bare name. Iterates a
-        // snapshot, since a cache hit removes its reference from the pending ones.
-        final Map<String, String> misses = new LinkedHashMap<>();
-        for (final var reference : List.copyOf(pending)) {
-          final var name = bareNameOf(reference);
-          final var cached = cache == null ? null : cache.get(name).orElse(null);
-          if (cached == null) {
-            misses.put(name, reference);
-          } else {
-            reveal(reference, cached, resolved, authentication);
-            pending.remove(reference);
-          }
-        }
-        if (misses.isEmpty()) {
-          continue;
-        }
+    pending.forEach(
+        reference -> {
+          final var code = failures.getOrDefault(reference, SecretErrorCode.NOT_FOUND);
+          errors.add(new SecretResolutionError(reference, code, messageFor(code)));
+        });
+    return new SecretResolution(resolved, errors);
+  }
 
-        final var results = store.getValue().resolve(misses.keySet());
-        for (final var miss : misses.entrySet()) {
-          final var name = miss.getKey();
-          final var reference = miss.getValue();
+  /**
+   * Asks one store for every reference still {@code pending}, revealing the ones it resolves and
+   * taking those out of {@code pending}. A reference the store fails on is recorded in {@code
+   * failures} and left pending, so a later store can still resolve it; only if none does is the
+   * recorded reason reported.
+   */
+  private void readFromStore(
+      final String storeId,
+      final SecretStore store,
+      final Set<String> pending,
+      final Map<String, SecretErrorCode> failures,
+      final List<ResolvedSecret> resolved,
+      final CamundaAuthentication authentication) {
+    // the references to ask this store for, keyed by the bare name the stores are keyed by. A
+    // separate map, since resolving a reference takes it out of the pending ones.
+    final Map<String, String> requested = new LinkedHashMap<>();
+    pending.forEach(reference -> requested.put(bareNameOf(reference), reference));
+
+    final var results = store.resolve(requested.keySet());
+    requested.forEach(
+        (name, reference) -> {
           switch (results.get(name)) {
             case final SecretResolutionResult.Resolved value -> {
-              if (cache != null) {
-                cache.put(name, value.value());
-              }
               reveal(reference, value.value(), resolved, authentication);
               pending.remove(reference);
             }
@@ -255,22 +268,7 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
             // it, rather than dropping the reference from the response entirely
             case null -> failures.putIfAbsent(reference, SecretErrorCode.NOT_FOUND);
           }
-        }
-      }
-    } catch (final SecretStoreException e) {
-      // a store that cannot be read at all fails the whole request rather than reporting every
-      // reference as missing, which a caller could not tell apart from a genuinely empty store
-      LOG.warn("Failed to read a configured secret store while resolving secret references", e);
-      throw new ServiceException(
-          "Failed to read the configured secret store.", ServiceException.Status.UNAVAILABLE);
-    }
-
-    pending.forEach(
-        reference -> {
-          final var code = failures.getOrDefault(reference, SecretErrorCode.NOT_FOUND);
-          errors.add(new SecretResolutionError(reference, code, messageFor(code)));
         });
-    return new SecretResolution(resolved, errors);
   }
 
   private void reveal(

--- a/service/src/main/java/io/camunda/service/SecretServices.java
+++ b/service/src/main/java/io/camunda/service/SecretServices.java
@@ -328,6 +328,7 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
   public enum SecretErrorCode {
     NOT_FOUND,
     ACCESS_DENIED,
-    INVALID_REFERENCE
+    INVALID_REFERENCE,
+    UNREADABLE
   }
 }

--- a/service/src/main/java/io/camunda/service/SecretServices.java
+++ b/service/src/main/java/io/camunda/service/SecretServices.java
@@ -37,6 +37,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -416,9 +417,14 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
   /**
    * Whether a store's secret name can form a reference this service accepts, so that {@link #list}
    * only ever offers references {@link #resolve} takes.
+   *
+   * <p>A {@code null} name is one of those it cannot. The store SPI is {@code @NullMarked} and so
+   * promises not to list one, but a store is third-party code: a broken one should cost the caller
+   * that name, not the whole listing with an internal error.
    */
-  private static boolean isResolvableName(final String name) {
-    return REFERENCE_PREFIX.length() + name.length() <= MAX_REFERENCE_LENGTH
+  private static boolean isResolvableName(final @Nullable String name) {
+    return name != null
+        && REFERENCE_PREFIX.length() + name.length() <= MAX_REFERENCE_LENGTH
         && REFERENCE_NAME_PATTERN.matcher(name).matches();
   }
 

--- a/service/src/main/java/io/camunda/service/SecretServices.java
+++ b/service/src/main/java/io/camunda/service/SecretServices.java
@@ -10,6 +10,9 @@ package io.camunda.service;
 import static io.camunda.service.authorization.Authorizations.SECRET_READ_AUTHORIZATION;
 import static io.camunda.service.authorization.Authorizations.SECRET_REVEAL_AUTHORIZATION;
 
+import io.camunda.secretstore.SecretCache;
+import io.camunda.secretstore.SecretResolutionResult;
+import io.camunda.secretstore.SecretStoreException;
 import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.api.model.authz.AuthorizationResourceMatcher;
@@ -19,14 +22,18 @@ import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.security.core.authz.AuthorizationChecker;
 import io.camunda.service.exception.ErrorMapper;
+import io.camunda.service.exception.ServiceException;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -41,23 +48,23 @@ import org.slf4j.LoggerFactory;
  * unresolvable reference is reported in {@link SecretResolution#errors()} rather than failing the
  * batch.
  *
- * <p><b>Phase 1 scope (#56567, #56568):</b> the per-reference authorization, deduplication,
- * reference validation and per-reference outcome routing are real. The secret backend itself is
- * <b>mocked</b> ({@link #mockResolve}, {@link #mockListReferences}). The physical tenant's {@link
- * SecretStoreRegistry} is wired in (#58784) but not read yet; replacing the mocks with real store
- * reads is tracked in #58497.
+ * <p>Both read the secret stores of this service's physical tenant, taken from the {@link
+ * SecretStoreRegistry} the service is constructed with. Resolving is cache-first: a reference whose
+ * value is in the store's cache is served from there, and only the remaining references reach the
+ * store, whose values are then cached. Listing always polls the stores, since the caches only hold
+ * the values read so far rather than the tenant's set of secrets.
  */
 @NullMarked
 public class SecretServices extends PhysicalTenantScopedApiServices<SecretServices> {
 
   /**
    * Bounds the length of a single reference string. Each reference is used as an authorization
-   * resource id and (once a real store is wired) a store lookup key, so an unbounded string must
-   * not reach either. Enforced here (rather than only at the request-validation layer) so an
-   * over-long reference is reported as a per-reference {@link SecretErrorCode#INVALID_REFERENCE}
-   * like every other malformed reference, instead of failing the whole batch. Mirrored by the
-   * {@code maxLength: 256} on {@code SecretResolveRequest.references} items in {@code
-   * secrets.yaml}; kept in sync by {@code SecretRequestValidatorSpecSyncTest}.
+   * resource id and a store lookup key, so an unbounded string must not reach either. Enforced here
+   * (rather than only at the request-validation layer) so an over-long reference is reported as a
+   * per-reference {@link SecretErrorCode#INVALID_REFERENCE} like every other malformed reference,
+   * instead of failing the whole batch. Mirrored by the {@code maxLength: 256} on {@code
+   * SecretResolveRequest.references} items in {@code secrets.yaml}; kept in sync by {@code
+   * SecretRequestValidatorSpecSyncTest}.
    */
   public static final int MAX_REFERENCE_LENGTH = 256;
 
@@ -66,19 +73,12 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
   private static final String REFERENCE_PREFIX = "camunda.secrets.";
 
   // The <name> segment of a reference: a single, non-empty token of alphanumeric characters and
-  // underscores. Deliberately narrow — the reference is used as an authorization resource id and
-  // (once a real store is wired) a store lookup key, so pattern/glob characters ('*', '%'),
-  // whitespace and dots must never reach either. Kept identical to the engine detector's
-  // single-segment camunda.secrets.<name> pattern (see SecretReferenceLiteralValidator) so both
-  // subsystems agree on what counts as a valid reference name for the same syntax.
+  // underscores. Deliberately narrow — the reference is used as an authorization resource id and a
+  // store lookup key, so pattern/glob characters ('*', '%'), whitespace and dots must never reach
+  // either. Kept identical to the engine detector's single-segment camunda.secrets.<name> pattern
+  // (see SecretReferenceLiteralValidator) so both subsystems agree on what counts as a valid
+  // reference name for the same syntax.
   private static final Pattern REFERENCE_NAME_PATTERN = Pattern.compile("[\\p{Alnum}_]+");
-
-  // Phase 1 only: the references the mocked backend pretends to know, shared by mockResolve and
-  // mockListReferences so a caller who lists then resolves sees consistent references. Any other
-  // authorized, valid reference resolves to NOT_FOUND and is absent from the listing. Removed once
-  // the wired secret stores replace the mocks (#58497).
-  private static final Set<String> MOCK_RESOLVABLE_REFERENCES =
-      Set.of("camunda.secrets.token", "camunda.secrets.a", "camunda.secrets.b");
 
   private final AuthorizationChecker authorizationChecker;
   private final AuthorizationsConfiguration authorizationsConfig;
@@ -105,11 +105,10 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
   }
 
   /**
-   * Returns the secret stores and caches of this service's physical tenant. Not consulted by the
-   * mocked backend yet; the store-backed resolve/list lands with #58497, and reads the field
-   * directly. Exposed only so the wiring can be asserted, deliberately not a production read path:
-   * a caller holding the registry could read a value without the per-reference {@code
-   * SECRET:REVEAL} check {@link #resolve} applies.
+   * Returns the secret stores and caches of this service's physical tenant. {@link #resolve} and
+   * {@link #list} read the field directly, so this exists only so the wiring can be asserted,
+   * deliberately not a production read path: a caller holding the registry could read a value
+   * without the per-reference {@code SECRET:REVEAL} check {@link #resolve} applies.
    */
   @VisibleForTesting
   public SecretStoreRegistry getSecretStoreRegistry() {
@@ -121,9 +120,9 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
    * returned {@link SecretResolution} always describes every distinct reference exactly once,
    * across {@code resolved} and {@code errors}.
    *
-   * <p>Synchronous today (no broker round-trip while the backend is mocked), but returns a future
-   * like every other action method on this base class so the signature does not have to break once
-   * the real, likely I/O-bound {@code SecretStore} lookup replaces {@link #mockResolve} (#58497).
+   * <p>Reference validation and authorization run on the calling thread, as they did before a store
+   * was wired. The store lookup is handed to the API executor: reading an external store (a file,
+   * an AWS Secrets Manager call) is blocking I/O that must not occupy the request thread.
    */
   public CompletableFuture<SecretResolution> resolve(
       final List<String> references, final CamundaAuthentication authentication) {
@@ -154,8 +153,11 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
       final var authorizedScopes =
           retrieveAuthorizedScopes(authentication, SECRET_REVEAL_AUTHORIZATION);
 
+      final List<String> authorizedReferences = new ArrayList<>();
       for (final var reference : validReferences) {
-        if (!authorizedScopes.authorizes(reference)) {
+        if (authorizedScopes.authorizes(reference)) {
+          authorizedReferences.add(reference);
+        } else {
           LOG.debug(
               "Denied secret reveal of '{}' for {}",
               reference,
@@ -165,26 +167,142 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
                   reference,
                   SecretErrorCode.ACCESS_DENIED,
                   "The caller is not authorized to reveal the secret reference."));
-          continue;
         }
-        mockResolve(reference)
-            .ifPresentOrElse(
-                value -> {
-                  LOG.debug(
-                      "Revealed secret '{}' to {}", reference, authentication.formattedPrincipal());
-                  resolved.add(new ResolvedSecret(reference, value));
-                },
-                () ->
-                    errors.add(
-                        new SecretResolutionError(
-                            reference,
-                            SecretErrorCode.NOT_FOUND,
-                            "No secret was found for the reference.")));
       }
-      return CompletableFuture.completedFuture(new SecretResolution(resolved, errors));
+      if (authorizedReferences.isEmpty()) {
+        return CompletableFuture.completedFuture(new SecretResolution(resolved, errors));
+      }
+
+      return CompletableFuture.supplyAsync(
+          () -> readFromStores(authorizedReferences, resolved, errors, authentication),
+          executorProvider.getExecutor());
     } catch (final Exception ex) {
       return CompletableFuture.failedFuture(ErrorMapper.mapError(ex));
     }
+  }
+
+  /**
+   * Reads the authorized references cache-first, adding each outcome to {@code resolved} or {@code
+   * errors}: a reference cached for a store is served from there, the remaining ones are read from
+   * that store in a single batched call, and every value read is cached. A reference no store could
+   * resolve is reported with the reason of the last store that failed on it, or {@code NOT_FOUND}
+   * if no store knew it at all.
+   */
+  private SecretResolution readFromStores(
+      final List<String> references,
+      final List<ResolvedSecret> resolved,
+      final List<SecretResolutionError> errors,
+      final CamundaAuthentication authentication) {
+    // the references still to be resolved, in a stable order so the outcomes do not come out in
+    // whatever order a hash map happens to iterate in
+    final Set<String> pending = new LinkedHashSet<>(references);
+    final Map<String, SecretErrorCode> failures = new HashMap<>();
+
+    try {
+      final var caches = secretStoreRegistry.getCaches();
+      for (final var store : secretStoreRegistry.getStores().entrySet()) {
+        if (pending.isEmpty()) {
+          break;
+        }
+        final var storeId = store.getKey();
+        final SecretCache cache = caches.get(storeId);
+
+        // the references this store still has to be asked for, keyed by their bare name. Iterates a
+        // snapshot, since a cache hit removes its reference from the pending ones.
+        final Map<String, String> misses = new LinkedHashMap<>();
+        for (final var reference : List.copyOf(pending)) {
+          final var name = bareNameOf(reference);
+          final var cached = cache == null ? null : cache.get(name).orElse(null);
+          if (cached == null) {
+            misses.put(name, reference);
+          } else {
+            reveal(reference, cached, resolved, authentication);
+            pending.remove(reference);
+          }
+        }
+        if (misses.isEmpty()) {
+          continue;
+        }
+
+        final var results = store.getValue().resolve(misses.keySet());
+        for (final var miss : misses.entrySet()) {
+          final var name = miss.getKey();
+          final var reference = miss.getValue();
+          switch (results.get(name)) {
+            case final SecretResolutionResult.Resolved value -> {
+              if (cache != null) {
+                cache.put(name, value.value());
+              }
+              reveal(reference, value.value(), resolved, authentication);
+              pending.remove(reference);
+            }
+            case final SecretResolutionResult.Failed failure -> {
+              LOG.debug(
+                  "Store '{}' could not resolve secret '{}': {} ({})",
+                  storeId,
+                  reference,
+                  failure.code(),
+                  failure.message());
+              failures.put(reference, toApiErrorCode(failure.code()));
+            }
+            // a store that answers without an entry for a requested name is treated as not knowing
+            // it, rather than dropping the reference from the response entirely
+            case null -> failures.putIfAbsent(reference, SecretErrorCode.NOT_FOUND);
+          }
+        }
+      }
+    } catch (final SecretStoreException e) {
+      // a store that cannot be read at all fails the whole request rather than reporting every
+      // reference as missing, which a caller could not tell apart from a genuinely empty store
+      LOG.warn("Failed to read a configured secret store while resolving secret references", e);
+      throw new ServiceException(
+          "Failed to read the configured secret store.", ServiceException.Status.UNAVAILABLE);
+    }
+
+    pending.forEach(
+        reference -> {
+          final var code = failures.getOrDefault(reference, SecretErrorCode.NOT_FOUND);
+          errors.add(new SecretResolutionError(reference, code, messageFor(code)));
+        });
+    return new SecretResolution(resolved, errors);
+  }
+
+  private void reveal(
+      final String reference,
+      final String value,
+      final List<ResolvedSecret> resolved,
+      final CamundaAuthentication authentication) {
+    LOG.debug("Revealed secret '{}' to {}", reference, authentication.formattedPrincipal());
+    resolved.add(new ResolvedSecret(reference, value));
+  }
+
+  /**
+   * Maps a store's failure to the API-facing error code. A store's {@code ACCESS_DENIED} is the
+   * cluster's own store credentials being rejected, not the caller lacking {@code SECRET:REVEAL},
+   * so it must not surface as this API's {@code ACCESS_DENIED}, which always refers to the caller's
+   * permission.
+   */
+  private static SecretErrorCode toApiErrorCode(final io.camunda.secretstore.SecretErrorCode code) {
+    return switch (code) {
+      case NOT_FOUND -> SecretErrorCode.NOT_FOUND;
+      case INVALID_REF -> SecretErrorCode.INVALID_REFERENCE;
+      case ACCESS_DENIED, UNREADABLE -> SecretErrorCode.UNREADABLE;
+      // the SPI may add codes in a minor version; an unknown one is still a value we cannot read
+      default -> SecretErrorCode.UNREADABLE;
+    };
+  }
+
+  /**
+   * The message reported for a failed reference. Deliberately fixed per code: a store's own message
+   * carries its internals (secret ids, file paths, status codes) and is only logged.
+   */
+  private static String messageFor(final SecretErrorCode code) {
+    return switch (code) {
+      case NOT_FOUND -> "No secret was found for the reference.";
+      case ACCESS_DENIED -> "The caller is not authorized to reveal the secret reference.";
+      case INVALID_REFERENCE -> "The configured secret store rejected the reference.";
+      case UNREADABLE -> "The configured secret store could not read a value for the reference.";
+    };
   }
 
   /**
@@ -193,12 +311,12 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
    * caller-supplied batch (contrast {@link #resolve}).
    *
    * <p>Authorizes before enumerating, mirroring {@link #resolve}: a caller with no wildcard and no
-   * ID-scoped grant is denied everything, so the (mocked, but eventually store-backed) enumeration
-   * is never invoked for them. Once a real {@code SecretStore} is wired, that enumeration is a
-   * tenant-wide backend call with real cost (money, rate limits on AWS/GCP); skipping it for a
-   * zero-grant caller avoids paying that cost for a result that is discarded anyway.
+   * ID-scoped grant is denied everything, so the enumeration is never invoked for them. That
+   * enumeration is a tenant-wide store call with real cost (money, rate limits on AWS/GCP);
+   * skipping it for a zero-grant caller avoids paying that cost for a result that is discarded
+   * anyway.
    *
-   * <p>Synchronous today for the same reason {@link #resolve} is (see its Javadoc).
+   * <p>Runs the enumeration on the API executor, for the same reason {@link #resolve} does.
    */
   public CompletableFuture<List<String>> list(final CamundaAuthentication authentication) {
     try {
@@ -207,12 +325,45 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
       if (!authorizedScopes.authorizesEverything() && authorizedScopes.isEmpty()) {
         return CompletableFuture.completedFuture(List.of());
       }
-      final var references = mockListReferences();
-      final var result = references.stream().filter(authorizedScopes::authorizes).toList();
-      return CompletableFuture.completedFuture(result);
+      return CompletableFuture.supplyAsync(
+          () -> listFromStores().stream().filter(authorizedScopes::authorizes).toList(),
+          executorProvider.getExecutor());
     } catch (final Exception ex) {
       return CompletableFuture.failedFuture(ErrorMapper.mapError(ex));
     }
+  }
+
+  /**
+   * Enumerates the references of every configured store, sorted and without duplicates. The caches
+   * are deliberately bypassed: they hold the values read so far, which is not the tenant's set of
+   * secrets.
+   */
+  private List<String> listFromStores() {
+    final var references = new TreeSet<String>();
+    try {
+      for (final var store : secretStoreRegistry.getStores().entrySet()) {
+        for (final var name : store.getValue().list()) {
+          if (isResolvableName(name)) {
+            references.add(REFERENCE_PREFIX + name);
+          } else {
+            // A store may allow names this API cannot: a reference is a single
+            // camunda.secrets.<name> segment, so a name carrying a dot or a dash could neither be
+            // resolved by resolve() nor written in a BPMN expression or granted a permission.
+            // Listing it would only offer the caller a reference every other surface rejects.
+            LOG.debug(
+                "Omitting secret '{}' of store '{}' from the listing: its name cannot form a valid"
+                    + " secret reference",
+                name,
+                store.getKey());
+          }
+        }
+      }
+    } catch (final SecretStoreException e) {
+      LOG.warn("Failed to read a configured secret store while listing secret references", e);
+      throw new ServiceException(
+          "Failed to read the configured secret store.", ServiceException.Status.UNAVAILABLE);
+    }
+    return List.copyOf(references);
   }
 
   /**
@@ -247,40 +398,23 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
   }
 
   private static boolean isValidReference(final String reference) {
-    if (reference == null
-        || reference.length() > MAX_REFERENCE_LENGTH
-        || !reference.startsWith(REFERENCE_PREFIX)) {
-      return false;
-    }
-    final var name = reference.substring(REFERENCE_PREFIX.length());
-    return REFERENCE_NAME_PATTERN.matcher(name).matches();
+    return reference != null
+        && reference.startsWith(REFERENCE_PREFIX)
+        && isResolvableName(bareNameOf(reference));
   }
 
   /**
-   * Mocked secret lookup for Phase 1. Resolves only an explicit allow-list of references to a
-   * deterministic placeholder value so dependent work (inbound connectors) can integrate against a
-   * live endpoint; every other authorized, valid reference yields {@code NOT_FOUND}, exercising the
-   * real not-found path rather than fabricating a value for an arbitrary reference. The value is
-   * scoped by physical tenant so the mock cannot mask a cross-tenant leak once the real {@code
-   * SecretStore} (which is itself registered per physical tenant) replaces it. TODO(#58497):
-   * replace with a lookup through {@link #secretStoreRegistry}.
+   * Whether a store's secret name can form a reference this service accepts, so that {@link #list}
+   * only ever offers references {@link #resolve} takes.
    */
-  private Optional<String> mockResolve(final String reference) {
-    if (!MOCK_RESOLVABLE_REFERENCES.contains(reference)) {
-      return Optional.empty();
-    }
-    final var name = reference.substring(REFERENCE_PREFIX.length());
-    return Optional.of("mock-value-for-" + name + "-in-tenant-" + getPhysicalTenantId());
+  private static boolean isResolvableName(final String name) {
+    return REFERENCE_PREFIX.length() + name.length() <= MAX_REFERENCE_LENGTH
+        && REFERENCE_NAME_PATTERN.matcher(name).matches();
   }
 
-  /**
-   * Mocked reference enumeration for Phase 1, sharing {@link #MOCK_RESOLVABLE_REFERENCES} with
-   * {@link #mockResolve} so a caller who lists then resolves sees consistent references. Sorted for
-   * a deterministic response, since the backing {@link Set} has no defined iteration order.
-   * TODO(#58497): replace with an enumeration through {@link #secretStoreRegistry}.
-   */
-  private List<String> mockListReferences() {
-    return MOCK_RESOLVABLE_REFERENCES.stream().sorted().toList();
+  /** The bare secret name the stores are keyed by, i.e. the reference without its prefix. */
+  private static String bareNameOf(final String reference) {
+    return reference.substring(REFERENCE_PREFIX.length());
   }
 
   /**

--- a/service/src/main/java/io/camunda/service/SecretServices.java
+++ b/service/src/main/java/io/camunda/service/SecretServices.java
@@ -446,9 +446,18 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
     }
   }
 
-  /** The per-reference outcome of a resolve request. */
+  /**
+   * The per-reference outcome of a resolve request. Copies both lists, since {@link
+   * #readFromStores} builds them by mutation and a caller must not be handed a handle on that.
+   */
   public record SecretResolution(
-      List<ResolvedSecret> resolved, List<SecretResolutionError> errors) {}
+      List<ResolvedSecret> resolved, List<SecretResolutionError> errors) {
+
+    public SecretResolution {
+      resolved = List.copyOf(resolved);
+      errors = List.copyOf(errors);
+    }
+  }
 
   /**
    * A revealed secret. {@code toString} masks the value, mirroring the {@code secret-store} SPI's

--- a/service/src/test/java/io/camunda/service/SecretServicesAuthorizationCheckerDelegationTest.java
+++ b/service/src/test/java/io/camunda/service/SecretServicesAuthorizationCheckerDelegationTest.java
@@ -23,6 +23,7 @@ import io.camunda.security.core.authz.AuthorizationChecker;
 import io.camunda.service.SecretServices.ResolvedSecret;
 import io.camunda.service.SecretServices.SecretErrorCode;
 import io.camunda.service.SecretServices.SecretResolutionError;
+import io.camunda.service.SecretTestSupport.TestSecretStore;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.List;
@@ -98,14 +99,17 @@ class SecretServicesAuthorizationCheckerDelegationTest {
       final String physicalTenantId,
       final AuthorizationChecker authorizationChecker,
       final AuthorizationsConfiguration authorizationsConfig) {
+    // a store holding the reference, so an authorized reveal shows up as a resolved value rather
+    // than as NOT_FOUND
+    final var store = new TestSecretStore().holds("token", "token-value");
     return new SecretServices(
         physicalTenantId,
         mock(BrokerClient.class),
         mock(SecurityContextProvider.class),
         authorizationChecker,
         authorizationsConfig,
-        new SecretStoreRegistry(Map.of()),
-        mock(ApiServicesExecutorProvider.class),
+        new SecretStoreRegistry(Map.of("main", store)),
+        SecretTestSupport.sameThreadExecutorProvider(),
         null);
   }
 }

--- a/service/src/test/java/io/camunda/service/SecretServicesTest.java
+++ b/service/src/test/java/io/camunda/service/SecretServicesTest.java
@@ -729,6 +729,22 @@ public class SecretServicesTest {
   }
 
   @Test
+  void shouldOmitANullNameFromTheListingWithoutFailingIt() {
+    // given a store that lists a null name, which the store SPI's nullness contract forbids but a
+    // third-party store could still do
+    authorizationsConfig.setEnabled(true);
+    grantReadWildcard();
+    store.alsoLists(null);
+
+    // when
+    final var references = services.list(authentication).join();
+
+    // then the listing costs that one name rather than failing as an internal error
+    assertThat(references)
+        .containsExactly("camunda.secrets.a", "camunda.secrets.b", "camunda.secrets.token");
+  }
+
+  @Test
   void shouldOmitStoreNameThatWouldExceedTheReferenceLengthCap() {
     // given a name whose reference would be one character over the cap resolve() accepts
     authorizationsConfig.setEnabled(true);

--- a/service/src/test/java/io/camunda/service/SecretServicesTest.java
+++ b/service/src/test/java/io/camunda/service/SecretServicesTest.java
@@ -827,6 +827,23 @@ public class SecretServicesTest {
   }
 
   @Test
+  void shouldReturnOutcomeListsThatCannotBeModified() {
+    // given a resolved and a failed reference, so both lists are non-empty
+    authorizationsConfig.setEnabled(true);
+    grantRevealWildcard();
+    final var resolution =
+        services
+            .resolve(List.of("camunda.secrets.token", "camunda.secrets.unknown"), authentication)
+            .join();
+
+    // when / then the caller cannot mutate the outcomes the service built
+    assertThatThrownBy(() -> resolution.resolved().clear())
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> resolution.errors().clear())
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
   void shouldListOnlyAuthorizedReferences() {
     // given the caller is granted READ on one of the three references the store holds
     authorizationsConfig.setEnabled(true);

--- a/service/src/test/java/io/camunda/service/SecretServicesTest.java
+++ b/service/src/test/java/io/camunda/service/SecretServicesTest.java
@@ -36,6 +36,7 @@ import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -324,6 +325,58 @@ public class SecretServicesTest {
     assertThat(resolution.errors()).hasSize(1);
     assertThat(resolution.errors().get(0).reference()).isEqualTo("camunda.secrets.token");
     assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.UNREADABLE);
+  }
+
+  @Test
+  void shouldReportAStoreFailureWithoutAskingTheNextStore() {
+    // given two stores, the first failing on a reference the second holds. A physical tenant is
+    // capped at one configured store today, so this pins what the loop does rather than a case a
+    // deployment can reach.
+    authorizationsConfig.setEnabled(true);
+    grantRevealWildcard();
+    final var failing = new TestSecretStore();
+    failing.failsResolving(
+        "token", io.camunda.secretstore.SecretErrorCode.UNREADABLE, "cannot read the value");
+    final var holding = new TestSecretStore().holds("token", "second-store-value");
+    final var stores = new LinkedHashMap<String, SecretStore>();
+    stores.put("first", failing);
+    stores.put("second", holding);
+
+    // when
+    final var resolution =
+        newSecretServices(PHYSICAL_TENANT_ID, new SecretStoreRegistry(stores))
+            .resolve(List.of("camunda.secrets.token"), authentication)
+            .join();
+
+    // then the first store's failure is the answer, and the second is never asked
+    assertThat(resolution.resolved()).isEmpty();
+    assertThat(resolution.errors()).hasSize(1);
+    assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.UNREADABLE);
+    assertThat(holding.resolveCalls()).isEmpty();
+  }
+
+  @Test
+  void shouldAskTheNextStoreForAReferenceTheFirstDidNotAnswerFor() {
+    // given two stores, the first answering without a result for the reference the second holds
+    authorizationsConfig.setEnabled(true);
+    grantRevealWildcard();
+    final var silent = new TestSecretStore();
+    silent.omitsResults();
+    final var holding = new TestSecretStore().holds("token", "second-store-value");
+    final var stores = new LinkedHashMap<String, SecretStore>();
+    stores.put("first", silent);
+    stores.put("second", holding);
+
+    // when
+    final var resolution =
+        newSecretServices(PHYSICAL_TENANT_ID, new SecretStoreRegistry(stores))
+            .resolve(List.of("camunda.secrets.token"), authentication)
+            .join();
+
+    // then the missing entry is not an answer, so the reference reaches the second store
+    assertThat(resolution.errors()).isEmpty();
+    assertThat(resolution.resolved()).hasSize(1);
+    assertThat(resolution.resolved().get(0).value()).isEqualTo("second-store-value");
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/SecretServicesTest.java
+++ b/service/src/test/java/io/camunda/service/SecretServicesTest.java
@@ -810,6 +810,23 @@ public class SecretServicesTest {
   }
 
   @Test
+  void shouldMaskTheResolvedValueInToString() {
+    // given a resolved reference
+    authorizationsConfig.setEnabled(true);
+    grantReveal("camunda.secrets.token");
+    final var resolution =
+        services.resolve(List.of("camunda.secrets.token"), authentication).join();
+
+    // when the outcome is rendered, as a log statement or a test failure would render it
+    final var rendered = resolution.toString();
+
+    // then the value is masked, so printing the outcome anywhere cannot leak the secret. Mirrors
+    // the store SPI's SecretResolutionResult.Resolved, which masks for the same reason.
+    assertThat(rendered).doesNotContain("token-value").contains("***");
+    assertThat(rendered).contains("camunda.secrets.token");
+  }
+
+  @Test
   void shouldListOnlyAuthorizedReferences() {
     // given the caller is granted READ on one of the three references the store holds
     authorizationsConfig.setEnabled(true);

--- a/service/src/test/java/io/camunda/service/SecretServicesTest.java
+++ b/service/src/test/java/io/camunda/service/SecretServicesTest.java
@@ -10,15 +10,19 @@ package io.camunda.service;
 import static io.camunda.service.authorization.Authorizations.SECRET_READ_AUTHORIZATION;
 import static io.camunda.service.authorization.Authorizations.SECRET_REVEAL_AUTHORIZATION;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import io.camunda.secretstore.NoopSecretStore;
+import io.camunda.secretstore.InMemorySecretCache;
+import io.camunda.secretstore.SecretStore;
 import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.api.model.authz.AuthorizationScope;
@@ -26,28 +30,45 @@ import io.camunda.security.api.model.config.AuthorizationsConfiguration;
 import io.camunda.security.core.authz.AuthorizationChecker;
 import io.camunda.service.SecretServices.ResolvedSecret;
 import io.camunda.service.SecretServices.SecretErrorCode;
+import io.camunda.service.SecretTestSupport.TestSecretStore;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class SecretServicesTest {
 
   private static final String PHYSICAL_TENANT_ID = "testtenant";
+  private static final String STORE_ID = "main";
 
   private final AuthorizationChecker authorizationChecker = mock(AuthorizationChecker.class);
   private final AuthorizationsConfiguration authorizationsConfig =
       new AuthorizationsConfiguration();
   private final CamundaAuthentication authentication = mock(CamundaAuthentication.class);
 
+  private final TestSecretStore store = new TestSecretStore();
+  private final InMemorySecretCache cache = new InMemorySecretCache();
+  private final BrokerClient brokerClient = mock(BrokerClient.class);
+
   private SecretServices services;
 
   @BeforeEach
   void before() {
-    services = newSecretServices(PHYSICAL_TENANT_ID);
+    store.holds("token", "token-value");
+    store.holds("a", "a-value");
+    store.holds("b", "b-value");
+    services = newSecretServices(PHYSICAL_TENANT_ID, registryOf(store, cache));
+  }
+
+  private static SecretStoreRegistry registryOf(
+      final SecretStore store, final InMemorySecretCache cache) {
+    return new SecretStoreRegistry(Map.of(STORE_ID, store), Map.of(STORE_ID, cache));
   }
 
   private SecretServices newSecretServices(final String physicalTenantId) {
@@ -58,12 +79,12 @@ public class SecretServicesTest {
       final String physicalTenantId, final SecretStoreRegistry secretStoreRegistry) {
     return new SecretServices(
         physicalTenantId,
-        mock(BrokerClient.class),
+        brokerClient,
         mock(SecurityContextProvider.class),
         authorizationChecker,
         authorizationsConfig,
         secretStoreRegistry,
-        mock(ApiServicesExecutorProvider.class),
+        SecretTestSupport.sameThreadExecutorProvider(),
         null);
   }
 
@@ -106,12 +127,12 @@ public class SecretServicesTest {
   @Test
   void shouldExposeTheSecretStoreRegistryItWasConstructedWith() {
     // given the per-physical-tenant registry handed in by the dist wiring (#58784)
-    final var registry = new SecretStoreRegistry(Map.of("main", new NoopSecretStore()));
+    final var registry = registryOf(store, cache);
 
     // when
     final var services = newSecretServices(PHYSICAL_TENANT_ID, registry);
 
-    // then the same registry is exposed for the store-backed resolve/list (#58497)
+    // then the same registry is exposed, so the dist wiring can be asserted on it
     assertThat(services.getSecretStoreRegistry()).isSameAs(registry);
   }
 
@@ -136,11 +157,13 @@ public class SecretServicesTest {
     assertThat(resolution.errors()).isEmpty();
     // and the authorization query runs once for the whole batch, not once per distinct reference
     verify(authorizationChecker, times(1)).retrieveAuthorizedAuthorizationScopes(any(), any());
+    // and the store is asked once, for both distinct names together
+    assertThat(store.resolveCalls()).containsExactly(Set.of("a", "b"));
   }
 
   @Test
-  void shouldResolveAuthorizedReference() {
-    // given authorization passes for the reference
+  void shouldResolveAuthorizedReferenceFromTheStore() {
+    // given authorization passes for the reference and the store holds it
     authorizationsConfig.setEnabled(true);
     grantReveal("camunda.secrets.token");
 
@@ -148,45 +171,106 @@ public class SecretServicesTest {
     final var resolution =
         services.resolve(List.of("camunda.secrets.token"), authentication).join();
 
-    // then the (mocked) value is returned, scoped to this tenant
+    // then the store's value is returned
     assertThat(resolution.errors()).isEmpty();
     assertThat(resolution.resolved()).hasSize(1);
     assertThat(resolution.resolved().get(0).reference()).isEqualTo("camunda.secrets.token");
-    assertThat(resolution.resolved().get(0).value())
-        .isEqualTo("mock-value-for-token-in-tenant-" + PHYSICAL_TENANT_ID);
+    assertThat(resolution.resolved().get(0).value()).isEqualTo("token-value");
   }
 
   @Test
-  void shouldScopeMockedValuesByPhysicalTenant() {
-    // given two SecretServices instances scoped to different physical tenants, both authorized
+  void shouldStripTheReferencePrefixForTheStoreLookup() {
+    // given authorization passes for the reference
     authorizationsConfig.setEnabled(true);
     grantReveal("camunda.secrets.token");
-    final var otherTenantServices = newSecretServices("othertenant");
+
+    // when
+    services.resolve(List.of("camunda.secrets.token"), authentication).join();
+
+    // then the store is asked for the bare secret name it is keyed by, not the full reference
+    assertThat(store.resolveCalls()).containsExactly(Set.of("token"));
+  }
+
+  @Test
+  void shouldResolveFromTheStoreOfItsOwnPhysicalTenant() {
+    // given two SecretServices instances, each with its own physical tenant's store holding a
+    // different value for the same secret name
+    authorizationsConfig.setEnabled(true);
+    grantReveal("camunda.secrets.token");
+    final var otherStore = new TestSecretStore();
+    otherStore.holds("token", "other-tenant-token-value");
+    final var otherTenantServices =
+        newSecretServices("othertenant", registryOf(otherStore, new InMemorySecretCache()));
 
     // when the same reference is resolved under each tenant
-    final var value =
-        services
-            .resolve(List.of("camunda.secrets.token"), authentication)
-            .join()
-            .resolved()
-            .get(0)
-            .value();
-    final var otherValue =
-        otherTenantServices
-            .resolve(List.of("camunda.secrets.token"), authentication)
-            .join()
-            .resolved()
-            .get(0)
-            .value();
+    final var resolution =
+        services.resolve(List.of("camunda.secrets.token"), authentication).join();
+    final var otherResolution =
+        otherTenantServices.resolve(List.of("camunda.secrets.token"), authentication).join();
 
-    // then the resolved values differ per tenant — the mock never returns an identical value
-    // across tenants, which would otherwise mask a cross-tenant leak
-    assertThat(value).isNotEqualTo(otherValue);
+    // then each reads only its own tenant's store, so a cross-tenant read cannot go unnoticed
+    assertThat(resolution.resolved().get(0).value()).isEqualTo("token-value");
+    assertThat(otherResolution.resolved().get(0).value()).isEqualTo("other-tenant-token-value");
+    assertThat(store.resolveCalls()).containsExactly(Set.of("token"));
+    assertThat(otherStore.resolveCalls()).containsExactly(Set.of("token"));
+  }
+
+  @Test
+  void shouldServeCachedReferenceWithoutCallingTheStore() {
+    // given the value is already cached for the store
+    authorizationsConfig.setEnabled(true);
+    grantReveal("camunda.secrets.token");
+    cache.put("token", "cached-token-value");
+
+    // when
+    final var resolution =
+        services.resolve(List.of("camunda.secrets.token"), authentication).join();
+
+    // then the cached value is served and the store is never consulted
+    assertThat(resolution.resolved()).hasSize(1);
+    assertThat(resolution.resolved().get(0).value()).isEqualTo("cached-token-value");
+    assertThat(store.resolveCalls()).isEmpty();
+  }
+
+  @Test
+  void shouldCacheValueReadFromTheStore() {
+    // given authorization passes for the reference
+    authorizationsConfig.setEnabled(true);
+    grantReveal("camunda.secrets.token");
+
+    // when the same reference is resolved twice
+    services.resolve(List.of("camunda.secrets.token"), authentication).join();
+    final var second = services.resolve(List.of("camunda.secrets.token"), authentication).join();
+
+    // then the store was read once and the second resolve came from the cache
+    assertThat(store.resolveCalls()).containsExactly(Set.of("token"));
+    assertThat(second.resolved().get(0).value()).isEqualTo("token-value");
+    assertThat(cache.get("token")).contains("token-value");
+  }
+
+  @Test
+  void shouldOnlyAskTheStoreForUncachedReferences() {
+    // given one of two references is cached
+    authorizationsConfig.setEnabled(true);
+    grantReveal("camunda.secrets.a", "camunda.secrets.b");
+    cache.put("a", "cached-a-value");
+
+    // when both are resolved
+    final var resolution =
+        services.resolve(List.of("camunda.secrets.a", "camunda.secrets.b"), authentication).join();
+
+    // then only the cache miss reaches the store, and both references are still resolved
+    assertThat(store.resolveCalls()).containsExactly(Set.of("b"));
+    assertThat(resolution.errors()).isEmpty();
+    assertThat(resolution.resolved())
+        .extracting(ResolvedSecret::reference, ResolvedSecret::value)
+        .containsExactlyInAnyOrder(
+            tuple("camunda.secrets.a", "cached-a-value"), tuple("camunda.secrets.b", "b-value"));
   }
 
   @Test
   void shouldRouteUnknownReferenceToNotFound() {
-    // given authorization passes but the reference is not one the mock backend knows
+    // given authorization passes but the store does not hold the secret
     authorizationsConfig.setEnabled(true);
     grantReveal("camunda.secrets.unknown");
 
@@ -199,6 +283,188 @@ public class SecretServicesTest {
     assertThat(resolution.errors()).hasSize(1);
     assertThat(resolution.errors().get(0).reference()).isEqualTo("camunda.secrets.unknown");
     assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.NOT_FOUND);
+  }
+
+  @Test
+  void shouldReportReferenceMissingFromTheStoreResponseAsNotFound() {
+    // given a store that answers without an entry for the requested name
+    authorizationsConfig.setEnabled(true);
+    grantReveal("camunda.secrets.token");
+    store.omitsResults();
+
+    // when
+    final var resolution =
+        services.resolve(List.of("camunda.secrets.token"), authentication).join();
+
+    // then the reference is still described exactly once, as NOT_FOUND, rather than dropped from
+    // the response
+    assertThat(resolution.resolved()).isEmpty();
+    assertThat(resolution.errors()).hasSize(1);
+    assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.NOT_FOUND);
+  }
+
+  @Test
+  void shouldReportUnreadableStoreFailureWithoutFailingOthers() {
+    // given the store cannot read one of two secrets
+    authorizationsConfig.setEnabled(true);
+    grantRevealWildcard();
+    store.failsResolving(
+        "token", io.camunda.secretstore.SecretErrorCode.UNREADABLE, "cannot read the value");
+
+    // when
+    final var resolution =
+        services
+            .resolve(List.of("camunda.secrets.token", "camunda.secrets.a"), authentication)
+            .join();
+
+    // then only that reference fails, as UNREADABLE
+    assertThat(resolution.resolved())
+        .extracting(ResolvedSecret::reference)
+        .containsExactly("camunda.secrets.a");
+    assertThat(resolution.errors()).hasSize(1);
+    assertThat(resolution.errors().get(0).reference()).isEqualTo("camunda.secrets.token");
+    assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.UNREADABLE);
+  }
+
+  @Test
+  void shouldReportStoreAccessDenialAsUnreadable() {
+    // given the store rejects the cluster's own credentials for the secret
+    authorizationsConfig.setEnabled(true);
+    grantRevealWildcard();
+    store.failsResolving(
+        "token", io.camunda.secretstore.SecretErrorCode.ACCESS_DENIED, "denied by the store");
+
+    // when
+    final var resolution =
+        services.resolve(List.of("camunda.secrets.token"), authentication).join();
+
+    // then it is UNREADABLE, not ACCESS_DENIED: this API's ACCESS_DENIED always means the caller
+    // lacks SECRET:REVEAL, which is not what a store-side denial says
+    assertThat(resolution.errors()).hasSize(1);
+    assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.UNREADABLE);
+  }
+
+  @Test
+  void shouldReportStoreReferenceRejectionAsInvalidReference() {
+    // given the store rejects the name as invalid for its own key syntax
+    authorizationsConfig.setEnabled(true);
+    grantRevealWildcard();
+    store.failsResolving(
+        "token", io.camunda.secretstore.SecretErrorCode.INVALID_REF, "not a valid secret id");
+
+    // when
+    final var resolution =
+        services.resolve(List.of("camunda.secrets.token"), authentication).join();
+
+    // then
+    assertThat(resolution.errors()).hasSize(1);
+    assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.INVALID_REFERENCE);
+  }
+
+  @Test
+  void shouldNotExposeTheStoreFailureMessageInErrors() {
+    // given a store failure whose message carries store internals (a path, a secret id)
+    authorizationsConfig.setEnabled(true);
+    grantRevealWildcard();
+    store.failsResolving(
+        "token",
+        io.camunda.secretstore.SecretErrorCode.UNREADABLE,
+        "Failed to read /etc/camunda/secrets/token");
+
+    // when
+    final var resolution =
+        services.resolve(List.of("camunda.secrets.token"), authentication).join();
+
+    // then the reported message is the API's own, so the store's layout does not leak to the caller
+    assertThat(resolution.errors().get(0).message())
+        .doesNotContain("/etc/camunda/secrets")
+        .isEqualTo("The configured secret store could not read a value for the reference.");
+  }
+
+  @Test
+  void shouldNotCacheAFailedResolution() {
+    // given the store cannot read the secret
+    authorizationsConfig.setEnabled(true);
+    grantRevealWildcard();
+    store.failsResolving(
+        "token", io.camunda.secretstore.SecretErrorCode.UNREADABLE, "cannot read the value");
+
+    // when the reference is resolved twice
+    services.resolve(List.of("camunda.secrets.token"), authentication).join();
+    services.resolve(List.of("camunda.secrets.token"), authentication).join();
+
+    // then the store is asked again: a failure must not be cached, or a secret would stay
+    // unresolvable until the process restarts
+    assertThat(store.resolveCalls()).containsExactly(Set.of("token"), Set.of("token"));
+    assertThat(cache.get("token")).isEmpty();
+  }
+
+  @Test
+  void shouldFailResolveWhenTheStoreCannotBeRead() {
+    // given the store itself is unavailable
+    authorizationsConfig.setEnabled(true);
+    grantRevealWildcard();
+    store.isUnavailable();
+
+    // when
+    final var resolve = services.resolve(List.of("camunda.secrets.token"), authentication);
+
+    // then the request fails as unavailable rather than reporting the reference as missing, which a
+    // caller could not tell apart from a genuinely empty store
+    assertThatThrownBy(resolve::join)
+        .cause()
+        .isInstanceOf(ServiceException.class)
+        .extracting(error -> ((ServiceException) error).getStatus())
+        .isEqualTo(Status.UNAVAILABLE);
+  }
+
+  @Test
+  void shouldFailListWhenTheStoreCannotBeRead() {
+    // given the store itself is unavailable
+    authorizationsConfig.setEnabled(true);
+    grantReadWildcard();
+    store.isUnavailable();
+
+    // when
+    final var list = services.list(authentication);
+
+    // then the request fails as unavailable rather than looking like an empty tenant
+    assertThatThrownBy(list::join)
+        .cause()
+        .isInstanceOf(ServiceException.class)
+        .extracting(error -> ((ServiceException) error).getStatus())
+        .isEqualTo(Status.UNAVAILABLE);
+  }
+
+  @Test
+  void shouldReportNotFoundWhenNoStoreIsConfigured() {
+    // given a physical tenant without any configured store
+    authorizationsConfig.setEnabled(true);
+    grantRevealWildcard();
+    final var withoutStores = newSecretServices(PHYSICAL_TENANT_ID);
+
+    // when
+    final var resolution =
+        withoutStores.resolve(List.of("camunda.secrets.token"), authentication).join();
+
+    // then every reference is reported as not found
+    assertThat(resolution.resolved()).isEmpty();
+    assertThat(resolution.errors()).hasSize(1);
+    assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.NOT_FOUND);
+  }
+
+  @Test
+  void shouldListNothingWhenNoStoreIsConfigured() {
+    // given a physical tenant without any configured store
+    authorizationsConfig.setEnabled(true);
+    grantReadWildcard();
+    final var withoutStores = newSecretServices(PHYSICAL_TENANT_ID);
+
+    // when
+    final var references = withoutStores.list(authentication).join();
+
+    // then
+    assertThat(references).isEmpty();
   }
 
   @Test
@@ -220,11 +486,13 @@ public class SecretServicesTest {
     assertThat(resolution.errors()).hasSize(1);
     assertThat(resolution.errors().get(0).reference()).isEqualTo("camunda.secrets.denied");
     assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+    // and the store is only ever asked for the authorized reference
+    assertThat(store.resolveCalls()).containsExactly(Set.of("a"));
   }
 
   @Test
   void shouldReturnAccessDeniedForDeniedNonExistentReference() {
-    // given a reference the mock backend does not know AND the caller is not authorized for it
+    // given a reference the store does not hold AND the caller is not authorized for it
     authorizationsConfig.setEnabled(true);
     denyAllReveals();
 
@@ -238,7 +506,8 @@ public class SecretServicesTest {
     assertThat(resolution.resolved()).isEmpty();
     assertThat(resolution.errors()).hasSize(1);
     assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
-    // the lookup is never consulted for a denied reference
+    // the store is never consulted for a denied reference
+    assertThat(store.resolveCalls()).isEmpty();
     verify(authorizationChecker).retrieveAuthorizedAuthorizationScopes(any(), any());
   }
 
@@ -256,12 +525,12 @@ public class SecretServicesTest {
             .join();
 
     // then all are INVALID_REFERENCE and none is ever authorized (they must not reach the
-    // resource-id
-    // check or, later, a store lookup) — no authorization query is even issued for the batch
+    // resource-id check or a store lookup) — no authorization query is even issued for the batch
     assertThat(resolution.resolved()).isEmpty();
     assertThat(resolution.errors())
         .extracting(SecretServices.SecretResolutionError::code)
         .containsOnly(SecretErrorCode.INVALID_REFERENCE);
+    assertThat(store.resolveCalls()).isEmpty();
     verify(authorizationChecker, never()).retrieveAuthorizedAuthorizationScopes(any(), any());
   }
 
@@ -292,11 +561,12 @@ public class SecretServicesTest {
     // when
     final var resolution = services.resolve(List.of(reference), authentication).join();
 
-    // then the boundary is inclusive: NOT_FOUND (mock backend doesn't know it), not
-    // INVALID_REFERENCE
+    // then the boundary is inclusive: the store is asked and answers NOT_FOUND, rather than the
+    // reference being rejected as INVALID_REFERENCE
     assertThat(resolution.resolved()).isEmpty();
     assertThat(resolution.errors()).hasSize(1);
     assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.NOT_FOUND);
+    assertThat(store.resolveCalls()).hasSize(1);
   }
 
   private static String referenceOfLength(final int totalLength) {
@@ -339,7 +609,7 @@ public class SecretServicesTest {
   }
 
   @Test
-  void shouldNotEnumerateBackendWhenCallerHasNoReadGrant() {
+  void shouldNotEnumerateTheStoreWhenCallerHasNoReadGrant() {
     // given the caller holds no SECRET:READ grant at all (no wildcard, no ID scope)
     authorizationsConfig.setEnabled(true);
     denyAllReads();
@@ -347,10 +617,93 @@ public class SecretServicesTest {
     // when
     final var references = services.list(authentication).join();
 
-    // then nothing is listed — the empty-grant short-circuit skips the (mocked, but eventually
-    // tenant-wide and costly) backend enumeration entirely rather than enumerating then filtering
-    // everything out
+    // then nothing is listed and the store is never enumerated: that enumeration is a tenant-wide
+    // store call with real cost, so it is skipped for a result that would be filtered away anyway
     assertThat(references).isEmpty();
+    assertThat(store.listCalls()).isZero();
+  }
+
+  @Test
+  void shouldListReferencesFromTheStore() {
+    // given a wildcard read grant
+    authorizationsConfig.setEnabled(true);
+    grantReadWildcard();
+
+    // when
+    final var references = services.list(authentication).join();
+
+    // then every name the store holds is listed as a reference, in a stable sorted order
+    assertThat(references)
+        .containsExactly("camunda.secrets.a", "camunda.secrets.b", "camunda.secrets.token");
+  }
+
+  @Test
+  void shouldListFromTheStoreOfItsOwnPhysicalTenant() {
+    // given another physical tenant whose store holds a different secret
+    authorizationsConfig.setEnabled(true);
+    grantReadWildcard();
+    final var otherStore = new TestSecretStore().holds("othertenantsecret", "value");
+    final var otherTenantServices =
+        newSecretServices("othertenant", registryOf(otherStore, new InMemorySecretCache()));
+
+    // when each tenant lists its references
+    final var references = services.list(authentication).join();
+    final var otherReferences = otherTenantServices.list(authentication).join();
+
+    // then neither tenant sees the other's secrets
+    assertThat(references).doesNotContain("camunda.secrets.othertenantsecret");
+    assertThat(otherReferences).containsExactly("camunda.secrets.othertenantsecret");
+    assertThat(store.listCalls()).isOne();
+    assertThat(otherStore.listCalls()).isOne();
+  }
+
+  @Test
+  void shouldOmitStoreNamesThatCannotFormAReference() {
+    // given the store holds names outside the reference syntax, as a file or AWS store may
+    authorizationsConfig.setEnabled(true);
+    grantReadWildcard();
+    store.holds("tls.crt", "certificate");
+    store.holds("db-password", "password");
+    store.holds("ok_name", "value");
+
+    // when
+    final var references = services.list(authentication).join();
+
+    // then only the names that form a valid reference are offered: the others could neither be
+    // resolved nor written in a BPMN expression, so listing them would only mislead the caller
+    assertThat(references).contains("camunda.secrets.ok_name");
+    assertThat(references).doesNotContain("camunda.secrets.tls.crt", "camunda.secrets.db-password");
+  }
+
+  @Test
+  void shouldOmitStoreNameThatWouldExceedTheReferenceLengthCap() {
+    // given a name whose reference would be one character over the cap resolve() accepts
+    authorizationsConfig.setEnabled(true);
+    grantReadWildcard();
+    final var tooLong = referenceOfLength(SecretServices.MAX_REFERENCE_LENGTH + 1);
+    store.holds(tooLong.substring("camunda.secrets.".length()), "value");
+
+    // when
+    final var references = services.list(authentication).join();
+
+    // then it is omitted, so the listing only ever offers references resolve() accepts
+    assertThat(references).doesNotContain(tooLong);
+  }
+
+  @Test
+  void shouldNotListCachedNamesThatTheStoreDoesNotHold() {
+    // given a value that is cached but no longer held by the store
+    authorizationsConfig.setEnabled(true);
+    grantReadWildcard();
+    cache.put("ghost", "cached-value");
+
+    // when
+    final var references = services.list(authentication).join();
+
+    // then the listing polls the store only: the cache holds the values read so far, which is not
+    // the tenant's set of secrets
+    assertThat(references).doesNotContain("camunda.secrets.ghost");
+    assertThat(store.listCalls()).isOne();
   }
 
   @Test
@@ -426,9 +779,22 @@ public class SecretServicesTest {
   }
 
   @Test
-  // Covers the response-body facet of the no-leak AC only. The other facets (no secret value in
-  // logs, exported records, or persistence) are not observable while the backend is mocked and are
-  // deferred to the store wiring (#56561/#57199).
+  void shouldNotSendAnyBrokerRequestWhenResolvingOrListing() {
+    // given a caller authorized for everything
+    authorizationsConfig.setEnabled(true);
+    grantRevealWildcard();
+    grantReadWildcard();
+
+    // when both endpoints are served
+    services.resolve(List.of("camunda.secrets.token"), authentication).join();
+    services.list(authentication).join();
+
+    // then neither goes to the broker: a resolved value never enters a command, so it cannot reach
+    // the log stream, engine state or an exported record
+    verifyNoInteractions(brokerClient);
+  }
+
+  @Test
   void shouldNotExposeSecretValuesInErrorEntries() {
     // given a denied reference (no value should ever be produced for it)
     authorizationsConfig.setEnabled(true);
@@ -436,16 +802,16 @@ public class SecretServicesTest {
 
     // when
     final var resolution =
-        services.resolve(List.of("camunda.secrets.denied"), authentication).join();
+        services.resolve(List.of("camunda.secrets.token"), authentication).join();
 
     // then values only ever live in resolved entries; error entries carry metadata only
     assertThat(resolution.resolved()).isEmpty();
-    assertThat(resolution.errors().get(0).message()).doesNotContain("mock-value-for-");
+    assertThat(resolution.errors().get(0).message()).doesNotContain("token-value");
   }
 
   @Test
   void shouldListOnlyAuthorizedReferences() {
-    // given the caller is granted READ on one of the three known references
+    // given the caller is granted READ on one of the three references the store holds
     authorizationsConfig.setEnabled(true);
     grantRead("camunda.secrets.a");
 
@@ -467,7 +833,7 @@ public class SecretServicesTest {
     // when
     final var references = services.list(authentication).join();
 
-    // then every known reference is listed, in a stable sorted order
+    // then every reference the store holds is listed, in a stable sorted order
     assertThat(references)
         .containsExactly("camunda.secrets.a", "camunda.secrets.b", "camunda.secrets.token");
   }
@@ -481,7 +847,7 @@ public class SecretServicesTest {
     // when
     final var references = services.list(authentication).join();
 
-    // then nothing is listed, even though the backend knows references
+    // then nothing is listed, even though the store holds references
     assertThat(references).isEmpty();
   }
 
@@ -495,7 +861,7 @@ public class SecretServicesTest {
     // when
     final var references = services.list(authentication).join();
 
-    // then every known reference is listed and the checker (which cannot be trusted while
+    // then every reference the store holds is listed and the checker (which cannot be trusted while
     // disabled) is never consulted
     assertThat(references)
         .containsExactly("camunda.secrets.a", "camunda.secrets.b", "camunda.secrets.token");
@@ -505,7 +871,7 @@ public class SecretServicesTest {
 
   @Test
   void shouldNotAuthorizeListingWithRevealOnlyGrant() {
-    // given the caller holds SECRET:REVEAL on every known reference but no SECRET:READ
+    // given the caller holds SECRET:REVEAL on every reference the store holds but no SECRET:READ
     authorizationsConfig.setEnabled(true);
     grantReveal("camunda.secrets.a", "camunda.secrets.b", "camunda.secrets.token");
     denyAllReads();

--- a/service/src/test/java/io/camunda/service/SecretTestSupport.java
+++ b/service/src/test/java/io/camunda/service/SecretTestSupport.java
@@ -54,6 +54,9 @@ final class SecretTestSupport {
     private final Map<String, String> values = new LinkedHashMap<>();
     private final Map<String, SecretResolutionResult.Failed> failures = new HashMap<>();
     private final List<Set<String>> resolveCalls = new ArrayList<>();
+    // names this store lists but holds no value for, so a test can list one the SPI's nullness
+    // contract forbids
+    private final List<String> additionalListedNames = new ArrayList<>();
     private int listCalls;
     private boolean unavailable;
     private boolean omitResults;
@@ -74,12 +77,21 @@ final class SecretTestSupport {
     public List<String> list() {
       listCalls++;
       failIfUnavailable();
-      return List.copyOf(values.keySet());
+      final List<String> names = new ArrayList<>(values.keySet());
+      names.addAll(additionalListedNames);
+      return names;
     }
 
     TestSecretStore holds(final String name, final String value) {
       values.put(name, value);
       return this;
+    }
+
+    /**
+     * Makes the store list the given name without holding a value for it, {@code null} included.
+     */
+    void alsoLists(final String name) {
+      additionalListedNames.add(name);
     }
 
     void failsResolving(

--- a/service/src/test/java/io/camunda/service/SecretTestSupport.java
+++ b/service/src/test/java/io/camunda/service/SecretTestSupport.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.secretstore.SecretResolutionResult;
+import io.camunda.secretstore.SecretStore;
+import io.camunda.secretstore.SecretStoreUnavailableException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/** Shared doubles for the tests of {@link SecretServices}. */
+final class SecretTestSupport {
+
+  private static final ExecutorService SAME_THREAD_EXECUTOR = new SameThreadExecutorService();
+
+  private SecretTestSupport() {}
+
+  /**
+   * An executor provider that runs the store lookup on the calling thread, so the futures the
+   * service hands back are already complete when a test joins them.
+   *
+   * <p>Stubbed rather than real: a real provider wraps the executor in the physical-tenant
+   * propagating decorator, which needs Spring's web request context that this module's tests do not
+   * have on the classpath. Note {@link SecretServices} reads the executor while being constructed,
+   * so the stub has to be in place before then, which it is.
+   */
+  static ApiServicesExecutorProvider sameThreadExecutorProvider() {
+    final var executorProvider = mock(ApiServicesExecutorProvider.class);
+    when(executorProvider.getExecutor()).thenReturn(SAME_THREAD_EXECUTOR);
+    return executorProvider;
+  }
+
+  /**
+   * A map-backed {@link SecretStore} that records what it was asked for, so a test can assert that
+   * the cache spares the store and that only authorized, valid references ever reach it.
+   */
+  static final class TestSecretStore implements SecretStore {
+
+    private final Map<String, String> values = new LinkedHashMap<>();
+    private final Map<String, SecretResolutionResult.Failed> failures = new HashMap<>();
+    private final List<Set<String>> resolveCalls = new ArrayList<>();
+    private int listCalls;
+    private boolean unavailable;
+    private boolean omitResults;
+
+    @Override
+    public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
+      resolveCalls.add(Set.copyOf(names));
+      failIfUnavailable();
+      final Map<String, SecretResolutionResult> results = new LinkedHashMap<>();
+      if (omitResults) {
+        return results;
+      }
+      names.forEach(name -> results.put(name, resultFor(name)));
+      return results;
+    }
+
+    @Override
+    public List<String> list() {
+      listCalls++;
+      failIfUnavailable();
+      return List.copyOf(values.keySet());
+    }
+
+    TestSecretStore holds(final String name, final String value) {
+      values.put(name, value);
+      return this;
+    }
+
+    void failsResolving(
+        final String name,
+        final io.camunda.secretstore.SecretErrorCode code,
+        final String message) {
+      failures.put(name, new SecretResolutionResult.Failed(code, message, null));
+    }
+
+    /** Makes the store answer without an entry for the names it was asked for. */
+    void omitsResults() {
+      omitResults = true;
+    }
+
+    void isUnavailable() {
+      unavailable = true;
+    }
+
+    List<Set<String>> resolveCalls() {
+      return resolveCalls;
+    }
+
+    int listCalls() {
+      return listCalls;
+    }
+
+    private SecretResolutionResult resultFor(final String name) {
+      final var failure = failures.get(name);
+      if (failure != null) {
+        return failure;
+      }
+      final var value = values.get(name);
+      return value == null
+          ? new SecretResolutionResult.Failed(
+              io.camunda.secretstore.SecretErrorCode.NOT_FOUND, "No secret found: " + name, null)
+          : new SecretResolutionResult.Resolved(value);
+    }
+
+    private void failIfUnavailable() {
+      if (unavailable) {
+        throw new SecretStoreUnavailableException("the test store is unavailable");
+      }
+    }
+  }
+
+  private static final class SameThreadExecutorService extends AbstractExecutorService {
+
+    @Override
+    public void shutdown() {}
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      return List.of();
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return false;
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return false;
+    }
+
+    @Override
+    public boolean awaitTermination(final long timeout, final TimeUnit unit) {
+      return true;
+    }
+
+    @Override
+    public void execute(final Runnable command) {
+      command.run();
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
@@ -231,20 +231,8 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
           (ref, result) -> {
             switch (result) {
               case SecretResolutionResult.Resolved(final String value) -> {
-                if (cache == null) {
-                  // The registry guarantees a cache per store, so this is a broken invariant. Do
-                  // NOT write RESOLUTION_COMPLETE: completing without a cached value reactivates
-                  // the job, misses the cache on activation, and re-parks it in a loop. Fail
-                  // loudly, leave pending.
-                  LOG.error(
-                      "Secret store '{}' resolved '{}' but has no associated cache; leaving it"
-                          + " pending",
-                      storeId,
-                      ref);
-                } else {
-                  cache.put(ref, value);
-                  appendResolutionComplete(resultBuilder, storeId, ref);
-                }
+                cache.put(ref, value);
+                appendResolutionComplete(resultBuilder, storeId, ref);
               }
               case SecretResolutionResult.Failed(
                       final var code,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -210,8 +210,8 @@ final class SecretResolutionSchedulerTest {
   }
 
   @Test
-  void shouldNotCompleteWhenResolvedButStoreHasNoCache() throws Exception {
-    // given — store is configured but has no associated cache in the registry
+  void shouldCacheTheValueOfAStoreTheRegistryWasGivenNoCacheFor() throws Exception {
+    // given a registry built without a cache for the configured store
     final var registry = new SecretStoreRegistry(Map.of("my-store", secretStore), Map.of());
     final var localScheduler =
         new SecretResolutionScheduler(
@@ -224,8 +224,10 @@ final class SecretResolutionSchedulerTest {
     // when
     localScheduler.resolveSecrets(resultBuilder);
 
-    // then
-    verify(resultBuilder, never()).appendCommandRecord(any(), any());
+    // then the registry's own cache took the value and the reference completes: a configured store
+    // always has a cache, so resolving cannot strand a job by completing it uncached
+    assertThat(registry.getCaches().get("my-store").get("db-password")).contains("v");
+    verify(resultBuilder).appendCommandRecord(eq(SecretReferenceIntent.RESOLUTION_COMPLETE), any());
   }
 
   @Test

--- a/zeebe/gateway-protocol/src/main/proto/v2/secrets.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/secrets.yaml
@@ -168,11 +168,16 @@ components:
 
         - `NOT_FOUND`: no secret exists for the reference.
         - `ACCESS_DENIED`: the caller lacks `SECRET:REVEAL` on the reference.
-        - `INVALID_REFERENCE`: the reference is malformed.
+        - `INVALID_REFERENCE`: the reference is malformed, or the configured store rejected it as
+          an invalid secret identifier.
+        - `UNREADABLE`: the configured store could not return a value for the reference, for
+          example because it rejected the cluster's own store credentials or the stored value could
+          not be read. Whether the secret exists is not implied.
       enum:
         - NOT_FOUND
         - ACCESS_DENIED
         - INVALID_REFERENCE
+        - UNREADABLE
     SecretListRequest:
       type: object
       additionalProperties: false

--- a/zeebe/gateway-protocol/src/main/proto/v2/secrets.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/secrets.yaml
@@ -25,10 +25,11 @@ paths:
         one reference never fails the others. Only structurally invalid requests are rejected with
         HTTP 400: a missing or non-array `references` field, more than 20 references, or a null entry.
 
-        This endpoint is an alpha feature and may be subject to change in future releases.
+        References are resolved against the secret stores configured for the caller's physical
+        tenant, served from the gateway's secret cache when the value is already cached and read
+        from the store otherwise.
 
-        Phase 1: the secret backend is mocked. Only a fixed allow-list of references resolves;
-        every other authorized, valid reference returns `NOT_FOUND`.
+        This endpoint is an alpha feature and may be subject to change in future releases.
       requestBody:
         required: true
         content:
@@ -72,6 +73,11 @@ paths:
 
         Only references the caller holds `SECRET:READ` on are returned. This endpoint never
         returns secret values, only the reference names.
+
+        The references are read from the secret stores configured for the caller's physical tenant.
+        Secret names that cannot form a valid `camunda.secrets.<name>` reference (for example names
+        containing a dot or a dash) are omitted, since they could neither be resolved nor be used in
+        a BPMN expression.
 
         This endpoint is an alpha feature and may be subject to change in future releases.
       requestBody:
@@ -191,10 +197,9 @@ components:
       description: |
         The secret references the caller is authorized to see.
 
-        Unbounded for now: Phase 1's backend is mocked with at most 3 references. Pagination is
-        expected to land here before GA, once a real secret store can return a tenant's full
-        enumeration in one response. This is an alpha endpoint, so that is not yet a
-        breaking-contract concern.
+        Unbounded for now: the response carries the configured stores' full enumeration for the
+        physical tenant. Pagination is expected to land here before GA. This is an alpha endpoint,
+        so that is not yet a breaking-contract concern.
       properties:
         references:
           type: array

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -14,6 +14,7 @@ import io.camunda.application.commons.CommonsModuleConfiguration;
 import io.camunda.configuration.EngineJob;
 import io.camunda.configuration.NodeIdProvider.Type;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.Secrets.FileStore;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.beans.SearchEngineConnectProperties;
 import io.camunda.configuration.beans.SearchEngineIndexProperties;
@@ -32,7 +33,12 @@ import io.camunda.zeebe.qa.util.actuator.GatewayHealthActuator;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.util.FileUtil;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,6 +46,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.util.unit.DataSize;
 
@@ -51,8 +59,14 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
   public static final String DEFAULT_MAPPING_RULE_CLAIM_NAME = "client_id";
   public static final String DEFAULT_MAPPING_RULE_CLAIM_VALUE = "default";
   public static final String RECORDING_EXPORTER_ID = "recordingExporter";
+
+  // a physical tenant is capped at one configured secret store, so the ID only has to be stable
+  private static final String SECRET_STORE_ID = "test";
+  private static final Logger LOGGER = LoggerFactory.getLogger(TestStandaloneBroker.class);
+
   private boolean isGatewayEnabled = true;
   private final Map<String, Consumer<Map<String, Object>>> exporterMutators = new HashMap<>();
+  private Path secretStoreDirectory;
 
   public TestStandaloneBroker() {
     super(
@@ -235,6 +249,66 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
   /** Enables multi-tenancy in the security configuration. */
   public TestStandaloneBroker withMultiTenancyEnabled() {
     return withSecurityConfig(cfg -> cfg.getMultiTenancy().setChecksEnabled(true));
+  }
+
+  /**
+   * Configures a file-based secret store on a temporary directory and lets {@code secrets} write
+   * the store's content into it, one file per secret named after the secret:
+   *
+   * <pre>{@code
+   * new TestStandaloneBroker()
+   *     .withFileBasedSecretStore(
+   *         directory -> Files.writeString(directory.resolve("token"), "token-value"));
+   * }</pre>
+   *
+   * <p>The directory is written now, so its secrets are in place before the broker starts, and
+   * deleted when this broker is closed. A test that has to reach it later gets it from {@link
+   * #getFileBasedSecretStoreDirectory()}.
+   *
+   * @param secrets writes the store's secrets into the directory it is handed
+   * @return itself for chaining
+   */
+  public TestStandaloneBroker withFileBasedSecretStore(final SecretsWriter secrets) {
+    try {
+      secretStoreDirectory = Files.createTempDirectory("secret-store-");
+      secrets.writeTo(secretStoreDirectory);
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to write the file-based secret store", e);
+    }
+
+    final var store = new FileStore();
+    store.setPath(secretStoreDirectory.toString());
+    unifiedConfig.getSecrets().getStores().getFile().put(SECRET_STORE_ID, store);
+    return this;
+  }
+
+  /**
+   * Returns the directory backing the file-based secret store, or null if none was configured with
+   * {@link #withFileBasedSecretStore(SecretsWriter)}.
+   */
+  public Path getFileBasedSecretStoreDirectory() {
+    return secretStoreDirectory;
+  }
+
+  @Override
+  public void close() {
+    try {
+      super.close();
+    } finally {
+      deleteSecretStoreDirectory();
+    }
+  }
+
+  private void deleteSecretStoreDirectory() {
+    if (secretStoreDirectory == null) {
+      return;
+    }
+    try {
+      FileUtil.deleteFolderIfExists(secretStoreDirectory);
+    } catch (final IOException e) {
+      LOGGER.warn("Failed to delete the secret store directory {}", secretStoreDirectory, e);
+    }
+    secretStoreDirectory = null;
   }
 
   /**
@@ -528,5 +602,15 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     // enable schema creation as ES is used in the current tests
     withCreateSchema(true);
     return this;
+  }
+
+  /**
+   * Writes the content of a file-based secret store into the directory backing it. Declared with
+   * {@code throws IOException} so a test can call {@link Files} directly.
+   */
+  @FunctionalInterface
+  public interface SecretsWriter {
+
+    void writeTo(Path directory) throws IOException;
   }
 }


### PR DESCRIPTION
## Description

Replaces the mocked allow-list behind `POST /v2/secrets/resolve` and `POST /v2/secrets/list` with real reads of the physical tenant's secret stores, which the base PR made reachable from `SecretServices`.

- `resolve()` serves a reference from its store's cache and reads only the remaining ones from the store, in one batched call, caching every value it reads.
- `list()` always polls the stores. The caches only hold the values read so far, which is not the tenant's set of secrets.
- A store failure is reported per reference with a message of our own, because a store's own message carries its internals (AWS secret ids, on-disk paths). A store that cannot be read at all fails the request with 503 instead: reporting every reference as missing would be indistinguishable from a genuinely empty store.
- The store lookup runs on the API executor, since reading a file or calling AWS Secrets Manager is blocking I/O that must not hold the request thread. Validation and authorization stay on the calling thread, as before.

Two contract points that go beyond the issue text:

- **New `UNREADABLE` error code.** The store SPI reports `UNREADABLE` when it cannot return a value for a secret that is not simply absent. Without a counterpart the endpoint would have to answer `NOT_FOUND`, which claims the secret does not exist. A store's own `ACCESS_DENIED` maps to `UNREADABLE` as well, since this API's `ACCESS_DENIED` always means the caller lacks `SECRET:REVEAL`, not that the cluster's store credentials were rejected.
- **The listing omits store names that cannot form a `camunda.secrets.<name>` reference** (for example `tls.crt` or `db-password`, both valid for a file store). Such a name could not be resolved, written in a BPMN expression, or granted a permission, so listing it would only offer the caller something every other surface rejects. Dropped names are logged at debug level.

Notes on the issue's acceptance criteria, which predate the current code:

- "authorisation matched by the bare secret name" does not hold: grants are keyed by the full `camunda.secrets.<name>` reference, which is what a process author writes and what the API exposes. Tests pin that a grant on the bare name alone does not match.
- The open point about cache ownership versus #56569 is settled by #58886: the registry already carries one `InMemorySecretCache` per store, and this PR reads and writes those. #56569 remains for TTL, eviction and metrics.

`json-body-assertions/_generated/responses.json` still lacks `UNREADABLE`. That file is regenerated from `main` by the scheduled `c8-orchestration-cluster-responses-regenerate` workflow and must not be edited by hand, so it will pick the value up after this merges.

## Related

Stacked on #58886 (base branch `bcan/58784-wire-secret-store-gateway`), so please merge that one first.

## Closes

Closes #58497
