### PR TITLE
test: again activate flaky test for batch operations cleanup

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
@@ -24,7 +24,6 @@ import java.time.Duration;
 import java.util.Objects;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @HistoryMultiDbTest
@@ -111,7 +110,6 @@ public class HistoryCleanupIT {
     assertThat(result.items().getFirst().getProcessInstanceKey()).isNotEqualTo(processInstanceKey);
   }
 
-  @Disabled("flaky, will be fixed #35023")
   @Test
   void shouldDeleteBatchOperationsWhichAreMarkedForCleanup() {
     // given


### PR DESCRIPTION
This pull request re-enables a previously disabled test in the `HistoryCleanupIT` integration test class. The test `shouldDeleteBatchOperationsWhichAreMarkedForCleanup` was marked as flaky and disabled, but it has now been reactivated.

Test improvements:

* Re-enabled the `shouldDeleteBatchOperationsWhichAreMarkedForCleanup` test by removing the `@Disabled` annotation, allowing it to run as part of the test suite.


