### PR TITLE
fix: name specific index in schema validation error messages

### DIFF
--- a/schema-manager/src/main/java/io/camunda/search/schema/IndexSchemaValidator.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/IndexSchemaValidator.java
@@ -13,6 +13,7 @@ import io.camunda.search.schema.exceptions.IndexSchemaValidationException;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import java.util.*;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,10 +73,9 @@ public class IndexSchemaValidator {
           filterIndexMappings(mappings, indexDescriptor);
       // we don't check indices that were not yet created
       if (!indexMappingsGroup.isEmpty()) {
-        final IndexMappingDifference difference =
+        final DifferingIndices differingIndices =
             getIndexMappingDifference(indexDescriptor, indexMappingsGroup);
-        validateDifferenceAndCollectNewFields(
-            indexDescriptor, indexMappingsGroup.keySet(), difference, newFields);
+        validateDifferenceAndCollectNewFields(indexDescriptor, differingIndices, newFields);
       }
     }
     return newFields;
@@ -83,20 +83,20 @@ public class IndexSchemaValidator {
 
   private void validateDifferenceAndCollectNewFields(
       final IndexDescriptor indexDescriptor,
-      final Set<String> indexNames,
-      final IndexMappingDifference difference,
+      final DifferingIndices differingIndices,
       final Map<IndexDescriptor, Collection<IndexMappingProperty>> newFields) {
-    if (difference != null && !difference.equal()) {
+    if (differingIndices != null) {
+      final IndexMappingDifference difference = differingIndices.difference();
       LOGGER.debug(
           "Index fields differ from expected. Index names: {}. Difference: {}.",
-          indexNames,
+          differingIndices.indexNames(),
           difference);
 
       if (!difference.entriesDiffering().isEmpty()) {
         final String errorMsg =
             String.format(
-                "Index name: %s. Unsupported index changes have been introduced. Data migration is required. Changes found: %s",
-                indexDescriptor.getFullQualifiedName(), difference.entriesDiffering());
+                "Index names: %s. Unsupported index changes have been introduced. Data migration is required. Changes found: %s",
+                differingIndices.indexNames(), difference.entriesDiffering());
         LOGGER.error(errorMsg);
         throw new IndexSchemaValidationException(errorMsg);
       }
@@ -104,7 +104,7 @@ public class IndexSchemaValidator {
       if (!difference.entriesOnlyOnRight().isEmpty()) {
         LOGGER.info(
             "Index names '{}': Field deletion is requested, will be ignored. Fields: {}",
-            indexNames,
+            differingIndices.indexNames(),
             difference.entriesOnlyOnRight());
 
       } else if (!difference.entriesOnlyOnLeft().isEmpty()) {
@@ -118,34 +118,47 @@ public class IndexSchemaValidator {
     }
   }
 
-  private IndexMappingDifference getIndexMappingDifference(
+  private DifferingIndices getIndexMappingDifference(
       final IndexDescriptor indexDescriptor, final Map<String, IndexMapping> indexMappingsGroup) {
     final IndexMapping indexMappingMustBe = IndexMapping.from(indexDescriptor, objectMapper);
 
-    final var differences =
-        indexMappingsGroup.values().stream()
-            .map(mapping -> IndexMappingDifference.of(indexMappingMustBe, mapping))
-            .filter(difference -> !difference.equal())
-            .map(this::filterOutDynamicProperties)
-            .distinct()
-            .toList();
+    // sorted by index name so grouping and the reported index names are stable regardless of
+    // the source map's (HashMap) iteration order
+    final Map<IndexMappingDifference, List<String>> differencesByIndexName =
+        indexMappingsGroup.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .map(
+                entry ->
+                    Map.entry(
+                        entry.getKey(),
+                        filterOutDynamicProperties(
+                            IndexMappingDifference.of(indexMappingMustBe, entry.getValue()))))
+            // filtered after dynamic properties are stripped: `equal` is fixed at construction
+            // and won't reflect a diff that only turned out to be dynamic-property noise
+            .filter(entry -> hasRealDifference(entry.getValue()))
+            .collect(
+                Collectors.groupingBy(
+                    Map.Entry::getValue,
+                    LinkedHashMap::new,
+                    Collectors.mapping(Map.Entry::getKey, Collectors.toList())));
 
-    if (differences.isEmpty()) {
+    if (differencesByIndexName.isEmpty()) {
       return null;
     }
 
-    if (differences.size() > 1) {
+    if (differencesByIndexName.size() > 1) {
       LOGGER.debug(
           "Ambiguous schema update. Index names: {}. Difference: {}.",
           indexMappingsGroup.keySet(),
-          differences);
+          differencesByIndexName);
       throw new IndexSchemaValidationException(
           String.format(
-              "Ambiguous schema update. Multiple indices for mapping '%s' has different fields. Differences: '%s'",
-              indexDescriptor.getIndexName(), differences));
+              "Ambiguous schema update. Multiple indices for mapping '%s' have different fields. Differences by index: %s",
+              indexDescriptor.getIndexName(), differencesByIndexName));
     }
 
-    return differences.getFirst();
+    final var onlyEntry = differencesByIndexName.entrySet().iterator().next();
+    return new DifferingIndices(onlyEntry.getKey(), onlyEntry.getValue());
   }
 
   /** Filters out differences that are only related to dynamic properties. */
@@ -155,6 +168,17 @@ public class IndexSchemaValidator {
         .filterEntriesInCommon(indexMappingProperty -> !isDynamicProperty(indexMappingProperty))
         .filterEntriesDiffering(
             propertyDifference -> !isDynamicProperty(propertyDifference.leftValue()));
+  }
+
+  /**
+   * {@link IndexMappingDifference#equal()} is fixed at construction time and isn't recomputed by
+   * {@link #filterOutDynamicProperties}, so it can no longer be trusted after filtering. Checks the
+   * actual remaining entries instead.
+   */
+  private boolean hasRealDifference(final IndexMappingDifference difference) {
+    return !difference.entriesDiffering().isEmpty()
+        || !difference.entriesOnlyOnLeft().isEmpty()
+        || !difference.entriesOnlyOnRight().isEmpty();
   }
 
   /**
@@ -177,4 +201,6 @@ public class IndexSchemaValidator {
     return indexMappingProperty.typeDefinition() instanceof final Map typeDefMap
         && Boolean.parseBoolean(typeDefMap.getOrDefault("dynamic", "false").toString());
   }
+
+  private record DifferingIndices(IndexMappingDifference difference, List<String> indexNames) {}
 }

--- a/schema-manager/src/test/java/io/camunda/search/schema/IndexSchemaValidatorTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/IndexSchemaValidatorTest.java
@@ -124,7 +124,9 @@ public class IndexSchemaValidatorTest {
     // then
     assertThatThrownBy(() -> VALIDATOR.validateIndexMappings(currentIndices, Set.of(currentIndex)))
         .isInstanceOf(IndexSchemaValidationException.class)
-        .hasMessageContaining("Ambiguous schema update.");
+        .hasMessageContaining("Ambiguous schema update.")
+        .hasMessageContaining(qualifiedName)
+        .hasMessageContaining(qualifiedName + "_2");
   }
 
   @Test
@@ -133,20 +135,56 @@ public class IndexSchemaValidatorTest {
     final var indexMapping =
         createTestIndexDescriptor("index_name", "/mappings-dynamic-property.json");
     final String fullQualifiedName = indexMapping.getFullQualifiedName();
+    // both indices also differ from the descriptor in "world"'s dynamic sub-properties (noise,
+    // filtered out), but have genuinely different, non-dynamic types for "hello" - a real,
+    // distinct difference each - so this must still be reported as ambiguous
     final var currentIndices =
         Map.of(
             fullQualifiedName,
-            jsonToIndexMappingProperties(
-                "/mappings-dynamic-property-properties.json", fullQualifiedName),
+            new IndexMapping.Builder()
+                .indexName(fullQualifiedName)
+                .properties(
+                    Set.of(
+                        new IndexMappingProperty.Builder()
+                            .name("hello")
+                            .typeDefinition(Map.of("type", "keyword"))
+                            .build(),
+                        new IndexMappingProperty.Builder()
+                            .name("world")
+                            .typeDefinition(
+                                Map.of(
+                                    "type",
+                                    "object",
+                                    "dynamic",
+                                    true,
+                                    "properties",
+                                    Map.of("header1", Map.of("type", "keyword"))))
+                            .build()))
+                .dynamic("strict")
+                .build(),
             fullQualifiedName + "_2",
-            jsonToIndexMappingProperties(
-                "/mappings-dynamic-property-properties-deleted.json", fullQualifiedName + "_2"));
+            new IndexMapping.Builder()
+                .indexName(fullQualifiedName + "_2")
+                .properties(
+                    Set.of(
+                        new IndexMappingProperty.Builder()
+                            .name("hello")
+                            .typeDefinition(Map.of("type", "integer"))
+                            .build(),
+                        new IndexMappingProperty.Builder()
+                            .name("world")
+                            .typeDefinition(Map.of("type", "object", "dynamic", true))
+                            .build()))
+                .dynamic("strict")
+                .build());
 
     // when
     // then
     assertThatThrownBy(() -> VALIDATOR.validateIndexMappings(currentIndices, Set.of(indexMapping)))
         .isInstanceOf(IndexSchemaValidationException.class)
-        .hasMessageContaining("Ambiguous schema update.");
+        .hasMessageContaining("Ambiguous schema update.")
+        .hasMessageContaining(fullQualifiedName)
+        .hasMessageContaining(fullQualifiedName + "_2");
   }
 
   @Test
@@ -175,6 +213,44 @@ public class IndexSchemaValidatorTest {
                     .name("foo")
                     .typeDefinition(Map.of("type", "keyword"))
                     .build()));
+  }
+
+  @Test
+  void shouldTreatPurelyDynamicPropertyDifferenceAsUpToDate() throws IOException {
+    // given
+    final var index = createTestIndexDescriptor("index_name", "/mappings-dynamic-property.json");
+    final var fullQualifiedName = index.getFullQualifiedName();
+    // "world" only differs from the descriptor in its dynamic sub-properties, which is the only
+    // difference here - once dynamic noise is filtered out, no real difference remains
+    final var actualMapping =
+        new IndexMapping.Builder()
+            .indexName(fullQualifiedName)
+            .properties(
+                Set.of(
+                    new IndexMappingProperty.Builder()
+                        .name("hello")
+                        .typeDefinition(Map.of("type", "text"))
+                        .build(),
+                    new IndexMappingProperty.Builder()
+                        .name("world")
+                        .typeDefinition(
+                            Map.of(
+                                "type",
+                                "object",
+                                "dynamic",
+                                true,
+                                "properties",
+                                Map.of("header1", Map.of("type", "keyword"))))
+                        .build()))
+            .dynamic("strict")
+            .build();
+    final var currentIndices = Map.of(fullQualifiedName, actualMapping);
+
+    // when
+    final var difference = VALIDATOR.validateIndexMappings(currentIndices, Set.of(index));
+
+    // then
+    assertThat(difference).isEmpty();
   }
 
   @Test
@@ -209,7 +285,32 @@ public class IndexSchemaValidatorTest {
     assertThatThrownBy(() -> VALIDATOR.validateIndexMappings(currentIndices, Set.of(index)))
         .isInstanceOf(IndexSchemaValidationException.class)
         .hasMessageContaining(
-            "Unsupported index changes have been introduced. Data migration is required.");
+            "Unsupported index changes have been introduced. Data migration is required.")
+        .hasMessageContaining(index.getFullQualifiedName());
+  }
+
+  @Test
+  void shouldNameAllMatchingIndicesWhenSameUnsupportedChangeAffectsMultipleIndices()
+      throws IOException {
+    // given
+    final var index =
+        createTestIndexDescriptor("index_name", "/mappings-changed-property-invalid.json");
+    final var fullQualifiedName = index.getFullQualifiedName();
+    final var currentIndices =
+        Map.of(
+            fullQualifiedName,
+            jsonToIndexMappingProperties("/mappings.json", fullQualifiedName),
+            fullQualifiedName + "_2",
+            jsonToIndexMappingProperties("/mappings.json", fullQualifiedName + "_2"));
+
+    // when
+    // then
+    assertThatThrownBy(() -> VALIDATOR.validateIndexMappings(currentIndices, Set.of(index)))
+        .isInstanceOf(IndexSchemaValidationException.class)
+        .hasMessageContaining(
+            "Unsupported index changes have been introduced. Data migration is required.")
+        .hasMessageContaining(fullQualifiedName)
+        .hasMessageContaining(fullQualifiedName + "_2");
   }
 
   @Test

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -1201,7 +1201,7 @@ public class SchemaManagerIT {
     assertThatThrownBy(schemaManager::startup)
         .isInstanceOf(IndexSchemaValidationException.class)
         .hasMessageContaining(
-            "Index name: custom-prefix-test-template_name-1.0.0_. Unsupported index changes have been introduced. Data migration is required.");
+            "Index names: [custom-prefix-test-template_name-1.0.0_]. Unsupported index changes have been introduced. Data migration is required.");
   }
 
   @TestTemplate


### PR DESCRIPTION
## Description

Schema validation compares an index descriptor's expected mapping against every physical index matching it (e.g. several dated indices for the same template). When a mismatch was found, the thrown `IndexSchemaValidationException` only named the generic descriptor pattern, never the concrete index that actually diverged. With multiple indices matching a descriptor, this made it impossible to tell from the message alone which physical index needed a migration without manually inspecting every match.

Debug/info logs one level below the thrown exceptions were also updated to use the same precise index names, since they had the same generic-name issue.

Closes #58775