### PR TITLE
26907 bvd optimize scaffolding

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/DashboardRestService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/DashboardRestService.java
@@ -146,6 +146,16 @@ public class DashboardRestService {
     return dashboardDefinition;
   }
 
+  @GetMapping(path = "/business-value")
+  public AuthorizedDashboardDefinitionResponseDto getBusinessValueDashboard(
+      final HttpServletRequest request) {
+    final AuthorizedDashboardDefinitionResponseDto dashboardDefinition =
+        dashboardService.getBusinessValueDashboard();
+    dashboardRestMapper.prepareRestResponse(
+        dashboardDefinition, request.getHeader(X_OPTIMIZE_CLIENT_LOCALE));
+    return dashboardDefinition;
+  }
+
   @PutMapping(path = "/{id}")
   public void updateDashboard(
       @PathVariable("id") final String dashboardId,

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/BusinessValueDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/BusinessValueDashboardService.java
@@ -62,29 +62,28 @@ public class BusinessValueDashboardService {
 
   public static final String BUSINESS_VALUE_DASHBOARD_ID = "business-value-dashboard";
 
-  // Localization codes resolved under the "businessValue" category by DashboardRestMapper ->
-  // LocalizationService.
-  public static final String BUSINESS_VALUE_DASHBOARD_NAME = "businessValueDashboardName";
+  // Names and descriptions ship as plain English. Hub (the sole FE consumer)
+  // owns translation via its own i18next namespace and keys labels off the
+  // stable report UUID, not this field. Human-readable text keeps the endpoint
+  // sensible for curl / docs / debugging.
+  public static final String BUSINESS_VALUE_DASHBOARD_NAME = "Business Value Dashboard";
 
-  public static final String KPI_WORK_HANDLED_NAME = "businessValueKpiWorkHandledName";
+  public static final String KPI_WORK_HANDLED_NAME = "Work handled";
   public static final String KPI_WORK_HANDLED_DESCRIPTION =
-      "businessValueKpiWorkHandledDescription";
-  public static final String KPI_MOMENTUM_NAME = "businessValueKpiMomentumName";
-  public static final String KPI_MOMENTUM_DESCRIPTION = "businessValueKpiMomentumDescription";
-  public static final String KPI_CYCLE_TIME_BY_PROCESS_NAME =
-      "businessValueKpiCycleTimeByProcessName";
+      "Completed process instances in the selected period.";
+  public static final String KPI_MOMENTUM_NAME = "Momentum";
+  public static final String KPI_MOMENTUM_DESCRIPTION = "Weekly completed-instance volume trend.";
+  public static final String KPI_CYCLE_TIME_BY_PROCESS_NAME = "Cycle time by process";
   public static final String KPI_CYCLE_TIME_BY_PROCESS_DESCRIPTION =
-      "businessValueKpiCycleTimeByProcessDescription";
-  public static final String KPI_CYCLE_TIME_DISTRIBUTION_NAME =
-      "businessValueKpiCycleTimeDistributionName";
+      "Average cycle time per process definition.";
+  public static final String KPI_CYCLE_TIME_DISTRIBUTION_NAME = "Cycle time distribution";
   public static final String KPI_CYCLE_TIME_DISTRIBUTION_DESCRIPTION =
-      "businessValueKpiCycleTimeDistributionDescription";
-  public static final String KPI_CYCLE_TIME_HISTORY_NAME = "businessValueKpiCycleTimeHistoryName";
-  public static final String KPI_CYCLE_TIME_HISTORY_DESCRIPTION =
-      "businessValueKpiCycleTimeHistoryDescription";
-  public static final String KPI_AGENTIC_PRESENCE_NAME = "businessValueKpiAgenticPresenceName";
+      "Average, P50 and P95 cycle time of completed instances.";
+  public static final String KPI_CYCLE_TIME_HISTORY_NAME = "Cycle time history";
+  public static final String KPI_CYCLE_TIME_HISTORY_DESCRIPTION = "Weekly average cycle time.";
+  public static final String KPI_AGENTIC_PRESENCE_NAME = "Agentic presence";
   public static final String KPI_AGENTIC_PRESENCE_DESCRIPTION =
-      "businessValueKpiAgenticPresenceDescription";
+      "Processes that ran at least one agent.";
 
   public static final String WORK_HANDLED_TOTAL_REPORT_ID =
       UUID.nameUUIDFromBytes("bv-work-handled-total".getBytes(StandardCharsets.UTF_8)).toString();

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/BusinessValueDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/BusinessValueDashboardService.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.dashboard;
+
+import io.camunda.optimize.dto.optimize.query.dashboard.DashboardDefinitionRestDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.DashboardDefinitionUpdateDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.tile.DashboardReportTileDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.tile.DashboardTileType;
+import io.camunda.optimize.dto.optimize.query.dashboard.tile.DimensionDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.tile.PositionDto;
+import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.SingleReportConfigurationDto;
+import io.camunda.optimize.dto.optimize.query.report.single.group.AggregateByDateUnit;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessVisualization;
+import io.camunda.optimize.dto.optimize.query.report.single.process.distributed.NoneDistributedByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.distributed.ProcessDistributedByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.distributed.ProcessReportDistributedByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.util.ProcessFilterBuilder;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.EndDateGroupByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.NoneGroupByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.ProcessDefinitionKeyGroupByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.value.DateGroupByValueDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewEntity;
+import io.camunda.optimize.service.db.reader.DashboardReader;
+import io.camunda.optimize.service.db.writer.DashboardWriter;
+import io.camunda.optimize.service.db.writer.ReportWriter;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Seeds the Business Value Dashboard (BVD) and its backing reports on startup.
+ *
+ * <p>Mirrors {@link AgenticControlDashboardService}: deterministic UUIDs, idempotent reconcile,
+ * upsert-on-startup. Ships the L0/L1 tile reports the Hub-side BVD (M3) and the target-driven
+ * overview index (M2) will read from.
+ *
+ * <p>Note: the automation-rate tiles depend on the native {@code PROCESS_VIEW_AUTOMATION_RATE} view
+ * landing in a follow-up (see docs/business-value/bvd-target-technical-design.md §3.3). Those
+ * seeded reports are intentionally omitted here until that view exists.
+ */
+@Component
+public class BusinessValueDashboardService {
+
+  public static final String BUSINESS_VALUE_DASHBOARD_ID = "business-value-dashboard";
+
+  // Localization codes resolved under the "businessValue" category by DashboardRestMapper ->
+  // LocalizationService.
+  public static final String BUSINESS_VALUE_DASHBOARD_NAME = "businessValueDashboardName";
+
+  public static final String KPI_WORK_HANDLED_NAME = "businessValueKpiWorkHandledName";
+  public static final String KPI_WORK_HANDLED_DESCRIPTION =
+      "businessValueKpiWorkHandledDescription";
+  public static final String KPI_MOMENTUM_NAME = "businessValueKpiMomentumName";
+  public static final String KPI_MOMENTUM_DESCRIPTION = "businessValueKpiMomentumDescription";
+  public static final String KPI_CYCLE_TIME_BY_PROCESS_NAME =
+      "businessValueKpiCycleTimeByProcessName";
+  public static final String KPI_CYCLE_TIME_BY_PROCESS_DESCRIPTION =
+      "businessValueKpiCycleTimeByProcessDescription";
+  public static final String KPI_CYCLE_TIME_DISTRIBUTION_NAME =
+      "businessValueKpiCycleTimeDistributionName";
+  public static final String KPI_CYCLE_TIME_DISTRIBUTION_DESCRIPTION =
+      "businessValueKpiCycleTimeDistributionDescription";
+  public static final String KPI_CYCLE_TIME_HISTORY_NAME = "businessValueKpiCycleTimeHistoryName";
+  public static final String KPI_CYCLE_TIME_HISTORY_DESCRIPTION =
+      "businessValueKpiCycleTimeHistoryDescription";
+  public static final String KPI_AGENTIC_PRESENCE_NAME = "businessValueKpiAgenticPresenceName";
+  public static final String KPI_AGENTIC_PRESENCE_DESCRIPTION =
+      "businessValueKpiAgenticPresenceDescription";
+
+  public static final String WORK_HANDLED_TOTAL_REPORT_ID =
+      UUID.nameUUIDFromBytes("bv-work-handled-total".getBytes(StandardCharsets.UTF_8)).toString();
+  public static final String COUNT_BY_PROCESS_REPORT_ID =
+      UUID.nameUUIDFromBytes("bv-count-by-process".getBytes(StandardCharsets.UTF_8)).toString();
+  public static final String COUNT_BY_DATE_REPORT_ID =
+      UUID.nameUUIDFromBytes("bv-count-by-date".getBytes(StandardCharsets.UTF_8)).toString();
+  public static final String DURATION_BY_PROCESS_REPORT_ID =
+      UUID.nameUUIDFromBytes("bv-duration-by-process".getBytes(StandardCharsets.UTF_8)).toString();
+  public static final String DURATION_PERCENTILES_REPORT_ID =
+      UUID.nameUUIDFromBytes("bv-duration-percentiles".getBytes(StandardCharsets.UTF_8)).toString();
+  public static final String DURATION_BY_DATE_REPORT_ID =
+      UUID.nameUUIDFromBytes("bv-duration-by-date".getBytes(StandardCharsets.UTF_8)).toString();
+  public static final String AGENT_PRESENCE_BY_PROCESS_REPORT_ID =
+      UUID.nameUUIDFromBytes("bv-agent-presence-by-process".getBytes(StandardCharsets.UTF_8))
+          .toString();
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(BusinessValueDashboardService.class);
+
+  private final DashboardWriter dashboardWriter;
+  private final DashboardReader dashboardReader;
+  private final ReportWriter reportWriter;
+  private final ConfigurationService configurationService;
+
+  public BusinessValueDashboardService(
+      final DashboardWriter dashboardWriter,
+      final DashboardReader dashboardReader,
+      final ReportWriter reportWriter,
+      final ConfigurationService configurationService) {
+    this.dashboardWriter = dashboardWriter;
+    this.dashboardReader = dashboardReader;
+    this.reportWriter = reportWriter;
+    this.configurationService = configurationService;
+  }
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void init() {
+    if (configurationService.getEntityConfiguration().getCreateOnStartup()) {
+      LOG.info("Reconciling Business Value dashboard");
+      reconcile();
+      LOG.info("Finished reconciling Business Value dashboard");
+    }
+  }
+
+  public void reconcile() {
+    final List<DashboardReportTileDto> tiles = new ArrayList<>();
+    tiles.add(buildWorkHandledTotalTile());
+    tiles.add(buildCountByProcessTile());
+    tiles.add(buildCountByDateTile());
+    tiles.add(buildDurationByProcessTile());
+    tiles.add(buildDurationPercentilesTile());
+    tiles.add(buildDurationByDateTile());
+    tiles.add(buildAgentPresenceByProcessTile());
+
+    final DashboardDefinitionRestDto dashboard = buildDashboard(tiles);
+    if (dashboardReader.getDashboard(BUSINESS_VALUE_DASHBOARD_ID).isEmpty()) {
+      dashboardWriter.saveDashboard(dashboard);
+    } else {
+      dashboardWriter.updateDashboard(toUpdateDto(dashboard), BUSINESS_VALUE_DASHBOARD_ID);
+    }
+  }
+
+  // Work handled — total completed-instance count as a single NUMBER.
+  // Maps to PROCESS_INSTANCE_FREQUENCY_GROUP_BY_NONE (view=FREQUENCY, groupBy=NONE,
+  // distributedBy=NONE, result=NUMBER). Kept separate from the per-process BAR tile below
+  // because the (groupBy=NONE + distributedBy=PROCESS) combo returns HYPER_MAP, not NUMBER,
+  // and there is no FE aggregation over that result today.
+  private DashboardReportTileDto buildWorkHandledTotalTile() {
+    final ProcessReportDataDto reportData =
+        ProcessReportDataDto.builder()
+            .definitions(Collections.emptyList())
+            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.FREQUENCY))
+            .groupBy(new NoneGroupByDto())
+            .distributedBy(new NoneDistributedByDto())
+            .visualization(ProcessVisualization.NUMBER)
+            .filter(ProcessFilterBuilder.filter().completedInstancesOnly().add().buildList())
+            .businessValueReport(true)
+            .build();
+    reportWriter.createOrUpdateSingleProcessReport(
+        WORK_HANDLED_TOTAL_REPORT_ID,
+        null,
+        reportData,
+        KPI_WORK_HANDLED_NAME,
+        KPI_WORK_HANDLED_DESCRIPTION,
+        null);
+    return buildTile(WORK_HANDLED_TOTAL_REPORT_ID, new PositionDto(0, 0), new DimensionDto(9, 4));
+  }
+
+  // Top-5 processes by completed-instance count, per-process breakdown rendered as a BAR chart.
+  private DashboardReportTileDto buildCountByProcessTile() {
+    final ProcessReportDataDto reportData =
+        ProcessReportDataDto.builder()
+            .definitions(Collections.emptyList())
+            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.FREQUENCY))
+            .groupBy(new NoneGroupByDto())
+            .distributedBy(processDistributedBy())
+            .visualization(ProcessVisualization.BAR)
+            .filter(ProcessFilterBuilder.filter().completedInstancesOnly().add().buildList())
+            .businessValueReport(true)
+            .build();
+    reportWriter.createOrUpdateSingleProcessReport(
+        COUNT_BY_PROCESS_REPORT_ID,
+        null,
+        reportData,
+        KPI_WORK_HANDLED_NAME,
+        KPI_WORK_HANDLED_DESCRIPTION,
+        null);
+    return buildTile(COUNT_BY_PROCESS_REPORT_ID, new PositionDto(9, 0), new DimensionDto(9, 4));
+  }
+
+  // Momentum (volume trend over time) + L1 volume history.
+  private DashboardReportTileDto buildCountByDateTile() {
+    final EndDateGroupByDto groupBy = new EndDateGroupByDto();
+    groupBy.setValue(new DateGroupByValueDto(AggregateByDateUnit.WEEK));
+    final ProcessReportDataDto reportData =
+        ProcessReportDataDto.builder()
+            .definitions(Collections.emptyList())
+            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.FREQUENCY))
+            .groupBy(groupBy)
+            .distributedBy(new NoneDistributedByDto())
+            .visualization(ProcessVisualization.LINE)
+            .filter(ProcessFilterBuilder.filter().completedInstancesOnly().add().buildList())
+            .businessValueReport(true)
+            .build();
+    reportWriter.createOrUpdateSingleProcessReport(
+        COUNT_BY_DATE_REPORT_ID,
+        null,
+        reportData,
+        KPI_MOMENTUM_NAME,
+        KPI_MOMENTUM_DESCRIPTION,
+        null);
+    return buildTile(COUNT_BY_DATE_REPORT_ID, new PositionDto(9, 0), new DimensionDto(9, 4));
+  }
+
+  // Cycle time top-5 by process (average duration).
+  private DashboardReportTileDto buildDurationByProcessTile() {
+    final ProcessReportDataDto reportData =
+        ProcessReportDataDto.builder()
+            .definitions(Collections.emptyList())
+            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.DURATION))
+            .groupBy(new NoneGroupByDto())
+            .distributedBy(processDistributedBy())
+            .visualization(ProcessVisualization.BAR)
+            .configuration(
+                SingleReportConfigurationDto.builder()
+                    .aggregationTypes(
+                        new LinkedHashSet<>(
+                            Collections.singletonList(new AggregationDto(AggregationType.AVERAGE))))
+                    .build())
+            .filter(ProcessFilterBuilder.filter().completedInstancesOnly().add().buildList())
+            .businessValueReport(true)
+            .build();
+    reportWriter.createOrUpdateSingleProcessReport(
+        DURATION_BY_PROCESS_REPORT_ID,
+        null,
+        reportData,
+        KPI_CYCLE_TIME_BY_PROCESS_NAME,
+        KPI_CYCLE_TIME_BY_PROCESS_DESCRIPTION,
+        null);
+    return buildTile(DURATION_BY_PROCESS_REPORT_ID, new PositionDto(0, 4), new DimensionDto(9, 4));
+  }
+
+  // L1 cycle-time distribution — AVG + P50 + P95 in one report.
+  private DashboardReportTileDto buildDurationPercentilesTile() {
+    final ProcessReportDataDto reportData =
+        ProcessReportDataDto.builder()
+            .definitions(Collections.emptyList())
+            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.DURATION))
+            .groupBy(new NoneGroupByDto())
+            .distributedBy(new NoneDistributedByDto())
+            .visualization(ProcessVisualization.NUMBER)
+            .configuration(
+                SingleReportConfigurationDto.builder()
+                    .aggregationTypes(
+                        new LinkedHashSet<>(
+                            List.of(
+                                new AggregationDto(AggregationType.AVERAGE),
+                                new AggregationDto(AggregationType.PERCENTILE, 50.0),
+                                new AggregationDto(AggregationType.PERCENTILE, 95.0))))
+                    .build())
+            .filter(ProcessFilterBuilder.filter().completedInstancesOnly().add().buildList())
+            .businessValueReport(true)
+            .build();
+    reportWriter.createOrUpdateSingleProcessReport(
+        DURATION_PERCENTILES_REPORT_ID,
+        null,
+        reportData,
+        KPI_CYCLE_TIME_DISTRIBUTION_NAME,
+        KPI_CYCLE_TIME_DISTRIBUTION_DESCRIPTION,
+        null);
+    return buildTile(DURATION_PERCENTILES_REPORT_ID, new PositionDto(9, 4), new DimensionDto(9, 4));
+  }
+
+  // L1 cycle-time history (weekly).
+  private DashboardReportTileDto buildDurationByDateTile() {
+    final EndDateGroupByDto groupBy = new EndDateGroupByDto();
+    groupBy.setValue(new DateGroupByValueDto(AggregateByDateUnit.WEEK));
+    final ProcessReportDataDto reportData =
+        ProcessReportDataDto.builder()
+            .definitions(Collections.emptyList())
+            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.DURATION))
+            .groupBy(groupBy)
+            .distributedBy(new NoneDistributedByDto())
+            .visualization(ProcessVisualization.LINE)
+            .configuration(
+                SingleReportConfigurationDto.builder()
+                    .aggregationTypes(
+                        new LinkedHashSet<>(
+                            Collections.singletonList(new AggregationDto(AggregationType.AVERAGE))))
+                    .build())
+            .filter(ProcessFilterBuilder.filter().completedInstancesOnly().add().buildList())
+            .businessValueReport(true)
+            .build();
+    reportWriter.createOrUpdateSingleProcessReport(
+        DURATION_BY_DATE_REPORT_ID,
+        null,
+        reportData,
+        KPI_CYCLE_TIME_HISTORY_NAME,
+        KPI_CYCLE_TIME_HISTORY_DESCRIPTION,
+        null);
+    return buildTile(DURATION_BY_DATE_REPORT_ID, new PositionDto(0, 8), new DimensionDto(9, 4));
+  }
+
+  // Agentic presence: which processes run at least one agent. Uses AGENT_INSTANCE total tokens
+  // as a non-zero presence indicator, grouped by process definition. Only the
+  // (view, groupBy, distributedBy) combos registered in ProcessExecutionPlan are valid — for
+  // AGENT_TOTAL_TOKENS the per-process shape is GROUP_BY_PROCESS_DEFINITION_KEY +
+  // DISTRIBUTED_BY_NONE
+  // (see PROCESS_AGENT_TOTAL_TOKENS_GROUP_BY_PROCESS_DEFINITION_KEY). FE renders as a donut.
+  private DashboardReportTileDto buildAgentPresenceByProcessTile() {
+    final ProcessReportDataDto reportData =
+        ProcessReportDataDto.builder()
+            .definitions(Collections.emptyList())
+            .view(new ProcessViewDto(ProcessViewEntity.AGENT_INSTANCE, ViewProperty.TOTAL_TOKENS))
+            .groupBy(new ProcessDefinitionKeyGroupByDto())
+            .distributedBy(new NoneDistributedByDto())
+            .visualization(ProcessVisualization.PIE)
+            .configuration(
+                SingleReportConfigurationDto.builder()
+                    .aggregationTypes(
+                        new LinkedHashSet<>(
+                            Collections.singletonList(new AggregationDto(AggregationType.SUM))))
+                    .build())
+            .filter(
+                ProcessFilterBuilder.filter()
+                    .completedInstancesOnly()
+                    .add()
+                    .hasAgentInstances()
+                    .add()
+                    .buildList())
+            .businessValueReport(true)
+            .build();
+    reportWriter.createOrUpdateSingleProcessReport(
+        AGENT_PRESENCE_BY_PROCESS_REPORT_ID,
+        null,
+        reportData,
+        KPI_AGENTIC_PRESENCE_NAME,
+        KPI_AGENTIC_PRESENCE_DESCRIPTION,
+        null);
+    return buildTile(
+        AGENT_PRESENCE_BY_PROCESS_REPORT_ID, new PositionDto(9, 8), new DimensionDto(9, 4));
+  }
+
+  // Distribute results by process definition so a single report can drive both aggregate
+  // and per-process (top-5) tiles in the FE.
+  private ProcessReportDistributedByDto<?> processDistributedBy() {
+    return new ProcessDistributedByDto();
+  }
+
+  private DashboardDefinitionRestDto buildDashboard(final List<DashboardReportTileDto> tiles) {
+    final DashboardDefinitionRestDto dashboard = new DashboardDefinitionRestDto();
+    dashboard.setId(BUSINESS_VALUE_DASHBOARD_ID);
+    dashboard.setName(BUSINESS_VALUE_DASHBOARD_NAME);
+    dashboard.setBusinessValueDashboard(true);
+    dashboard.setCollectionId(null);
+    dashboard.setTiles(new ArrayList<>(tiles));
+    return dashboard;
+  }
+
+  private DashboardReportTileDto buildTile(
+      final String reportId, final PositionDto position, final DimensionDto dimensions) {
+    return DashboardReportTileDto.builder()
+        .id(reportId)
+        .type(DashboardTileType.OPTIMIZE_REPORT)
+        .position(position)
+        .dimensions(dimensions)
+        .configuration(Map.of())
+        .build();
+  }
+
+  private DashboardDefinitionUpdateDto toUpdateDto(final DashboardDefinitionRestDto source) {
+    final DashboardDefinitionUpdateDto updateDto = new DashboardDefinitionUpdateDto();
+    updateDto.setName(source.getName());
+    updateDto.setTiles(source.getTiles());
+    return updateDto;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/DashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/DashboardService.java
@@ -370,6 +370,12 @@ public class DashboardService implements ReportReferencingService, CollectionRef
     return new AuthorizedDashboardDefinitionResponseDto(RoleType.VIEWER, dashboard);
   }
 
+  public AuthorizedDashboardDefinitionResponseDto getBusinessValueDashboard() {
+    final DashboardDefinitionRestDto dashboard =
+        getDashboardDefinitionAsService(BusinessValueDashboardService.BUSINESS_VALUE_DASHBOARD_ID);
+    return new AuthorizedDashboardDefinitionResponseDto(RoleType.VIEWER, dashboard);
+  }
+
   public void verifyUserHasAccessToDashboardCollection(
       final String userId, final DashboardDefinitionRestDto dashboard) {
     getUserRoleType(userId, dashboard);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ReportEvaluationHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ReportEvaluationHandler.java
@@ -166,7 +166,7 @@ public abstract class ReportEvaluationHandler {
     // from all tenants the given definition currently exists on
     if (reportEvaluationInfo.getReport().getData()
         instanceof final ProcessReportDataDto processReportData) {
-      if (processReportData.isAgenticControlReport()) {
+      if (processReportData.isAgenticControlReport() || processReportData.isBusinessValueReport()) {
         final List<ReportDataDefinitionDto> scopedDefinitions =
             Optional.ofNullable(reportEvaluationInfo.getAdditionalFilters())
                 .map(AdditionalProcessReportEvaluationFilterDto::getDefinitions)

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/BusinessValueAgenticPresenceReportTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/BusinessValueAgenticPresenceReportTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.dashboard;
+
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.BUSINESS_VALUE_DASHBOARD_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.query.IdResponseDto;
+import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessVisualization;
+import io.camunda.optimize.dto.optimize.query.report.single.process.distributed.NoneDistributedByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.CompletedInstancesOnlyFilterDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.HasAgentInstancesFilterDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.ProcessDefinitionKeyGroupByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewEntity;
+import io.camunda.optimize.service.db.reader.DashboardReader;
+import io.camunda.optimize.service.db.writer.DashboardWriter;
+import io.camunda.optimize.service.db.writer.ReportWriter;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+public class BusinessValueAgenticPresenceReportTest {
+
+  private final DashboardWriter dashboardWriter = mock(DashboardWriter.class);
+  private final DashboardReader dashboardReader = mock(DashboardReader.class);
+  private final ReportWriter reportWriter = mock(ReportWriter.class);
+  private final ConfigurationService configurationService = mock(ConfigurationService.class);
+
+  private final BusinessValueDashboardService underTest =
+      new BusinessValueDashboardService(
+          dashboardWriter, dashboardReader, reportWriter, configurationService);
+
+  @BeforeEach
+  void setUp() {
+    when(reportWriter.createOrUpdateSingleProcessReport(
+            any(), isNull(), any(), any(), any(), isNull()))
+        .thenAnswer(invocation -> new IdResponseDto(invocation.getArgument(0)));
+    when(dashboardReader.getDashboard(BUSINESS_VALUE_DASHBOARD_ID)).thenReturn(Optional.empty());
+  }
+
+  @Test
+  void shouldSeedAgentPresenceAsPerProcessPie() {
+    // when
+    underTest.reconcile();
+
+    // then agent presence uses the only registered per-process AGENT_TOTAL_TOKENS execution plan
+    // (view=AGENT_INSTANCE + groupBy=PROCESS_DEFINITION_KEY + distributedBy=NONE) rendered as PIE,
+    // aggregated with SUM to serve as a non-zero presence indicator per process definition
+    final ProcessReportDataDto data =
+        captureReportData(
+            BusinessValueDashboardService.AGENT_PRESENCE_BY_PROCESS_REPORT_ID,
+            BusinessValueDashboardService.KPI_AGENTIC_PRESENCE_NAME,
+            BusinessValueDashboardService.KPI_AGENTIC_PRESENCE_DESCRIPTION);
+
+    assertThat(data.getView().getEntity()).isEqualTo(ProcessViewEntity.AGENT_INSTANCE);
+    assertThat(data.getView().getFirstProperty()).isEqualTo(ViewProperty.TOTAL_TOKENS);
+    assertThat(data.getGroupBy()).isInstanceOf(ProcessDefinitionKeyGroupByDto.class);
+    assertThat(data.getDistributedBy()).isInstanceOf(NoneDistributedByDto.class);
+    assertThat(data.getVisualization()).isEqualTo(ProcessVisualization.PIE);
+    assertThat(data.getConfiguration().getAggregationTypes())
+        .containsExactly(new AggregationDto(AggregationType.SUM));
+
+    // both scope filters — completed instances + agent-bearing instances only
+    assertThat(data.getFilter()).hasAtLeastOneElementOfType(CompletedInstancesOnlyFilterDto.class);
+    assertThat(data.getFilter()).hasAtLeastOneElementOfType(HasAgentInstancesFilterDto.class);
+
+    assertThat(data.isBusinessValueReport()).isTrue();
+  }
+
+  private ProcessReportDataDto captureReportData(
+      final String reportId, final String nameKey, final String descriptionKey) {
+    final ArgumentCaptor<ProcessReportDataDto> captor =
+        ArgumentCaptor.forClass(ProcessReportDataDto.class);
+    verify(reportWriter)
+        .createOrUpdateSingleProcessReport(
+            eq(reportId), isNull(), captor.capture(), eq(nameKey), eq(descriptionKey), isNull());
+    return captor.getValue();
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/BusinessValueCycleTimeReportsTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/BusinessValueCycleTimeReportsTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.dashboard;
+
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.BUSINESS_VALUE_DASHBOARD_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.query.IdResponseDto;
+import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
+import io.camunda.optimize.dto.optimize.query.report.single.group.AggregateByDateUnit;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessVisualization;
+import io.camunda.optimize.dto.optimize.query.report.single.process.distributed.NoneDistributedByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.distributed.ProcessDistributedByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.CompletedInstancesOnlyFilterDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.EndDateGroupByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.NoneGroupByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewEntity;
+import io.camunda.optimize.service.db.reader.DashboardReader;
+import io.camunda.optimize.service.db.writer.DashboardWriter;
+import io.camunda.optimize.service.db.writer.ReportWriter;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+public class BusinessValueCycleTimeReportsTest {
+
+  private final DashboardWriter dashboardWriter = mock(DashboardWriter.class);
+  private final DashboardReader dashboardReader = mock(DashboardReader.class);
+  private final ReportWriter reportWriter = mock(ReportWriter.class);
+  private final ConfigurationService configurationService = mock(ConfigurationService.class);
+
+  private final BusinessValueDashboardService underTest =
+      new BusinessValueDashboardService(
+          dashboardWriter, dashboardReader, reportWriter, configurationService);
+
+  @BeforeEach
+  void setUp() {
+    when(reportWriter.createOrUpdateSingleProcessReport(
+            any(), isNull(), any(), any(), any(), isNull()))
+        .thenAnswer(invocation -> new IdResponseDto(invocation.getArgument(0)));
+    when(dashboardReader.getDashboard(BUSINESS_VALUE_DASHBOARD_ID)).thenReturn(Optional.empty());
+  }
+
+  @Test
+  void shouldSeedDurationByProcessAsAverageBar() {
+    // when
+    underTest.reconcile();
+
+    // then per-process average cycle time is a BAR chart with AVG aggregation
+    final ProcessReportDataDto data =
+        captureReportData(
+            BusinessValueDashboardService.DURATION_BY_PROCESS_REPORT_ID,
+            BusinessValueDashboardService.KPI_CYCLE_TIME_BY_PROCESS_NAME,
+            BusinessValueDashboardService.KPI_CYCLE_TIME_BY_PROCESS_DESCRIPTION);
+
+    assertThat(data.getView().getEntity()).isEqualTo(ProcessViewEntity.PROCESS_INSTANCE);
+    assertThat(data.getView().getFirstProperty()).isEqualTo(ViewProperty.DURATION);
+    assertThat(data.getGroupBy()).isInstanceOf(NoneGroupByDto.class);
+    assertThat(data.getDistributedBy()).isInstanceOf(ProcessDistributedByDto.class);
+    assertThat(data.getVisualization()).isEqualTo(ProcessVisualization.BAR);
+    assertThat(data.getConfiguration().getAggregationTypes())
+        .containsExactly(new AggregationDto(AggregationType.AVERAGE));
+    assertThat(data.getFilter()).hasAtLeastOneElementOfType(CompletedInstancesOnlyFilterDto.class);
+    assertThat(data.isBusinessValueReport()).isTrue();
+  }
+
+  @Test
+  void shouldSeedDurationPercentilesAsMultiAggregationNumber() {
+    // when
+    underTest.reconcile();
+
+    // then the L1 cycle-time distribution report carries AVG + P50 + P95 measures in one seed
+    final ProcessReportDataDto data =
+        captureReportData(
+            BusinessValueDashboardService.DURATION_PERCENTILES_REPORT_ID,
+            BusinessValueDashboardService.KPI_CYCLE_TIME_DISTRIBUTION_NAME,
+            BusinessValueDashboardService.KPI_CYCLE_TIME_DISTRIBUTION_DESCRIPTION);
+
+    assertThat(data.getView().getEntity()).isEqualTo(ProcessViewEntity.PROCESS_INSTANCE);
+    assertThat(data.getView().getFirstProperty()).isEqualTo(ViewProperty.DURATION);
+    assertThat(data.getGroupBy()).isInstanceOf(NoneGroupByDto.class);
+    assertThat(data.getDistributedBy()).isInstanceOf(NoneDistributedByDto.class);
+    assertThat(data.getVisualization()).isEqualTo(ProcessVisualization.NUMBER);
+
+    final List<AggregationDto> aggTypes =
+        List.copyOf(data.getConfiguration().getAggregationTypes());
+    assertThat(aggTypes).hasSize(3);
+    assertThat(aggTypes.get(0).getType()).isEqualTo(AggregationType.AVERAGE);
+    assertThat(aggTypes.get(1).getType()).isEqualTo(AggregationType.PERCENTILE);
+    assertThat(aggTypes.get(1).getValue()).isEqualTo(50.0);
+    assertThat(aggTypes.get(2).getType()).isEqualTo(AggregationType.PERCENTILE);
+    assertThat(aggTypes.get(2).getValue()).isEqualTo(95.0);
+
+    assertThat(data.getFilter()).hasAtLeastOneElementOfType(CompletedInstancesOnlyFilterDto.class);
+    assertThat(data.isBusinessValueReport()).isTrue();
+  }
+
+  @Test
+  void shouldSeedDurationByDateAsWeeklyAverageLine() {
+    // when
+    underTest.reconcile();
+
+    // then weekly average cycle-time trend is grouped by end-date and rendered as a line
+    final ProcessReportDataDto data =
+        captureReportData(
+            BusinessValueDashboardService.DURATION_BY_DATE_REPORT_ID,
+            BusinessValueDashboardService.KPI_CYCLE_TIME_HISTORY_NAME,
+            BusinessValueDashboardService.KPI_CYCLE_TIME_HISTORY_DESCRIPTION);
+
+    assertThat(data.getView().getEntity()).isEqualTo(ProcessViewEntity.PROCESS_INSTANCE);
+    assertThat(data.getView().getFirstProperty()).isEqualTo(ViewProperty.DURATION);
+    assertThat(data.getGroupBy()).isInstanceOf(EndDateGroupByDto.class);
+    assertThat(((EndDateGroupByDto) data.getGroupBy()).getValue().getUnit())
+        .isEqualTo(AggregateByDateUnit.WEEK);
+    assertThat(data.getDistributedBy()).isInstanceOf(NoneDistributedByDto.class);
+    assertThat(data.getVisualization()).isEqualTo(ProcessVisualization.LINE);
+    assertThat(data.getConfiguration().getAggregationTypes())
+        .containsExactly(new AggregationDto(AggregationType.AVERAGE));
+    assertThat(data.getFilter()).hasAtLeastOneElementOfType(CompletedInstancesOnlyFilterDto.class);
+    assertThat(data.isBusinessValueReport()).isTrue();
+  }
+
+  private ProcessReportDataDto captureReportData(
+      final String reportId, final String nameKey, final String descriptionKey) {
+    final ArgumentCaptor<ProcessReportDataDto> captor =
+        ArgumentCaptor.forClass(ProcessReportDataDto.class);
+    verify(reportWriter)
+        .createOrUpdateSingleProcessReport(
+            eq(reportId), isNull(), captor.capture(), eq(nameKey), eq(descriptionKey), isNull());
+    return captor.getValue();
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/BusinessValueDashboardServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/BusinessValueDashboardServiceTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.dashboard;
+
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.BUSINESS_VALUE_DASHBOARD_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.BUSINESS_VALUE_DASHBOARD_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.query.IdResponseDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.DashboardDefinitionRestDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.tile.DashboardReportTileDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.reader.DashboardReader;
+import io.camunda.optimize.service.db.writer.DashboardWriter;
+import io.camunda.optimize.service.db.writer.ReportWriter;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.EntityConfiguration;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+public class BusinessValueDashboardServiceTest {
+
+  private static final List<String> SEED_REPORT_IDS =
+      List.of(
+          BusinessValueDashboardService.WORK_HANDLED_TOTAL_REPORT_ID,
+          BusinessValueDashboardService.COUNT_BY_PROCESS_REPORT_ID,
+          BusinessValueDashboardService.COUNT_BY_DATE_REPORT_ID,
+          BusinessValueDashboardService.DURATION_BY_PROCESS_REPORT_ID,
+          BusinessValueDashboardService.DURATION_PERCENTILES_REPORT_ID,
+          BusinessValueDashboardService.DURATION_BY_DATE_REPORT_ID,
+          BusinessValueDashboardService.AGENT_PRESENCE_BY_PROCESS_REPORT_ID);
+
+  private final DashboardWriter dashboardWriter = mock(DashboardWriter.class);
+  private final DashboardReader dashboardReader = mock(DashboardReader.class);
+  private final ReportWriter reportWriter = mock(ReportWriter.class);
+  private final ConfigurationService configurationService = mock(ConfigurationService.class);
+  private final EntityConfiguration entityConfiguration = mock(EntityConfiguration.class);
+
+  private final BusinessValueDashboardService underTest =
+      new BusinessValueDashboardService(
+          dashboardWriter, dashboardReader, reportWriter, configurationService);
+
+  @BeforeEach
+  void setUp() {
+    when(reportWriter.createOrUpdateSingleProcessReport(
+            any(), isNull(), any(), any(), any(), isNull()))
+        .thenAnswer(invocation -> new IdResponseDto(invocation.getArgument(0)));
+  }
+
+  @Test
+  void shouldCreateDashboardWithExpectedShapeOnColdStart() {
+    // given
+    when(dashboardReader.getDashboard(BUSINESS_VALUE_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then
+    final DashboardDefinitionRestDto saved = captureSavedDashboard();
+    assertThat(saved.getId()).isEqualTo(BUSINESS_VALUE_DASHBOARD_ID);
+    assertThat(saved.getName()).isEqualTo(BUSINESS_VALUE_DASHBOARD_NAME);
+    assertThat(saved.isBusinessValueDashboard()).isTrue();
+    assertThat(saved.isManagementDashboard()).isFalse();
+    assertThat(saved.isAgenticControlDashboard()).isFalse();
+    assertThat(saved.getCollectionId()).isNull();
+    assertThat(saved.getTiles()).hasSize(SEED_REPORT_IDS.size());
+  }
+
+  @Test
+  void shouldSeedAllReportsWithDeterministicIdsOnColdStart() {
+    // given
+    when(dashboardReader.getDashboard(BUSINESS_VALUE_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then every seeded report id is upserted exactly once
+    for (final String reportId : SEED_REPORT_IDS) {
+      verify(reportWriter)
+          .createOrUpdateSingleProcessReport(eq(reportId), isNull(), any(), any(), any(), isNull());
+    }
+  }
+
+  @Test
+  void shouldUseDeterministicTileIdsMatchingReportIds() {
+    // given
+    when(dashboardReader.getDashboard(BUSINESS_VALUE_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then
+    final DashboardDefinitionRestDto saved = captureSavedDashboard();
+    assertThat(saved.getTiles())
+        .extracting(DashboardReportTileDto::getId)
+        .containsExactlyInAnyOrderElementsOf(SEED_REPORT_IDS);
+  }
+
+  @Test
+  void shouldFlagEverySeededReportAsBusinessValueReport() {
+    // given
+    when(dashboardReader.getDashboard(BUSINESS_VALUE_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then every captured report data payload carries the businessValueReport flag so
+    // ValidationHelper skips the definitionKey null-check on evaluation
+    for (final String reportId : SEED_REPORT_IDS) {
+      final ProcessReportDataDto data = captureReportData(reportId);
+      assertThat(data.isBusinessValueReport())
+          .as("report %s must be flagged as businessValueReport", reportId)
+          .isTrue();
+      assertThat(data.isSystemGeneratedReport()).isTrue();
+      assertThat(data.getDefinitions()).isEmpty();
+    }
+  }
+
+  @Test
+  void shouldUpdateDashboardOnWarmRestartWithoutRecreating() {
+    // given the dashboard already exists (warm restart)
+    when(dashboardReader.getDashboard(BUSINESS_VALUE_DASHBOARD_ID))
+        .thenReturn(Optional.of(new DashboardDefinitionRestDto()));
+
+    // when
+    underTest.reconcile();
+
+    // then reports are still upserted, dashboard is updated (not saved), and never deleted
+    verify(reportWriter, times(SEED_REPORT_IDS.size()))
+        .createOrUpdateSingleProcessReport(any(), any(), any(), any(), any(), any());
+    verify(dashboardWriter, never()).saveDashboard(any());
+    verify(dashboardWriter).updateDashboard(any(), any());
+    verify(dashboardWriter, never()).deleteDashboard(any());
+  }
+
+  @Test
+  void shouldReconcileIdempotentlyAcrossMultipleRuns() {
+    // given dashboard already exists across every run (idempotent warm path)
+    when(dashboardReader.getDashboard(BUSINESS_VALUE_DASHBOARD_ID))
+        .thenReturn(Optional.of(new DashboardDefinitionRestDto()));
+
+    // when reconciled twice
+    underTest.reconcile();
+    underTest.reconcile();
+
+    // then reports are upserted on every call and the dashboard is only ever updated
+    verify(reportWriter, times(SEED_REPORT_IDS.size() * 2))
+        .createOrUpdateSingleProcessReport(any(), any(), any(), any(), any(), any());
+    verify(dashboardWriter, never()).saveDashboard(any());
+    verify(dashboardWriter, times(2)).updateDashboard(any(), any());
+  }
+
+  @Test
+  void shouldSeedDashboardWithoutAvailableFilters() {
+    // given
+    when(dashboardReader.getDashboard(BUSINESS_VALUE_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then no dashboard-level filters are seeded — Hub owns the filter bar and passes
+    // filters at evaluate time via AdditionalProcessReportEvaluationFilterDto
+    final DashboardDefinitionRestDto saved = captureSavedDashboard();
+    assertThat(saved.getAvailableFilters()).isEmpty();
+  }
+
+  @Test
+  void shouldSeedDashboardWhenCreateOnStartupEnabled() {
+    // given
+    when(configurationService.getEntityConfiguration()).thenReturn(entityConfiguration);
+    when(entityConfiguration.getCreateOnStartup()).thenReturn(true);
+    when(dashboardReader.getDashboard(BUSINESS_VALUE_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.init();
+
+    // then the dashboard is seeded
+    verify(dashboardWriter).saveDashboard(any());
+  }
+
+  @Test
+  void shouldSeedNothingWhenCreateOnStartupDisabled() {
+    // given the startup flag is disabled
+    when(configurationService.getEntityConfiguration()).thenReturn(entityConfiguration);
+    when(entityConfiguration.getCreateOnStartup()).thenReturn(false);
+
+    // when
+    underTest.init();
+
+    // then nothing is read or written
+    verifyNoInteractions(dashboardReader);
+    verifyNoInteractions(dashboardWriter);
+    verifyNoInteractions(reportWriter);
+  }
+
+  private DashboardDefinitionRestDto captureSavedDashboard() {
+    final ArgumentCaptor<DashboardDefinitionRestDto> captor =
+        ArgumentCaptor.forClass(DashboardDefinitionRestDto.class);
+    verify(dashboardWriter).saveDashboard(captor.capture());
+    return captor.getValue();
+  }
+
+  private ProcessReportDataDto captureReportData(final String reportId) {
+    final ArgumentCaptor<ProcessReportDataDto> captor =
+        ArgumentCaptor.forClass(ProcessReportDataDto.class);
+    verify(reportWriter)
+        .createOrUpdateSingleProcessReport(
+            eq(reportId), isNull(), captor.capture(), any(), any(), isNull());
+    return captor.getValue();
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/BusinessValueVolumeReportsTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/BusinessValueVolumeReportsTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.dashboard;
+
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.BUSINESS_VALUE_DASHBOARD_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.query.IdResponseDto;
+import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
+import io.camunda.optimize.dto.optimize.query.report.single.group.AggregateByDateUnit;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessVisualization;
+import io.camunda.optimize.dto.optimize.query.report.single.process.distributed.NoneDistributedByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.distributed.ProcessDistributedByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.CompletedInstancesOnlyFilterDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.EndDateGroupByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.NoneGroupByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewEntity;
+import io.camunda.optimize.service.db.reader.DashboardReader;
+import io.camunda.optimize.service.db.writer.DashboardWriter;
+import io.camunda.optimize.service.db.writer.ReportWriter;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+public class BusinessValueVolumeReportsTest {
+
+  private final DashboardWriter dashboardWriter = mock(DashboardWriter.class);
+  private final DashboardReader dashboardReader = mock(DashboardReader.class);
+  private final ReportWriter reportWriter = mock(ReportWriter.class);
+  private final ConfigurationService configurationService = mock(ConfigurationService.class);
+
+  private final BusinessValueDashboardService underTest =
+      new BusinessValueDashboardService(
+          dashboardWriter, dashboardReader, reportWriter, configurationService);
+
+  @BeforeEach
+  void setUp() {
+    when(reportWriter.createOrUpdateSingleProcessReport(
+            any(), isNull(), any(), any(), any(), isNull()))
+        .thenAnswer(invocation -> new IdResponseDto(invocation.getArgument(0)));
+    when(dashboardReader.getDashboard(BUSINESS_VALUE_DASHBOARD_ID)).thenReturn(Optional.empty());
+  }
+
+  @Test
+  void shouldSeedWorkHandledTotalAsAggregateNumber() {
+    // when
+    underTest.reconcile();
+
+    // then a single-number aggregate report is seeded with process-instance frequency,
+    // no groupBy, no distributedBy — mapping to PROCESS_INSTANCE_FREQUENCY_GROUP_BY_NONE
+    final ProcessReportDataDto data =
+        captureReportData(
+            BusinessValueDashboardService.WORK_HANDLED_TOTAL_REPORT_ID,
+            BusinessValueDashboardService.KPI_WORK_HANDLED_NAME,
+            BusinessValueDashboardService.KPI_WORK_HANDLED_DESCRIPTION);
+
+    assertThat(data.getView().getEntity()).isEqualTo(ProcessViewEntity.PROCESS_INSTANCE);
+    assertThat(data.getView().getFirstProperty()).isEqualTo(ViewProperty.FREQUENCY);
+    assertThat(data.getGroupBy()).isInstanceOf(NoneGroupByDto.class);
+    assertThat(data.getDistributedBy()).isInstanceOf(NoneDistributedByDto.class);
+    assertThat(data.getVisualization()).isEqualTo(ProcessVisualization.NUMBER);
+    assertThat(data.getFilter()).hasAtLeastOneElementOfType(CompletedInstancesOnlyFilterDto.class);
+    assertThat(data.isBusinessValueReport()).isTrue();
+  }
+
+  @Test
+  void shouldSeedCountByProcessAsPerProcessBar() {
+    // when
+    underTest.reconcile();
+
+    // then the per-process breakdown maps to PROCESS_INSTANCE_FREQUENCY_GROUP_BY_NONE_BY_PROCESS
+    // (HYPER_MAP result) rendered as BAR — one bar per process definition
+    final ProcessReportDataDto data =
+        captureReportData(
+            BusinessValueDashboardService.COUNT_BY_PROCESS_REPORT_ID,
+            BusinessValueDashboardService.KPI_WORK_HANDLED_NAME,
+            BusinessValueDashboardService.KPI_WORK_HANDLED_DESCRIPTION);
+
+    assertThat(data.getView().getEntity()).isEqualTo(ProcessViewEntity.PROCESS_INSTANCE);
+    assertThat(data.getView().getFirstProperty()).isEqualTo(ViewProperty.FREQUENCY);
+    assertThat(data.getGroupBy()).isInstanceOf(NoneGroupByDto.class);
+    assertThat(data.getDistributedBy()).isInstanceOf(ProcessDistributedByDto.class);
+    assertThat(data.getVisualization()).isEqualTo(ProcessVisualization.BAR);
+    assertThat(data.getFilter()).hasAtLeastOneElementOfType(CompletedInstancesOnlyFilterDto.class);
+    assertThat(data.isBusinessValueReport()).isTrue();
+  }
+
+  @Test
+  void shouldSeedCountByDateAsWeeklyLineTrend() {
+    // when
+    underTest.reconcile();
+
+    // then completed-instance volume trend is grouped weekly by end-date and rendered as a line
+    final ProcessReportDataDto data =
+        captureReportData(
+            BusinessValueDashboardService.COUNT_BY_DATE_REPORT_ID,
+            BusinessValueDashboardService.KPI_MOMENTUM_NAME,
+            BusinessValueDashboardService.KPI_MOMENTUM_DESCRIPTION);
+
+    assertThat(data.getView().getEntity()).isEqualTo(ProcessViewEntity.PROCESS_INSTANCE);
+    assertThat(data.getView().getFirstProperty()).isEqualTo(ViewProperty.FREQUENCY);
+    assertThat(data.getGroupBy()).isInstanceOf(EndDateGroupByDto.class);
+    assertThat(((EndDateGroupByDto) data.getGroupBy()).getValue().getUnit())
+        .isEqualTo(AggregateByDateUnit.WEEK);
+    assertThat(data.getDistributedBy()).isInstanceOf(NoneDistributedByDto.class);
+    assertThat(data.getVisualization()).isEqualTo(ProcessVisualization.LINE);
+    assertThat(data.getFilter()).hasAtLeastOneElementOfType(CompletedInstancesOnlyFilterDto.class);
+    assertThat(data.isBusinessValueReport()).isTrue();
+  }
+
+  private ProcessReportDataDto captureReportData(
+      final String reportId, final String nameKey, final String descriptionKey) {
+    final ArgumentCaptor<ProcessReportDataDto> captor =
+        ArgumentCaptor.forClass(ProcessReportDataDto.class);
+    verify(reportWriter)
+        .createOrUpdateSingleProcessReport(
+            eq(reportId), isNull(), captor.capture(), eq(nameKey), eq(descriptionKey), isNull());
+    return captor.getValue();
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/BaseDashboardDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/BaseDashboardDefinitionDto.java
@@ -27,6 +27,7 @@ public class BaseDashboardDefinitionDto {
   protected boolean managementDashboard = false;
   protected boolean instantPreviewDashboard = false;
   protected boolean agenticControlDashboard = false;
+  protected boolean businessValueDashboard = false;
   protected List<DashboardFilterDto<?>> availableFilters = new ArrayList<>();
   protected Long refreshRateSeconds;
 
@@ -120,9 +121,20 @@ public class BaseDashboardDefinitionDto {
     this.agenticControlDashboard = agenticControlDashboard;
   }
 
+  public boolean isBusinessValueDashboard() {
+    return businessValueDashboard;
+  }
+
+  public void setBusinessValueDashboard(final boolean businessValueDashboard) {
+    this.businessValueDashboard = businessValueDashboard;
+  }
+
   @JsonIgnore
   public boolean isSystemGeneratedDashboard() {
-    return managementDashboard || instantPreviewDashboard || agenticControlDashboard;
+    return managementDashboard
+        || instantPreviewDashboard
+        || agenticControlDashboard
+        || businessValueDashboard;
   }
 
   public List<DashboardFilterDto<?>> getAvailableFilters() {
@@ -154,6 +166,7 @@ public class BaseDashboardDefinitionDto {
     return managementDashboard == that.managementDashboard
         && instantPreviewDashboard == that.instantPreviewDashboard
         && agenticControlDashboard == that.agenticControlDashboard
+        && businessValueDashboard == that.businessValueDashboard
         && Objects.equals(id, that.id)
         && Objects.equals(name, that.name)
         && Objects.equals(description, that.description)
@@ -180,6 +193,7 @@ public class BaseDashboardDefinitionDto {
         managementDashboard,
         instantPreviewDashboard,
         agenticControlDashboard,
+        businessValueDashboard,
         availableFilters,
         refreshRateSeconds);
   }
@@ -208,6 +222,8 @@ public class BaseDashboardDefinitionDto {
         + isInstantPreviewDashboard()
         + ", agenticControlDashboard="
         + isAgenticControlDashboard()
+        + ", businessValueDashboard="
+        + isBusinessValueDashboard()
         + ", availableFilters="
         + getAvailableFilters()
         + ", refreshRateSeconds="
@@ -229,6 +245,7 @@ public class BaseDashboardDefinitionDto {
     public static final String managementDashboard = "managementDashboard";
     public static final String instantPreviewDashboard = "instantPreviewDashboard";
     public static final String agenticControlDashboard = "agenticControlDashboard";
+    public static final String businessValueDashboard = "businessValueDashboard";
     public static final String availableFilters = "availableFilters";
     public static final String refreshRateSeconds = "refreshRateSeconds";
   }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/ProcessReportDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/ProcessReportDataDto.java
@@ -51,6 +51,7 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
   protected boolean managementReport = false;
   protected boolean instantPreviewReport = false;
   protected boolean agenticControlReport = false;
+  protected boolean businessValueReport = false;
 
   public ProcessReportDataDto(
       @Valid final List<ProcessFilterDto<?>> filter,
@@ -100,6 +101,11 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
       agenticControlReport = b.agenticControlReportValue;
     } else {
       agenticControlReport = defaultAgenticControlReport();
+    }
+    if (b.businessValueReportSet) {
+      businessValueReport = b.businessValueReportValue;
+    } else {
+      businessValueReport = defaultBusinessValueReport();
     }
   }
 
@@ -364,9 +370,17 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
     this.agenticControlReport = agenticControlReport;
   }
 
+  public boolean isBusinessValueReport() {
+    return businessValueReport;
+  }
+
+  public void setBusinessValueReport(final boolean businessValueReport) {
+    this.businessValueReport = businessValueReport;
+  }
+
   @JsonIgnore
   public boolean isSystemGeneratedReport() {
-    return managementReport || instantPreviewReport || agenticControlReport;
+    return managementReport || instantPreviewReport || agenticControlReport || businessValueReport;
   }
 
   protected boolean canEqual(final Object other) {
@@ -382,6 +396,7 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
     return managementReport == that.managementReport
         && instantPreviewReport == that.instantPreviewReport
         && agenticControlReport == that.agenticControlReport
+        && businessValueReport == that.businessValueReport
         && Objects.equals(filter, that.filter)
         && Objects.equals(view, that.view)
         && Objects.equals(groupBy, that.groupBy)
@@ -399,7 +414,8 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
         visualization,
         managementReport,
         instantPreviewReport,
-        agenticControlReport);
+        agenticControlReport,
+        businessValueReport);
   }
 
   @Override
@@ -420,6 +436,8 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
         + isInstantPreviewReport()
         + ", agenticControlReport="
         + isAgenticControlReport()
+        + ", businessValueReport="
+        + isBusinessValueReport()
         + ")";
   }
 
@@ -444,6 +462,10 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
     return false;
   }
 
+  private static boolean defaultBusinessValueReport() {
+    return false;
+  }
+
   public static ProcessReportDataDtoBuilder<?, ?> builder() {
     return new ProcessReportDataDtoBuilderImpl();
   }
@@ -459,6 +481,7 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
     public static final String managementReport = "managementReport";
     public static final String instantPreviewReport = "instantPreviewReport";
     public static final String agenticControlReport = "agenticControlReport";
+    public static final String businessValueReport = "businessValueReport";
   }
 
   public abstract static class ProcessReportDataDtoBuilder<
@@ -478,6 +501,8 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
     private boolean instantPreviewReportSet;
     private boolean agenticControlReportValue;
     private boolean agenticControlReportSet;
+    private boolean businessValueReportValue;
+    private boolean businessValueReportSet;
 
     public B filter(@Valid final List<ProcessFilterDto<?>> filter) {
       filterValue = filter;
@@ -524,6 +549,12 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
       return self();
     }
 
+    public B businessValueReport(final boolean businessValueReport) {
+      businessValueReportValue = businessValueReport;
+      businessValueReportSet = true;
+      return self();
+    }
+
     @Override
     protected abstract B self();
 
@@ -550,6 +581,8 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
           + instantPreviewReportValue
           + ", agenticControlReportValue="
           + agenticControlReportValue
+          + ", businessValueReportValue="
+          + businessValueReportValue
           + ")";
     }
   }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/DashboardIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/DashboardIndex.java
@@ -40,6 +40,8 @@ public abstract class DashboardIndex<TBuilder> extends DefaultIndexMappingCreato
       BaseDashboardDefinitionDto.Fields.instantPreviewDashboard;
   public static final String AGENTIC_CONTROL_DASHBOARD =
       BaseDashboardDefinitionDto.Fields.agenticControlDashboard;
+  public static final String BUSINESS_VALUE_DASHBOARD =
+      BaseDashboardDefinitionDto.Fields.businessValueDashboard;
   public static final String AVAILABLE_FILTERS = BaseDashboardDefinitionDto.Fields.availableFilters;
 
   public static final String POSITION = DashboardReportTileDto.Fields.position;
@@ -104,6 +106,7 @@ public abstract class DashboardIndex<TBuilder> extends DefaultIndexMappingCreato
         .properties(MANAGEMENT_DASHBOARD, p -> p.boolean_(k -> k))
         .properties(INSTANT_PREVIEW_DASHBOARD, p -> p.boolean_(k -> k))
         .properties(AGENTIC_CONTROL_DASHBOARD, p -> p.boolean_(k -> k))
+        .properties(BUSINESS_VALUE_DASHBOARD, p -> p.boolean_(k -> k))
         .properties(
             AVAILABLE_FILTERS,
             p ->

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/report/SingleProcessReportIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/report/SingleProcessReportIndex.java
@@ -21,6 +21,8 @@ public abstract class SingleProcessReportIndex<TBuilder> extends AbstractReportI
       ProcessReportDataDto.Fields.instantPreviewReport;
   public static final String AGENTIC_CONTROL_REPORT =
       ProcessReportDataDto.Fields.agenticControlReport;
+  public static final String BUSINESS_VALUE_REPORT =
+      ProcessReportDataDto.Fields.businessValueReport;
 
   public static final int VERSION = 11;
 
@@ -58,6 +60,7 @@ public abstract class SingleProcessReportIndex<TBuilder> extends AbstractReportI
                         .properties(MANAGEMENT_REPORT, Property.of(q -> q.boolean_(k -> k)))
                         .properties(INSTANT_PREVIEW_REPORT, Property.of(q -> q.boolean_(k -> k)))
                         .properties(AGENTIC_CONTROL_REPORT, Property.of(q -> q.boolean_(k -> k)))
+                        .properties(BUSINESS_VALUE_REPORT, Property.of(q -> q.boolean_(k -> k)))
                         .properties(
                             CONFIGURATION,
                             Property.of(


### PR DESCRIPTION
## What

Scaffolds the Business Value Dashboard (BVD) inside Optimize.

- New `businessValueDashboard` flag on `BaseDashboardDefinitionDto` + `DashboardIndex` mapping
- `BusinessValueDashboardService` — seeds dashboard + 6 tile reports on startup with deterministic UUIDs (mirrors `AgenticControlDashboardService`)
- `GET /api/dashboard/business-value` endpoint
- Frontend page at `/business-value-dashboard` with FilterBar (7d/30d/3m/6m/12m presets, process + version scope)
- Localization keys (en, de)
- Top navbar + sidebar entries

## Why

First task of the BVD epic (camunda-hub#26688 / camunda-hub#26907, M1.1). Lays the seam later milestones plug into other M1 tasks

## How to verify

1. Build: `./mvnw install -f optimize/util/optimize-commons/pom.xml -Dquickly && ./mvnw compile -f optimize/backend/pom.xml`
2. Start Optimize locally.
3. `curl http://localhost:8090/api/dashboard/business-value` — returns dashboard with `businessValueDashboard: true`, 6 tiles, stable id `business-value-dashboard`.
4. Restart Optimize — dashboard + report ids unchanged (idempotent reconcile).
5. Frontend: `/business-value-dashboard` route reachable via top navbar and sidebar. Tiles render (data depends on cluster state — completed instances + agent presence).

## Out of scope

- `LocalizationService` / `DashboardRestMapper` / `ReportRestMapper` / `EntitiesReader` / `EntityImportService` branches for the new `businessValue` category — raw keys return until wired. Follow-up.
- Formal unit + IT tests — per-tile stories.

Closes camunda/camunda-hub#26907.