### PR TITLE
fix: include truncated indictor in Operate selection counts

### DIFF
--- a/operate/client/src/App/Decisions/InstancesTable/Toolbar/index.tsx
+++ b/operate/client/src/App/Decisions/InstancesTable/Toolbar/index.tsx
@@ -25,87 +25,98 @@ import {pluralSuffix} from 'modules/utils/pluralSuffix';
 
 type Props = {
   selectedCount: number;
+  isSelectedCountTruncated?: boolean;
 };
 
-const Toolbar: React.FC<Props> = observer(({selectedCount}) => {
-  const displaySuccessNotification = useBatchOperationSuccessNotification();
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const deleteRequestBody =
-    useDeleteDecisionInstancesBatchOperationRequestBody();
+const Toolbar: React.FC<Props> = observer(
+  ({selectedCount, isSelectedCountTruncated = false}) => {
+    const displaySuccessNotification = useBatchOperationSuccessNotification();
+    const [showDeleteModal, setShowDeleteModal] = useState(false);
+    const deleteRequestBody =
+      useDeleteDecisionInstancesBatchOperationRequestBody();
 
-  const deleteMutation = useDeleteDecisionInstancesBatchOperation({
-    onSuccess: ({batchOperationKey, batchOperationType}) => {
-      displaySuccessNotification(batchOperationType, batchOperationKey);
-      tracking.track({
-        eventName: 'batch-operation',
-        operationType: 'DELETE_DECISION_INSTANCE',
-      });
-      decisionInstancesSelectionStore.resetState();
-    },
-    onError: (error) => {
-      handleOperationError(error.response?.status);
-    },
-  });
+    const deleteMutation = useDeleteDecisionInstancesBatchOperation({
+      onSuccess: ({batchOperationKey, batchOperationType}) => {
+        displaySuccessNotification(batchOperationType, batchOperationKey);
+        tracking.track({
+          eventName: 'batch-operation',
+          operationType: 'DELETE_DECISION_INSTANCE',
+        });
+        decisionInstancesSelectionStore.resetState();
+      },
+      onError: (error) => {
+        handleOperationError(error.response?.status);
+      },
+    });
 
-  if (selectedCount === 0) {
-    return null;
-  }
+    if (selectedCount === 0) {
+      return null;
+    }
 
-  return (
-    <>
-      <TableToolbar size="sm">
-        <TableBatchActions
-          shouldShowBatchActions
-          totalSelected={selectedCount}
-          onCancel={decisionInstancesSelectionStore.resetState}
-          translateWithId={(id) => {
-            switch (id) {
-              case 'carbon.table.batch.cancel':
-                return 'Discard';
-              case 'carbon.table.batch.items.selected':
-                return `${selectedCount} items selected`;
-              case 'carbon.table.batch.item.selected':
-                return `${selectedCount} item selected`;
-              case 'carbon.table.batch.selectAll':
-                return 'Select all items';
-              default:
-                return id;
-            }
-          }}
-        >
-          <TableBatchAction
-            renderIcon={TrashCan}
-            onClick={() => setShowDeleteModal(true)}
+    return (
+      <>
+        <TableToolbar size="sm">
+          <TableBatchActions
+            shouldShowBatchActions
+            totalSelected={selectedCount}
+            onCancel={decisionInstancesSelectionStore.resetState}
+            translateWithId={(id) => {
+              switch (id) {
+                case 'carbon.table.batch.cancel':
+                  return 'Discard';
+                case 'carbon.table.batch.items.selected':
+                  return `${selectedCount}${
+                    isSelectedCountTruncated ? '+' : ''
+                  } items selected`;
+                case 'carbon.table.batch.item.selected':
+                  return `${selectedCount}${
+                    isSelectedCountTruncated ? '+' : ''
+                  } item selected`;
+                case 'carbon.table.batch.selectAll':
+                  return 'Select all items';
+                default:
+                  return id;
+              }
+            }}
           >
-            Delete
-          </TableBatchAction>
-        </TableBatchActions>
-      </TableToolbar>
+            <TableBatchAction
+              renderIcon={TrashCan}
+              onClick={() => setShowDeleteModal(true)}
+            >
+              Delete
+            </TableBatchAction>
+          </TableBatchActions>
+        </TableToolbar>
 
-      <Modal
-        open={showDeleteModal}
-        preventCloseOnClickOutside
-        modalHeading="Apply operation"
-        primaryButtonText="Delete"
-        danger
-        secondaryButtonText="Cancel"
-        onRequestSubmit={() => {
-          deleteMutation.mutate(deleteRequestBody);
-          setShowDeleteModal(false);
-        }}
-        onRequestClose={() => setShowDeleteModal(false)}
-        onSecondarySubmit={() => {
-          setShowDeleteModal(false);
-          decisionInstancesSelectionStore.resetState();
-        }}
-        size="md"
-      >
-        <p>
-          {`${pluralSuffix(selectedCount, 'instance')} selected for delete operation. This permanently deletes the selected decision instances and their history. This cannot be undone.`}
-        </p>
-      </Modal>
-    </>
-  );
-});
+        <Modal
+          open={showDeleteModal}
+          preventCloseOnClickOutside
+          modalHeading="Apply operation"
+          primaryButtonText="Delete"
+          danger
+          secondaryButtonText="Cancel"
+          onRequestSubmit={() => {
+            deleteMutation.mutate(deleteRequestBody);
+            setShowDeleteModal(false);
+          }}
+          onRequestClose={() => setShowDeleteModal(false)}
+          onSecondarySubmit={() => {
+            setShowDeleteModal(false);
+            decisionInstancesSelectionStore.resetState();
+          }}
+          size="md"
+        >
+          <p>
+            {`${
+              isSelectedCountTruncated
+                ? `${selectedCount}+ instances`
+                : pluralSuffix(selectedCount, 'instance')
+            } selected for delete operation. This permanently deletes the selected decision instances and their history. This cannot be undone.`}
+          </p>
+        </Modal>
+      </>
+    );
+  },
+);
 
 export {Toolbar};

--- a/operate/client/src/App/Decisions/InstancesTable/Toolbar/index.tsx
+++ b/operate/client/src/App/Decisions/InstancesTable/Toolbar/index.tsx
@@ -69,9 +69,7 @@ const Toolbar: React.FC<Props> = observer(
                     isSelectedCountTruncated ? '+' : ''
                   } items selected`;
                 case 'carbon.table.batch.item.selected':
-                  return `${selectedCount}${
-                    isSelectedCountTruncated ? '+' : ''
-                  } item selected`;
+                  return `${selectedCount} item selected`;
                 case 'carbon.table.batch.selectAll':
                   return 'Select all items';
                 default:

--- a/operate/client/src/App/Decisions/InstancesTable/Toolbar/tests/index.test.tsx
+++ b/operate/client/src/App/Decisions/InstancesTable/Toolbar/tests/index.test.tsx
@@ -99,6 +99,31 @@ describe('<Toolbar />', () => {
     expect(screen.getByText('1 item selected')).toBeInTheDocument();
   });
 
+  it('should append "+" to the selected count label when truncated', () => {
+    render(<Toolbar selectedCount={10000} isSelectedCountTruncated />, {
+      wrapper: Wrapper,
+    });
+
+    expect(screen.getByText('10000+ items selected')).toBeInTheDocument();
+  });
+
+  it('should append "+" to the count in the delete confirmation modal when truncated', async () => {
+    const {user} = render(
+      <Toolbar selectedCount={10000} isSelectedCountTruncated />,
+      {wrapper: Wrapper},
+    );
+
+    const toolbar = screen.getByRole('group', {name: 'data table toolbar'});
+    await user.click(within(toolbar).getByRole('button', {name: 'Delete'}));
+
+    const modal = screen.getByRole('dialog');
+    expect(
+      within(modal).getByText(
+        /10000\+ instances selected for delete operation\. This permanently deletes/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
   it('should perform delete batch operation successfully', async () => {
     vi.useFakeTimers({shouldAdvanceTime: true});
 

--- a/operate/client/src/App/Decisions/InstancesTable/index.tsx
+++ b/operate/client/src/App/Decisions/InstancesTable/index.tsx
@@ -63,6 +63,7 @@ const InstancesTable: React.FC = observer(() => {
   useEffect(() => {
     decisionInstancesSelectionStore.setRuntime({
       totalCount: data?.totalCount ?? 0,
+      hasMoreTotalItems: data?.hasMoreTotalItems ?? false,
       visibleIds: (data?.decisionInstances ?? []).map(
         (instance) => instance.decisionEvaluationInstanceKey,
       ),
@@ -109,7 +110,12 @@ const InstancesTable: React.FC = observer(() => {
         count={filteredDecisionInstancesCount}
         hasMoreTotalItems={hasMoreTotalItems}
       />
-      <Toolbar selectedCount={decisionInstancesSelectionStore.selectedCount} />
+      <Toolbar
+        selectedCount={decisionInstancesSelectionStore.selectedCount}
+        isSelectedCountTruncated={
+          decisionInstancesSelectionStore.isSelectedCountTruncated
+        }
+      />
       <PaginatedSortableTable
         state={getTableState()}
         emptyMessage={getEmptyListMessage()}

--- a/operate/client/src/App/OperationsLog/InstancesTable/index.test.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/index.test.tsx
@@ -70,6 +70,28 @@ describe('OperationsLog InstancesTable', () => {
     expect(screen.getByText('Operations Log')).toBeInTheDocument();
   });
 
+  it('should display "10000+ results" when there are more than 10000 results', async () => {
+    mockQueryAuditLogs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 10000,
+        hasMoreTotalItems: true,
+        startCursor: null,
+        endCursor: null,
+      },
+    });
+
+    render(<InstancesTable />, {
+      wrapper: Wrapper,
+    });
+
+    expect(
+      await screen.findByRole('heading', {
+        name: /Operations Log - 10000\+ results/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
   it('should show loading state when data is being fetched', () => {
     mockQueryAuditLogs().withDelay(searchResult([]));
 

--- a/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
@@ -186,6 +186,7 @@ const InstancesTable: React.FC = observer(() => {
       return {
         auditLogs: data.pages.flatMap((page) => page.items),
         totalCount: data.pages.at(0)?.page.totalItems ?? 0,
+        hasMoreTotalItems: data.pages.at(0)?.page.hasMoreTotalItems ?? false,
       };
     },
   });
@@ -284,7 +285,11 @@ const InstancesTable: React.FC = observer(() => {
 
   return (
     <Container>
-      <BasePanelHeader title="Operations Log" count={data?.totalCount} />
+      <BasePanelHeader
+        title="Operations Log"
+        count={data?.totalCount}
+        hasMoreTotalItems={data?.hasMoreTotalItems}
+      />
       <PaginatedSortableTable
         state={getTableState()}
         rows={rows}

--- a/operate/client/src/App/Processes/ListView/InstancesTable/InstancesTableWrapper.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/InstancesTableWrapper.tsx
@@ -89,12 +89,13 @@ const InstancesTableWrapper: React.FC = observer(() => {
 
     processInstancesSelectionStore.setRuntime({
       totalCount,
+      hasMoreTotalItems,
       visibleIds,
       visibleRunningIds,
       visibleFinishedIds,
       visibleIncidentIds,
     });
-  }, [processInstances, totalCount]);
+  }, [processInstances, totalCount, hasMoreTotalItems]);
 
   return (
     <InstancesTable

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/index.test.tsx
@@ -271,6 +271,45 @@ describe('<MigrateAction />', () => {
     trackSpy.mockRestore();
   });
 
+  it('should capture the truncated selection count when entering migration mode', async () => {
+    // given a "select all" selection with more instances than the API reports
+    const visibleRunningIds = mockProcessInstancesV2
+      .filter((instance) => instance.state === 'ACTIVE' || instance.hasIncident)
+      .map((instance) => instance.processInstanceKey);
+    processInstancesSelectionStore.setRuntime({
+      totalCount: 10000,
+      hasMoreTotalItems: true,
+
+      visibleIds: mockProcessInstancesV2.map(
+        (instance) => instance.processInstanceKey,
+      ),
+      visibleRunningIds,
+    });
+
+    const {user} = render(<MigrateAction />, {
+      wrapper: createWrapper({
+        initialPath: `/processes?processDefinitionId=eventBasedGatewayProcess&processDefinitionVersion=1`,
+        withTestButtons: true,
+      }),
+    });
+
+    await user.click(
+      screen.getByRole('button', {name: /select all instances/i}),
+    );
+
+    expect(processInstancesSelectionStore.isSelectedCountTruncated).toBe(true);
+
+    await user.click(screen.getByRole('button', {name: /migrate/i}));
+    await user.click(screen.getByRole('button', {name: /continue/i}));
+
+    expect(processInstanceMigrationStore.state.selectedInstancesCount).toBe(
+      10000,
+    );
+    expect(
+      processInstanceMigrationStore.state.isSelectedInstancesCountTruncated,
+    ).toBe(true);
+  });
+
   it('should disable migrate action in batch modification mode', async () => {
     const {user} = render(<MigrateAction />, {
       wrapper: createWrapper({

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/index.tsx
@@ -66,6 +66,7 @@ const MigrateAction: React.FC = observer(() => {
 
     processInstanceMigrationStore.setSelectedInstancesCount(
       processInstancesSelectionStore.selectedCount,
+      processInstancesSelectionStore.isSelectedCountTruncated,
     );
     processInstanceMigrationStore.setBatchOperationQuery({
       conditions:

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
@@ -33,6 +33,7 @@ import {processInstancesSelectionStore} from 'modules/stores/instancesSelection'
 
 type Props = {
   selectedInstancesCount: number;
+  isSelectedCountTruncated?: boolean;
 };
 
 const ACTION_NAMES: Readonly<
@@ -46,231 +47,238 @@ const ACTION_NAMES: Readonly<
   DELETE_PROCESS_INSTANCE: 'delete',
 };
 
-const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
-  const displaySuccessNotification = useBatchOperationSuccessNotification();
-  const [modalMode, setModalMode] = useState<
-    | 'RESOLVE_INCIDENT'
-    | 'CANCEL_PROCESS_INSTANCE'
-    | 'DELETE_PROCESS_INSTANCE'
-    | null
-  >(null);
-  const closeModal = () => {
-    setModalMode(null);
-  };
+const Toolbar: React.FC<Props> = observer(
+  ({selectedInstancesCount, isSelectedCountTruncated = false}) => {
+    const displaySuccessNotification = useBatchOperationSuccessNotification();
+    const [modalMode, setModalMode] = useState<
+      | 'RESOLVE_INCIDENT'
+      | 'CANCEL_PROCESS_INSTANCE'
+      | 'DELETE_PROCESS_INSTANCE'
+      | null
+    >(null);
+    const closeModal = () => {
+      setModalMode(null);
+    };
 
-  const batchOperationMutationRequestBody =
-    useBatchOperationMutationRequestBody();
+    const batchOperationMutationRequestBody =
+      useBatchOperationMutationRequestBody();
 
-  const deleteBatchOperationMutationRequestBody =
-    useDeleteProcessInstancesBatchOperationMutationRequestBody();
+    const deleteBatchOperationMutationRequestBody =
+      useDeleteProcessInstancesBatchOperationMutationRequestBody();
 
-  const cancelMutation = useCancelProcessInstancesBatchOperation({
-    onSuccess: ({batchOperationKey, batchOperationType}) => {
-      displaySuccessNotification(batchOperationType, batchOperationKey);
-      tracking.track({
-        eventName: 'batch-operation',
-        operationType: 'CANCEL_PROCESS_INSTANCE',
-      });
+    const cancelMutation = useCancelProcessInstancesBatchOperation({
+      onSuccess: ({batchOperationKey, batchOperationType}) => {
+        displaySuccessNotification(batchOperationType, batchOperationKey);
+        tracking.track({
+          eventName: 'batch-operation',
+          operationType: 'CANCEL_PROCESS_INSTANCE',
+        });
+        processInstancesSelectionStore.resetState();
+      },
+      onError: (error) => {
+        handleOperationError(error.response?.status);
+      },
+    });
+
+    const resolveMutation = useResolveProcessInstancesIncidentsBatchOperation({
+      onSuccess: ({batchOperationKey, batchOperationType}) => {
+        displaySuccessNotification(batchOperationType, batchOperationKey);
+        tracking.track({
+          eventName: 'batch-operation',
+          operationType: 'RESOLVE_INCIDENT',
+        });
+        processInstancesSelectionStore.resetState();
+      },
+      onError: (error) => {
+        handleOperationError(error.response?.status);
+      },
+    });
+
+    const deleteMutation = useDeleteProcessInstancesBatchOperation({
+      onSuccess: ({batchOperationKey, batchOperationType}) => {
+        displaySuccessNotification(batchOperationType, batchOperationKey);
+        tracking.track({
+          eventName: 'batch-operation',
+          operationType: 'DELETE_PROCESS_INSTANCE',
+        });
+        processInstancesSelectionStore.resetState();
+      },
+      onError: (error) => {
+        handleOperationError(error.response?.status);
+      },
+    });
+
+    const handleApplyClick = () => {
+      if (modalMode === null) {
+        return;
+      }
+
+      if (modalMode === 'CANCEL_PROCESS_INSTANCE') {
+        cancelMutation.mutate(batchOperationMutationRequestBody);
+      } else if (modalMode === 'DELETE_PROCESS_INSTANCE') {
+        deleteMutation.mutate(deleteBatchOperationMutationRequestBody);
+      } else if (modalMode === 'RESOLVE_INCIDENT') {
+        resolveMutation.mutate(batchOperationMutationRequestBody);
+      }
+
+      closeModal();
+    };
+
+    const handleCancelClick = () => {
+      closeModal();
       processInstancesSelectionStore.resetState();
-    },
-    onError: (error) => {
-      handleOperationError(error.response?.status);
-    },
-  });
+    };
 
-  const resolveMutation = useResolveProcessInstancesIncidentsBatchOperation({
-    onSuccess: ({batchOperationKey, batchOperationType}) => {
-      displaySuccessNotification(batchOperationType, batchOperationKey);
-      tracking.track({
-        eventName: 'batch-operation',
-        operationType: 'RESOLVE_INCIDENT',
-      });
-      processInstancesSelectionStore.resetState();
-    },
-    onError: (error) => {
-      handleOperationError(error.response?.status);
-    },
-  });
+    const getBodyText = () => {
+      if (modalMode === null) {
+        return '';
+      }
 
-  const deleteMutation = useDeleteProcessInstancesBatchOperation({
-    onSuccess: ({batchOperationKey, batchOperationType}) => {
-      displaySuccessNotification(batchOperationType, batchOperationKey);
-      tracking.track({
-        eventName: 'batch-operation',
-        operationType: 'DELETE_PROCESS_INSTANCE',
-      });
-      processInstancesSelectionStore.resetState();
-    },
-    onError: (error) => {
-      handleOperationError(error.response?.status);
-    },
-  });
+      const runningInstancesCount =
+        processInstancesSelectionStore.checkedRunningIds.length;
 
-  const handleApplyClick = () => {
-    if (modalMode === null) {
-      return;
-    }
+      const selectedInstancesText = isSelectedCountTruncated
+        ? `${selectedInstancesCount}+ instances`
+        : pluralSuffix(selectedInstancesCount, 'instance');
 
-    if (modalMode === 'CANCEL_PROCESS_INSTANCE') {
-      cancelMutation.mutate(batchOperationMutationRequestBody);
-    } else if (modalMode === 'DELETE_PROCESS_INSTANCE') {
-      deleteMutation.mutate(deleteBatchOperationMutationRequestBody);
-    } else if (modalMode === 'RESOLVE_INCIDENT') {
-      resolveMutation.mutate(batchOperationMutationRequestBody);
-    }
+      const operationMessage = `${selectedInstancesText} selected for ${ACTION_NAMES[modalMode]} operation.`;
 
-    closeModal();
-  };
+      const messages = [operationMessage];
 
-  const handleCancelClick = () => {
-    closeModal();
-    processInstancesSelectionStore.resetState();
-  };
-
-  const getBodyText = () => {
-    if (modalMode === null) {
-      return '';
-    }
-
-    const runningInstancesCount =
-      processInstancesSelectionStore.checkedRunningIds.length;
-
-    const operationMessage = `${pluralSuffix(
-      selectedInstancesCount,
-      'instance',
-    )} selected for ${ACTION_NAMES[modalMode]} operation.`;
-
-    const messages = [operationMessage];
-
-    if (modalMode === 'CANCEL_PROCESS_INSTANCE') {
-      messages.push(
-        'In case there are called instances, these will be canceled too.',
-      );
-    }
-
-    if (modalMode === 'DELETE_PROCESS_INSTANCE') {
-      messages.push(
-        'This permanently deletes the selected process instances and their history. This cannot be undone.',
-      );
-    } else if (modalMode === 'RESOLVE_INCIDENT') {
-      const incidentInstancesCount =
-        processInstancesSelectionStore.checkedIncidentIds.length;
-
-      if (selectedInstancesCount > incidentInstancesCount) {
+      if (modalMode === 'CANCEL_PROCESS_INSTANCE') {
         messages.push(
-          'Instances without an incident in your selection will be ignored.',
+          'In case there are called instances, these will be canceled too.',
         );
       }
-    } else if (selectedInstancesCount > runningInstancesCount) {
-      messages.push('Finished instances in your selection will be ignored.');
+
+      if (modalMode === 'DELETE_PROCESS_INSTANCE') {
+        messages.push(
+          'This permanently deletes the selected process instances and their history. This cannot be undone.',
+        );
+      } else if (modalMode === 'RESOLVE_INCIDENT') {
+        const incidentInstancesCount =
+          processInstancesSelectionStore.checkedIncidentIds.length;
+
+        if (selectedInstancesCount > incidentInstancesCount) {
+          messages.push(
+            'Instances without an incident in your selection will be ignored.',
+          );
+        }
+      } else if (selectedInstancesCount > runningInstancesCount) {
+        messages.push('Finished instances in your selection will be ignored.');
+      }
+
+      return messages.join(' ');
+    };
+
+    if (selectedInstancesCount === 0) {
+      return null;
     }
 
-    return messages.join(' ');
-  };
+    return (
+      <>
+        <TableToolbar size="sm">
+          <TableBatchActions
+            shouldShowBatchActions={selectedInstancesCount > 0}
+            totalSelected={selectedInstancesCount}
+            onCancel={processInstancesSelectionStore.resetState}
+            translateWithId={(id) => {
+              switch (id) {
+                case 'carbon.table.batch.cancel':
+                  return 'Discard';
+                case 'carbon.table.batch.items.selected':
+                  return `${selectedInstancesCount}${
+                    isSelectedCountTruncated ? '+' : ''
+                  } items selected`;
+                case 'carbon.table.batch.item.selected':
+                  return `${selectedInstancesCount}${
+                    isSelectedCountTruncated ? '+' : ''
+                  } item selected`;
+                case 'carbon.table.batch.selectAll':
+                  return 'Select all items';
+                default:
+                  return id;
+              }
+            }}
+          >
+            <MoveAction />
+            <MigrateAction />
+            <TableBatchAction
+              renderIcon={TrashCan}
+              onClick={() => setModalMode('DELETE_PROCESS_INSTANCE')}
+              disabled={
+                batchModificationStore.state.isEnabled ||
+                !processInstancesSelectionStore.hasSelectedFinishedInstances
+              }
+              title={
+                batchModificationStore.state.isEnabled
+                  ? 'Not available in batch modification mode'
+                  : !processInstancesSelectionStore.hasSelectedFinishedInstances
+                    ? 'No finished process instances selected. Please select at least one completed or canceled process instance to delete.'
+                    : undefined
+              }
+              data-testid="delete-batch-operation"
+            >
+              Delete
+            </TableBatchAction>
+            <TableBatchAction
+              renderIcon={Error}
+              onClick={() => setModalMode('CANCEL_PROCESS_INSTANCE')}
+              disabled={
+                batchModificationStore.state.isEnabled ||
+                !processInstancesSelectionStore.hasSelectedRunningInstances
+              }
+              title={
+                batchModificationStore.state.isEnabled
+                  ? 'Not available in batch modification mode'
+                  : !processInstancesSelectionStore.hasSelectedRunningInstances
+                    ? 'No running process instances selected. Please select at least one active or incident process instance to cancel.'
+                    : undefined
+              }
+              data-testid="cancel-batch-operation"
+            >
+              Cancel
+            </TableBatchAction>
+            <TableBatchAction
+              renderIcon={RetryFailed}
+              onClick={() => setModalMode('RESOLVE_INCIDENT')}
+              disabled={
+                batchModificationStore.state.isEnabled ||
+                !processInstancesSelectionStore.hasSelectedInstancesWithIncidents
+              }
+              title={
+                batchModificationStore.state.isEnabled
+                  ? 'Not available in batch modification mode'
+                  : !processInstancesSelectionStore.hasSelectedInstancesWithIncidents
+                    ? 'No process instances with an incident selected. Please select at least one process instance with an incident to retry.'
+                    : undefined
+              }
+              data-testid="retry-batch-operation"
+            >
+              Retry
+            </TableBatchAction>
+          </TableBatchActions>
+        </TableToolbar>
 
-  if (selectedInstancesCount === 0) {
-    return null;
-  }
-
-  return (
-    <>
-      <TableToolbar size="sm">
-        <TableBatchActions
-          shouldShowBatchActions={selectedInstancesCount > 0}
-          totalSelected={selectedInstancesCount}
-          onCancel={processInstancesSelectionStore.resetState}
-          translateWithId={(id) => {
-            switch (id) {
-              case 'carbon.table.batch.cancel':
-                return 'Discard';
-              case 'carbon.table.batch.items.selected':
-                return `${selectedInstancesCount} items selected`;
-              case 'carbon.table.batch.item.selected':
-                return `${selectedInstancesCount} item selected`;
-              case 'carbon.table.batch.selectAll':
-                return 'Select all items';
-              default:
-                return id;
-            }
-          }}
+        <Modal
+          open={modalMode !== null}
+          preventCloseOnClickOutside
+          modalHeading="Apply operation"
+          primaryButtonText={
+            modalMode === 'DELETE_PROCESS_INSTANCE' ? 'Delete' : 'Apply'
+          }
+          danger={modalMode === 'DELETE_PROCESS_INSTANCE'}
+          secondaryButtonText="Cancel"
+          onRequestSubmit={handleApplyClick}
+          onRequestClose={closeModal}
+          onSecondarySubmit={handleCancelClick}
+          size="md"
         >
-          <MoveAction />
-          <MigrateAction />
-          <TableBatchAction
-            renderIcon={TrashCan}
-            onClick={() => setModalMode('DELETE_PROCESS_INSTANCE')}
-            disabled={
-              batchModificationStore.state.isEnabled ||
-              !processInstancesSelectionStore.hasSelectedFinishedInstances
-            }
-            title={
-              batchModificationStore.state.isEnabled
-                ? 'Not available in batch modification mode'
-                : !processInstancesSelectionStore.hasSelectedFinishedInstances
-                  ? 'No finished process instances selected. Please select at least one completed or canceled process instance to delete.'
-                  : undefined
-            }
-            data-testid="delete-batch-operation"
-          >
-            Delete
-          </TableBatchAction>
-          <TableBatchAction
-            renderIcon={Error}
-            onClick={() => setModalMode('CANCEL_PROCESS_INSTANCE')}
-            disabled={
-              batchModificationStore.state.isEnabled ||
-              !processInstancesSelectionStore.hasSelectedRunningInstances
-            }
-            title={
-              batchModificationStore.state.isEnabled
-                ? 'Not available in batch modification mode'
-                : !processInstancesSelectionStore.hasSelectedRunningInstances
-                  ? 'No running process instances selected. Please select at least one active or incident process instance to cancel.'
-                  : undefined
-            }
-            data-testid="cancel-batch-operation"
-          >
-            Cancel
-          </TableBatchAction>
-          <TableBatchAction
-            renderIcon={RetryFailed}
-            onClick={() => setModalMode('RESOLVE_INCIDENT')}
-            disabled={
-              batchModificationStore.state.isEnabled ||
-              !processInstancesSelectionStore.hasSelectedInstancesWithIncidents
-            }
-            title={
-              batchModificationStore.state.isEnabled
-                ? 'Not available in batch modification mode'
-                : !processInstancesSelectionStore.hasSelectedInstancesWithIncidents
-                  ? 'No process instances with an incident selected. Please select at least one process instance with an incident to retry.'
-                  : undefined
-            }
-            data-testid="retry-batch-operation"
-          >
-            Retry
-          </TableBatchAction>
-        </TableBatchActions>
-      </TableToolbar>
-
-      <Modal
-        open={modalMode !== null}
-        preventCloseOnClickOutside
-        modalHeading="Apply operation"
-        primaryButtonText={
-          modalMode === 'DELETE_PROCESS_INSTANCE' ? 'Delete' : 'Apply'
-        }
-        danger={modalMode === 'DELETE_PROCESS_INSTANCE'}
-        secondaryButtonText="Cancel"
-        onRequestSubmit={handleApplyClick}
-        onRequestClose={closeModal}
-        onSecondarySubmit={handleCancelClick}
-        size="md"
-      >
-        <p>{getBodyText()}</p>
-      </Modal>
-    </>
-  );
-});
+          <p>{getBodyText()}</p>
+        </Modal>
+      </>
+    );
+  },
+);
 
 export {Toolbar};

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
@@ -191,9 +191,7 @@ const Toolbar: React.FC<Props> = observer(
                     isSelectedCountTruncated ? '+' : ''
                   } items selected`;
                 case 'carbon.table.batch.item.selected':
-                  return `${selectedInstancesCount}${
-                    isSelectedCountTruncated ? '+' : ''
-                  } item selected`;
+                  return `${selectedInstancesCount} item selected`;
                 case 'carbon.table.batch.selectAll':
                   return 'Select all items';
                 default:

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/tests/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/tests/index.test.tsx
@@ -134,6 +134,30 @@ describe('<ProcessOperations />', () => {
     expect(screen.getByText('10 items selected')).toBeInTheDocument();
   });
 
+  it('should append "+" to the selected count label when truncated', async () => {
+    render(
+      <Toolbar selectedInstancesCount={10000} isSelectedCountTruncated />,
+      {wrapper: Wrapper},
+    );
+
+    expect(screen.getByText('10000+ items selected')).toBeInTheDocument();
+  });
+
+  it('should append "+" to the count in the operation confirmation modal when truncated', async () => {
+    const {user} = render(
+      <Toolbar selectedInstancesCount={10000} isSelectedCountTruncated />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    await user.click(screen.getByTestId('cancel-batch-operation'));
+
+    expect(
+      screen.getByText(/10000\+ instances selected for cancel operation/i),
+    ).toBeInTheDocument();
+  });
+
   it('should disable cancel, delete and retry in batch modification mode', async () => {
     const {user} = render(<Toolbar selectedInstancesCount={1} />, {
       wrapper: Wrapper,

--- a/operate/client/src/App/Processes/ListView/InstancesTable/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/index.tsx
@@ -121,6 +121,9 @@ const InstancesTable: React.FC<InstancesTableProps> = observer(
         />
         <Toolbar
           selectedInstancesCount={processInstancesSelectionStore.selectedCount}
+          isSelectedCountTruncated={
+            processInstancesSelectionStore.isSelectedCountTruncated
+          }
         />
         <SortableTable
           state={state}

--- a/operate/client/src/App/Processes/MigrationView/MigrationDetails/index.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/MigrationDetails/index.test.tsx
@@ -27,7 +27,9 @@ const targetDefinition = createProcessDefinition({
   tenantId: '<default>',
 });
 
-function createWrapper() {
+function createWrapper(params: Record<string, string>) {
+  const initialPath = `/processes?${new URLSearchParams(params).toString()}`;
+
   const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
     useEffect(() => {
       processInstanceMigrationStore.enable();
@@ -35,27 +37,28 @@ function createWrapper() {
         processInstanceMigrationStore.reset();
       };
     }, []);
-    return <MemoryRouter>{children}</MemoryRouter>;
+    return (
+      <MemoryRouter initialEntries={[initialPath]}>{children}</MemoryRouter>
+    );
   };
   return Wrapper;
 }
 
 describe('MigrationDetails', () => {
   it('should render migration details', async () => {
-    const queryString =
-      '?active=true&incidents=true&processDefinitionId=demoProcess&processDefinitionVersion=3';
-
-    vi.stubGlobal('location', {
-      ...window.location,
-      search: queryString,
-    });
-
     processInstanceMigrationStore.setSelectedInstancesCount(7);
     processInstanceMigrationStore.setCurrentStep('summary');
     processInstanceMigrationStore.setSourceProcessDefinition(sourceDefinition);
     processInstanceMigrationStore.setTargetProcessDefinition(targetDefinition);
 
-    render(<MigrationDetails />, {wrapper: createWrapper()});
+    render(<MigrationDetails />, {
+      wrapper: createWrapper({
+        active: 'true',
+        incidents: 'true',
+        processDefinitionId: 'demoProcess',
+        processDefinitionVersion: '3',
+      }),
+    });
 
     expect(
       screen.getByText(
@@ -75,20 +78,19 @@ describe('MigrationDetails', () => {
   });
 
   it('should append "+" to the summary count when the selection is truncated', async () => {
-    const queryString =
-      '?active=true&incidents=true&processDefinitionId=demoProcess&processDefinitionVersion=3';
-
-    vi.stubGlobal('location', {
-      ...window.location,
-      search: queryString,
-    });
-
     processInstanceMigrationStore.setSelectedInstancesCount(10000, true);
     processInstanceMigrationStore.setCurrentStep('summary');
     processInstanceMigrationStore.setSourceProcessDefinition(sourceDefinition);
     processInstanceMigrationStore.setTargetProcessDefinition(targetDefinition);
 
-    render(<MigrationDetails />, {wrapper: createWrapper()});
+    render(<MigrationDetails />, {
+      wrapper: createWrapper({
+        active: 'true',
+        incidents: 'true',
+        processDefinitionId: 'demoProcess',
+        processDefinitionVersion: '3',
+      }),
+    });
 
     expect(
       screen.getByText(

--- a/operate/client/src/App/Processes/MigrationView/MigrationDetails/index.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/MigrationDetails/index.test.tsx
@@ -73,4 +73,27 @@ describe('MigrationDetails', () => {
       screen.getByText(/Big variable process - version 1/i),
     ).toBeInTheDocument();
   });
+
+  it('should append "+" to the summary count when the selection is truncated', async () => {
+    const queryString =
+      '?active=true&incidents=true&processDefinitionId=demoProcess&processDefinitionVersion=3';
+
+    vi.stubGlobal('location', {
+      ...window.location,
+      search: queryString,
+    });
+
+    processInstanceMigrationStore.setSelectedInstancesCount(10000, true);
+    processInstanceMigrationStore.setCurrentStep('summary');
+    processInstanceMigrationStore.setSourceProcessDefinition(sourceDefinition);
+    processInstanceMigrationStore.setTargetProcessDefinition(targetDefinition);
+
+    render(<MigrationDetails />, {wrapper: createWrapper()});
+
+    expect(
+      screen.getByText(
+        /You are about to migrate 10000\+ process instances from the process definition:/i,
+      ),
+    ).toBeInTheDocument();
+  });
 });

--- a/operate/client/src/App/Processes/MigrationView/MigrationDetails/index.tsx
+++ b/operate/client/src/App/Processes/MigrationView/MigrationDetails/index.tsx
@@ -16,6 +16,7 @@ const MigrationDetails: React.FC = observer(() => {
     sourceProcessDefinition,
     targetProcessDefinition,
     selectedInstancesCount,
+    isSelectedInstancesCountTruncated,
   } = processInstanceMigrationStore.state;
 
   const sourceVersion = sourceProcessDefinition?.version;
@@ -28,13 +29,15 @@ const MigrationDetails: React.FC = observer(() => {
     ? getProcessDefinitionName(targetProcessDefinition)
     : 'Process';
 
+  const selectedInstancesText = isSelectedInstancesCountTruncated
+    ? `${selectedInstancesCount}+ process instances`
+    : pluralSuffix(selectedInstancesCount, 'process instance');
+
   return (
     <p>
-      You are about to migrate{' '}
-      {pluralSuffix(selectedInstancesCount, 'process instance')} from the
-      process definition:{' '}
-      <strong>{`${sourceName} - version ${sourceVersion}`}</strong> to the
-      process definition:{' '}
+      You are about to migrate {selectedInstancesText} from the process
+      definition: <strong>{`${sourceName} - version ${sourceVersion}`}</strong>{' '}
+      to the process definition:{' '}
       <strong>{`${targetName} - version ${targetVersion}`}</strong>
     </p>
   );

--- a/operate/client/src/modules/stores/instancesSelection.test.ts
+++ b/operate/client/src/modules/stores/instancesSelection.test.ts
@@ -569,6 +569,57 @@ describe('InstancesSelection - excludedIds', () => {
   });
 });
 
+describe('InstancesSelection - isSelectedCountTruncated', () => {
+  afterEach(() => {
+    processInstancesSelectionStore.reset();
+  });
+
+  it('should be false in INCLUDE mode even when there are more total items', () => {
+    processInstancesSelectionStore.setRuntime({
+      totalCount: 3,
+      hasMoreTotalItems: true,
+      visibleIds: ['1', '2', '3'],
+    });
+    processInstancesSelectionStore.select('1');
+
+    expect(processInstancesSelectionStore.isSelectedCountTruncated).toBe(false);
+  });
+
+  it('should be true in ALL mode when there are more total items', () => {
+    processInstancesSelectionStore.setRuntime({
+      totalCount: 3,
+      hasMoreTotalItems: true,
+      visibleIds: ['1', '2', '3'],
+    });
+    processInstancesSelectionStore.selectAll();
+
+    expect(processInstancesSelectionStore.isSelectedCountTruncated).toBe(true);
+  });
+
+  it('should be true in EXCLUDE mode when there are more total items', () => {
+    processInstancesSelectionStore.setRuntime({
+      totalCount: 3,
+      hasMoreTotalItems: true,
+      visibleIds: ['1', '2', '3'],
+    });
+    processInstancesSelectionStore.selectAll();
+    processInstancesSelectionStore.select('1');
+
+    expect(processInstancesSelectionStore.isSelectedCountTruncated).toBe(true);
+  });
+
+  it('should be false in ALL mode when there are no more total items', () => {
+    processInstancesSelectionStore.setRuntime({
+      totalCount: 3,
+      hasMoreTotalItems: false,
+      visibleIds: ['1', '2', '3'],
+    });
+    processInstancesSelectionStore.selectAll();
+
+    expect(processInstancesSelectionStore.isSelectedCountTruncated).toBe(false);
+  });
+});
+
 describe('InstancesSelection - resetState', () => {
   beforeEach(() => {
     processInstancesSelectionStore.setRuntime({

--- a/operate/client/src/modules/stores/instancesSelection.ts
+++ b/operate/client/src/modules/stores/instancesSelection.ts
@@ -16,6 +16,7 @@ import {
 
 type Runtime = {
   totalCount: number;
+  hasMoreTotalItems?: boolean;
   visibleIds: string[];
   visibleRunningIds?: string[];
   visibleFinishedIds?: string[];
@@ -37,6 +38,7 @@ class InstancesSelection {
   state: State = {...DEFAULT_STATE};
   runtime: Runtime = {
     totalCount: 0,
+    hasMoreTotalItems: false,
     visibleIds: [],
     visibleRunningIds: [],
     visibleFinishedIds: [],
@@ -70,6 +72,7 @@ class InstancesSelection {
 
     if (
       prev.totalCount === next.totalCount &&
+      !!prev.hasMoreTotalItems === !!next.hasMoreTotalItems &&
       isEqual(prev.visibleIds, next.visibleIds) &&
       isEqual(prev.visibleRunningIds ?? [], next.visibleRunningIds ?? []) &&
       isEqual(prev.visibleFinishedIds ?? [], next.visibleFinishedIds ?? []) &&
@@ -161,6 +164,12 @@ class InstancesSelection {
 
   get isAllChecked(): boolean {
     return this.state.selectionMode === 'ALL';
+  }
+
+  get isSelectedCountTruncated(): boolean {
+    return (
+      !!this.runtime.hasMoreTotalItems && this.state.selectionMode !== 'INCLUDE'
+    );
   }
 
   get hasSelectedRunningInstances() {
@@ -267,6 +276,7 @@ class InstancesSelection {
     this.resetState();
     this.runtime = {
       totalCount: 0,
+      hasMoreTotalItems: false,
       visibleIds: [],
       visibleRunningIds: [],
       visibleFinishedIds: [],

--- a/operate/client/src/modules/stores/processInstanceMigration.ts
+++ b/operate/client/src/modules/stores/processInstanceMigration.ts
@@ -34,6 +34,7 @@ type State = {
   selectedSourceElementId?: string;
   selectedTargetElementId?: string;
   selectedInstancesCount: number;
+  isSelectedInstancesCountTruncated: boolean;
   batchOperationQuery: BatchOperationQuery | null;
   sourceProcessDefinition: ProcessDefinition | null;
   targetProcessDefinition: ProcessDefinition | null;
@@ -46,6 +47,7 @@ const DEFAULT_STATE: State = {
   selectedSourceElementId: undefined,
   selectedTargetElementId: undefined,
   selectedInstancesCount: 0,
+  isSelectedInstancesCountTruncated: false,
   batchOperationQuery: null,
   sourceProcessDefinition: null,
   targetProcessDefinition: null,
@@ -151,8 +153,13 @@ class ProcessInstanceMigration {
     return Object.keys(this.state.elementMapping).length > 0;
   }
 
-  setSelectedInstancesCount = (selectedInstancesCount: number) => {
+  setSelectedInstancesCount = (
+    selectedInstancesCount: number,
+    isSelectedInstancesCountTruncated = false,
+  ) => {
     this.state.selectedInstancesCount = selectedInstancesCount;
+    this.state.isSelectedInstancesCountTruncated =
+      isSelectedInstancesCountTruncated;
   };
 
   setBatchOperationQuery = (query: BatchOperationQuery) => {


### PR DESCRIPTION
## Description

This PR improves the selection counts to include truncation markers (`+`) when the total count has more items and users are in `ALL` or `EXCLUDE` selection mode.

- Applied to counts in process instance "selected items" and batch operation modals (delete, cancel, etc.)
- Applied to count in migration summary description
- Applied to count in decision instance "selected items" and batch delete modal

Furthermore, I noticed that the Operations Log page is missing this indicator. I've decided to add it there as well in this PR. Now it should be included in every relevant page.

## Checklist

<!--- Please delete options that are not relevant. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #51096
