### PR TITLE
Detect cluster-variable references in input mappings

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ClusterVariableReference.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ClusterVariableReference.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.element;
+
+import io.camunda.zeebe.el.Expression;
+import io.camunda.zeebe.el.impl.FeelExpression;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Set;
+import org.camunda.feel.syntaxtree.ConstContext;
+import org.camunda.feel.syntaxtree.Exp;
+import org.camunda.feel.syntaxtree.ParsedExpression;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import scala.Tuple2;
+import scala.jdk.javaapi.CollectionConverters;
+
+/**
+ * A reference to a cluster variable in the {@code camunda.vars.<scope>.<name>} format, with an
+ * optional trailing field path (e.g. {@code camunda.vars.env.myVar.a.b}), used in an input mapping.
+ * {@code scope} is one of {@code env}, {@code tenant} or {@code cluster}.
+ *
+ * <p>Detection works on the parsed FEEL AST (feel-scala's variable references), not the raw text,
+ * so it follows the grammar the engine evaluates. What this implies:
+ *
+ * <ul>
+ *   <li>only expressions are scanned; a static value (no leading {@code =}) is a plain string;
+ *   <li>a reference inside a string literal (e.g. {@code ="camunda.vars.env.token"}) stays literal,
+ *       so a runtime value that merely looks like a reference is never resolved (injection-safe);
+ *   <li>FEEL variants — whitespace, unicode, backtick names, comments — are handled by feel-scala;
+ *   <li>unlike a secret reference, a trailing path access into the variable (e.g. {@code
+ *       camunda.vars.env.myVar.a.b}) IS part of the reference: feel-scala folds it into one
+ *       qualified name, and the segments beyond the variable name are captured as {@code
+ *       fieldPath};
+ *   <li>the scope whitelist ({@code env}, {@code tenant}, {@code cluster}) excludes {@code
+ *       camunda.vars.processInstance.*} and any other non-cluster-variable scope; a bare 3-segment
+ *       name (e.g. {@code camunda.vars.env}) is rejected by the four-segment minimum, since it
+ *       carries no variable name.
+ * </ul>
+ *
+ * <p>Known gaps (an undetected or less-specific reference is simply not resolved, so nothing
+ * leaks): a {@code camunda} bound by an iterator/parameter/context key still reports the reference;
+ * and a reference inside a context produced by a non-context expression (e.g. {@code =if c then {x:
+ * camunda.vars.env.token} else null}) is reported at the enclosing path, not the inner {@code x}.
+ */
+@NullMarked
+public record ClusterVariableReference(String scope, String name, List<String> fieldPath) {
+
+  private static final String ROOT = "camunda";
+  private static final String NAMESPACE = "vars";
+  private static final Set<String> SCOPES = Set.of("env", "tenant", "cluster");
+
+  /**
+   * Minimum segments a {@code camunda.vars.<scope>.<name>} reference has: root, namespace, scope
+   * and name.
+   */
+  private static final int MIN_SEGMENT_COUNT = 4;
+
+  /** Defensively copies {@code fieldPath} so the record's set membership can't be broken later. */
+  public ClusterVariableReference {
+    fieldPath = List.copyOf(fieldPath);
+  }
+
+  /** Creates a reference to the whole variable, with no trailing field path. */
+  public ClusterVariableReference(final String scope, final String name) {
+    this(scope, name, List.of());
+  }
+
+  /**
+   * Parses the cluster-variable references used as expressions in a mapping source, each with the
+   * FEEL context path where it occurs ({@code ="prefix" + camunda.vars.env.myVar} → one reference
+   * at the empty path). Empty when the source is not a FEEL expression or holds no reference.
+   */
+  public static List<DetectedClusterVariable> parse(@Nullable final Expression expression) {
+    if (!(expression instanceof final FeelExpression feelExpression)) {
+      // static values, null sources, and invalid expressions never contain references
+      return List.of();
+    }
+    final var clusterVariables = new ArrayList<DetectedClusterVariable>();
+    collect(
+        feelExpression.getParsedExpression().expression(), new ArrayDeque<>(), clusterVariables);
+    return clusterVariables;
+  }
+
+  /**
+   * Walks a FEEL AST node, recording each cluster-variable reference with its enclosing context
+   * path. A context is descended key by key; any other node is handed to feel-scala for its
+   * variable references (which already exclude literals, comments and bound names).
+   */
+  private static void collect(
+      final Exp node,
+      final Deque<String> path,
+      final List<DetectedClusterVariable> clusterVariables) {
+    if (node instanceof final ConstContext context) {
+      // keep track of nested paths
+      // foo -> {x: camunda.vars.env.x} will have path ["foo", "x"]
+      for (final Tuple2<String, Exp> entry : CollectionConverters.asJava(context.entries())) {
+        path.addLast(entry._1());
+        collect(entry._2(), path, clusterVariables);
+        path.removeLast();
+      }
+      return;
+    }
+    for (final var reference : new ParsedExpression(node, "").getVariableReferences()) {
+      final var qualifiedName = reference.getFullQualifiedName();
+      if (isClusterVariableReference(qualifiedName)) {
+        final var scope = qualifiedName.get(2);
+        final var name = qualifiedName.get(3);
+        final var fieldPath = qualifiedName.subList(MIN_SEGMENT_COUNT, qualifiedName.size());
+        clusterVariables.add(
+            new DetectedClusterVariable(
+                List.copyOf(path), new ClusterVariableReference(scope, name, fieldPath)));
+      }
+    }
+  }
+
+  private static boolean isClusterVariableReference(final List<String> qualifiedName) {
+    // at least four segments — root, namespace, scope and name; anything beyond that is a field
+    // path into the variable. The four-segment minimum (not the scope check) is what rejects a
+    // bare 3-segment name such as camunda.vars.env: `env` is a valid scope, so it is the missing
+    // name that excludes it. The scope whitelist excludes camunda.vars.processInstance.* and any
+    // other non-cluster-variable scope.
+    return qualifiedName.size() >= MIN_SEGMENT_COUNT
+        && ROOT.equals(qualifiedName.get(0))
+        && NAMESPACE.equals(qualifiedName.get(1))
+        && SCOPES.contains(qualifiedName.get(2));
+  }
+
+  /**
+   * A cluster-variable reference with the FEEL context path where it occurs. {@code [x]} for {@code
+   * ={x: camunda.vars.env.myVar}}. The path is appended to the mapping target to form the cluster
+   * variable leaf's JSON pointer.
+   */
+  public record DetectedClusterVariable(
+      List<String> path, ClusterVariableReference clusterVariable) {}
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
@@ -70,6 +70,15 @@ public class ExecutableFlowNode extends AbstractFlowElement {
     return inputMappings.map(InputMappings::secretReferences).orElse(Map.of());
   }
 
+  /**
+   * Cluster-variable references detected in this flow node's input mappings, keyed by the JSON
+   * pointer (RFC 6901) of the leaf each reference belongs to (e.g. {@code /tokens/token}). Empty
+   * when no input mapping references a cluster variable.
+   */
+  public Map<String, Set<ClusterVariableReference>> getClusterVariableReferences() {
+    return inputMappings.map(InputMappings::clusterVariableReferences).orElse(Map.of());
+  }
+
   public List<ExecutionListener> getBeforeAllExecutionListeners() {
     return executionListeners.stream()
         .filter(el -> el.getEventType() == ZeebeExecutionListenerEventType.beforeAll)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableJobWorkerElement.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableJobWorkerElement.java
@@ -27,4 +27,12 @@ public interface ExecutableJobWorkerElement extends ExecutableFlowElement {
    * references a secret.
    */
   Map<String, Set<SecretReference>> getSecretReferences();
+
+  /**
+   * Returns the input-mapping cluster-variable references detected at deploy time, keyed by the
+   * JSON pointer (RFC 6901) where each reference is injected. Every job-worker element is a flow
+   * node, so this mirrors {@link ExecutableFlowNode#getClusterVariableReferences()}. Empty when no
+   * input mapping references a cluster variable.
+   */
+  Map<String, Set<ClusterVariableReference>> getClusterVariableReferences();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/InputMappings.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/InputMappings.java
@@ -17,7 +17,13 @@ import org.jspecify.annotations.NullMarked;
  * modeling order, plus the secret references detected in them, keyed by the JSON pointer (RFC 6901)
  * of the leaf each secret belongs to (e.g. {@code /tokens/token}). {@code secretReferences} is
  * empty when no input mapping references a secret.
+ *
+ * <p>{@code clusterVariableReferences} mirrors {@code secretReferences} for cluster-variable
+ * references ({@code camunda.vars.<scope>.<name>}) detected in the input mappings, keyed by the
+ * same RFC-6901 leaf JSON pointer; empty when no input mapping references a cluster variable.
  */
 @NullMarked
 public record InputMappings(
-    List<InputMapping> mappings, Map<String, Set<SecretReference>> secretReferences) {}
+    List<InputMapping> mappings,
+    Map<String, Set<SecretReference>> secretReferences,
+    Map<String, Set<ClusterVariableReference>> clusterVariableReferences) {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -11,6 +11,8 @@ import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.impl.NullExpression;
 import io.camunda.zeebe.el.impl.StaticExpression;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ClusterVariableReference;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ClusterVariableReference.DetectedClusterVariable;
 import io.camunda.zeebe.engine.processing.deployment.model.element.InputMapping;
 import io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings;
 import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
@@ -105,7 +107,10 @@ public final class VariableMappingTransformer {
                         toInputSourceExpression(mapping.source, expressionLanguage),
                         splitPathExpression(mapping.target)))
             .toList();
-    return new InputMappings(transformedMappings, detectSecretReferences(context));
+    return new InputMappings(
+        transformedMappings,
+        detectSecretReferences(context),
+        detectClusterVariableReferences(context));
   }
 
   private static Expression toInputSourceExpression(
@@ -195,6 +200,66 @@ public final class VariableMappingTransformer {
     path.add(key);
     path.addAll(detected.path());
     return new DetectedSecret(path, detected.secret());
+  }
+
+  /**
+   * Detects the cluster variables referenced by the built mapping context, keyed by the JSON
+   * pointer (RFC 6901) of the leaf each reference belongs to — the leaf's target path plus the
+   * reference's FEEL context path. Mirrors {@link #detectSecretReferences} for cluster-variable
+   * references (see {@link ClusterVariableReference} for what counts).
+   */
+  private static Map<String, Set<ClusterVariableReference>> detectClusterVariableReferences(
+      final MappingContext context) {
+    final var clusterVariablesByPointer =
+        new LinkedHashMap<String, Set<ClusterVariableReference>>();
+    for (final var detected : context.visit(clusterVariableCollector())) {
+      clusterVariablesByPointer
+          .computeIfAbsent(toJsonPointer(detected.path()), key -> new LinkedHashSet<>())
+          .add(detected.clusterVariable());
+    }
+    return clusterVariablesByPointer;
+  }
+
+  /**
+   * Visitor that collects the cluster-variable references of a mapping context as a flat list, each
+   * carrying the path segments of its leaf: the target path (built up from the context keys as the
+   * visit descends) plus the reference's FEEL context path within the source. A nested context is
+   * descended; a leaf holds the source expression to scan.
+   */
+  private static MappingContextVisitor<List<DetectedClusterVariable>> clusterVariableCollector() {
+    return new MappingContextVisitor<>() {
+      @Override
+      public List<DetectedClusterVariable> onEntry(
+          final String targetKey, final Expression source) {
+        return ClusterVariableReference.parse(source).stream()
+            .map(detected -> prependKey(targetKey, detected))
+            .collect(Collectors.toList());
+      }
+
+      @Override
+      public List<DetectedClusterVariable> onContext(
+          final List<List<DetectedClusterVariable>> entries) {
+        return entries.stream().flatMap(List::stream).collect(Collectors.toList());
+      }
+
+      @Override
+      public List<DetectedClusterVariable> onContextEntry(
+          final String targetKey,
+          final List<DetectedClusterVariable> contextValue,
+          final List<String> contextPath) {
+        return contextValue.stream()
+            .map(detected -> prependKey(targetKey, detected))
+            .collect(Collectors.toList());
+      }
+    };
+  }
+
+  private static DetectedClusterVariable prependKey(
+      final String key, final DetectedClusterVariable detected) {
+    final var path = new ArrayList<String>();
+    path.add(key);
+    path.addAll(detected.path());
+    return new DetectedClusterVariable(path, detected.clusterVariable());
   }
 
   /**

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/element/ClusterVariableReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/element/ClusterVariableReferenceTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.element;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ClusterVariableReference.DetectedClusterVariable;
+import java.time.InstantSource;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ClusterVariableReferenceTest {
+
+  private final ExpressionLanguage expressionLanguage =
+      ExpressionLanguageFactory.createExpressionLanguage(
+          new ZeebeFeelEngineClock(InstantSource.system()));
+
+  @ParameterizedTest(name = "[{index}] {0}")
+  @MethodSource("sourcesWithReferences")
+  void shouldParseClusterVariableReferencesUsedAsExpression(
+      final String source, final Set<ClusterVariableReference> expected) {
+    // when / then
+    assertThat(referencesIn(source)).isEqualTo(expected);
+  }
+
+  @ParameterizedTest(name = "[{index}] {0}")
+  @ValueSource(
+      strings = {
+        // not an expression (does not start with '='): the whole value is a literal
+        "",
+        "camunda.vars.env.myVar",
+        // a cluster-variable reference used inside a string literal stays a literal
+        "=\"camunda.vars.env.myVar\"",
+        // 'camunda' is not the root variable
+        "=xcamunda.vars.env.myVar",
+        "=order.camunda.vars.env.myVar",
+        // a reference commented out is not part of the parsed expression
+        "=1 // camunda.vars.env.myVar",
+        // wrong or incomplete reference format: only 3 segments, no variable name
+        "=camunda.vars.env",
+        "=camunda.vars.",
+        "=camunda.vars",
+        // 'processInstance' is not a whitelisted scope
+        "=camunda.vars.processInstance.x",
+        // a secret reference is not a cluster-variable reference (detectors are disjoint)
+        "=camunda.secrets.token",
+        // no reference at all
+        "=",
+        "=userId + orderId",
+        "=\"only literal text\"",
+        // static value (no '='): the whole thing is a literal
+        "\"camunda.vars.env.myVar\"",
+        // a FEEL context holds no reference
+        "={x: \"camunda.vars.env.myVar\"}",
+        "={x: userId, y: orderId}",
+        "={}"
+      })
+  void shouldReturnEmptyWhenNoClusterVariableReferenceUsedAsExpression(final String source) {
+    // when / then
+    assertThat(referencesIn(source)).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyForNullExpression() {
+    // when / then
+    assertThat(ClusterVariableReference.parse(null)).isEmpty();
+  }
+
+  @Test
+  void shouldReportRepeatedReferenceOnce() {
+    // feel-scala's variable references are already de-duplicated, so a reference used twice in one
+    // expression is reported once by parse() itself — before any Set/JSON-pointer collapse in the
+    // transformer. Asserting on the parse() list (not the Set-collecting helper) pins that.
+    final var located =
+        ClusterVariableReference.parse(
+            expressionLanguage.parseExpression(
+                "=camunda.vars.env.token + \"-\" + camunda.vars.env.token"));
+
+    assertThat(located)
+        .extracting(DetectedClusterVariable::clusterVariable)
+        .containsExactly(new ClusterVariableReference("env", "token"));
+  }
+
+  @Test
+  void shouldTreatWholeVariableAndFieldAccessAsDistinctReferences() {
+    // given - one reference to the whole variable, one to a field of the same variable
+    final var references = referencesIn("=camunda.vars.env.x + \"-\" + camunda.vars.env.x.f");
+
+    // then
+    assertThat(references)
+        .containsExactlyInAnyOrder(
+            new ClusterVariableReference("env", "x"),
+            new ClusterVariableReference("env", "x", List.of("f")));
+  }
+
+  @Test
+  void shouldTreatDifferentFieldAccessesAsDistinctReferences() {
+    // given - two different fields of the same variable
+    final var references =
+        referencesIn("=camunda.vars.env.x.field1 + \"-\" + camunda.vars.env.x.field2");
+
+    // then
+    assertThat(references)
+        .containsExactlyInAnyOrder(
+            new ClusterVariableReference("env", "x", List.of("field1")),
+            new ClusterVariableReference("env", "x", List.of("field2")));
+  }
+
+  @Test
+  void shouldDropFieldPathWhenAccessBreaksQualifiedNameChain() {
+    // indexed or parenthesized access is a separate AST node that breaks feel-scala's flat
+    // qualified name, so the reference degrades to the whole variable and the trailing field path
+    // is dropped. The job-join sub-issue keys on fieldPath, so this boundary is pinned here.
+    assertThat(referencesIn("=camunda.vars.env.x[1].y"))
+        .containsExactly(new ClusterVariableReference("env", "x"));
+    assertThat(referencesIn("=(camunda.vars.env.x).y"))
+        .containsExactly(new ClusterVariableReference("env", "x"));
+  }
+
+  @ParameterizedTest(name = "[{index}] {0}")
+  @ValueSource(
+      strings = {
+        "=for camunda in [1, 2] return camunda.vars.env.token",
+        "=some camunda in [1, 2] satisfies camunda.vars.env.token = 1",
+        "=every camunda in [1, 2] satisfies camunda.vars.env.token = 1"
+      })
+  void shouldStillReportReferenceWhenRootIsShadowedByIteration(final String source) {
+    // documented limitation: feel-scala suppresses only whole-name matches, so a bound 'camunda'
+    // does not shadow a qualified camunda.vars.<scope>.<name> path; the reference is still reported
+    assertThat(referencesIn(source)).containsExactly(new ClusterVariableReference("env", "token"));
+  }
+
+  @Test
+  void shouldParseReferenceOutsideButNotInsideStringLiteralWithEscapedQuote() {
+    final var source = "=\"a\\\"b camunda.vars.env.ignored\" + camunda.vars.env.real";
+    assertThat(referencesIn(source)).containsExactly(new ClusterVariableReference("env", "real"));
+  }
+
+  @Test
+  void shouldParseReferenceAfterStringLiteralEndingInEscapedBackslash() {
+    final var source = "=\"a\\\\\" + camunda.vars.env.real";
+    assertThat(referencesIn(source)).containsExactly(new ClusterVariableReference("env", "real"));
+  }
+
+  @Test
+  void shouldReportContextPathForNestedReferences() {
+    // given - a FEEL context with references at different depths and a literal to ignore
+    final var source =
+        "={a: camunda.vars.env.x, b: \"camunda.vars.env.y\", c: {d: camunda.vars.tenant.z}}";
+
+    // when
+    final var located = ClusterVariableReference.parse(expressionLanguage.parseExpression(source));
+
+    // then - the literal 'y' is ignored; each reference carries the keys of its enclosing context
+    assertThat(located)
+        .extracting(DetectedClusterVariable::path, DetectedClusterVariable::clusterVariable)
+        .containsExactlyInAnyOrder(
+            tuple(List.of("a"), new ClusterVariableReference("env", "x")),
+            tuple(List.of("c", "d"), new ClusterVariableReference("tenant", "z")));
+  }
+
+  static Stream<Arguments> sourcesWithReferences() {
+    return Stream.of(
+        arguments("=camunda.vars.env.myVar", Set.of(new ClusterVariableReference("env", "myVar"))),
+        arguments(
+            "=camunda.vars.tenant.myVar", Set.of(new ClusterVariableReference("tenant", "myVar"))),
+        arguments(
+            "=camunda.vars.cluster.myVar",
+            Set.of(new ClusterVariableReference("cluster", "myVar"))),
+        arguments(
+            "=camunda.vars.env.myVar.a",
+            Set.of(new ClusterVariableReference("env", "myVar", List.of("a")))),
+        arguments(
+            "=camunda.vars.env.myVar.a.b.c",
+            Set.of(new ClusterVariableReference("env", "myVar", List.of("a", "b", "c")))),
+        // whitespace and line breaks around the dots are insignificant in FEEL
+        arguments(
+            "=camunda . vars . env . myVar", Set.of(new ClusterVariableReference("env", "myVar"))),
+        arguments(
+            "=camunda\n  .vars\n  .env\n  .myVar",
+            Set.of(new ClusterVariableReference("env", "myVar"))),
+        // unicode names are valid FEEL identifiers
+        arguments("=camunda.vars.env.myVár", Set.of(new ClusterVariableReference("env", "myVár"))),
+        // backtick-escaped names allow special characters
+        arguments(
+            "=camunda.vars.env.`my-var`", Set.of(new ClusterVariableReference("env", "my-var"))),
+        // a reference used inside a comment is not part of the expression
+        arguments(
+            "=camunda.vars.env.myVar // camunda.vars.env.other",
+            Set.of(new ClusterVariableReference("env", "myVar"))),
+        // reference nested inside a FEEL context value
+        arguments(
+            "={ v: camunda.vars.env.myVar }", Set.of(new ClusterVariableReference("env", "myVar"))),
+        // a literal reference is ignored, a real reference after it is captured
+        arguments(
+            "=\"camunda.vars.env.a\" + camunda.vars.env.b",
+            Set.of(new ClusterVariableReference("env", "b"))));
+  }
+
+  private Set<ClusterVariableReference> referencesIn(final String source) {
+    return ClusterVariableReference.parse(expressionLanguage.parseExpression(source)).stream()
+        .map(DetectedClusterVariable::clusterVariable)
+        .collect(Collectors.toSet());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeClusterVariableReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeClusterVariableReferenceTest.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.transformer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ClusterVariableReference;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
+import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
+import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder;
+import java.time.InstantSource;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+class FlowNodeClusterVariableReferenceTest {
+
+  private static final String TASK_ID = "task";
+
+  private final ExpressionLanguage expressionLanguage =
+      ExpressionLanguageFactory.createExpressionLanguage(
+          new ZeebeFeelEngineClock(InstantSource.system()));
+  private final BpmnTransformer transformer = new BpmnTransformer(expressionLanguage);
+
+  @Test
+  void shouldStoreClusterVariableReferenceKeyedByJsonPointer() {
+    // given
+    final var task =
+        transform(
+            t -> t.zeebeInputExpression("\"prefix\" + camunda.vars.env.myVar", "tokens.value"));
+
+    // when
+    final var clusterVariableReferences = task.getClusterVariableReferences();
+
+    // then - the dotted target path is stored as a JSON pointer
+    assertThat(clusterVariableReferences)
+        .containsExactly(
+            entry("/tokens/value", Set.of(new ClusterVariableReference("env", "myVar"))));
+  }
+
+  @Test
+  void shouldStoreClusterVariableReferenceWithFieldPath() {
+    // given
+    final var task =
+        transform(t -> t.zeebeInputExpression("camunda.vars.tenant.myVar.field", "a.b"));
+
+    // when
+    final var clusterVariableReferences = task.getClusterVariableReferences();
+
+    // then
+    assertThat(clusterVariableReferences)
+        .containsExactly(
+            entry(
+                "/a/b", Set.of(new ClusterVariableReference("tenant", "myVar", List.of("field")))));
+  }
+
+  @Test
+  void shouldStoreMultipleReferencesForSingleInputMapping() {
+    // given
+    final var task =
+        transform(
+            t -> t.zeebeInputExpression("camunda.vars.env.a + camunda.vars.env.b", "tokens.value"));
+
+    // when
+    final var clusterVariableReferences = task.getClusterVariableReferences();
+
+    // then
+    assertThat(clusterVariableReferences)
+        .containsExactly(
+            entry(
+                "/tokens/value",
+                Set.of(
+                    new ClusterVariableReference("env", "a"),
+                    new ClusterVariableReference("env", "b"))));
+  }
+
+  @Test
+  void shouldStoreReferencesFromMultipleInputMappings() {
+    // given
+    final var task =
+        transform(
+            t ->
+                t.zeebeInputExpression("camunda.vars.env.a", "auth.a")
+                    .zeebeInputExpression("camunda.vars.env.b", "auth.b"));
+
+    // when
+    final var clusterVariableReferences = task.getClusterVariableReferences();
+
+    // then
+    assertThat(clusterVariableReferences)
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                "/auth/a", Set.of(new ClusterVariableReference("env", "a")),
+                "/auth/b", Set.of(new ClusterVariableReference("env", "b"))));
+  }
+
+  @Test
+  void shouldStoreClusterVariablesForSiblingNestedTargets() {
+    // given - two mappings under the same parent target, each referencing a different variable
+    final var task =
+        transform(
+            t ->
+                t.zeebeInputExpression("camunda.vars.env.v1", "a.b")
+                    .zeebeInputExpression("camunda.vars.env.v2", "a.c"));
+
+    // when
+    final var clusterVariableReferences = task.getClusterVariableReferences();
+
+    // then - each sibling leaf keeps its own pointer
+    assertThat(clusterVariableReferences)
+        .containsExactly(
+            entry("/a/b", Set.of(new ClusterVariableReference("env", "v1"))),
+            entry("/a/c", Set.of(new ClusterVariableReference("env", "v2"))));
+  }
+
+  @Test
+  void shouldScopeJsonPointerToContextEntryOfReference() {
+    // given - the source is a FEEL context; only one entry holds a cluster-variable reference
+    final var task =
+        transform(
+            t ->
+                t.zeebeInputExpression(
+                    "{x1: \"camunda.vars.env.x\", x2: camunda.vars.env.x}", "foo"));
+
+    // when
+    final var clusterVariableReferences = task.getClusterVariableReferences();
+
+    // then - the pointer targets the entry that references the variable, not the whole target
+    assertThat(clusterVariableReferences)
+        .containsExactly(entry("/foo/x2", Set.of(new ClusterVariableReference("env", "x"))));
+  }
+
+  @Test
+  void shouldNotStoreClusterVariableReferenceUsedAsTarget() {
+    // given - the reference-looking path is the target, the source holds no reference
+    final var task = transform(t -> t.zeebeInputExpression("someVariable", "camunda.vars.env.x"));
+
+    // when
+    final var clusterVariableReferences = task.getClusterVariableReferences();
+
+    // then
+    assertThat(clusterVariableReferences).isEmpty();
+  }
+
+  @Test
+  void shouldStoreClusterVariableReferencesByJsonPointerForNestedTargetPath() {
+    // given - a nested (multi-segment) target path
+    final var task =
+        transform(t -> t.zeebeInputExpression("camunda.vars.env.myVar", "auth.headers.token"));
+
+    // when
+    final var clusterVariableReferences = task.getClusterVariableReferences();
+
+    // then - each dot becomes a pointer segment
+    assertThat(clusterVariableReferences)
+        .containsExactly(
+            entry("/auth/headers/token", Set.of(new ClusterVariableReference("env", "myVar"))));
+  }
+
+  @Test
+  void shouldNotStoreClusterVariableReferenceFromOutputMapping() {
+    // given - a cluster-variable reference outside of an input mapping stays a literal
+    final var task = transform(t -> t.zeebeOutputExpression("camunda.vars.env.myVar", "result"));
+
+    // when
+    final var clusterVariableReferences = task.getClusterVariableReferences();
+
+    // then
+    assertThat(clusterVariableReferences).isEmpty();
+  }
+
+  @Test
+  void shouldNotStoreClusterVariableReferenceUsedAsStringLiteral() {
+    // given - the reference is a string literal, not an expression
+    final var task =
+        transform(t -> t.zeebeInputExpression("\"camunda.vars.env.myVar\"", "tokens.value"));
+
+    // when
+    final var clusterVariableReferences = task.getClusterVariableReferences();
+
+    // then
+    assertThat(clusterVariableReferences).isEmpty();
+  }
+
+  @Test
+  void shouldNotStoreClusterVariableReferenceFromStaticInputMapping() {
+    // given - a static (non-expression) input mapping source is a literal
+    final var task = transform(t -> t.zeebeInput("camunda.vars.env.myVar", "tokens.value"));
+
+    // when
+    final var clusterVariableReferences = task.getClusterVariableReferences();
+
+    // then
+    assertThat(clusterVariableReferences).isEmpty();
+  }
+
+  @Test
+  void shouldHaveEmptyClusterVariableReferencesWithoutInputMappings() {
+    // given
+    final var task = transform(t -> {});
+
+    // when
+    final var clusterVariableReferences = task.getClusterVariableReferences();
+
+    // then
+    assertThat(clusterVariableReferences).isEmpty();
+  }
+
+  @Test
+  void shouldStoreOnlyEffectiveClusterVariableWhenTargetIsOverridden() {
+    // given - two input mappings with the same target; the later one overrides the earlier, so
+    // the generated mapping expression keeps only the last source for that target
+    final var task =
+        transform(
+            t ->
+                t.zeebeInputExpression("camunda.vars.env.a", "x")
+                    .zeebeInputExpression("camunda.vars.env.b", "x"));
+
+    // when
+    final var clusterVariableReferences = task.getClusterVariableReferences();
+
+    // then - only the effective (last) mapping's reference is stored, not the overridden one
+    assertThat(clusterVariableReferences)
+        .containsExactly(entry("/x", Set.of(new ClusterVariableReference("env", "b"))));
+  }
+
+  @Test
+  void shouldNotDetectClusterVariablesAndSecretsIntoEachOthersMaps() {
+    // given - one mapping references a secret, another references a cluster variable
+    final var task =
+        transform(
+            t ->
+                t.zeebeInputExpression("camunda.secrets.token", "auth.secret")
+                    .zeebeInputExpression("camunda.vars.env.region", "auth.region"));
+
+    // when
+    final var secretReferences = task.getSecretReferences();
+    final var clusterVariableReferences = task.getClusterVariableReferences();
+
+    // then - each detector only reports its own kind of reference
+    assertThat(secretReferences)
+        .containsExactly(entry("/auth/secret", Set.of(new SecretReference("token"))));
+    assertThat(secretReferences).doesNotContainKey("/auth/region");
+
+    assertThat(clusterVariableReferences)
+        .containsExactly(
+            entry("/auth/region", Set.of(new ClusterVariableReference("env", "region"))));
+    assertThat(clusterVariableReferences).doesNotContainKey("/auth/secret");
+  }
+
+  @Test
+  void shouldNotStoreClusterVariableFromScalarTargetReplacedByNestedTarget() {
+    // given - a scalar target 'a' is replaced by a nested target 'a.b', so 'a' becomes a context
+    // and its scalar source is dropped from the generated mapping
+    final var task =
+        transform(
+            t ->
+                t.zeebeInputExpression("camunda.vars.env.s1", "a")
+                    .zeebeInputExpression("camunda.vars.env.s2", "a.b"));
+
+    // when
+    final var clusterVariableReferences = task.getClusterVariableReferences();
+
+    // then - the overridden scalar 'a' contributes nothing; only the surviving /a/b remains
+    assertThat(clusterVariableReferences)
+        .containsExactly(entry("/a/b", Set.of(new ClusterVariableReference("env", "s2"))));
+  }
+
+  @Test
+  void shouldStoreOnlyEffectiveClusterVariableWhenTargetIsOverriddenByScalarTarget() {
+    // given
+    final var task =
+        transform(
+            t ->
+                t.zeebeInputExpression("camunda.vars.env.s1", "a.b")
+                    .zeebeInputExpression("camunda.vars.env.s2", "a"));
+
+    // when
+    final var clusterVariableReferences = task.getClusterVariableReferences();
+
+    // then
+    assertThat(clusterVariableReferences)
+        .containsExactly(entry("/a", Set.of(new ClusterVariableReference("env", "s2"))));
+  }
+
+  private ExecutableFlowNode transform(final Consumer<ServiceTaskBuilder> modifier) {
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                TASK_ID,
+                t -> {
+                  t.zeebeJobType("test");
+                  modifier.accept(t);
+                })
+            .endEvent()
+            .done();
+
+    final List<ExecutableProcess> processes = transformer.transformDefinitions(model);
+    return processes.getFirst().getElementById(TASK_ID, ExecutableFlowNode.class);
+  }
+}


### PR DESCRIPTION
## Description

First of the three pieces of secret resolution for cluster variables (#56559). At deployment it detects `camunda.vars.{env|tenant|cluster}.<name>` references — a 4-segment whole-variable reference, with an optional trailing field path — in input-mapping source expressions, and stores them on the deployed element model keyed by the input-mapping leaf's RFC-6901 JSON pointer, right next to the existing secret references.

I've kept it as close a mirror of the existing `camunda.secrets.*` detection as I could: detection runs on the parsed FEEL AST (not the raw text), the `env`/`tenant`/`cluster` scope whitelist drops `camunda.vars.processInstance.*` and bare 3-segment names for free, and nothing is persisted — it's recomputed from the BPMN on process-cache load. One deliberate difference from secrets: where a trailing path access into a secret (`camunda.secrets.token.length`) is *not* a reference, for cluster variables the field path *is* captured (as `fieldPath`), since the join needs to know which field is consumed.

Like the secret mirror, detection is unconditional — it doesn't check whether the referenced variable is actually a secret, because that's runtime state and the point is to keep deploy-time free of it.

On its own this doesn't change any runtime behavior; nothing consumes `getClusterVariableReferences()` yet. It's the prerequisite for the job-join sub-issue, which is where the folding actually happens.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #58930 
Relates to #56559
