### PR TITLE
test: pin custom-headers tasklist test to its own seeded instance

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -15,7 +15,8 @@ import {sleep} from 'utils/sleep';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {findUserTask, expectProcessState} from '@requestHelpers';
 import {buildUrl, jsonHeaders} from 'utils/http';
-import {defaultAssertionOptions} from 'utils/constants';
+
+let customHeadersProcessInstanceKey: string;
 
 test.beforeAll(async () => {
   await deploy([
@@ -84,8 +85,16 @@ test.beforeAll(async () => {
     createInstances('zeebe_and_job_worker_process', 1, 1),
     createInstances('bigVariableProcessWithForm', 1, 1),
     createInstances('employee_registration_no_output_mapping', 1, 1),
-    createInstances('usertask_with_custom_headers', 1, 1),
   ]);
+
+  const [customHeadersInstance] = await createInstances(
+    'usertask_with_custom_headers',
+    1,
+    1,
+  );
+  customHeadersProcessInstanceKey = String(
+    customHeadersInstance.processInstanceKey,
+  );
 
   await sleep(1000);
 });
@@ -710,25 +719,12 @@ test.describe('task details page', () => {
     taskPanelPage,
     taskDetailsPage,
   }) => {
-    let processInstanceKey = '';
-    await expect(async () => {
-      const res = await request.post(buildUrl('/process-instances/search'), {
-        headers: jsonHeaders(),
-        data: {
-          filter: {
-            processDefinitionId: 'usertask_with_custom_headers',
-            state: 'ACTIVE',
-          },
-        },
-      });
-      const body = await res.json();
-      // This spec runs under several Playwright projects against one shared
-      // cluster and each project's beforeAll seeds an instance, so more than
-      // one ACTIVE instance of this process can exist. Take any one and drive
-      // the rest of the flow against that specific instance.
-      expect(body.items.length).toBeGreaterThanOrEqual(1);
-      processInstanceKey = body.items[0].processInstanceKey;
-    }).toPass(defaultAssertionOptions);
+    // Drive the flow against the exact instance this project seeded in
+    // beforeAll. This spec runs under several Playwright projects against one
+    // shared cluster, so searching /process-instances for an ACTIVE instance
+    // could return one another project is concurrently assigning/completing,
+    // making findUserTask's single-CREATED-task assertion race.
+    const processInstanceKey = customHeadersProcessInstanceKey;
 
     const userTaskKey = await findUserTask(
       request,


### PR DESCRIPTION
## Description

[Successful run](https://github.com/camunda/camunda/actions/runs/30438379650/job/90531491975) ✅ 

Follow-up to #58972 addressing [Copilot's review comment](https://github.com/camunda/camunda/pull/58972#discussion_r3672203487) on the "user task with custom headers" test.

That test still selected an ACTIVE instance of `usertask_with_custom_headers` via `/process-instances/search` and drove the flow against `items[0]`. Because this suite runs under several Playwright projects against **one shared cluster**, the shared search result can point at an instance another project is concurrently assigning/completing — so `findUserTask`'s "exactly one CREATED task" assertion (and the subsequent assign/complete) can still race. Tolerating multiple instances removed the deterministic `exactly 1` failure but not the cross-project contention.

This change captures the `processInstanceKey` of the instance **this project seeds in `beforeAll`** and drives the flow against that exact key, giving each run its own isolated instance. It follows the existing `const [instance] = await createInstances(...)` destructuring pattern already used elsewhere in the suite, and the repo's test-isolation guideline (unique data per test).

Stacked on `fix/nightly-8.8-tasklist-shared-cluster-isolation` (#58972); retarget to `stable/8.8` once that merges.

Test-only change (`test:` type). Prettier + eslint clean on the changed file (only the pre-existing `test.skip` for bug #54020 remains); `tsc` shows only the pre-existing `versionCells` error in `processInstanceMigration.spec.ts`, unrelated to this change.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Addresses a review comment on #58972