### PR TITLE
fix: keep serving readiness at the root path under a context path

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
@@ -114,7 +114,7 @@ public class OptimizeTomcatConfig {
         final Optional<String> contextPath = getContextPath();
         if (contextPath.isPresent()) {
           factory.setContextPath(contextPath.get());
-          if (isCslEnabled()) {
+          if (isCslEnabled() && servesUnderSubPath(contextPath.get())) {
             factory.addEngineValves(readyzAtRootValve(contextPath.get()));
           }
         }
@@ -278,6 +278,14 @@ public class OptimizeTomcatConfig {
     }
 
     connector.addSslHostConfig(getSslHostConfig());
+  }
+
+  /**
+   * True when the context path actually moves the app off the root. A blank or {@code "/"} context
+   * path already serves the readiness endpoint at the root, so rewriting would be a no-op.
+   */
+  private static boolean servesUnderSubPath(final String contextPath) {
+    return StringUtils.isNotBlank(contextPath) && !"/".equals(contextPath.trim());
   }
 
   /** Builds the readiness rewrite valve for the given servlet context path. */

--- a/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
@@ -24,7 +24,9 @@ import io.camunda.optimize.tomcat.ResponseSecurityHeaderFilter;
 import io.camunda.optimize.tomcat.ResponseTimezoneFilter;
 import io.camunda.optimize.tomcat.URLRedirectFilter;
 import java.util.Optional;
+import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Connector;
+import org.apache.catalina.valves.rewrite.RewriteValve;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.coyote.http2.Http2Protocol;
 import org.apache.tomcat.util.net.SSLHostConfig;
@@ -94,6 +96,10 @@ public class OptimizeTomcatConfig {
   private static final String CSL_ALLOWED_URL_EXTENSION =
       String.join("|", new String[] {"/oauth2", "/logout"});
 
+  /** Readiness endpoint, relative to the servlet context path. */
+  private static final String READYZ_ENDPOINT =
+      OptimizeResourceConstants.REST_API_PATH + HealthRestService.READYZ_PATH;
+
   private static final String HTTP11_NIO_PROTOCOL = "org.apache.coyote.http11.Http11Nio2Protocol";
 
   @Autowired private ConfigurationService configurationService;
@@ -108,6 +114,9 @@ public class OptimizeTomcatConfig {
         final Optional<String> contextPath = getContextPath();
         if (contextPath.isPresent()) {
           factory.setContextPath(contextPath.get());
+          if (isCslEnabled()) {
+            factory.addEngineValves(readyzAtRootValve(contextPath.get()));
+          }
         }
 
         // NOTE: With the current implementation, we install the mandatory HTTPS connector first,
@@ -269,5 +278,44 @@ public class OptimizeTomcatConfig {
     }
 
     connector.addSslHostConfig(getSslHostConfig());
+  }
+
+  /** Builds the readiness rewrite valve for the given servlet context path. */
+  static RewriteValve readyzAtRootValve(final String contextPath) {
+    return new ReadyzAtRootValve(contextPath);
+  }
+
+  /**
+   * Serves {@link #READYZ_ENDPOINT} at the root path in addition to the servlet context path, by
+   * rewriting {@code /api/readyz} to {@code <contextPath>/api/readyz} in the Tomcat engine
+   * pipeline, which runs before a request is mapped to a context.
+   *
+   * <p>CSL mode derives a {@code /<clusterId>} servlet context path on CCSaaS, but the SaaS
+   * readiness and liveness probes target {@code /api/readyz} on the main connector without that
+   * prefix, so they would 404 and the pod would never become ready. Rewriting keeps those probes
+   * working without a deployment change.
+   *
+   * <p>Only the readiness endpoint is rewritten. It is an unprotected path, so this grants no
+   * access that the context-path-prefixed URL does not already grant.
+   */
+  private static final class ReadyzAtRootValve extends RewriteValve {
+
+    private final String rule;
+
+    private ReadyzAtRootValve(final String contextPath) {
+      rule = "RewriteRule ^" + READYZ_ENDPOINT + "$ " + contextPath + READYZ_ENDPOINT;
+    }
+
+    @Override
+    protected void startInternal() throws LifecycleException {
+      // The superclass looks for a rewrite.config file, finds none and leaves the rules untouched;
+      // it also initialises the logger that setConfiguration needs, so ours must be applied after.
+      super.startInternal();
+      try {
+        setConfiguration(rule);
+      } catch (final Exception e) {
+        throw new LifecycleException("Could not apply the readiness rewrite rule: " + rule, e);
+      }
+    }
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/OptimizeTomcatConfigTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/OptimizeTomcatConfigTest.java
@@ -10,6 +10,7 @@ package io.camunda.optimize;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -45,6 +46,7 @@ public class OptimizeTomcatConfigTest {
   public void shouldAddConnectorsForHttpAndHttps() {
     // when
     when(environment.getProperty(anyString())).thenReturn("property");
+    givenCslDisabled();
     when(environment.getProperty(EnvironmentPropertiesConstants.HTTP_PORT_KEY)).thenReturn("8090");
     when(environment.getProperty(EnvironmentPropertiesConstants.HTTPS_PORT_KEY)).thenReturn("8091");
 
@@ -73,6 +75,7 @@ public class OptimizeTomcatConfigTest {
   public void shouldNotAddConnectorForEmptyHttpPort() {
     // when
     when(environment.getProperty(anyString())).thenReturn("property");
+    givenCslDisabled();
     when(environment.getProperty(EnvironmentPropertiesConstants.HTTP_PORT_KEY)).thenReturn("");
     when(environment.getProperty(EnvironmentPropertiesConstants.HTTPS_PORT_KEY)).thenReturn("8091");
 
@@ -124,5 +127,12 @@ public class OptimizeTomcatConfigTest {
     when(environment.getProperty(httpPortKey)).thenReturn("");
     // then
     assertThat(optimizeTomcatConfig.getPort(httpPortKey)).isEqualTo(-1);
+  }
+
+  /** customize() reads the CSL flag to decide on the readiness rewrite valve. */
+  private void givenCslDisabled() {
+    lenient()
+        .when(environment.getProperty("optimize.security.csl.enabled", Boolean.class, false))
+        .thenReturn(false);
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/ReadyzAtRootPathTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/ReadyzAtRootPathTest.java
@@ -25,9 +25,12 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -45,6 +48,7 @@ class ReadyzAtRootPathTest {
 
   private static final String CONTEXT = "/cluster-1";
   private static final String READYZ = "/api/readyz";
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
 
   @Mock private Environment environment;
   @Mock private ConfigurationService configurationService;
@@ -106,6 +110,18 @@ class ReadyzAtRootPathTest {
     verify(factory, never()).addEngineValves(any());
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"", "  ", "/"})
+  void shouldNotRegisterTheValveForARootContextPath(final String contextPath) {
+    // given — the app already serves the readiness endpoint at the root, so a rewrite is pointless
+    givenContextPath(contextPath);
+    givenCslEnabled(true);
+
+    optimizeTomcatConfig.tomcatFactoryCustomizer().customize(factory);
+
+    verify(factory, never()).addEngineValves(any());
+  }
+
   private void givenContextPath(final String contextPath) {
     lenient().when(environment.getProperty(CONTEXT_PATH)).thenReturn(contextPath);
   }
@@ -140,11 +156,14 @@ class ReadyzAtRootPathTest {
   }
 
   private static int statusOf(final int port, final String path) throws Exception {
+    // Bounded so a failed server start or a hung request fails this test instead of the suite.
+    final HttpClient client = HttpClient.newBuilder().connectTimeout(REQUEST_TIMEOUT).build();
     final HttpResponse<String> response =
-        HttpClient.newHttpClient()
-            .send(
-                HttpRequest.newBuilder(URI.create("http://localhost:" + port + path)).build(),
-                HttpResponse.BodyHandlers.ofString());
+        client.send(
+            HttpRequest.newBuilder(URI.create("http://localhost:" + port + path))
+                .timeout(REQUEST_TIMEOUT)
+                .build(),
+            HttpResponse.BodyHandlers.ofString());
     return response.statusCode();
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/ReadyzAtRootPathTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/ReadyzAtRootPathTest.java
@@ -48,6 +48,7 @@ class ReadyzAtRootPathTest {
 
   private static final String CONTEXT = "/cluster-1";
   private static final String READYZ = "/api/readyz";
+  private static final String OTHER_ENDPOINT = "/api/ui-configuration";
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
 
   @Mock private Environment environment;
@@ -61,15 +62,19 @@ class ReadyzAtRootPathTest {
     realFactory.setContextPath(CONTEXT);
     realFactory.addEngineValves(OptimizeTomcatConfig.readyzAtRootValve(CONTEXT));
 
-    final WebServer server = realFactory.getWebServer(ReadyzAtRootPathTest::registerReadyzServlet);
+    final WebServer server = realFactory.getWebServer(ReadyzAtRootPathTest::registerServlets);
     server.start();
     try {
       assertThat(statusOf(server.getPort(), CONTEXT + READYZ)).isEqualTo(200);
       assertThat(statusOf(server.getPort(), READYZ))
           .describedAs("the legacy probe path must keep working behind a context path")
           .isEqualTo(200);
-      assertThat(statusOf(server.getPort(), "/api/ui-configuration"))
-          .describedAs("only the readiness endpoint is rewritten")
+
+      // Control for the assertion below: this endpoint is served under the context path, so a 404
+      // at the root can only mean the request was not rewritten.
+      assertThat(statusOf(server.getPort(), CONTEXT + OTHER_ENDPOINT)).isEqualTo(200);
+      assertThat(statusOf(server.getPort(), OTHER_ENDPOINT))
+          .describedAs("only the readiness endpoint is rewritten, this is not a prefix strip")
           .isEqualTo(404);
     } finally {
       server.stop();
@@ -139,10 +144,18 @@ class ReadyzAtRootPathTest {
         .thenReturn(null);
   }
 
-  private static void registerReadyzServlet(final jakarta.servlet.ServletContext servletContext) {
+  private static void registerServlets(final jakarta.servlet.ServletContext servletContext) {
+    registerOkServlet(servletContext, "readyz", READYZ);
+    registerOkServlet(servletContext, "uiConfiguration", OTHER_ENDPOINT);
+  }
+
+  private static void registerOkServlet(
+      final jakarta.servlet.ServletContext servletContext,
+      final String name,
+      final String mapping) {
     servletContext
         .addServlet(
-            "readyz",
+            name,
             new HttpServlet() {
               @Override
               protected void doGet(
@@ -152,7 +165,7 @@ class ReadyzAtRootPathTest {
                 response.getWriter().write("ok");
               }
             })
-        .addMapping(READYZ);
+        .addMapping(mapping);
   }
 
   private static int statusOf(final int port, final String path) throws Exception {

--- a/optimize/backend/src/test/java/io/camunda/optimize/ReadyzAtRootPathTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/ReadyzAtRootPathTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.EnvironmentPropertiesConstants;
+import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -144,15 +145,13 @@ class ReadyzAtRootPathTest {
         .thenReturn(null);
   }
 
-  private static void registerServlets(final jakarta.servlet.ServletContext servletContext) {
+  private static void registerServlets(final ServletContext servletContext) {
     registerOkServlet(servletContext, "readyz", READYZ);
     registerOkServlet(servletContext, "uiConfiguration", OTHER_ENDPOINT);
   }
 
   private static void registerOkServlet(
-      final jakarta.servlet.ServletContext servletContext,
-      final String name,
-      final String mapping) {
+      final ServletContext servletContext, final String name, final String mapping) {
     servletContext
         .addServlet(
             name,

--- a/optimize/backend/src/test/java/io/camunda/optimize/ReadyzAtRootPathTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/ReadyzAtRootPathTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize;
+
+import static io.camunda.optimize.service.util.configuration.EnvironmentPropertiesConstants.CONTEXT_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.EnvironmentPropertiesConstants;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServer;
+import org.springframework.core.env.Environment;
+
+/**
+ * CSL mode derives a {@code /<clusterId>} servlet context path on CCSaaS, but the SaaS readiness
+ * and liveness probes target {@code /api/readyz} on the main connector without that prefix.
+ * Optimize rewrites that path in the Tomcat engine pipeline so those probes keep working unchanged.
+ */
+@ExtendWith(MockitoExtension.class)
+class ReadyzAtRootPathTest {
+
+  private static final String CONTEXT = "/cluster-1";
+  private static final String READYZ = "/api/readyz";
+
+  @Mock private Environment environment;
+  @Mock private ConfigurationService configurationService;
+  @Mock private TomcatServletWebServerFactory factory;
+  @InjectMocks private OptimizeTomcatConfig optimizeTomcatConfig;
+
+  @Test
+  void shouldServeReadyzWithAndWithoutTheContextPath() throws Exception {
+    final TomcatServletWebServerFactory realFactory = new TomcatServletWebServerFactory(0);
+    realFactory.setContextPath(CONTEXT);
+    realFactory.addEngineValves(OptimizeTomcatConfig.readyzAtRootValve(CONTEXT));
+
+    final WebServer server = realFactory.getWebServer(ReadyzAtRootPathTest::registerReadyzServlet);
+    server.start();
+    try {
+      assertThat(statusOf(server.getPort(), CONTEXT + READYZ)).isEqualTo(200);
+      assertThat(statusOf(server.getPort(), READYZ))
+          .describedAs("the legacy probe path must keep working behind a context path")
+          .isEqualTo(200);
+      assertThat(statusOf(server.getPort(), "/api/ui-configuration"))
+          .describedAs("only the readiness endpoint is rewritten")
+          .isEqualTo(404);
+    } finally {
+      server.stop();
+    }
+  }
+
+  @Test
+  void shouldRegisterTheValveInCslModeWithAContextPath() {
+    givenContextPath(CONTEXT);
+    givenCslEnabled(true);
+
+    optimizeTomcatConfig.tomcatFactoryCustomizer().customize(factory);
+
+    verify(factory).setContextPath(CONTEXT);
+    verify(factory).addEngineValves(any());
+  }
+
+  @Test
+  void shouldNotRegisterTheValveWhenCslIsDisabled() {
+    givenContextPath(CONTEXT);
+    givenCslEnabled(false);
+
+    optimizeTomcatConfig.tomcatFactoryCustomizer().customize(factory);
+
+    verify(factory).setContextPath(CONTEXT);
+    verify(factory, never()).addEngineValves(any());
+  }
+
+  @Test
+  void shouldNotRegisterTheValveWithoutAContextPath() {
+    givenContextPath(null);
+    when(configurationService.getContextPath()).thenReturn(Optional.empty());
+    givenCslEnabled(true);
+
+    optimizeTomcatConfig.tomcatFactoryCustomizer().customize(factory);
+
+    verify(factory, never()).setContextPath(any());
+    verify(factory, never()).addEngineValves(any());
+  }
+
+  private void givenContextPath(final String contextPath) {
+    lenient().when(environment.getProperty(CONTEXT_PATH)).thenReturn(contextPath);
+  }
+
+  private void givenCslEnabled(final boolean enabled) {
+    lenient()
+        .when(environment.getProperty("optimize.security.csl.enabled", Boolean.class, false))
+        .thenReturn(enabled);
+    // Keep the connector setup in customize() inert: no HTTP or HTTPS port configured.
+    lenient()
+        .when(environment.getProperty(EnvironmentPropertiesConstants.HTTP_PORT_KEY))
+        .thenReturn(null);
+    lenient()
+        .when(environment.getProperty(EnvironmentPropertiesConstants.HTTPS_PORT_KEY))
+        .thenReturn(null);
+  }
+
+  private static void registerReadyzServlet(final jakarta.servlet.ServletContext servletContext) {
+    servletContext
+        .addServlet(
+            "readyz",
+            new HttpServlet() {
+              @Override
+              protected void doGet(
+                  final HttpServletRequest request, final HttpServletResponse response)
+                  throws IOException {
+                response.setStatus(200);
+                response.getWriter().write("ok");
+              }
+            })
+        .addMapping(READYZ);
+  }
+
+  private static int statusOf(final int port, final String path) throws Exception {
+    final HttpResponse<String> response =
+        HttpClient.newHttpClient()
+            .send(
+                HttpRequest.newBuilder(URI.create("http://localhost:" + port + path)).build(),
+                HttpResponse.BodyHandlers.ofString());
+    return response.statusCode();
+  }
+}


### PR DESCRIPTION
> **Temporary workaround.** This exists only so deploying Optimize with CSL stays non-breaking
> against the 8.9 deployment shape. It should be reverted once the controller is updated for 8.10
> deployments (#58486), where the probes move to a path that works with the context path. The revert
> is recorded as an acceptance criterion there.

## Description

CSL mode derives a `/<clusterId>` servlet context path on CCSaaS, but the SaaS probes target `/api/readyz` on the main connector without that prefix:

```yaml
readinessProbe:
  httpGet:
    path: /api/readyz
    port: optimize-http     # the main connector, not the metrics port
```

Those requests map to no context, so they 404 and the pod never becomes ready. Enabling the flag on a test cluster put Optimize into a crashloop.

This rewrites that one path in the Tomcat engine pipeline, which runs before a request is mapped to a context, so `/api/readyz` reaches the app at `/<clusterId>/api/readyz`. Existing probes keep working with no deployment change.

Nothing else is rewritten, and only when CSL is enabled and the context path actually moves the app off the root. `/api/readyz` is an unprotected path, so this grants no access the prefixed URL does not already grant. `ReadyzAtRootPathTest` boots a real Tomcat to prove it: `/api/readyz` and `/cluster-1/api/readyz` both return 200, while `/api/ui-configuration` returns 200 under the context path and 404 at the root, so a general prefix strip would fail the test.

## Related issues

Reverted by #58486 when the 8.10 controller config lands
Follow-up to #58470, which derives the context path from the cluster id
Parent epic #58403
Unblocks #58481

🤖 Generated with [Claude Code](https://claude.com/claude-code)
