### PR TITLE
fix: add missing JRE modules for connectors runtime to bundled JDK 25

### DIFF
--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -41,12 +41,29 @@ var conservativeJREModules = []string{
 }
 
 var runtimeProviderJREModules = []string{
-	// The connectors runtime is a Spring Boot fat JAR. Running jdeps on it is prohibitively slow,
-	// so keep provider modules that are commonly resolved indirectly at runtime explicit.
+	// The connectors runtime is a Spring Boot fat JAR. Running jdeps directly against it only sees
+	// the loader classes (everything else is nested under BOOT-INF), so its real module needs -
+	// verified by running jdeps against the exploded BOOT-INF/classes and BOOT-INF/lib - are kept
+	// explicit here instead. Without java.desktop in particular, the bundled runtime fails on any
+	// JDK version with NoClassDefFoundError: java/beans/PropertyEditorSupport while Spring Boot
+	// binds configuration properties.
+	"java.compiler",
+	"java.desktop",
+	"java.instrument",
+	"java.management",
 	"java.management.rmi",
+	"java.naming",
+	"java.net.http",
+	"java.prefs",
+	"java.scripting",
+	"java.security.jgss",
+	"java.sql",
 	"java.xml.crypto",
+	"jdk.jfr",
 	"jdk.management.agent",
 	"jdk.naming.dns",
+	"jdk.net",
+	"jdk.unsupported",
 }
 
 func Clean(camundaVersion, connectorJarToKeep string) {

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -42,8 +42,8 @@ var conservativeJREModules = []string{
 
 var runtimeProviderJREModules = []string{
 	// The connectors runtime is a Spring Boot fat JAR. Running jdeps directly against it only sees
-	// the loader classes (everything else is nested under BOOT-INF), so its real module needs -
-	// verified by running jdeps against the exploded BOOT-INF/classes and BOOT-INF/lib - are kept
+	// the loader classes, since everything else is nested under BOOT-INF, so its real module needs
+	// (verified by running jdeps against the exploded BOOT-INF/classes and BOOT-INF/lib) are kept
 	// explicit here instead. Without java.desktop in particular, the bundled runtime fails on any
 	// JDK version with NoClassDefFoundError: java/beans/PropertyEditorSupport while Spring Boot
 	// binds configuration properties.

--- a/c8run/internal/packages/package_test.go
+++ b/c8run/internal/packages/package_test.go
@@ -159,13 +159,26 @@ func TestMergeModulesAddsRuntimeJREModules(t *testing.T) {
 	// then
 	for _, expectedModule := range []string{
 		"java.base",
+		"java.compiler",
+		"java.desktop",
+		"java.instrument",
+		"java.management",
 		"java.management.rmi",
+		"java.naming",
+		"java.net.http",
+		"java.prefs",
+		"java.scripting",
+		"java.security.jgss",
+		"java.sql",
 		"java.xml.crypto",
 		"jdk.charsets",
 		"jdk.crypto.ec",
+		"jdk.jfr",
 		"jdk.localedata",
 		"jdk.management.agent",
 		"jdk.naming.dns",
+		"jdk.net",
+		"jdk.unsupported",
 		"jdk.zipfs",
 	} {
 		found := false


### PR DESCRIPTION
## Summary

C8Run builds a minimal JRE via `jlink` for its bundled Java 25 runtime. The module list is derived from `jdeps` against the Camunda broker jar, plus a hand-maintained fallback list (`runtimeProviderJREModules`) for modules the Connectors runtime commonly needs — `jdeps` can't see through the Connectors Spring Boot fat jar's `BOOT-INF` layout, so its real dependencies were guessed rather than measured.

That fallback list was missing several modules the Connectors runtime actually requires, most critically `java.desktop`. Without it, Spring Boot's configuration property binding fails during startup with:

```
NoClassDefFoundError: java/beans/PropertyEditorSupport
```

so the bundled Connectors runtime never comes up under Java 25 — matching the symptoms in camunda/connectors#7984 (outbound/MCP jobs never processed, inbound webhooks 404, only on Java 25, only when the bundled JRE is used).

This only affects C8Run's bundled jlinked JRE, a `main`-only feature — `stable/8.9` does no jlink pruning and was never exposed to it, so no backport applies here.

## Root cause verification

- Confirmed the failing nightly CI job (`connector-runtime-bundle 8.10.0-alpha3`) had its "Remove bundled JRE to force system Java" step skipped, i.e. it used the pruned jlinked JRE, and that the alpha3 tag includes the jlink-JRE feature commits.
- Extracted `BOOT-INF/classes` and `BOOT-INF/lib` from a real `connector-runtime-bundle` jar and ran `jdeps` against the exploded classpath to get the real module dependency list (`java.compiler`, `java.desktop`, `java.instrument`, `java.management`, `java.naming`, `java.net.http`, `java.prefs`, `java.scripting`, `java.security.jgss`, `java.sql`, `jdk.jfr`, `jdk.net`, `jdk.unsupported` — none of which were in the old fallback list except `java.management.rmi`/`java.xml.crypto`/`jdk.management.agent`/`jdk.naming.dns`).
- Built two custom jlinked JREs (old module list vs. corrected list) and ran the actual Connectors fat jar under each using c8run's exact launch invocation (`PropertiesLauncher` + wildcard classpath): the old list reproduces the `NoClassDefFoundError` crash; the corrected list starts cleanly.
- Diffed `startuphandler.go` and `unix.go` between `main` and `stable/8.9` to rule out an earlier theory that JDK 25 flag-propagation code (`--enable-native-access`, `--sun-misc-unsafe-memory-access`) was missing on `main` — it's present and equivalent on both branches (in fact `main` is more complete: 8.9's Connectors health check was a `// TODO` stub). The jlink-JRE feature simply doesn't exist on 8.9, which is why the bug is `main`-only.

## Fix

Expanded `runtimeProviderJREModules` in `c8run/internal/packages/package.go` with the missing modules, and updated the corresponding unit test.

## Test plan

- [x] `go test ./...` passes in `c8run/`
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go build -o c8run ./cmd/c8run` succeeds
- [x] Reproduced the failure and the fix locally with jlinked JREs built from the old vs. corrected module lists (see commit message / PR description above)

Refs camunda/connectors#7984

🤖 Generated with [Claude Code](https://claude.com/claude-code)