### PR TITLE
feat: hide seeded Business Value entities from user-facing lists

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/dashboard/DashboardDefinitionExportDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/dashboard/DashboardDefinitionExportDto.java
@@ -30,6 +30,7 @@ public class DashboardDefinitionExportDto extends OptimizeEntityExportDto {
   private String collectionId;
   private boolean isInstantPreviewDashboard = false;
   private boolean isAgenticControlDashboard = false;
+  private boolean isBusinessValueDashboard = false;
 
   public DashboardDefinitionExportDto(final DashboardDefinitionRestDto dashboardDefinition) {
     super(
@@ -101,6 +102,14 @@ public class DashboardDefinitionExportDto extends OptimizeEntityExportDto {
     this.isAgenticControlDashboard = isAgenticControlDashboard;
   }
 
+  public boolean isBusinessValueDashboard() {
+    return isBusinessValueDashboard;
+  }
+
+  public void setBusinessValueDashboard(final boolean isBusinessValueDashboard) {
+    this.isBusinessValueDashboard = isBusinessValueDashboard;
+  }
+
   @Override
   protected boolean canEqual(final Object other) {
     return other instanceof DashboardDefinitionExportDto;
@@ -114,7 +123,8 @@ public class DashboardDefinitionExportDto extends OptimizeEntityExportDto {
         availableFilters,
         collectionId,
         isInstantPreviewDashboard,
-        isAgenticControlDashboard);
+        isAgenticControlDashboard,
+        isBusinessValueDashboard);
   }
 
   @Override
@@ -131,6 +141,7 @@ public class DashboardDefinitionExportDto extends OptimizeEntityExportDto {
     final DashboardDefinitionExportDto that = (DashboardDefinitionExportDto) o;
     return isInstantPreviewDashboard == that.isInstantPreviewDashboard
         && isAgenticControlDashboard == that.isAgenticControlDashboard
+        && isBusinessValueDashboard == that.isBusinessValueDashboard
         && Objects.equals(tiles, that.tiles)
         && Objects.equals(availableFilters, that.availableFilters)
         && Objects.equals(collectionId, that.collectionId);
@@ -148,6 +159,8 @@ public class DashboardDefinitionExportDto extends OptimizeEntityExportDto {
         + isInstantPreviewDashboard()
         + ", isAgenticControlDashboard="
         + isAgenticControlDashboard()
+        + ", isBusinessValueDashboard="
+        + isBusinessValueDashboard()
         + ")";
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/DashboardReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/DashboardReaderES.java
@@ -72,6 +72,14 @@ public class DashboardReaderES implements DashboardReader {
                                                         t.field(
                                                                 DashboardIndex
                                                                     .AGENTIC_CONTROL_DASHBOARD)
+                                                            .value(true)))
+                                        .mustNot(
+                                            m ->
+                                                m.term(
+                                                    t ->
+                                                        t.field(
+                                                                DashboardIndex
+                                                                    .BUSINESS_VALUE_DASHBOARD)
                                                             .value(true))))));
     try {
       return esClient.count(countRequest).count();

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/EntitiesReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/EntitiesReaderES.java
@@ -15,6 +15,7 @@ import static io.camunda.optimize.service.db.DatabaseConstants.SINGLE_DECISION_R
 import static io.camunda.optimize.service.db.DatabaseConstants.SINGLE_PROCESS_REPORT_INDEX_NAME;
 import static io.camunda.optimize.service.db.es.reader.ElasticsearchReaderUtil.atLeastOneResponseExistsForMultiGet;
 import static io.camunda.optimize.service.db.schema.index.DashboardIndex.AGENTIC_CONTROL_DASHBOARD;
+import static io.camunda.optimize.service.db.schema.index.DashboardIndex.BUSINESS_VALUE_DASHBOARD;
 import static io.camunda.optimize.service.db.schema.index.DashboardIndex.INSTANT_PREVIEW_DASHBOARD;
 import static io.camunda.optimize.service.db.schema.index.DashboardIndex.MANAGEMENT_DASHBOARD;
 import static io.camunda.optimize.service.db.schema.index.report.AbstractReportIndex.COLLECTION_ID;
@@ -109,6 +110,7 @@ public class EntitiesReaderES implements EntitiesReader {
                     b -> {
                       b.mustNot(m -> m.exists(e -> e.field(COLLECTION_ID)))
                           .mustNot(m -> m.term(t -> t.field(AGENTIC_CONTROL_DASHBOARD).value(true)))
+                          .mustNot(m -> m.term(t -> t.field(BUSINESS_VALUE_DASHBOARD).value(true)))
                           .must(
                               m ->
                                   m.bool(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/ReportReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/ReportReaderES.java
@@ -16,6 +16,7 @@ import static io.camunda.optimize.service.db.schema.index.report.CombinedReportI
 import static io.camunda.optimize.service.db.schema.index.report.CombinedReportIndex.REPORTS;
 import static io.camunda.optimize.service.db.schema.index.report.CombinedReportIndex.REPORT_ITEM_ID;
 import static io.camunda.optimize.service.db.schema.index.report.SingleProcessReportIndex.AGENTIC_CONTROL_REPORT;
+import static io.camunda.optimize.service.db.schema.index.report.SingleProcessReportIndex.BUSINESS_VALUE_REPORT;
 import static io.camunda.optimize.service.db.schema.index.report.SingleProcessReportIndex.INSTANT_PREVIEW_REPORT;
 import static io.camunda.optimize.service.db.schema.index.report.SingleProcessReportIndex.MANAGEMENT_REPORT;
 
@@ -188,6 +189,7 @@ public class ReportReaderES implements ReportReader {
             b.mustNot(m -> m.term(t -> t.field(DATA + "." + MANAGEMENT_REPORT).value(true)))
                 .mustNot(m -> m.term(t -> t.field(DATA + "." + INSTANT_PREVIEW_REPORT).value(true)))
                 .mustNot(m -> m.term(t -> t.field(DATA + "." + AGENTIC_CONTROL_REPORT).value(true)))
+                .mustNot(m -> m.term(t -> t.field(DATA + "." + BUSINESS_VALUE_REPORT).value(true)))
                 .mustNot(m -> m.exists(e -> e.field(COLLECTION_ID))));
     final SearchResponse<ReportDefinitionDto> searchResponse =
         performGetReportRequestOmitXml(
@@ -261,6 +263,15 @@ public class ReportReaderES implements ReportReader {
                                                                   DATA
                                                                       + "."
                                                                       + AGENTIC_CONTROL_REPORT)
+                                                              .value(true)))
+                                          .mustNot(
+                                              m ->
+                                                  m.term(
+                                                      t ->
+                                                          t.field(
+                                                                  DATA
+                                                                      + "."
+                                                                      + BUSINESS_VALUE_REPORT)
                                                               .value(true))))));
     } else {
       countRequest =

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/DashboardReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/DashboardReaderOS.java
@@ -50,7 +50,8 @@ public class DashboardReaderOS implements DashboardReader {
         new String[] {DASHBOARD_INDEX_NAME},
         QueryDSL.and(
             QueryDSL.term(DashboardIndex.MANAGEMENT_DASHBOARD, false),
-            QueryDSL.not(QueryDSL.term(DashboardIndex.AGENTIC_CONTROL_DASHBOARD, true))),
+            QueryDSL.not(QueryDSL.term(DashboardIndex.AGENTIC_CONTROL_DASHBOARD, true)),
+            QueryDSL.not(QueryDSL.term(DashboardIndex.BUSINESS_VALUE_DASHBOARD, true))),
         errorMessage);
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/EntitiesReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/EntitiesReaderOS.java
@@ -16,6 +16,7 @@ import static io.camunda.optimize.service.db.DatabaseConstants.SINGLE_PROCESS_RE
 import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.term;
 import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.terms;
 import static io.camunda.optimize.service.db.schema.index.DashboardIndex.AGENTIC_CONTROL_DASHBOARD;
+import static io.camunda.optimize.service.db.schema.index.DashboardIndex.BUSINESS_VALUE_DASHBOARD;
 import static io.camunda.optimize.service.db.schema.index.DashboardIndex.INSTANT_PREVIEW_DASHBOARD;
 import static io.camunda.optimize.service.db.schema.index.DashboardIndex.MANAGEMENT_DASHBOARD;
 import static io.camunda.optimize.service.db.schema.index.report.AbstractReportIndex.COLLECTION_ID;
@@ -107,6 +108,7 @@ public class EntitiesReaderOS implements EntitiesReader {
         new BoolQuery.Builder()
             .mustNot(QueryDSL.exists(COLLECTION_ID))
             .mustNot(term(AGENTIC_CONTROL_DASHBOARD, true))
+            .mustNot(term(BUSINESS_VALUE_DASHBOARD, true))
             .must(
                 new BoolQuery.Builder()
                     .minimumShouldMatch("1")

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/ReportReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/ReportReaderOS.java
@@ -16,6 +16,7 @@ import static io.camunda.optimize.service.db.schema.index.report.AbstractReportI
 import static io.camunda.optimize.service.db.schema.index.report.CombinedReportIndex.REPORTS;
 import static io.camunda.optimize.service.db.schema.index.report.CombinedReportIndex.REPORT_ITEM_ID;
 import static io.camunda.optimize.service.db.schema.index.report.SingleProcessReportIndex.AGENTIC_CONTROL_REPORT;
+import static io.camunda.optimize.service.db.schema.index.report.SingleProcessReportIndex.BUSINESS_VALUE_REPORT;
 import static io.camunda.optimize.service.db.schema.index.report.SingleProcessReportIndex.INSTANT_PREVIEW_REPORT;
 import static io.camunda.optimize.service.db.schema.index.report.SingleProcessReportIndex.MANAGEMENT_REPORT;
 
@@ -193,6 +194,7 @@ public class ReportReaderOS implements ReportReader {
             .mustNot(QueryDSL.term(DATA + "." + MANAGEMENT_REPORT, true))
             .mustNot(QueryDSL.term(DATA + "." + INSTANT_PREVIEW_REPORT, true))
             .mustNot(QueryDSL.term(DATA + "." + AGENTIC_CONTROL_REPORT, true))
+            .mustNot(QueryDSL.term(DATA + "." + BUSINESS_VALUE_REPORT, true))
             .build()
             .toQuery();
 
@@ -252,6 +254,7 @@ public class ReportReaderOS implements ReportReader {
               .mustNot(QueryDSL.term(DATA + "." + MANAGEMENT_REPORT, true))
               .mustNot(QueryDSL.term(DATA + "." + INSTANT_PREVIEW_REPORT, true))
               .mustNot(QueryDSL.term(DATA + "." + AGENTIC_CONTROL_REPORT, true))
+              .mustNot(QueryDSL.term(DATA + "." + BUSINESS_VALUE_REPORT, true))
               .build()
               .toQuery();
       return osClient.count(new String[] {SINGLE_PROCESS_REPORT_INDEX_NAME}, query, errorMessage);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/entities/EntityImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/entities/EntityImportService.java
@@ -68,6 +68,7 @@ public class EntityImportService {
     validateCompletenessOrFail(entitiesToImport);
     validateNoInstantPreviewEntities(entitiesToImport);
     validateNoAgenticControlEntities(entitiesToImport);
+    validateNoBusinessValueEntities(entitiesToImport);
     return importValidatedEntities(collectionId, entitiesToImport);
   }
 
@@ -250,6 +251,17 @@ public class EntityImportService {
                 (DASHBOARD.equals(exportDto.getExportEntityType())
                     && ((DashboardDefinitionExportDto) exportDto).isAgenticControlDashboard()))) {
       throw new OptimizeValidationException("Cannot import agentic control dashboards.");
+    }
+  }
+
+  private void validateNoBusinessValueEntities(
+      final Set<OptimizeEntityExportDto> entitiesToImport) {
+    if (entitiesToImport.stream()
+        .anyMatch(
+            exportDto ->
+                (DASHBOARD.equals(exportDto.getExportEntityType())
+                    && ((DashboardDefinitionExportDto) exportDto).isBusinessValueDashboard()))) {
+      throw new OptimizeValidationException("Cannot import business value dashboards.");
     }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/entities/dashboard/DashboardImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/entities/dashboard/DashboardImportService.java
@@ -163,6 +163,7 @@ public class DashboardImportService {
     dashboardDefinition.setManagementDashboard(false);
     dashboardDefinition.setInstantPreviewDashboard(dashboardToImport.isInstantPreviewDashboard());
     dashboardDefinition.setAgenticControlDashboard(false);
+    dashboardDefinition.setBusinessValueDashboard(false);
     return dashboardDefinition;
   }
 }


### PR DESCRIPTION
## Description

The Business Value Dashboard and its backing reports are seeded on startup by `BusinessValueDashboardService` (already on `main`), but nothing distinguished them from user-created content once written. They appeared in the Home and collection entity lists, inflated the dashboard and report counts shown there, and could be exported and re-imported as ordinary duplicates — leaving a second, editable copy that looks system-generated but is never reconciled on startup.

### Changes

**Entity visibility** — the dashboard, report and entity readers exclude documents carrying the indexed `BUSINESS_VALUE_DASHBOARD` / `BUSINESS_VALUE_REPORT` flags, for both Elasticsearch and OpenSearch, mirroring how management, instant preview and agentic control entities are already filtered.

**Import/export** — `DashboardDefinitionExportDto` carries the dashboard flag so an export round-trip cannot silently launder it, imports of a business value dashboard are rejected, and the flag is cleared on any imported dashboard so a copy can never masquerade as the seeded one.

The alternative was filtering on the fixed seed IDs at each call site. Reusing the flags keeps these queries consistent with the existing system-generated entities and avoids spreading knowledge of the seed IDs through the reader layer.

### Localization removed

Per review, **no localization is added**. The seeded entities carry plain display names, and the dashboard is consumed by the Hub, which supplies its own labels.

This also removes a latent bug: `main` now names the seeded entities with plain literals (`"Work handled"`, `"Business Value Dashboard"`), so the previous mapper changes would have tried to resolve a real display name as a message code against a `businessValue` node that does not exist. Dropped in this revision:

- `LocalizationService.getLocalizationForBusinessValue{Dashboard,Report}Code`
- the `businessValueDashboard` / `businessValueReport` branches in `DashboardRestMapper`, `ReportRestMapper` and `EntitiesReader`
- the `businessValue` nodes in `en.json` and `de.json`

### Rebase

Rebased onto `main`. The scaffolding PR merged in the meantime, so this branch previously replayed those commits and conflicted with the squashed version — mostly over the entity name constants. Now a single commit of 9 files on top of `main`.

### Testing

`optimize-commons` and `optimize-backend` compile; 23/23 tests pass (`BusinessValue*Test`, `LocalizationFileTest` en/de key parity, `EntityImportServiceTest`). No dedicated test yet for the reader exclusions and import guards — happy to add one if reviewers want it in this PR.

## Checklist

- [ ] Enable backports when necessary — not needed, this is unreleased feature work.

## Related issues

<!-- Part of the Business Value Dashboard work. -->

