### PR TITLE
fix: skip release comment on issues closed as not planned or duplicate

### DIFF
--- a/.github/scripts/add-release-comments.sh
+++ b/.github/scripts/add-release-comments.sh
@@ -80,7 +80,14 @@ echo "$RELEASES" | jq -c '.' | while read -r release; do
       echo "    Skipping #$ISSUE_NUMBER - issue is not closed (state: $STATE)"
       continue
     fi
-    
+
+    # Skip issues closed as not planned or as a duplicate - they were not actually released
+    STATE_REASON=$(echo "$ISSUE_INFO" | jq -r '.state_reason // empty')
+    if [ "$STATE_REASON" = "not_planned" ] || [ "$STATE_REASON" = "duplicate" ]; then
+      echo "    Skipping #$ISSUE_NUMBER - closed as $STATE_REASON"
+      continue
+    fi
+
     # Check if release comment already exists
     COMMENT_EXISTS=$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100" \
       --paginate \

--- a/.github/scripts/add-release-comments.sh
+++ b/.github/scripts/add-release-comments.sh
@@ -81,9 +81,10 @@ echo "$RELEASES" | jq -c '.' | while read -r release; do
       continue
     fi
 
-    # Skip issues closed as not planned or as a duplicate - they were not actually released
+    # Skip issues closed as not planned (this also covers "closed as duplicate",
+    # since the GitHub REST API reports that as state_reason "not_planned" too)
     STATE_REASON=$(echo "$ISSUE_INFO" | jq -r '.state_reason // empty')
-    if [ "$STATE_REASON" = "not_planned" ] || [ "$STATE_REASON" = "duplicate" ]; then
+    if [ "$STATE_REASON" = "not_planned" ]; then
       echo "    Skipping #$ISSUE_NUMBER - closed as $STATE_REASON"
       continue
     fi

--- a/.github/workflows/add-release-comments-to-issues.yml
+++ b/.github/workflows/add-release-comments-to-issues.yml
@@ -19,6 +19,7 @@
 # Safety features:
 #   - Only processes closed issues
 #   - Excludes pull requests
+#   - Excludes issues closed as "not planned" or "duplicate"
 #   - Prevents duplicate comments
 #   - Supports dry-run mode for testing
 

--- a/.github/workflows/add-release-comments-to-issues.yml
+++ b/.github/workflows/add-release-comments-to-issues.yml
@@ -19,7 +19,7 @@
 # Safety features:
 #   - Only processes closed issues
 #   - Excludes pull requests
-#   - Excludes issues closed as "not planned" or "duplicate"
+#   - Excludes issues closed as "not planned" (covers "duplicate" too)
 #   - Prevents duplicate comments
 #   - Supports dry-run mode for testing
 


### PR DESCRIPTION
## Summary
- The weekly release-comment bot (`.github/workflows/add-release-comments-to-issues.yml`) now skips issues closed with `state_reason` `not_planned` or `duplicate` — these were never actually released, so the comment is misleading noise.

Raised in Slack:
- https://camunda.slack.com/archives/C06UWQNCU7M/p1785319813319419?thread_ts=1785319530.308079&cid=C06UWQNCU7M
- https://camunda.slack.com/archives/C06UWQNCU7M/p1785319869159619?thread_ts=1785319530.308079&cid=C06UWQNCU7M

Example of the noisy comment: https://github.com/camunda/camunda/issues/49717#issuecomment-5116072625

Note: the workflow only runs on `schedule` / `workflow_dispatch` and batch-scans recent release notes — there's no per-issue GitHub event to filter at the trigger level, so the check lives in the script.

## Test plan
- [ ] Run workflow with `dry_run: true` against a release referencing an issue closed as "not planned" and one closed as "duplicate" — confirm both are skipped and logged
- [ ] Confirm a normally-closed, actually-released issue still gets the comment