### PR TITLE
ci: match api_es nightly report artifact with mode suffix in triage

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -227,7 +227,7 @@ jobs:
                 rm -rf "$tmp_dir"
                 continue
               fi
-              mapfile -t results_files < <(find "$tmp_dir" -name 'results.json' -type f)
+mapfile -t results_files < <(find "$tmp_dir" -name 'results.json' -type f | LC_ALL=C sort)
               if [ "${#results_files[@]}" -eq 0 ]; then
                 rm -rf "$tmp_dir"
                 continue

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -227,7 +227,7 @@ jobs:
                 rm -rf "$tmp_dir"
                 continue
               fi
-mapfile -t results_files < <(find "$tmp_dir" -name 'results.json' -type f | LC_ALL=C sort)
+              mapfile -t results_files < <(find "$tmp_dir" -name 'results.json' -type f | LC_ALL=C sort)
               if [ "${#results_files[@]}" -eq 0 ]; then
                 rm -rf "$tmp_dir"
                 continue

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -201,7 +201,10 @@ jobs:
                 patterns+=("json-report-nightly-e2e-${safe_version}-${mode}|${mode}")
               done
             elif [ "$test_type" = "api_es" ]; then
-              patterns+=("json-report-nightly-api-${safe_version}|elasticsearch")
+              # Trailing glob tolerates the mode suffix (e.g. "-profiles") the
+              # API-tests job now appends to the artifact name. Does not collide
+              # with rdbms artifacts (json-report-nightly-api-rdbms-...).
+              patterns+=("json-report-nightly-api-${safe_version}*|elasticsearch")
             elif [ "$test_type" = "api_rdbms" ]; then
               # List the per-database artifact names from the run
               gh api "repos/${REPO}/actions/runs/${run_id}/artifacts" --paginate \

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -227,38 +227,43 @@ jobs:
                 rm -rf "$tmp_dir"
                 continue
               fi
-              results=$(find "$tmp_dir" -name 'results.json' -type f | head -1)
-              if [ -z "$results" ]; then
+              mapfile -t results_files < <(find "$tmp_dir" -name 'results.json' -type f)
+              if [ "${#results_files[@]}" -eq 0 ]; then
                 rm -rf "$tmp_dir"
                 continue
               fi
-              # Extract failing specs. tasklist_mode is non-null only for e2e; database for api.
-              if [ "$test_type" = "e2e" ]; then
-                jq -c --arg v "$version" --arg mode "$dim" '
-                  [.. | objects | select(.specs?) | .specs[]]
-                  | map(select(.ok == false))
-                  | .[] | {
-                      version: $v,
-                      file: .file,
-                      test_name: .title,
-                      error: (.tests[0].results[-1].error.message // "unknown error"),
-                      test_type: "e2e",
-                      tasklist_mode: $mode
-                    }' "$results" >> "$all_failures" || true
-              else
-                # API tests (ES or RDBMS): set database from dim
-                jq -c --arg v "$version" --arg db "$dim" '
-                  [.. | objects | select(.specs?) | .specs[]]
-                  | map(select(.ok == false))
-                  | .[] | {
-                      version: $v,
-                      file: .file,
-                      test_name: .title,
-                      error: (.tests[0].results[-1].error.message // "unknown error"),
-                      test_type: "api",
-                      database: $db
-                    }' "$results" >> "$all_failures" || true
-              fi
+              # A glob pattern (api_es) can match multiple report artifacts for one
+              # run (e.g. -profiles and -all-in-one), so parse every results.json.
+              # e2e / api_rdbms download one exact artifact, so the loop runs once.
+              for results in "${results_files[@]}"; do
+                # Extract failing specs. tasklist_mode is non-null only for e2e; database for api.
+                if [ "$test_type" = "e2e" ]; then
+                  jq -c --arg v "$version" --arg mode "$dim" '
+                    [.. | objects | select(.specs?) | .specs[]]
+                    | map(select(.ok == false))
+                    | .[] | {
+                        version: $v,
+                        file: .file,
+                        test_name: .title,
+                        error: (.tests[0].results[-1].error.message // "unknown error"),
+                        test_type: "e2e",
+                        tasklist_mode: $mode
+                      }' "$results" >> "$all_failures" || true
+                else
+                  # API tests (ES or RDBMS): set database from dim
+                  jq -c --arg v "$version" --arg db "$dim" '
+                    [.. | objects | select(.specs?) | .specs[]]
+                    | map(select(.ok == false))
+                    | .[] | {
+                        version: $v,
+                        file: .file,
+                        test_name: .title,
+                        error: (.tests[0].results[-1].error.message // "unknown error"),
+                        test_type: "api",
+                        database: $db
+                      }' "$results" >> "$all_failures" || true
+                fi
+              done
               rm -rf "$tmp_dir"
             done
           done
@@ -322,6 +327,11 @@ jobs:
               | select(.file != null and .file != "")
               | select(.file | test("\\.spec\\.[jt]s$"))
             )
+            # Collapse true duplicates: one api_es run can now emit the same failing
+            # spec from two report artifacts (-profiles and -all-in-one), both tagged
+            # database=elasticsearch. Distinct databases (rdbms) and tasklist modes
+            # (e2e) remain separate rows.
+            | unique_by([.version, .file, .test_name, (.database // ""), (.tasklist_mode // "")])
           ' /tmp/all_failures.jsonl > /tmp/failures_normalized.json
 
           echo "After normalization + filtering: $(jq 'length' /tmp/failures_normalized.json)"


### PR DESCRIPTION
## Description

The C8 Orchestration Cluster nightly triage extractor was missing api_es (Elasticsearch API) test failures. This PR fixes two related gaps found by auditing every json-report artifact/pattern combination across all scanned nightly workflows (8.7 / 8.8 / 8.9 / main × e2e / api_es / api_rdbms).

### 1. Artifact-name pattern no longer matched (the reported symptom)

The API-tests nightly now uploads its report as `json-report-nightly-api-<version>-profiles` (the job runs "Mode profiles"), but the extractor downloaded with the literal pattern `json-report-nightly-api-<version>` — no wildcard. `gh run download --pattern` uses glob matching, so the literal name no longer matched. The download failed → `continue` → no `results.json` parsed → **zero** failing specs extracted → the run was reported as `workflow-level failure (no failing tests detected)` and the fix agent was dispatched with empty `test_specs`.

Observed on [run 30412767338](https://github.com/camunda/camunda/actions/runs/30412767338) (8.8 API ES). The report was healthy (`unexpected: 3`); 3 `process-definition` v2 API tests were dropped.

**Fix:** append a trailing glob so the pattern tolerates the mode suffix. Verified:
- `json-report-nightly-api-stable-8.8` → `no artifact matches` (exit 1)
- `json-report-nightly-api-stable-8.8*` → downloads `results.json`

### 2. Only one of multiple api_es reports was parsed

Auditing live artifacts showed **8.9 and main now emit two api_es reports per run** — `-profiles` **and** `-all-in-one`. The glob correctly downloads both, but the extractor then read only the first `results.json` (`find … | head -1`), so failures in the second report would be silently dropped.

**Fix:** iterate over every `results.json` the download produced. e2e (`-v1`/`-v2`) and api_rdbms (dynamic per-artifact enumeration) download one exact artifact each, so their behavior is unchanged. Added `unique_by(...)` to collapse the true duplicates the two ES reports can produce (same spec, both `database=elasticsearch`), while keeping distinct rdbms databases and e2e tasklist modes as separate rows.

### Audit result (all combinations)

| Type | Pattern | Actual artifacts | Status |
|------|---------|------------------|--------|
| e2e | `…-e2e-<ver>-{v1,v2}` (exact) | names end exactly `-v1`/`-v2` | already fine |
| api_es | `…-api-<ver>` → `…-api-<ver>*` | `…-profiles`, `…-all-in-one` | **both fixes here** |
| api_rdbms | dynamic per-artifact enumeration | `…-rdbms-<ver>-<DB>-<mode>` | already fine |

Glob safety: `…-api-<ver>*` cannot collide with rdbms (`…-api-rdbms-…`) or e2e (`…-e2e-…`) names.

## Validation

- `python3 -c yaml.safe_load` → OK; `actionlint` (with shellcheck) → OK
- dedup unit test: two identical ES rows collapse to one; distinct rdbms DBs and e2e v1/v2 stay separate
- glob download against live runs confirms both ES reports are pulled

## Notes

Scheduled workflows run only from `main`, so the fix lands here — the only branch where this triage workflow executes.