### PR TITLE
feat: use per physical tenant cluster configuration for topology and routing in gateway

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
+++ b/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
@@ -103,7 +103,8 @@ public class DynamicClusterServices {
       final BrokerTopologyManager brokerTopologyManager) {
     return new ClusterConfigurationManagementRequestSender(
         clusterCommunicationService,
-        ClusterConfigurationCoordinatorSupplier.of(brokerTopologyManager::getClusterConfiguration),
+        ClusterConfigurationCoordinatorSupplier.from(
+            brokerTopologyManager::getClusterConfiguration),
         new ProtoBufSerializer());
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
@@ -21,7 +21,7 @@ import io.camunda.application.commons.hub.ping.M2MTokenProvider;
 import io.camunda.service.ManagementServices;
 import io.camunda.service.license.LicenseType;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.util.retry.RetryConfiguration;
 import java.io.IOException;
 import java.net.URI;
@@ -49,8 +49,8 @@ class PingConsoleConfigurationTest {
   private static final ApplicationContext APPLICATION_CONTEXT = mock(ApplicationContext.class);
   private static final BrokerTopologyManager BROKER_TOPOLOGY_MANAGER =
       mock(BrokerTopologyManager.class);
-  private static final ClusterConfiguration BROKER_CLUSTER_CONFIGURATION =
-      mock(ClusterConfiguration.class);
+  private static final CurrentClusterConfiguration BROKER_CLUSTER_CONFIGURATION =
+      mock(CurrentClusterConfiguration.class);
   private static final M2MCredentials VALID_CREDENTIALS =
       new M2MCredentials(
           URI.create("http://auth-server.com/token"), "test-client-id", "test-client-secret", null);

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
@@ -26,7 +26,7 @@ import io.camunda.application.commons.hub.ping.M2MCredentials;
 import io.camunda.service.ManagementServices;
 import io.camunda.service.license.LicenseType;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.retry.RetryConfiguration;
 import java.net.URI;
@@ -44,8 +44,8 @@ public class PingConsoleRunnerIT {
 
   private static final BrokerTopologyManager BROKER_TOPOLOGY_MANAGER =
       mock(BrokerTopologyManager.class);
-  private static final ClusterConfiguration BROKER_CLUSTER_CONFIGURATION =
-      mock(ClusterConfiguration.class);
+  private static final CurrentClusterConfiguration BROKER_CLUSTER_CONFIGURATION =
+      mock(CurrentClusterConfiguration.class);
   private ApplicationContext applicationContext;
   private WireMockServer wireMockServer;
   private ManagementServices managementServices;

--- a/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubConfigurationTest.java
@@ -19,7 +19,7 @@ import io.camunda.application.commons.hub.ping.PingHubRunner.HubPingConfiguratio
 import io.camunda.service.ManagementServices;
 import io.camunda.service.license.LicenseType;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.util.retry.RetryConfiguration;
 import java.io.IOException;
 import java.net.URI;
@@ -50,8 +50,8 @@ class PingHubConfigurationTest {
   private static final ApplicationContext APPLICATION_CONTEXT = mock(ApplicationContext.class);
   private static final BrokerTopologyManager BROKER_TOPOLOGY_MANAGER =
       mock(BrokerTopologyManager.class);
-  private static final ClusterConfiguration BROKER_CLUSTER_CONFIGURATION =
-      mock(ClusterConfiguration.class);
+  private static final CurrentClusterConfiguration BROKER_CLUSTER_CONFIGURATION =
+      mock(CurrentClusterConfiguration.class);
   private static final M2MCredentials VALID_CREDENTIALS =
       new M2MCredentials(
           URI.create("http://auth-server.com/token"), "test-client-id", "test-client-secret", null);

--- a/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubRunnerIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubRunnerIT.java
@@ -25,7 +25,7 @@ import io.camunda.application.commons.hub.ping.PingHubRunner.HubPingConfiguratio
 import io.camunda.service.ManagementServices;
 import io.camunda.service.license.LicenseType;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.retry.RetryConfiguration;
 import java.net.URI;
@@ -44,8 +44,8 @@ public class PingHubRunnerIT {
 
   private static final BrokerTopologyManager BROKER_TOPOLOGY_MANAGER =
       mock(BrokerTopologyManager.class);
-  private static final ClusterConfiguration BROKER_CLUSTER_CONFIGURATION =
-      mock(ClusterConfiguration.class);
+  private static final CurrentClusterConfiguration BROKER_CLUSTER_CONFIGURATION =
+      mock(CurrentClusterConfiguration.class);
   private ApplicationContext applicationContext;
   private WireMockServer wireMockServer;
   private ManagementServices managementServices;

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClientTopologyMetrics.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClientTopologyMetrics.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.client.api;
 import static io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.PARTITION_ROLE;
 
 import io.atomix.cluster.BrokerMemberId;
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.PartitionRoleValues;
 import io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.TopologyKeyNames;
 import io.camunda.zeebe.util.collection.Table;
@@ -26,7 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public final class BrokerClientTopologyMetrics {
 
   private final MeterRegistry registry;
-  private final Table<Integer, BrokerMemberId, AtomicInteger> brokerTopologyRole;
+  private final Table<PartitionId, BrokerMemberId, AtomicInteger> brokerTopologyRole;
 
   public BrokerClientTopologyMetrics(final MeterRegistry registry) {
     this.registry = Objects.requireNonNull(registry, "must specify a meter registry");
@@ -38,18 +39,21 @@ public final class BrokerClientTopologyMetrics {
    * {@code partitionId}
    */
   public void setRoleForPartition(
-      final int partitionId, final BrokerMemberId brokerId, final PartitionRoleValues roleValue) {
+      final PartitionId partitionId,
+      final BrokerMemberId brokerId,
+      final PartitionRoleValues roleValue) {
     brokerTopologyRole
         .computeIfAbsent(partitionId, brokerId, this::registerBrokerTopologyRole)
         .set(roleValue.value());
   }
 
   private AtomicInteger registerBrokerTopologyRole(
-      final int partitionId, final BrokerMemberId brokerId) {
+      final PartitionId partitionId, final BrokerMemberId brokerId) {
     final var role = new AtomicInteger();
     Gauge.builder(PARTITION_ROLE.getName(), role, Number::intValue)
         .description(PARTITION_ROLE.getDescription())
-        .tag(PartitionKeyNames.PARTITION.asString(), String.valueOf(partitionId))
+        .tag(PartitionKeyNames.PHYSICAL_TENANT.asString(), partitionId.group())
+        .tag(PartitionKeyNames.PARTITION.asString(), String.valueOf(partitionId.number()))
         .tag(TopologyKeyNames.BROKER.asString(), brokerId.id())
         .register(registry);
     return role;

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.broker.client.api;
 import io.atomix.cluster.BrokerMemberId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationUpdateNotifier.ClusterConfigurationUpdateListener;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import org.jspecify.annotations.NonNull;
 
 public interface BrokerTopologyManager extends ClusterConfigurationUpdateListener {
@@ -34,7 +34,7 @@ public interface BrokerTopologyManager extends ClusterConfigurationUpdateListene
    * are part of the cluster, and the partition distribution. Unlike {@link BrokerClusterState} this
    * also includes information about brokers which are currently unreachable.
    */
-  ClusterConfiguration getClusterConfiguration();
+  CurrentClusterConfiguration getClusterConfiguration();
 
   /**
    * Adds the topology listener. For each existing broker-group pair, the listener will be notified

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerAddressProvider.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerAddressProvider.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.client.impl;
 
 import io.atomix.cluster.BrokerMemberId;
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.dynamic.config.state.Mode;
@@ -66,18 +67,16 @@ final class BrokerAddressProvider implements Supplier<@Nullable String> {
    * when no leader is elected. Only requests understood by the recovery-mode API should use this.
    */
   static BrokerAddressProvider leaderOrAnyRecovery(
-      final BrokerTopologyManager topologyManager,
-      final String partitionGroup,
-      final int partitionId) {
+      final BrokerTopologyManager topologyManager, final PartitionId partitionId) {
     return new BrokerAddressProvider(
         topologyManager,
-        partitionGroup,
+        partitionId.group(),
         state -> {
-          final var leader = state.getLeaderForPartition(partitionId);
+          final var leader = state.getLeaderForPartition(partitionId.number());
           if (leader != null) {
             return leader;
           }
-          return findRecoveringNode(topologyManager, state, partitionId, partitionGroup);
+          return findRecoveringNode(topologyManager, state, partitionId);
         });
   }
 
@@ -100,14 +99,13 @@ final class BrokerAddressProvider implements Supplier<@Nullable String> {
   private static @Nullable BrokerMemberId findRecoveringNode(
       final BrokerTopologyManager topologyManager,
       final BrokerClusterState topology,
-      final int partitionId,
-      final String partitionGroup) {
+      final PartitionId partitionId) {
     final var clusterConfiguration = topologyManager.getClusterConfiguration();
-    return topology.getInactiveNodesForPartition(partitionId).stream()
+    return topology.getInactiveNodesForPartition(partitionId.number()).stream()
         .filter(
             node -> {
               final var partitionGroupConfiguration =
-                  clusterConfiguration.partitionGroups().get(partitionGroup);
+                  clusterConfiguration.partitionGroups().get(partitionId.group());
               if (partitionGroupConfiguration == null) {
                 return false;
               }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerAddressProvider.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerAddressProvider.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.broker.client.impl;
 import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
-import io.camunda.zeebe.dynamic.config.state.MemberState.State;
+import io.camunda.zeebe.dynamic.config.state.Mode;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.jspecify.annotations.NullMarked;
@@ -77,7 +77,7 @@ final class BrokerAddressProvider implements Supplier<@Nullable String> {
           if (leader != null) {
             return leader;
           }
-          return findRecoveringNode(topologyManager, state, partitionId);
+          return findRecoveringNode(topologyManager, state, partitionId, partitionGroup);
         });
   }
 
@@ -100,13 +100,19 @@ final class BrokerAddressProvider implements Supplier<@Nullable String> {
   private static @Nullable BrokerMemberId findRecoveringNode(
       final BrokerTopologyManager topologyManager,
       final BrokerClusterState topology,
-      final int partitionId) {
+      final int partitionId,
+      final String partitionGroup) {
     final var clusterConfiguration = topologyManager.getClusterConfiguration();
     return topology.getInactiveNodesForPartition(partitionId).stream()
         .filter(
             node -> {
-              final var member = clusterConfiguration.getMember(node.memberId());
-              return member != null && member.state() == State.RECOVERING;
+              final var partitionGroupConfiguration =
+                  clusterConfiguration.partitionGroups().get(partitionGroup);
+              if (partitionGroupConfiguration == null) {
+                return false;
+              }
+              final var member = partitionGroupConfiguration.getMember(node.memberId());
+              return member != null && member.mode() == Mode.RECOVERING;
             })
         .findFirst()
         .orElse(null);

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.client.impl;
 
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.AdditionalErrorCodes;
 import io.camunda.zeebe.broker.client.api.BrokerClientRequestMetrics;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
@@ -221,7 +222,7 @@ final class BrokerRequestManager extends Actor {
       throwIfPartitionInactive(partitionGroup, request.getPartitionId());
       if (request.shouldRouteToRecovery()) {
         return BrokerAddressProvider.leaderOrAnyRecovery(
-            topologyManager, partitionGroup, request.getPartitionId());
+            topologyManager, new PartitionId(partitionGroup, request.getPartitionId()));
       }
       return BrokerAddressProvider.leader(
           topologyManager, partitionGroup, request.getPartitionId());

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.broker.client.api.PartitionNotFoundException;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
-import io.camunda.zeebe.dynamic.config.state.MemberState.State;
+import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
@@ -266,8 +266,13 @@ final class BrokerRequestManager extends Actor {
         inactiveNodes.stream()
             .anyMatch(
                 node -> {
-                  final var member = clusterConfiguration.getMember(node.memberId());
-                  return member != null && member.state() == State.RECOVERING;
+                  final var partitionGroupConfiguration =
+                      clusterConfiguration.partitionGroup(partitionGroup);
+                  if (partitionGroupConfiguration == null) {
+                    return false;
+                  }
+                  final var member = partitionGroupConfiguration.members().get(node.memberId());
+                  return member != null && member.mode() == Mode.RECOVERING;
                 });
 
     if (someNodesInactive && leaderNode == null && !nodeInRecovery) {

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -12,6 +12,7 @@ import io.atomix.cluster.ClusterMembershipEvent;
 import io.atomix.cluster.ClusterMembershipEvent.Type;
 import io.atomix.cluster.ClusterMembershipEventListener;
 import io.atomix.cluster.Member;
+import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.PartitionRoleValues;
 import io.camunda.zeebe.broker.client.api.BrokerClientTopologyMetrics;
@@ -19,8 +20,11 @@ import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.impl.BrokerClientTopologyImpl.ConfiguredClusterState;
+import io.camunda.zeebe.dynamic.config.ClusterConfigurationManagerService;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationUpdateNotifier.ClusterConfigurationUpdateListener;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.Actor;
@@ -30,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +54,8 @@ public final class BrokerTopologyManagerImpl extends Actor
   // Immutable snapshot replaced atomically; keyed by partition group name.
   private volatile Map<String, BrokerClientTopologyImpl> topologyPerGroup = Map.of();
 
-  private volatile ClusterConfiguration clusterConfiguration = ClusterConfiguration.uninitialized();
+  private volatile CurrentClusterConfiguration clusterConfiguration =
+      CurrentClusterConfiguration.uninitialized();
   private final Supplier<Set<Member>> membersSupplier;
   private final BrokerClientTopologyMetrics topologyMetrics;
 
@@ -70,7 +76,7 @@ public final class BrokerTopologyManagerImpl extends Actor
   }
 
   @Override
-  public ClusterConfiguration getClusterConfiguration() {
+  public CurrentClusterConfiguration getClusterConfiguration() {
     return clusterConfiguration;
   }
 
@@ -167,9 +173,7 @@ public final class BrokerTopologyManagerImpl extends Actor
     topologyPerGroup = Map.copyOf(updated);
 
     // temp: only update metrics for default group until we support group-specific metrics
-    if (PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
-      updateMetrics(newGroupTopology);
-    }
+    updateMetrics(physicalTenantId, newGroupTopology);
   }
 
   private ConfiguredClusterState currentConfiguredState() {
@@ -215,13 +219,14 @@ public final class BrokerTopologyManagerImpl extends Actor
     }
   }
 
-  private void updateMetrics(final BrokerClusterState topology) {
+  private void updateMetrics(final String partitionGroup, final BrokerClusterState topology) {
     final var partitions = topology.getPartitions();
     partitions.forEach(
         partition -> {
           final var leader = topology.getLeaderForPartition(partition);
           if (leader != null) {
-            topologyMetrics.setRoleForPartition(partition, leader, PartitionRoleValues.LEADER);
+            topologyMetrics.setRoleForPartition(
+                new PartitionId(partitionGroup, partition), leader, PartitionRoleValues.LEADER);
           }
 
           final var followers = topology.getFollowersForPartition(partition);
@@ -229,7 +234,9 @@ public final class BrokerTopologyManagerImpl extends Actor
             followers.forEach(
                 broker ->
                     topologyMetrics.setRoleForPartition(
-                        partition, broker, PartitionRoleValues.FOLLOWER));
+                        new PartitionId(partitionGroup, partition),
+                        broker,
+                        PartitionRoleValues.FOLLOWER));
           }
         });
   }
@@ -239,51 +246,70 @@ public final class BrokerTopologyManagerImpl extends Actor
     if (clusterTopology.isUninitialized()) {
       return;
     }
-    clusterConfiguration = clusterTopology;
-    actor.run(() -> applyClusterConfiguration(clusterTopology));
+    onClusterConfigurationUpdated(CurrentClusterConfiguration.fromLegacy(clusterTopology));
   }
 
-  private void applyClusterConfiguration(final ClusterConfiguration clusterTopology) {
-    // Run the full comparison + listener-notification logic against the default group once.
-    final var oldDefault =
-        topologyPerGroup.getOrDefault(
-            PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, BrokerClientTopologyImpl.uninitialized());
-    final var updatedDefault = updateConfiguredClusterState(clusterTopology, oldDefault);
-    final var newConfiguredState = updatedDefault.configuredClusterState();
+  @Override
+  public void onClusterConfigurationUpdated(
+      final CurrentClusterConfiguration clusterConfiguration) {
+    if (clusterConfiguration.isUninitialized()) {
+      return;
+    }
+    this.clusterConfiguration = clusterConfiguration;
+    actor.run(() -> applyClusterConfiguration(clusterConfiguration));
+  }
 
-    final Map<String, BrokerClientTopologyImpl> allGroups = new HashMap<>(topologyPerGroup);
-    allGroups.put(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, updatedDefault);
+  private void applyClusterConfiguration(final CurrentClusterConfiguration clusterConfiguration) {
+    // For each known group, update the configured cluster state and notify listeners if anything
+    // changed. The default group is always updated, even if no broker has joined it yet, since the
+    // cluster configuration can be gossiped before the local membership events for that group are
+    // observed.
+    final Set<String> groupIds = new HashSet<>(memberPropertiesPerGroup.keySet());
+    groupIds.add(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
 
-    // temp: apply the same configured state to all other known groups. This must be revisited when
-    // we add support for group-specific cluster configurations.
-    memberPropertiesPerGroup.keySet().stream()
-        .filter(
-            physicalTenantId ->
-                !physicalTenantId.equals(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
-        .forEach(
-            physicalTenantId -> {
-              final var oldGroup =
-                  topologyPerGroup.getOrDefault(
-                      physicalTenantId, BrokerClientTopologyImpl.uninitialized());
-              allGroups.put(
-                  physicalTenantId,
-                  new BrokerClientTopologyImpl(oldGroup.liveClusterState(), newConfiguredState));
-            });
-
-    topologyPerGroup = Map.copyOf(allGroups);
-    updateMetrics(updatedDefault);
+    final var allGroups =
+        groupIds.stream()
+            .collect(
+                Collectors.toMap(
+                    physicalTenantId -> physicalTenantId,
+                    physicalTenantId -> {
+                      final var oldGroup =
+                          topologyPerGroup.getOrDefault(
+                              physicalTenantId, BrokerClientTopologyImpl.uninitialized());
+                      final var updated =
+                          updateConfiguredClusterState(
+                              physicalTenantId, clusterConfiguration, oldGroup);
+                      updateMetrics(physicalTenantId, updated);
+                      return updated;
+                    }));
+    final Map<String, BrokerClientTopologyImpl> updatedTopologyPerGroup =
+        new HashMap<>(topologyPerGroup);
+    updatedTopologyPerGroup.putAll(allGroups);
+    topologyPerGroup = Map.copyOf(updatedTopologyPerGroup);
   }
 
   private BrokerClientTopologyImpl updateConfiguredClusterState(
-      final ClusterConfiguration clusterTopology, final BrokerClientTopologyImpl oldTopology) {
+      final String groupId,
+      final CurrentClusterConfiguration clusterTopology,
+      final BrokerClientTopologyImpl oldTopology) {
     final var newClusterSize = clusterTopology.clusterSize();
-    final var newPartitionsCount = clusterTopology.partitionCount();
-    final var newReplicationFactor = clusterTopology.minReplicationFactor();
+    final PartitionGroupConfiguration partitionGroupConfiguration =
+        ClusterConfigurationManagerService.USE_NEW_CONFIG
+            ? clusterTopology.partitionGroup(groupId)
+            : clusterTopology.partitionGroup(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    if (partitionGroupConfiguration == null) {
+      LOG.warn("No partition group configuration found for group {}, skipping update", groupId);
+      return oldTopology;
+    }
+
+    final var newPartitionsCount = partitionGroupConfiguration.partitionCount();
+    final var newReplicationFactor = partitionGroupConfiguration.minReplicationFactor();
     // cluster id is not expected to be null as it is always initialized in the cluster topology.
     // Unless the persisted topology is modified manually, and set to null.
     final var clusterId = clusterTopology.clusterId().orElse("");
     final long newLastChange =
         clusterTopology
+            .phasedChangeState()
             .lastChange()
             .filter(lastChange -> lastChange.id() > oldTopology.getLastCompletedChangeId())
             .map(
@@ -295,11 +321,11 @@ public final class BrokerTopologyManagerImpl extends Actor
             .orElse(oldTopology.getLastCompletedChangeId());
 
     if (oldTopology.configuredClusterState().incarnationNumber()
-        != clusterTopology.incarnationNumber()) {
+        != partitionGroupConfiguration.incarnationNumber()) {
       topologyListeners.forEach(BrokerTopologyListener::clusterIncarnationChanged);
     }
 
-    final var newPartitionStates = buildPartitionStates(clusterTopology);
+    final var newPartitionStates = buildPartitionStates(partitionGroupConfiguration);
 
     if (newClusterSize != oldTopology.getClusterSize()
         || newPartitionsCount != oldTopology.getPartitionsCount()
@@ -312,7 +338,7 @@ public final class BrokerTopologyManagerImpl extends Actor
           newPartitionsCount,
           newReplicationFactor);
 
-      final var partitionIds = clusterTopology.partitionIds().boxed().toList();
+      final var partitionIds = partitionGroupConfiguration.partitionIds().boxed().toList();
 
       final var newClusterInfo =
           new ConfiguredClusterState(
@@ -322,7 +348,7 @@ public final class BrokerTopologyManagerImpl extends Actor
               partitionIds,
               newLastChange,
               clusterId,
-              clusterTopology.incarnationNumber(),
+              partitionGroupConfiguration.incarnationNumber(),
               newPartitionStates);
 
       return new BrokerClientTopologyImpl(oldTopology.liveClusterState(), newClusterInfo);
@@ -332,7 +358,7 @@ public final class BrokerTopologyManagerImpl extends Actor
   }
 
   private static Map<BrokerMemberId, Map<Integer, PartitionState.State>> buildPartitionStates(
-      final ClusterConfiguration clusterTopology) {
+      final PartitionGroupConfiguration clusterTopology) {
     final Map<BrokerMemberId, Map<Integer, PartitionState.State>> partitionStates = new HashMap<>();
     clusterTopology
         .members()

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.zeebe.broker.client.impl;
 
-import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
 import java.util.Optional;
@@ -73,20 +73,18 @@ public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy
    * span over all statically configured partitions when routing state is not available (i.e.
    * partition scaling is not enabled) or creates a new partition ring to span over the active
    * partitions from the latest routing state.
-   *
-   * <p>Routing state is only consulted for the default partition group: it is a single cluster-wide
-   * state that describes scaling of the default group, while all other groups have a static
-   * partition distribution.
    */
   private PartitionRing updatePartitionRing(
       final BrokerTopologyManager topologyManager,
       final String partitionGroup,
       final BrokerClusterState topology,
       final GroupState state) {
+    final PartitionGroupConfiguration partitionGroupConfiguration =
+        topologyManager.getClusterConfiguration().partitionGroup(partitionGroup);
     final var routingState =
-        PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(partitionGroup)
-            ? topologyManager.getClusterConfiguration().routingState()
-            : Optional.<RoutingState>empty();
+        partitionGroupConfiguration == null
+            ? Optional.<RoutingState>empty()
+            : partitionGroupConfiguration.routingState();
     final long expectedVersion =
         routingState.map(RoutingState::version).orElse(VersionedPartitionRing.NO_ROUTING_STATE);
 
@@ -115,21 +113,21 @@ public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy
     return newPartitionRing;
   }
 
-  private record GroupState(
-      AtomicLong offset, AtomicReference<VersionedPartitionRing> partitionRing) {
-    GroupState(final int initialOffset) {
-      this(
-          new AtomicLong(initialOffset),
-          new AtomicReference<>(VersionedPartitionRing.uninitialized()));
-    }
-  }
-
   record VersionedPartitionRing(long version, PartitionRing partitions) {
     static final long NOT_INITIALIZED = -2;
     static final long NO_ROUTING_STATE = -1;
 
     private static VersionedPartitionRing uninitialized() {
       return new VersionedPartitionRing(NOT_INITIALIZED, null);
+    }
+  }
+
+  private record GroupState(
+      AtomicLong offset, AtomicReference<VersionedPartitionRing> partitionRing) {
+    GroupState(final int initialOffset) {
+      this(
+          new AtomicLong(initialOffset),
+          new AtomicReference<>(VersionedPartitionRing.uninitialized()));
     }
   }
 

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
@@ -24,8 +24,10 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.broker.client.impl.BrokerClientImpl;
 import io.camunda.zeebe.broker.client.impl.BrokerTopologyManagerImpl;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.protocol.Protocol;
@@ -652,7 +654,14 @@ public final class BrokerClientTest {
                 .updateGlobalConfiguration(
                     globalConfig ->
                         globalConfig.addMember(
-                            otherBroker.member().id(), BrokerState.initializeAsActive()));
+                            otherBroker.member().id(), BrokerState.initializeAsActive()))
+                .updatePartitionGroupConfig(
+                    CurrentClusterConfiguration.DEFAULT_GROUP,
+                    group ->
+                        group.addMember(
+                            otherBroker.member().id(),
+                            BrokerPartitionState.initialize(
+                                Map.of(2, PartitionState.active(2, null)))));
         topologyManager.onClusterConfigurationUpdated(updatedClusterConfiguration);
         topologyManager.event(new ClusterMembershipEvent(Type.MEMBER_ADDED, otherBroker.member()));
         Awaitility.await("Topology is updated")

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.broker.client.impl.BrokerClientImpl;
 import io.camunda.zeebe.broker.client.impl.BrokerTopologyManagerImpl;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
@@ -648,9 +649,10 @@ public final class BrokerClientTest {
         final var updatedClusterConfiguration =
             topologyManager
                 .getClusterConfiguration()
-                .addMember(
-                    otherBroker.member().id(),
-                    MemberState.initializeAsActive(Map.of(2, PartitionState.active(2, null))));
+                .updateGlobalConfiguration(
+                    globalConfig ->
+                        globalConfig.addMember(
+                            otherBroker.member().id(), BrokerState.initializeAsActive()));
         topologyManager.onClusterConfigurationUpdated(updatedClusterConfiguration);
         topologyManager.event(new ClusterMembershipEvent(Type.MEMBER_ADDED, otherBroker.member()));
         Awaitility.await("Topology is updated")

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -20,9 +20,12 @@ import io.camunda.zeebe.broker.client.impl.BrokerTopologyManagerImpl;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
@@ -736,6 +739,93 @@ final class BrokerTopologyManagerTest {
     // then — broker is gone from both groups
     assertThat(topologyManager.getTopology().getBrokers()).doesNotContain(brokerId);
     assertThat(topologyManager.getTopology("tenant1").getBrokers()).doesNotContain(brokerId);
+  }
+
+  @Test
+  void shouldApplyConfigurationReceivedBeforeAnyBrokerJoined() {
+    // given -- the cluster configuration is gossiped in before any local membership event for the
+    // default group is observed
+    final var clusterTopologyWithTwoBrokers =
+        ClusterConfiguration.init()
+            .addMember(
+                MemberId.from("1"),
+                MemberState.initializeAsActive(
+                    Map.of(
+                        1,
+                        PartitionState.active(1, DynamicPartitionConfig.init()),
+                        2,
+                        PartitionState.active(2, DynamicPartitionConfig.init()))))
+            .addMember(MemberId.from("2"), MemberState.initializeAsActive(Map.of()));
+    topologyManager.onClusterConfigurationUpdated(clusterTopologyWithTwoBrokers);
+    actorSchedulerRule.workUntilDone();
+
+    // when -- a broker for the default group joins afterward
+    final var broker = createBroker(BrokerMemberId.from(1));
+    notifyEvent(createMemberAddedEvent(broker));
+
+    // then -- the previously-received configuration was not dropped
+    assertThat(topologyManager.getTopology().getClusterSize()).isEqualTo(2);
+    assertThat(topologyManager.getTopology().getPartitions()).isEqualTo(List.of(1, 2));
+  }
+
+  @Test
+  void shouldApplyDefaultGroupConfigurationToAllTenantsWhileNewConfigDisabled() {
+    // given -- a broker joins a non-default tenant group
+    final var brokerId = BrokerMemberId.from(0);
+    final var tenant1Info = createBrokerWithGroup(brokerId, "tenant1");
+    notifyEvent(createMemberAddedEvent(tenant1Info));
+
+    // when -- the cluster configuration (single, legacy group) is updated with partition
+    // assignments
+    final var clusterTopologyWithTwoBrokers =
+        ClusterConfiguration.init()
+            .addMember(
+                MemberId.from("1"),
+                MemberState.initializeAsActive(
+                    Map.of(
+                        1,
+                        PartitionState.active(1, DynamicPartitionConfig.init()),
+                        2,
+                        PartitionState.active(2, DynamicPartitionConfig.init()))))
+            .addMember(MemberId.from("2"), MemberState.initializeAsActive(Map.of()));
+    topologyManager.onClusterConfigurationUpdated(clusterTopologyWithTwoBrokers);
+    actorSchedulerRule.workUntilDone();
+
+    // then -- tenant1's configured cluster state mirrors the default group's: with
+    // USE_NEW_CONFIG disabled, updateConfiguredClusterState always resolves the default group's
+    // configuration regardless of which tenant is being updated. This does not yet exercise
+    // per-tenant configuration resolution, which is unreachable while the flag is off.
+    Awaitility.await()
+        .untilAsserted(
+            () -> assertThat(topologyManager.getTopology("tenant1").getClusterSize()).isEqualTo(2));
+    assertThat(topologyManager.getTopology("tenant1").getPartitionsCount()).isEqualTo(2);
+    assertThat(topologyManager.getTopology("tenant1").getPartitions()).isEqualTo(List.of(1, 2));
+  }
+
+  @Test
+  void shouldPreserveLiveStateWhenGroupHasNoPartitionGroupConfiguration() {
+    // given -- a broker has already joined the "tenant1" group, so live state (brokers, leaders)
+    // is established for it
+    final var brokerId = BrokerMemberId.from(0);
+    final var tenant1Info = createBrokerWithGroup(brokerId, "tenant1");
+    tenant1Info.setLeaderForPartition(1, 1L);
+    notifyEvent(createMemberAddedEvent(tenant1Info));
+
+    assertThat(topologyManager.getTopology("tenant1").getLeaderForPartition(1)).isEqualTo(brokerId);
+
+    // when -- a cluster configuration update arrives whose partition groups do not contain
+    // "tenant1" at all (e.g. the group is not part of the new model config)
+    final var configurationWithoutTenant1 =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of(),
+            PhasedChangeState.empty());
+    topologyManager.onClusterConfigurationUpdated(configurationWithoutTenant1);
+    actorSchedulerRule.workUntilDone();
+
+    // then -- the live state for tenant1 (leader, brokers) is preserved, not reset
+    assertThat(topologyManager.getTopology("tenant1").getLeaderForPartition(1)).isEqualTo(brokerId);
   }
 
   @Test

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -842,11 +842,7 @@ final class BrokerTopologyManagerTest {
 
   private BrokerInfo createBroker(final BrokerMemberId brokerId) {
     final BrokerInfo broker =
-        new BrokerInfo()
-            .setBrokerId(brokerId.nodeIdx(), brokerId.zone())
-            .setPartitionsCount(1)
-            .setClusterSize(3)
-            .setReplicationFactor(3);
+        new BrokerInfo().setBrokerId(brokerId.nodeIdx(), brokerId.zone()).setClusterSize(3);
     broker.setCommandApiAddress("localhost:1000");
     broker.setVersion("0.23.0-SNAPSHOT");
     return broker;

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/BrokerAddressProviderTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/BrokerAddressProviderTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.client.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.BrokerMemberId;
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+final class BrokerAddressProviderTest {
+
+  private static final String TENANT_B = "tenant-b";
+  private static final int PARTITION_ID = 1;
+  private static final BrokerMemberId NODE = BrokerMemberId.from(0);
+
+  @Test
+  void shouldResolveRecoveringNodeOnlyForItsOwnGroup() {
+    // given -- node is recovering in tenant-b's partition group but merely processing in
+    // default's, and is inactive for partition 1 in both groups' live topology
+    final var topologyManager =
+        new TestTopologyManager()
+            .addInactiveNode(TENANT_B, PARTITION_ID, NODE)
+            .addInactiveNode(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, PARTITION_ID, NODE)
+            .withClusterConfiguration(
+                new CurrentClusterConfiguration(
+                    CurrentClusterConfiguration.INITIAL_VERSION,
+                    GlobalConfiguration.init(),
+                    Map.of(
+                        PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                        groupWithMember(BrokerPartitionState.initialize(Map.of())),
+                        TENANT_B,
+                        groupWithMember(
+                            BrokerPartitionState.initialize(Map.of()).setMode(Mode.RECOVERING))),
+                    PhasedChangeState.empty()));
+
+    // when -- tenant-b is queried, recovering in that group
+    final var tenantBAddress =
+        BrokerAddressProvider.leaderOrAnyRecovery(topologyManager, TENANT_B, PARTITION_ID).get();
+
+    // then
+    assertThat(tenantBAddress).isEqualTo("address-" + NODE.id());
+
+    // when -- default is queried, only processing (not recovering) in that group
+    final var defaultAddress =
+        BrokerAddressProvider.leaderOrAnyRecovery(
+                topologyManager, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, PARTITION_ID)
+            .get();
+
+    // then -- the node is not treated as recovering in the default group
+    assertThat(defaultAddress).isNull();
+  }
+
+  private static PartitionGroupConfiguration groupWithMember(final BrokerPartitionState state) {
+    return new PartitionGroupConfiguration(
+        PartitionGroupConfiguration.INITIAL_VERSION,
+        PartitionGroupConfiguration.INITIAL_INCARNATION_NUMBER,
+        Map.of(NODE.memberId(), state),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+}

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/BrokerAddressProviderTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/BrokerAddressProviderTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.client.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.BrokerMemberId;
+import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
@@ -49,7 +50,9 @@ final class BrokerAddressProviderTest {
 
     // when -- tenant-b is queried, recovering in that group
     final var tenantBAddress =
-        BrokerAddressProvider.leaderOrAnyRecovery(topologyManager, TENANT_B, PARTITION_ID).get();
+        BrokerAddressProvider.leaderOrAnyRecovery(
+                topologyManager, new PartitionId(TENANT_B, PARTITION_ID))
+            .get();
 
     // then
     assertThat(tenantBAddress).isEqualTo("address-" + NODE.id());
@@ -57,7 +60,8 @@ final class BrokerAddressProviderTest {
     // when -- default is queried, only processing (not recovering) in that group
     final var defaultAddress =
         BrokerAddressProvider.leaderOrAnyRecovery(
-                topologyManager, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, PARTITION_ID)
+                topologyManager,
+                new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, PARTITION_ID))
             .get();
 
     // then -- the node is not treated as recovering in the default group

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
@@ -12,12 +12,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
-import java.util.Optional;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -66,13 +69,8 @@ final class RoundRobinDispatchStrategyTest {
         .addPartition(2, ONE)
         .addPartition(3, TWO)
         .withClusterConfiguration(
-            ClusterConfiguration.builder()
-                .version(1)
-                .routingState(
-                    Optional.of(
-                        new RoutingState(
-                            1, new AllPartitions(2), new MessageCorrelation.HashMod(2))))
-                .build());
+            getConfigurationWithRoutingState(
+                new RoutingState(1, new AllPartitions(2), new MessageCorrelation.HashMod(2))));
 
     // when - then
     assertThat(
@@ -93,6 +91,16 @@ final class RoundRobinDispatchStrategyTest {
         .isEqualTo(2);
   }
 
+  private static CurrentClusterConfiguration getConfigurationWithRoutingState(
+      final RoutingState value) {
+    final var partitionGroup = PartitionGroupConfiguration.empty(1).setRoutingState(value);
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        GlobalConfiguration.init(),
+        Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, partitionGroup),
+        PhasedChangeState.empty());
+  }
+
   @Test
   void shouldIterateOverNonContiguousActivePartitions() {
     // given
@@ -103,15 +111,11 @@ final class RoundRobinDispatchStrategyTest {
         .addPartition(2, ONE)
         .addPartition(3, TWO)
         .withClusterConfiguration(
-            ClusterConfiguration.builder()
-                .version(1)
-                .routingState(
-                    Optional.of(
-                        new RoutingState(
-                            1,
-                            new ActivePartitions(1, Set.of(3), Set.of()),
-                            new MessageCorrelation.HashMod(3))))
-                .build());
+            getConfigurationWithRoutingState(
+                new RoutingState(
+                    1,
+                    new ActivePartitions(1, Set.of(3), Set.of()),
+                    new MessageCorrelation.HashMod(3))));
 
     // when - then
     assertThat(
@@ -140,15 +144,11 @@ final class RoundRobinDispatchStrategyTest {
 
     // when -- starting with routing state version 1, with active partitions 1 and 3
     topologyManager.withClusterConfiguration(
-        ClusterConfiguration.builder()
-            .version(1)
-            .routingState(
-                Optional.of(
-                    new RoutingState(
-                        1,
-                        new ActivePartitions(1, Set.of(3), Set.of()),
-                        new MessageCorrelation.HashMod(1))))
-            .build());
+        getConfigurationWithRoutingState(
+            new RoutingState(
+                1,
+                new ActivePartitions(1, Set.of(3), Set.of()),
+                new MessageCorrelation.HashMod(1))));
 
     // then
     assertThat(
@@ -162,12 +162,8 @@ final class RoundRobinDispatchStrategyTest {
 
     // when -- updating to routing state version 2, with active partitions 1, 2 and 3
     topologyManager.withClusterConfiguration(
-        ClusterConfiguration.builder()
-            .version(1)
-            .routingState(
-                Optional.of(
-                    new RoutingState(2, new AllPartitions(3), new MessageCorrelation.HashMod(1))))
-            .build());
+        getConfigurationWithRoutingState(
+            new RoutingState(2, new AllPartitions(3), new MessageCorrelation.HashMod(1))));
 
     // then
     assertThat(
@@ -252,15 +248,11 @@ final class RoundRobinDispatchStrategyTest {
         .addPartition("tenant-b", 2, ONE)
         .addPartition("tenant-b", 3, TWO)
         .withClusterConfiguration(
-            ClusterConfiguration.builder()
-                .version(1)
-                .routingState(
-                    Optional.of(
-                        new RoutingState(
-                            1,
-                            new ActivePartitions(1, Set.of(3), Set.of()),
-                            new MessageCorrelation.HashMod(3))))
-                .build());
+            getConfigurationWithRoutingState(
+                new RoutingState(
+                    1,
+                    new ActivePartitions(1, Set.of(3), Set.of()),
+                    new MessageCorrelation.HashMod(3))));
 
     // when - then - the default group cycles over the active partitions only
     assertThat(

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
@@ -271,6 +271,55 @@ final class RoundRobinDispatchStrategyTest {
   }
 
   @Test
+  void shouldApplyOwnRoutingStatePerNonDefaultGroup() {
+    // given - default and tenant-b each have their own routing state, restricting active
+    // partitions differently
+    final var dispatchStrategy = new RoundRobinDispatchStrategy();
+    final var topologyManager = new TestTopologyManager();
+    topologyManager
+        .addPartition(1, ZERO)
+        .addPartition(2, ONE)
+        .addPartition(3, TWO)
+        .addPartition("tenant-b", 1, ZERO)
+        .addPartition("tenant-b", 2, ONE)
+        .addPartition("tenant-b", 3, TWO)
+        .withClusterConfiguration(
+            new CurrentClusterConfiguration(
+                CurrentClusterConfiguration.INITIAL_VERSION,
+                GlobalConfiguration.init(),
+                Map.of(
+                    PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                    PartitionGroupConfiguration.empty(1)
+                        .setRoutingState(
+                            new RoutingState(
+                                1,
+                                new ActivePartitions(1, Set.of(3), Set.of()),
+                                new MessageCorrelation.HashMod(3))),
+                    "tenant-b",
+                    PartitionGroupConfiguration.empty(1)
+                        .setRoutingState(
+                            new RoutingState(
+                                1,
+                                new ActivePartitions(1, Set.of(2), Set.of()),
+                                new MessageCorrelation.HashMod(3)))),
+                PhasedChangeState.empty()));
+
+    // when - then - the default group cycles over partitions 1 and 3 only
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+        .isEqualTo(1);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+        .isEqualTo(3);
+
+    // and tenant-b cycles over partitions 1 and 2 only, per its own routing state
+    assertThat(dispatchStrategy.determinePartition(topologyManager, "tenant-b")).isEqualTo(1);
+    assertThat(dispatchStrategy.determinePartition(topologyManager, "tenant-b")).isEqualTo(2);
+  }
+
+  @Test
   void shouldReturnNullValueForUnknownGroup() {
     // given - only the default group is known
     final var dispatchStrategy = new RoundRobinDispatchStrategy();

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.ArrayList;
@@ -26,7 +27,8 @@ import org.jspecify.annotations.Nullable;
 
 final class TestTopologyManager implements BrokerTopologyManager {
   private final Map<String, TestBrokerClusterState> topologies = new HashMap<>();
-  private ClusterConfiguration clusterConfiguration = ClusterConfiguration.uninitialized();
+  private CurrentClusterConfiguration clusterConfiguration =
+      CurrentClusterConfiguration.uninitialized();
 
   TestTopologyManager() {
     this(new TestBrokerClusterState());
@@ -55,7 +57,8 @@ final class TestTopologyManager implements BrokerTopologyManager {
     return this;
   }
 
-  TestTopologyManager withClusterConfiguration(final ClusterConfiguration clusterConfiguration) {
+  TestTopologyManager withClusterConfiguration(
+      final CurrentClusterConfiguration clusterConfiguration) {
     this.clusterConfiguration = clusterConfiguration;
     return this;
   }
@@ -66,7 +69,7 @@ final class TestTopologyManager implements BrokerTopologyManager {
   }
 
   @Override
-  public ClusterConfiguration getClusterConfiguration() {
+  public CurrentClusterConfiguration getClusterConfiguration() {
     return clusterConfiguration;
   }
 

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -54,6 +55,15 @@ final class TestTopologyManager implements BrokerTopologyManager {
     }
 
     topology.addPartitionIfAbsent(id);
+    return this;
+  }
+
+  TestTopologyManager addInactiveNode(
+      final String partitionGroup, final int partitionId, final BrokerMemberId nodeId) {
+    final var topology =
+        topologies.computeIfAbsent(partitionGroup, group -> new TestBrokerClusterState());
+    topology.addBrokerIfAbsent(nodeId);
+    topology.addInactiveNode(partitionId, nodeId);
     return this;
   }
 
@@ -94,6 +104,7 @@ final class TestTopologyManager implements BrokerTopologyManager {
     private final List<BrokerMemberId> brokers = new ArrayList<>();
     private final Map<Integer, BrokerMemberId> partitionLeaders = new HashMap<>();
     private final List<Integer> partitions = new ArrayList<>();
+    private final Map<Integer, Set<BrokerMemberId>> inactiveNodesPerPartition = new HashMap<>();
 
     @Override
     public boolean isInitialized() {
@@ -127,7 +138,7 @@ final class TestTopologyManager implements BrokerTopologyManager {
 
     @Override
     public Set<BrokerMemberId> getInactiveNodesForPartition(final int partition) {
-      return Set.of();
+      return inactiveNodesPerPartition.getOrDefault(partition, Set.of());
     }
 
     @Override
@@ -147,7 +158,7 @@ final class TestTopologyManager implements BrokerTopologyManager {
 
     @Override
     public String getBrokerAddress(final BrokerMemberId brokerId) {
-      return "";
+      return "address-" + brokerId.id();
     }
 
     @Override
@@ -187,6 +198,10 @@ final class TestTopologyManager implements BrokerTopologyManager {
 
     public void addPartitionIfAbsent(final int id) {
       partitions.add(id);
+    }
+
+    public void addInactiveNode(final int partitionId, final BrokerMemberId nodeId) {
+      inactiveNodesPerPartition.computeIfAbsent(partitionId, id -> new HashSet<>()).add(nodeId);
     }
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -141,10 +141,7 @@ public final class Broker implements AutoCloseable {
 
     // initialize this fields from config for the first startup, they will be overwritten with
     // the persisted values once the cluster has bootstrapped
-    result
-        .setClusterSize(clusterCfg.getClusterSize())
-        .setPartitionsCount(clusterCfg.getPartitionsCount())
-        .setReplicationFactor(clusterCfg.getReplicationFactor());
+    result.setClusterSize(clusterCfg.getClusterSize());
 
     final String version = VersionUtil.getVersion();
     if (version != null && !version.isBlank()) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterConfigurationManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterConfigurationManagerStep.java
@@ -13,7 +13,7 @@ import io.camunda.zeebe.broker.partitioning.topology.ClusterChangeExecutorImpl;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.partitioning.topology.DynamicClusterConfigurationService;
 import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.time.Duration;
@@ -57,10 +57,7 @@ public class ClusterConfigurationManagerStep
             clusterConfiguration -> {
               brokerStartupContext.setClusterConfigurationService(clusterConfigurationService);
               final var brokerInfo = brokerStartupContext.getBrokerInfo();
-              brokerInfo
-                  .setClusterSize(clusterConfiguration.clusterSize())
-                  .setPartitionsCount(clusterConfiguration.partitionCount())
-                  .setReplicationFactor(clusterConfiguration.minReplicationFactor());
+              brokerInfo.setClusterSize(clusterConfiguration.clusterSize());
               return brokerStartupContext;
             });
   }
@@ -99,7 +96,7 @@ public class ClusterConfigurationManagerStep
    * @param retriesLeft the number of retries left to attempt
    * @return an ActorFuture that completes with the ClusterConfiguration
    */
-  private ActorFuture<ClusterConfiguration> getClusterConfiguration(
+  private ActorFuture<CurrentClusterConfiguration> getClusterConfiguration(
       final BrokerStartupContext brokerStartupContext, final int retriesLeft) {
     if (retriesLeft <= 0) {
       return CompletableActorFuture.completedExceptionally(
@@ -110,7 +107,7 @@ public class ClusterConfigurationManagerStep
     final var configuration =
         brokerStartupContext.getBrokerClient().getTopologyManager().getClusterConfiguration();
     if (configuration.isUninitialized()) {
-      final ActorFuture<ClusterConfiguration> future =
+      final ActorFuture<CurrentClusterConfiguration> future =
           brokerStartupContext.getConcurrencyControl().createFuture();
       brokerStartupContext
           .getConcurrencyControl()

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -185,7 +185,7 @@ public final class ZeebePartitionFactory {
     final var context =
         new PartitionStartupAndTransitionContextImpl(
             BrokerMemberId.from(localBroker.getZone(), localBroker.getNodeId()),
-            localBroker.getPartitionsCount(),
+            brokerCfg.getCluster().getPartitionsCount(),
             communicationService,
             raftPartition,
             partitionListeners,
@@ -279,7 +279,7 @@ public final class ZeebePartitionFactory {
 
       return EngineProcessors.createEngineProcessors(
           recordProcessorContext,
-          localBroker.getPartitionsCount(),
+          brokerCfg.getCluster().getPartitionsCount(),
           subscriptionCommandSender,
           partitionCommandSender,
           featureFlags,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/engine/RecordVersionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/engine/RecordVersionTest.java
@@ -36,7 +36,8 @@ public final class RecordVersionTest {
       VersionUtil.getVersion().replaceAll("-SNAPSHOT", "");
 
   private static final EmbeddedBrokerRule BROKER_RULE = new EmbeddedBrokerRule();
-  private static final CommandApiRule API_RULE = new CommandApiRule(BROKER_RULE::getAtomixCluster);
+  private static final CommandApiRule API_RULE =
+      new CommandApiRule(1, BROKER_RULE::getAtomixCluster);
   @ClassRule public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(API_RULE);
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/engine/RejectIncompleteCommandsTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/engine/RejectIncompleteCommandsTest.java
@@ -22,7 +22,8 @@ public final class RejectIncompleteCommandsTest {
 
   private static final EmbeddedBrokerRule BROKER_RULE = new EmbeddedBrokerRule();
 
-  private static final CommandApiRule API_RULE = new CommandApiRule(BROKER_RULE::getAtomixCluster);
+  private static final CommandApiRule API_RULE =
+      new CommandApiRule(1, BROKER_RULE::getAtomixCluster);
 
   @ClassRule public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(API_RULE);
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/ExporterManagerPartitionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/ExporterManagerPartitionTest.java
@@ -42,7 +42,8 @@ public final class ExporterManagerPartitionTest {
             brokerCfg.getExporters().put(TEST_EXPORTER_ID, exporterCfg);
           });
 
-  public final CommandApiRule clientRule = new CommandApiRule(brokerRule::getAtomixCluster);
+  public final CommandApiRule clientRule =
+      new CommandApiRule(PARTITIONS, brokerRule::getAtomixCluster);
   @Rule public RuleChain ruleChain = RuleChain.outerRule(brokerRule).around(clientRule);
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/UniqueKeyFormatTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/UniqueKeyFormatTest.java
@@ -24,7 +24,7 @@ import org.junit.rules.RuleChain;
 public final class UniqueKeyFormatTest {
 
   public final EmbeddedBrokerRule brokerRule = new EmbeddedBrokerRule(setPartitionCount(3));
-  public final CommandApiRule apiRule = new CommandApiRule(brokerRule::getAtomixCluster);
+  public final CommandApiRule apiRule = new CommandApiRule(3, brokerRule::getAtomixCluster);
 
   @Rule public RuleChain ruleChain = RuleChain.outerRule(brokerRule).around(apiRule);
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiIT.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiIT.java
@@ -44,7 +44,7 @@ public final class QueryApiIT {
   public final ActorSchedulerRule actor = new ActorSchedulerRule();
   public final EmbeddedBrokerRule broker =
       new EmbeddedBrokerRule(cfg -> cfg.getExperimental().getQueryApi().setEnabled(true));
-  public final CommandApiRule command = new CommandApiRule(broker::getAtomixCluster);
+  public final CommandApiRule command = new CommandApiRule(1, broker::getAtomixCluster);
 
   @Rule
   public final RuleChain ruleChain = RuleChain.outerRule(broker).around(command).around(actor);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationCoordinatorSupplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationCoordinatorSupplier.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
@@ -69,6 +70,11 @@ public interface ClusterConfigurationCoordinatorSupplier {
         return newMembers.isEmpty() ? Optional.empty() : Optional.of(lowestMemberId(newMembers));
       }
     };
+  }
+
+  static ClusterConfigurationCoordinatorSupplier from(
+      final Supplier<CurrentClusterConfiguration> clusterTopologySupplier) {
+    return ofMembers(() -> clusterTopologySupplier.get().globalConfiguration().members().keySet());
   }
 
   static ClusterConfigurationCoordinatorSupplier of(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -78,6 +78,20 @@ public record CurrentClusterConfiguration(
     return globalConfiguration.members().keySet();
   }
 
+  public int getClusterSize() {
+    return (int)
+        globalConfiguration.members().values().stream()
+            .filter(
+                brokerState ->
+                    brokerState.state() != BrokerState.State.LEFT
+                        && brokerState.state() != BrokerState.State.UNINITIALIZED)
+            .count();
+  }
+
+  public Optional<String> clusterId() {
+    return globalConfiguration.clusterId();
+  }
+
   /**
    * Creates an empty configuration with an initial global configuration and no partition groups.
    */

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
@@ -21,6 +21,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -405,5 +406,25 @@ public record PartitionGroupConfiguration(
             Comparator.comparingInt(
                 e -> Objects.requireNonNull(e.getValue().getPartition(partitionId)).priority()))
         .map(Entry::getKey);
+  }
+
+  public int minReplicationFactor() {
+    // return minimum replication factor. During a configuration change, replication factor might
+    // increase temporarily.
+    return members.values().stream()
+        .flatMap(m -> m.partitions().entrySet().stream())
+        .collect(Collectors.groupingBy(Entry::getKey, Collectors.counting()))
+        .values()
+        .stream()
+        .reduce(Math::min)
+        .map(Long::intValue)
+        .orElse(0);
+  }
+
+  public IntStream partitionIds() {
+    return members.values().stream()
+        .flatMapToInt(m -> m.partitions().keySet().stream().mapToInt(i -> i))
+        .sorted()
+        .distinct();
   }
 }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
@@ -33,7 +33,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerErrorResponse;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejectionResponse;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.gateway.Gateway;
 import io.camunda.zeebe.gateway.RequestMapper;
 import io.camunda.zeebe.gateway.ResponseMapper;
@@ -1173,7 +1173,7 @@ public final class LongPollingActivateJobsTest {
     when(topologyManager.getTopology()).thenReturn(clusterState);
     when(topologyManager.getTopology(anyString())).thenReturn(clusterState);
     when(topologyManager.getClusterConfiguration())
-        .thenReturn(ClusterConfiguration.uninitialized());
+        .thenReturn(CurrentClusterConfiguration.uninitialized());
 
     final var firstCallDone = new AtomicBoolean(false);
     final var broker = mock(BrokerClient.class);

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategy.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategy.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.api.NoTopologyAvailableException;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
 import java.util.Optional;
@@ -46,9 +47,10 @@ public final class HashBasedDispatchStrategy implements RequestDispatchStrategy 
   @Override
   public int determinePartition(
       final BrokerTopologyManager topologyManager, final String partitionGroup) {
-    return topologyManager
-        .getClusterConfiguration()
-        .routingState()
+    final var partitionGroupConfiguration =
+        topologyManager.getClusterConfiguration().partitionGroup(partitionGroup);
+    return Optional.ofNullable(partitionGroupConfiguration)
+        .flatMap(PartitionGroupConfiguration::routingState)
         .map(this::fromRoutingState)
         .or(
             () ->

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -21,14 +22,14 @@ import org.jspecify.annotations.NonNull;
 public final class StubbedTopologyManager implements BrokerTopologyManager {
 
   private final TestBrokerClusterState clusterState;
-  private final ClusterConfiguration clusterConfiguration;
+  private final CurrentClusterConfiguration clusterConfiguration;
 
   public StubbedTopologyManager() {
     this(8);
   }
 
   public StubbedTopologyManager(final int partitionsCount) {
-    clusterConfiguration = ClusterConfiguration.uninitialized();
+    clusterConfiguration = CurrentClusterConfiguration.uninitialized();
     clusterState = new TestBrokerClusterState(partitionsCount);
     clusterState.addBroker(BrokerMemberId.from(0), "localhost:26501");
     clusterState.setClusterId(UUID.randomUUID().toString());
@@ -46,7 +47,7 @@ public final class StubbedTopologyManager implements BrokerTopologyManager {
   }
 
   @Override
-  public ClusterConfiguration getClusterConfiguration() {
+  public CurrentClusterConfiguration getClusterConfiguration() {
     return clusterConfiguration;
   }
 

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategyTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategyTest.java
@@ -14,13 +14,17 @@ import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
 import io.camunda.zeebe.gateway.api.util.TestBrokerClusterState;
 import io.camunda.zeebe.protocol.impl.PartitionUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.util.Optional;
+import java.util.Map;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +40,8 @@ final class HashBasedDispatchStrategyTest {
     // when -- No routing state in cluster configuration
     final var topologyManager =
         new TestTopologyManager(
-            new TestBrokerClusterState(partitionCount), ClusterConfiguration.uninitialized());
+            new TestBrokerClusterState(partitionCount),
+            CurrentClusterConfiguration.uninitialized());
 
     // then - the request is dispatched based on the partition count from the topology
     assertThat(
@@ -56,8 +61,7 @@ final class HashBasedDispatchStrategyTest {
     // when -- Routing state is available in cluster configuration
     final var routingState =
         new RoutingState(1, new AllPartitions(3), new HashMod(messagePartitionCount));
-    final var clusterConfiguration =
-        ClusterConfiguration.builder().version(1).routingState(Optional.of(routingState)).build();
+    final var clusterConfiguration = getConfigurationWithRoutingState(routingState);
 
     final var topologyManager =
         new TestTopologyManager(new TestBrokerClusterState(partitionCount), clusterConfiguration);
@@ -70,6 +74,16 @@ final class HashBasedDispatchStrategyTest {
             PartitionUtil.getPartitionId(BufferUtil.wrapString(businessId), messagePartitionCount));
   }
 
+  private static CurrentClusterConfiguration getConfigurationWithRoutingState(
+      final RoutingState value) {
+    final var partitionGroup = PartitionGroupConfiguration.empty(1).setRoutingState(value);
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        GlobalConfiguration.init(),
+        Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, partitionGroup),
+        PhasedChangeState.empty());
+  }
+
   @Test
   void shouldAlwaysRouteToSamePartitionForSameKey() {
     // given
@@ -78,7 +92,8 @@ final class HashBasedDispatchStrategyTest {
 
     final var topologyManager =
         new TestTopologyManager(
-            new TestBrokerClusterState(partitionCount), ClusterConfiguration.uninitialized());
+            new TestBrokerClusterState(partitionCount),
+            CurrentClusterConfiguration.uninitialized());
 
     // when - we create multiple strategies with the same key
     final var strategy1 = new HashBasedDispatchStrategy(businessId, "business id");
@@ -101,7 +116,8 @@ final class HashBasedDispatchStrategyTest {
 
     final var topologyManager =
         new TestTopologyManager(
-            new TestBrokerClusterState(partitionCount), ClusterConfiguration.uninitialized());
+            new TestBrokerClusterState(partitionCount),
+            CurrentClusterConfiguration.uninitialized());
 
     // when
     final var hashBasedStrategy = new HashBasedDispatchStrategy(key, "business id");
@@ -117,7 +133,7 @@ final class HashBasedDispatchStrategyTest {
   }
 
   private record TestTopologyManager(
-      BrokerClusterState topology, ClusterConfiguration clusterConfiguration)
+      BrokerClusterState topology, CurrentClusterConfiguration clusterConfiguration)
       implements BrokerTopologyManager {
 
     @Override
@@ -126,7 +142,7 @@ final class HashBasedDispatchStrategyTest {
     }
 
     @Override
-    public ClusterConfiguration getClusterConfiguration() {
+    public CurrentClusterConfiguration getClusterConfiguration() {
       return clusterConfiguration;
     }
 

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategyTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategyTest.java
@@ -85,6 +85,59 @@ final class HashBasedDispatchStrategyTest {
   }
 
   @Test
+  void shouldDispatchViaTopologyForNonDefaultTenantWithNoOwnPartitionGroupConfig() {
+    // given -- a non-default tenant that has no entry in the cluster configuration's partition
+    // groups (e.g. the tenant only exists in the legacy single-group model)
+    final var businessId = "order-12345";
+    final var dispatchStrategy = new HashBasedDispatchStrategy(businessId, "business id");
+    final var partitionCount = 3;
+    final var tenantB = "tenant-b";
+
+    final var topologyManager =
+        new TestTopologyManager(
+            new TestBrokerClusterState(partitionCount),
+            CurrentClusterConfiguration.uninitialized());
+
+    // then - falls back to the tenant's own topology partition count instead of throwing
+    assertThat(dispatchStrategy.determinePartition(topologyManager, tenantB))
+        .isEqualTo(PartitionUtil.getPartitionId(BufferUtil.wrapString(businessId), partitionCount));
+  }
+
+  @Test
+  void shouldDispatchViaOwnRoutingStateForNonDefaultTenant() {
+    // given -- the default tenant and "tenant-b" each have their own, different routing state
+    final var businessId = "order-12345";
+    final var dispatchStrategy = new HashBasedDispatchStrategy(businessId, "business id");
+    final var partitionCount = 3;
+    final var tenantB = "tenant-b";
+
+    final var defaultRoutingState = new RoutingState(1, new AllPartitions(3), new HashMod(2));
+    final var tenantBRoutingState = new RoutingState(1, new AllPartitions(3), new HashMod(4));
+
+    final var clusterConfiguration =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                PartitionGroupConfiguration.empty(1).setRoutingState(defaultRoutingState),
+                tenantB,
+                PartitionGroupConfiguration.empty(1).setRoutingState(tenantBRoutingState)),
+            PhasedChangeState.empty());
+
+    final var topologyManager =
+        new TestTopologyManager(new TestBrokerClusterState(partitionCount), clusterConfiguration);
+
+    // then - each tenant is dispatched according to its own routing state
+    assertThat(dispatchStrategy.determinePartition(topologyManager, tenantB))
+        .isEqualTo(PartitionUtil.getPartitionId(BufferUtil.wrapString(businessId), 4));
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+        .isEqualTo(PartitionUtil.getPartitionId(BufferUtil.wrapString(businessId), 2));
+  }
+
+  @Test
   void shouldAlwaysRouteToSamePartitionForSameKey() {
     // given
     final var businessId = "consistent-key";

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
@@ -14,13 +14,17 @@ import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
 import io.camunda.zeebe.gateway.api.util.TestBrokerClusterState;
 import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.util.Optional;
+import java.util.Map;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +40,8 @@ final class PublishMessageDispatchStrategyTest {
     // when -- No routing state in cluster configuration
     final var topologyManager =
         new TestTopologyManager(
-            new TestBrokerClusterState(partitionCount), ClusterConfiguration.uninitialized());
+            new TestBrokerClusterState(partitionCount),
+            CurrentClusterConfiguration.uninitialized());
 
     // then - the request is dispatched based on the partition count from the topology
     assertThat(
@@ -58,8 +63,7 @@ final class PublishMessageDispatchStrategyTest {
     // when -- Routing state is available in cluster configuration
     final var routingState =
         new RoutingState(1, new AllPartitions(3), new HashMod(messagePartitionCount));
-    final var clusterConfiguration =
-        ClusterConfiguration.builder().version(1).routingState(Optional.of(routingState)).build();
+    final var clusterConfiguration = getConfigurationWithRoutingState(routingState);
 
     final var topologyManager =
         new TestTopologyManager(new TestBrokerClusterState(partitionCount), clusterConfiguration);
@@ -73,8 +77,18 @@ final class PublishMessageDispatchStrategyTest {
                 BufferUtil.wrapString(correlationKey), messagePartitionCount));
   }
 
+  private static CurrentClusterConfiguration getConfigurationWithRoutingState(
+      final RoutingState value) {
+    final var partitionGroup = PartitionGroupConfiguration.empty(1).setRoutingState(value);
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        GlobalConfiguration.init(),
+        Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, partitionGroup),
+        PhasedChangeState.empty());
+  }
+
   private record TestTopologyManager(
-      BrokerClusterState topology, ClusterConfiguration clusterConfiguration)
+      BrokerClusterState topology, CurrentClusterConfiguration clusterConfiguration)
       implements BrokerTopologyManager {
 
     @Override
@@ -83,7 +97,7 @@ final class PublishMessageDispatchStrategyTest {
     }
 
     @Override
-    public ClusterConfiguration getClusterConfiguration() {
+    public CurrentClusterConfiguration getClusterConfiguration() {
       return clusterConfiguration;
     }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -146,6 +146,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     return MemberIdUtil.memberIdString(zone, getNodeId());
   }
 
+  @Deprecated
   public int getPartitionsCount() {
     if (partitionsCountNullValue() == partitionsCount) {
       throw new IllegalStateException("partitionsCount is not set");
@@ -153,6 +154,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     return partitionsCount;
   }
 
+  @Deprecated
   public BrokerInfo setPartitionsCount(final int partitionsCount) {
     if (partitionsCount <= 0) {
       throw new IllegalArgumentException(
@@ -177,6 +179,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     return this;
   }
 
+  @Deprecated
   public int getReplicationFactor() {
     if (replicationFactorNullValue() == replicationFactor) {
       throw new IllegalStateException("replicationFactor is not set");
@@ -184,6 +187,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     return replicationFactor;
   }
 
+  @Deprecated
   public BrokerInfo setReplicationFactor(final int replicationFactor) {
     if (replicationFactor <= 0) {
       throw new IllegalArgumentException(

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -10,8 +10,6 @@ package io.camunda.zeebe.protocol.impl.encoding;
 import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.clusterSizeNullValue;
 import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.nodeIdNullValue;
 import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.partitionGroupHeaderLength;
-import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.partitionsCountNullValue;
-import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.replicationFactorNullValue;
 import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.versionHeaderLength;
 import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.zoneHeaderLength;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
@@ -84,9 +82,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   private final Map<Integer, PartitionHealthStatus> partitionHealthStatuses = new HashMap<>();
 
   private int nodeId;
-  private int partitionsCount;
   private int clusterSize;
-  private int replicationFactor;
   private DirectBuffer version = new UnsafeBuffer();
   private @Nullable String zone;
   private @Nullable String partitionGroup;
@@ -104,9 +100,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
 
   public BrokerInfo reset() {
     nodeId = nodeIdNullValue();
-    partitionsCount = partitionsCountNullValue();
     clusterSize = clusterSizeNullValue();
-    replicationFactor = replicationFactorNullValue();
     addresses.clear();
     version.wrap(0, 0);
     zone = null;
@@ -146,24 +140,6 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     return MemberIdUtil.memberIdString(zone, getNodeId());
   }
 
-  @Deprecated
-  public int getPartitionsCount() {
-    if (partitionsCountNullValue() == partitionsCount) {
-      throw new IllegalStateException("partitionsCount is not set");
-    }
-    return partitionsCount;
-  }
-
-  @Deprecated
-  public BrokerInfo setPartitionsCount(final int partitionsCount) {
-    if (partitionsCount <= 0) {
-      throw new IllegalArgumentException(
-          "partitionsCount must be positive, was " + partitionsCount);
-    }
-    this.partitionsCount = partitionsCount;
-    return this;
-  }
-
   public int getClusterSize() {
     if (clusterSizeNullValue() == clusterSize) {
       throw new IllegalStateException("clusterSize is not set");
@@ -176,24 +152,6 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
       throw new IllegalArgumentException("clusterSize must be positive, was " + clusterSize);
     }
     this.clusterSize = clusterSize;
-    return this;
-  }
-
-  @Deprecated
-  public int getReplicationFactor() {
-    if (replicationFactorNullValue() == replicationFactor) {
-      throw new IllegalStateException("replicationFactor is not set");
-    }
-    return replicationFactor;
-  }
-
-  @Deprecated
-  public BrokerInfo setReplicationFactor(final int replicationFactor) {
-    if (replicationFactor <= 0) {
-      throw new IllegalArgumentException(
-          "replicationFactor must be positive, was " + replicationFactor);
-    }
-    this.replicationFactor = replicationFactor;
     return this;
   }
 
@@ -322,9 +280,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     bodyDecoder.wrap(buffer, offset, headerDecoder.blockLength(), headerDecoder.version());
 
     nodeId = bodyDecoder.nodeId();
-    partitionsCount = bodyDecoder.partitionsCount();
     clusterSize = bodyDecoder.clusterSize();
-    replicationFactor = bodyDecoder.replicationFactor();
 
     final AddressesDecoder addressesDecoder = bodyDecoder.addresses();
     while (addressesDecoder.hasNext()) {
@@ -432,9 +388,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     bodyEncoder
         .wrapAndApplyHeader(buffer, offset, headerEncoder)
         .nodeId(nodeId)
-        .partitionsCount(partitionsCount)
-        .clusterSize(clusterSize)
-        .replicationFactor(replicationFactor);
+        .clusterSize(clusterSize);
 
     final int addressesCount = addresses.size();
     final AddressesEncoder addressesEncoder = bodyEncoder.addressesCount(addressesCount);
@@ -577,9 +531,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     // (e.g. partitionsCount before it has been set) are preserved faithfully.
     copy.nodeId = nodeId;
     copy.zone = zone;
-    copy.partitionsCount = partitionsCount;
     copy.clusterSize = clusterSize;
-    copy.replicationFactor = replicationFactor;
     copy.version = BufferUtil.cloneBuffer(version);
     copy.partitionGroup = partitionGroup;
     addresses.forEach(copy::addAddress);
@@ -647,12 +599,8 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     return "BrokerInfo{"
         + "nodeId="
         + nodeId
-        + ", partitionsCount="
-        + partitionsCount
         + ", clusterSize="
         + clusterSize
-        + ", replicationFactor="
-        + replicationFactor
         + ", partitionRoles="
         + partitionRoles
         + ", partitionLeaderTerms="

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/BrokerInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/BrokerInfoTest.java
@@ -30,20 +30,10 @@ final class BrokerInfoTest {
   @Test
   void shouldReadBrokerInfoForSpecificPartitionGroup() {
     // given
-    final BrokerInfo defaultBroker =
-        new BrokerInfo()
-            .setBrokerId(1, null)
-            .setPartitionsCount(1)
-            .setClusterSize(1)
-            .setReplicationFactor(1);
+    final BrokerInfo defaultBroker = new BrokerInfo().setBrokerId(1, null).setClusterSize(1);
 
     final BrokerInfo tenant1Broker =
-        new BrokerInfo()
-            .setBrokerId(1, null)
-            .setPartitionsCount(1)
-            .setClusterSize(1)
-            .setReplicationFactor(1)
-            .setPartitionGroup("tenant1");
+        new BrokerInfo().setBrokerId(1, null).setClusterSize(1).setPartitionGroup("tenant1");
     tenant1Broker.setLeaderForPartition(1, 5L);
 
     final Properties props = new Properties();
@@ -67,19 +57,10 @@ final class BrokerInfoTest {
   @Test
   void shouldReadAllBrokerInfosFromProperties() {
     // given
-    final BrokerInfo defaultBroker =
-        new BrokerInfo()
-            .setBrokerId(1, null)
-            .setPartitionsCount(1)
-            .setClusterSize(1)
-            .setReplicationFactor(1);
+    final BrokerInfo defaultBroker = new BrokerInfo().setBrokerId(1, null).setClusterSize(1);
+
     final BrokerInfo tenant1Broker =
-        new BrokerInfo()
-            .setBrokerId(1, null)
-            .setPartitionsCount(1)
-            .setClusterSize(1)
-            .setReplicationFactor(1)
-            .setPartitionGroup("tenant1");
+        new BrokerInfo().setBrokerId(1, null).setClusterSize(1).setPartitionGroup("tenant1");
 
     final Properties props = new Properties();
     defaultBroker.writeIntoProperties(props);
@@ -123,9 +104,7 @@ final class BrokerInfoTest {
     final BrokerInfo original =
         new BrokerInfo()
             .setBrokerId(3, "us-east-1a")
-            .setPartitionsCount(3)
             .setClusterSize(3)
-            .setReplicationFactor(1)
             .setPartitionGroup(BrokerInfo.DEFAULT_PARTITION_GROUP);
     original.setVersion("8.10.0");
     original.setCommandApiAddress("10.0.0.1:26501");
@@ -137,9 +116,9 @@ final class BrokerInfoTest {
     // then -- broker-level fields are copied
     assertThat(copy.getNodeId()).isEqualTo(3);
     assertThat(copy.getZone()).isEqualTo("us-east-1a");
-    assertThat(copy.getPartitionsCount()).isEqualTo(3);
+
     assertThat(copy.getClusterSize()).isEqualTo(3);
-    assertThat(copy.getReplicationFactor()).isEqualTo(1);
+
     assertThat(copy.getVersion()).isEqualTo("8.10.0");
     assertThat(copy.getCommandApiAddress()).isEqualTo("10.0.0.1:26501");
     assertThat(copy.getPartitionGroup()).isEqualTo("tenant1");
@@ -155,12 +134,7 @@ final class BrokerInfoTest {
   void shouldWriteToNamespacedPropertyKeyForNonDefaultGroup() {
     // given
     final BrokerInfo brokerInfo =
-        new BrokerInfo()
-            .setBrokerId(1, null)
-            .setPartitionsCount(1)
-            .setClusterSize(1)
-            .setReplicationFactor(1)
-            .setPartitionGroup("tenant1");
+        new BrokerInfo().setBrokerId(1, null).setClusterSize(1).setPartitionGroup("tenant1");
 
     // when
     final Properties props = new Properties();
@@ -174,12 +148,8 @@ final class BrokerInfoTest {
   @Test
   void shouldWriteToLegacyKeyForDefaultGroup() {
     // given
-    final BrokerInfo brokerInfo =
-        new BrokerInfo()
-            .setBrokerId(1, null)
-            .setPartitionsCount(1)
-            .setClusterSize(1)
-            .setReplicationFactor(1);
+    final BrokerInfo brokerInfo = new BrokerInfo().setBrokerId(1, null).setClusterSize(1);
+
     // partitionGroup not set → defaults to "default"
 
     // when
@@ -195,12 +165,7 @@ final class BrokerInfoTest {
   void shouldEncodeDecodePartitionGroup() {
     // given
     final BrokerInfo brokerInfo =
-        new BrokerInfo()
-            .setBrokerId(1, null)
-            .setPartitionsCount(3)
-            .setClusterSize(3)
-            .setReplicationFactor(1)
-            .setPartitionGroup("tenant1");
+        new BrokerInfo().setBrokerId(1, null).setClusterSize(3).setPartitionGroup("tenant1");
 
     // when
     final var decoded = encodeDecode(brokerInfo);
@@ -212,12 +177,7 @@ final class BrokerInfoTest {
   @Test
   void shouldReturnDefaultPartitionGroupWhenNotSet() {
     // given
-    final BrokerInfo brokerInfo =
-        new BrokerInfo()
-            .setBrokerId(1, null)
-            .setPartitionsCount(1)
-            .setClusterSize(1)
-            .setReplicationFactor(1);
+    final BrokerInfo brokerInfo = new BrokerInfo().setBrokerId(1, null).setClusterSize(1);
 
     // when
     final var decoded = encodeDecode(brokerInfo);
@@ -279,9 +239,7 @@ final class BrokerInfoTest {
   void shouldEncodeDecodeBrokerInfo() {
     // given
     final int nodeId = 123;
-    final int partitionsCount = 345;
     final int clusterSize = 567;
-    final int replicationFactor = 789;
     final Map<DirectBuffer, DirectBuffer> addresses = new HashMap<>();
     addresses.put(wrapString("foo"), wrapString("192.159.12.1:23"));
     addresses.put(wrapString("bar"), wrapString("zeebe-0.cluster.loc:12312"));
@@ -295,11 +253,7 @@ final class BrokerInfoTest {
     partitionHealthStatuses.put(123, PartitionHealthStatus.HEALTHY);
 
     final BrokerInfo brokerInfo =
-        new BrokerInfo()
-            .setBrokerId(nodeId, "eu-west-1b")
-            .setPartitionsCount(partitionsCount)
-            .setClusterSize(clusterSize)
-            .setReplicationFactor(replicationFactor);
+        new BrokerInfo().setBrokerId(nodeId, "eu-west-1b").setClusterSize(clusterSize);
 
     addresses.forEach(brokerInfo::addAddress);
     partitionRoles.forEach(brokerInfo::addPartitionRole);
@@ -310,9 +264,7 @@ final class BrokerInfoTest {
 
     // then
     assertThat(decoded.getNodeId()).isEqualTo(nodeId);
-    assertThat(decoded.getPartitionsCount()).isEqualTo(partitionsCount);
     assertThat(decoded.getClusterSize()).isEqualTo(clusterSize);
-    assertThat(decoded.getReplicationFactor()).isEqualTo(replicationFactor);
     assertThat(decoded.getAddresses()).containsAllEntriesOf(addresses);
     assertThat(decoded.getPartitionRoles()).containsAllEntriesOf(partitionRoles);
     assertThat(decoded.getPartitionHealthStatuses()).containsAllEntriesOf(partitionHealthStatuses);
@@ -323,25 +275,17 @@ final class BrokerInfoTest {
   void shouldEncodeDecodeBrokerInfoWithEmptyMaps() {
     // given
     final int nodeId = 123;
-    final int partitionsCount = 345;
     final int clusterSize = 567;
-    final int replicationFactor = 789;
 
     final BrokerInfo brokerInfo =
-        new BrokerInfo()
-            .setBrokerId(nodeId, null)
-            .setPartitionsCount(partitionsCount)
-            .setClusterSize(clusterSize)
-            .setReplicationFactor(replicationFactor);
+        new BrokerInfo().setBrokerId(nodeId, null).setClusterSize(clusterSize);
 
     // when
     final var decoded = encodeDecode(brokerInfo);
 
     // then
     assertThat(decoded.getNodeId()).isEqualTo(nodeId);
-    assertThat(decoded.getPartitionsCount()).isEqualTo(partitionsCount);
     assertThat(decoded.getClusterSize()).isEqualTo(clusterSize);
-    assertThat(decoded.getReplicationFactor()).isEqualTo(replicationFactor);
     assertThat(decoded.getAddresses()).isEmpty();
     assertThat(decoded.getPartitionRoles()).isEmpty();
     assertThat(decoded.getPartitionHealthStatuses()).isEmpty();
@@ -360,15 +304,11 @@ final class BrokerInfoTest {
     assertThatIllegalStateException()
         .isThrownBy(decoded::getNodeId)
         .withMessageContaining("nodeId");
-    assertThatIllegalStateException()
-        .isThrownBy(decoded::getPartitionsCount)
-        .withMessageContaining("partitionsCount");
+
     assertThatIllegalStateException()
         .isThrownBy(decoded::getClusterSize)
         .withMessageContaining("clusterSize");
-    assertThatIllegalStateException()
-        .isThrownBy(decoded::getReplicationFactor)
-        .withMessageContaining("replicationFactor");
+
     assertThat(decoded.getAddresses()).isEmpty();
     assertThat(decoded.getPartitionRoles()).isEmpty();
     assertThat(decoded.getPartitionHealthStatuses()).isEmpty();
@@ -425,9 +365,7 @@ final class BrokerInfoTest {
 
     // then -- all v7 fields decode correctly, zone is null
     assertThat(decoded.getNodeId()).isEqualTo(nodeId);
-    assertThat(decoded.getPartitionsCount()).isEqualTo(partitionsCount);
     assertThat(decoded.getClusterSize()).isEqualTo(clusterSize);
-    assertThat(decoded.getReplicationFactor()).isEqualTo(replicationFactor);
     assertThat(decoded.getVersion()).isEqualTo(versionStr);
     assertThat(decoded.getZone()).isNull();
   }
@@ -485,9 +423,7 @@ final class BrokerInfoTest {
 
     // then — all fields decode correctly, zone is null
     assertThat(decoded.getNodeId()).isEqualTo(nodeId);
-    assertThat(decoded.getPartitionsCount()).isEqualTo(partitionsCount);
     assertThat(decoded.getClusterSize()).isEqualTo(clusterSize);
-    assertThat(decoded.getReplicationFactor()).isEqualTo(replicationFactor);
     assertThat(decoded.getVersion()).isEqualTo(versionStr);
     assertThat(decoded.getZone()).isNull();
     assertThat(decoded.getAddresses()).isEmpty();

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBroker.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBroker.java
@@ -65,8 +65,6 @@ public final class StubBroker implements AutoCloseable {
         new BrokerInfo()
             .setCommandApiAddress(Address.from("localhost", socketAddress.getPort()).toString())
             .setClusterSize(1)
-            .setReplicationFactor(1)
-            .setPartitionsCount(1)
             .setBrokerId(nodeId, null)
             .setPartitionHealthy(1)
             .setLeaderForPartition(partitionId, 1);

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/CommandApiRule.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/CommandApiRule.java
@@ -44,8 +44,10 @@ public final class CommandApiRule extends ExternalResource {
       new Int2ObjectHashMap<>();
   private final ControlledActorClock controlledActorClock = new ControlledActorClock();
   private ActorScheduler scheduler;
+  private final int partitionCount;
 
-  public CommandApiRule(final Supplier<AtomixCluster> atomixSupplier) {
+  public CommandApiRule(final int partitionCount, final Supplier<AtomixCluster> atomixSupplier) {
+    this.partitionCount = partitionCount;
     nodeId = 0;
     this.atomixSupplier = atomixSupplier;
   }
@@ -146,15 +148,9 @@ public final class CommandApiRule extends ExternalResource {
   }
 
   public List<Integer> getPartitionIds() {
-    return getBrokerInfoStream()
-        .findFirst()
-        .map(
-            brokerInfo ->
-                IntStream.range(
-                        START_PARTITION_ID, START_PARTITION_ID + brokerInfo.getPartitionsCount())
-                    .boxed()
-                    .collect(Collectors.toList()))
-        .orElse(Collections.emptyList());
+    return IntStream.range(START_PARTITION_ID, START_PARTITION_ID + partitionCount)
+        .boxed()
+        .collect(Collectors.toList());
   }
 
   private Stream<BrokerInfo> getBrokerInfoStream() {

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -221,8 +221,10 @@
 
   <sbe:message name="BrokerInfo" id="201" description="Broker topology information">
     <field name="nodeId" id="1" type="int32"/>
+    <!-- partitionCount is not used anymore, but kept for backward compatibility -->
     <field name="partitionsCount" id="2" type="int32"/>
     <field name="clusterSize" id="3" type="int32"/>
+    <!-- replicationFactor is not used anymore, but kept for backward compatibility -->
     <field name="replicationFactor" id="4" type="int32"/>
     <group name="addresses" id="5">
       <data name="apiName" id="6" type="varDataEncoding"/>


### PR DESCRIPTION
Stacked on #58878.

## Summary

This PR adpats Gateway and BrokerClient to use the new model for the cluster configuration even when the feature flag is off. No code change will be required when the feature flag is turned on. 

Using the new model :
- Allow `BrokerTopologyManagerImpl` to update each partition group's topology from its own cluster configuration once the new-model feature flag is enabled (previously every tenant mirrored the default tenant's configuration).
- Allow various dispatch strategies to use the correct config for the tenant, instead of using the default tenant's config. 

In addition, this PR
- Removes the partitionCount and replicationCount set in BrokerInfo. This is not used anywhere. The Gateway topology manager already uses the values from dynamic cluster configuration. The fields are not removed as they are still used in some tests. This could be cleaned up later.
- Add test coverage for non-default tenants across the changed consumers: dispatch strategies, `BrokerTopologyManagerImpl`, and `BrokerAddressProvider`'s per-group `Mode.RECOVERING` resolution (previously untested).