### PR TITLE
fix: source exporter cluster ID from gossip-resolved cluster configuration

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
-import static java.util.Objects.requireNonNullElse;
-
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
@@ -132,7 +130,12 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
             .exporterMode(exporterMode)
             .positionsToSkipFilter(exporterFilter)
             .meterRegistry(context.getPartitionTransitionMeterRegistry())
-            .clusterId(requireNonNullElse(brokerCfg.getCluster().getClusterId(), ""))
+            .clusterId(
+                context
+                    .getClusterConfigurationService()
+                    .getCurrentClusterConfiguration()
+                    .clusterId()
+                    .orElse(""))
             .licenseKey(brokerCfg.getLicenseKey())
             .tenantName(tenantName)
             .receiveOnLegacySubject(

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
@@ -24,11 +24,13 @@ import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext;
 import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.partitions.TestPartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionTestArgumentProviders.TransitionsThatShouldCloseService;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionTestArgumentProviders.TransitionsThatShouldDoNothing;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionTestArgumentProviders.TransitionsThatShouldInstallService;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
@@ -70,6 +72,14 @@ class ExporterDirectorPartitionTransitionStepTest {
         .thenReturn(TestActorFuture.completedFuture(null));
     transitionContext.setActorSchedulingService(actorSchedulingService);
     transitionContext.setBrokerCfg(new BrokerCfg());
+
+    final var clusterConfigurationService = mock(ClusterConfigurationService.class);
+    when(clusterConfigurationService.getCurrentClusterConfiguration())
+        .thenReturn(
+            CurrentClusterConfiguration.init()
+                .updateGlobalConfiguration(
+                    global -> global.setClusterId("gossip-resolved-cluster-id")));
+    transitionContext.setClusterConfigurationService(clusterConfigurationService);
 
     final var raftPartition = mock(RaftPartition.class);
     final var raftPartitionConfig = new RaftPartitionConfig();
@@ -314,6 +324,25 @@ class ExporterDirectorPartitionTransitionStepTest {
     // then
     verify(mockedExporterDirector, timeout(1000))
         .enableExporterWithRetry(eq(reEnabledExporterId), any(), any());
+  }
+
+  @Test
+  void shouldUseGossipResolvedClusterIdEvenWhenStaticConfigDiffers() {
+    // given - the static broker config disagrees with the gossip-resolved cluster topology
+    // (e.g. this broker joined an existing cluster without an explicit clusterId configured)
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg.getCluster().setClusterId("locally-configured-candidate-id");
+    transitionContext.setBrokerCfg(brokerCfg);
+
+    final AtomicReference<ExporterDirectorContext> capturedContext = new AtomicReference<>();
+    final var exporterDirectorStep = getExporterDirectorPartitionTransitionStep(capturedContext);
+
+    // when
+    exporterDirectorStep.prepareTransition(transitionContext, 1, Role.LEADER).join();
+    exporterDirectorStep.transitionTo(transitionContext, 1, Role.LEADER).join();
+
+    // then - the exporter observes the cluster-wide agreed id, not the diverged local candidate
+    assertThat(capturedContext.get().getClusterId()).isEqualTo("gossip-resolved-cluster-id");
   }
 
   private void setExportersInContext(


### PR DESCRIPTION
## Summary

Exporters read `clusterId` from a static per-broker config bean, populated once from YAML/env or otherwise locally-generated random uuid. In a self-managed cluster without an explicit, configured cluster ID across all brokers, each exporters would each have a different value for cluster ID.

I don't think this value is ever used by exporters right now, but I found this while working on something else in #28286, and it _could_ have introduced a bug there. Consider this boyscouting rather than a functional change