### PR TITLE
ci: fix and scope optimize base-image digest check

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -357,7 +357,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   validate-base-image:
-    if: inputs.runDockerfileChecks
+    if: inputs.runDockerfileChecks && github.event_name != 'push' && github.event_name != 'schedule'
     name: "Tool / Dockerfile / Validate Base Image"
     runs-on: ubuntu-latest
     permissions: { }  # GITHUB_TOKEN unused in this job
@@ -387,11 +387,17 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
       # Same class of check as camunda.Dockerfile gets in the docker-checks job
-      # (.github/workflows/ci.yml) via a full build; here it's a metadata-only resolve since
-      # this job never builds the image. Minimus "-dev" tags are floating and old digests get
-      # GC'd fast, so a digest pinned by Renovate can go stale before it's ever built - which for
-      # optimize.Dockerfile only happens post-merge (deploy-optimize-docker-snapshot runs only on
-      # push to main/stable, never on pull_request). Catch that here instead of on main.
+      # (.github/workflows/ci.yml), but here it's a metadata-only resolve since this job never
+      # builds the image. The pinned digest is content-addressable, so we must resolve it by digest
+      # exactly as BuildKit does for `FROM ${BASE_IMAGE}@${BASE_DIGEST}`. `docker buildx imagetools
+      # inspect` mirrors that resolution path; plain `docker manifest inspect` on the tag@digest
+      # form instead false-fails as soon as the rolling Minimus 25-dev tag advances off the pinned
+      # digest, even though that digest is still perfectly pullable. This job runs only on
+      # pull_request/merge_group, where it gates a Renovate digest bump before it lands. On push
+      # to main/stable the digest is already resolved as a side effect of the real image build in
+      # deploy-optimize-docker-snapshot (.github/workflows/ci.yml) - mirroring how docker-checks
+      # covers camunda.Dockerfile - so running this standalone resolve on push/schedule would be
+      # redundant, hence it is scoped out of push/schedule events.
       - name: Validate base image digest is resolvable
         if: steps.is-fork.outputs.is-fork != 'true'
         run: |
@@ -399,7 +405,7 @@ jobs:
           base_image=$(grep -m1 '^ARG BASE_IMAGE=' ${{ matrix.dockerfile }} | cut -d'"' -f2)
           base_digest=$(grep -m1 '^ARG BASE_DIGEST=' ${{ matrix.dockerfile }} | cut -d'"' -f2)
           echo "Resolving ${base_image}@${base_digest}"
-          docker manifest inspect "${base_image}@${base_digest}" > /dev/null
+          docker buildx imagetools inspect "${base_image}@${base_digest}" > /dev/null
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
Introduced in 6e69a0174702a6f8bae6cf37431490b07c6fa802.

## Problem

`validate-base-image` in `.github/workflows/ci-optimize.yml` reddened `main` on unrelated commits, for two reasons:

**1. Wrong inspect command (root cause).** `optimize.Dockerfile` pins the base as a `tag@digest` reference (`reg.mini.dev/1212/openjre-base:25-dev@sha256:…`, used in `FROM ${BASE_IMAGE}@${BASE_DIGEST}`). The check ran `docker manifest inspect` on that form. Minimus continuously repatches the hardened base under the **rolling `25-dev` tag**, so the tag advances off the pinned digest — and `docker manifest inspect tag@digest` false-fails once the tag no longer matches, **even though the digest is still pullable**.

**2. Ran on every push (redundant).** Gated only on `runDockerfileChecks` (hard-coded `true` on push/schedule), so it ran on every push to `main`, where the digest is already resolved by the real image build in `deploy-optimize-docker-snapshot` (`ci.yml`) — like `docker-checks` covers `camunda.Dockerfile`.

## Change

- **`docker manifest inspect` → `docker buildx imagetools inspect`** (same `${BASE_IMAGE}@${BASE_DIGEST}` reference). imagetools resolves by digest like BuildKit does for the `FROM`, so it's immune to `25-dev` tag advancement and asserts exactly what the check should: the pinned digest is pullable.
- **Scope to `pull_request` / `merge_group`** via `github.event_name != 'push' && github.event_name != 'schedule'`, where it still gates a Renovate digest bump before it lands. (Reusable workflow — `github.event_name` reflects the caller `ci.yml`'s event.)
- **`hadolint` untouched** — deterministic lint keeps running on push.

Aligns `optimize.Dockerfile` with `camunda.Dockerfile`: post-merge resolution comes from the real build; the pre-merge check faithfully verifies the pinned digest is pullable. Workflow-only change.