### PR TITLE
ci: add list-maintained-branches action for dynamic stable-branch matrices

### DIFF
--- a/.github/actions/list-maintained-branches/README.md
+++ b/.github/actions/list-maintained-branches/README.md
@@ -16,15 +16,15 @@ version list to maintain.
 
 ## Inputs
 
-| Input         | Description                                               | Required |
-|---------------|-----------------------------------------------------------|----------|
-| `min-version` | Minimum stable version to include, as `MAJOR.MINOR` (e.g. `8.8`). | yes |
+|     Input     |                            Description                            | Required |
+|---------------|-------------------------------------------------------------------|----------|
+| `min-version` | Minimum stable version to include, as `MAJOR.MINOR` (e.g. `8.8`). | yes      |
 
 ## Outputs
 
-| Output            | Description                                                              |
-|-------------------|--------------------------------------------------------------------------|
-| `branches`        | JSON array including `main`, e.g. `["main","stable/8.8","stable/8.9"]`.   |
+|      Output       |                                    Description                                    |
+|-------------------|-----------------------------------------------------------------------------------|
+| `branches`        | JSON array including `main`, e.g. `["main","stable/8.8","stable/8.9"]`.           |
 | `stable-branches` | JSON array of only the `stable/X.Y` branches, e.g. `["stable/8.8","stable/8.9"]`. |
 
 > **Ordering is not guaranteed.** The action does not sort its output. Callers
@@ -52,3 +52,4 @@ jobs:
         branch: ${{ fromJSON(needs.prepare-matrix.outputs.branches) }}
     # ...
 ```
+

--- a/.github/actions/list-maintained-branches/README.md
+++ b/.github/actions/list-maintained-branches/README.md
@@ -1,0 +1,54 @@
+# List Maintained Branches Action
+
+Discovers the maintained branches (`main` plus every `stable/X.Y` at or above a
+`min-version`) from the git remote and exposes them as JSON arrays ready for
+`strategy.matrix` via `fromJSON()`.
+
+Because it reads refs with `git ls-remote`, the list stays correct as new
+`stable/*` branches are cut and older ones reach EOL — there is no hardcoded
+version list to maintain.
+
+## Prerequisites
+
+- The repository must be checked out (e.g. `actions/checkout`) **before** this
+  action runs, so the `origin` remote is configured.
+- `jq` must be available on the runner (present on GitHub-hosted runners).
+
+## Inputs
+
+| Input         | Description                                               | Required |
+|---------------|-----------------------------------------------------------|----------|
+| `min-version` | Minimum stable version to include, as `MAJOR.MINOR` (e.g. `8.8`). | yes |
+
+## Outputs
+
+| Output            | Description                                                              |
+|-------------------|--------------------------------------------------------------------------|
+| `branches`        | JSON array including `main`, e.g. `["main","stable/8.8","stable/8.9"]`.   |
+| `stable-branches` | JSON array of only the `stable/X.Y` branches, e.g. `["stable/8.8","stable/8.9"]`. |
+
+> **Ordering is not guaranteed.** The action does not sort its output. Callers
+> that need a specific order (e.g. ascending by version) must sort it themselves.
+
+## Example
+
+```yaml
+jobs:
+  prepare-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.branches.outputs.branches }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: branches
+        uses: ./.github/actions/list-maintained-branches
+        with:
+          min-version: '8.8'
+
+  scan:
+    needs: prepare-matrix
+    strategy:
+      matrix:
+        branch: ${{ fromJSON(needs.prepare-matrix.outputs.branches) }}
+    # ...
+```

--- a/.github/actions/list-maintained-branches/action.yml
+++ b/.github/actions/list-maintained-branches/action.yml
@@ -10,7 +10,13 @@ description: |
   Because it reads refs with `git ls-remote`, the list stays correct as new
   `stable/*` branches are cut and older ones reach EOL — no hardcoded lists.
 
-  The repository must already be checked out before this action is called.
+  Prerequisites:
+    - The repository must be checked out (e.g. actions/checkout) before this
+      action runs, so the `origin` remote is configured.
+    - `jq` must be available on PATH (present on GitHub-hosted runners).
+
+  The order of the returned branches is not guaranteed; sort in the caller if a
+  specific order is required.
 
 inputs:
   min-version:
@@ -19,10 +25,10 @@ inputs:
 
 outputs:
   branches:
-    description: 'JSON array including main, e.g. ["main","stable/8.8","stable/8.9"].'
+    description: 'JSON array including main (unordered), e.g. ["main","stable/8.8","stable/8.9"].'
     value: ${{ steps.list.outputs.branches }}
   stable-branches:
-    description: 'JSON array of only the stable/X.Y branches, e.g. ["stable/8.8","stable/8.9"].'
+    description: 'JSON array of only the stable/X.Y branches (unordered), e.g. ["stable/8.8","stable/8.9"].'
     value: ${{ steps.list.outputs.stable-branches }}
 
 runs:
@@ -33,38 +39,4 @@ runs:
       shell: bash
       env:
         MIN_VERSION: ${{ inputs.min-version }}
-      run: |
-        if ! command -v jq >/dev/null 2>&1; then
-          echo "::error::list-maintained-branches requires 'jq', which was not found on PATH."
-          exit 1
-        fi
-
-        if [[ ! "$MIN_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
-          echo "::error::Invalid min-version '${MIN_VERSION}'; expected MAJOR.MINOR (e.g. 8.8)."
-          exit 1
-        fi
-
-        min_major="${MIN_VERSION%%.*}"
-        min_minor="${MIN_VERSION#*.}"
-
-        branches=$(
-          git ls-remote --heads origin 'refs/heads/stable/*' \
-            | sed -nE 's|.*refs/heads/(stable/[0-9]+\.[0-9]+)$|\1|p' \
-            | awk -F/ -v maj="$min_major" -v min="$min_minor" \
-                '{ split($2, v, "."); if (v[1] > maj || (v[1] == maj && v[2] >= min)) print }' \
-            | sort -t/ -k2 -V
-        )
-
-        if [[ -z "$branches" ]]; then
-          echo "::error::No stable branch matched stable/X.Y >= ${MIN_VERSION}."
-          exit 1
-        fi
-
-        to_json() { printf '%s\n' "$1" | jq -Rsc 'split("\n") | map(select(length > 0))'; }
-        stable_json=$(to_json "$branches")
-        all_json=$(to_json "$(printf 'main\n%s\n' "$branches")")
-        echo "Discovered branches: ${all_json}"
-        {
-          echo "branches=${all_json}"
-          echo "stable-branches=${stable_json}"
-        } >> "$GITHUB_OUTPUT"
+      run: ${{ github.action_path }}/list-branches.sh

--- a/.github/actions/list-maintained-branches/action.yml
+++ b/.github/actions/list-maintained-branches/action.yml
@@ -1,0 +1,60 @@
+name: List maintained branches
+
+# owner: @camunda/engineering-operations
+
+description: |
+  Discovers the maintained branches (`main` plus every `stable/X.Y` at or above
+  `min-version`) from the git remote and exposes them as a JSON array ready for
+  `strategy.matrix` via `fromJSON()`.
+
+  Because it reads refs with `git ls-remote`, the list stays correct as new
+  `stable/*` branches are cut and older ones reach EOL — no hardcoded lists.
+
+  The repository must already be checked out before this action is called.
+
+inputs:
+  min-version:
+    description: Minimum stable version to include, as `MAJOR.MINOR` (e.g. `8.8`).
+    required: true
+
+outputs:
+  branches:
+    description: 'JSON array including main, e.g. ["main","stable/8.8","stable/8.9"].'
+    value: ${{ steps.list.outputs.branches }}
+  stable-branches:
+    description: 'JSON array of only the stable/X.Y branches, e.g. ["stable/8.8","stable/8.9"].'
+    value: ${{ steps.list.outputs.stable-branches }}
+
+runs:
+  using: composite
+  steps:
+    - name: List maintained branches
+      id: list
+      shell: bash
+      env:
+        MIN_VERSION: ${{ inputs.min-version }}
+      run: |
+        min_major="${MIN_VERSION%%.*}"
+        min_minor="${MIN_VERSION#*.}"
+
+        branches=$(
+          git ls-remote --heads origin 'refs/heads/stable/*' \
+            | sed -nE 's|.*refs/heads/(stable/[0-9]+\.[0-9]+)$|\1|p' \
+            | awk -F/ -v maj="$min_major" -v min="$min_minor" \
+                '{ split($2, v, "."); if (v[1] > maj || (v[1] == maj && v[2] >= min)) print }' \
+            | sort -t/ -k2 -V
+        )
+
+        if [[ -z "$branches" ]]; then
+          echo "::error::No stable branch matched stable/X.Y >= ${MIN_VERSION}."
+          exit 1
+        fi
+
+        to_json() { printf '%s\n' "$1" | jq -Rsc 'split("\n") | map(select(length > 0))'; }
+        stable_json=$(to_json "$branches")
+        all_json=$(to_json "$(printf 'main\n%s\n' "$branches")")
+        echo "Discovered branches: ${all_json}"
+        {
+          echo "branches=${all_json}"
+          echo "stable-branches=${stable_json}"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/actions/list-maintained-branches/action.yml
+++ b/.github/actions/list-maintained-branches/action.yml
@@ -34,6 +34,16 @@ runs:
       env:
         MIN_VERSION: ${{ inputs.min-version }}
       run: |
+        if ! command -v jq >/dev/null 2>&1; then
+          echo "::error::list-maintained-branches requires 'jq', which was not found on PATH."
+          exit 1
+        fi
+
+        if [[ ! "$MIN_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+          echo "::error::Invalid min-version '${MIN_VERSION}'; expected MAJOR.MINOR (e.g. 8.8)."
+          exit 1
+        fi
+
         min_major="${MIN_VERSION%%.*}"
         min_minor="${MIN_VERSION#*.}"
 

--- a/.github/actions/list-maintained-branches/list-branches.sh
+++ b/.github/actions/list-maintained-branches/list-branches.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Discovers the maintained branches (main plus every stable/X.Y at or above
+# MIN_VERSION) from the git remote and writes two JSON arrays to $GITHUB_OUTPUT
+# for use with strategy.matrix via fromJSON().
+#
+# Prerequisites:
+#   - The repository is checked out (e.g. actions/checkout) so the `origin`
+#     remote is configured; this reads refs via `git ls-remote origin`.
+#   - `jq` is available on PATH (present on GitHub-hosted runners).
+#
+# Inputs (environment):
+#   MIN_VERSION  Minimum stable version to include, as MAJOR.MINOR (e.g. 8.8).
+#
+# The order of the emitted branches is intentionally NOT guaranteed. Callers that
+# need a specific order must sort the result themselves.
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "::error::list-maintained-branches requires 'jq', which was not found on PATH."
+  exit 1
+fi
+
+if [[ ! "${MIN_VERSION:-}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+  echo "::error::Invalid min-version '${MIN_VERSION:-}'; expected MAJOR.MINOR (e.g. 8.8)."
+  exit 1
+fi
+
+min_major="${MIN_VERSION%%.*}"
+min_minor="${MIN_VERSION#*.}"
+
+# List remote stable/X.Y branches and keep only those at or above MIN_VERSION.
+# awk compares major/minor numerically, so 8.10 is correctly kept over 8.9.
+stable_branches=$(
+  git ls-remote --heads origin 'refs/heads/stable/*' \
+    | sed -nE 's|.*refs/heads/(stable/[0-9]+\.[0-9]+)$|\1|p' \
+    | awk -F/ -v maj="$min_major" -v min="$min_minor" \
+        '{ split($2, v, "."); if (v[1] > maj || (v[1] == maj && v[2] >= min)) print }'
+)
+
+if [[ -z "$stable_branches" ]]; then
+  echo "::error::No stable branch matched stable/X.Y >= ${MIN_VERSION}."
+  exit 1
+fi
+
+to_json() {
+  printf '%s\n' "$1" | jq -Rsc 'split("\n") | map(select(length > 0))'
+}
+
+stable_json=$(to_json "$stable_branches")
+all_json=$(to_json "$(printf 'main\n%s\n' "$stable_branches")")
+
+echo "Discovered branches: ${all_json}"
+{
+  echo "branches=${all_json}"
+  echo "stable-branches=${stable_json}"
+} >> "$GITHUB_OUTPUT"

--- a/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
@@ -43,8 +43,17 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: List maintained branches
+        id: maintained-branches
+        # Forward compatibility tests start from 8.8 (feature-availability floor).
+        uses: ./.github/actions/list-maintained-branches
+        with:
+          min-version: '8.8'
+
       - name: Generate matrix
         id: matrix
+        env:
+          STABLE_BRANCHES_JSON: ${{ steps.maintained-branches.outputs.stable-branches }}
         run: |
           # Resolve the public Docker image for a branch.
           # - stable/X.Y → camunda/camunda:X.Y-SNAPSHOT
@@ -77,14 +86,9 @@ jobs:
               '{"include": [{"server_branch": $server, "test_branch": $test, "server_image": $image}]}')
           else
             echo "Discovering stable branches from remote..."
-            # List remote stable/X.Y branches, extract version, sort ascending by version
-            # Only include branches >= 8.8 (forward compatibility tests start from 8.8)
-            STABLE_BRANCHES=$(git ls-remote --heads origin 'refs/heads/stable/*' \
-              | sed -n 's|.*refs/heads/\(stable/[0-9]\+\.[0-9]\+\)$|\1|p' \
-              | sort -t/ -k2 -V \
-              | awk -F/ '{ split($2, v, "."); if (v[1] > 8 || (v[1] == 8 && v[2] >= 8)) print }')
-
-            mapfile -t BRANCHES <<< "$STABLE_BRANCHES"
+            # stable/X.Y branches >= 8.8, sorted ascending by version, from the
+            # list-maintained-branches action (STABLE_BRANCHES_JSON).
+            mapfile -t BRANCHES < <(jq -r '.[]' <<< "$STABLE_BRANCHES_JSON")
             echo "Discovered stable branches (ascending): ${BRANCHES[*]}"
 
             if [[ ${#BRANCHES[@]} -lt 2 ]]; then

--- a/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
@@ -45,6 +45,10 @@ jobs:
 
       - name: List maintained branches
         id: maintained-branches
+        # Only needed for the default (discovered) matrix. Skipped when explicit
+        # branches are dispatched, so the manual path never depends on git
+        # ls-remote (which can fail in forks or repos without stable branches).
+        if: ${{ inputs.server_branch == '' && inputs.test_branch == '' }}
         # Forward compatibility tests start from 8.8 (feature-availability floor).
         uses: ./.github/actions/list-maintained-branches
         with:

--- a/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
@@ -90,9 +90,10 @@ jobs:
               '{"include": [{"server_branch": $server, "test_branch": $test, "server_image": $image}]}')
           else
             echo "Discovering stable branches from remote..."
-            # stable/X.Y branches >= 8.8, sorted ascending by version, from the
-            # list-maintained-branches action (STABLE_BRANCHES_JSON).
-            mapfile -t BRANCHES < <(jq -r '.[]' <<< "$STABLE_BRANCHES_JSON")
+            # stable/X.Y branches >= 8.8 from the list-maintained-branches action
+            # (STABLE_BRANCHES_JSON). The action does not guarantee ordering, so
+            # sort ascending by version here — the pairing logic below relies on it.
+            mapfile -t BRANCHES < <(jq -r '.[]' <<< "$STABLE_BRANCHES_JSON" | sort -t/ -k2 -V)
             echo "Discovered stable branches (ascending): ${BRANCHES[*]}"
 
             if [[ ${#BRANCHES[@]} -lt 2 ]]; then

--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -39,7 +39,7 @@ jobs:
         uses: ./.github/actions/list-maintained-branches
         with:
           min-version: '8.7'
-      - name: Set stable/8.* branches as JSON array of strings
+      - name: Compute maintained branch matrix as JSON array of objects
         id: set-matrix
         env:
           STABLE_BRANCHES_JSON: ${{ steps.maintained-branches.outputs.stable-branches }}

--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -33,22 +33,25 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: List maintained branches
+        id: maintained-branches
+        # 8.7+ require daily QA; older minors (e.g. 8.6 in extended support) do not.
+        uses: ./.github/actions/list-maintained-branches
+        with:
+          min-version: '8.7'
       - name: Set stable/8.* branches as JSON array of strings
         id: set-matrix
+        env:
+          STABLE_BRANCHES_JSON: ${{ steps.maintained-branches.outputs.stable-branches }}
         run: |
-          # List all `stable/8.*` branches
+          # Take the maintained stable/X.Y branches (from list-maintained-branches)
           # Sort them in desc order
-          # Exclude versions that don't require daily QA - for example, 8.6 in extended support
-          # Remove the `origin/` prefix
           # Transform to json-formatted objects with branch and generation_template fields
           # Transform them to json-formatted array of those objects
           # Add the `main` branch to the json array
           matrix=$( \
-            git ls-remote origin "refs/heads/stable/8.*" | awk '{print $2}' | sed 's|refs/heads/||' \
+            jq -r '.[]' <<< "$STABLE_BRANCHES_JSON" \
               | sort -Vr \
-              | grep -v '^stable/8.4$' \
-              | grep -v '^stable/8.5$' \
-              | grep -v '^stable/8.6$' \
               | while read -r branch; do
                   version="${branch#stable/}"
                   printf '{"branch":"%s","generation_template":"Camunda %s+gen1"}\n' "$branch" "$version"


### PR DESCRIPTION
## Description

Introduces a reusable composite action, `list-maintained-branches`, that discovers the currently maintained branches (`main` plus every `stable/X.Y` at or above a `min-version`) from the git remote and exposes them as JSON arrays ready for `strategy.matrix` via `fromJSON()`.

Because it reads refs with `git ls-remote`, the branch list stays correct automatically as new `stable/*` branches are cut and older ones reach EOL — replacing hand-maintained version lists and ad-hoc `awk`/`grep -v` pipelines that were duplicated across workflows.

### Outputs
- `branches` — JSON array including `main`, e.g. `["main","stable/8.8","stable/8.9"]`
- `stable-branches` — JSON array of only the `stable/X.Y` branches

### Adopted in two workflows that already derived the list inline
- **`c8-orchestration-cluster-forward-compatibility-tests.yml`** — feature-availability floor (`min-version: '8.8'`); the paired matrix logic is unchanged.
- **`zeebe-daily-qa.yml`** — EOL floor (`min-version: '8.7'`), replacing the `grep -v '^stable/8.4$'` / `8.5` / `8.6` excludes with a single declarative floor.

## Why

The same `git ls-remote ... stable/*` + version-threshold logic was reimplemented (slightly differently) in multiple workflows, and EOL handling relied on hand-edited exclude lists. Centralizing it removes list drift and makes the version math reviewable in one place.

## Notes / scope

- Two floor kinds exist and behave differently: a **feature-availability floor** (set once, never moves — forward-compat's 8.8) and an **EOL floor** (drifts upward — daily-qa's 8.7). The action removes *list* drift; an EOL floor still requires bumping one `min-version` number when a minor goes EOL. That is intentional (KISS) and left as a per-caller input rather than a global constant.
- **`zeebe-release-stable-dry-run.yml` was intentionally left unchanged.** Its per-version release jobs pin `uses: ...@stable/8.X` as literals (GitHub forbids expressions there) and each ref must run *its own* release workflow, so the list cannot be collapsed into a discovered matrix. Making that workflow generic is a separate `@camunda/engineering-operations` design task.

## Validation

- `actionlint` passes on both modified workflows.
- Matrix-generation jobs; a `workflow_dispatch` run on this branch is the real proof before merge.
