### PR TITLE
refactor: convert 5 more RDBMS DbModels to records (derived-accessor classes)

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapper.java
@@ -20,6 +20,8 @@ public class AgentHistoryEntityMapper {
     if (dbModel == null) {
       return null;
     }
+    final var contentItems = dbModel.contentItems();
+    final var toolCallValues = dbModel.toolCallValues();
     return new AgentInstanceHistoryEntity(
         dbModel.agentHistoryKey(),
         dbModel.agentInstanceKey(),
@@ -32,8 +34,8 @@ public class AgentHistoryEntityMapper {
         nullToEmpty(dbModel.jobLease()),
         dbModel.loopIteration(),
         dbModel.role(),
-        dbModel.contentItems() != null ? dbModel.contentItems() : List.of(),
-        dbModel.toolCallValues() != null ? dbModel.toolCallValues() : List.of(),
+        contentItems != null ? contentItems : List.of(),
+        toolCallValues != null ? toolCallValues : List.of(),
         toMetrics(dbModel.inputTokens(), dbModel.outputTokens(), dbModel.durationMs()),
         dbModel.commitStatus(),
         dbModel.producedAt());

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModel.java
@@ -203,7 +203,9 @@ public record AgentHistoryDbModel(
 
     // Seeds the raw serialized column values for toBuilder()/copy(), so a copy that never
     // touches contentItems()/toolCallValues() carries the original JSON through unparsed instead
-    // of round-tripping it through Jackson.
+    // of round-tripping it through Jackson. Package-private, not a public setter: a second
+    // public setter aliasing the same fields as contentItems(List)/toolCallValues(List) would
+    // let callers silently drop a write (e.g. builder.content(x).contentItems(y) loses x).
     Builder(final String content, final String toolCalls) {
       this.content = content;
       this.toolCalls = toolCalls;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModel.java
@@ -24,36 +24,32 @@ import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class AgentHistoryDbModel implements Copyable<AgentHistoryDbModel> {
+public record AgentHistoryDbModel(
+    long agentHistoryKey,
+    long agentInstanceKey,
+    long elementInstanceKey,
+    long processInstanceKey,
+    long rootProcessInstanceKey,
+    String processDefinitionId,
+    long processDefinitionKey,
+    String tenantId,
+    int partitionId,
+    long jobKey,
+    String jobLease,
+    int loopIteration,
+    AgentInstanceHistoryRole role,
+    AgentInstanceHistoryCommitStatus commitStatus,
+    OffsetDateTime producedAt,
+    Long inputTokens,
+    Long outputTokens,
+    Long durationMs,
+    String content,
+    String toolCalls)
+    implements Copyable<AgentHistoryDbModel> {
 
   private static final Logger LOG = LoggerFactory.getLogger(AgentHistoryDbModel.class);
   private static final ObjectMapper MAPPER =
       new ObjectMapper().registerModule(new JavaTimeModule());
-
-  private long agentHistoryKey;
-  private long agentInstanceKey;
-  private long elementInstanceKey;
-  private long processInstanceKey;
-  private long rootProcessInstanceKey;
-  private String processDefinitionId;
-  private long processDefinitionKey;
-  private String tenantId;
-  private int partitionId;
-  private long jobKey;
-  private String jobLease;
-  private int loopIteration;
-  private AgentInstanceHistoryRole role;
-  private AgentInstanceHistoryCommitStatus commitStatus;
-  private OffsetDateTime producedAt;
-  private Long inputTokens;
-  private Long outputTokens;
-  private Long durationMs;
-  private String content;
-  private List<ContentItem> contentItems;
-  private String toolCalls;
-  private List<ToolCall> toolCallValues;
-
-  public AgentHistoryDbModel() {}
 
   @Override
   public AgentHistoryDbModel copy(
@@ -62,224 +58,57 @@ public class AgentHistoryDbModel implements Copyable<AgentHistoryDbModel> {
     return copyFunction.apply(toBuilder()).build();
   }
 
-  public ObjectBuilder<AgentHistoryDbModel> toBuilder() {
-    return new Builder()
-        .agentHistoryKey(agentHistoryKey)
-        .agentInstanceKey(agentInstanceKey)
-        .elementInstanceKey(elementInstanceKey)
-        .processInstanceKey(processInstanceKey)
-        .rootProcessInstanceKey(rootProcessInstanceKey)
-        .processDefinitionId(processDefinitionId)
-        .processDefinitionKey(processDefinitionKey)
-        .tenantId(tenantId)
-        .partitionId(partitionId)
-        .jobKey(jobKey)
-        .jobLease(jobLease)
-        .loopIteration(loopIteration)
-        .role(role)
-        .commitStatus(commitStatus)
-        .producedAt(producedAt)
-        .inputTokens(inputTokens)
-        .outputTokens(outputTokens)
-        .durationMs(durationMs)
-        // route through the getter so DB-hydrated models (only `content` JSON populated)
-        // are lazily deserialized and the structured form is preserved on the copy
-        .contentItems(contentItems())
-        // route through the getter so DB-hydrated models (only `toolCalls` JSON populated)
-        // are lazily deserialized and the structured form is preserved on the copy
-        .toolCallValues(toolCallValues());
-  }
-
-  public long agentHistoryKey() {
-    return agentHistoryKey;
-  }
-
-  public void agentHistoryKey(final long agentHistoryKey) {
-    this.agentHistoryKey = agentHistoryKey;
-  }
-
-  public long agentInstanceKey() {
-    return agentInstanceKey;
-  }
-
-  public void agentInstanceKey(final long agentInstanceKey) {
-    this.agentInstanceKey = agentInstanceKey;
-  }
-
-  public long elementInstanceKey() {
-    return elementInstanceKey;
-  }
-
-  public void elementInstanceKey(final long elementInstanceKey) {
-    this.elementInstanceKey = elementInstanceKey;
-  }
-
-  public long processInstanceKey() {
-    return processInstanceKey;
-  }
-
-  public void processInstanceKey(final long processInstanceKey) {
-    this.processInstanceKey = processInstanceKey;
-  }
-
-  public long rootProcessInstanceKey() {
-    return rootProcessInstanceKey;
-  }
-
-  public void rootProcessInstanceKey(final long rootProcessInstanceKey) {
-    this.rootProcessInstanceKey = rootProcessInstanceKey;
-  }
-
-  public String processDefinitionId() {
-    return processDefinitionId;
-  }
-
-  public void processDefinitionId(final String processDefinitionId) {
-    this.processDefinitionId = processDefinitionId;
-  }
-
-  public long processDefinitionKey() {
-    return processDefinitionKey;
-  }
-
-  public void processDefinitionKey(final long processDefinitionKey) {
-    this.processDefinitionKey = processDefinitionKey;
-  }
-
-  public String tenantId() {
-    return tenantId;
-  }
-
-  public void tenantId(final String tenantId) {
-    this.tenantId = tenantId;
-  }
-
-  public int partitionId() {
-    return partitionId;
-  }
-
-  public void partitionId(final int partitionId) {
-    this.partitionId = partitionId;
-  }
-
-  public long jobKey() {
-    return jobKey;
-  }
-
-  public void jobKey(final long jobKey) {
-    this.jobKey = jobKey;
-  }
-
-  public String jobLease() {
-    return jobLease;
-  }
-
-  public void jobLease(final String jobLease) {
-    this.jobLease = jobLease;
-  }
-
-  public void truncateJobLease(final int sizeLimit, final Integer byteLimit) {
-    if (TruncateUtil.shouldTruncate(jobLease, sizeLimit, byteLimit)) {
-      jobLease = TruncateUtil.truncateValue(jobLease, sizeLimit, byteLimit);
+  public AgentHistoryDbModel truncateJobLease(final int sizeLimit, final Integer byteLimit) {
+    if (!TruncateUtil.shouldTruncate(jobLease, sizeLimit, byteLimit)) {
+      return this;
     }
-  }
 
-  public int loopIteration() {
-    return loopIteration;
-  }
-
-  public void loopIteration(final int loopIteration) {
-    this.loopIteration = loopIteration;
-  }
-
-  public AgentInstanceHistoryRole role() {
-    return role;
-  }
-
-  public void role(final AgentInstanceHistoryRole role) {
-    this.role = role;
-  }
-
-  public AgentInstanceHistoryCommitStatus commitStatus() {
-    return commitStatus;
-  }
-
-  public void commitStatus(final AgentInstanceHistoryCommitStatus commitStatus) {
-    this.commitStatus = commitStatus;
-  }
-
-  public OffsetDateTime producedAt() {
-    return producedAt;
-  }
-
-  public void producedAt(final OffsetDateTime producedAt) {
-    this.producedAt = producedAt;
-  }
-
-  public Long inputTokens() {
-    return inputTokens;
-  }
-
-  public void inputTokens(final Long inputTokens) {
-    this.inputTokens = inputTokens;
-  }
-
-  public Long outputTokens() {
-    return outputTokens;
-  }
-
-  public void outputTokens(final Long outputTokens) {
-    this.outputTokens = outputTokens;
-  }
-
-  public Long durationMs() {
-    return durationMs;
-  }
-
-  public void durationMs(final Long durationMs) {
-    this.durationMs = durationMs;
-  }
-
-  public String content() {
-    return content;
+    return new AgentHistoryDbModel(
+        agentHistoryKey,
+        agentInstanceKey,
+        elementInstanceKey,
+        processInstanceKey,
+        rootProcessInstanceKey,
+        processDefinitionId,
+        processDefinitionKey,
+        tenantId,
+        partitionId,
+        jobKey,
+        TruncateUtil.truncateValue(jobLease, sizeLimit, byteLimit),
+        loopIteration,
+        role,
+        commitStatus,
+        producedAt,
+        inputTokens,
+        outputTokens,
+        durationMs,
+        content,
+        toolCalls);
   }
 
   /**
-   * Setter used by MyBatis when hydrating this model from the DB. Stores the raw JSON and
-   * invalidates the cached structured form so the next {@link #contentItems()} call re-derives from
-   * the new JSON (otherwise readers see stale data).
-   */
-  public void content(final String content) {
-    this.content = content;
-    contentItems = null;
-  }
-
-  /**
-   * Returns the structured content list. If only the JSON form (set via {@link #content(String)},
-   * e.g. when the model is hydrated from the DB) is present, the JSON is deserialized lazily and
-   * cached on the model.
+   * Returns the structured content list, deserializing the JSON form on every call. Returns null,
+   * not an empty list, when no JSON is stored.
    */
   public List<ContentItem> contentItems() {
-    if (contentItems == null && content != null && !content.isEmpty()) {
-      contentItems = deserializeContentItems(content);
+    if (content == null || content.isEmpty()) {
+      return null;
     }
-    return contentItems;
+    return deserializeContentItems(content);
   }
 
   /**
-   * Sets the structured content list and derives the JSON form from it. The JSON is what MyBatis
-   * writes to the {@code AGENT_HISTORY.CONTENT} CLOB column.
+   * Returns the structured tool-call list, deserializing the JSON form on every call. Returns null,
+   * not an empty list, when no JSON is stored.
    */
-  public void contentItems(final List<ContentItem> contentItems) {
-    this.contentItems = contentItems;
-    content = serializeContentItems(contentItems);
+  public List<ToolCall> toolCallValues() {
+    if (toolCalls == null || toolCalls.isEmpty()) {
+      return null;
+    }
+    return deserializeToolCallValues(toolCalls);
   }
 
   private static List<ContentItem> deserializeContentItems(final String json) {
-    if (json == null || json.isEmpty()) {
-      return Collections.emptyList();
-    }
-
     try {
       return MAPPER.readValue(json, new TypeReference<>() {});
     } catch (final JsonProcessingException e) {
@@ -301,46 +130,7 @@ public class AgentHistoryDbModel implements Copyable<AgentHistoryDbModel> {
     }
   }
 
-  public String toolCalls() {
-    return toolCalls;
-  }
-
-  /**
-   * Setter used by MyBatis when hydrating this model from the DB. Stores the raw JSON and
-   * invalidates the cached structured form so the next {@link #toolCallValues()} call re-derives
-   * from the new JSON (otherwise readers see stale data).
-   */
-  public void toolCalls(final String toolCalls) {
-    this.toolCalls = toolCalls;
-    toolCallValues = null;
-  }
-
-  /**
-   * Returns the structured tool-call list. If only the JSON form (set via {@link
-   * #toolCalls(String)}, e.g. when the model is hydrated from the DB) is present, the JSON is
-   * deserialized lazily and cached on the model.
-   */
-  public List<ToolCall> toolCallValues() {
-    if (toolCallValues == null && toolCalls != null && !toolCalls.isEmpty()) {
-      toolCallValues = deserializeToolCallValues(toolCalls);
-    }
-    return toolCallValues;
-  }
-
-  /**
-   * Sets the structured tool-call list and derives the JSON form from it. The JSON is what MyBatis
-   * writes to the {@code AGENT_HISTORY.TOOL_CALLS} CLOB column.
-   */
-  public void toolCallValues(final List<ToolCall> toolCallValues) {
-    this.toolCallValues = toolCallValues;
-    toolCalls = serializeToolCallValues(toolCallValues);
-  }
-
   private static List<ToolCall> deserializeToolCallValues(final String json) {
-    if (json == null || json.isEmpty()) {
-      return Collections.emptyList();
-    }
-
     try {
       return MAPPER.readValue(json, new TypeReference<>() {});
     } catch (final JsonProcessingException e) {
@@ -360,6 +150,28 @@ public class AgentHistoryDbModel implements Copyable<AgentHistoryDbModel> {
       LOG.error("Failed to serialize agent history tool calls", e);
       return null;
     }
+  }
+
+  public Builder toBuilder() {
+    return new Builder(content, toolCalls)
+        .agentHistoryKey(agentHistoryKey)
+        .agentInstanceKey(agentInstanceKey)
+        .elementInstanceKey(elementInstanceKey)
+        .processInstanceKey(processInstanceKey)
+        .rootProcessInstanceKey(rootProcessInstanceKey)
+        .processDefinitionId(processDefinitionId)
+        .processDefinitionKey(processDefinitionKey)
+        .tenantId(tenantId)
+        .partitionId(partitionId)
+        .jobKey(jobKey)
+        .jobLease(jobLease)
+        .loopIteration(loopIteration)
+        .role(role)
+        .commitStatus(commitStatus)
+        .producedAt(producedAt)
+        .inputTokens(inputTokens)
+        .outputTokens(outputTokens)
+        .durationMs(durationMs);
   }
 
   public static class Builder implements ObjectBuilder<AgentHistoryDbModel> {
@@ -382,8 +194,18 @@ public class AgentHistoryDbModel implements Copyable<AgentHistoryDbModel> {
     private Long inputTokens;
     private Long outputTokens;
     private Long durationMs;
-    private List<ContentItem> contentItems;
-    private List<ToolCall> toolCallValues;
+    private String content;
+    private String toolCalls;
+
+    public Builder() {}
+
+    // Seeds the raw serialized column values for toBuilder()/copy(), so a copy that never
+    // touches contentItems()/toolCallValues() carries the original JSON through unparsed instead
+    // of round-tripping it through Jackson.
+    Builder(final String content, final String toolCalls) {
+      this.content = content;
+      this.toolCalls = toolCalls;
+    }
 
     public Builder agentHistoryKey(final long agentHistoryKey) {
       this.agentHistoryKey = agentHistoryKey;
@@ -476,39 +298,38 @@ public class AgentHistoryDbModel implements Copyable<AgentHistoryDbModel> {
     }
 
     public Builder contentItems(final List<ContentItem> contentItems) {
-      this.contentItems = contentItems;
+      content = serializeContentItems(contentItems);
       return this;
     }
 
     public Builder toolCallValues(final List<ToolCall> toolCallValues) {
-      this.toolCallValues = toolCallValues;
+      toolCalls = serializeToolCallValues(toolCallValues);
       return this;
     }
 
     @Override
     public AgentHistoryDbModel build() {
-      final var result = new AgentHistoryDbModel();
-      result.agentHistoryKey(agentHistoryKey);
-      result.agentInstanceKey(agentInstanceKey);
-      result.elementInstanceKey(elementInstanceKey);
-      result.processInstanceKey(processInstanceKey);
-      result.rootProcessInstanceKey(rootProcessInstanceKey);
-      result.processDefinitionId(processDefinitionId);
-      result.processDefinitionKey(processDefinitionKey);
-      result.tenantId(tenantId);
-      result.partitionId(partitionId);
-      result.jobKey(jobKey);
-      result.jobLease(jobLease);
-      result.loopIteration(loopIteration);
-      result.role(role);
-      result.commitStatus(commitStatus);
-      result.producedAt(producedAt);
-      result.inputTokens(inputTokens);
-      result.outputTokens(outputTokens);
-      result.durationMs(durationMs);
-      result.contentItems(contentItems);
-      result.toolCallValues(toolCallValues);
-      return result;
+      return new AgentHistoryDbModel(
+          agentHistoryKey,
+          agentInstanceKey,
+          elementInstanceKey,
+          processInstanceKey,
+          rootProcessInstanceKey,
+          processDefinitionId,
+          processDefinitionKey,
+          tenantId,
+          partitionId,
+          jobKey,
+          jobLease,
+          loopIteration,
+          role,
+          commitStatus,
+          producedAt,
+          inputTokens,
+          outputTokens,
+          durationMs,
+          content,
+          toolCalls);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModel.java
@@ -20,6 +20,7 @@ import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +60,8 @@ public record AgentHistoryDbModel(
   }
 
   public AgentHistoryDbModel truncateJobLease(final int sizeLimit, final Integer byteLimit) {
-    if (!TruncateUtil.shouldTruncate(jobLease, sizeLimit, byteLimit)) {
+    final var truncatedJobLease = TruncateUtil.truncateValue(jobLease, sizeLimit, byteLimit);
+    if (Objects.equals(truncatedJobLease, jobLease)) {
       return this;
     }
 
@@ -74,7 +76,7 @@ public record AgentHistoryDbModel(
         tenantId,
         partitionId,
         jobKey,
-        TruncateUtil.truncateValue(jobLease, sizeLimit, byteLimit),
+        truncatedJobLease,
         loopIteration,
         role,
         commitStatus,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentInstanceDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentInstanceDbModel.java
@@ -259,7 +259,9 @@ public record AgentInstanceDbModel(
 
     // Seeds the raw serialized column value for toBuilder()/copy(), so a copy that never touches
     // toolValues() carries the original JSON through unparsed instead of round-tripping it
-    // through Jackson.
+    // through Jackson. Package-private, not a public setter: a second public setter aliasing the
+    // same field as toolValues(List) would let callers silently drop one write (e.g.
+    // builder.tools(x).toolValues(y) loses x).
     Builder(final String tools) {
       this.tools = tools;
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentInstanceDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentInstanceDbModel.java
@@ -125,14 +125,8 @@ public record AgentInstanceDbModel(
 
   public AgentInstanceDbModel truncateDefinitionFields(
       final int sizeLimit, final Integer byteLimit) {
-    final var truncatedModel =
-        TruncateUtil.shouldTruncate(model, sizeLimit, byteLimit)
-            ? TruncateUtil.truncateValue(model, sizeLimit, byteLimit)
-            : model;
-    final var truncatedProvider =
-        TruncateUtil.shouldTruncate(provider, sizeLimit, byteLimit)
-            ? TruncateUtil.truncateValue(provider, sizeLimit, byteLimit)
-            : provider;
+    final var truncatedModel = TruncateUtil.truncateValue(model, sizeLimit, byteLimit);
+    final var truncatedProvider = TruncateUtil.truncateValue(provider, sizeLimit, byteLimit);
     if (Objects.equals(truncatedModel, model) && Objects.equals(truncatedProvider, provider)) {
       return this;
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentInstanceDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentInstanceDbModel.java
@@ -14,46 +14,107 @@ import io.camunda.db.rdbms.write.util.TruncateUtil;
 import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
 import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class AgentInstanceDbModel implements Copyable<AgentInstanceDbModel> {
+public record AgentInstanceDbModel(
+    long agentInstanceKey,
+    String elementId,
+    long processInstanceKey,
+    long rootProcessInstanceKey,
+    String processDefinitionId,
+    long processDefinitionKey,
+    int processDefinitionVersion,
+    String versionTag,
+    String tenantId,
+    int partitionId,
+    AgentInstanceStatus status,
+    String model,
+    String provider,
+    String systemPrompt,
+    long maxTokens,
+    int maxModelCalls,
+    int maxToolCalls,
+    long inputTokens,
+    long outputTokens,
+    int modelCalls,
+    int toolCalls,
+    String tools,
+    OffsetDateTime creationDate,
+    OffsetDateTime lastUpdatedDate,
+    OffsetDateTime completionDate,
+    List<Long> elementInstanceKeys)
+    implements Copyable<AgentInstanceDbModel> {
 
   private static final Logger LOG = LoggerFactory.getLogger(AgentInstanceDbModel.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
-  private long agentInstanceKey;
-  private String elementId;
-  private long processInstanceKey;
-  private long rootProcessInstanceKey;
-  private String processDefinitionId;
-  private long processDefinitionKey;
-  private int processDefinitionVersion;
-  private String versionTag;
-  private String tenantId;
-  private int partitionId;
-  private AgentInstanceStatus status;
-  private String model;
-  private String provider;
-  private String systemPrompt;
-  private long maxTokens;
-  private int maxModelCalls;
-  private int maxToolCalls;
-  private long inputTokens;
-  private long outputTokens;
-  private int modelCalls;
-  private int toolCalls;
-  private String tools;
-  private List<AgentInstanceToolDbValue> toolValues;
-  private OffsetDateTime creationDate;
-  private OffsetDateTime lastUpdatedDate;
-  private OffsetDateTime completionDate;
-  private List<Long> elementInstanceKeys;
+  public AgentInstanceDbModel {
+    // Must stay mutable: MyBatis appends to this via <collection> after construction.
+    elementInstanceKeys = Objects.requireNonNullElse(elementInstanceKeys, new ArrayList<>());
+  }
 
-  public AgentInstanceDbModel() {}
+  // Matches searchResultMap's <constructor>, which omits elementInstanceKeys -- populated
+  // separately via the sibling <collection> element.
+  public AgentInstanceDbModel(
+      final long agentInstanceKey,
+      final String elementId,
+      final long processInstanceKey,
+      final long rootProcessInstanceKey,
+      final String processDefinitionId,
+      final long processDefinitionKey,
+      final int processDefinitionVersion,
+      final String versionTag,
+      final String tenantId,
+      final int partitionId,
+      final AgentInstanceStatus status,
+      final String model,
+      final String provider,
+      final String systemPrompt,
+      final long maxTokens,
+      final int maxModelCalls,
+      final int maxToolCalls,
+      final long inputTokens,
+      final long outputTokens,
+      final int modelCalls,
+      final int toolCalls,
+      final String tools,
+      final OffsetDateTime creationDate,
+      final OffsetDateTime lastUpdatedDate,
+      final OffsetDateTime completionDate) {
+    this(
+        agentInstanceKey,
+        elementId,
+        processInstanceKey,
+        rootProcessInstanceKey,
+        processDefinitionId,
+        processDefinitionKey,
+        processDefinitionVersion,
+        versionTag,
+        tenantId,
+        partitionId,
+        status,
+        model,
+        provider,
+        systemPrompt,
+        maxTokens,
+        maxModelCalls,
+        maxToolCalls,
+        inputTokens,
+        outputTokens,
+        modelCalls,
+        toolCalls,
+        tools,
+        creationDate,
+        lastUpdatedDate,
+        completionDate,
+        null);
+  }
 
   @Override
   public AgentInstanceDbModel copy(
@@ -62,255 +123,65 @@ public class AgentInstanceDbModel implements Copyable<AgentInstanceDbModel> {
     return copyFunction.apply(toBuilder()).build();
   }
 
-  public ObjectBuilder<AgentInstanceDbModel> toBuilder() {
-    return new Builder()
-        .agentInstanceKey(agentInstanceKey)
-        .elementId(elementId)
-        .processInstanceKey(processInstanceKey)
-        .rootProcessInstanceKey(rootProcessInstanceKey)
-        .processDefinitionId(processDefinitionId)
-        .processDefinitionKey(processDefinitionKey)
-        .processDefinitionVersion(processDefinitionVersion)
-        .versionTag(versionTag)
-        .tenantId(tenantId)
-        .partitionId(partitionId)
-        .status(status)
-        .model(model)
-        .provider(provider)
-        .systemPrompt(systemPrompt)
-        .maxTokens(maxTokens)
-        .maxModelCalls(maxModelCalls)
-        .maxToolCalls(maxToolCalls)
-        .inputTokens(inputTokens)
-        .outputTokens(outputTokens)
-        .modelCalls(modelCalls)
-        .toolCalls(toolCalls)
-        // route through the getter so DB-hydrated models (only `tools` JSON populated)
-        // are lazily deserialized and the structured form is preserved on the copy
-        .toolValues(toolValues())
-        .creationDate(creationDate)
-        .lastUpdatedDate(lastUpdatedDate)
-        .completionDate(completionDate)
-        .elementInstanceKeys(elementInstanceKeys);
-  }
-
-  public long agentInstanceKey() {
-    return agentInstanceKey;
-  }
-
-  public void agentInstanceKey(final long agentInstanceKey) {
-    this.agentInstanceKey = agentInstanceKey;
-  }
-
-  public String elementId() {
-    return elementId;
-  }
-
-  public void elementId(final String elementId) {
-    this.elementId = elementId;
-  }
-
-  public long processInstanceKey() {
-    return processInstanceKey;
-  }
-
-  public void processInstanceKey(final long processInstanceKey) {
-    this.processInstanceKey = processInstanceKey;
-  }
-
-  public long rootProcessInstanceKey() {
-    return rootProcessInstanceKey;
-  }
-
-  public void rootProcessInstanceKey(final long rootProcessInstanceKey) {
-    this.rootProcessInstanceKey = rootProcessInstanceKey;
-  }
-
-  public String processDefinitionId() {
-    return processDefinitionId;
-  }
-
-  public void processDefinitionId(final String processDefinitionId) {
-    this.processDefinitionId = processDefinitionId;
-  }
-
-  public long processDefinitionKey() {
-    return processDefinitionKey;
-  }
-
-  public void processDefinitionKey(final long processDefinitionKey) {
-    this.processDefinitionKey = processDefinitionKey;
-  }
-
-  public int processDefinitionVersion() {
-    return processDefinitionVersion;
-  }
-
-  public void processDefinitionVersion(final int processDefinitionVersion) {
-    this.processDefinitionVersion = processDefinitionVersion;
-  }
-
-  public String versionTag() {
-    return versionTag;
-  }
-
-  public void versionTag(final String versionTag) {
-    this.versionTag = versionTag;
-  }
-
-  public String tenantId() {
-    return tenantId;
-  }
-
-  public void tenantId(final String tenantId) {
-    this.tenantId = tenantId;
-  }
-
-  public int partitionId() {
-    return partitionId;
-  }
-
-  public void partitionId(final int partitionId) {
-    this.partitionId = partitionId;
-  }
-
-  public AgentInstanceStatus status() {
-    return status;
-  }
-
-  public void status(final AgentInstanceStatus status) {
-    this.status = status;
-  }
-
-  public String model() {
-    return model;
-  }
-
-  public void model(final String model) {
-    this.model = model;
-  }
-
-  public String provider() {
-    return provider;
-  }
-
-  public void provider(final String provider) {
-    this.provider = provider;
-  }
-
-  public void truncateDefinitionFields(final int sizeLimit, final Integer byteLimit) {
-    if (TruncateUtil.shouldTruncate(model, sizeLimit, byteLimit)) {
-      model = TruncateUtil.truncateValue(model, sizeLimit, byteLimit);
+  public AgentInstanceDbModel truncateDefinitionFields(
+      final int sizeLimit, final Integer byteLimit) {
+    final var truncatedModel =
+        TruncateUtil.shouldTruncate(model, sizeLimit, byteLimit)
+            ? TruncateUtil.truncateValue(model, sizeLimit, byteLimit)
+            : model;
+    final var truncatedProvider =
+        TruncateUtil.shouldTruncate(provider, sizeLimit, byteLimit)
+            ? TruncateUtil.truncateValue(provider, sizeLimit, byteLimit)
+            : provider;
+    if (Objects.equals(truncatedModel, model) && Objects.equals(truncatedProvider, provider)) {
+      return this;
     }
-    if (TruncateUtil.shouldTruncate(provider, sizeLimit, byteLimit)) {
-      provider = TruncateUtil.truncateValue(provider, sizeLimit, byteLimit);
-    }
-  }
 
-  public String systemPrompt() {
-    return systemPrompt;
-  }
-
-  public void systemPrompt(final String systemPrompt) {
-    this.systemPrompt = systemPrompt;
-  }
-
-  public long maxTokens() {
-    return maxTokens;
-  }
-
-  public void maxTokens(final long maxTokens) {
-    this.maxTokens = maxTokens;
-  }
-
-  public int maxModelCalls() {
-    return maxModelCalls;
-  }
-
-  public void maxModelCalls(final int maxModelCalls) {
-    this.maxModelCalls = maxModelCalls;
-  }
-
-  public int maxToolCalls() {
-    return maxToolCalls;
-  }
-
-  public void maxToolCalls(final int maxToolCalls) {
-    this.maxToolCalls = maxToolCalls;
-  }
-
-  public long inputTokens() {
-    return inputTokens;
-  }
-
-  public void inputTokens(final long inputTokens) {
-    this.inputTokens = inputTokens;
-  }
-
-  public long outputTokens() {
-    return outputTokens;
-  }
-
-  public void outputTokens(final long outputTokens) {
-    this.outputTokens = outputTokens;
-  }
-
-  public int modelCalls() {
-    return modelCalls;
-  }
-
-  public void modelCalls(final int modelCalls) {
-    this.modelCalls = modelCalls;
-  }
-
-  public int toolCalls() {
-    return toolCalls;
-  }
-
-  public void toolCalls(final int toolCalls) {
-    this.toolCalls = toolCalls;
-  }
-
-  public String tools() {
-    return tools;
+    return new AgentInstanceDbModel(
+        agentInstanceKey,
+        elementId,
+        processInstanceKey,
+        rootProcessInstanceKey,
+        processDefinitionId,
+        processDefinitionKey,
+        processDefinitionVersion,
+        versionTag,
+        tenantId,
+        partitionId,
+        status,
+        truncatedModel,
+        truncatedProvider,
+        systemPrompt,
+        maxTokens,
+        maxModelCalls,
+        maxToolCalls,
+        inputTokens,
+        outputTokens,
+        modelCalls,
+        toolCalls,
+        tools,
+        creationDate,
+        lastUpdatedDate,
+        completionDate,
+        elementInstanceKeys);
   }
 
   /**
-   * Setter used by MyBatis when hydrating this model from the DB. Stores the raw JSON and
-   * invalidates the cached structured form so the next {@link #toolValues()} call re-derives from
-   * the new JSON (otherwise readers see stale data).
-   */
-  public void tools(final String tools) {
-    this.tools = tools;
-    toolValues = null;
-  }
-
-  /**
-   * Returns the structured tool list. If only the JSON form (set via {@link #tools(String)}, e.g.
-   * when the model is hydrated from the DB) is present, the JSON is deserialized lazily and cached
-   * on the model.
+   * Returns the structured tool list, deserializing the JSON form on every call. Returns null, not
+   * an empty list, when no JSON is stored -- covers both the never-set and the explicit-empty-list
+   * case (an empty list also serializes to a null {@code tools}), as well as the Oracle
+   * empty-string-treated-as-null edge case. Unlike the pre-record class, this implementation cannot
+   * distinguish "never set" from "explicitly set to an empty list", since both collapse to the same
+   * null string; no current caller depends on that distinction.
    */
   public List<AgentInstanceToolDbValue> toolValues() {
-    if (toolValues == null && tools != null && !tools.isEmpty()) {
-      toolValues = deserializeTools(tools);
+    if (tools == null || tools.isEmpty()) {
+      return null;
     }
-    return toolValues;
-  }
-
-  /**
-   * Sets the structured tool list and derives the JSON form from it. The JSON is what MyBatis
-   * writes to the {@code AGENT_INSTANCE.TOOLS} CLOB column.
-   */
-  public void toolValues(final List<AgentInstanceToolDbValue> toolValues) {
-    this.toolValues = toolValues;
-    tools = serializeTools(toolValues);
+    return deserializeTools(tools);
   }
 
   private static List<AgentInstanceToolDbValue> deserializeTools(final String tools) {
-    if (tools == null || tools.isEmpty()) {
-      return Collections.emptyList();
-    }
-
     try {
       return MAPPER.readValue(tools, new TypeReference<>() {});
     } catch (final JsonProcessingException e) {
@@ -332,36 +203,33 @@ public class AgentInstanceDbModel implements Copyable<AgentInstanceDbModel> {
     }
   }
 
-  public OffsetDateTime creationDate() {
-    return creationDate;
-  }
-
-  public void creationDate(final OffsetDateTime creationDate) {
-    this.creationDate = creationDate;
-  }
-
-  public OffsetDateTime lastUpdatedDate() {
-    return lastUpdatedDate;
-  }
-
-  public void lastUpdatedDate(final OffsetDateTime lastUpdatedDate) {
-    this.lastUpdatedDate = lastUpdatedDate;
-  }
-
-  public OffsetDateTime completionDate() {
-    return completionDate;
-  }
-
-  public void completionDate(final OffsetDateTime completionDate) {
-    this.completionDate = completionDate;
-  }
-
-  public List<Long> elementInstanceKeys() {
-    return elementInstanceKeys;
-  }
-
-  public void elementInstanceKeys(final List<Long> elementInstanceKeys) {
-    this.elementInstanceKeys = elementInstanceKeys;
+  public Builder toBuilder() {
+    return new Builder(tools)
+        .agentInstanceKey(agentInstanceKey)
+        .elementId(elementId)
+        .processInstanceKey(processInstanceKey)
+        .rootProcessInstanceKey(rootProcessInstanceKey)
+        .processDefinitionId(processDefinitionId)
+        .processDefinitionKey(processDefinitionKey)
+        .processDefinitionVersion(processDefinitionVersion)
+        .versionTag(versionTag)
+        .tenantId(tenantId)
+        .partitionId(partitionId)
+        .status(status)
+        .model(model)
+        .provider(provider)
+        .systemPrompt(systemPrompt)
+        .maxTokens(maxTokens)
+        .maxModelCalls(maxModelCalls)
+        .maxToolCalls(maxToolCalls)
+        .inputTokens(inputTokens)
+        .outputTokens(outputTokens)
+        .modelCalls(modelCalls)
+        .toolCalls(toolCalls)
+        .creationDate(creationDate)
+        .lastUpdatedDate(lastUpdatedDate)
+        .completionDate(completionDate)
+        .elementInstanceKeys(elementInstanceKeys);
   }
 
   public static class Builder implements ObjectBuilder<AgentInstanceDbModel> {
@@ -387,11 +255,20 @@ public class AgentInstanceDbModel implements Copyable<AgentInstanceDbModel> {
     private long outputTokens;
     private int modelCalls;
     private int toolCalls;
-    private List<AgentInstanceToolDbValue> toolValues;
+    private String tools;
     private OffsetDateTime creationDate;
     private OffsetDateTime lastUpdatedDate;
     private OffsetDateTime completionDate;
     private List<Long> elementInstanceKeys;
+
+    public Builder() {}
+
+    // Seeds the raw serialized column value for toBuilder()/copy(), so a copy that never touches
+    // toolValues() carries the original JSON through unparsed instead of round-tripping it
+    // through Jackson.
+    Builder(final String tools) {
+      this.tools = tools;
+    }
 
     public Builder agentInstanceKey(final long agentInstanceKey) {
       this.agentInstanceKey = agentInstanceKey;
@@ -498,8 +375,8 @@ public class AgentInstanceDbModel implements Copyable<AgentInstanceDbModel> {
       return this;
     }
 
-    public Builder toolValues(final List<AgentInstanceToolDbValue> tools) {
-      toolValues = tools;
+    public Builder toolValues(final List<AgentInstanceToolDbValue> toolValues) {
+      tools = serializeTools(toolValues);
       return this;
     }
 
@@ -525,34 +402,33 @@ public class AgentInstanceDbModel implements Copyable<AgentInstanceDbModel> {
 
     @Override
     public AgentInstanceDbModel build() {
-      final var result = new AgentInstanceDbModel();
-      result.agentInstanceKey(agentInstanceKey);
-      result.elementId(elementId);
-      result.processInstanceKey(processInstanceKey);
-      result.rootProcessInstanceKey(rootProcessInstanceKey);
-      result.processDefinitionId(processDefinitionId);
-      result.processDefinitionKey(processDefinitionKey);
-      result.processDefinitionVersion(processDefinitionVersion);
-      result.versionTag(versionTag);
-      result.tenantId(tenantId);
-      result.partitionId(partitionId);
-      result.status(status);
-      result.model(model);
-      result.provider(provider);
-      result.systemPrompt(systemPrompt);
-      result.maxTokens(maxTokens);
-      result.maxModelCalls(maxModelCalls);
-      result.maxToolCalls(maxToolCalls);
-      result.inputTokens(inputTokens);
-      result.outputTokens(outputTokens);
-      result.modelCalls(modelCalls);
-      result.toolCalls(toolCalls);
-      result.toolValues(toolValues);
-      result.creationDate(creationDate);
-      result.lastUpdatedDate(lastUpdatedDate);
-      result.completionDate(completionDate);
-      result.elementInstanceKeys(elementInstanceKeys);
-      return result;
+      return new AgentInstanceDbModel(
+          agentInstanceKey,
+          elementId,
+          processInstanceKey,
+          rootProcessInstanceKey,
+          processDefinitionId,
+          processDefinitionKey,
+          processDefinitionVersion,
+          versionTag,
+          tenantId,
+          partitionId,
+          status,
+          model,
+          provider,
+          systemPrompt,
+          maxTokens,
+          maxModelCalls,
+          maxToolCalls,
+          inputTokens,
+          outputTokens,
+          modelCalls,
+          toolCalls,
+          tools,
+          creationDate,
+          lastUpdatedDate,
+          completionDate,
+          elementInstanceKeys);
     }
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuditLogDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuditLogDbModel.java
@@ -12,6 +12,7 @@ import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.BatchOperationType;
 import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 import java.util.function.Function;
 
 public record AuditLogDbModel(
@@ -106,15 +107,13 @@ public record AuditLogDbModel(
   }
 
   public AuditLogDbModel truncateEntityDescription(final int sizeLimit, final Integer byteLimit) {
-    if (TruncateUtil.shouldTruncate(entityDescription(), sizeLimit, byteLimit)) {
-
-      return copy(
-          fn ->
-              ((Builder) fn)
-                  .entityDescription(
-                      TruncateUtil.truncateValue(entityDescription(), sizeLimit, byteLimit)));
+    final var truncatedEntityDescription =
+        TruncateUtil.truncateValue(entityDescription(), sizeLimit, byteLimit);
+    if (Objects.equals(truncatedEntityDescription, entityDescription())) {
+      return this;
     }
-    return this;
+
+    return copy(fn -> ((Builder) fn).entityDescription(truncatedEntityDescription));
   }
 
   public static class Builder implements ObjectBuilder<AuditLogDbModel> {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/JobDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/JobDbModel.java
@@ -175,7 +175,9 @@ public record JobDbModel(
 
     // Seeds the raw serialized column value for toBuilder()/copy(), so a copy that never touches
     // customHeaders() carries the original string through unparsed instead of round-tripping it
-    // through Jackson.
+    // through Jackson. Package-private, not a public setter: a second public setter aliasing the
+    // same field as customHeaders(Map) would let callers silently drop one write (e.g.
+    // builder.serializedCustomHeaders(x).customHeaders(y) loses x).
     Builder(final String serializedCustomHeaders) {
       this.serializedCustomHeaders = serializedCustomHeaders;
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/JobDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/JobDbModel.java
@@ -20,99 +20,37 @@ import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class JobDbModel implements Copyable<JobDbModel> {
+public record JobDbModel(
+    Long jobKey,
+    String type,
+    String worker,
+    JobState state,
+    JobKind kind,
+    ListenerEventType listenerEventType,
+    Integer retries,
+    Integer priority,
+    Boolean isDenied,
+    String deniedReason,
+    Boolean hasFailedWithRetriesLeft,
+    String errorCode,
+    String errorMessage,
+    String serializedCustomHeaders,
+    OffsetDateTime deadline,
+    OffsetDateTime endTime,
+    String processDefinitionId,
+    Long processDefinitionKey,
+    Long processInstanceKey,
+    Long rootProcessInstanceKey,
+    String businessId,
+    String elementId,
+    Long elementInstanceKey,
+    String tenantId,
+    int partitionId,
+    OffsetDateTime creationTime,
+    OffsetDateTime lastUpdateTime)
+    implements Copyable<JobDbModel> {
+
   private static final Logger LOG = LoggerFactory.getLogger(JobDbModel.class);
-
-  private Long jobKey;
-  private String type;
-  private String worker;
-  private JobState state;
-  private JobKind kind;
-  private ListenerEventType listenerEventType;
-  private Integer retries;
-  private Integer priority;
-  private Boolean isDenied;
-  private String deniedReason;
-  private Boolean hasFailedWithRetriesLeft = false;
-  private String errorCode;
-  private String errorMessage;
-  private String serializedCustomHeaders;
-  private Map<String, String> customHeaders;
-  private OffsetDateTime deadline;
-  private OffsetDateTime endTime;
-  private String processDefinitionId;
-  private Long processDefinitionKey;
-  private Long processInstanceKey;
-  private Long rootProcessInstanceKey;
-  private String businessId;
-  private String elementId;
-  private Long elementInstanceKey;
-  private String tenantId;
-  private int partitionId;
-  private OffsetDateTime creationTime;
-  private OffsetDateTime lastUpdateTime;
-
-  public JobDbModel(final Long jobKey) {
-    this.jobKey = jobKey;
-  }
-
-  public JobDbModel(
-      final Long jobKey,
-      final String type,
-      final String worker,
-      final JobState state,
-      final JobKind kind,
-      final ListenerEventType listenerEventType,
-      final Integer retries,
-      final Integer priority,
-      final Boolean isDenied,
-      final String deniedReason,
-      final boolean hasFailedWithRetriesLeft,
-      final String errorCode,
-      final String errorMessage,
-      final Map<String, String> customHeaders,
-      final OffsetDateTime deadline,
-      final OffsetDateTime endTime,
-      final String processDefinitionId,
-      final Long processDefinitionKey,
-      final Long processInstanceKey,
-      final Long rootProcessInstanceKey,
-      final String businessId,
-      final String elementId,
-      final Long elementInstanceKey,
-      final String tenantId,
-      final int partitionId,
-      final OffsetDateTime creationTime,
-      final OffsetDateTime lastUpdateTime) {
-    this.jobKey = jobKey;
-    this.type = type;
-    this.worker = worker;
-    this.state = state;
-    this.kind = kind;
-    this.listenerEventType = listenerEventType;
-    this.retries = retries;
-    this.priority = priority;
-    this.isDenied = isDenied;
-    this.deniedReason = deniedReason;
-    this.hasFailedWithRetriesLeft = hasFailedWithRetriesLeft;
-    this.errorCode = errorCode;
-    this.errorMessage = errorMessage;
-    serializedCustomHeaders = MapSerializer.serialize(customHeaders);
-    this.customHeaders = customHeaders;
-    this.deadline = deadline;
-    this.endTime = endTime;
-    this.processDefinitionId = processDefinitionId;
-    this.processDefinitionKey = processDefinitionKey;
-    this.processInstanceKey = processInstanceKey;
-    this.rootProcessInstanceKey = rootProcessInstanceKey;
-    this.businessId = businessId;
-    this.elementId = elementId;
-    this.elementInstanceKey = elementInstanceKey;
-    this.tenantId = tenantId;
-    this.partitionId = partitionId;
-    this.creationTime = creationTime;
-    this.lastUpdateTime = lastUpdateTime;
-  }
 
   @Override
   public JobDbModel copy(
@@ -140,7 +78,7 @@ public class JobDbModel implements Copyable<JobDbModel> {
         hasFailedWithRetriesLeft,
         errorCode,
         truncatedValue,
-        customHeaders,
+        serializedCustomHeaders,
         deadline,
         endTime,
         processDefinitionId,
@@ -169,229 +107,12 @@ public class JobDbModel implements Copyable<JobDbModel> {
     return truncatedValue;
   }
 
-  public Long jobKey() {
-    return jobKey;
-  }
-
-  public void jobKey(final Long jobKey) {
-    this.jobKey = jobKey;
-  }
-
-  public String type() {
-    return type;
-  }
-
-  public void type(final String type) {
-    this.type = type;
-  }
-
-  public String worker() {
-    return worker;
-  }
-
-  public void worker(final String worker) {
-    this.worker = worker;
-  }
-
-  public JobState state() {
-    return state;
-  }
-
-  public void state(final JobState state) {
-    this.state = state;
-  }
-
-  public JobKind kind() {
-    return kind;
-  }
-
-  public void kind(final JobKind kind) {
-    this.kind = kind;
-  }
-
-  public ListenerEventType listenerEventType() {
-    return listenerEventType;
-  }
-
-  public void listenerEventType(final ListenerEventType listenerEventType) {
-    this.listenerEventType = listenerEventType;
-  }
-
-  public Integer retries() {
-    return retries;
-  }
-
-  public void retries(final Integer retries) {
-    this.retries = retries;
-  }
-
-  public Integer priority() {
-    return priority;
-  }
-
-  public void priority(final Integer priority) {
-    this.priority = priority;
-  }
-
-  public Boolean isDenied() {
-    return isDenied;
-  }
-
-  public void isDenied(final Boolean isDenied) {
-    this.isDenied = isDenied;
-  }
-
-  public String deniedReason() {
-    return deniedReason;
-  }
-
-  public void deniedReason(final String deniedReason) {
-    this.deniedReason = deniedReason;
-  }
-
-  public Boolean hasFailedWithRetriesLeft() {
-    return hasFailedWithRetriesLeft;
-  }
-
-  public void hasFailedWithRetriesLeft(final Boolean hasFailedWithRetriesLeft) {
-    this.hasFailedWithRetriesLeft = hasFailedWithRetriesLeft;
-  }
-
-  public String errorCode() {
-    return errorCode;
-  }
-
-  public void errorCode(final String errorCode) {
-    this.errorCode = errorCode;
-  }
-
-  public String errorMessage() {
-    return errorMessage;
-  }
-
-  public void errorMessage(final String errorMessage) {
-    this.errorMessage = errorMessage;
-  }
-
-  public String serializedCustomHeaders() {
-    return serializedCustomHeaders;
-  }
-
-  public void setSerializedCustomHeaders(final String serializedCustomHeaders) {
-    this.serializedCustomHeaders = serializedCustomHeaders;
-    customHeaders = MapSerializer.deserialize(serializedCustomHeaders);
-  }
-
   public Map<String, String> customHeaders() {
-    return customHeaders;
+    return MapSerializer.deserialize(serializedCustomHeaders);
   }
 
-  public OffsetDateTime deadline() {
-    return deadline;
-  }
-
-  public void deadline(final OffsetDateTime deadline) {
-    this.deadline = deadline;
-  }
-
-  public OffsetDateTime endTime() {
-    return endTime;
-  }
-
-  public void endTime(final OffsetDateTime endTime) {
-    this.endTime = endTime;
-  }
-
-  public String processDefinitionId() {
-    return processDefinitionId;
-  }
-
-  public void processDefinitionId(final String processDefinitionId) {
-    this.processDefinitionId = processDefinitionId;
-  }
-
-  public Long processDefinitionKey() {
-    return processDefinitionKey;
-  }
-
-  public void processDefinitionKey(final Long processDefinitionKey) {
-    this.processDefinitionKey = processDefinitionKey;
-  }
-
-  public Long processInstanceKey() {
-    return processInstanceKey;
-  }
-
-  public void processInstanceKey(final Long processInstanceKey) {
-    this.processInstanceKey = processInstanceKey;
-  }
-
-  public Long rootProcessInstanceKey() {
-    return rootProcessInstanceKey;
-  }
-
-  public void rootProcessInstanceKey(final Long rootProcessInstanceKey) {
-    this.rootProcessInstanceKey = rootProcessInstanceKey;
-  }
-
-  public String businessId() {
-    return businessId;
-  }
-
-  public void businessId(final String businessId) {
-    this.businessId = businessId;
-  }
-
-  public String elementId() {
-    return elementId;
-  }
-
-  public void elementId(final String elementId) {
-    this.elementId = elementId;
-  }
-
-  public Long elementInstanceKey() {
-    return elementInstanceKey;
-  }
-
-  public void elementInstanceKey(final Long elementInstanceKey) {
-    this.elementInstanceKey = elementInstanceKey;
-  }
-
-  public String tenantId() {
-    return tenantId;
-  }
-
-  public void tenantId(final String tenantId) {
-    this.tenantId = tenantId;
-  }
-
-  public int partitionId() {
-    return partitionId;
-  }
-
-  public void partitionId(final int partitionId) {
-    this.partitionId = partitionId;
-  }
-
-  public OffsetDateTime creationTime() {
-    return creationTime;
-  }
-
-  public void creationTime(final OffsetDateTime creationTime) {
-    this.creationTime = creationTime;
-  }
-
-  public OffsetDateTime lastUpdateTime() {
-    return lastUpdateTime;
-  }
-
-  public void lastUpdateTime(final OffsetDateTime lastUpdateTime) {
-    this.lastUpdateTime = lastUpdateTime;
-  }
-
-  public ObjectBuilder<JobDbModel> toBuilder() {
-    return new Builder()
+  public Builder toBuilder() {
+    return new Builder(serializedCustomHeaders)
         .jobKey(jobKey)
         .type(type)
         .worker(worker)
@@ -405,7 +126,6 @@ public class JobDbModel implements Copyable<JobDbModel> {
         .hasFailedWithRetriesLeft(hasFailedWithRetriesLeft)
         .errorCode(errorCode)
         .errorMessage(errorMessage)
-        .customHeaders(customHeaders)
         .deadline(deadline)
         .endTime(endTime)
         .processDefinitionId(processDefinitionId)
@@ -436,7 +156,7 @@ public class JobDbModel implements Copyable<JobDbModel> {
     private Boolean hasFailedWithRetriesLeft = false;
     private String errorCode;
     private String errorMessage;
-    private Map<String, String> customHeaders;
+    private String serializedCustomHeaders;
     private OffsetDateTime deadline;
     private OffsetDateTime endTime;
     private String processDefinitionId;
@@ -450,6 +170,15 @@ public class JobDbModel implements Copyable<JobDbModel> {
     private int partitionId;
     private OffsetDateTime creationTime;
     private OffsetDateTime lastUpdateTime;
+
+    public Builder() {}
+
+    // Seeds the raw serialized column value for toBuilder()/copy(), so a copy that never touches
+    // customHeaders() carries the original string through unparsed instead of round-tripping it
+    // through Jackson.
+    Builder(final String serializedCustomHeaders) {
+      this.serializedCustomHeaders = serializedCustomHeaders;
+    }
 
     public Builder jobKey(final Long jobKey) {
       this.jobKey = jobKey;
@@ -522,7 +251,7 @@ public class JobDbModel implements Copyable<JobDbModel> {
     }
 
     public Builder customHeaders(final Map<String, String> customHeaders) {
-      this.customHeaders = customHeaders;
+      serializedCustomHeaders = MapSerializer.serialize(customHeaders);
       return this;
     }
 
@@ -607,7 +336,7 @@ public class JobDbModel implements Copyable<JobDbModel> {
           hasFailedWithRetriesLeft,
           errorCode,
           errorMessage,
-          customHeaders,
+          serializedCustomHeaders,
           deadline,
           endTime,
           processDefinitionId,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
@@ -45,14 +45,9 @@ public record MessageSubscriptionDbModel(
 
   public MessageSubscriptionDbModel truncateToolFields(
       final int sizeLimit, final Integer byteLimit) {
-    final var truncatedToolName =
-        TruncateUtil.shouldTruncate(toolName, sizeLimit, byteLimit)
-            ? TruncateUtil.truncateValue(toolName, sizeLimit, byteLimit)
-            : toolName;
+    final var truncatedToolName = TruncateUtil.truncateValue(toolName, sizeLimit, byteLimit);
     final var truncatedInboundConnectorType =
-        TruncateUtil.shouldTruncate(inboundConnectorType, sizeLimit, byteLimit)
-            ? TruncateUtil.truncateValue(inboundConnectorType, sizeLimit, byteLimit)
-            : inboundConnectorType;
+        TruncateUtil.truncateValue(inboundConnectorType, sizeLimit, byteLimit);
     if (Objects.equals(truncatedToolName, toolName)
         && Objects.equals(truncatedInboundConnectorType, inboundConnectorType)) {
       return this;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
@@ -130,7 +130,9 @@ public record MessageSubscriptionDbModel(
 
     // Seeds the raw serialized column value for toBuilder()/copy(), so a copy that never touches
     // toolProperties() carries the original string through unparsed instead of round-tripping it
-    // through Jackson.
+    // through Jackson. Package-private, not a public setter: a second public setter aliasing the
+    // same field as toolProperties(Map) would let callers silently drop one write (e.g.
+    // builder.serializedToolProperties(x).toolProperties(y) loses x).
     Builder(final String serializedToolProperties) {
       this.serializedToolProperties = serializedToolProperties;
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
@@ -14,241 +14,70 @@ import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionT
 import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 
-public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionDbModel> {
-  private Long messageSubscriptionKey;
-  private String processDefinitionId;
-  private Long processDefinitionKey;
-  private Long processInstanceKey;
-  private Long rootProcessInstanceKey;
-  private String flowNodeId;
-  private Long flowNodeInstanceKey;
-  private MessageSubscriptionState messageSubscriptionState;
-  private MessageSubscriptionType messageSubscriptionType;
-  private OffsetDateTime dateTime;
-  private String messageName;
-  private String correlationKey;
-  private String tenantId;
-  private int partitionId;
-  private String processDefinitionName;
-  private Integer processDefinitionVersion;
-  private String serializedToolProperties;
-  private Map<String, String> toolProperties;
-  private String toolName;
-  private String inboundConnectorType;
-
-  public MessageSubscriptionDbModel(final Long messageSubscriptionKey) {
-    this.messageSubscriptionKey = messageSubscriptionKey;
-  }
-
-  public MessageSubscriptionDbModel(
-      final Long messageSubscriptionKey,
-      final String processDefinitionId,
-      final Long processDefinitionKey,
-      final Long processInstanceKey,
-      final Long rootProcessInstanceKey,
-      final String flowNodeId,
-      final Long flowNodeInstanceKey,
-      final MessageSubscriptionState messageSubscriptionState,
-      final MessageSubscriptionType messageSubscriptionType,
-      final OffsetDateTime dateTime,
-      final String messageName,
-      final String correlationKey,
-      final String tenantId,
-      final int partitionId,
-      final String processDefinitionName,
-      final Integer processDefinitionVersion,
-      final Map<String, String> toolProperties,
-      final String toolName,
-      final String inboundConnectorType) {
-    this.messageSubscriptionKey = messageSubscriptionKey;
-    this.processDefinitionId = processDefinitionId;
-    this.processDefinitionKey = processDefinitionKey;
-    this.rootProcessInstanceKey = rootProcessInstanceKey;
-    this.processInstanceKey = processInstanceKey;
-    this.flowNodeId = flowNodeId;
-    this.flowNodeInstanceKey = flowNodeInstanceKey;
-    this.messageSubscriptionState = messageSubscriptionState;
-    this.messageSubscriptionType = messageSubscriptionType;
-    this.dateTime = dateTime;
-    this.messageName = messageName;
-    this.correlationKey = correlationKey;
-    this.tenantId = tenantId;
-    this.partitionId = partitionId;
-    this.processDefinitionName = processDefinitionName;
-    this.processDefinitionVersion = processDefinitionVersion;
-    serializedToolProperties = MapSerializer.serialize(toolProperties);
-    this.toolProperties = toolProperties;
-    this.toolName = toolName;
-    this.inboundConnectorType = inboundConnectorType;
-  }
-
-  public Long messageSubscriptionKey() {
-    return messageSubscriptionKey;
-  }
-
-  public void messageSubscriptionKey(final Long messageSubscriptionKey) {
-    this.messageSubscriptionKey = messageSubscriptionKey;
-  }
-
-  public String processDefinitionId() {
-    return processDefinitionId;
-  }
-
-  public void processDefinitionId(final String processDefinitionId) {
-    this.processDefinitionId = processDefinitionId;
-  }
-
-  public Long processDefinitionKey() {
-    return processDefinitionKey;
-  }
-
-  public void processDefinitionKey(final Long processDefinitionKey) {
-    this.processDefinitionKey = processDefinitionKey;
-  }
-
-  public Long processInstanceKey() {
-    return processInstanceKey;
-  }
-
-  public void processInstanceKey(final Long processInstanceKey) {
-    this.processInstanceKey = processInstanceKey;
-  }
-
-  public Long rootProcessInstanceKey() {
-    return rootProcessInstanceKey;
-  }
-
-  public void rootProcessInstanceKey(final Long rootProcessInstanceKey) {
-    this.rootProcessInstanceKey = rootProcessInstanceKey;
-  }
-
-  public String flowNodeId() {
-    return flowNodeId;
-  }
-
-  public void flowNodeId(final String flowNodeId) {
-    this.flowNodeId = flowNodeId;
-  }
-
-  public Long flowNodeInstanceKey() {
-    return flowNodeInstanceKey;
-  }
-
-  public void flowNodeInstanceKey(final Long flowNodeInstanceKey) {
-    this.flowNodeInstanceKey = flowNodeInstanceKey;
-  }
-
-  public MessageSubscriptionState messageSubscriptionState() {
-    return messageSubscriptionState;
-  }
-
-  public void messageSubscriptionState(final MessageSubscriptionState messageSubscriptionState) {
-    this.messageSubscriptionState = messageSubscriptionState;
-  }
-
-  public MessageSubscriptionType messageSubscriptionType() {
-    return messageSubscriptionType;
-  }
-
-  public void messageSubscriptionType(final MessageSubscriptionType messageSubscriptionType) {
-    this.messageSubscriptionType = messageSubscriptionType;
-  }
-
-  public String processDefinitionName() {
-    return processDefinitionName;
-  }
-
-  public void processDefinitionName(final String processDefinitionName) {
-    this.processDefinitionName = processDefinitionName;
-  }
-
-  public Integer processDefinitionVersion() {
-    return processDefinitionVersion;
-  }
-
-  public void processDefinitionVersion(final Integer processDefinitionVersion) {
-    this.processDefinitionVersion = processDefinitionVersion;
-  }
-
-  public String serializedToolProperties() {
-    return serializedToolProperties;
-  }
-
-  public void setSerializedToolProperties(final String serializedToolProperties) {
-    this.serializedToolProperties = serializedToolProperties;
-    toolProperties = MapSerializer.deserialize(serializedToolProperties);
-  }
+public record MessageSubscriptionDbModel(
+    Long messageSubscriptionKey,
+    String processDefinitionId,
+    Long processDefinitionKey,
+    Long processInstanceKey,
+    Long rootProcessInstanceKey,
+    String flowNodeId,
+    Long flowNodeInstanceKey,
+    MessageSubscriptionState messageSubscriptionState,
+    MessageSubscriptionType messageSubscriptionType,
+    OffsetDateTime dateTime,
+    String messageName,
+    String correlationKey,
+    String tenantId,
+    int partitionId,
+    String processDefinitionName,
+    Integer processDefinitionVersion,
+    String serializedToolProperties,
+    String toolName,
+    String inboundConnectorType)
+    implements Copyable<MessageSubscriptionDbModel> {
 
   public Map<String, String> toolProperties() {
-    return toolProperties;
+    return MapSerializer.deserialize(serializedToolProperties);
   }
 
-  public String toolName() {
-    return toolName;
-  }
-
-  public void toolName(final String toolName) {
-    this.toolName = toolName;
-  }
-
-  public String inboundConnectorType() {
-    return inboundConnectorType;
-  }
-
-  public void inboundConnectorType(final String inboundConnectorType) {
-    this.inboundConnectorType = inboundConnectorType;
-  }
-
-  public OffsetDateTime dateTime() {
-    return dateTime;
-  }
-
-  public void dateTime(final OffsetDateTime dateTime) {
-    this.dateTime = dateTime;
-  }
-
-  public String messageName() {
-    return messageName;
-  }
-
-  public void messageName(final String messageName) {
-    this.messageName = messageName;
-  }
-
-  public String correlationKey() {
-    return correlationKey;
-  }
-
-  public void correlationKey(final String correlationKey) {
-    this.correlationKey = correlationKey;
-  }
-
-  public String tenantId() {
-    return tenantId;
-  }
-
-  public void tenantId(final String tenantId) {
-    this.tenantId = tenantId;
-  }
-
-  public int partitionId() {
-    return partitionId;
-  }
-
-  public MessageSubscriptionDbModel partitionId(final int partitionId) {
-    this.partitionId = partitionId;
-    return this;
-  }
-
-  public void truncateToolFields(final int sizeLimit, final Integer byteLimit) {
-    if (TruncateUtil.shouldTruncate(toolName, sizeLimit, byteLimit)) {
-      toolName = TruncateUtil.truncateValue(toolName, sizeLimit, byteLimit);
+  public MessageSubscriptionDbModel truncateToolFields(
+      final int sizeLimit, final Integer byteLimit) {
+    final var truncatedToolName =
+        TruncateUtil.shouldTruncate(toolName, sizeLimit, byteLimit)
+            ? TruncateUtil.truncateValue(toolName, sizeLimit, byteLimit)
+            : toolName;
+    final var truncatedInboundConnectorType =
+        TruncateUtil.shouldTruncate(inboundConnectorType, sizeLimit, byteLimit)
+            ? TruncateUtil.truncateValue(inboundConnectorType, sizeLimit, byteLimit)
+            : inboundConnectorType;
+    if (Objects.equals(truncatedToolName, toolName)
+        && Objects.equals(truncatedInboundConnectorType, inboundConnectorType)) {
+      return this;
     }
-    if (TruncateUtil.shouldTruncate(inboundConnectorType, sizeLimit, byteLimit)) {
-      inboundConnectorType = TruncateUtil.truncateValue(inboundConnectorType, sizeLimit, byteLimit);
-    }
+
+    return new MessageSubscriptionDbModel(
+        messageSubscriptionKey,
+        processDefinitionId,
+        processDefinitionKey,
+        processInstanceKey,
+        rootProcessInstanceKey,
+        flowNodeId,
+        flowNodeInstanceKey,
+        messageSubscriptionState,
+        messageSubscriptionType,
+        dateTime,
+        messageName,
+        correlationKey,
+        tenantId,
+        partitionId,
+        processDefinitionName,
+        processDefinitionVersion,
+        serializedToolProperties,
+        truncatedToolName,
+        truncatedInboundConnectorType);
   }
 
   @Override
@@ -259,8 +88,8 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     return copyFunction.apply(toBuilder()).build();
   }
 
-  public ObjectBuilder<MessageSubscriptionDbModel> toBuilder() {
-    return new Builder()
+  public Builder toBuilder() {
+    return new Builder(serializedToolProperties)
         .messageSubscriptionKey(messageSubscriptionKey)
         .processDefinitionId(processDefinitionId)
         .processDefinitionKey(processDefinitionKey)
@@ -277,7 +106,6 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
         .partitionId(partitionId)
         .processDefinitionName(processDefinitionName)
         .processDefinitionVersion(processDefinitionVersion)
-        .toolProperties(toolProperties)
         .toolName(toolName)
         .inboundConnectorType(inboundConnectorType);
   }
@@ -299,9 +127,18 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     private int partitionId;
     private String processDefinitionName;
     private Integer processDefinitionVersion;
-    private Map<String, String> toolProperties;
+    private String serializedToolProperties;
     private String toolName;
     private String inboundConnectorType;
+
+    public Builder() {}
+
+    // Seeds the raw serialized column value for toBuilder()/copy(), so a copy that never touches
+    // toolProperties() carries the original string through unparsed instead of round-tripping it
+    // through Jackson.
+    Builder(final String serializedToolProperties) {
+      this.serializedToolProperties = serializedToolProperties;
+    }
 
     public Builder messageSubscriptionKey(final Long messageSubscriptionKey) {
       this.messageSubscriptionKey = messageSubscriptionKey;
@@ -360,7 +197,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     }
 
     public Builder toolProperties(final Map<String, String> toolProperties) {
-      this.toolProperties = toolProperties;
+      serializedToolProperties = MapSerializer.serialize(toolProperties);
       return this;
     }
 
@@ -418,7 +255,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
           partitionId,
           processDefinitionName,
           processDefinitionVersion,
-          toolProperties,
+          serializedToolProperties,
           toolName,
           inboundConnectorType);
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UserTaskDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UserTaskDbModel.java
@@ -178,7 +178,9 @@ public record UserTaskDbModel(
 
     // Seeds the raw serialized column value for toBuilder()/copy(), so a copy that never touches
     // customHeaders() carries the original string through unparsed instead of round-tripping it
-    // through Jackson.
+    // through Jackson. Package-private, not a public setter: a second public setter aliasing the
+    // same field as customHeaders(Map) would let callers silently drop one write (e.g.
+    // builder.serializedCustomHeaders(x).customHeaders(y) loses x).
     Builder(final String serializedCustomHeaders) {
       this.serializedCustomHeaders = serializedCustomHeaders;
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UserTaskDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UserTaskDbModel.java
@@ -10,44 +10,53 @@ package io.camunda.db.rdbms.write.domain;
 import io.camunda.db.rdbms.write.util.MapSerializer;
 import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
-public class UserTaskDbModel implements Copyable<UserTaskDbModel> {
+public record UserTaskDbModel(
+    Long userTaskKey,
+    String elementId,
+    String name,
+    String processDefinitionId,
+    OffsetDateTime creationDate,
+    OffsetDateTime completionDate,
+    String assignee,
+    UserTaskState state,
+    Long formKey,
+    Long processDefinitionKey,
+    Long processInstanceKey,
+    Long rootProcessInstanceKey,
+    String businessId,
+    Long elementInstanceKey,
+    String tenantId,
+    OffsetDateTime dueDate,
+    OffsetDateTime followUpDate,
+    List<String> candidateGroups,
+    List<String> candidateUsers,
+    String externalFormReference,
+    Integer processDefinitionVersion,
+    String serializedCustomHeaders,
+    Integer priority,
+    Set<String> tags,
+    int partitionId)
+    implements Copyable<UserTaskDbModel> {
 
-  private Long userTaskKey;
-  private String elementId;
-  private String name;
-  private String processDefinitionId;
-  private OffsetDateTime creationDate;
-  private OffsetDateTime completionDate;
-  private String assignee;
-  private UserTaskState state;
-  private Long formKey;
-  private Long processDefinitionKey;
-  private Long processInstanceKey;
-  private Long rootProcessInstanceKey;
-  private String businessId;
-  private Long elementInstanceKey;
-  private String tenantId;
-  private OffsetDateTime dueDate;
-  private OffsetDateTime followUpDate;
-  private List<String> candidateGroups;
-  private List<String> candidateUsers;
-  private String externalFormReference;
-  private Integer processDefinitionVersion;
-  private String serializedCustomHeaders;
-  private Map<String, String> customHeaders;
-  private Integer priority;
-  private Set<String> tags;
-  private int partitionId;
-
-  public UserTaskDbModel(final Long userTaskKey) {
-    this.userTaskKey = userTaskKey;
+  public UserTaskDbModel {
+    // Must stay mutable: MyBatis appends to these via <collection> after construction.
+    candidateGroups = Objects.requireNonNullElse(candidateGroups, new ArrayList<>());
+    candidateUsers = Objects.requireNonNullElse(candidateUsers, new ArrayList<>());
+    tags = Objects.requireNonNullElse(tags, new HashSet<>());
   }
 
+  // Matches searchResultMap's <constructor>, which omits candidateGroups/candidateUsers/tags --
+  // populated separately via the sibling <collection> elements -- and partitionId, which the
+  // search query never selects (matching the pre-record behavior of always defaulting to 0 for
+  // search-hydrated instances).
   public UserTaskDbModel(
       final Long userTaskKey,
       final String elementId,
@@ -68,34 +77,34 @@ public class UserTaskDbModel implements Copyable<UserTaskDbModel> {
       final OffsetDateTime followUpDate,
       final String externalFormReference,
       final Integer processDefinitionVersion,
-      final Map<String, String> customHeaders,
-      final Integer priority,
-      final Set<String> tags,
-      final int partitionId) {
-    this.userTaskKey = userTaskKey;
-    this.elementId = elementId;
-    this.name = name;
-    this.processDefinitionId = processDefinitionId;
-    this.creationDate = creationDate;
-    this.completionDate = completionDate;
-    this.assignee = assignee;
-    this.state = state;
-    this.formKey = formKey;
-    this.processDefinitionKey = processDefinitionKey;
-    this.processInstanceKey = processInstanceKey;
-    this.rootProcessInstanceKey = rootProcessInstanceKey;
-    this.businessId = businessId;
-    this.elementInstanceKey = elementInstanceKey;
-    this.tenantId = tenantId;
-    this.dueDate = dueDate;
-    this.followUpDate = followUpDate;
-    this.externalFormReference = externalFormReference;
-    this.processDefinitionVersion = processDefinitionVersion;
-    this.customHeaders = customHeaders;
-    serializedCustomHeaders = MapSerializer.serialize(customHeaders);
-    this.priority = priority;
-    this.tags = tags;
-    this.partitionId = partitionId;
+      final String serializedCustomHeaders,
+      final Integer priority) {
+    this(
+        userTaskKey,
+        elementId,
+        name,
+        processDefinitionId,
+        creationDate,
+        completionDate,
+        assignee,
+        state,
+        formKey,
+        processDefinitionKey,
+        processInstanceKey,
+        rootProcessInstanceKey,
+        businessId,
+        elementInstanceKey,
+        tenantId,
+        dueDate,
+        followUpDate,
+        null,
+        null,
+        externalFormReference,
+        processDefinitionVersion,
+        serializedCustomHeaders,
+        priority,
+        null,
+        0);
   }
 
   @Override
@@ -104,215 +113,12 @@ public class UserTaskDbModel implements Copyable<UserTaskDbModel> {
     return copyFunction.apply(toBuilder()).build();
   }
 
-  // Methods without get/set prefix
-
-  public Long userTaskKey() {
-    return userTaskKey;
-  }
-
-  public void userTaskKey(final Long userTaskKey) {
-    this.userTaskKey = userTaskKey;
-  }
-
-  public String elementId() {
-    return elementId;
-  }
-
-  public void elementId(final String elementId) {
-    this.elementId = elementId;
-  }
-
-  public String name() {
-    return name;
-  }
-
-  public void name(final String name) {
-    this.name = name;
-  }
-
-  public String processDefinitionId() {
-    return processDefinitionId;
-  }
-
-  public void processDefinitionId(final String processDefinitionId) {
-    this.processDefinitionId = processDefinitionId;
-  }
-
-  public OffsetDateTime creationDate() {
-    return creationDate;
-  }
-
-  public void creationDate(final OffsetDateTime creationDate) {
-    this.creationDate = creationDate;
-  }
-
-  public OffsetDateTime completionDate() {
-    return completionDate;
-  }
-
-  public void completionDate(final OffsetDateTime completionDate) {
-    this.completionDate = completionDate;
-  }
-
-  public String assignee() {
-    return assignee;
-  }
-
-  public void assignee(final String assignee) {
-    this.assignee = assignee;
-  }
-
-  public UserTaskState state() {
-    return state;
-  }
-
-  public void state(final UserTaskState state) {
-    this.state = state;
-  }
-
-  public Long formKey() {
-    return formKey;
-  }
-
-  public void formKey(final Long formKey) {
-    this.formKey = formKey;
-  }
-
-  public Long processDefinitionKey() {
-    return processDefinitionKey;
-  }
-
-  public void processDefinitionKey(final Long processDefinitionKey) {
-    this.processDefinitionKey = processDefinitionKey;
-  }
-
-  public Long processInstanceKey() {
-    return processInstanceKey;
-  }
-
-  public void processInstanceKey(final Long processInstanceKey) {
-    this.processInstanceKey = processInstanceKey;
-  }
-
-  public Long rootProcessInstanceKey() {
-    return rootProcessInstanceKey;
-  }
-
-  public void rootProcessInstanceKey(final Long rootProcessInstanceKey) {
-    this.rootProcessInstanceKey = rootProcessInstanceKey;
-  }
-
-  public String businessId() {
-    return businessId;
-  }
-
-  public void businessId(final String businessId) {
-    this.businessId = businessId;
-  }
-
-  public Long elementInstanceKey() {
-    return elementInstanceKey;
-  }
-
-  public void elementInstanceKey(final Long elementInstanceKey) {
-    this.elementInstanceKey = elementInstanceKey;
-  }
-
-  public String tenantId() {
-    return tenantId;
-  }
-
-  public void tenantId(final String tenantId) {
-    this.tenantId = tenantId;
-  }
-
-  public OffsetDateTime dueDate() {
-    return dueDate;
-  }
-
-  public void dueDate(final OffsetDateTime dueDate) {
-    this.dueDate = dueDate;
-  }
-
-  public OffsetDateTime followUpDate() {
-    return followUpDate;
-  }
-
-  public void followUpDate(final OffsetDateTime followUpDate) {
-    this.followUpDate = followUpDate;
-  }
-
-  public List<String> candidateGroups() {
-    return candidateGroups;
-  }
-
-  public void candidateGroups(final List<String> candidateGroups) {
-    this.candidateGroups = candidateGroups;
-  }
-
-  public List<String> candidateUsers() {
-    return candidateUsers;
-  }
-
-  public void candidateUsers(final List<String> candidateUsers) {
-    this.candidateUsers = candidateUsers;
-  }
-
-  public String externalFormReference() {
-    return externalFormReference;
-  }
-
-  public void externalFormReference(final String externalFormReference) {
-    this.externalFormReference = externalFormReference;
-  }
-
-  public Integer processDefinitionVersion() {
-    return processDefinitionVersion;
-  }
-
-  public void processDefinitionVersion(final Integer processDefinitionVersion) {
-    this.processDefinitionVersion = processDefinitionVersion;
-  }
-
-  public String serializedCustomHeaders() {
-    return serializedCustomHeaders;
-  }
-
-  public void serializedCustomHeaders(final String serializedCustomHeaders) {
-    this.serializedCustomHeaders = serializedCustomHeaders;
-    customHeaders = MapSerializer.deserialize(serializedCustomHeaders);
-  }
-
   public Map<String, String> customHeaders() {
-    return customHeaders;
-  }
-
-  public void customHeaders(final Map<String, String> customHeaders) {
-    this.customHeaders = customHeaders;
-  }
-
-  public Integer priority() {
-    return priority;
-  }
-
-  public void priority(final Integer priority) {
-    this.priority = priority;
-  }
-
-  public Set<String> tags() {
-    return tags;
-  }
-
-  public void tags(final Set<String> tags) {
-    this.tags = tags;
-  }
-
-  public int partitionId() {
-    return partitionId;
+    return MapSerializer.deserialize(serializedCustomHeaders);
   }
 
   public Builder toBuilder() {
-    return new Builder()
+    return new Builder(serializedCustomHeaders)
         .userTaskKey(userTaskKey)
         .elementId(elementId)
         .name(name)
@@ -334,7 +140,6 @@ public class UserTaskDbModel implements Copyable<UserTaskDbModel> {
         .candidateUsers(candidateUsers)
         .externalFormReference(externalFormReference)
         .processDefinitionVersion(processDefinitionVersion)
-        .customHeaders(customHeaders)
         .priority(priority)
         .tags(tags)
         .partitionId(partitionId);
@@ -363,13 +168,20 @@ public class UserTaskDbModel implements Copyable<UserTaskDbModel> {
     private List<String> candidateUsers;
     private String externalFormReference;
     private Integer processDefinitionVersion;
-    private Map<String, String> customHeaders;
+    private String serializedCustomHeaders;
     private Integer priority;
     private Set<String> tags;
     private int partitionId;
 
     // Public constructor to initialize the builder
     public Builder() {}
+
+    // Seeds the raw serialized column value for toBuilder()/copy(), so a copy that never touches
+    // customHeaders() carries the original string through unparsed instead of round-tripping it
+    // through Jackson.
+    Builder(final String serializedCustomHeaders) {
+      this.serializedCustomHeaders = serializedCustomHeaders;
+    }
 
     public static UserTaskDbModel of(
         final Function<UserTaskDbModel.Builder, ObjectBuilder<UserTaskDbModel>> fn) {
@@ -483,7 +295,7 @@ public class UserTaskDbModel implements Copyable<UserTaskDbModel> {
     }
 
     public Builder customHeaders(final Map<String, String> customHeaders) {
-      this.customHeaders = customHeaders;
+      serializedCustomHeaders = MapSerializer.serialize(customHeaders);
       return this;
     }
 
@@ -505,36 +317,32 @@ public class UserTaskDbModel implements Copyable<UserTaskDbModel> {
     // Build method to create the record
     @Override
     public UserTaskDbModel build() {
-      final var model =
-          new UserTaskDbModel(
-              userTaskKey,
-              elementId,
-              name,
-              processDefinitionId,
-              creationDate,
-              completionDate,
-              assignee,
-              state,
-              formKey,
-              processDefinitionKey,
-              processInstanceKey,
-              rootProcessInstanceKey,
-              businessId,
-              elementInstanceKey,
-              tenantId,
-              dueDate,
-              followUpDate,
-              externalFormReference,
-              processDefinitionVersion,
-              customHeaders,
-              priority,
-              tags,
-              partitionId);
-
-      model.candidateUsers(candidateUsers);
-      model.candidateGroups(candidateGroups);
-
-      return model;
+      return new UserTaskDbModel(
+          userTaskKey,
+          elementId,
+          name,
+          processDefinitionId,
+          creationDate,
+          completionDate,
+          assignee,
+          state,
+          formKey,
+          processDefinitionKey,
+          processInstanceKey,
+          rootProcessInstanceKey,
+          businessId,
+          elementInstanceKey,
+          tenantId,
+          dueDate,
+          followUpDate,
+          candidateGroups,
+          candidateUsers,
+          externalFormReference,
+          processDefinitionVersion,
+          serializedCustomHeaders,
+          priority,
+          tags,
+          partitionId);
     }
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentHistoryWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentHistoryWriter.java
@@ -30,16 +30,17 @@ public class AgentHistoryWriter extends ProcessInstanceDependant implements Rdbm
   }
 
   public void create(final AgentHistoryDbModel model) {
-    model.truncateJobLease(
-        vendorDatabaseProperties.userCharColumnSize(),
-        vendorDatabaseProperties.charColumnMaxBytes());
+    final var truncated =
+        model.truncateJobLease(
+            vendorDatabaseProperties.userCharColumnSize(),
+            vendorDatabaseProperties.charColumnMaxBytes());
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.AGENT_HISTORY,
             WriteStatementType.INSERT,
-            model.agentHistoryKey(),
+            truncated.agentHistoryKey(),
             "io.camunda.db.rdbms.sql.AgentHistoryMapper.insert",
-            model));
+            truncated));
   }
 
   public void updateCommitStatus(final AgentHistoryDbModel model) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentInstanceWriter.java
@@ -33,18 +33,19 @@ public class AgentInstanceWriter extends ProcessInstanceDependant implements Rdb
   }
 
   public void create(final AgentInstanceDbModel agentInstance) {
-    agentInstance.truncateDefinitionFields(
-        vendorDatabaseProperties.userCharColumnSize(),
-        vendorDatabaseProperties.charColumnMaxBytes());
+    final var truncated =
+        agentInstance.truncateDefinitionFields(
+            vendorDatabaseProperties.userCharColumnSize(),
+            vendorDatabaseProperties.charColumnMaxBytes());
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.AGENT_INSTANCE,
             WriteStatementType.INSERT,
-            agentInstance.agentInstanceKey(),
+            truncated.agentInstanceKey(),
             "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
-            agentInstance));
+            truncated));
 
-    insertElementInstanceKeys(agentInstance);
+    insertElementInstanceKeys(truncated);
   }
 
   public void update(final AgentInstanceDbModel agentInstance) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriter.java
@@ -33,29 +33,31 @@ public class MessageSubscriptionWriter extends ProcessInstanceDependant implemen
   }
 
   public void create(final MessageSubscriptionDbModel messageSubscription) {
-    messageSubscription.truncateToolFields(
-        vendorDatabaseProperties.userCharColumnSize(),
-        vendorDatabaseProperties.charColumnMaxBytes());
+    final var truncated =
+        messageSubscription.truncateToolFields(
+            vendorDatabaseProperties.userCharColumnSize(),
+            vendorDatabaseProperties.charColumnMaxBytes());
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.MESSAGE_SUBSCRIPTION,
             WriteStatementType.INSERT,
-            messageSubscription.messageSubscriptionKey(),
+            truncated.messageSubscriptionKey(),
             "io.camunda.db.rdbms.sql.MessageSubscriptionMapper.insert",
-            messageSubscription));
+            truncated));
   }
 
   public void update(final MessageSubscriptionDbModel messageSubscription) {
-    messageSubscription.truncateToolFields(
-        vendorDatabaseProperties.userCharColumnSize(),
-        vendorDatabaseProperties.charColumnMaxBytes());
+    final var truncated =
+        messageSubscription.truncateToolFields(
+            vendorDatabaseProperties.userCharColumnSize(),
+            vendorDatabaseProperties.charColumnMaxBytes());
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.MESSAGE_SUBSCRIPTION,
             WriteStatementType.UPDATE,
-            messageSubscription.messageSubscriptionKey(),
+            truncated.messageSubscriptionKey(),
             "io.camunda.db.rdbms.sql.MessageSubscriptionMapper.update",
-            messageSubscription));
+            truncated));
   }
 
   public int deleteStartEventSubscriptionsByProcessDefinitionKeys(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/util/TruncateUtil.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/util/TruncateUtil.java
@@ -11,17 +11,12 @@ import java.nio.charset.StandardCharsets;
 
 public class TruncateUtil {
 
-  public static boolean shouldTruncate(
-      final String value, final int sizeLimit, final Integer byteLimit) {
-    if (value == null) {
-      return false;
-    }
-    return value.length() > sizeLimit
-        || byteLimit != null && value.getBytes(StandardCharsets.UTF_8).length > byteLimit;
-  }
-
   public static String truncateValue(
       final String value, final int sizeLimit, final Integer byteLimit) {
+    if (value == null) {
+      return null;
+    }
+
     var truncatedValue = value;
 
     if (truncatedValue.length() > sizeLimit) {

--- a/db/rdbms/src/main/resources/mapper/AgentHistoryMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AgentHistoryMapper.xml
@@ -87,28 +87,32 @@
     them lazily on first access.
   -->
   <resultMap id="searchResultMap" type="io.camunda.db.rdbms.write.domain.AgentHistoryDbModel">
-    <id property="agentHistoryKey" column="AGENT_HISTORY_KEY" javaType="long"/>
-    <result property="agentInstanceKey" column="AGENT_INSTANCE_KEY" javaType="long"/>
-    <result property="elementInstanceKey" column="ELEMENT_INSTANCE_KEY" javaType="long"/>
-    <result property="processInstanceKey" column="PROCESS_INSTANCE_KEY" javaType="long"/>
-    <result property="rootProcessInstanceKey" column="ROOT_PROCESS_INSTANCE_KEY" javaType="long"/>
-    <result property="processDefinitionId" column="PROCESS_DEFINITION_ID" javaType="java.lang.String"/>
-    <result property="processDefinitionKey" column="PROCESS_DEFINITION_KEY" javaType="long"/>
-    <result property="tenantId" column="TENANT_ID" javaType="java.lang.String"/>
-    <result property="partitionId" column="PARTITION_ID" javaType="java.lang.Integer"/>
-    <result property="jobKey" column="JOB_KEY" javaType="long"/>
-    <result property="jobLease" column="JOB_LEASE" javaType="java.lang.String"/>
-    <result property="loopIteration" column="LOOP_ITERATION" javaType="int"/>
-    <result property="role" column="ROLE"
-      javaType="io.camunda.search.entities.AgentInstanceHistoryEntity$AgentInstanceHistoryRole"/>
-    <result property="commitStatus" column="COMMIT_STATUS"
-      javaType="io.camunda.search.entities.AgentInstanceHistoryEntity$AgentInstanceHistoryCommitStatus"/>
-    <result property="producedAt" column="PRODUCED_AT" javaType="java.time.OffsetDateTime"/>
-    <result property="inputTokens" column="INPUT_TOKENS" javaType="java.lang.Long"/>
-    <result property="outputTokens" column="OUTPUT_TOKENS" javaType="java.lang.Long"/>
-    <result property="durationMs" column="DURATION_MS" javaType="java.lang.Long"/>
-    <result property="content" column="CONTENT" javaType="java.lang.String"/>
-    <result property="toolCalls" column="TOOL_CALLS" javaType="java.lang.String"/>
+    <constructor>
+      <idArg column="AGENT_HISTORY_KEY" javaType="_long" name="agentHistoryKey"/>
+      <arg column="AGENT_INSTANCE_KEY" javaType="_long" name="agentInstanceKey"/>
+      <arg column="ELEMENT_INSTANCE_KEY" javaType="_long" name="elementInstanceKey"/>
+      <arg column="PROCESS_INSTANCE_KEY" javaType="_long" name="processInstanceKey"/>
+      <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="_long" name="rootProcessInstanceKey"/>
+      <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String" name="processDefinitionId"/>
+      <arg column="PROCESS_DEFINITION_KEY" javaType="_long" name="processDefinitionKey"/>
+      <arg column="TENANT_ID" javaType="java.lang.String" name="tenantId"/>
+      <arg column="PARTITION_ID" javaType="_int" name="partitionId"/>
+      <arg column="JOB_KEY" javaType="_long" name="jobKey"/>
+      <arg column="JOB_LEASE" javaType="java.lang.String" name="jobLease"/>
+      <arg column="LOOP_ITERATION" javaType="_int" name="loopIteration"/>
+      <arg column="ROLE"
+        javaType="io.camunda.search.entities.AgentInstanceHistoryEntity$AgentInstanceHistoryRole"
+        name="role"/>
+      <arg column="COMMIT_STATUS"
+        javaType="io.camunda.search.entities.AgentInstanceHistoryEntity$AgentInstanceHistoryCommitStatus"
+        name="commitStatus"/>
+      <arg column="PRODUCED_AT" javaType="java.time.OffsetDateTime" name="producedAt"/>
+      <arg column="INPUT_TOKENS" javaType="java.lang.Long" name="inputTokens"/>
+      <arg column="OUTPUT_TOKENS" javaType="java.lang.Long" name="outputTokens"/>
+      <arg column="DURATION_MS" javaType="java.lang.Long" name="durationMs"/>
+      <arg column="CONTENT" javaType="java.lang.String" name="content"/>
+      <arg column="TOOL_CALLS" javaType="java.lang.String" name="toolCalls"/>
+    </constructor>
   </resultMap>
 
   <select id="search"

--- a/db/rdbms/src/main/resources/mapper/AgentInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AgentInstanceMapper.xml
@@ -145,33 +145,33 @@
   -->
   <resultMap id="searchResultMap"
     type="io.camunda.db.rdbms.write.domain.AgentInstanceDbModel">
-    <id property="agentInstanceKey" column="AGENT_INSTANCE_KEY" javaType="long"/>
-    <result property="elementId" column="ELEMENT_ID" javaType="java.lang.String"/>
-    <result property="processInstanceKey" column="PROCESS_INSTANCE_KEY" javaType="long"/>
-    <result property="rootProcessInstanceKey" column="ROOT_PROCESS_INSTANCE_KEY" javaType="long"/>
-    <result property="processDefinitionId" column="PROCESS_DEFINITION_ID" javaType="java.lang.String"/>
-    <result property="processDefinitionKey" column="PROCESS_DEFINITION_KEY" javaType="long"/>
-    <result property="processDefinitionVersion" column="PROCESS_DEFINITION_VERSION"
-      javaType="java.lang.Integer"/>
-    <result property="versionTag" column="VERSION_TAG" javaType="java.lang.String"/>
-    <result property="tenantId" column="TENANT_ID" javaType="java.lang.String"/>
-    <result property="partitionId" column="PARTITION_ID" javaType="java.lang.Integer"/>
-    <result property="status" column="STATUS" javaType="io.camunda.search.entities.AgentInstanceEntity$AgentInstanceStatus"/>
-    <result property="model" column="MODEL" javaType="java.lang.String"/>
-    <result property="provider" column="PROVIDER" javaType="java.lang.String"/>
-    <result property="systemPrompt" column="SYSTEM_PROMPT" javaType="java.lang.String"/>
-    <result property="maxTokens" column="MAX_TOKENS" javaType="long"/>
-    <result property="maxModelCalls" column="MAX_MODEL_CALLS" javaType="java.lang.Integer"/>
-    <result property="maxToolCalls" column="MAX_TOOL_CALLS" javaType="java.lang.Integer"/>
-    <result property="inputTokens" column="INPUT_TOKENS" javaType="long"/>
-    <result property="outputTokens" column="OUTPUT_TOKENS" javaType="long"/>
-    <result property="modelCalls" column="MODEL_CALLS" javaType="java.lang.Integer"/>
-    <result property="toolCalls" column="TOOL_CALLS" javaType="java.lang.Integer"/>
-    <result property="tools" column="TOOLS" javaType="java.lang.String"/>
-    <result property="creationDate" column="CREATION_DATE" javaType="java.time.OffsetDateTime"/>
-    <result property="lastUpdatedDate" column="LAST_UPDATED_DATE"
-      javaType="java.time.OffsetDateTime"/>
-    <result property="completionDate" column="COMPLETION_DATE" javaType="java.time.OffsetDateTime"/>
+    <constructor>
+      <idArg column="AGENT_INSTANCE_KEY" javaType="_long" name="agentInstanceKey"/>
+      <arg column="ELEMENT_ID" javaType="java.lang.String" name="elementId"/>
+      <arg column="PROCESS_INSTANCE_KEY" javaType="_long" name="processInstanceKey"/>
+      <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="_long" name="rootProcessInstanceKey"/>
+      <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String" name="processDefinitionId"/>
+      <arg column="PROCESS_DEFINITION_KEY" javaType="_long" name="processDefinitionKey"/>
+      <arg column="PROCESS_DEFINITION_VERSION" javaType="_int" name="processDefinitionVersion"/>
+      <arg column="VERSION_TAG" javaType="java.lang.String" name="versionTag"/>
+      <arg column="TENANT_ID" javaType="java.lang.String" name="tenantId"/>
+      <arg column="PARTITION_ID" javaType="_int" name="partitionId"/>
+      <arg column="STATUS" javaType="io.camunda.search.entities.AgentInstanceEntity$AgentInstanceStatus" name="status"/>
+      <arg column="MODEL" javaType="java.lang.String" name="model"/>
+      <arg column="PROVIDER" javaType="java.lang.String" name="provider"/>
+      <arg column="SYSTEM_PROMPT" javaType="java.lang.String" name="systemPrompt"/>
+      <arg column="MAX_TOKENS" javaType="_long" name="maxTokens"/>
+      <arg column="MAX_MODEL_CALLS" javaType="_int" name="maxModelCalls"/>
+      <arg column="MAX_TOOL_CALLS" javaType="_int" name="maxToolCalls"/>
+      <arg column="INPUT_TOKENS" javaType="_long" name="inputTokens"/>
+      <arg column="OUTPUT_TOKENS" javaType="_long" name="outputTokens"/>
+      <arg column="MODEL_CALLS" javaType="_int" name="modelCalls"/>
+      <arg column="TOOL_CALLS" javaType="_int" name="toolCalls"/>
+      <arg column="TOOLS" javaType="java.lang.String" name="tools"/>
+      <arg column="CREATION_DATE" javaType="java.time.OffsetDateTime" name="creationDate"/>
+      <arg column="LAST_UPDATED_DATE" javaType="java.time.OffsetDateTime" name="lastUpdatedDate"/>
+      <arg column="COMPLETION_DATE" javaType="java.time.OffsetDateTime" name="completionDate"/>
+    </constructor>
     <collection property="elementInstanceKeys" ofType="java.lang.Long" javaType="java.util.List">
       <id column="ELEMENT_INSTANCE_KEY"/>
     </collection>

--- a/db/rdbms/src/main/resources/mapper/JobMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMapper.xml
@@ -232,34 +232,34 @@
 
   <resultMap id="searchResultMap" type="io.camunda.db.rdbms.write.domain.JobDbModel">
     <constructor>
-    <idArg column="JOB_KEY" javaType="java.lang.Long" />
+      <idArg column="JOB_KEY" javaType="java.lang.Long" name="jobKey" />
+      <arg column="TYPE" javaType="java.lang.String" name="type" />
+      <arg column="WORKER" javaType="java.lang.String" name="worker" />
+      <arg column="STATE" javaType="io.camunda.search.entities.JobEntity$JobState" name="state" />
+      <arg column="KIND" javaType="io.camunda.search.entities.JobEntity$JobKind" name="kind" />
+      <arg column="LISTENER_EVENT_TYPE" javaType="io.camunda.search.entities.JobEntity$ListenerEventType" name="listenerEventType" />
+      <arg column="RETRIES" javaType="java.lang.Integer" name="retries" />
+      <arg column="PRIORITY" javaType="java.lang.Integer" name="priority" />
+      <arg column="IS_DENIED" javaType="java.lang.Boolean" name="isDenied" />
+      <arg column="DENIED_REASON" javaType="java.lang.String" name="deniedReason" />
+      <arg column="HAS_FAILED_WITH_RETRIES_LEFT" javaType="java.lang.Boolean" name="hasFailedWithRetriesLeft" />
+      <arg column="ERROR_CODE" javaType="java.lang.String" name="errorCode" />
+      <arg column="ERROR_MESSAGE" javaType="java.lang.String" name="errorMessage" />
+      <arg column="CUSTOM_HEADERS" javaType="java.lang.String" name="serializedCustomHeaders" />
+      <arg column="DEADLINE" javaType="java.time.OffsetDateTime" name="deadline" />
+      <arg column="END_TIME" javaType="java.time.OffsetDateTime" name="endTime" />
+      <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String" name="processDefinitionId" />
+      <arg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long" name="processDefinitionKey" />
+      <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long" name="processInstanceKey" />
+      <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long" name="rootProcessInstanceKey" />
+      <arg column="BUSINESS_ID" javaType="java.lang.String" name="businessId" />
+      <arg column="ELEMENT_ID" javaType="java.lang.String" name="elementId" />
+      <arg column="ELEMENT_INSTANCE_KEY" javaType="java.lang.Long" name="elementInstanceKey" />
+      <arg column="TENANT_ID" javaType="java.lang.String" name="tenantId" />
+      <arg column="PARTITION_ID" javaType="_int" name="partitionId" />
+      <arg column="CREATION_TIME" javaType="java.time.OffsetDateTime" name="creationTime" />
+      <arg column="LAST_UPDATE_TIME" javaType="java.time.OffsetDateTime" name="lastUpdateTime" />
     </constructor>
-    <result column="PARTITION_ID" property="partitionId" javaType="java.lang.Integer" />
-    <result column="PROCESS_INSTANCE_KEY" property="processInstanceKey" javaType="java.lang.Long" />
-    <result column="ROOT_PROCESS_INSTANCE_KEY" property="rootProcessInstanceKey" javaType="java.lang.Long" />
-    <result column="BUSINESS_ID" property="businessId" javaType="java.lang.String" />
-    <result column="ELEMENT_INSTANCE_KEY" property="elementInstanceKey" javaType="java.lang.Long" />
-    <result column="PROCESS_DEFINITION_ID" property="processDefinitionId" javaType="java.lang.String" />
-    <result column="PROCESS_DEFINITION_KEY" property="processDefinitionKey" javaType="java.lang.Long" />
-    <result column="TENANT_ID" property="tenantId" javaType="java.lang.String" />
-    <result column="TYPE" property="type" javaType="java.lang.String" />
-    <result column="WORKER" property="worker" javaType="java.lang.String" />
-    <result column="STATE" property="state" javaType="io.camunda.search.entities.JobEntity$JobState" />
-    <result column="RETRIES" property="retries" javaType="java.lang.Integer" />
-    <result column="PRIORITY" property="priority" javaType="java.lang.Integer" />
-    <result column="ERROR_MESSAGE" property="errorMessage" javaType="java.lang.String" />
-    <result column="ERROR_CODE" property="errorCode" javaType="java.lang.String" />
-    <result column="END_TIME" property="endTime" javaType="java.time.OffsetDateTime" />
-    <result column="CUSTOM_HEADERS" property="serializedCustomHeaders" javaType="java.lang.String" />
-    <result column="KIND" property="kind" javaType="io.camunda.search.entities.JobEntity$JobKind" />
-    <result column="ELEMENT_ID" property="elementId" javaType="java.lang.String" />
-    <result column="IS_DENIED" property="isDenied" javaType="java.lang.Boolean" />
-    <result column="DENIED_REASON" property="deniedReason" javaType="java.lang.String" />
-    <result column="LISTENER_EVENT_TYPE" property="listenerEventType" javaType="io.camunda.search.entities.JobEntity$ListenerEventType" />
-    <result column="DEADLINE" property="deadline" javaType="java.time.OffsetDateTime" />
-    <result column="HAS_FAILED_WITH_RETRIES_LEFT" property="hasFailedWithRetriesLeft" javaType="java.lang.Boolean" />
-    <result column="CREATION_TIME" property="creationTime" javaType="java.time.OffsetDateTime" />
-    <result column="LAST_UPDATE_TIME" property="lastUpdateTime" javaType="java.time.OffsetDateTime" />
   </resultMap>
 
 

--- a/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
@@ -177,26 +177,26 @@
 
   <resultMap id="searchResultMap" type="io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel">
     <constructor>
-      <idArg column="MESSAGE_SUBSCRIPTION_KEY" javaType="java.lang.Long" />
+      <idArg column="MESSAGE_SUBSCRIPTION_KEY" javaType="java.lang.Long" name="messageSubscriptionKey" />
+      <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String" name="processDefinitionId" />
+      <arg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long" name="processDefinitionKey" />
+      <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long" name="processInstanceKey" />
+      <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long" name="rootProcessInstanceKey" />
+      <arg column="FLOW_NODE_ID" javaType="java.lang.String" name="flowNodeId" />
+      <arg column="FLOW_NODE_INSTANCE_KEY" javaType="java.lang.Long" name="flowNodeInstanceKey" />
+      <arg column="MESSAGE_SUBSCRIPTION_STATE" javaType="io.camunda.search.entities.MessageSubscriptionEntity$MessageSubscriptionState" name="messageSubscriptionState" />
+      <arg column="MESSAGE_SUBSCRIPTION_TYPE" javaType="io.camunda.search.entities.MessageSubscriptionEntity$MessageSubscriptionType" name="messageSubscriptionType" />
+      <arg column="DATE_TIME" javaType="java.time.OffsetDateTime" name="dateTime" />
+      <arg column="MESSAGE_NAME" javaType="java.lang.String" name="messageName" />
+      <arg column="CORRELATION_KEY" javaType="java.lang.String" name="correlationKey" />
+      <arg column="TENANT_ID" javaType="java.lang.String" name="tenantId" />
+      <arg column="PARTITION_ID" javaType="_int" name="partitionId" />
+      <arg column="PROCESS_DEFINITION_NAME" javaType="java.lang.String" name="processDefinitionName" />
+      <arg column="PROCESS_DEFINITION_VERSION" javaType="java.lang.Integer" name="processDefinitionVersion" />
+      <arg column="TOOL_PROPERTIES" javaType="java.lang.String" name="serializedToolProperties" />
+      <arg column="TOOL_NAME" javaType="java.lang.String" name="toolName" />
+      <arg column="INBOUND_CONNECTOR_TYPE" javaType="java.lang.String" name="inboundConnectorType" />
     </constructor>
-    <result column="PROCESS_DEFINITION_ID" property="processDefinitionId" javaType="java.lang.String" />
-    <result column="PROCESS_DEFINITION_KEY" property="processDefinitionKey" javaType="java.lang.Long" />
-    <result column="PROCESS_INSTANCE_KEY" property="processInstanceKey" javaType="java.lang.Long" />
-    <result column="ROOT_PROCESS_INSTANCE_KEY" property="rootProcessInstanceKey" javaType="java.lang.Long" />
-    <result column="FLOW_NODE_ID" property="flowNodeId" javaType="java.lang.String" />
-    <result column="FLOW_NODE_INSTANCE_KEY" property="flowNodeInstanceKey" javaType="java.lang.Long" />
-    <result column="MESSAGE_SUBSCRIPTION_STATE" property="messageSubscriptionState" javaType="io.camunda.search.entities.MessageSubscriptionEntity$MessageSubscriptionState" />
-    <result column="MESSAGE_SUBSCRIPTION_TYPE" property="messageSubscriptionType" javaType="io.camunda.search.entities.MessageSubscriptionEntity$MessageSubscriptionType" />
-    <result column="DATE_TIME" property="dateTime" javaType="java.time.OffsetDateTime" />
-    <result column="MESSAGE_NAME" property="messageName" javaType="java.lang.String" />
-    <result column="CORRELATION_KEY" property="correlationKey" javaType="java.lang.String" />
-    <result column="TENANT_ID" property="tenantId" javaType="java.lang.String" />
-    <result column="PARTITION_ID" property="partitionId" javaType="java.lang.Integer" />
-    <result column="PROCESS_DEFINITION_NAME" property="processDefinitionName" javaType="java.lang.String" />
-    <result column="PROCESS_DEFINITION_VERSION" property="processDefinitionVersion" javaType="java.lang.Integer" />
-    <result column="TOOL_PROPERTIES" property="serializedToolProperties" javaType="java.lang.String" />
-    <result column="TOOL_NAME" property="toolName" javaType="java.lang.String" />
-    <result column="INBOUND_CONNECTOR_TYPE" property="inboundConnectorType" javaType="java.lang.String" />
   </resultMap>
 
 

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -79,33 +79,28 @@
 
   <resultMap id="searchResultMap" type="io.camunda.db.rdbms.write.domain.UserTaskDbModel">
     <constructor>
-      <idArg column="USER_TASK_KEY" javaType="java.lang.Long"/>
+      <idArg column="USER_TASK_KEY" javaType="java.lang.Long" name="userTaskKey"/>
+      <arg column="ELEMENT_ID" javaType="java.lang.String" name="elementId"/>
+      <arg column="NAME" javaType="java.lang.String" name="name"/>
+      <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String" name="processDefinitionId"/>
+      <arg column="CREATION_DATE" javaType="java.time.OffsetDateTime" name="creationDate"/>
+      <arg column="COMPLETION_DATE" javaType="java.time.OffsetDateTime" name="completionDate"/>
+      <arg column="ASSIGNEE" javaType="java.lang.String" name="assignee"/>
+      <arg column="STATE" javaType="io.camunda.db.rdbms.write.domain.UserTaskDbModel$UserTaskState" name="state"/>
+      <arg column="FORM_KEY" javaType="java.lang.Long" name="formKey"/>
+      <arg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long" name="processDefinitionKey"/>
+      <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long" name="processInstanceKey"/>
+      <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long" name="rootProcessInstanceKey"/>
+      <arg column="BUSINESS_ID" javaType="java.lang.String" name="businessId"/>
+      <arg column="ELEMENT_INSTANCE_KEY" javaType="java.lang.Long" name="elementInstanceKey"/>
+      <arg column="TENANT_ID" javaType="java.lang.String" name="tenantId"/>
+      <arg column="DUE_DATE" javaType="java.time.OffsetDateTime" name="dueDate"/>
+      <arg column="FOLLOW_UP_DATE" javaType="java.time.OffsetDateTime" name="followUpDate"/>
+      <arg column="EXTERNAL_FORM_REFERENCE" javaType="java.lang.String" name="externalFormReference"/>
+      <arg column="PROCESS_DEFINITION_VERSION" javaType="java.lang.Integer" name="processDefinitionVersion"/>
+      <arg column="CUSTOM_HEADERS" javaType="java.lang.String" name="serializedCustomHeaders"/>
+      <arg column="PRIORITY" javaType="java.lang.Integer" name="priority"/>
     </constructor>
-    <result property="elementId" column="ELEMENT_ID" javaType="java.lang.String"/>
-    <result property="name" column="NAME" javaType="java.lang.String"/>
-    <result property="processDefinitionId" column="PROCESS_DEFINITION_ID"
-      javaType="java.lang.String"/>
-    <result property="creationDate" column="CREATION_DATE" javaType="java.time.OffsetDateTime"/>
-    <result property="completionDate" column="COMPLETION_DATE" javaType="java.time.OffsetDateTime"/>
-    <result property="assignee" column="ASSIGNEE" javaType="java.lang.String"/>
-    <result property="state" column="STATE"
-      javaType="io.camunda.db.rdbms.write.domain.UserTaskDbModel$UserTaskState"/>
-    <result property="formKey" column="FORM_KEY" javaType="java.lang.Long"/>
-    <result property="processDefinitionKey" column="PROCESS_DEFINITION_KEY"
-      javaType="java.lang.Long"/>
-    <result property="processInstanceKey" column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
-    <result property="rootProcessInstanceKey" column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
-    <result property="businessId" column="BUSINESS_ID" javaType="java.lang.String"/>
-    <result property="elementInstanceKey" column="ELEMENT_INSTANCE_KEY" javaType="java.lang.Long"/>
-    <result property="tenantId" column="TENANT_ID" javaType="java.lang.String"/>
-    <result property="dueDate" column="DUE_DATE" javaType="java.time.OffsetDateTime"/>
-    <result property="followUpDate" column="FOLLOW_UP_DATE" javaType="java.time.OffsetDateTime"/>
-    <result property="externalFormReference" column="EXTERNAL_FORM_REFERENCE"
-      javaType="java.lang.String"/>
-    <result property="processDefinitionVersion" column="PROCESS_DEFINITION_VERSION"
-      javaType="java.lang.Integer"/>
-    <result property="serializedCustomHeaders" column="CUSTOM_HEADERS" javaType="java.lang.String"/>
-    <result property="priority" column="PRIORITY" javaType="java.lang.Integer"/>
     <collection property="candidateGroups" ofType="java.lang.String" javaType="java.util.List">
       <id column="CANDIDATE_GROUP"/>
     </collection>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapperTest.java
@@ -27,29 +27,31 @@ class AgentHistoryEntityMapperTest {
   void shouldMapAllFields() {
     final var producedAt = OffsetDateTime.parse("2024-06-01T12:00:00Z");
 
-    final var dbModel = new AgentHistoryDbModel();
-    dbModel.agentHistoryKey(100L);
-    dbModel.agentInstanceKey(200L);
-    dbModel.elementInstanceKey(300L);
-    dbModel.processInstanceKey(400L);
-    dbModel.rootProcessInstanceKey(500L);
-    dbModel.processDefinitionKey(600L);
-    dbModel.processDefinitionId("myProcess");
-    dbModel.tenantId("<default>");
-    dbModel.partitionId(1);
-    dbModel.jobKey(700L);
-    dbModel.jobLease("lease-abc");
-    dbModel.loopIteration(3);
-    dbModel.role(AgentInstanceHistoryRole.ASSISTANT);
-    dbModel.commitStatus(AgentInstanceHistoryCommitStatus.COMMITTED);
-    dbModel.producedAt(producedAt);
-    dbModel.inputTokens(150L);
-    dbModel.outputTokens(75L);
-    dbModel.durationMs(300L);
-    dbModel.contentItems(
-        List.of(new ContentItem(ContentType.TEXT, "Hello from assistant", null, null)));
-    dbModel.toolCallValues(
-        List.of(new ToolCall("tc-1", "myTool", "Task_1", Map.of("key", "value"))));
+    final var dbModel =
+        new AgentHistoryDbModel.Builder()
+            .agentHistoryKey(100L)
+            .agentInstanceKey(200L)
+            .elementInstanceKey(300L)
+            .processInstanceKey(400L)
+            .rootProcessInstanceKey(500L)
+            .processDefinitionKey(600L)
+            .processDefinitionId("myProcess")
+            .tenantId("<default>")
+            .partitionId(1)
+            .jobKey(700L)
+            .jobLease("lease-abc")
+            .loopIteration(3)
+            .role(AgentInstanceHistoryRole.ASSISTANT)
+            .commitStatus(AgentInstanceHistoryCommitStatus.COMMITTED)
+            .producedAt(producedAt)
+            .inputTokens(150L)
+            .outputTokens(75L)
+            .durationMs(300L)
+            .contentItems(
+                List.of(new ContentItem(ContentType.TEXT, "Hello from assistant", null, null)))
+            .toolCallValues(
+                List.of(new ToolCall("tc-1", "myTool", "Task_1", Map.of("key", "value"))))
+            .build();
 
     final AgentInstanceHistoryEntity entity = AgentHistoryEntityMapper.toEntity(dbModel);
 
@@ -79,9 +81,7 @@ class AgentHistoryEntityMapperTest {
 
   @Test
   void shouldMapNullContentAndToolCallsToEmptyLists() {
-    final var dbModel = minimalDbModel(42L);
-    dbModel.contentItems(null);
-    dbModel.toolCallValues(null);
+    final var dbModel = minimalDbModel(42L).contentItems(null).toolCallValues(null).build();
 
     final AgentInstanceHistoryEntity entity = AgentHistoryEntityMapper.toEntity(dbModel);
 
@@ -97,10 +97,8 @@ class AgentHistoryEntityMapperTest {
   @Test
   void shouldMapAllNullMetricsToNullMetrics() {
     // given — all three null means metrics were never provided
-    final var dbModel = minimalDbModel(43L);
-    dbModel.inputTokens(null);
-    dbModel.outputTokens(null);
-    dbModel.durationMs(null);
+    final var dbModel =
+        minimalDbModel(43L).inputTokens(null).outputTokens(null).durationMs(null).build();
 
     // when
     final AgentInstanceHistoryEntity entity = AgentHistoryEntityMapper.toEntity(dbModel);
@@ -112,10 +110,8 @@ class AgentHistoryEntityMapperTest {
   @Test
   void shouldPreservePartialMetricsWhenOnlyDurationMsIsNull() {
     // given — inputTokens and outputTokens set, durationMs absent
-    final var dbModel = minimalDbModel(44L);
-    dbModel.inputTokens(100L);
-    dbModel.outputTokens(200L);
-    dbModel.durationMs(null);
+    final var dbModel =
+        minimalDbModel(44L).inputTokens(100L).outputTokens(200L).durationMs(null).build();
 
     // when
     final AgentInstanceHistoryEntity entity = AgentHistoryEntityMapper.toEntity(dbModel);
@@ -127,28 +123,27 @@ class AgentHistoryEntityMapperTest {
     assertThat(entity.metrics().durationMs()).isNull();
   }
 
-  private AgentHistoryDbModel minimalDbModel(final long key) {
-    final var model = new AgentHistoryDbModel();
-    model.agentHistoryKey(key);
-    model.agentInstanceKey(1L);
-    model.elementInstanceKey(2L);
-    model.processInstanceKey(3L);
-    model.rootProcessInstanceKey(4L);
-    model.processDefinitionKey(5L);
-    model.processDefinitionId("process");
-    model.tenantId("<default>");
-    model.partitionId(1);
-    model.jobKey(6L);
-    model.jobLease("lease");
-    model.loopIteration(1);
-    model.role(AgentInstanceHistoryRole.USER);
-    model.commitStatus(AgentInstanceHistoryCommitStatus.PENDING);
-    model.producedAt(OffsetDateTime.parse("2024-01-01T00:00:00Z"));
-    model.inputTokens(0L);
-    model.outputTokens(0L);
-    model.durationMs(0L);
-    model.contentItems(List.of());
-    model.toolCallValues(List.of());
-    return model;
+  private AgentHistoryDbModel.Builder minimalDbModel(final long key) {
+    return new AgentHistoryDbModel.Builder()
+        .agentHistoryKey(key)
+        .agentInstanceKey(1L)
+        .elementInstanceKey(2L)
+        .processInstanceKey(3L)
+        .rootProcessInstanceKey(4L)
+        .processDefinitionKey(5L)
+        .processDefinitionId("process")
+        .tenantId("<default>")
+        .partitionId(1)
+        .jobKey(6L)
+        .jobLease("lease")
+        .loopIteration(1)
+        .role(AgentInstanceHistoryRole.USER)
+        .commitStatus(AgentInstanceHistoryCommitStatus.PENDING)
+        .producedAt(OffsetDateTime.parse("2024-01-01T00:00:00Z"))
+        .inputTokens(0L)
+        .outputTokens(0L)
+        .durationMs(0L)
+        .contentItems(List.of())
+        .toolCallValues(List.of());
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapperTest.java
@@ -120,9 +120,9 @@ class AgentInstanceEntityMapperTest {
   }
 
   private AgentInstanceDbModel buildModel(
-      final java.util.function.Consumer<AgentInstanceDbModel> config) {
-    final var model = new AgentInstanceDbModel();
-    config.accept(model);
-    return model;
+      final java.util.function.Consumer<AgentInstanceDbModel.Builder> config) {
+    final var builder = new AgentInstanceDbModel.Builder();
+    config.accept(builder);
+    return builder.build();
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapperTest.java
@@ -44,7 +44,8 @@ public class MessageSubscriptionEntityMapperTest {
     final var entity = MessageSubscriptionEntityMapper.toEntity(model);
 
     // Then
-    assertThat(entity).usingRecursiveComparison().isEqualTo(model);
+    assertThat(entity).usingRecursiveComparison().ignoringFields("toolProperties").isEqualTo(model);
+    assertThat(entity.toolProperties()).isEqualTo(model.toolProperties());
   }
 
   @Test

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModelTest.java
@@ -37,8 +37,10 @@ class AgentHistoryDbModelTest {
   @Test
   void shouldDeserializeContentFromJson() {
     // given — simulate a model hydrated from the DB: only the JSON form is populated
-    final var model = new AgentHistoryDbModel();
-    model.content("[{\"contentType\":\"TEXT\",\"text\":\"hello\",\"documentReference\":null}]");
+    final var model =
+        new AgentHistoryDbModel.Builder(
+                "[{\"contentType\":\"TEXT\",\"text\":\"hello\",\"documentReference\":null}]", null)
+            .build();
 
     // when
     final List<ContentItem> deserialized = model.contentItems();
@@ -65,8 +67,11 @@ class AgentHistoryDbModelTest {
   @Test
   void shouldDeserializeToolCallsFromJson() {
     // given — simulate a model hydrated from the DB: only the JSON form is populated
-    final var model = new AgentHistoryDbModel();
-    model.toolCalls("[{\"toolCallId\":\"call-1\",\"toolName\":\"myTool\",\"elementId\":\"el-1\"}]");
+    final var model =
+        new AgentHistoryDbModel.Builder(
+                null,
+                "[{\"toolCallId\":\"call-1\",\"toolName\":\"myTool\",\"elementId\":\"el-1\"}]")
+            .build();
 
     // when
     final List<ToolCall> deserialized = model.toolCallValues();
@@ -121,17 +126,22 @@ class AgentHistoryDbModelTest {
   }
 
   @Test
-  void shouldInvalidateCacheOnMyBatisSetter() {
-    // given — model with both forms populated (cache primed)
-    final var item = new ContentItem(ContentType.TEXT, "original", null, null);
-    final var model = new AgentHistoryDbModel.Builder().contentItems(List.of(item)).build();
-    assertThat(model.contentItems().getFirst().text()).isEqualTo("original");
+  void shouldDeriveContentAndToolCallsFreshOnEveryCall() {
+    // given
+    final var item = new ContentItem(ContentType.TEXT, "hello", null, null);
+    final var toolCall = new ToolCall("call-1", "myTool", "el-1", null);
+    final var model =
+        new AgentHistoryDbModel.Builder()
+            .contentItems(List.of(item))
+            .toolCallValues(List.of(toolCall))
+            .build();
 
-    // when — the JSON form is replaced (simulates the model being re-hydrated from the DB)
-    model.content("[{\"contentType\":\"TEXT\",\"text\":\"replaced\",\"documentReference\":null}]");
-
-    // then — the cached list is invalidated and the next read re-derives from the new JSON
-    assertThat(model.contentItems()).hasSize(1);
-    assertThat(model.contentItems().getFirst().text()).isEqualTo("replaced");
+    // then — equal content, but freshly deserialized each time (no cache)
+    assertThat(model.contentItems())
+        .isEqualTo(model.contentItems())
+        .isNotSameAs(model.contentItems());
+    assertThat(model.toolCallValues())
+        .isEqualTo(model.toolCallValues())
+        .isNotSameAs(model.toolCallValues());
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/AgentInstanceDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/AgentInstanceDbModelTest.java
@@ -10,7 +10,13 @@ package io.camunda.db.rdbms.write.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.write.domain.AgentInstanceDbModel.AgentInstanceToolDbValue;
+import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.UpsertMerger;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
 import java.util.List;
+import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
 class AgentInstanceDbModelTest {
@@ -31,9 +37,10 @@ class AgentInstanceDbModelTest {
   @Test
   void shouldLazilyDeserializeToolsWhenOnlyJsonIsSet() {
     // given — simulate a model hydrated from the DB: only the JSON form is populated
-    final var model = new AgentInstanceDbModel();
-    model.tools(
-        "[{\"name\":\"search\",\"description\":\"search the web\",\"elementId\":\"el-1\"}]");
+    final var model =
+        new AgentInstanceDbModel.Builder(
+                "[{\"name\":\"search\",\"description\":\"search the web\",\"elementId\":\"el-1\"}]")
+            .build();
 
     // when
     final List<AgentInstanceToolDbValue> deserialized = model.toolValues();
@@ -44,47 +51,56 @@ class AgentInstanceDbModelTest {
   }
 
   @Test
-  void shouldCacheDeserializedToolsOnTheModel() {
+  void shouldDeriveToolValuesFreshOnEveryCall() {
     // given
-    final var model = new AgentInstanceDbModel();
-    model.tools("[{\"name\":\"search\",\"description\":null,\"elementId\":null}]");
+    final var model =
+        new AgentInstanceDbModel.Builder()
+            .toolValues(List.of(new AgentInstanceToolDbValue("search", null, null)))
+            .build();
 
     // when — call twice
     final var first = model.toolValues();
     final var second = model.toolValues();
 
-    // then — same instance is returned, so deserialization happened only once
-    assertThat(second).isSameAs(first);
+    // then — equal content, but freshly deserialized each time (no cache)
+    assertThat(first).isEqualTo(second).isNotSameAs(second);
   }
 
   @Test
   void shouldReturnNullWhenBothFormsAreAbsent() {
-    final var model = new AgentInstanceDbModel();
+    final var model = new AgentInstanceDbModel.Builder().build();
     assertThat(model.toolValues()).isNull();
   }
 
   @Test
   void shouldReturnNullWhenJsonIsEmpty() {
-    final var model = new AgentInstanceDbModel();
-    model.tools("");
+    // Oracle treats empty CLOB as NULL; MyBatis maps it back to "" on read.
+    final var model = new AgentInstanceDbModel.Builder("").build();
     assertThat(model.toolValues()).isNull();
   }
 
   @Test
-  void shouldInvalidateCachedToolValuesWhenJsonIsReplaced() {
-    // given — model with both forms populated (cache primed)
-    final var model =
-        new AgentInstanceDbModel.Builder()
-            .toolValues(List.of(new AgentInstanceToolDbValue("first", null, null)))
-            .build();
-    assertThat(model.toolValues())
-        .containsExactly(new AgentInstanceToolDbValue("first", null, null));
+  void shouldPreserveRawToolsJsonByteForByteThroughQueueMerge() {
+    // given — a DB-hydrated instance whose stored JSON is non-canonically formatted (spaced out,
+    // key order Jackson would never itself produce for this record)
+    final var nonCanonicalJson =
+        "[ { \"description\": \"search the web\", \"name\": \"search\", \"elementId\": \"el-1\" } ]";
+    final var original =
+        new AgentInstanceDbModel.Builder(nonCanonicalJson).agentInstanceKey(1L).build();
+    final var queueItem =
+        new QueueItem(
+            ContextType.AGENT_INSTANCE, WriteStatementType.INSERT, 1L, "statement", original);
+    final Function<AgentInstanceDbModel.Builder, AgentInstanceDbModel.Builder> mergeFunction =
+        b -> b.status(AgentInstanceStatus.IDLE);
+    final var merger =
+        new UpsertMerger<>(
+            ContextType.AGENT_INSTANCE, 1L, AgentInstanceDbModel.class, mergeFunction);
 
-    // when — the JSON form is replaced (simulates the model being re-hydrated from the DB)
-    model.tools("[{\"name\":\"second\",\"description\":null,\"elementId\":null}]");
+    // when — coalesce a change to an unrelated field, never touching toolValues()
+    final var merged = (AgentInstanceDbModel) merger.merge(queueItem).parameter();
 
-    // then — the cached list is invalidated and the next read re-derives from the new JSON
-    assertThat(model.toolValues())
-        .containsExactly(new AgentInstanceToolDbValue("second", null, null));
+    // then — the raw JSON is carried through completely unparsed, not reserialized
+    assertThat(merged.tools()).isEqualTo(nonCanonicalJson);
+    assertThat(merged.status()).isEqualTo(AgentInstanceStatus.IDLE);
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/JobDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/JobDbModelTest.java
@@ -11,7 +11,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.camunda.db.rdbms.write.domain.JobDbModel.Builder;
+import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.UpsertMerger;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.time.OffsetDateTime;
+import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
 class JobDbModelTest {
@@ -77,5 +82,24 @@ class JobDbModelTest {
             .build();
 
     assertThatCode(() -> jobDbModel.truncateErrorMessage(10, 5)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldPreserveRawCustomHeadersJsonByteForByteThroughQueueMerge() {
+    // given — a DB-hydrated instance whose stored JSON is non-canonically formatted (spaced out,
+    // key order Jackson would never itself produce for this record)
+    final var nonCanonicalJson = "{ \"b\": \"2\", \"a\": \"1\" }";
+    final var original = new Builder(nonCanonicalJson).jobKey(1L).build();
+    final var queueItem =
+        new QueueItem(ContextType.JOB, WriteStatementType.INSERT, 1L, "statement", original);
+    final Function<Builder, Builder> mergeFunction = b -> b.worker("new-worker");
+    final var merger = new UpsertMerger<>(ContextType.JOB, 1L, JobDbModel.class, mergeFunction);
+
+    // when — coalesce a change to an unrelated field, never touching customHeaders()
+    final var merged = (JobDbModel) merger.merge(queueItem).parameter();
+
+    // then — the raw JSON is carried through completely unparsed, not reserialized
+    assertThat(merged.serializedCustomHeaders()).isEqualTo(nonCanonicalJson);
+    assertThat(merged.worker()).isEqualTo("new-worker");
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/AgentHistoryWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/AgentHistoryWriterTest.java
@@ -24,6 +24,7 @@ import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistor
 import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryRole;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class AgentHistoryWriterTest {
 
@@ -89,9 +90,13 @@ class AgentHistoryWriterTest {
     // when
     writer.create(model);
 
-    // then — jobLease is truncated in-place to the column size limit
-    assertThat(model.jobLease()).hasSize(10);
-    assertThat(longLease).startsWith(model.jobLease());
+    // then — the queued model (a new instance) carries the truncated value; the original is
+    // untouched since AgentHistoryDbModel is immutable
+    final var captor = ArgumentCaptor.forClass(QueueItem.class);
+    verify(executionQueue).executeInQueue(captor.capture());
+    final var queuedModel = (AgentHistoryDbModel) captor.getValue().parameter();
+    assertThat(queuedModel.jobLease()).hasSize(10);
+    assertThat(longLease).startsWith(queuedModel.jobLease());
   }
 
   private AgentHistoryDbModel buildModel(final long key, final String jobLease) {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriterTest.java
@@ -21,6 +21,7 @@ import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class MessageSubscriptionWriterTest {
 
@@ -103,9 +104,13 @@ class MessageSubscriptionWriterTest {
     // when
     writer.create(model);
 
-    // then
-    assertThat(model.toolName()).hasSize(5);
-    assertThat(model.inboundConnectorType()).hasSize(5);
+    // then — the queued model (a new instance) carries the truncated values; the original is
+    // untouched since MessageSubscriptionDbModel is immutable
+    final var captor = ArgumentCaptor.forClass(QueueItem.class);
+    verify(executionQueue).executeInQueue(captor.capture());
+    final var queuedModel = (MessageSubscriptionDbModel) captor.getValue().parameter();
+    assertThat(queuedModel.toolName()).hasSize(5);
+    assertThat(queuedModel.inboundConnectorType()).hasSize(5);
   }
 
   @Test
@@ -122,8 +127,12 @@ class MessageSubscriptionWriterTest {
     // when
     writer.update(model);
 
-    // then
-    assertThat(model.toolName()).hasSize(5);
-    assertThat(model.inboundConnectorType()).hasSize(5);
+    // then — the queued model (a new instance) carries the truncated values; the original is
+    // untouched since MessageSubscriptionDbModel is immutable
+    final var captor = ArgumentCaptor.forClass(QueueItem.class);
+    verify(executionQueue).executeInQueue(captor.capture());
+    final var queuedModel = (MessageSubscriptionDbModel) captor.getValue().parameter();
+    assertThat(queuedModel.toolName()).hasSize(5);
+    assertThat(queuedModel.inboundConnectorType()).hasSize(5);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceIT.java
@@ -9,11 +9,13 @@ package io.camunda.it.rdbms.db.agentinstance;
 
 import static io.camunda.it.rdbms.db.fixtures.AgentInstanceFixtures.createAndSaveRandomAgentInstance;
 import static io.camunda.it.rdbms.db.fixtures.AgentInstanceFixtures.createAndSaveRandomAgentInstances;
+import static io.camunda.it.rdbms.db.fixtures.AgentInstanceFixtures.createRandomAgentInstance;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.AgentInstanceDbModel;
+import io.camunda.db.rdbms.write.domain.AgentInstanceDbModel.AgentInstanceToolDbValue;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.AgentInstanceEntity;
@@ -23,6 +25,7 @@ import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.sort.AgentInstanceSort;
 import io.camunda.security.core.authz.ResourceAccessChecks;
+import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -76,6 +79,58 @@ public class AgentInstanceIT {
     assertThat(entity.processDefinitionVersion()).isEqualTo(migrated.processDefinitionVersion());
     assertThat(entity.versionTag()).isEqualTo("v2");
     assertThat(entity.elementId()).isEqualTo("migrated-element");
+  }
+
+  @TestTemplate
+  public void shouldCoalescePendingCreateAndUpdateBeforeFlush(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given — a create() queued but not yet flushed
+    final RdbmsWriters rdbmsWriters = testApplication.getRdbmsService().createWriter(0);
+    final var initialTools =
+        List.of(new AgentInstanceToolDbValue("search", "search the web", "el-1"));
+    final var created =
+        createRandomAgentInstance(
+            b ->
+                b.status(AgentInstanceStatus.IDLE)
+                    .toolValues(initialTools)
+                    // Empty on purpose: a non-empty list makes create() queue a second QueueItem
+                    // (insertElementInstanceKeys) whose parameter is also an AgentInstanceDbModel,
+                    // which UpsertMerger.canBeMerged() can't tell apart from the row-INSERT item
+                    // by id+contextType+type alone -- a separate, pre-existing bug (tracked
+                    // separately, out of scope here) that would make the update() below merge
+                    // into the wrong queued item.
+                    .elementInstanceKeys(List.of()));
+    rdbmsWriters.getAgentInstanceWriter().create(created);
+
+    // when — a second write to the same row is queued before the first is flushed, so it must
+    // coalesce into the still-pending INSERT via UpsertMerger/Copyable.copy() instead of issuing
+    // a separate UPDATE
+    final var updatedTools =
+        List.of(new AgentInstanceToolDbValue("calculator", "does math", "el-2"));
+    final var updated =
+        created.copy(
+            b ->
+                ((AgentInstanceDbModel.Builder) b)
+                    .status(AgentInstanceStatus.THINKING)
+                    .toolValues(updatedTools));
+    rdbmsWriters.getAgentInstanceWriter().update(updated);
+    rdbmsWriters.flush();
+
+    // then — only the merged, final state was ever persisted; fields the update never touched
+    // (model/provider/systemPrompt/tenantId) survive from the original create() untouched
+    final var entity =
+        testApplication
+            .getRdbmsService()
+            .getAgentInstanceDbReader()
+            .getByKey(created.agentInstanceKey(), ResourceAccessChecks.disabled());
+
+    assertThat(entity).isNotNull();
+    assertThat(entity.status()).isEqualTo(AgentInstanceStatus.THINKING);
+    assertThat(entity.tools()).hasSize(1);
+    assertThat(entity.tools().getFirst().name()).isEqualTo("calculator");
+    assertThat(entity.definition().model()).isEqualTo(created.model());
+    assertThat(entity.definition().provider()).isEqualTo(created.provider());
+    assertThat(entity.tenantId()).isEqualTo(created.tenantId());
   }
 
   @TestTemplate

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobIT.java
@@ -13,6 +13,7 @@ import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.resourceAccessCheck
 import static io.camunda.it.rdbms.db.fixtures.JobFixtures.createAndSaveJob;
 import static io.camunda.it.rdbms.db.fixtures.JobFixtures.createAndSaveRandomJobs;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.JobDbReader;
@@ -31,6 +32,7 @@ import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Map;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
@@ -98,6 +100,37 @@ public class JobIT {
 
     assertThat(instance).isNotNull();
     assertThat(instance.errorMessage().length()).isLessThan(errorMessage.length());
+  }
+
+  @TestTemplate
+  public void shouldCoalescePendingCreateAndUpdateBeforeFlush(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final JobDbReader jobReader = rdbmsService.getJobReader();
+
+    // given — a create() queued but not yet flushed
+    final var created =
+        JobFixtures.createRandomized(b -> b.customHeaders(Map.of("k1", "v1")).worker("worker-1"));
+    rdbmsWriters.getJobWriter().create(created);
+
+    // when — a second write to the same row is queued before the first is flushed, so it must
+    // coalesce into the still-pending INSERT via UpsertMerger/Copyable.copy() instead of issuing
+    // a separate UPDATE
+    final var updated =
+        created.copy(
+            b -> ((JobDbModel.Builder) b).customHeaders(Map.of("k2", "v2")).worker("worker-2"));
+    rdbmsWriters.getJobWriter().update(updated);
+    rdbmsWriters.flush();
+
+    // then — only the merged, final state was ever persisted; businessId is deliberately never
+    // touched by update() and must survive from the original create() untouched
+    final var instance = jobReader.findOne(created.jobKey()).orElse(null);
+
+    assertThat(instance).isNotNull();
+    assertThat(instance.worker()).isEqualTo("worker-2");
+    assertThat(instance.customHeaders()).containsExactly(entry("k2", "v2"));
+    assertThat(instance.businessId()).isEqualTo(created.businessId());
   }
 
   @TestTemplate

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionIT.java
@@ -341,6 +341,10 @@ public class MessageSubscriptionIT {
   private static void compareMessageSubscriptions(
       final MessageSubscriptionEntity instance, final MessageSubscriptionDbModel role) {
     assertThat(instance).isNotNull();
-    assertThat(instance).usingRecursiveComparison().isEqualTo(role);
+    assertThat(instance)
+        .usingRecursiveComparison()
+        .ignoringFields("toolProperties")
+        .isEqualTo(role);
+    assertThat(instance.toolProperties()).isEqualTo(role.toolProperties());
   }
 }


### PR DESCRIPTION
## Summary

Second and final PR converting the remaining plain-class `*DbModel`s in `db/rdbms/write/domain` to
records (follow-up to #58458). These 5 classes each carried a raw JSON string plus a derived
Map/List field kept in sync by mutating setters, with two of them (`AgentInstanceDbModel`,
`AgentHistoryDbModel`) caching the deserialized result. The redesign keeps only the raw JSON string
as a record component; the Map/List accessor derives fresh on every call instead of caching.

- `JobDbModel`, `UserTaskDbModel`, `MessageSubscriptionDbModel` — eager dual-field, simple drop.
- `AgentInstanceDbModel`, `AgentHistoryDbModel` — lazy cache, plus in-place `truncate*` mutators
  converted to return-a-new-instance (all writer call sites updated accordingly).

`toBuilder()`/`copy()` carry the raw JSON string through unparsed via a package-private seed
constructor on each `Builder`, so a queue-merge that never touches the JSON field never
round-trips it through Jackson.

Once this merges, an ArchUnit rule enforcing all DbModels stay records follows in a third PR.

## Notes

- Found and filed a separate, pre-existing bug while adding coalescing-write test coverage:
  #58968 — `UpsertMerger` can merge into the wrong queued item when a writer queues two
  same-typed items (affects `AgentInstanceWriter`). Not caused by this change; deliberately not
  fixed here.