### PR TITLE
test: preserve filtered view across reloads in operations single test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -127,7 +127,10 @@ test.describe('Operations', () => {
 
       // The cancel operation's success count is only rendered once Operate's
       // importer marks the cancellation complete, which can lag under load.
-      // Reload and retry generously so this importer delay does not flake.
+      // Reload and retry so this importer delay does not flake — via the
+      // captured URL, so the current filtered view is restored rather than
+      // dropping a fill-based filter on a bare reload.
+      const filteredProcessUrl = page.url();
       let cancelOperationIds: string[] = [];
       await waitForAssertion({
         assertion: async () => {
@@ -148,7 +151,7 @@ test.describe('Operations', () => {
           await expect(operationEntry.getByText(DATE_REGEX)).toBeVisible();
         },
         onFailure: async () => {
-          await page.reload();
+          await page.goto(filteredProcessUrl);
         },
         maxRetries: 15,
       });
@@ -165,6 +168,9 @@ test.describe('Operations', () => {
     });
 
     await test.step('Validate canceled instance details', async () => {
+      // Restore this exact (operationId-filtered) view on retry instead of a
+      // bare reload, keeping recovery consistent with the rest of the test.
+      const canceledInstanceUrl = page.url();
       await waitForAssertion({
         assertion: async () => {
           const instanceRow = operateProcessesPage.getInstanceRow(0);
@@ -181,7 +187,7 @@ test.describe('Operations', () => {
           ).toBeVisible();
         },
         onFailure: async () => {
-          await page.reload();
+          await page.goto(canceledInstanceUrl);
         },
         maxRetries: 8,
       });


### PR DESCRIPTION
## Description

[Successful run](https://github.com/camunda/camunda/actions/runs/30444107379/j) ✅ 

Proactive stabilization of `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts` › **Retry and cancel single instance**.

Its two `waitForAssertion` loops recovered from Operate importer lag with a bare `page.reload()`. A bare reload can drop a fill-based filter and land the retry on the wrong view. This captures the current filtered URL before each loop and reloads via `page.goto(capturedUrl)`, so recovery restores the exact filtered view.

No retry budgets changed; only the reload mechanism.

## Why

This mirrors the fix applied to the sibling **Retry and cancel multiple instances** test (in PR #58973), which was observed failing on the stable/8.7 nightly E2E. Both tests read the cluster-wide operations panel and use the same reload-based recovery, so the single-instance test is prone to the same flake even though it was not the one that surfaced red. Kept as a separate PR since this test is not currently failing — proactive hardening, not a fix for an observed regression.

## Related

- Sibling fixes (migration, decisionNav, batchMove, migrated-tasks incident, operations batch): #58973

🤖 Generated with [Claude Code](https://claude.com/claude-code)