### PR TITLE
fix: allow blob URLs in img-src to unblock form-js document preview

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.bouncycastle>1.85</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha58</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha59</version.camunda-security-library>
     <version.checkstyle>13.8.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>


### PR DESCRIPTION
## Description

Fixed the CSP bug from https://github.com/camunda/camunda/issues/56249#issuecomment-5091607176 by using the latest CSL version where this was fixed. 


