### PR TITLE
feat: wire Optimize logout for CSL server-side sessions

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/UIConfigurationService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/UIConfigurationService.java
@@ -65,6 +65,8 @@ public class UIConfigurationService {
   public UIConfigurationResponseDto getUIConfiguration() {
     final UIConfigurationResponseDto uiConfigurationDto = new UIConfigurationResponseDto();
     uiConfigurationDto.setLogoutHidden(configurationService.getUiConfiguration().isLogoutHidden());
+    uiConfigurationDto.setCslEnabled(
+        Boolean.parseBoolean(environment.getProperty("optimize.security.csl.enabled")));
     uiConfigurationDto.setEmailEnabled(configurationService.getEmailEnabled());
     uiConfigurationDto.setSharingEnabled(
         settingService.getSettings().getSharingEnabled().orElse(false));

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/uiconfiguration/UIConfigurationServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/uiconfiguration/UIConfigurationServiceTest.java
@@ -199,6 +199,33 @@ public class UIConfigurationServiceTest {
     assertThat(configurationResponse.getExpiresAt()).isEqualTo(null);
   }
 
+  @Test
+  public void testCslDisabledByDefault() {
+    // given
+    initializeMocks();
+    when(environment.getActiveProfiles()).thenReturn(new String[] {CCSM_PROFILE});
+
+    // when
+    final UIConfigurationResponseDto configurationResponse = underTest.getUIConfiguration();
+
+    // then
+    assertThat(configurationResponse.isCslEnabled()).isFalse();
+  }
+
+  @Test
+  public void testCslEnabledWhenFlagSet() {
+    // given
+    initializeMocks();
+    when(environment.getActiveProfiles()).thenReturn(new String[] {CCSM_PROFILE});
+    when(environment.getProperty("optimize.security.csl.enabled")).thenReturn("true");
+
+    // when
+    final UIConfigurationResponseDto configurationResponse = underTest.getUIConfiguration();
+
+    // then
+    assertThat(configurationResponse.isCslEnabled()).isTrue();
+  }
+
   private void initializeMocks() {
     when(identity.users()).thenReturn(identityUsers);
     when(identityUsers.isAvailable()).thenReturn(true);

--- a/optimize/client/src/components/Logout.js
+++ b/optimize/client/src/components/Logout.js
@@ -8,14 +8,54 @@
 
 import {useEffect} from 'react';
 import {withRouter} from 'react-router-dom';
-import {get} from 'request';
+import {get, post} from 'request';
 import {withErrorHandling} from 'HOC';
 import {addNotification} from 'notifications';
+import {isCslEnabled} from 'config';
 import {t} from 'translation';
 
 export function Logout({mightFail, history}) {
   useEffect(() => {
     (async () => {
+      if (await isCslEnabled()) {
+        // CSL mode (ADR-0038): log out via the CSL server-side logout endpoint (aligned with OC),
+        // which invalidates the session and triggers the IdP end-session. For fetch/XHR it responds
+        // 200 {"url": <IdP end-session URL>}, or 204 when the IdP has no end-session endpoint. We
+        // drive the top-level navigation ourselves, because a 302 from fetch cannot follow a
+        // cross-origin redirect. The URL is relative so it resolves under Optimize's servlet
+        // context path (e.g. /<clusterId> on CCSaaS), like every other request the SPA makes.
+        await mightFail(
+          post('logout'),
+          async (response) => {
+            // No success notification here: both branches below do a full top-level
+            // navigation, which discards the in-memory notification before it can render.
+            if (response.status === 200) {
+              // Navigate to the IdP end-session URL from the response body. Fall back to the
+              // app root if it is missing or the body is not parseable, so we never navigate
+              // to "<contextPath>/undefined" and the user still lands back in the login flow.
+              let url;
+              try {
+                ({url} = await response.json());
+              } catch {
+                url = undefined;
+              }
+              window.location.href = url || '.';
+              return;
+            }
+            // 204: no IdP end-session endpoint. Go to the app root (relative to the context
+            // path) so the webapp chain re-initiates login. We navigate to '.' rather than
+            // reload() because Optimize's HashRouter serves /logout as a route: a reload would
+            // remount this component and re-POST logout against an already-invalidated session.
+            window.location.href = '.';
+          },
+          () => {
+            addNotification({text: t('navigation.logoutFailed'), type: 'error'});
+            history.replace('/');
+          }
+        );
+        return;
+      }
+
       await mightFail(
         get('api/authentication/logout'),
         () => addNotification({text: t('navigation.logoutSuccess')}),

--- a/optimize/client/src/components/Logout.test.js
+++ b/optimize/client/src/components/Logout.test.js
@@ -11,43 +11,131 @@ import React, {runLastEffect} from 'react';
 import {shallow} from 'enzyme';
 
 import {Logout} from './Logout';
-import {get} from 'request';
+import {get, post} from 'request';
 import {addNotification} from 'notifications';
+import {isCslEnabled} from 'config';
 
-jest.mock('request', () => ({get: jest.fn()}));
+jest.mock('request', () => ({get: jest.fn(), post: jest.fn()}));
 jest.mock('notifications', () => ({addNotification: jest.fn()}));
+jest.mock('config', () => ({isCslEnabled: jest.fn()}));
 
 const props = {
   mightFail: jest.fn(),
   history: {replace: jest.fn()},
 };
 
-it('should logout from server', () => {
-  shallow(<Logout {...props} />);
-  runLastEffect();
+let originalLocation;
 
-  expect(get).toHaveBeenCalledWith('api/authentication/logout');
+beforeEach(() => {
+  jest.clearAllMocks();
+  isCslEnabled.mockResolvedValue(false);
+  originalLocation = window.location;
+  Object.defineProperty(window, 'location', {configurable: true, value: {href: ''}});
 });
 
-it('should redirect to the index page', async () => {
-  props.history.replace.mockClear();
-  shallow(<Logout {...props} mightFail={(_, cb) => cb()} />);
-  runLastEffect();
-
-  await flushPromises();
-
-  expect(props.history.replace).toHaveBeenCalledWith('/');
+afterEach(() => {
+  Object.defineProperty(window, 'location', {configurable: true, value: originalLocation});
 });
 
-it('should show an error if the logout fails', async () => {
-  props.history.replace.mockClear();
-  addNotification.mockClear();
-  shallow(<Logout {...props} mightFail={(_, _cb, fail) => fail()} />);
-  runLastEffect();
+describe('legacy logout (CSL disabled)', () => {
+  it('should logout from the server', async () => {
+    shallow(<Logout {...props} />);
+    runLastEffect();
 
-  await flushPromises();
+    await flushPromises();
 
-  expect(props.history.replace).toHaveBeenCalledWith('/');
-  expect(addNotification).toHaveBeenCalled();
-  expect(addNotification.mock.calls[0][0].type).toBe('error');
+    expect(get).toHaveBeenCalledWith('api/authentication/logout');
+  });
+
+  it('should redirect to the index page', async () => {
+    shallow(<Logout {...props} mightFail={(_, cb) => cb()} />);
+    runLastEffect();
+
+    await flushPromises();
+
+    expect(props.history.replace).toHaveBeenCalledWith('/');
+  });
+
+  it('should show an error and go to the index page if the logout fails', async () => {
+    shallow(<Logout {...props} mightFail={(_, _cb, fail) => fail()} />);
+    runLastEffect();
+
+    await flushPromises();
+
+    expect(props.history.replace).toHaveBeenCalledWith('/');
+    expect(addNotification).toHaveBeenCalled();
+    expect(addNotification.mock.calls[0][0].type).toBe('error');
+  });
+});
+
+describe('CSL logout (CSL enabled)', () => {
+  beforeEach(() => {
+    isCslEnabled.mockResolvedValue(true);
+  });
+
+  it('should logout via the CSL /logout endpoint', async () => {
+    shallow(<Logout {...props} />);
+    runLastEffect();
+
+    await flushPromises();
+
+    expect(post).toHaveBeenCalledWith('logout');
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('should navigate to the IdP end-session url on a 200 response', async () => {
+    const response = {status: 200, json: async () => ({url: 'http://idp/end-session'})};
+    shallow(<Logout {...props} mightFail={(_, cb) => cb(response)} />);
+    runLastEffect();
+
+    await flushPromises();
+
+    expect(window.location.href).toBe('http://idp/end-session');
+  });
+
+  it('should fall back to the app root on a 200 response without a url', async () => {
+    const response = {status: 200, json: async () => ({})};
+    shallow(<Logout {...props} mightFail={(_, cb) => cb(response)} />);
+    runLastEffect();
+
+    await flushPromises();
+
+    expect(window.location.href).toBe('.');
+  });
+
+  it('should fall back to the app root on a 200 response with an unparseable body', async () => {
+    const response = {
+      status: 200,
+      json: async () => {
+        throw new Error('not json');
+      },
+    };
+    shallow(<Logout {...props} mightFail={(_, cb) => cb(response)} />);
+    runLastEffect();
+
+    await flushPromises();
+
+    expect(window.location.href).toBe('.');
+  });
+
+  it('should navigate to the app root on a 204 response', async () => {
+    const response = {status: 204};
+    shallow(<Logout {...props} mightFail={(_, cb) => cb(response)} />);
+    runLastEffect();
+
+    await flushPromises();
+
+    expect(window.location.href).toBe('.');
+  });
+
+  it('should show an error and go to the index page if the logout fails', async () => {
+    shallow(<Logout {...props} mightFail={(_, _cb, fail) => fail()} />);
+    runLastEffect();
+
+    await flushPromises();
+
+    expect(props.history.replace).toHaveBeenCalledWith('/');
+    expect(addNotification).toHaveBeenCalled();
+    expect(addNotification.mock.calls[0][0].type).toBe('error');
+  });
 });

--- a/optimize/client/src/modules/config.tsx
+++ b/optimize/client/src/modules/config.tsx
@@ -45,6 +45,7 @@ export type UiConfig = {
   webappsLinks: WebappLinks;
   mixpanel: MixpanelConfig;
   logoutHidden: boolean;
+  cslEnabled: boolean;
   exportCsvLimit: number;
   maxNumDataSourcesForReport: number;
   onboarding: Onboarding;
@@ -117,6 +118,7 @@ export const getMixpanelConfig = createAccessorFunction<MixpanelConfig>('mixpane
 export const getOptimizeProfile =
   createAccessorFunction<UiConfig['optimizeProfile']>('optimizeProfile');
 export const isLogoutHidden = createAccessorFunction<boolean>('logoutHidden');
+export const isCslEnabled = createAccessorFunction<boolean>('cslEnabled');
 export const getExportCsvLimit = createAccessorFunction<number>('exportCsvLimit');
 export const getMaxNumDataSourcesForReport = createAccessorFunction<number>(
   'maxNumDataSourcesForReport'

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/ui_configuration/UIConfigurationResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/ui_configuration/UIConfigurationResponseDto.java
@@ -26,6 +26,7 @@ public class UIConfigurationResponseDto {
   private Map<AppName, String> webappsLinks; // links for the app switcher
   private String notificationsUrl;
   private boolean logoutHidden;
+  private boolean cslEnabled;
   private int maxNumDataSourcesForReport;
   private Integer exportCsvLimit;
   private DatabaseType optimizeDatabase;
@@ -177,6 +178,18 @@ public class UIConfigurationResponseDto {
     this.logoutHidden = logoutHidden;
   }
 
+  /**
+   * Whether Optimize runs with the CSL security stack ({@code optimize.security.csl.enabled}). The
+   * SPA reads this to drive the CSL server-side logout flow instead of the legacy cookie logout.
+   */
+  public boolean isCslEnabled() {
+    return cslEnabled;
+  }
+
+  public void setCslEnabled(final boolean cslEnabled) {
+    this.cslEnabled = cslEnabled;
+  }
+
   public int getMaxNumDataSourcesForReport() {
     return maxNumDataSourcesForReport;
   }
@@ -257,6 +270,7 @@ public class UIConfigurationResponseDto {
   public int hashCode() {
     return Objects.hash(
         logoutHidden,
+        cslEnabled,
         maxNumDataSourcesForReport,
         userTaskAssigneeAnalyticsEnabled,
         emailEnabled,
@@ -283,6 +297,7 @@ public class UIConfigurationResponseDto {
     }
     final UIConfigurationResponseDto that = (UIConfigurationResponseDto) o;
     return logoutHidden == that.logoutHidden
+        && cslEnabled == that.cslEnabled
         && maxNumDataSourcesForReport == that.maxNumDataSourcesForReport
         && userTaskAssigneeAnalyticsEnabled == that.userTaskAssigneeAnalyticsEnabled
         && emailEnabled == that.emailEnabled
@@ -323,6 +338,8 @@ public class UIConfigurationResponseDto {
         + getNotificationsUrl()
         + ", logoutHidden="
         + isLogoutHidden()
+        + ", cslEnabled="
+        + isCslEnabled()
         + ", maxNumDataSourcesForReport="
         + getMaxNumDataSourcesForReport()
         + ", exportCsvLimit="


### PR DESCRIPTION
## Description

Wires logout for Optimize's CSL mode (ADR-0038, epic #58403, task 1.6), behind
the default-off `optimize.security.csl.enabled` flag. No change when off.

Under CSL's server-side sessions the legacy `GET /api/authentication/logout`
neither invalidates the session nor ends the IdP session (and is unsupported on
CCSaaS). This drives logout through CSL's `POST /logout` instead, which does
both. That endpoint comes from the CSL webapp chain; this PR is the host wiring.

## Changes

- **`Logout.js`**: in CSL mode `POST logout` and follow the `200 {url}` IdP
  end-session response, falling back to the app root if `url` is missing or the
  body is unparseable (`204` also goes to the app root). Legacy `GET` path
  unchanged when off. URLs are relative so they resolve under the servlet
  context path.
- **`UIConfigurationResponseDto` / `UIConfigurationService` / `config.tsx`**:
  expose `cslEnabled` so the SPA selects the logout flow.
- Tests: `Logout.test.js`, `UIConfigurationServiceTest`.

## Acceptance criteria

- [x] Logout invalidates the CSL session and returns to login. Wiring done;
  `/logout` passthrough landed in #58858; ES session-doc removal is #58471.
- [x] IdP end-session triggered where supported.
- [x] Legacy logout unchanged when the flag is off.
- [x] Frontend `Logout` test updated for the CSL flow.

## Notes for reviewers

- CSL current-user resolution (`SessionService`) is handled on main by #58982,
  so it is intentionally not part of this PR.
- Needs #58471 (session store) and #58475/#58883 (frontend `X-CSRF-TOKEN`) for
  the full end-to-end cluster flow. Complementary, no file overlap.
- Frontend changes are in `optimize/client/` (not shared `webapp/client/`);
  flagged for FE review.

Closes #58474