### PR TITLE
fix: load-test: set Keycloak hostname to localhost

### DIFF
--- a/load-tests/setup/charts/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/charts/load-test-setup/templates/keycloak/keycloak.yaml
@@ -60,7 +60,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "{{ .Release.Namespace }}"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-main-chaos-killer"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-main-elasticsearch-stable"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-main-elasticsearch"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/main/max/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/max/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-main-max"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/main/none-optimize/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-main-none-optimize"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/main/none/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/none/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-main-none"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-main-opensearch-stable"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/main/opensearch/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-main-opensearch"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-main-rdbms-optimize"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-main-rdbms-physical-tenants"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-main-rdbms-stable"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-main-rdbms"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/main/realistic/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/realistic/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-main-realistic"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-87-chaos-killer"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-87-elasticsearch-stable"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-87-elasticsearch"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-87/max/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-87/max/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-87-max"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-87/realistic/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-87/realistic/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-87-realistic"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-88-chaos-killer"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-88-elasticsearch-stable"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-88-elasticsearch"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-88/max/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/max/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-88-max"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-88-none-optimize"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-88/none/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-88-none"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-88-opensearch-stable"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-88-opensearch"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-88-realistic"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-89-chaos-killer"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-89-elasticsearch-stable"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-89-elasticsearch"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-89/max/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/max/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-89-max"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-89-none-optimize"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-89/none/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-89-none"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-89-opensearch-stable"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-89-opensearch"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-89-rdbms-optimize"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-89-rdbms-stable"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-89-rdbms"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:

--- a/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/templates/keycloak/keycloak.yaml
@@ -56,7 +56,10 @@ spec:
     enabled: false
 
   hostname:
-    hostname: "c8-golden-stable-89-realistic"
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
     strict: false
 
   resources:


### PR DESCRIPTION


## Description

This is used (at least) when we authenticate through the UI. Keycloak may redirect web clients to the hostname exposed here. Since the assumption is to port-forward to Keycloak if we want to use it locally, this should be set to `localhost` as web clients connect on http://localhost:18080.

Otherwise, Keycloak redirect to `{{ .Release.Namespace }}`, which is not reachable from outside the cluster.

It's not 100% clear in the doc what are the consequences here though: https://www.keycloak.org/operator/advanced-configuration#_configuring_the_kubernetes_service_name_and_port

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
