### PR TITLE
feat: add suspendedDate filter, sort, and result field to CamundaClient process instance search

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilter.java
@@ -122,6 +122,14 @@ public interface ProcessInstanceFilter extends ProcessInstanceFilterBase {
   @Override
   ProcessInstanceFilter hasIncident(final Boolean hasIncident);
 
+  /** Filter by suspendedDate */
+  @Override
+  ProcessInstanceFilter suspendedDate(final OffsetDateTime suspendedDate);
+
+  /** Filter by suspendedDate using {@link DateTimeProperty} consumer */
+  @Override
+  ProcessInstanceFilter suspendedDate(final Consumer<DateTimeProperty> fn);
+
   /** Filter by tenantId */
   @Override
   ProcessInstanceFilter tenantId(final String tenantId);

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilterBase.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilterBase.java
@@ -101,6 +101,12 @@ public interface ProcessInstanceFilterBase extends SearchRequestFilter {
   /** Filter by hasIncident */
   ProcessInstanceFilterBase hasIncident(final Boolean hasIncident);
 
+  /** Filter by suspendedDate */
+  ProcessInstanceFilterBase suspendedDate(final OffsetDateTime suspendedDate);
+
+  /** Filter by suspendedDate using {@link DateTimeProperty} consumer */
+  ProcessInstanceFilterBase suspendedDate(final Consumer<DateTimeProperty> fn);
+
   /** Filter by tenantId */
   ProcessInstanceFilterBase tenantId(final String tenantId);
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/ProcessInstance.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/ProcessInstance.java
@@ -52,6 +52,12 @@ public interface ProcessInstance {
 
   OffsetDateTime getEndDate();
 
+  /**
+   * @return the time this process instance most recently entered the {@code SUSPENDED} state, or
+   *     {@code null} if it is not currently suspended
+   */
+  OffsetDateTime getSuspendedDate();
+
   ProcessInstanceState getState();
 
   Boolean getHasIncident();

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/ProcessInstanceSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/ProcessInstanceSort.java
@@ -39,6 +39,8 @@ public interface ProcessInstanceSort extends SearchRequestSort<ProcessInstanceSo
 
   ProcessInstanceSort endDate();
 
+  ProcessInstanceSort suspendedDate();
+
   ProcessInstanceSort state();
 
   ProcessInstanceSort hasIncident();

--- a/clients/java/src/main/java/io/camunda/client/api/statistics/filter/ProcessDefinitionStatisticsFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/statistics/filter/ProcessDefinitionStatisticsFilter.java
@@ -84,6 +84,14 @@ public interface ProcessDefinitionStatisticsFilter extends ProcessDefinitionStat
   @Override
   ProcessDefinitionStatisticsFilter hasIncident(final Boolean hasIncident);
 
+  /** Filter by suspendedDate */
+  @Override
+  ProcessDefinitionStatisticsFilter suspendedDate(final OffsetDateTime suspendedDate);
+
+  /** Filter by suspendedDate using {@link DateTimeProperty} consumer */
+  @Override
+  ProcessDefinitionStatisticsFilter suspendedDate(final Consumer<DateTimeProperty> fn);
+
   /** Filter by tenantId */
   @Override
   ProcessDefinitionStatisticsFilter tenantId(final String tenantId);

--- a/clients/java/src/main/java/io/camunda/client/api/statistics/filter/ProcessDefinitionStatisticsFilterBase.java
+++ b/clients/java/src/main/java/io/camunda/client/api/statistics/filter/ProcessDefinitionStatisticsFilterBase.java
@@ -75,6 +75,12 @@ public interface ProcessDefinitionStatisticsFilterBase extends StatisticsRequest
   /** Filter by hasIncident */
   ProcessDefinitionStatisticsFilterBase hasIncident(final Boolean hasIncident);
 
+  /** Filter by suspendedDate */
+  ProcessDefinitionStatisticsFilterBase suspendedDate(final OffsetDateTime suspendedDate);
+
+  /** Filter by suspendedDate using {@link DateTimeProperty} consumer */
+  ProcessDefinitionStatisticsFilterBase suspendedDate(final Consumer<DateTimeProperty> fn);
+
   /** Filter by tenantId */
   ProcessDefinitionStatisticsFilterBase tenantId(final String tenantId);
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
@@ -216,6 +216,20 @@ public class ProcessInstanceFilterImpl
   }
 
   @Override
+  public ProcessInstanceFilter suspendedDate(final OffsetDateTime suspendedDate) {
+    suspendedDate(b -> b.eq(suspendedDate));
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceFilter suspendedDate(final Consumer<DateTimeProperty> fn) {
+    final DateTimeProperty property = new DateTimePropertyImpl();
+    fn.accept(property);
+    filter.setSuspendedDate(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
   public ProcessInstanceFilter tenantId(final String tenantId) {
     tenantId(b -> b.eq(tenantId));
     return this;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessInstanceImpl.java
@@ -36,6 +36,7 @@ public class ProcessInstanceImpl implements ProcessInstance {
   private final Long parentElementInstanceKey;
   private final OffsetDateTime startDate;
   private final OffsetDateTime endDate;
+  private final OffsetDateTime suspendedDate;
   private final ProcessInstanceState state;
   private final Boolean hasIncident;
   private final String tenantId;
@@ -54,6 +55,7 @@ public class ProcessInstanceImpl implements ProcessInstance {
     parentElementInstanceKey = ParseUtil.parseLongOrNull(item.getParentElementInstanceKey());
     startDate = ParseUtil.parseOffsetDateTimeOrNull(item.getStartDate());
     endDate = ParseUtil.parseOffsetDateTimeOrNull(item.getEndDate());
+    suspendedDate = ParseUtil.parseOffsetDateTimeOrNull(item.getSuspendedDate());
     state = EnumUtil.convert(item.getState(), ProcessInstanceState.class);
     hasIncident = item.getHasIncident();
     tenantId = item.getTenantId();
@@ -114,6 +116,11 @@ public class ProcessInstanceImpl implements ProcessInstance {
   @Override
   public OffsetDateTime getEndDate() {
     return endDate;
+  }
+
+  @Override
+  public OffsetDateTime getSuspendedDate() {
+    return suspendedDate;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/ProcessInstanceSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/ProcessInstanceSortImpl.java
@@ -72,6 +72,11 @@ public class ProcessInstanceSortImpl extends SearchRequestSortBase<ProcessInstan
   }
 
   @Override
+  public ProcessInstanceSort suspendedDate() {
+    return field("suspendedDate");
+  }
+
+  @Override
   public ProcessInstanceSort state() {
     return field("state");
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/filter/ProcessDefinitionStatisticsFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/filter/ProcessDefinitionStatisticsFilterImpl.java
@@ -128,6 +128,20 @@ public class ProcessDefinitionStatisticsFilterImpl
   }
 
   @Override
+  public ProcessDefinitionStatisticsFilter suspendedDate(final OffsetDateTime suspendedDate) {
+    suspendedDate(b -> b.eq(suspendedDate));
+    return this;
+  }
+
+  @Override
+  public ProcessDefinitionStatisticsFilter suspendedDate(final Consumer<DateTimeProperty> fn) {
+    final DateTimeProperty property = new DateTimePropertyImpl();
+    fn.accept(property);
+    filter.setSuspendedDate(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
   public ProcessDefinitionStatisticsFilter state(final ProcessInstanceState state) {
     return state(b -> b.eq(state));
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/util/ProcessDefinitionStatisticsFilterMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/ProcessDefinitionStatisticsFilterMapper.java
@@ -36,6 +36,7 @@ public final class ProcessDefinitionStatisticsFilterMapper {
     target.setEndDate(filter.getEndDate());
     target.setState(filter.getState());
     target.setHasIncident(filter.getHasIncident());
+    target.setSuspendedDate(filter.getSuspendedDate());
     target.setTenantId(filter.getTenantId());
     target.setVariables(filter.getVariables());
     target.setProcessInstanceKey(filter.getProcessInstanceKey());

--- a/clients/java/src/test/java/io/camunda/client/process/ProcessDefinitionStatisticsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/ProcessDefinitionStatisticsTest.java
@@ -63,6 +63,7 @@ public class ProcessDefinitionStatisticsTest extends ClientRestTest {
     // when
     final OffsetDateTime startDate = OffsetDateTime.now().minusDays(1);
     final OffsetDateTime endDate = OffsetDateTime.now();
+    final OffsetDateTime suspendedDate = OffsetDateTime.now().minusHours(3);
     final Map<String, Object> variablesMap = new LinkedHashMap<>();
     variablesMap.put("n1", "v1");
     variablesMap.put("n2", "v2");
@@ -83,6 +84,7 @@ public class ProcessDefinitionStatisticsTest extends ClientRestTest {
                     .parentElementInstanceKey(30L)
                     .startDate(startDate)
                     .endDate(endDate)
+                    .suspendedDate(suspendedDate)
                     .state(ProcessInstanceState.ACTIVE)
                     .hasIncident(true)
                     .tenantId("tenant")
@@ -108,6 +110,7 @@ public class ProcessDefinitionStatisticsTest extends ClientRestTest {
     assertThat(filter.getParentElementInstanceKey().get$Eq()).isEqualTo("30");
     assertThat(filter.getStartDate().get$Eq()).isEqualTo(startDate.toString());
     assertThat(filter.getEndDate().get$Eq()).isEqualTo(endDate.toString());
+    assertThat(filter.getSuspendedDate().get$Eq()).isEqualTo(suspendedDate.toString());
     assertThat(filter.getState().get$Eq()).isEqualTo(ProcessInstanceStateEnum.ACTIVE);
     assertThat(filter.getHasIncident()).isEqualTo(true);
     assertThat(filter.getTenantId().get$Eq()).isEqualTo("tenant");

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
@@ -24,8 +24,10 @@ import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.search.enums.ElementInstanceState;
 import io.camunda.client.api.search.filter.ProcessInstanceFilterBase;
+import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.impl.search.request.SearchRequestSort;
 import io.camunda.client.impl.search.request.SearchRequestSortMapper;
+import io.camunda.client.impl.search.response.ProcessInstanceImpl;
 import io.camunda.client.protocol.rest.*;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
@@ -71,6 +73,7 @@ public class QueryProcessInstanceTest extends ClientRestTest {
     // when
     final OffsetDateTime startDate = OffsetDateTime.now().minusDays(1);
     final OffsetDateTime endDate = OffsetDateTime.now();
+    final OffsetDateTime suspendedDate = OffsetDateTime.now().minusHours(2);
     final Map<String, Object> variablesMap = new LinkedHashMap<>();
     variablesMap.put("n1", "v1");
     variablesMap.put("n2", "v2");
@@ -98,6 +101,7 @@ public class QueryProcessInstanceTest extends ClientRestTest {
                     .endDate(endDate)
                     .state(ACTIVE)
                     .hasIncident(true)
+                    .suspendedDate(suspendedDate)
                     .tenantId("tenant")
                     .variables(variablesMap)
                     .batchOperationId("batchOperationId")
@@ -128,6 +132,7 @@ public class QueryProcessInstanceTest extends ClientRestTest {
     assertThat(filter.getState().get$Eq())
         .isEqualTo(io.camunda.client.protocol.rest.ProcessInstanceStateEnum.ACTIVE);
     assertThat(filter.getHasIncident()).isEqualTo(true);
+    assertThat(filter.getSuspendedDate().get$Eq()).isEqualTo(suspendedDate.toString());
     assertThat(filter.getTenantId().get$Eq()).isEqualTo("tenant");
     assertThat(filter.getVariables()).isEqualTo(variables);
     assertThat(filter.getBatchOperationId().get$Eq()).isEqualTo("batchOperationId");
@@ -253,6 +258,28 @@ public class QueryProcessInstanceTest extends ClientRestTest {
   }
 
   @Test
+  void shouldSearchProcessInstanceBySuspendedDateRange() {
+    // given
+    final OffsetDateTime from = OffsetDateTime.now().minusDays(1);
+    final OffsetDateTime to = OffsetDateTime.now();
+
+    // when
+    client
+        .newProcessInstanceSearchRequest()
+        .filter(f -> f.suspendedDate(d -> d.gte(from).lte(to)))
+        .send()
+        .join();
+
+    // then
+    final ProcessInstanceSearchQuery request =
+        gatewayService.getLastRequest(ProcessInstanceSearchQuery.class);
+    final ProcessInstanceFilter filter = request.getFilter();
+    assertThat(filter).isNotNull();
+    assertThat(filter.getSuspendedDate().get$Gte()).isEqualTo(from.toString());
+    assertThat(filter.getSuspendedDate().get$Lte()).isEqualTo(to.toString());
+  }
+
+  @Test
   void shouldSearchProcessInstanceByVariablesFilter() {
     // given
     final Map<String, Object> variablesMap = new LinkedHashMap<>();
@@ -305,6 +332,8 @@ public class QueryProcessInstanceTest extends ClientRestTest {
                     .asc()
                     .endDate()
                     .asc()
+                    .suspendedDate()
+                    .desc()
                     .state()
                     .asc()
                     .hasIncident()
@@ -322,7 +351,7 @@ public class QueryProcessInstanceTest extends ClientRestTest {
     final List<SearchRequestSort> sorts =
         SearchRequestSortMapper.fromProcessInstanceSearchQuerySortRequest(
             Objects.requireNonNull(request.getSort()));
-    assertThat(sorts).hasSize(14);
+    assertThat(sorts).hasSize(15);
     assertSort(sorts.get(0), "processInstanceKey", SortOrderEnum.ASC);
     assertSort(sorts.get(1), "processDefinitionId", SortOrderEnum.DESC);
     assertSort(sorts.get(2), "processDefinitionName", SortOrderEnum.ASC);
@@ -333,10 +362,11 @@ public class QueryProcessInstanceTest extends ClientRestTest {
     assertSort(sorts.get(7), "parentElementInstanceKey", SortOrderEnum.ASC);
     assertSort(sorts.get(8), "startDate", SortOrderEnum.ASC);
     assertSort(sorts.get(9), "endDate", SortOrderEnum.ASC);
-    assertSort(sorts.get(10), "state", SortOrderEnum.ASC);
-    assertSort(sorts.get(11), "hasIncident", SortOrderEnum.DESC);
-    assertSort(sorts.get(12), "tenantId", SortOrderEnum.ASC);
-    assertSort(sorts.get(13), "businessId", SortOrderEnum.ASC);
+    assertSort(sorts.get(10), "suspendedDate", SortOrderEnum.DESC);
+    assertSort(sorts.get(11), "state", SortOrderEnum.ASC);
+    assertSort(sorts.get(12), "hasIncident", SortOrderEnum.DESC);
+    assertSort(sorts.get(13), "tenantId", SortOrderEnum.ASC);
+    assertSort(sorts.get(14), "businessId", SortOrderEnum.ASC);
   }
 
   @Test
@@ -424,6 +454,32 @@ public class QueryProcessInstanceTest extends ClientRestTest {
                     .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("batchOperationKey");
+  }
+
+  @Test
+  void shouldMapSuspendedDateFromResult() {
+    // given
+    final OffsetDateTime suspendedDate = OffsetDateTime.now();
+    final ProcessInstanceResult result =
+        new ProcessInstanceResult().suspendedDate(suspendedDate.toString());
+
+    // when
+    final ProcessInstance processInstance = new ProcessInstanceImpl(result);
+
+    // then
+    assertThat(processInstance.getSuspendedDate()).isEqualTo(suspendedDate);
+  }
+
+  @Test
+  void shouldMapNullSuspendedDateFromResult() {
+    // given
+    final ProcessInstanceResult result = new ProcessInstanceResult();
+
+    // when
+    final ProcessInstance processInstance = new ProcessInstanceImpl(result);
+
+    // then
+    assertThat(processInstance.getSuspendedDate()).isNull();
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendedSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendedSearchIT.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.client.api.search.enums.ProcessInstanceState.SUSPENDED;
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class ProcessInstanceSuspendedSearchIT {
+
+  private static final String PROCESS_ID = "service_tasks_v1";
+
+  private static CamundaClient camundaClient;
+  private static long suspendedInstanceKey;
+  private static long activeInstanceKey;
+
+  @BeforeAll
+  static void beforeAll() {
+    Objects.requireNonNull(camundaClient);
+    deployResource(camundaClient, "process/service_tasks_v1.bpmn");
+    waitForProcessesToBeDeployed(camundaClient, 1);
+
+    suspendedInstanceKey = startProcessInstance(camundaClient, PROCESS_ID).getProcessInstanceKey();
+    activeInstanceKey = startProcessInstance(camundaClient, PROCESS_ID).getProcessInstanceKey();
+    waitForProcessInstancesToStart(camundaClient, 2);
+
+    camundaClient.newSuspendProcessInstanceCommand(suspendedInstanceKey).send().join();
+
+    // wait until the suspension is visible in secondary storage
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final ProcessInstance instance =
+                  camundaClient.newProcessInstanceGetRequest(suspendedInstanceKey).send().join();
+              assertThat(instance.getState()).isEqualTo(SUSPENDED);
+              assertThat(instance.getSuspendedDate()).isNotNull();
+            });
+  }
+
+  @Test
+  void shouldFilterProcessInstancesByExistingSuspendedDate() {
+    // when
+    final List<ProcessInstance> result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.processDefinitionId(PROCESS_ID).suspendedDate(d -> d.exists(true)))
+            .send()
+            .join()
+            .items();
+
+    // then
+    assertThat(result)
+        .extracting(ProcessInstance::getProcessInstanceKey)
+        .containsExactly(suspendedInstanceKey);
+  }
+
+  @Test
+  void shouldNotFindActiveProcessInstanceByExistingSuspendedDate() {
+    // when
+    final List<ProcessInstance> result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.processDefinitionId(PROCESS_ID).suspendedDate(d -> d.exists(false)))
+            .send()
+            .join()
+            .items();
+
+    // then
+    assertThat(result)
+        .extracting(ProcessInstance::getProcessInstanceKey)
+        .containsExactly(activeInstanceKey);
+  }
+
+  @Test
+  void shouldFilterProcessInstancesBySuspendedDateRange() {
+    // given
+    final OffsetDateTime suspendedDate =
+        camundaClient
+            .newProcessInstanceGetRequest(suspendedInstanceKey)
+            .send()
+            .join()
+            .getSuspendedDate();
+
+    // when
+    final List<ProcessInstance> result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(
+                f ->
+                    f.processDefinitionId(PROCESS_ID)
+                        .suspendedDate(
+                            d ->
+                                d.gte(suspendedDate.minusMinutes(1))
+                                    .lte(suspendedDate.plusMinutes(1))))
+            .send()
+            .join()
+            .items();
+
+    // then
+    assertThat(result)
+        .extracting(ProcessInstance::getProcessInstanceKey)
+        .containsExactly(suspendedInstanceKey);
+  }
+
+  @Test
+  void shouldSortProcessInstancesBySuspendedDate() {
+    // when
+    final List<ProcessInstance> result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.processDefinitionId(PROCESS_ID))
+            .sort(s -> s.suspendedDate().desc())
+            .send()
+            .join()
+            .items();
+
+    // then
+    assertThat(result).hasSize(2);
+    assertThat(result)
+        .extracting(ProcessInstance::getProcessInstanceKey)
+        .containsExactlyInAnyOrder(suspendedInstanceKey, activeInstanceKey);
+    assertThat(result.get(0).getProcessInstanceKey()).isEqualTo(suspendedInstanceKey);
+    assertThat(result.get(0).getSuspendedDate()).isNotNull();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendedSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendedSearchIT.java
@@ -76,7 +76,7 @@ public class ProcessInstanceSuspendedSearchIT {
   }
 
   @Test
-  void shouldNotFindActiveProcessInstanceByExistingSuspendedDate() {
+  void shouldFindOnlyActiveProcessInstanceByAbsentSuspendedDate() {
     // when
     final List<ProcessInstance> result =
         camundaClient

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/ProcessInstanceBuilder.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/ProcessInstanceBuilder.java
@@ -36,6 +36,7 @@ public class ProcessInstanceBuilder implements ProcessInstance {
   private Long parentElementInstanceKey;
   private OffsetDateTime startDate;
   private OffsetDateTime endDate;
+  private OffsetDateTime suspendedDate;
   private ProcessInstanceState state;
   private Boolean hasIncident;
   private String tenantId;
@@ -98,6 +99,11 @@ public class ProcessInstanceBuilder implements ProcessInstance {
   }
 
   @Override
+  public OffsetDateTime getSuspendedDate() {
+    return suspendedDate;
+  }
+
+  @Override
   public ProcessInstanceState getState() {
     return state;
   }
@@ -149,6 +155,11 @@ public class ProcessInstanceBuilder implements ProcessInstance {
 
   public ProcessInstanceBuilder setEndDate(final OffsetDateTime endDate) {
     this.endDate = endDate;
+    return this;
+  }
+
+  public ProcessInstanceBuilder setSuspendedDate(final OffsetDateTime suspendedDate) {
+    this.suspendedDate = suspendedDate;
     return this;
   }
 


### PR DESCRIPTION
## Description

Adds `suspendedDate` to the Java `CamundaClient` search API for process instances. The
field is written by the engine and stored in secondary storage, but the client could not
filter, sort, or read it.

Four capabilities, one per commit:

- **Filter** process instances by `suspendedDate` (`DateTimeProperty`, so `exists`,
  `gt/gte/lt/lte`, `in`, and `eq` all work).
- **Sort** process instances by `suspendedDate`.
- **Read** `suspendedDate` from the `ProcessInstance` search result.
- **Filter** process definition statistics by `suspendedDate`, for parity with the
  process instance filter.

The last commit adds an acceptance test that covers the whole path — engine suspend
command, secondary storage, REST search, client result — because the module unit tests
stub out the exporter and the search client mapping.

### Reviewer notes

- The `suspendedDate` filter follows the existing `startDate`/`endDate` pattern
  throughout. No new abstractions.
- `ProcessDefinitionStatisticsFilterMapper` copies `suspendedDate` like the other date
  fields, but no test asserts it survives the `$or` mapping path. This gap already exists
  for `startDate` and `endDate`, so it is left as-is rather than fixed here.
- `shouldSortProcessInstancesBySuspendedDate` asserts that a suspended instance sorts
  ahead of an active one (whose `suspendedDate` is null) on a descending sort. This relies
  on the null-ordering convention of the secondary storage, so it may need adjusting if
  RDBMS and ES/OS disagree. The test passed locally against Elasticsearch.

## Checklist

- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57794
