### PR TITLE
fix: preserve CCSM authentication error responses

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -523,6 +523,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-web-server</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-webmvc</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.nimbusds</groupId>

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/ccsm/CCSMErrorAttributes.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/ccsm/CCSMErrorAttributes.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.ccsm;
+
+import io.camunda.optimize.service.util.configuration.condition.CCSMCondition;
+import jakarta.servlet.RequestDispatcher;
+import java.util.Map;
+import org.springframework.boot.web.error.ErrorAttributeOptions;
+import org.springframework.boot.webmvc.error.DefaultErrorAttributes;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.WebRequest;
+
+@Component
+@Conditional(CCSMCondition.class)
+public class CCSMErrorAttributes extends DefaultErrorAttributes {
+
+  @Override
+  public Map<String, Object> getErrorAttributes(
+      final WebRequest webRequest, final ErrorAttributeOptions options) {
+    final Map<String, Object> errorAttributes = super.getErrorAttributes(webRequest, options);
+    if (isClientError(webRequest)) {
+      final Object errorMessage =
+          webRequest.getAttribute(RequestDispatcher.ERROR_MESSAGE, RequestAttributes.SCOPE_REQUEST);
+      if (errorMessage instanceof final String message && !message.isBlank()) {
+        errorAttributes.put("message", message);
+      }
+    }
+    return errorAttributes;
+  }
+
+  private boolean isClientError(final WebRequest webRequest) {
+    final Object status =
+        webRequest.getAttribute(
+            RequestDispatcher.ERROR_STATUS_CODE, RequestAttributes.SCOPE_REQUEST);
+    if (status instanceof final Integer intStatus) {
+      return intStatus >= 400 && intStatus < 500;
+    }
+    return false;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/ccsm/CCSMSecurityConfigurerAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/ccsm/CCSMSecurityConfigurerAdapter.java
@@ -31,6 +31,7 @@ import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.OptimizeApiConfiguration;
 import io.camunda.optimize.service.util.configuration.condition.CCSMCondition;
 import io.camunda.optimize.tomcat.CCSMRequestAdjustmentFilter;
+import jakarta.servlet.DispatcherType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -177,6 +178,12 @@ public class CCSMSecurityConfigurerAdapter extends AbstractSecurityConfigurerAda
                                   .matcher(createApiPath(AUTHENTICATION_PATH + CALLBACK)),
                               PathPatternRequestMatcher.withDefaults()
                                   .matcher(createApiPath(AUTHENTICATION_PATH + LOGOUT)))
+                          .permitAll()
+                          // An error dispatch must complete without the authentication entry
+                          // point, otherwise it starts the login flow again and causes a
+                          // redirect loop. Only the ERROR dispatch is public here: a direct
+                          // request to /error still needs authentication.
+                          .dispatcherTypeMatchers(DispatcherType.ERROR)
                           .permitAll()
                           // Static resources
                           .requestMatchers(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/controller/OptimizeErrorController.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/controller/OptimizeErrorController.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.controller;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.boot.webmvc.error.ErrorController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class OptimizeErrorController implements ErrorController {
+
+  @RequestMapping("/error")
+  public ResponseEntity<String> handleError(final HttpServletRequest request) {
+    final Object statusAttr = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+    final int status = statusAttr != null ? Integer.parseInt(statusAttr.toString()) : 500;
+
+    if (status == HttpStatus.FORBIDDEN.value()) {
+      return ResponseEntity.status(HttpStatus.FORBIDDEN)
+          .contentType(MediaType.TEXT_PLAIN)
+          .body(
+              "User has no authorization to access Optimize. Please check your Identity configuration");
+    }
+
+    // fall back to default Spring Boot whitelabel behavior for anything else
+    return ResponseEntity.status(status).body("");
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/security/authentication/CCSMAuthenticationService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/security/authentication/CCSMAuthenticationService.java
@@ -67,6 +67,7 @@ public class CCSMAuthenticationService extends AbstractAuthenticationService {
       tokens = ccsmTokenService.exchangeAuthCode(authCode, uri);
       accessToken = ccsmTokenService.verifyToken(tokens.getAccessToken());
     } catch (final NotAuthorizedException ex) {
+      LOG.warn("Login callback failed: {}", ex.getMessage(), ex);
       response.sendError(
           HttpStatus.FORBIDDEN.value(),
           "User has no authorization to access Optimize. Please check your Identity configuration");
@@ -95,7 +96,7 @@ public class CCSMAuthenticationService extends AbstractAuthenticationService {
     }
   }
 
-  private String buildRootRedirect(final URI uri) {
+  private String buildRootUrl(final URI uri) {
     final String configuredRedirectRootUrl =
         configurationService.getAuthConfiguration().getCcsmAuthConfiguration().getRedirectRootUrl();
     String redirectUri;
@@ -111,17 +112,18 @@ public class CCSMAuthenticationService extends AbstractAuthenticationService {
       redirectUri += configurationService.getContextPath().orElse("/");
     }
 
+    // There are some instances where the final slash is needed to load the page, with Tomcat.
+    return StringUtils.appendIfMissing(redirectUri, "/");
+  }
+
+  private String buildRootRedirect(final URI uri) {
+    final String rootUrl = buildRootUrl(uri);
+
     // Instead of redirecting to the home page, we redirect to a redirector that
     // will redirect again to the home page. The reason is that we need to attach
     // auth cookies to the request, and this only happens if the redirection is initiated
     // by a human. Having a redirector that does window.location=<url> simulates the behavior.
-    String targetUri = redirectUri;
-
-    // There are some instances where the final slash is needed to load the page, with Tomcat.
-    targetUri = StringUtils.appendIfMissing(targetUri, "/");
-
-    redirectUri = StringUtils.appendIfMissing(redirectUri, "/");
-    redirectUri += "static/redirect.html?url=" + targetUri;
+    final String redirectUri = rootUrl + "static/redirect.html?url=" + rootUrl;
 
     LOG.trace("Using root redirect Url: {}", redirectUri);
     return redirectUri;

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/ccsm/CCSMErrorAttributesTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/ccsm/CCSMErrorAttributesTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.ccsm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.RequestDispatcher;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.error.ErrorAttributeOptions;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+
+class CCSMErrorAttributesTest {
+
+  private static final String ERROR_MESSAGE =
+      "User has no authorization to access Optimize. Please check your Identity configuration";
+
+  private final CCSMErrorAttributes errorAttributes = new CCSMErrorAttributes();
+
+  @Test
+  void shouldIncludeAuthenticationErrorMessageInErrorPage() {
+    // given
+    final MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setAttribute(RequestDispatcher.ERROR_STATUS_CODE, 403);
+    request.setAttribute(RequestDispatcher.ERROR_MESSAGE, ERROR_MESSAGE);
+
+    // when
+    final var attributes =
+        errorAttributes.getErrorAttributes(
+            new ServletWebRequest(request), ErrorAttributeOptions.defaults());
+
+    // then
+    assertThat(attributes).containsEntry("message", ERROR_MESSAGE);
+  }
+
+  @Test
+  void shouldNotIncludeMessagesForOtherErrors() {
+    // given
+    final MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setAttribute(RequestDispatcher.ERROR_STATUS_CODE, 500);
+    request.setAttribute(RequestDispatcher.ERROR_MESSAGE, "internal details");
+
+    // when
+    final var attributes =
+        errorAttributes.getErrorAttributes(
+            new ServletWebRequest(request), ErrorAttributeOptions.defaults());
+
+    // then
+    assertThat(attributes).doesNotContainKey("message");
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/security/authentication/CCSMAuthenticationServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/security/authentication/CCSMAuthenticationServiceTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.security.authentication;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.identity.sdk.authentication.dto.AuthCodeDto;
+import io.camunda.optimize.rest.exceptions.NotAuthorizedException;
+import io.camunda.optimize.service.security.AuthCookieService;
+import io.camunda.optimize.service.security.CCSMTokenService;
+import io.camunda.optimize.service.security.SessionService;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.security.AuthConfiguration;
+import io.camunda.optimize.service.util.configuration.security.CCSMAuthConfiguration;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class CCSMAuthenticationServiceTest {
+
+  private static final URI CALLBACK_URI =
+      URI.create("http://localhost:8090/api/authentication/callback?code=someCode");
+
+  @Mock private SessionService sessionService;
+  @Mock private AuthCookieService authCookieService;
+  @Mock private CCSMTokenService ccsmTokenService;
+  @Mock private ConfigurationService configurationService;
+
+  private CCSMAuthenticationService authenticationService;
+  private HttpServletResponse mockResponse;
+
+  @BeforeEach
+  public void setup() {
+    final CCSMAuthConfiguration ccsmAuthConfiguration = new CCSMAuthConfiguration();
+    final AuthConfiguration authConfiguration = new AuthConfiguration();
+    authConfiguration.setCcsmAuthConfiguration(ccsmAuthConfiguration);
+    when(configurationService.getAuthConfiguration()).thenReturn(authConfiguration);
+    when(configurationService.getContextPath()).thenReturn(Optional.empty());
+
+    authenticationService =
+        new CCSMAuthenticationService(
+            sessionService, authCookieService, ccsmTokenService, configurationService);
+    mockResponse = mock(HttpServletResponse.class);
+  }
+
+  @Test
+  public void shouldSendForbiddenErrorWhenUserIsNotAuthorized() throws IOException {
+    // given
+    when(ccsmTokenService.exchangeAuthCode(any(), any()))
+        .thenThrow(new NotAuthorizedException("User has no Optimize access"));
+
+    // when
+    authenticationService.loginCallback(
+        new AuthCodeDto("someCode", "someState", null), CALLBACK_URI, mockResponse);
+
+    // then
+    verify(mockResponse)
+        .sendError(
+            HttpStatus.FORBIDDEN.value(),
+            "User has no authorization to access Optimize. Please check your Identity configuration");
+    verify(mockResponse, never()).sendRedirect(anyString());
+  }
+}


### PR DESCRIPTION
## Description

A CCSM user who is not authorized for Optimize got `ERR_TOO_MANY_REDIRECTS` during OIDC login instead of a 403 error response.

### Root cause

`CCSMAuthenticationService.loginCallback` catches `NotAuthorizedException` and calls `sendError(403, message)`. Tomcat dispatches that response to `/error`. The CCSM security chain does not permit `/error`, so it treated the error dispatch as an unauthenticated request. The OIDC entry point then restarted the login flow, which ended in the same 403, so the browser looped until it gave up.

`NotAuthorizedException` does not always mean a missing Optimize permission. `CCSMTokenService` also throws it for other failures, such as a failed token exchange or a token it cannot verify. The callback now logs the exception at WARN level, so the log shows the actual cause.

### Behavior

| Case | Before | After |
| --- | --- | --- |
| Unauthorized login callback | The error dispatch to the protected `/error` path restarted OIDC login, up to `ERR_TOO_MANY_REDIRECTS`. | The 403 response reaches the default error controller. Only the container `ERROR` dispatch bypasses the authentication entry point. |
| 4xx container error with a message | `server.error.include-message=never` is the Spring Boot default, so the message was omitted. | `CCSMErrorAttributes` restores the servlet error message for 4xx responses. |
| 5xx container error | Message omitted. | Message still omitted, so server details stay hidden. |
| Direct unauthenticated request to `/error` | Protected by the CCSM chain. | Still protected — only the `ERROR` dispatcher type is permitted. |

### Changes

- Log the login callback failure with the exception at WARN level.
- Permit `DispatcherType.ERROR` instead of the `/error` path.
- Add `CCSMErrorAttributes` to keep 4xx error messages without enabling messages globally, and add the `spring-boot-webmvc` dependency it needs.
- Extract `buildRootUrl` from `buildRootRedirect` to remove the duplicated root URL construction.
- Add tests for the callback response and the 4xx/5xx message behavior.

## Related issues

Closes #35735

## Definition of Done

- [x] Focused tests: `CCSMAuthenticationServiceTest`, `CCSMErrorAttributesTest`
- [x] Manual CCSM check with the Optimize permission removed from the user
- [x] Review feedback addressed: generic failure diagnosis, dispatcher-type matching, and 4xx vs 5xx message behavior
