### PR TITLE
fix: correctly handle unrecoverable exporter-open failures in ExporterDirector

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -611,6 +611,11 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
                           "Failed to open exporter '{}'. Not retrying.", container.getId(), e);
                       unrecoverableFailureDetected.set(true);
                       updateHealthStatusWithError(e);
+                      // The container never finished opening (e.g. its writer was never
+                      // assigned), so it must not receive records once exporting starts -
+                      // otherwise every export attempt on this partition would fail on it forever.
+                      containers.remove(container);
+                      recordExporter.resetExporterIndex();
                       return false;
                     } catch (final Exception e) {
                       LOG.warn("Failed to open exporter '{}'. Retrying...", container.getId());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -321,18 +321,24 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       final String exporterId,
       final ExporterInitializationInfo initializationInfo,
       final ExporterDescriptor descriptor) {
+    final var unrecoverableFailureDetected = new AtomicBoolean(false);
     return new BackOffRetryStrategy(actor, Duration.ofSeconds(10))
         .runWithRetry(
             () -> {
               try {
                 addExporter(exporterId, initializationInfo, descriptor);
                 return true;
+              } catch (final UnrecoverableException e) {
+                LOG.error("Failed to add exporter '{}'. Not retrying.", exporterId, e);
+                unrecoverableFailureDetected.set(true);
+                updateHealthStatusWithError(e);
+                return false;
               } catch (final Exception e) {
                 LOG.error("Failed to add exporter '{}'. Retrying...", exporterId, e);
                 return false;
               }
             },
-            this::isClosed);
+            () -> isClosed() || unrecoverableFailureDetected.get());
   }
 
   private void addExporter(
@@ -582,6 +588,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     final var containerOpenFutures = new ArrayList<ActorFuture<Boolean>>();
     for (final ExporterContainer container : containers) {
       container.initMetadata();
+      final var unrecoverableFailureDetected = new AtomicBoolean(false);
       final var openFuture =
           new BackOffRetryStrategy(actor, Duration.ofSeconds(10), Duration.ofMillis(150))
               .runWithRetry(
@@ -597,6 +604,14 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
                             container.getId());
                       }
                       return true;
+                    } catch (final UnrecoverableException e) {
+                      // Permanent misconfiguration (e.g. incompatible schema/cluster state) won't
+                      // resolve itself on retry, so retrying forever would just hide the failure.
+                      LOG.error(
+                          "Failed to open exporter '{}'. Not retrying.", container.getId(), e);
+                      unrecoverableFailureDetected.set(true);
+                      updateHealthStatusWithError(e);
+                      return false;
                     } catch (final Exception e) {
                       LOG.warn("Failed to open exporter '{}'. Retrying...", container.getId());
                       LOG.debug(
@@ -604,7 +619,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
                       return false;
                     }
                   },
-                  this::isClosed);
+                  () -> isClosed() || unrecoverableFailureDetected.get());
 
       containerOpenFutures.add(openFuture);
     }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -232,6 +232,37 @@ public final class ExporterDirectorTest {
   }
 
   @Test
+  public void shouldNotExportToContainerThatFailedToOpenUnrecoverably() throws Exception {
+    // given - exporter-1 fails to open unrecoverably. It never finished opening, so it must
+    // never receive an export call - a real exporter relies on state only assigned in open()
+    // (e.g. CamundaExporter's writer field), so exporting to it anyway fails unpredictably.
+    final ControlledTestExporter failingExporter = exporters.get(0);
+    final var failingExportCallCount = new AtomicInteger();
+    failingExporter.onExport(record -> failingExportCallCount.incrementAndGet());
+    doThrow(new UnrecoverableException("permanent misconfiguration"))
+        .when(failingExporter)
+        .open(any());
+
+    // when
+    startExporterDirector(exporterDescriptors);
+    Awaitility.await("director reports the exporter failure as unrecoverable")
+        .untilAsserted(
+            () ->
+                assertThat(rule.getDirector().getHealthReport().status())
+                    .isEqualTo(HealthStatus.DEAD));
+    writeEvent();
+
+    // then - give the pipeline time to attempt exporting, then confirm the failed container was
+    // never called
+    Awaitility.await("healthy exporter has had a chance to export")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(exporters.get(1).getExportedRecords()).hasSize(1));
+    assertThat(failingExportCallCount.get()).isZero();
+
+    rule.closeExporterDirector();
+  }
+
+  @Test
   public void shouldExportAfterOpenRetried() throws Exception {
     // given
     final var exporter = startExporterWithFaultyOpenCall();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -41,6 +41,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.impl.SkipPositionsFilter;
+import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.health.HealthStatus;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -203,6 +204,29 @@ public final class ExporterDirectorTest {
     Awaitility.await("exporter open has been retried")
         .atMost(Duration.ofSeconds(10))
         .untilAsserted(() -> verify(exporter, times(2)).open(any()));
+
+    rule.closeExporterDirector();
+  }
+
+  @Test
+  public void shouldNotRetryOpenCallOnUnrecoverableException() throws Exception {
+    // given, when
+    final ControlledTestExporter exporter = spy(new ControlledTestExporter());
+    doThrow(new UnrecoverableException("permanent misconfiguration")).when(exporter).open(any());
+    final ExporterDescriptor descriptor =
+        spy(
+            new ExporterDescriptor(
+                "exporter-unrecoverable", exporter.getClass(), Collections.singletonMap("x", 1)));
+    doAnswer(c -> exporter).when(descriptor).newInstance();
+    startExporterDirector(List.of(descriptor));
+
+    // then
+    Awaitility.await("director reports the exporter failure as unrecoverable")
+        .untilAsserted(
+            () ->
+                assertThat(rule.getDirector().getHealthReport().status())
+                    .isEqualTo(HealthStatus.DEAD));
+    verify(exporter, times(1)).open(any());
 
     rule.closeExporterDirector();
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterEnableTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterEnableTest.java
@@ -24,6 +24,8 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.util.exception.UnrecoverableException;
+import io.camunda.zeebe.util.health.HealthStatus;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -207,6 +209,30 @@ public class ExporterEnableTest {
     Awaitility.await("exporter open has been retried")
         .atMost(Duration.ofSeconds(10))
         .untilAsserted(() -> verify(exporter, times(2)).open(any()));
+  }
+
+  @Test
+  public void shouldNotRetryExporterEnableOnUnrecoverableException() {
+    // given
+    rule.startExporterDirector(exporterDescriptors);
+    rule.getDirector().removeExporter(EXPORTER_ID_2).join();
+
+    final var descriptor = createExporter(EXPORTER_ID_2, Collections.singletonMap("x", 1));
+    final var exporter = exporters.get(EXPORTER_ID_2);
+    doThrow(new UnrecoverableException("permanent misconfiguration")).when(exporter).open(any());
+
+    // when
+    rule.getDirector()
+        .enableExporterWithRetry(EXPORTER_ID_2, new ExporterInitializationInfo(1, null), descriptor)
+        .join();
+
+    // then
+    Awaitility.await("director reports the exporter failure as unrecoverable")
+        .untilAsserted(
+            () ->
+                assertThat(rule.getDirector().getHealthReport().status())
+                    .isEqualTo(HealthStatus.DEAD));
+    verify(exporter, times(1)).open(any());
   }
 
   private void waitUntilExportersHaveSeenTheExpectedRecords() {


### PR DESCRIPTION
## Summary

`ExporterDirector` retried a failing `Exporter.open()` forever with no distinction between transient and permanent failures. A permanent misconfiguration (anything an exporter throws as `UnrecoverableException`) never resolves itself on retry, so it was retried indefinitely instead of surfacing as a clear, terminal error.

- Both exporter-open retry loops (initial partition transition, and dynamic exporter enable) now stop retrying and report the exporter as dead as soon as an `UnrecoverableException` is thrown.
- Fixing that surfaced a second, related bug: `startActiveExportingMode()`'s completion callback proceeded to `startActiveExportingFrom()` unconditionally, ignoring whether each container's `open()` actually succeeded. A container whose `open()` threw stayed in the shared `containers` list and still received export calls once exporting started - previously unreachable, since before this fix any exception in that loop just retried `open()` forever and never reached the callback at all. A real exporter that never finished opening likely has state that's only assigned in `open()`, so exporting to it fails unpredictably instead of surfacing the original, already-diagnosed failure. Fixed by removing the container from the export set (and resetting `RecordExporter`'s index, matching the existing `removeExporter()` pattern) as soon as its `open()` is given up on.

`UnrecoverableException` is a general-purpose marker any exporter - including a custom exporter loaded via `jarPath` - can throw from `open()` today, so both bugs are real and exploitable independent of any specific exporter implementation.

Found while working on cluster ID validation for #28286 (parked for now, see that issue); these are genuine, independent bug fixes regardless of that feature's status.