### PR TITLE
ci: skip vulnerability gate on release merge-back PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2039,11 +2039,14 @@ jobs:
     name: "Security / Dependency Vulnerability Gate"
     # Runs on all PRs (including forks) that change dependency manifests.
     # Skip backport PRs: code already gated on main. Skip the backport bot.
+    # Skip release merge-backs since release branches never add new dependencies
+    # but cause HTTP 502 errors on GH due to many pom.xml changes.
     # Depends on pr-maven-snapshot to ensure the head snapshot is indexed
     # before the Dependency Review API is called.
     if: >-
       needs.detect-changes.outputs.deps-changed == 'true'
       && github.event_name == 'pull_request'
+      && !startsWith(github.head_ref, 'release-')
       && !startsWith(github.head_ref, 'backport')
       && github.event.pull_request.user.login != 'monorepo-devops-automation[bot]'
     needs: [ detect-changes, pr-maven-snapshot ]


### PR DESCRIPTION
## Description

The `Security / Dependency Vulnerability Gate` (`pr-vuln-check`) runs on release→stable merge-back PRs (head `release-*`, base `stable/**`), where it consistently fails: the release plugin touches many `pom.xml` files, and the resulting Dependency Review API call hits **HTTP 502** on GitHub's side. These PRs introduce no new dependencies, so the gate adds no signal and was being unblocked by hand with the `ci:vuln-gate-override` label on every release (e.g. #59010).

This adds `&& !startsWith(github.head_ref, 'release-')` to the job condition so the gate is skipped automatically for merge-backs.

### Why `head_ref`, not `base_ref`

For a merge-back the **base** is the stable branch (e.g. `stable/8.8`), which never starts with `release` — a condition on `base_ref` would leave the job running. The **head** is the release branch, so the skip must test `github.head_ref`, matching the head-ref pattern already used for backports on the adjacent line and the canonical detector in `auto-merge-back-to-stable.yml`.

## Alternatives considered

- **Keep using the `ci:vuln-gate-override` label** — manual toil on every release; the label remains available as a fallback for anything the branch pattern doesn't cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)