### PR TITLE
fix: make Optimize's CSL mode resolve the current user

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCamundaSecurityConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCamundaSecurityConfig.java
@@ -8,10 +8,17 @@
 package io.camunda.optimize.rest.security.csl;
 
 import io.camunda.optimize.tomcat.CCSMRequestAdjustmentFilter;
+import io.camunda.security.api.context.CamundaAuthenticationConverter;
+import io.camunda.security.api.context.OidcClaimsProvider;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.core.port.out.MembershipPort;
 import io.camunda.security.core.port.out.SecurityPathPort;
 import io.camunda.security.spring.CamundaSecurityAutoConfiguration;
+import io.camunda.security.spring.converter.OidcTokenAuthenticationConverter;
+import io.camunda.security.spring.converter.OidcUserAuthenticationConverter;
+import io.camunda.security.spring.oidc.OidcAccessTokenDecoderFactory;
 import io.camunda.security.spring.spi.OidcAuthenticationEntryPoint;
+import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
@@ -20,8 +27,10 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 
 /**
  * Opt-in configuration that adopts CSL for Optimize. See <a
@@ -88,6 +97,34 @@ public class OptimizeCamundaSecurityConfig {
     registration.addUrlPatterns("/*");
     registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
     return registration;
+  }
+
+  /**
+   * Converts a CSL login session ({@code OAuth2AuthenticationToken}) into a {@code
+   * CamundaAuthentication}. CSL ships the converter but registers no converter beans of its own, so
+   * without this the delegating converter finds no match and every request that resolves the
+   * current user fails with a 500.
+   */
+  @Bean
+  public CamundaAuthenticationConverter<Authentication> oidcUserAuthenticationConverter(
+      final OAuth2AuthorizedClientRepository authorizedClientRepository,
+      final OidcAccessTokenDecoderFactory accessTokenDecoderFactory,
+      final LazyTokenClaimsConverter tokenClaimsConverter,
+      final HttpServletRequest request) {
+    return new OidcUserAuthenticationConverter(
+        authorizedClientRepository, accessTokenDecoderFactory, tokenClaimsConverter, request);
+  }
+
+  /**
+   * The same for bearer tokens ({@code JwtAuthenticationToken}) on the API chain, so the public API
+   * does not hit the identical failure. Optimize needs both because one {@code
+   * CamundaAuthenticationProvider} serves both chains.
+   */
+  @Bean
+  public CamundaAuthenticationConverter<Authentication> oidcTokenAuthenticationConverter(
+      final LazyTokenClaimsConverter tokenClaimsConverter,
+      final OidcClaimsProvider oidcClaimsProvider) {
+    return new OidcTokenAuthenticationConverter(tokenClaimsConverter, oidcClaimsProvider);
   }
 
   /** Overrides CSL's default OIDC entry point; see {@link OptimizeOidcAuthenticationEntryPoint}. */

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/security/SessionService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/security/SessionService.java
@@ -19,6 +19,8 @@ import io.camunda.optimize.service.security.util.LocalDateUtil;
 import io.camunda.optimize.service.util.configuration.ConfigurationReloadable;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.security.AuthConfiguration;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.security.api.model.CamundaAuthentication;
 import jakarta.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
@@ -30,8 +32,10 @@ import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
 import org.slf4j.Logger;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Component;
 
@@ -48,14 +52,21 @@ public class SessionService implements ConfigurationReloadable {
 
   private final TerminatedSessionService terminatedSessionService;
   private final ConfigurationService configurationService;
+
+  // Present only under CSL; absent in the legacy setup, which resolves the user from the auth
+  // cookie or a bearer token's sub claim.
+  private final ObjectProvider<CamundaAuthenticationProvider> camundaAuthenticationProviderProvider;
+
   private Algorithm hashingAlgorithm;
   private JWTVerifier jwtVerifier;
 
   public SessionService(
       final TerminatedSessionService terminatedSessionService,
-      final ConfigurationService configurationService) {
+      final ConfigurationService configurationService,
+      final ObjectProvider<CamundaAuthenticationProvider> camundaAuthenticationProviderProvider) {
     this.terminatedSessionService = terminatedSessionService;
     this.configurationService = configurationService;
+    this.camundaAuthenticationProviderProvider = camundaAuthenticationProviderProvider;
 
     initJwtVerifier();
   }
@@ -89,6 +100,9 @@ public class SessionService implements ConfigurationReloadable {
    * <p>Resolution order:
    *
    * <ol>
+   *   <li>Under CSL, the username CSL resolved for the interactive session (see {@link
+   *       #cslAuthenticatedUsername()}). There is no Optimize auth cookie in that mode, so without
+   *       this step every endpoint using this method would fail with a 401.
    *   <li>If the {@link SecurityContextHolder} already holds a {@link JwtAuthenticationToken} (set
    *       by Spring Security's OAuth2 resource server bearer-token authentication when {@code
    *       api.jwtAuthForApiEnabled=true}), the subject is taken directly from that token. This
@@ -100,12 +114,39 @@ public class SessionService implements ConfigurationReloadable {
    * @throws NotAuthorizedException if no authenticated identity can be resolved.
    */
   public String getRequestUserOrFailNotAuthorized(final HttpServletRequest request) {
-    return subjectFromSecurityContext()
+    return cslAuthenticatedUsername()
+        .or(this::subjectFromSecurityContext)
         .or(
             () ->
                 AuthCookieService.getAuthCookieToken(request)
                     .flatMap(AuthCookieService::getTokenSubject))
         .orElseThrow(() -> new NotAuthorizedException("Could not extract request user!"));
+  }
+
+  /**
+   * Resolves the user id CSL authenticated the interactive session as, which is the id Optimize
+   * stores entity ownership under (CSL's configured {@code username-claim}). Mirrors {@code
+   * CCSMTokenService#getCurrentUserIdFromAuthToken}, which reads the same source.
+   *
+   * <p>Empty unless CSL is active: the {@link CamundaAuthenticationProvider} bean exists only then,
+   * and the {@link OAuth2AuthenticationToken} check restricts this to sessions established by CSL's
+   * {@code oauth2Login} chain, so the legacy cookie path is unaffected.
+   */
+  private Optional<String> cslAuthenticatedUsername() {
+    final CamundaAuthenticationProvider provider =
+        camundaAuthenticationProviderProvider == null
+            ? null
+            : camundaAuthenticationProviderProvider.getIfAvailable();
+    if (provider == null) {
+      return Optional.empty();
+    }
+    if (!(SecurityContextHolder.getContext().getAuthentication()
+        instanceof OAuth2AuthenticationToken)) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(provider.getCamundaAuthentication())
+        .map(CamundaAuthentication::authenticatedUsername)
+        .filter(username -> !username.isBlank());
   }
 
   /**

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/security/SessionService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/security/SessionService.java
@@ -97,12 +97,16 @@ public class SessionService implements ConfigurationReloadable {
    * Resolves the authenticated user ID from the current request, regardless of whether the request
    * was authenticated via an Identity session cookie or a bearer JWT token.
    *
-   * <p>Resolution order:
+   * <p>A CSL login session is resolved on its own: when CSL is active and the request carries one,
+   * the user is whatever CSL authenticated (see {@link #cslAuthenticatedUsername(
+   * CamundaAuthenticationProvider)}) or nothing at all. It never falls back to the branches below,
+   * because the cookie branch reads its subject from an unverified token: under CSL no filter
+   * validates the Optimize auth cookie, so a stale or injected one could otherwise attribute the
+   * request to a different user.
+   *
+   * <p>Otherwise, in order:
    *
    * <ol>
-   *   <li>Under CSL, the username CSL resolved for the interactive session (see {@link
-   *       #cslAuthenticatedUsername()}). There is no Optimize auth cookie in that mode, so without
-   *       this step every endpoint using this method would fail with a 401.
    *   <li>If the {@link SecurityContextHolder} already holds a {@link JwtAuthenticationToken} (set
    *       by Spring Security's OAuth2 resource server bearer-token authentication when {@code
    *       api.jwtAuthForApiEnabled=true}), the subject is taken directly from that token. This
@@ -114,8 +118,15 @@ public class SessionService implements ConfigurationReloadable {
    * @throws NotAuthorizedException if no authenticated identity can be resolved.
    */
   public String getRequestUserOrFailNotAuthorized(final HttpServletRequest request) {
-    return cslAuthenticatedUsername()
-        .or(this::subjectFromSecurityContext)
+    final CamundaAuthenticationProvider cslProvider = cslAuthenticationProvider();
+    if (cslProvider != null && isCslLoginSession()) {
+      return cslAuthenticatedUsername(cslProvider)
+          .orElseThrow(
+              () ->
+                  new NotAuthorizedException(
+                      "Could not extract request user from the CSL login session!"));
+    }
+    return subjectFromSecurityContext()
         .or(
             () ->
                 AuthCookieService.getAuthCookieToken(request)
@@ -123,27 +134,26 @@ public class SessionService implements ConfigurationReloadable {
         .orElseThrow(() -> new NotAuthorizedException("Could not extract request user!"));
   }
 
+  /** The CSL authentication provider, or {@code null} when CSL is not active. */
+  private CamundaAuthenticationProvider cslAuthenticationProvider() {
+    return camundaAuthenticationProviderProvider == null
+        ? null
+        : camundaAuthenticationProviderProvider.getIfAvailable();
+  }
+
+  /** True when the current request was authenticated by CSL's {@code oauth2Login} chain. */
+  private static boolean isCslLoginSession() {
+    return SecurityContextHolder.getContext().getAuthentication()
+        instanceof OAuth2AuthenticationToken;
+  }
+
   /**
-   * Resolves the user id CSL authenticated the interactive session as, which is the id Optimize
-   * stores entity ownership under (CSL's configured {@code username-claim}). Mirrors {@code
+   * Resolves the user id CSL authenticated the session as, which is the id Optimize stores entity
+   * ownership under (CSL's configured {@code username-claim}). Mirrors {@code
    * CCSMTokenService#getCurrentUserIdFromAuthToken}, which reads the same source.
-   *
-   * <p>Empty unless CSL is active: the {@link CamundaAuthenticationProvider} bean exists only then,
-   * and the {@link OAuth2AuthenticationToken} check restricts this to sessions established by CSL's
-   * {@code oauth2Login} chain, so the legacy cookie path is unaffected.
    */
-  private Optional<String> cslAuthenticatedUsername() {
-    final CamundaAuthenticationProvider provider =
-        camundaAuthenticationProviderProvider == null
-            ? null
-            : camundaAuthenticationProviderProvider.getIfAvailable();
-    if (provider == null) {
-      return Optional.empty();
-    }
-    if (!(SecurityContextHolder.getContext().getAuthentication()
-        instanceof OAuth2AuthenticationToken)) {
-      return Optional.empty();
-    }
+  private static Optional<String> cslAuthenticatedUsername(
+      final CamundaAuthenticationProvider provider) {
     return Optional.ofNullable(provider.getCamundaAuthentication())
         .map(CamundaAuthentication::authenticatedUsername)
         .filter(username -> !username.isBlank());

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeCamundaSecurityConfigTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeCamundaSecurityConfigTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.csl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.api.context.CamundaAuthenticationConverter;
+import io.camunda.security.api.context.OidcClaimsProvider;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
+import io.camunda.security.spring.oidc.OidcAccessTokenDecoderFactory;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+/**
+ * CSL supplies the {@code CamundaAuthenticationConverter} implementations but registers none of
+ * them as beans, so the host must. Without a converter for the token type at hand, {@code
+ * CamundaSpringAuthenticationDelegatingConverter} throws and the request fails with a 500 rather
+ * than resolving the current user.
+ */
+@ExtendWith(MockitoExtension.class)
+class OptimizeCamundaSecurityConfigTest {
+
+  @Mock private OAuth2AuthorizedClientRepository authorizedClientRepository;
+  @Mock private OidcAccessTokenDecoderFactory accessTokenDecoderFactory;
+  @Mock private LazyTokenClaimsConverter tokenClaimsConverter;
+  @Mock private HttpServletRequest request;
+  @Mock private OidcClaimsProvider oidcClaimsProvider;
+
+  private final OptimizeCamundaSecurityConfig config = new OptimizeCamundaSecurityConfig();
+
+  @Test
+  void shouldConvertACslLoginSession() {
+    final CamundaAuthenticationConverter<Authentication> converter =
+        config.oidcUserAuthenticationConverter(
+            authorizedClientRepository, accessTokenDecoderFactory, tokenClaimsConverter, request);
+
+    assertThat(converter.supports(oauth2Session())).isTrue();
+  }
+
+  @Test
+  void shouldConvertABearerToken() {
+    final CamundaAuthenticationConverter<Authentication> converter =
+        config.oidcTokenAuthenticationConverter(tokenClaimsConverter, oidcClaimsProvider);
+
+    assertThat(converter.supports(new JwtAuthenticationToken(bearerJwt()))).isTrue();
+  }
+
+  private static OAuth2AuthenticationToken oauth2Session() {
+    final OidcIdToken idToken =
+        new OidcIdToken(
+            "id-token", Instant.now(), Instant.now().plusSeconds(300), Map.of("sub", "auth0|user"));
+    return new OAuth2AuthenticationToken(
+        new DefaultOidcUser(AuthorityUtils.createAuthorityList("ROLE_USER"), idToken),
+        List.of(),
+        "oidc");
+  }
+
+  private static Jwt bearerJwt() {
+    return Jwt.withTokenValue("token").header("alg", "none").claim("sub", "auth0|user").build();
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/security/SessionServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/security/SessionServiceTest.java
@@ -14,12 +14,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
 import io.camunda.optimize.rest.exceptions.NotAuthorizedException;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.OptimizeApiConfiguration;
 import io.camunda.optimize.service.util.configuration.security.AuthConfiguration;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.CamundaAuthentication;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.Instant;
 import java.util.Collections;
@@ -46,6 +49,7 @@ class SessionServiceTest {
 
   private static final String USER_SUBJECT = "user123";
   private static final String CSL_USERNAME = "auth0|csl-user";
+  private static final String OTHER_USER_SUBJECT = "someone-else";
 
   @Mock private TerminatedSessionService terminatedSessionService;
   @Mock private ConfigurationService configurationService;
@@ -126,14 +130,44 @@ class SessionServiceTest {
 
   @Test
   void shouldFailWhenCslResolvesNoUsernameForAnOauth2Session() {
-    // given — provider present but no authenticated username to offer, and no cookie to fall back
-    // to, so the request must not be attributed to some other identity
+    // given — provider present but no authenticated username to offer
     sessionService = sessionServiceWith(camundaAuthenticationProviderOf(null));
     SecurityContextHolder.getContext().setAuthentication(oauth2Session());
 
     // when - then
-    assertThatThrownBy(() -> sessionService.getRequestUserOrFailNotAuthorized(emptyRequest()))
+    assertThatThrownBy(
+            () -> sessionService.getRequestUserOrFailNotAuthorized(mock(HttpServletRequest.class)))
         .isInstanceOf(NotAuthorizedException.class);
+  }
+
+  @Test
+  void shouldNotFallBackToTheLegacyCookieForACslSession() {
+    // given — a CSL session that resolves no username, plus a leftover Optimize auth cookie naming
+    // a different user. That cookie's subject is decoded without verifying the signature, and under
+    // CSL no filter validates it, so it must never be used to attribute the request.
+    sessionService = sessionServiceWith(camundaAuthenticationProviderOf(null));
+    SecurityContextHolder.getContext().setAuthentication(oauth2Session());
+
+    // when - then
+    assertThatThrownBy(
+            () -> sessionService.getRequestUserOrFailNotAuthorized(requestWithAuthCookie()))
+        .isInstanceOf(NotAuthorizedException.class);
+  }
+
+  /** A request carrying a leftover Optimize auth cookie whose subject is a different user. */
+  private static HttpServletRequest requestWithAuthCookie() {
+    final HttpServletRequest request = mock(HttpServletRequest.class);
+    lenient().when(request.getAttributeNames()).thenReturn(Collections.emptyEnumeration());
+    lenient()
+        .when(request.getCookies())
+        .thenReturn(
+            new Cookie[] {
+              new Cookie(
+                  AuthCookieService.getAuthorizationCookieNameWithSuffix(0),
+                  AuthCookieService.createOptimizeAuthCookieValue(
+                      JWT.create().withSubject(OTHER_USER_SUBJECT).sign(Algorithm.none())))
+            });
+    return request;
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/security/SessionServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/security/SessionServiceTest.java
@@ -9,15 +9,22 @@ package io.camunda.optimize.service.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.optimize.rest.exceptions.NotAuthorizedException;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.OptimizeApiConfiguration;
 import io.camunda.optimize.service.util.configuration.security.AuthConfiguration;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.security.api.model.CamundaAuthentication;
 import jakarta.servlet.http.HttpServletRequest;
+import java.time.Instant;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,7 +32,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
@@ -33,20 +45,28 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 class SessionServiceTest {
 
   private static final String USER_SUBJECT = "user123";
+  private static final String CSL_USERNAME = "auth0|csl-user";
 
   @Mock private TerminatedSessionService terminatedSessionService;
   @Mock private ConfigurationService configurationService;
   @Mock private AuthConfiguration authConfiguration;
   @Mock private OptimizeApiConfiguration apiConfiguration;
+  @Mock private CamundaAuthenticationProvider camundaAuthenticationProvider;
 
   private SessionService sessionService;
 
   @BeforeEach
   void setUp() {
-    when(authConfiguration.getTokenSecret()).thenReturn(Optional.empty());
-    when(configurationService.getAuthConfiguration()).thenReturn(authConfiguration);
-    when(configurationService.getOptimizeApiConfiguration()).thenReturn(apiConfiguration);
-    sessionService = new SessionService(terminatedSessionService, configurationService);
+    lenient().when(authConfiguration.getTokenSecret()).thenReturn(Optional.empty());
+    lenient().when(configurationService.getAuthConfiguration()).thenReturn(authConfiguration);
+    lenient().when(configurationService.getOptimizeApiConfiguration()).thenReturn(apiConfiguration);
+    // Legacy setup by default: no CamundaAuthenticationProvider bean exists.
+    sessionService = sessionServiceWith(noCamundaAuthenticationProvider());
+  }
+
+  private SessionService sessionServiceWith(
+      final ObjectProvider<CamundaAuthenticationProvider> provider) {
+    return new SessionService(terminatedSessionService, configurationService, provider);
   }
 
   @AfterEach
@@ -88,6 +108,98 @@ class SessionServiceTest {
     // when - then
     assertThatThrownBy(() -> sessionService.getRequestUserOrFailNotAuthorized(emptyRequest()))
         .isInstanceOf(NotAuthorizedException.class);
+  }
+
+  @Test
+  void shouldReturnCslAuthenticatedUsernameForAnOauth2Session() {
+    // given — CSL mode: an oauth2Login session, no Optimize auth cookie
+    sessionService = sessionServiceWith(camundaAuthenticationProviderOf(CSL_USERNAME));
+    SecurityContextHolder.getContext().setAuthentication(oauth2Session());
+
+    // when — CSL resolves first, so the cookie path is never reached
+    final String user =
+        sessionService.getRequestUserOrFailNotAuthorized(mock(HttpServletRequest.class));
+
+    // then
+    assertThat(user).isEqualTo(CSL_USERNAME);
+  }
+
+  @Test
+  void shouldFailWhenCslResolvesNoUsernameForAnOauth2Session() {
+    // given — provider present but no authenticated username to offer, and no cookie to fall back
+    // to, so the request must not be attributed to some other identity
+    sessionService = sessionServiceWith(camundaAuthenticationProviderOf(null));
+    SecurityContextHolder.getContext().setAuthentication(oauth2Session());
+
+    // when - then
+    assertThatThrownBy(() -> sessionService.getRequestUserOrFailNotAuthorized(emptyRequest()))
+        .isInstanceOf(NotAuthorizedException.class);
+  }
+
+  @Test
+  void shouldNotConsultCslForABearerAuthenticatedRequest() {
+    // given — CSL present, but the context holds a bearer JWT rather than an oauth2 session, so the
+    // bearer subject must win and CSL must not be asked
+    when(apiConfiguration.isJwtAuthForApiEnabled()).thenReturn(true);
+    sessionService = sessionServiceWith(camundaAuthenticationProviderOf(CSL_USERNAME));
+    SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(buildJwt()));
+
+    // when — the bearer subject resolves first, so the cookie path is never reached
+    final String user =
+        sessionService.getRequestUserOrFailNotAuthorized(mock(HttpServletRequest.class));
+
+    // then
+    assertThat(user).isEqualTo(USER_SUBJECT);
+    verifyNoInteractions(camundaAuthenticationProvider);
+  }
+
+  private ObjectProvider<CamundaAuthenticationProvider> camundaAuthenticationProviderOf(
+      final String username) {
+    final CamundaAuthentication authentication = mock(CamundaAuthentication.class);
+    lenient().when(authentication.authenticatedUsername()).thenReturn(username);
+    lenient()
+        .when(camundaAuthenticationProvider.getCamundaAuthentication())
+        .thenReturn(authentication);
+    return singletonProvider(camundaAuthenticationProvider);
+  }
+
+  private static ObjectProvider<CamundaAuthenticationProvider> noCamundaAuthenticationProvider() {
+    return singletonProvider(null);
+  }
+
+  private static ObjectProvider<CamundaAuthenticationProvider> singletonProvider(
+      final CamundaAuthenticationProvider provider) {
+    return new ObjectProvider<>() {
+      @Override
+      public CamundaAuthenticationProvider getObject() {
+        return provider;
+      }
+
+      @Override
+      public CamundaAuthenticationProvider getObject(final Object... args) {
+        return provider;
+      }
+
+      @Override
+      public CamundaAuthenticationProvider getIfAvailable() {
+        return provider;
+      }
+
+      @Override
+      public CamundaAuthenticationProvider getIfUnique() {
+        return provider;
+      }
+    };
+  }
+
+  private static OAuth2AuthenticationToken oauth2Session() {
+    final OidcIdToken idToken =
+        new OidcIdToken(
+            "id-token", Instant.now(), Instant.now().plusSeconds(300), Map.of("sub", CSL_USERNAME));
+    return new OAuth2AuthenticationToken(
+        new DefaultOidcUser(AuthorityUtils.createAuthorityList("ROLE_USER"), idToken),
+        List.of(),
+        "oidc");
   }
 
   /** Returns a mock request that has no auth cookie and won't NPE inside AuthCookieService. */


### PR DESCRIPTION
## Description

Two fixes needed to make Optimize's CSL mode usable. Both were found while testing on a CCSaaS cluster: login worked, but the app was unusable afterwards.

**1. `SessionService` did not know about CSL sessions.** It looked for the user in two places: a bearer `JwtAuthenticationToken` in the `SecurityContext`, or the legacy `X-Optimize-Authorization` cookie. Under CSL the context holds an `OAuth2AuthenticationToken` and there is no Optimize cookie, so neither matched and the method threw. It has 84 call sites in 17 controllers, so nearly the whole authenticated API returned 401 and the SPA kept reloading.

A CSL login session now resolves on its own: either CSL's authenticated username, or a 401. It never falls through to the other two branches. That matters because the cookie branch decodes its subject without verifying the signature. Under the legacy stack a filter validates the cookie first, but under CSL nothing does, so a leftover or injected cookie could otherwise attribute the request to a different user. Leftover cookies are a normal state right now, since switching a cluster to CSL leaves them in the browser.

**2. No `CamundaAuthenticationConverter` beans were registered.** With the 401s gone, requests failed with a 500 instead:

```
Did not find a matching converter to convert a Spring Authentication
'OAuth2AuthenticationToken' to a Camunda Authentication
```

CSL ships the converters but registers none of them as beans, so each host must. OC does this in `OidcOverrideBeansConfiguration`; Optimize did not. Both are now registered: the user converter for login sessions, and the token converter for bearer tokens on the API chain, because one `CamundaAuthenticationProvider` serves both chains. Everything they depend on is already a CSL default bean from the umbrella auto-configuration.

## Notes for reviewers

The CSL branch in `SessionService` does nothing outside CSL. The `CamundaAuthenticationProvider` bean only exists there, and the `OAuth2AuthenticationToken` check limits it to CSL login sessions. The legacy cookie path is unchanged.

It is a separate branch on purpose, not an addition to `subjectFromSecurityContext()`. That method is gated on `api.jwtAuthForApiEnabled` so a stale or injected `JwtAuthenticationToken` cannot bypass cookie auth, and CSL sessions should not depend on that flag.

Using CSL's username rather than the OIDC principal name is deliberate: it follows the configured `username-claim`, and it is the id Optimize stores entity ownership under. `CCSMTokenService#getCurrentUserIdFromAuthToken` already reads the same source, so both now agree.

Not covered here: bearer requests under CSL still go through `subjectFromSecurityContext()` and still depend on `api.jwtAuthForApiEnabled`. The public API endpoints do not use that method, so nothing breaks today, but it needs a look when the flag goes away.

## Related issues

Gap left by #58473, which bridged `CCSMTokenService` but not `SessionService`
Parent epic #58403
Unblocks #58481
Decision: [ADR-0038](https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
