### PR TITLE
feat: apply BACKUP and EXPORTER authorizations to runtime backup and exporting endpoints

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BackupExportingAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BackupExportingAuthorizationIT.java
@@ -132,6 +132,19 @@ class BackupExportingAuthorizationIT {
   private static final Endpoint PAUSE_EXPORTING = new Endpoint("POST", "v2/exporting/pause");
   private static final Endpoint RESUME_EXPORTING = new Endpoint("POST", "v2/exporting/resume");
 
+  private static final List<Endpoint> BACKUP_ENDPOINTS =
+      List.of(
+          TAKE_BACKUP,
+          LIST_BACKUPS,
+          GET_BACKUP,
+          GET_STATE,
+          SYNC_STATE,
+          DELETE_BACKUP,
+          DELETE_STATE);
+
+  private static final List<Endpoint> EXPORTING_ENDPOINTS =
+      List.of(PAUSE_EXPORTING, RESUME_EXPORTING);
+
   @AfterAll
   static void deleteBackupDirectory() throws IOException {
     if (!Files.exists(BACKUP_DIR)) {
@@ -152,47 +165,37 @@ class BackupExportingAuthorizationIT {
   }
 
   static Stream<Arguments> allEndpoints() {
-    return Stream.of(
-            TAKE_BACKUP,
-            LIST_BACKUPS,
-            GET_BACKUP,
-            GET_STATE,
-            SYNC_STATE,
-            DELETE_BACKUP,
-            DELETE_STATE,
-            PAUSE_EXPORTING,
-            RESUME_EXPORTING)
+    return Stream.concat(BACKUP_ENDPOINTS.stream(), EXPORTING_ENDPOINTS.stream())
         .map(Arguments::of);
   }
 
   static Stream<Arguments> endpointsDeniedToBackupReader() {
-    // BACKUP:READ must not imply write access, nor any access to exporting
-    return Stream.of(TAKE_BACKUP, SYNC_STATE, DELETE_BACKUP, DELETE_STATE, PAUSE_EXPORTING)
-        .map(Arguments::of);
+    // BACKUP:READ must not imply write access
+    return deniedToBackupGrant(TAKE_BACKUP, SYNC_STATE, DELETE_BACKUP, DELETE_STATE);
   }
 
   static Stream<Arguments> endpointsDeniedToBackupCreator() {
     // BACKUP:CREATE must not imply read or delete access
-    return Stream.of(LIST_BACKUPS, GET_BACKUP, GET_STATE, DELETE_BACKUP, DELETE_STATE)
-        .map(Arguments::of);
+    return deniedToBackupGrant(LIST_BACKUPS, GET_BACKUP, GET_STATE, DELETE_BACKUP, DELETE_STATE);
   }
 
   static Stream<Arguments> endpointsDeniedToBackupDeleter() {
     // BACKUP:DELETE must not imply read or create access
-    return Stream.of(TAKE_BACKUP, LIST_BACKUPS, GET_BACKUP, GET_STATE, SYNC_STATE)
-        .map(Arguments::of);
+    return deniedToBackupGrant(TAKE_BACKUP, LIST_BACKUPS, GET_BACKUP, GET_STATE, SYNC_STATE);
   }
 
   static Stream<Arguments> backupEndpoints() {
     // EXPORTER:PAUSE must not grant anything on the BACKUP resource type
-    return Stream.of(
-            TAKE_BACKUP,
-            LIST_BACKUPS,
-            GET_BACKUP,
-            GET_STATE,
-            SYNC_STATE,
-            DELETE_BACKUP,
-            DELETE_STATE)
+    return BACKUP_ENDPOINTS.stream().map(Arguments::of);
+  }
+
+  /**
+   * Builds the denial matrix for a caller holding a single {@code BACKUP} permission: the backup
+   * endpoints that permission must not reach, plus <em>both</em> exporting endpoints — no {@code
+   * BACKUP} grant may ever authorize exporting, in either direction.
+   */
+  private static Stream<Arguments> deniedToBackupGrant(final Endpoint... backupEndpoints) {
+    return Stream.concat(Stream.of(backupEndpoints), EXPORTING_ENDPOINTS.stream())
         .map(Arguments::of);
   }
 
@@ -223,10 +226,10 @@ class BackupExportingAuthorizationIT {
 
   @ParameterizedTest
   @MethodSource("endpointsDeniedToBackupReader")
-  void shouldDenyWriteEndpointsWithReadOnlyGrant(
+  void shouldDenyWriteAndExportingEndpointsWithReadOnlyGrant(
       final Endpoint endpoint, @Authenticated(BACKUP_READ_USER) final CamundaClient client)
       throws Exception {
-    // when a user granted only BACKUP:READ calls a write endpoint
+    // when a user granted only BACKUP:READ calls a backup write or an exporting endpoint
     final var response = send(client, endpoint, BACKUP_READ_USER);
 
     // then it is forbidden: READ implies neither CREATE nor DELETE, and grants nothing on EXPORTER
@@ -235,10 +238,10 @@ class BackupExportingAuthorizationIT {
 
   @ParameterizedTest
   @MethodSource("endpointsDeniedToBackupCreator")
-  void shouldDenyReadAndDeleteEndpointsWithCreateOnlyGrant(
+  void shouldDenyReadDeleteAndExportingEndpointsWithCreateOnlyGrant(
       final Endpoint endpoint, @Authenticated(BACKUP_CREATE_USER) final CamundaClient client)
       throws Exception {
-    // when a user granted only BACKUP:CREATE calls a read or delete endpoint
+    // when a user granted only BACKUP:CREATE calls a read, delete or exporting endpoint
     final var response = send(client, endpoint, BACKUP_CREATE_USER);
 
     // then it is forbidden
@@ -247,10 +250,10 @@ class BackupExportingAuthorizationIT {
 
   @ParameterizedTest
   @MethodSource("endpointsDeniedToBackupDeleter")
-  void shouldDenyReadAndCreateEndpointsWithDeleteOnlyGrant(
+  void shouldDenyReadCreateAndExportingEndpointsWithDeleteOnlyGrant(
       final Endpoint endpoint, @Authenticated(BACKUP_DELETE_USER) final CamundaClient client)
       throws Exception {
-    // when a user granted only BACKUP:DELETE calls a read or create endpoint
+    // when a user granted only BACKUP:DELETE calls a read, create or exporting endpoint
     final var response = send(client, endpoint, BACKUP_DELETE_USER);
 
     // then it is forbidden

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BackupExportingAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BackupExportingAuthorizationIT.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.client.api.search.enums.PermissionType.CREATE;
+import static io.camunda.client.api.search.enums.PermissionType.DELETE;
+import static io.camunda.client.api.search.enums.PermissionType.PAUSE;
+import static io.camunda.client.api.search.enums.PermissionType.READ;
+import static io.camunda.client.api.search.enums.ResourceType.BACKUP;
+import static io.camunda.client.api.search.enums.ResourceType.EXPORTER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.configuration.PrimaryStorageBackup.BackupStoreType;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * End-to-end authorization coverage for the per-physical-tenant runtime backup ({@code
+ * /v2/backups/runtime}) and exporting ({@code /v2/exporting}) REST endpoints against a real
+ * authorization-enabled broker.
+ *
+ * <p>{@code RuntimeBackupServicesTest} and {@code ExportingServicesTest} mock the authorization
+ * stack, so they only prove the services <em>ask</em> for the right resource/permission pair. This
+ * IT proves that a real, persisted grant on the {@code BACKUP} and {@code EXPORTER} resource types
+ * actually resolves to a permit (and its absence to a 403) through the full stack — both resource
+ * types are new, so nothing else exercises that path.
+ *
+ * <p>A filesystem backup store is configured so the authorized calls genuinely succeed rather than
+ * merely getting past the authorization gate.
+ *
+ * <p>Unlike {@code SecretAuthorizationIT}, no test needs to be disabled under a physical tenant:
+ * these grants resolve correctly in that mode too, so the suite runs in full under {@code
+ * -Dtest.integration.camunda.physical-tenant}.
+ */
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+class BackupExportingAuthorizationIT {
+
+  /**
+   * Created eagerly rather than via {@code @TempDir}: {@link #BROKER} is configured in a static
+   * field initializer, which runs before JUnit resolves any injected temporary directory.
+   */
+  private static final Path BACKUP_DIR = createTempDirectory();
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withAuthorizationsEnabled()
+          .withDataConfig(
+              data -> {
+                final var backup = data.getPrimaryStorage().getBackup();
+                backup.setStore(BackupStoreType.FILESYSTEM);
+                backup.getFilesystem().setBasePath(BACKUP_DIR.toString());
+              });
+
+  private static final String PASSWORD = "password";
+
+  private static final String NO_PERMISSION_USER = "noPermissionUser";
+  private static final String BACKUP_READ_USER = "backupReadUser";
+  private static final String BACKUP_CREATE_USER = "backupCreateUser";
+  private static final String BACKUP_DELETE_USER = "backupDeleteUser";
+  private static final String EXPORTER_PAUSE_USER = "exporterPauseUser";
+
+  @UserDefinition
+  private static final TestUser NO_PERMISSION_USER_DEF =
+      new TestUser(NO_PERMISSION_USER, PASSWORD, List.of());
+
+  @UserDefinition
+  private static final TestUser BACKUP_READ_USER_DEF =
+      new TestUser(
+          BACKUP_READ_USER, PASSWORD, List.of(new Permissions(BACKUP, READ, List.of("*"))));
+
+  @UserDefinition
+  private static final TestUser BACKUP_CREATE_USER_DEF =
+      new TestUser(
+          BACKUP_CREATE_USER, PASSWORD, List.of(new Permissions(BACKUP, CREATE, List.of("*"))));
+
+  @UserDefinition
+  private static final TestUser BACKUP_DELETE_USER_DEF =
+      new TestUser(
+          BACKUP_DELETE_USER, PASSWORD, List.of(new Permissions(BACKUP, DELETE, List.of("*"))));
+
+  @UserDefinition
+  private static final TestUser EXPORTER_PAUSE_USER_DEF =
+      new TestUser(
+          EXPORTER_PAUSE_USER, PASSWORD, List.of(new Permissions(EXPORTER, PAUSE, List.of("*"))));
+
+  /** Backup ids must be unique per call so a retry never collides with an earlier attempt. */
+  private static final AtomicLong BACKUP_IDS = new AtomicLong(System.currentTimeMillis());
+
+  private static final Endpoint TAKE_BACKUP = new Endpoint("POST", "v2/backups/runtime");
+  private static final Endpoint LIST_BACKUPS = new Endpoint("GET", "v2/backups/runtime");
+  private static final Endpoint GET_BACKUP = new Endpoint("GET", "v2/backups/runtime/1");
+  private static final Endpoint GET_STATE = new Endpoint("GET", "v2/backups/runtime/state");
+  private static final Endpoint SYNC_STATE = new Endpoint("POST", "v2/backups/runtime/state/sync");
+  private static final Endpoint DELETE_BACKUP = new Endpoint("DELETE", "v2/backups/runtime/1");
+  private static final Endpoint DELETE_STATE = new Endpoint("DELETE", "v2/backups/runtime/state");
+  private static final Endpoint PAUSE_EXPORTING = new Endpoint("POST", "v2/exporting/pause");
+  private static final Endpoint RESUME_EXPORTING = new Endpoint("POST", "v2/exporting/resume");
+
+  @AfterAll
+  static void deleteBackupDirectory() throws IOException {
+    if (!Files.exists(BACKUP_DIR)) {
+      return;
+    }
+    try (final var paths = Files.walk(BACKUP_DIR)) {
+      paths
+          .sorted(Comparator.reverseOrder())
+          .forEach(
+              path -> {
+                try {
+                  Files.deleteIfExists(path);
+                } catch (final IOException e) {
+                  throw new UncheckedIOException(e);
+                }
+              });
+    }
+  }
+
+  static Stream<Arguments> allEndpoints() {
+    return Stream.of(
+            TAKE_BACKUP,
+            LIST_BACKUPS,
+            GET_BACKUP,
+            GET_STATE,
+            SYNC_STATE,
+            DELETE_BACKUP,
+            DELETE_STATE,
+            PAUSE_EXPORTING,
+            RESUME_EXPORTING)
+        .map(Arguments::of);
+  }
+
+  static Stream<Arguments> endpointsDeniedToBackupReader() {
+    // BACKUP:READ must not imply write access, nor any access to exporting
+    return Stream.of(TAKE_BACKUP, SYNC_STATE, DELETE_BACKUP, DELETE_STATE, PAUSE_EXPORTING)
+        .map(Arguments::of);
+  }
+
+  static Stream<Arguments> endpointsDeniedToBackupCreator() {
+    // BACKUP:CREATE must not imply read or delete access
+    return Stream.of(LIST_BACKUPS, GET_BACKUP, GET_STATE, DELETE_BACKUP, DELETE_STATE)
+        .map(Arguments::of);
+  }
+
+  static Stream<Arguments> endpointsDeniedToBackupDeleter() {
+    // BACKUP:DELETE must not imply read or create access
+    return Stream.of(TAKE_BACKUP, LIST_BACKUPS, GET_BACKUP, GET_STATE, SYNC_STATE)
+        .map(Arguments::of);
+  }
+
+  static Stream<Arguments> backupEndpoints() {
+    // EXPORTER:PAUSE must not grant anything on the BACKUP resource type
+    return Stream.of(
+            TAKE_BACKUP,
+            LIST_BACKUPS,
+            GET_BACKUP,
+            GET_STATE,
+            SYNC_STATE,
+            DELETE_BACKUP,
+            DELETE_STATE)
+        .map(Arguments::of);
+  }
+
+  @ParameterizedTest
+  @MethodSource("allEndpoints")
+  void shouldRejectUnauthenticatedRequest(
+      final Endpoint endpoint, @Authenticated(NO_PERMISSION_USER) final CamundaClient client)
+      throws Exception {
+    // when the endpoint is called without credentials — the injected client is used only to
+    // discover the broker's REST base address; the request below carries no Authorization header
+    final var response = send(client, endpoint, null);
+
+    // then it is rejected before any authorization decision is made
+    assertThat(response.statusCode()).isEqualTo(401);
+  }
+
+  @ParameterizedTest
+  @MethodSource("allEndpoints")
+  void shouldDenyEveryEndpointWhenUserHasNoGrants(
+      final Endpoint endpoint, @Authenticated(NO_PERMISSION_USER) final CamundaClient client)
+      throws Exception {
+    // when an authenticated user without any BACKUP or EXPORTER grant calls the endpoint
+    final var response = send(client, endpoint, NO_PERMISSION_USER);
+
+    // then it is forbidden
+    assertThat(response.statusCode()).isEqualTo(403);
+  }
+
+  @ParameterizedTest
+  @MethodSource("endpointsDeniedToBackupReader")
+  void shouldDenyWriteEndpointsWithReadOnlyGrant(
+      final Endpoint endpoint, @Authenticated(BACKUP_READ_USER) final CamundaClient client)
+      throws Exception {
+    // when a user granted only BACKUP:READ calls a write endpoint
+    final var response = send(client, endpoint, BACKUP_READ_USER);
+
+    // then it is forbidden: READ implies neither CREATE nor DELETE, and grants nothing on EXPORTER
+    assertThat(response.statusCode()).isEqualTo(403);
+  }
+
+  @ParameterizedTest
+  @MethodSource("endpointsDeniedToBackupCreator")
+  void shouldDenyReadAndDeleteEndpointsWithCreateOnlyGrant(
+      final Endpoint endpoint, @Authenticated(BACKUP_CREATE_USER) final CamundaClient client)
+      throws Exception {
+    // when a user granted only BACKUP:CREATE calls a read or delete endpoint
+    final var response = send(client, endpoint, BACKUP_CREATE_USER);
+
+    // then it is forbidden
+    assertThat(response.statusCode()).isEqualTo(403);
+  }
+
+  @ParameterizedTest
+  @MethodSource("endpointsDeniedToBackupDeleter")
+  void shouldDenyReadAndCreateEndpointsWithDeleteOnlyGrant(
+      final Endpoint endpoint, @Authenticated(BACKUP_DELETE_USER) final CamundaClient client)
+      throws Exception {
+    // when a user granted only BACKUP:DELETE calls a read or create endpoint
+    final var response = send(client, endpoint, BACKUP_DELETE_USER);
+
+    // then it is forbidden
+    assertThat(response.statusCode()).isEqualTo(403);
+  }
+
+  @ParameterizedTest
+  @MethodSource("backupEndpoints")
+  void shouldDenyBackupEndpointsWithExporterGrantOnly(
+      final Endpoint endpoint, @Authenticated(EXPORTER_PAUSE_USER) final CamundaClient client)
+      throws Exception {
+    // when a user granted only EXPORTER:PAUSE calls a backup endpoint
+    final var response = send(client, endpoint, EXPORTER_PAUSE_USER);
+
+    // then it is forbidden: a grant on one resource type must not leak into the other
+    assertThat(response.statusCode()).isEqualTo(403);
+  }
+
+  @Test
+  void shouldAllowReadEndpointsWithReadGrant(
+      @Authenticated(BACKUP_READ_USER) final CamundaClient client) throws Exception {
+    // when a user granted BACKUP:READ lists backups and queries the runtime state
+    // then both succeed
+    assertThat(send(client, LIST_BACKUPS, BACKUP_READ_USER).statusCode()).isEqualTo(200);
+    assertThat(send(client, GET_STATE, BACKUP_READ_USER).statusCode()).isEqualTo(200);
+  }
+
+  @Test
+  void shouldAllowTakingBackupWithCreateGrant(
+      @Authenticated(BACKUP_CREATE_USER) final CamundaClient client) throws Exception {
+    // when a user granted BACKUP:CREATE takes a backup
+    final var response =
+        send(client, TAKE_BACKUP, BACKUP_CREATE_USER, takeBackupBody(BACKUP_IDS.incrementAndGet()));
+
+    // then it is accepted
+    assertThat(response.statusCode()).isEqualTo(202);
+  }
+
+  @Test
+  void shouldAllowSyncingRuntimeStateWithCreateGrant(
+      @Authenticated(BACKUP_CREATE_USER) final CamundaClient client) throws Exception {
+    // when a user granted BACKUP:CREATE force-writes the runtime state
+    // (sync creates backup metadata, so it is gated on CREATE rather than READ)
+    final var response = send(client, SYNC_STATE, BACKUP_CREATE_USER);
+
+    // then it succeeds
+    assertThat(response.statusCode()).isEqualTo(200);
+  }
+
+  @Test
+  void shouldAllowDeletingRuntimeStateWithDeleteGrant(
+      @Authenticated(BACKUP_DELETE_USER) final CamundaClient client) throws Exception {
+    // when a user granted BACKUP:DELETE deletes the runtime state
+    final var response = send(client, DELETE_STATE, BACKUP_DELETE_USER);
+
+    // then it succeeds
+    assertThat(response.statusCode()).isEqualTo(204);
+  }
+
+  @Test
+  void shouldAllowPausingAndResumingExportingWithPauseGrant(
+      @Authenticated(EXPORTER_PAUSE_USER) final CamundaClient client) throws Exception {
+    try {
+      // when a user granted EXPORTER:PAUSE pauses exporting
+      final var pauseResponse = send(client, PAUSE_EXPORTING, EXPORTER_PAUSE_USER);
+
+      // then it succeeds
+      assertThat(pauseResponse.statusCode()).isEqualTo(204);
+
+      // and the same grant authorizes resuming: EXPORTER only defines PAUSE, so a caller able to
+      // stop exporting must be able to start it again
+      final var resumeResponse = send(client, RESUME_EXPORTING, EXPORTER_PAUSE_USER);
+      assertThat(resumeResponse.statusCode()).isEqualTo(204);
+    } finally {
+      // exporting is broker-wide: leaving it paused would starve the secondary storage that every
+      // other test in this class reads its authorizations from
+      send(client, RESUME_EXPORTING, EXPORTER_PAUSE_USER);
+    }
+  }
+
+  /**
+   * Issues a raw HTTP call to the given endpoint, authenticated as {@code username} when it is
+   * non-null. These endpoints have no fluent Java client methods yet.
+   */
+  private static HttpResponse<String> send(
+      final CamundaClient client, final Endpoint endpoint, final String username) throws Exception {
+    return send(client, endpoint, username, null);
+  }
+
+  private static HttpResponse<String> send(
+      final CamundaClient client, final Endpoint endpoint, final String username, final String body)
+      throws Exception {
+    final var builder = HttpRequest.newBuilder(createUri(client, endpoint.path()));
+    if (username != null) {
+      builder.header("Authorization", basicAuthentication(username));
+    }
+
+    // A valid body is sent to POST /v2/backups/runtime so denial tests fail the authorization
+    // check rather than request validation; the other endpoints declare no request body.
+    final var effectiveBody =
+        body == null && TAKE_BACKUP.equals(endpoint)
+            ? takeBackupBody(BACKUP_IDS.incrementAndGet())
+            : body;
+    if (effectiveBody != null) {
+      builder.header("Content-Type", "application/json");
+      builder.method(endpoint.method(), BodyPublishers.ofString(effectiveBody));
+    } else {
+      builder.method(endpoint.method(), BodyPublishers.noBody());
+    }
+
+    return HttpClient.newHttpClient().send(builder.build(), BodyHandlers.ofString());
+  }
+
+  private static String takeBackupBody(final long backupId) {
+    return "{\"backupId\": " + backupId + "}";
+  }
+
+  private static String basicAuthentication(final String username) {
+    return "Basic "
+        + Base64.getEncoder()
+            .encodeToString((username + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static URI createUri(final CamundaClient client, final String path) {
+    final var base = client.getConfiguration().getRestAddress().toString();
+    final var separator = base.endsWith("/") ? "" : "/";
+    return URI.create(base + separator + path);
+  }
+
+  private static Path createTempDirectory() {
+    try {
+      return Files.createTempDirectory("backup-exporting-authorization-it");
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  /** A REST endpoint under test, identified by HTTP method and path relative to the REST base. */
+  private record Endpoint(String method, String path) {
+
+    @Override
+    public String toString() {
+      return method + " /" + path;
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/ExportingServices.java
+++ b/service/src/main/java/io/camunda/service/ExportingServices.java
@@ -7,13 +7,12 @@
  */
 package io.camunda.service;
 
+import static io.camunda.service.authorization.Authorizations.EXPORTER_PAUSE_AUTHORIZATION;
+
 import io.camunda.security.api.model.CamundaAuthentication;
-import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.api.model.authz.AuthorizationScope;
-import io.camunda.security.api.model.authz.PermissionType;
 import io.camunda.security.api.model.config.AuthorizationsConfiguration;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
-import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.security.core.authz.AuthorizationChecker;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.security.SecurityContextProvider;
@@ -63,7 +62,7 @@ public final class ExportingServices extends PhysicalTenantScopedApiServices<Exp
 
   public CompletableFuture<Void> pauseExporting(
       final boolean soft, final CamundaAuthentication authentication) {
-    return withSystemUpdatePermission(
+    return withExporterPausePermission(
         authentication,
         () ->
             soft
@@ -72,24 +71,27 @@ public final class ExportingServices extends PhysicalTenantScopedApiServices<Exp
   }
 
   public CompletableFuture<Void> resumeExporting(final CamundaAuthentication authentication) {
-    return withSystemUpdatePermission(
+    return withExporterPausePermission(
         authentication, () -> exportingRequestBroadcaster.resumeExporting(getPhysicalTenantId()));
   }
 
   /**
-   * Runs {@code action} only if the caller holds the {@code SYSTEM/UPDATE} permission, mapping
+   * Runs {@code action} only if the caller holds the {@code EXPORTER/PAUSE} permission, mapping
    * failures from both the synchronous and asynchronous phases to {@link
    * io.camunda.service.exception.ServiceException} so they surface with the correct status. The
    * broadcaster validates topology synchronously (throwing before it returns a future) but
    * dispatches the broker requests asynchronously, so the returned future may also complete
    * exceptionally — both paths must be mapped.
+   *
+   * <p>Resume is gated on the same permission as pause: {@code EXPORTER} only defines {@code
+   * PAUSE}, and a caller allowed to stop exporting must also be able to start it again — otherwise
+   * they could leave the cluster in a paused state they cannot undo.
    */
-  private CompletableFuture<Void> withSystemUpdatePermission(
+  private CompletableFuture<Void> withExporterPausePermission(
       final CamundaAuthentication authentication, final Supplier<CompletableFuture<Void>> action) {
-    if (!hasSystemUpdatePermission(authentication)) {
+    if (!hasExporterPausePermission(authentication)) {
       return CompletableFuture.failedFuture(
-          ErrorMapper.createForbiddenException(
-              RequiredAuthorization.of(a -> a.system().permissionType(PermissionType.UPDATE))));
+          ErrorMapper.createForbiddenException(EXPORTER_PAUSE_AUTHORIZATION));
     }
 
     try {
@@ -101,14 +103,16 @@ public final class ExportingServices extends PhysicalTenantScopedApiServices<Exp
     }
   }
 
-  private boolean hasSystemUpdatePermission(final CamundaAuthentication authentication) {
+  private boolean hasExporterPausePermission(final CamundaAuthentication authentication) {
     if (!authorizationsConfig.isEnabled()) {
       return true;
     }
 
     return authorizationChecker
         .collectPermissionTypes(
-            AuthorizationScope.WILDCARD_CHAR, AuthorizationResourceType.SYSTEM, authentication)
-        .contains(PermissionType.UPDATE);
+            AuthorizationScope.WILDCARD_CHAR,
+            EXPORTER_PAUSE_AUTHORIZATION.resourceType(),
+            authentication)
+        .contains(EXPORTER_PAUSE_AUTHORIZATION.permissionType());
   }
 }

--- a/service/src/main/java/io/camunda/service/RuntimeBackupServices.java
+++ b/service/src/main/java/io/camunda/service/RuntimeBackupServices.java
@@ -7,10 +7,12 @@
  */
 package io.camunda.service;
 
+import static io.camunda.service.authorization.Authorizations.BACKUP_CREATE_AUTHORIZATION;
+import static io.camunda.service.authorization.Authorizations.BACKUP_DELETE_AUTHORIZATION;
+import static io.camunda.service.authorization.Authorizations.BACKUP_READ_AUTHORIZATION;
+
 import io.camunda.security.api.model.CamundaAuthentication;
-import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.api.model.authz.AuthorizationScope;
-import io.camunda.security.api.model.authz.PermissionType;
 import io.camunda.security.api.model.config.AuthorizationsConfiguration;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.core.auth.RequiredAuthorization;
@@ -62,8 +64,8 @@ public final class RuntimeBackupServices
 
   public CompletableFuture<Long> takeBackup(
       @Nullable final Long backupId, final CamundaAuthentication authentication) {
-    if (!hasPermission(PermissionType.UPDATE, authentication)) {
-      return failedFuture(PermissionType.UPDATE);
+    if (!hasPermission(BACKUP_CREATE_AUTHORIZATION, authentication)) {
+      return failedFuture(BACKUP_CREATE_AUTHORIZATION);
     }
 
     if (backupIdGenerated) {
@@ -91,8 +93,8 @@ public final class RuntimeBackupServices
 
   public CompletableFuture<BackupStatus> getBackupStatus(
       final long backupId, final CamundaAuthentication authentication) {
-    if (!hasPermission(PermissionType.READ, authentication)) {
-      return failedFuture(PermissionType.READ);
+    if (!hasPermission(BACKUP_READ_AUTHORIZATION, authentication)) {
+      return failedFuture(BACKUP_READ_AUTHORIZATION);
     }
 
     return mapErrors(
@@ -111,8 +113,8 @@ public final class RuntimeBackupServices
 
   public CompletableFuture<List<BackupStatus>> listBackups(
       final @Nullable String prefix, final CamundaAuthentication authentication) {
-    if (!hasPermission(PermissionType.READ, authentication)) {
-      return failedFuture(PermissionType.READ);
+    if (!hasPermission(BACKUP_READ_AUTHORIZATION, authentication)) {
+      return failedFuture(BACKUP_READ_AUTHORIZATION);
     }
 
     if (prefix != null && !prefix.endsWith(BackupApi.WILDCARD)) {
@@ -131,8 +133,8 @@ public final class RuntimeBackupServices
 
   public CompletableFuture<Void> deleteBackup(
       final long backupId, final CamundaAuthentication authentication) {
-    if (!hasPermission(PermissionType.UPDATE, authentication)) {
-      return failedFuture(PermissionType.UPDATE);
+    if (!hasPermission(BACKUP_DELETE_AUTHORIZATION, authentication)) {
+      return failedFuture(BACKUP_DELETE_AUTHORIZATION);
     }
 
     return mapErrors(
@@ -147,8 +149,8 @@ public final class RuntimeBackupServices
    */
   public CompletableFuture<RuntimeBackupState> getRuntimeState(
       final CamundaAuthentication authentication) {
-    if (!hasPermission(PermissionType.READ, authentication)) {
-      return failedFuture(PermissionType.READ);
+    if (!hasPermission(BACKUP_READ_AUTHORIZATION, authentication)) {
+      return failedFuture(BACKUP_READ_AUTHORIZATION);
     }
 
     final var checkpointState =
@@ -160,11 +162,14 @@ public final class RuntimeBackupServices
 
   /**
    * Force-writes checkpoint/backup metadata to the backup store, then returns the updated state.
+   *
+   * <p>Requires {@code BACKUP/CREATE} rather than {@code BACKUP/READ}: it creates backup metadata
+   * in the store, so it is a write operation from the caller's point of view.
    */
   public CompletableFuture<RuntimeBackupState> syncRuntimeState(
       final CamundaAuthentication authentication) {
-    if (!hasPermission(PermissionType.UPDATE, authentication)) {
-      return failedFuture(PermissionType.UPDATE);
+    if (!hasPermission(BACKUP_CREATE_AUTHORIZATION, authentication)) {
+      return failedFuture(BACKUP_CREATE_AUTHORIZATION);
     }
 
     final var ranges =
@@ -175,8 +180,8 @@ public final class RuntimeBackupServices
   }
 
   public CompletableFuture<Void> deleteRuntimeState(final CamundaAuthentication authentication) {
-    if (!hasPermission(PermissionType.UPDATE, authentication)) {
-      return failedFuture(PermissionType.UPDATE);
+    if (!hasPermission(BACKUP_DELETE_AUTHORIZATION, authentication)) {
+      return failedFuture(BACKUP_DELETE_AUTHORIZATION);
     }
 
     return mapErrors(
@@ -205,22 +210,23 @@ public final class RuntimeBackupServices
         });
   }
 
-  private <T> CompletableFuture<T> failedFuture(final PermissionType permissionType) {
+  private <T> CompletableFuture<T> failedFuture(
+      final RequiredAuthorization<?> requiredAuthorization) {
     return CompletableFuture.failedFuture(
-        ErrorMapper.createForbiddenException(
-            RequiredAuthorization.of(a -> a.system().permissionType(permissionType))));
+        ErrorMapper.createForbiddenException(requiredAuthorization));
   }
 
   private boolean hasPermission(
-      final PermissionType permission, final CamundaAuthentication authentication) {
+      final RequiredAuthorization<?> requiredAuthorization,
+      final CamundaAuthentication authentication) {
     if (!authorizationsConfig.isEnabled()) {
       return true;
     }
 
     return authorizationChecker
         .collectPermissionTypes(
-            AuthorizationScope.WILDCARD_CHAR, AuthorizationResourceType.SYSTEM, authentication)
-        .contains(permission);
+            AuthorizationScope.WILDCARD_CHAR, requiredAuthorization.resourceType(), authentication)
+        .contains(requiredAuthorization.permissionType());
   }
 
   public record RuntimeBackupState(

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -7,9 +7,14 @@
  */
 package io.camunda.service.authorization;
 
+import static io.camunda.security.api.model.authz.AuthorizationResourceType.BACKUP;
 import static io.camunda.security.api.model.authz.AuthorizationResourceType.COMPONENT;
+import static io.camunda.security.api.model.authz.AuthorizationResourceType.EXPORTER;
 import static io.camunda.security.api.model.authz.AuthorizationResourceType.SECRET;
 import static io.camunda.security.api.model.authz.PermissionType.ACCESS;
+import static io.camunda.security.api.model.authz.PermissionType.CREATE;
+import static io.camunda.security.api.model.authz.PermissionType.DELETE;
+import static io.camunda.security.api.model.authz.PermissionType.PAUSE;
 import static io.camunda.security.api.model.authz.PermissionType.READ;
 import static io.camunda.security.api.model.authz.PermissionType.READ_TASK_LISTENER;
 import static io.camunda.security.api.model.authz.PermissionType.REVEAL;
@@ -53,6 +58,15 @@ public abstract class Authorizations {
   public static final RequiredAuthorization<AuthorizationEntity> AUTHORIZATION_READ_AUTHORIZATION =
       RequiredAuthorization.of(a -> a.authorization().read());
 
+  public static final RequiredAuthorization<Object> BACKUP_CREATE_AUTHORIZATION =
+      RequiredAuthorization.of(a -> a.resourceType(BACKUP).permissionType(CREATE));
+
+  public static final RequiredAuthorization<Object> BACKUP_READ_AUTHORIZATION =
+      RequiredAuthorization.of(a -> a.resourceType(BACKUP).permissionType(READ));
+
+  public static final RequiredAuthorization<Object> BACKUP_DELETE_AUTHORIZATION =
+      RequiredAuthorization.of(a -> a.resourceType(BACKUP).permissionType(DELETE));
+
   public static final RequiredAuthorization<BatchOperationEntity>
       BATCH_OPERATION_READ_AUTHORIZATION = RequiredAuthorization.of(a -> a.batchOperation().read());
 
@@ -74,6 +88,9 @@ public abstract class Authorizations {
   public static final RequiredAuthorization<FlowNodeInstanceEntity>
       ELEMENT_INSTANCE_READ_AUTHORIZATION =
           RequiredAuthorization.of(a -> a.processDefinition().readProcessInstance());
+
+  public static final RequiredAuthorization<Object> EXPORTER_PAUSE_AUTHORIZATION =
+      RequiredAuthorization.of(a -> a.resourceType(EXPORTER).permissionType(PAUSE));
 
   public static final RequiredAuthorization<FormEntity> FORM_READ_AUTHORIZATION =
       RequiredAuthorization.of(a -> a.resource().read());

--- a/service/src/test/java/io/camunda/service/ExportingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/ExportingServicesTest.java
@@ -11,12 +11,14 @@ import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.api.model.authz.PermissionType;
 import io.camunda.security.api.model.config.AuthorizationsConfiguration;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
@@ -124,6 +126,69 @@ public class ExportingServicesTest {
         .isEqualTo(Status.FORBIDDEN);
     verify(exportingRequestBroadcaster, never()).pauseExporting(any());
     verify(exportingRequestBroadcaster, never()).softPauseExporting(any());
+  }
+
+  @Test
+  public void shouldDelegatePauseWhenUserHasExporterPausePermission() {
+    // given
+    grantExporterPausePermission();
+    when(exportingRequestBroadcaster.pauseExporting(PHYSICAL_TENANT_ID))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    final var future = services.pauseExporting(false, authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    verify(exportingRequestBroadcaster).pauseExporting(PHYSICAL_TENANT_ID);
+  }
+
+  @Test
+  public void shouldDelegateResumeWhenUserHasExporterPausePermission() {
+    // given
+    grantExporterPausePermission();
+    when(exportingRequestBroadcaster.resumeExporting(PHYSICAL_TENANT_ID))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    final var future = services.resumeExporting(authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    verify(exportingRequestBroadcaster).resumeExporting(PHYSICAL_TENANT_ID);
+  }
+
+  @Test
+  public void shouldFailPauseWithForbiddenWhenPausePermissionIsGrantedOnAnotherResourceType() {
+    // given - the caller holds PAUSE, but not on the EXPORTER resource type
+    authorizationsConfig.setEnabled(true);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Set.of(PermissionType.PAUSE));
+    when(authorizationChecker.collectPermissionTypes(
+            any(), eq(AuthorizationResourceType.EXPORTER), any()))
+        .thenReturn(Collections.emptySet());
+
+    // when
+    final var future = services.pauseExporting(false, authentication);
+
+    // then
+    assertThat(future)
+        .failsWithin(ofSeconds(1))
+        .withThrowableOfType(ExecutionException.class)
+        .havingCause()
+        .asInstanceOf(type(ServiceException.class))
+        .extracting(ServiceException::getStatus)
+        .isEqualTo(Status.FORBIDDEN);
+    verify(exportingRequestBroadcaster, never()).pauseExporting(any());
+  }
+
+  private void grantExporterPausePermission() {
+    authorizationsConfig.setEnabled(true);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Collections.emptySet());
+    when(authorizationChecker.collectPermissionTypes(
+            any(), eq(AuthorizationResourceType.EXPORTER), any()))
+        .thenReturn(Set.of(PermissionType.PAUSE));
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/RuntimeBackupServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RuntimeBackupServicesTest.java
@@ -10,12 +10,14 @@ package io.camunda.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.api.model.authz.PermissionType;
 import io.camunda.security.api.model.config.AuthorizationsConfiguration;
 import io.camunda.security.core.authz.AuthorizationChecker;
@@ -160,11 +162,9 @@ public class RuntimeBackupServicesTest {
   }
 
   @Test
-  public void takeBackupShouldCompleteExceptionallyWhenUserHasNoAuthorizations() {
+  public void takeBackupShouldCompleteExceptionallyWhenUserHasNoCreatePermission() {
     // given
-    authorizationsConfig.setEnabled(true);
-    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
-        .thenReturn(Collections.emptySet());
+    grantBackupPermissions(PermissionType.READ, PermissionType.DELETE);
 
     // when
     final var future = manualModeServices.takeBackup(42L, authentication);
@@ -175,11 +175,24 @@ public class RuntimeBackupServicesTest {
   }
 
   @Test
+  public void takeBackupShouldDelegateWhenUserHasCreatePermission() {
+    // given
+    grantBackupPermissions(PermissionType.CREATE);
+    when(backupApi.takeBackup(PHYSICAL_TENANT_ID, 42L))
+        .thenReturn(CompletableFuture.completedFuture(42L));
+
+    // when
+    final var future = manualModeServices.takeBackup(42L, authentication);
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofSeconds(1));
+    verify(backupApi).takeBackup(PHYSICAL_TENANT_ID, 42L);
+  }
+
+  @Test
   public void getBackupStatusShouldDelegateWhenAuthorized() {
     // given
-    authorizationsConfig.setEnabled(true);
-    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
-        .thenReturn(Set.of(PermissionType.READ));
+    grantBackupPermissions(PermissionType.READ);
     final var status = new BackupStatus(42L, State.COMPLETED, Optional.empty(), List.of());
     when(backupApi.getStatus(PHYSICAL_TENANT_ID, 42L))
         .thenReturn(CompletableFuture.completedFuture(status));
@@ -208,9 +221,7 @@ public class RuntimeBackupServicesTest {
   @Test
   public void getBackupStatusShouldCompleteExceptionallyWhenUserHasNoReadPermission() {
     // given
-    authorizationsConfig.setEnabled(true);
-    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
-        .thenReturn(Collections.emptySet());
+    grantBackupPermissions(PermissionType.CREATE, PermissionType.DELETE);
 
     // when
     final var future = manualModeServices.getBackupStatus(42L, authentication);
@@ -273,11 +284,9 @@ public class RuntimeBackupServicesTest {
   }
 
   @Test
-  public void deleteBackupShouldCompleteExceptionallyWhenUserHasNoUpdatePermission() {
+  public void deleteBackupShouldCompleteExceptionallyWhenUserHasNoDeletePermission() {
     // given
-    authorizationsConfig.setEnabled(true);
-    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
-        .thenReturn(Set.of(PermissionType.READ));
+    grantBackupPermissions(PermissionType.READ, PermissionType.CREATE);
 
     // when
     final var future = manualModeServices.deleteBackup(42L, authentication);
@@ -364,11 +373,9 @@ public class RuntimeBackupServicesTest {
   }
 
   @Test
-  public void syncRuntimeStateShouldCompleteExceptionallyWhenUserHasNoUpdatePermission() {
+  public void syncRuntimeStateShouldCompleteExceptionallyWhenUserHasNoCreatePermission() {
     // given
-    authorizationsConfig.setEnabled(true);
-    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
-        .thenReturn(Set.of(PermissionType.READ));
+    grantBackupPermissions(PermissionType.READ, PermissionType.DELETE);
 
     // when
     final var future = manualModeServices.syncRuntimeState(authentication);
@@ -393,11 +400,9 @@ public class RuntimeBackupServicesTest {
   }
 
   @Test
-  public void deleteRuntimeStateShouldCompleteExceptionallyWhenUserHasNoUpdatePermission() {
+  public void deleteRuntimeStateShouldCompleteExceptionallyWhenUserHasNoDeletePermission() {
     // given
-    authorizationsConfig.setEnabled(true);
-    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
-        .thenReturn(Set.of(PermissionType.READ));
+    grantBackupPermissions(PermissionType.READ, PermissionType.CREATE);
 
     // when
     final var future = manualModeServices.deleteRuntimeState(authentication);
@@ -405,6 +410,19 @@ public class RuntimeBackupServicesTest {
     // then
     assertServiceExceptionStatus(future, Status.FORBIDDEN);
     verify(backupApi, never()).deleteRuntimeState(any());
+  }
+
+  /**
+   * Enables authorizations and grants the given permissions on the {@code BACKUP} resource type
+   * only, so that a check against any other resource type resolves to "no permissions".
+   */
+  private void grantBackupPermissions(final PermissionType... permissions) {
+    authorizationsConfig.setEnabled(true);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Collections.emptySet());
+    when(authorizationChecker.collectPermissionTypes(
+            any(), eq(AuthorizationResourceType.BACKUP), any()))
+        .thenReturn(Set.of(permissions));
   }
 
   private void assertServiceExceptionStatus(

--- a/service/src/test/java/io/camunda/service/RuntimeBackupServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RuntimeBackupServicesTest.java
@@ -270,6 +270,34 @@ public class RuntimeBackupServicesTest {
   }
 
   @Test
+  public void listBackupsShouldDelegateWhenUserHasReadPermission() {
+    // given
+    grantBackupPermissions(PermissionType.READ);
+    when(backupApi.listBackups(PHYSICAL_TENANT_ID, BackupApi.WILDCARD))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    // when
+    final var future = manualModeServices.listBackups(null, authentication);
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofSeconds(1));
+    verify(backupApi).listBackups(PHYSICAL_TENANT_ID, BackupApi.WILDCARD);
+  }
+
+  @Test
+  public void listBackupsShouldCompleteExceptionallyWhenUserHasNoReadPermission() {
+    // given
+    grantBackupPermissions(PermissionType.CREATE, PermissionType.DELETE);
+
+    // when
+    final var future = manualModeServices.listBackups(null, authentication);
+
+    // then
+    assertServiceExceptionStatus(future, Status.FORBIDDEN);
+    verify(backupApi, never()).listBackups(any(), any());
+  }
+
+  @Test
   public void deleteBackupShouldDelegate() {
     // given
     when(backupApi.deleteBackup(PHYSICAL_TENANT_ID, 42L))
@@ -332,6 +360,36 @@ public class RuntimeBackupServicesTest {
 
     // then
     assertServiceExceptionStatus(future, Status.UNAVAILABLE);
+  }
+
+  @Test
+  public void getRuntimeStateShouldDelegateWhenUserHasReadPermission() {
+    // given
+    grantBackupPermissions(PermissionType.READ);
+    when(backupApi.getCheckpointState(PHYSICAL_TENANT_ID))
+        .thenReturn(CompletableFuture.completedFuture(new CheckpointStateResponse()));
+    when(backupApi.getBackupRanges(PHYSICAL_TENANT_ID))
+        .thenReturn(CompletableFuture.completedFuture(new BackupRangesResponse()));
+
+    // when
+    final var future = manualModeServices.getRuntimeState(authentication);
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofSeconds(1));
+  }
+
+  @Test
+  public void getRuntimeStateShouldCompleteExceptionallyWhenUserHasNoReadPermission() {
+    // given
+    grantBackupPermissions(PermissionType.CREATE, PermissionType.DELETE);
+
+    // when
+    final var future = manualModeServices.getRuntimeState(authentication);
+
+    // then
+    assertServiceExceptionStatus(future, Status.FORBIDDEN);
+    verify(backupApi, never()).getCheckpointState(any());
+    verify(backupApi, never()).getBackupRanges(any());
   }
 
   @Test


### PR DESCRIPTION
## Description

The per-physical-tenant runtime backup and exporting REST endpoints now authorize against the dedicated `BACKUP` and `EXPORTER` resource types added in #58301, instead of the generic `SYSTEM` type.

| Endpoint | Before | After |
|---|---|---|
| `POST /v2/backups/runtime` | SYSTEM/UPDATE | BACKUP/CREATE |
| `POST /v2/backups/runtime/state/sync` | SYSTEM/UPDATE | BACKUP/CREATE |
| `GET /v2/backups/runtime`, `/{backupId}`, `/state` | SYSTEM/READ | BACKUP/READ |
| `DELETE /v2/backups/runtime/{backupId}`, `/state` | SYSTEM/UPDATE | BACKUP/DELETE |
| `POST /v2/exporting/pause`, `/resume` | SYSTEM/UPDATE | EXPORTER/PAUSE |

### Decisions worth reviewing

- **`state/sync` requires CREATE, not READ.** It force-writes backup metadata to the store, so it's a write from the caller's point of view. Gating it on READ would let a read-only principal write to the backup store. `BACKUP` intentionally defines no `UPDATE`, so CREATE is the closest fit.
- **Resume shares `EXPORTER/PAUSE` with pause.** `EXPORTER` only defines `PAUSE`. The alternative — leaving resume on `SYSTEM/UPDATE` — would mean a caller could pause exporting but not undo it, leaving the cluster stuck.
- **Controllers are unchanged.** These aren't engine commands, so they're authorized explicitly in the service layer per ADR 002 D2, matching `SecretServices`/`SecretController`.

## Related issues

closes #58890
