### PR TITLE
fix: prevent silent loss of AgentInstance updates queued after create

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AgentInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AgentInstanceMapper.java
@@ -19,7 +19,7 @@ public interface AgentInstanceMapper extends ProcessInstanceDependantMapper {
 
   void deleteElementInstanceKeys(long agentInstanceKey);
 
-  void insertElementInstanceKeys(AgentInstanceDbModel agentInstance);
+  void insertElementInstanceKeys(AgentInstanceElementInstanceKeysDto elementInstanceKeys);
 
   Long count(AgentInstanceDbQuery query);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AgentInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AgentInstanceMapper.java
@@ -24,4 +24,7 @@ public interface AgentInstanceMapper extends ProcessInstanceDependantMapper {
   Long count(AgentInstanceDbQuery query);
 
   List<AgentInstanceDbModel> search(AgentInstanceDbQuery query);
+
+  record AgentInstanceElementInstanceKeysDto(
+      long agentInstanceKey, List<Long> elementInstanceKeys) {}
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/UpsertMerger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/UpsertMerger.java
@@ -30,14 +30,9 @@ public class UpsertMerger<T extends Copyable<T>> implements QueueItemMerger {
   }
 
   /**
-   * Matches on {@code id + contextType + (parameter instanceof clazz)} only, deliberately ignoring
-   * {@code statementId} so an update can merge into an earlier create's row-level insert as well as
-   * a prior update. This means a writer must never enqueue two {@link QueueItem}s sharing the same
-   * {@code contextType} and {@code id} whose parameters are both instances of {@code clazz} unless
-   * every such item is meant to be a valid merge target for that key — otherwise the merge can land
-   * on the wrong one silently. Auxiliary/child-table statements queued alongside a row-level
-   * insert/update must use a dedicated parameter type (see {@code ProcessInstanceTagsDto}) so they
-   * are not accidentally merge-eligible (see issue #58968).
+   * Ignores {@code statementId} by design, so two {@link QueueItem}s sharing {@code contextType} +
+   * {@code id} must not both be instances of {@code clazz} unless either is a valid merge target
+   * (see issue #58968).
    */
   @Override
   public boolean canBeMerged(final QueueItem queueItem) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/UpsertMerger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/UpsertMerger.java
@@ -29,6 +29,16 @@ public class UpsertMerger<T extends Copyable<T>> implements QueueItemMerger {
     this.mergeFunction = (Function<ObjectBuilder<T>, ObjectBuilder<T>>) mergeFunction;
   }
 
+  /**
+   * Matches on {@code id + contextType + (parameter instanceof clazz)} only, deliberately ignoring
+   * {@code statementId} so an update can merge into an earlier create's row-level insert as well as
+   * a prior update. This means a writer must never enqueue two {@link QueueItem}s sharing the same
+   * {@code contextType} and {@code id} whose parameters are both instances of {@code clazz} unless
+   * every such item is meant to be a valid merge target for that key — otherwise the merge can land
+   * on the wrong one silently. Auxiliary/child-table statements queued alongside a row-level
+   * insert/update must use a dedicated parameter type (see {@code ProcessInstanceTagsDto}) so they
+   * are not accidentally merge-eligible (see issue #58968).
+   */
   @Override
   public boolean canBeMerged(final QueueItem queueItem) {
     return queueItem.id().equals(id)

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentInstanceWriter.java
@@ -9,6 +9,7 @@ package io.camunda.db.rdbms.write.service;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.AgentInstanceMapper;
+import io.camunda.db.rdbms.sql.AgentInstanceMapper.AgentInstanceElementInstanceKeysDto;
 import io.camunda.db.rdbms.write.domain.AgentInstanceDbModel;
 import io.camunda.db.rdbms.write.domain.AgentInstanceDbModel.Builder;
 import io.camunda.db.rdbms.write.queue.ContextType;
@@ -97,7 +98,8 @@ public class AgentInstanceWriter extends ProcessInstanceDependant implements Rdb
               WriteStatementType.INSERT,
               agentInstance.agentInstanceKey(),
               "io.camunda.db.rdbms.sql.AgentInstanceMapper.insertElementInstanceKeys",
-              agentInstance));
+              new AgentInstanceElementInstanceKeysDto(
+                  agentInstance.agentInstanceKey(), agentInstance.elementInstanceKeys())));
     }
   }
 

--- a/db/rdbms/src/main/resources/mapper/AgentInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AgentInstanceMapper.xml
@@ -104,7 +104,7 @@
 
   <!-- bulk-insert element instance keys — default: PostgreSQL, H2, MariaDB, MySQL, MSSQL -->
   <insert id="insertElementInstanceKeys"
-    parameterType="io.camunda.db.rdbms.write.domain.AgentInstanceDbModel">
+    parameterType="io.camunda.db.rdbms.sql.AgentInstanceMapper$AgentInstanceElementInstanceKeysDto">
     INSERT INTO ${prefix}AGENT_INSTANCE_ELEMENT_INSTANCE (AGENT_INSTANCE_KEY, ELEMENT_INSTANCE_KEY)
     VALUES
     <foreach collection="elementInstanceKeys" item="elementInstanceKey" separator=", ">
@@ -114,7 +114,7 @@
 
   <!-- Oracle requires INSERT ALL syntax for multi-row inserts -->
   <insert id="insertElementInstanceKeys"
-    parameterType="io.camunda.db.rdbms.write.domain.AgentInstanceDbModel"
+    parameterType="io.camunda.db.rdbms.sql.AgentInstanceMapper$AgentInstanceElementInstanceKeysDto"
     databaseId="oracle">
     INSERT ALL
     <foreach collection="elementInstanceKeys" item="elementInstanceKey">

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/AgentInstanceWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/AgentInstanceWriterTest.java
@@ -7,25 +7,38 @@
  */
 package io.camunda.db.rdbms.write.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.AgentInstanceMapper;
+import io.camunda.db.rdbms.sql.AgentInstanceMapper.AgentInstanceElementInstanceKeysDto;
+import io.camunda.db.rdbms.write.RdbmsWriterMetrics;
 import io.camunda.db.rdbms.write.domain.AgentInstanceDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.DefaultExecutionQueue;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
+import java.sql.Connection;
 import java.time.OffsetDateTime;
 import java.util.List;
+import org.apache.ibatis.session.ExecutorType;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.TransactionIsolationLevel;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class AgentInstanceWriterTest {
 
@@ -67,7 +80,7 @@ class AgentInstanceWriterTest {
                     WriteStatementType.INSERT,
                     1L,
                     "io.camunda.db.rdbms.sql.AgentInstanceMapper.insertElementInstanceKeys",
-                    model)));
+                    new AgentInstanceElementInstanceKeysDto(1L, List.of(100L)))));
     verify(executionQueue, never())
         .executeInQueue(
             argThat(
@@ -145,7 +158,96 @@ class AgentInstanceWriterTest {
                     WriteStatementType.INSERT,
                     3L,
                     "io.camunda.db.rdbms.sql.AgentInstanceMapper.insertElementInstanceKeys",
-                    model)));
+                    new AgentInstanceElementInstanceKeysDto(3L, List.of(200L)))));
+  }
+
+  @Test
+  void shouldApplyUpdateToRowInsertNotToChildKeysInsertWhenMergedBeforeFlush() throws Exception {
+    // given: a real ExecutionQueue so the actual merge logic (UpsertMerger + newest-first scan)
+    // runs, reproducing https://github.com/camunda/camunda/issues/58968 - create() queues both a
+    // row INSERT and an insertElementInstanceKeys INSERT for the same agentInstanceKey; update()
+    // must merge into the former, not the latter. The update's elementInstanceKeys is a superset of
+    // create()'s, mirroring the real AgentInstanceExportHandler/engine contract that every update
+    // carries the full cumulative set of element instance keys (never a delta, never empty right
+    // after a non-empty create) - so update()'s unconditional DELETE-then-reinsert of child rows is
+    // exercised and asserted here rather than left unchecked.
+    final var session = mock(SqlSession.class);
+    final var sqlSessionFactory = mock(SqlSessionFactory.class);
+    final var metrics = mock(RdbmsWriterMetrics.class);
+    when(sqlSessionFactory.openSession(
+            ExecutorType.BATCH, TransactionIsolationLevel.READ_COMMITTED))
+        .thenReturn(session);
+    final var connection = mock(Connection.class);
+    when(connection.getAutoCommit()).thenReturn(false);
+    when(session.getConnection()).thenReturn(connection);
+
+    final var realExecutionQueue = new DefaultExecutionQueue(sqlSessionFactory, 1, 0, 0, metrics);
+    final var realWriter =
+        new AgentInstanceWriter(realExecutionQueue, mapper, vendorDatabaseProperties);
+
+    final var created = buildModel(4L, List.of(300L));
+    final var updated =
+        new AgentInstanceDbModel.Builder()
+            .agentInstanceKey(4L)
+            .status(AgentInstanceStatus.COMPLETED)
+            .inputTokens(42L)
+            .outputTokens(7L)
+            .modelCalls(3)
+            .toolCalls(2)
+            .lastUpdatedDate(OffsetDateTime.now())
+            .completionDate(OffsetDateTime.now())
+            .elementInstanceKeys(List.of(300L, 301L))
+            .build();
+
+    // when
+    realWriter.create(created);
+    realWriter.update(updated);
+    realExecutionQueue.flush();
+
+    // then: the row INSERT carries the merged (COMPLETED) status ...
+    final var rowInsertParam = ArgumentCaptor.forClass(Object.class);
+    verify(session)
+        .update(eq("io.camunda.db.rdbms.sql.AgentInstanceMapper.insert"), rowInsertParam.capture());
+    assertThat(rowInsertParam.getValue()).isInstanceOf(AgentInstanceDbModel.class);
+    assertThat(((AgentInstanceDbModel) rowInsertParam.getValue()).status())
+        .isEqualTo(AgentInstanceStatus.COMPLETED);
+
+    // ... no separate UPDATE statement was needed, since the merge absorbed it into the INSERT ...
+    verify(session, never())
+        .update(eq("io.camunda.db.rdbms.sql.AgentInstanceMapper.update"), any());
+
+    // ... create()'s child-table insert is unaffected by the merge, still carrying its original
+    // keys, and update()'s DELETE-then-reinsert of the (now larger) key set runs after it, in
+    // insertion order, without touching the row insert or create()'s child insert.
+    final var childInsertParam = ArgumentCaptor.forClass(Object.class);
+    verify(session, times(2))
+        .update(
+            eq("io.camunda.db.rdbms.sql.AgentInstanceMapper.insertElementInstanceKeys"),
+            childInsertParam.capture());
+    assertThat(childInsertParam.getAllValues())
+        .containsExactly(
+            new AgentInstanceElementInstanceKeysDto(4L, List.of(300L)),
+            new AgentInstanceElementInstanceKeysDto(4L, List.of(300L, 301L)));
+    verify(session)
+        .update(
+            eq("io.camunda.db.rdbms.sql.AgentInstanceMapper.deleteElementInstanceKeys"), eq(4L));
+
+    final var order = inOrder(session);
+    order.verify(session).update(eq("io.camunda.db.rdbms.sql.AgentInstanceMapper.insert"), any());
+    order
+        .verify(session)
+        .update(
+            eq("io.camunda.db.rdbms.sql.AgentInstanceMapper.insertElementInstanceKeys"),
+            eq(new AgentInstanceElementInstanceKeysDto(4L, List.of(300L))));
+    order
+        .verify(session)
+        .update(
+            eq("io.camunda.db.rdbms.sql.AgentInstanceMapper.deleteElementInstanceKeys"), eq(4L));
+    order
+        .verify(session)
+        .update(
+            eq("io.camunda.db.rdbms.sql.AgentInstanceMapper.insertElementInstanceKeys"),
+            eq(new AgentInstanceElementInstanceKeysDto(4L, List.of(300L, 301L))));
   }
 
   private AgentInstanceDbModel buildModel(final long key, final List<Long> elementInstanceKeys) {


### PR DESCRIPTION
## Summary

`AgentInstanceWriter.create()` queues two `QueueItem`s for the same `agentInstanceKey` when `elementInstanceKeys` is non-empty: a row `INSERT` and an `insertElementInstanceKeys` `INSERT`, both carrying the same `AgentInstanceDbModel` instance as their write-queue parameter.

`UpsertMerger.canBeMerged()` matches purely on `id + contextType + (parameter instanceof clazz)`, with no `statementId` check. `ExecutionQueue.tryMergeWithExistingQueueItem` scans the queue newest-first and merges into the first match. A `create()` immediately followed by `update()` before a flush could therefore merge the update into the `insertElementInstanceKeys` statement instead of the row insert - a statement that never writes `STATUS`, tokens, or tool values - silently discarding the update with no error and no row-count mismatch, since the row insert still executed with its stale `create()`-time values.

- Give `insertElementInstanceKeys` its own small parameter record (`AgentInstanceElementInstanceKeysDto`) instead of reusing the full `AgentInstanceDbModel`, so the type check in `canBeMerged()` naturally excludes it from matching. Mirrors an already-shipped pattern in the same module (`ProcessInstanceMapper.insertTags` / `ProcessInstanceTagsDto`).
- Scoped the fix to this one writer rather than generalizing `UpsertMerger` with statement-id awareness, since several writers intentionally rely on cross-statementType merging (an update merging into a prior create's row insert) that a stricter check would break.
- Added a Javadoc on `UpsertMerger.canBeMerged` documenting the matching invariant this bug violated.
- Strengthened the regression test to assert the full statement sequence (row insert merge, create's child insert, update's delete, update's re-insert) in order, using a realistic superset `elementInstanceKeys` on update to match the real exporter's cumulative-key contract.

Closes #58968