### PR TITLE
test: retry Optimize cloud E2E smoke test to absorb transient accounts-API timeouts

### DIFF
--- a/optimize/client/package.json
+++ b/optimize/client/package.json
@@ -44,7 +44,7 @@
     "e2e:visual:update": "testcafe 'chrome:headless --disable-features=LocalNetworkAccessChecks' e2e/sm-tests/*.js --test-meta type=visual -s path=e2e/screenshots --take-snapshot base",
     "e2e:visual": "testcafe 'chrome:headless --disable-features=LocalNetworkAccessChecks' e2e/sm-tests/*.js --test-meta type=visual -s path=e2e/screenshots --take-snapshot actual",
     "e2e:visual:compare": "testcafe-blink-diff e2e/screenshots e2e/screenshots --compare base:actual --open --threshold 0.4 || exit 1",
-    "e2e:ci:cloud:headless": "testcafe 'chrome:headless --disable-features=LocalNetworkAccessChecks' e2e/cloud-tests/smokeTest.js -e",
+    "e2e:ci:cloud:headless": "testcafe 'chrome:headless --disable-features=LocalNetworkAccessChecks' e2e/cloud-tests/smokeTest.js -e --assertion-timeout 40000 -q attemptLimit=3,successThreshold=1",
     "e2e:ci:sm:smoke:headless": "FORCE_COLOR=1 stdbuf -oL -eL testcafe 'chrome:headless --disable-features=LocalNetworkAccessChecks --no-sandbox --disable-dev-shm-usage --disable-gpu' e2e/sm-tests/*.js --test-meta type=smoke -e --assertion-timeout 40000 -q attemptLimit=3,successThreshold=1",
     "e2e:ci:sm:nightly:headless": "testcafe -c 3 'chrome:headless --disable-features=LocalNetworkAccessChecks' e2e/sm-tests/*.js -e --disable-screenshots --assertion-timeout 40000 -q attemptLimit=3,successThreshold=1",
     "e2e:cloud": "testcafe chrome e2e/cloud-tests/smokeTest.js",


### PR DESCRIPTION
## Description

The `Optimize / E2E Cloud` CI job intermittently fails on `main`. The smoke test
`create a report from a template` dies while loading the home page — e.g.
`The specified selector does not match any element in the DOM tree` for
`Selector('.CreateNewButton')` (and, in other runs, one step earlier at the
`collections` nav link).

Root cause is not a regression: the `.CreateNewButton` class still exists and the
failing runs were triggered by unrelated commits. The backend logs show the real
cause — while the page was loading, the backend's `getCurrentUser` call
(`CCSaaSUserClient.getCloudUserById`) to the **external Camunda Cloud accounts API**
timed out (`java.net.SocketTimeoutException: Read timed out`), returning 500 to the
frontend ~2s before the test interacted with the page. Without the current user, the
home page never rendered the create button.

None of the layers retried this transient failure:
- the `e2e:ci:cloud:headless` command ran with `-e` and **no quarantine mode**
  (unlike the sibling `e2e:ci:sm:*` commands, which already use `attemptLimit=3`),
- the CCSaaS HTTP client does not retry, and Apache HttpClient's default handler does
  not retry `SocketTimeoutException`,
- there is no job-level auto-rerun.

This change brings the cloud smoke command in line with the other smoke commands by
enabling TestCafe quarantine mode. On failure the whole test re-runs from scratch
(fresh browser session, re-login, re-navigation) up to 3 times and is marked green on
the first passing attempt — so a single transient accounts-API timeout no longer fails
the job. The `--assertion-timeout 40000` is added for parity with the sibling commands.

```diff
- "e2e:ci:cloud:headless": "testcafe '...' e2e/cloud-tests/smokeTest.js -e",
+ "e2e:ci:cloud:headless": "testcafe '...' e2e/cloud-tests/smokeTest.js -e --assertion-timeout 40000 -q attemptLimit=3,successThreshold=1",
```

This mitigates the flake at the CI layer; it does not change product behavior. A
backend-side retry/tolerance for a transient `getCurrentUser` failure would help real
users too, but is a larger behavioral change tracked separately.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Incident: https://camunda.slack.com/archives/C0BLGSAEA12
