### PR TITLE
feat: explicitly filter agent instance history item roles

### DIFF
--- a/operate/client/src/modules/queries/agentInstances/useAgentInstanceHistory.ts
+++ b/operate/client/src/modules/queries/agentInstances/useAgentInstanceHistory.ts
@@ -38,6 +38,7 @@ const useAgentInstanceHistory = <
   const historyPayload: QueryAgentInstanceHistoryRequestBody = {
     sort: [{field: 'producedAt', order: options?.sortOrder ?? 'desc'}],
     filter: {
+      role: {$in: ['ASSISTANT', 'USER', 'TOOL_RESULT']},
       commitStatus: 'COMMITTED',
       elementInstanceKey: options?.elementInstanceKey ?? undefined,
     },


### PR DESCRIPTION
## Description

This PR hardens the frontend for #58787, which likely introduces new history item roles. Whenever we call the history search, we are now explicitly filtering roles we currently support. The API is called in two places:
- [`useLatestAgentMessage`](https://github.com/camunda/camunda/blob/a3671ff92ac9bbf222aae26596b463c62675b0f3/operate/client/src/modules/queries/agentInstances/useLatestAgentMessage.ts#L16): Already filtered for the `ASSISTANT` role
- [`useAgentInstanceHistory`](https://github.com/camunda/camunda/blob/a3671ff92ac9bbf222aae26596b463c62675b0f3/operate/client/src/modules/queries/agentInstances/useAgentInstanceHistory.ts#L41): This PR. Now provides an `$in` filter with all currently known roles.

## Related issues

relates #58787
