### PR TITLE
ci: count nested Playwright suites when classifying downstream SaaS failures

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -996,10 +996,10 @@ jobs:
                 FLAKY=0
                 SETUP_FAILED=0
                 while IFS= read -r -d '' RESULTS; do
-                  T=$(jq '[.suites[]?.specs[]?] | length' "$RESULTS" 2>/dev/null || echo 0)
-                  F=$(jq '[.suites[]?.specs[]? | select(.ok==false)] | length' "$RESULTS" 2>/dev/null || echo 0)
-                  K=$(jq '[.suites[]?.specs[]? | select(.tests[]?.results | length > 1) | select(.ok==true)] | length' "$RESULTS" 2>/dev/null || echo 0)
-                  S=$(jq '[.suites[]?.specs[]? | select((.file // "") | endswith("test-setup.spec.ts")) | select(.ok==false)] | length' "$RESULTS" 2>/dev/null || echo 0)
+                  T=$(jq '[.. | objects | select(.specs?) | .specs[]] | length' "$RESULTS" 2>/dev/null || echo 0)
+                  F=$(jq '[.. | objects | select(.specs?) | .specs[] | select(.ok==false)] | length' "$RESULTS" 2>/dev/null || echo 0)
+                  K=$(jq '[.. | objects | select(.specs?) | .specs[] | select(.tests[]?.results | length > 1) | select(.ok==true)] | length' "$RESULTS" 2>/dev/null || echo 0)
+                  S=$(jq '[.. | objects | select(.specs?) | .specs[] | select((.file // "") | endswith("test-setup.spec.ts")) | select(.ok==false)] | length' "$RESULTS" 2>/dev/null || echo 0)
                   TOTAL=$((TOTAL + T))
                   FAILED=$((FAILED + F))
                   FLAKY=$((FLAKY + K))


### PR DESCRIPTION
## Description

The `Resolve downstream SaaS E2E failure category` step in `trigger-saas-e2e` counts
specs with `.suites[]?.specs[]?`, which walks only one level of the Playwright report.
Playwright nests `suites[].suites[].specs[]`, so `TOTAL` always evaluates to `0`, the
`TOTAL == 0` branch of the decision tree always wins, and the `product` and `mixed`
categories are **unreachable**. Every failing downstream run is labelled
`infrastructure`, and the `alwaysgreen-saas-category` artifact reports no test failures
even when tests did fail.

Measured on four real downstream reports, old path vs the recursive path:

| downstream run | current | with this fix |
|---|---|---|
| 30259132560 | `TOTAL=0 FAILED=0` | `TOTAL=15 FAILED=2` |
| 29993421382 | `TOTAL=0 FAILED=0` | `TOTAL=15 FAILED=1` |
| 30000066288 | `TOTAL=0 FAILED=0` | `TOTAL=14 FAILED=2` |
| 30107773485 | `TOTAL=0 FAILED=0` | `TOTAL=15 FAILED=0` |

Observed category distribution across 27 failing AlwaysGreen runs in the last three
weeks confirms the blind spot: `none` 11, `infrastructure` 11, `unknown` 3,
`unknown_artifact_unreachable` 2, **`product` 0, `mixed` 0**.

The fix adopts the recursive form already used for the same purpose in
`c8-orchestration-cluster-e2e-nightly-triage.yml`
(`[.. | objects | select(.specs?) | .specs[]]`).

**Scope note:** this does not change how many runs get flagged today. In every sampled
run the only spec failures were inside `test-setup.spec.ts`, so `SETUP_FAILED > 0` still
routes them to `infrastructure`. What changes is that a genuine non-setup SaaS test
failure will now be reported as `product` instead of being silently mislabelled.

**Verification:** the four patched jq programs were extracted verbatim from the edited
workflow and executed against a real `json-report` artifact. YAML parses; `actionlint`
findings unchanged at 1 (pre-existing self-hosted runner label); `zizmor` findings
unchanged at 145.

The same defect is present on `stable/8.7`, `stable/8.8` and `stable/8.9` — the block is
byte-identical there. Those are intentionally **not** included here; separate
branch-scoped PRs will follow once this one is confirmed.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

Backport note: not applicable via the backport action — each branch carries its own copy
of this workflow with a different chart version, so the stable-branch fixes land as
direct branch-scoped PRs rather than cherry-picks.

## Related issues

Part of camunda/team-test-automation#138
