### PR TITLE
ci: fix name clash on aurora async replication it w/ different engine

### DIFF
--- a/.github/workflows/aurora-async-replication-test.yml
+++ b/.github/workflows/aurora-async-replication-test.yml
@@ -171,7 +171,7 @@ jobs:
         id: tfvars
         run: |
           set -euo pipefail
-          NAME_PREFIX="aurora-it-${{ github.run_id }}"
+          NAME_PREFIX="aurora-it-${{ github.run_id }}-${{ inputs.db_engine || 'postgresql' }}"
           # 32 hex chars (128 bits of entropy) stays under RDS's 41-character master
           # password limit for MySQL/MariaDB engines (PostgreSQL allows up to 128).
           MASTER_PASSWORD="$(openssl rand -hex 16)"


### PR DESCRIPTION
## Description
name used for resources/state was used for both postgresql & mysql run that run concurrently
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
