### PR TITLE
feat: add per-physical-tenant exporting status endpoint

### DIFF
--- a/docs/adr/management/003-physical-tenant-management-endpoint-inventory.md
+++ b/docs/adr/management/003-physical-tenant-management-endpoint-inventory.md
@@ -42,6 +42,7 @@ Restore endpoints are not fully implemented yet but should follow the same patte
 
 |                Endpoint                 |                       Behavior                       |
 |-----------------------------------------|------------------------------------------------------|
+| `GET /v2/exporting`                     | Aggregate exporting status of the physical tenant.   |
 | `POST /v2/exporting/pause?soft=`        | Pause exporting.                                     |
 | `POST /v2/exporting/resume`             | Resume exporting.                                    |
 | `POST /v2/backups/runtime`              | Trigger runtime backup.                              |

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BackupExportingAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BackupExportingAuthorizationIT.java
@@ -131,6 +131,7 @@ class BackupExportingAuthorizationIT {
   private static final Endpoint DELETE_STATE = new Endpoint("DELETE", "v2/backups/runtime/state");
   private static final Endpoint PAUSE_EXPORTING = new Endpoint("POST", "v2/exporting/pause");
   private static final Endpoint RESUME_EXPORTING = new Endpoint("POST", "v2/exporting/resume");
+  private static final Endpoint GET_EXPORTING_STATUS = new Endpoint("GET", "v2/exporting");
 
   private static final List<Endpoint> BACKUP_ENDPOINTS =
       List.of(
@@ -143,7 +144,7 @@ class BackupExportingAuthorizationIT {
           DELETE_STATE);
 
   private static final List<Endpoint> EXPORTING_ENDPOINTS =
-      List.of(PAUSE_EXPORTING, RESUME_EXPORTING);
+      List.of(PAUSE_EXPORTING, RESUME_EXPORTING, GET_EXPORTING_STATUS);
 
   @AfterAll
   static void deleteBackupDirectory() throws IOException {
@@ -332,6 +333,17 @@ class BackupExportingAuthorizationIT {
       // other test in this class reads its authorizations from
       send(client, RESUME_EXPORTING, EXPORTER_PAUSE_USER);
     }
+  }
+
+  @Test
+  void shouldAllowReadingExportingStatusWithPauseGrant(
+      @Authenticated(EXPORTER_PAUSE_USER) final CamundaClient client) throws Exception {
+    // when a user granted EXPORTER:PAUSE reads the exporting status
+    final var response = send(client, GET_EXPORTING_STATUS, EXPORTER_PAUSE_USER);
+
+    // then it succeeds: EXPORTER only defines PAUSE, so the same grant gates the read
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(response.body()).contains("EXPORTING");
   }
 
   /**

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/exporter/ExportingStatusIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/exporter/ExportingStatusIT.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * End-to-end coverage for {@code GET /v2/exporting}, which reports the exporting phase of a
+ * physical tenant so backup tooling can confirm a pause took effect instead of trusting its own
+ * bookkeeping.
+ *
+ * <p>{@code ExportingRequestBroadcasterTest} and {@code ExportingControllerTest} stub the broker
+ * responses, so they only prove the phases are aggregated and rendered correctly. What they cannot
+ * prove is that the phase read out of a running broker is the one pause and resume just wrote —
+ * that spans the admin request round trip, the persisted partition state and the aggregation, and
+ * is the whole point of the endpoint. Every phase assertion is therefore cross-checked against the
+ * {@code partitions} actuator, which reads the phase by an independent path.
+ *
+ * <p>Several partitions are configured because the endpoint folds over all of them: with a single
+ * partition, an aggregation that dropped every partition but the first would still pass.
+ */
+@ZeebeIntegration
+final class ExportingStatusIT {
+
+  private static final Duration TIMEOUT = Duration.ofSeconds(30);
+  private static final int PARTITION_COUNT = 3;
+  private static final ObjectMapper JSON = new ObjectMapper();
+
+  @TestZeebe(partitionCount = PARTITION_COUNT)
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withUnauthenticatedAccess()
+          .withClusterConfig(cluster -> cluster.setPartitionCount(PARTITION_COUNT));
+
+  @AfterEach
+  void resumeExporting() throws Exception {
+    // The phase is persisted per partition, so a test leaving exporting paused would decide the
+    // outcome of the next one.
+    post("/v2/exporting/resume");
+  }
+
+  @Test
+  void shouldReportExportingWhenNotPaused() {
+    // when - then
+    assertThat(awaitSettledStatus()).isEqualTo("EXPORTING");
+    assertPartitionsReport("EXPORTING");
+  }
+
+  @Test
+  void shouldReportPausedAfterPausing() throws Exception {
+    // when
+    post("/v2/exporting/pause");
+
+    // then
+    assertThat(awaitSettledStatus()).isEqualTo("PAUSED");
+    assertPartitionsReport("PAUSED");
+  }
+
+  @Test
+  void shouldReportSoftPausedAfterSoftPausing() throws Exception {
+    // when
+    post("/v2/exporting/pause?soft=true");
+
+    // then - a soft pause must be distinguishable from a hard one: tooling that cannot tell them
+    // apart cannot tell whether exporting is still progressing
+    assertThat(awaitSettledStatus()).isEqualTo("SOFT_PAUSED");
+    assertPartitionsReport("SOFT_PAUSED");
+  }
+
+  @Test
+  void shouldReportExportingAgainAfterResuming() throws Exception {
+    // given
+    post("/v2/exporting/pause");
+    assertThat(awaitSettledStatus()).isEqualTo("PAUSED");
+
+    // when
+    post("/v2/exporting/resume");
+
+    // then
+    assertThat(awaitSettledStatus()).isEqualTo("EXPORTING");
+    assertPartitionsReport("EXPORTING");
+  }
+
+  @Test
+  void shouldStillReportPausedAfterRestart() throws Exception {
+    // given
+    post("/v2/exporting/pause");
+    assertThat(awaitSettledStatus()).isEqualTo("PAUSED");
+
+    // when - the phase is persisted, so a restart must not silently resume exporting and leave
+    // tooling believing the log is still protected from compaction
+    BROKER.stop();
+    BROKER.start().awaitCompleteTopology(BROKER.unifiedConfig());
+
+    // then
+    assertThat(awaitSettledStatus()).isEqualTo("PAUSED");
+    assertPartitionsReport("PAUSED");
+  }
+
+  /**
+   * The unprefixed path resolves to the default physical tenant, so on a single-tenant cluster both
+   * forms must answer identically.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"/v2/exporting", "/physical-tenants/default/v2/exporting"})
+  void shouldAnswerOnBothTenantScopedPaths(final String path) throws Exception {
+    // given
+    post("/v2/exporting/pause");
+    awaitSettledStatus();
+
+    // when
+    final var response = send("GET", path);
+
+    // then - the body carries the status and nothing else
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(JSON.readTree(response.body()).properties())
+        .singleElement()
+        .satisfies(
+            entry -> {
+              assertThat(entry.getKey()).isEqualTo("status");
+              assertThat(entry.getValue().asText()).isEqualTo("PAUSED");
+            });
+  }
+
+  /**
+   * Pause and resume answer once every partition has acknowledged, but a replica may still be
+   * mid-transition, so the status is polled until it settles on a single phase rather than read
+   * once.
+   */
+  private String awaitSettledStatus() {
+    return Awaitility.await("until the exporting status settles on a single phase")
+        .atMost(TIMEOUT)
+        .until(ExportingStatusIT::readStatus, phase -> !"MIXED".equals(phase));
+  }
+
+  private static String readStatus() throws Exception {
+    final var response = send("GET", "/v2/exporting");
+    assertThat(response.statusCode()).isEqualTo(200);
+    return JSON.readTree(response.body()).get("status").asText();
+  }
+
+  /**
+   * Cross-checks the aggregated status against the {@code partitions} actuator, which reads the
+   * exporter phase straight from each partition instead of through the endpoint under test.
+   */
+  private void assertPartitionsReport(final String expectedPhase) {
+    Awaitility.await("until every partition reports " + expectedPhase)
+        .atMost(TIMEOUT)
+        .untilAsserted(
+            () ->
+                assertThat(PartitionsActuator.of(BROKER).query().values())
+                    .hasSize(PARTITION_COUNT)
+                    .allSatisfy(
+                        partition ->
+                            assertThat(partition.exporterPhase()).isEqualTo(expectedPhase)));
+  }
+
+  private static void post(final String path) throws Exception {
+    final var response = send("POST", path);
+    assertThat(response.statusCode())
+        .as("POST %s should succeed, but got: %s", path, response.body())
+        .isEqualTo(204);
+  }
+
+  private static HttpResponse<String> send(final String method, final String path)
+      throws Exception {
+    final var base = BROKER.restAddress().toString();
+    final var root = base.endsWith("/") ? base.substring(0, base.length() - 1) : base;
+    final var request =
+        HttpRequest.newBuilder(URI.create(root + path))
+            .method(method, BodyPublishers.noBody())
+            .header("Accept", "application/json")
+            .build();
+    return HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
+  }
+}

--- a/service/src/main/java/io/camunda/service/ExportingServices.java
+++ b/service/src/main/java/io/camunda/service/ExportingServices.java
@@ -18,6 +18,7 @@ import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.admin.ExportingRequestBroadcaster;
+import io.camunda.zeebe.gateway.admin.ExportingStatus;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import org.jspecify.annotations.NullMarked;
@@ -76,6 +77,20 @@ public final class ExportingServices extends PhysicalTenantScopedApiServices<Exp
   }
 
   /**
+   * Returns the exporting status aggregated over all partitions of the physical tenant, so backup
+   * tooling can confirm a pause took effect instead of relying on its own bookkeeping.
+   *
+   * <p>Reading is gated on the same permission as pause/resume because {@code EXPORTER} only
+   * defines {@code PAUSE}: there is no separate read permission to grant.
+   */
+  public CompletableFuture<ExportingStatus> getExportingStatus(
+      final CamundaAuthentication authentication) {
+    return withExporterPausePermission(
+        authentication,
+        () -> exportingRequestBroadcaster.getExportingStatus(getPhysicalTenantId()));
+  }
+
+  /**
    * Runs {@code action} only if the caller holds the {@code EXPORTER/PAUSE} permission, mapping
    * failures from both the synchronous and asynchronous phases to {@link
    * io.camunda.service.exception.ServiceException} so they surface with the correct status. The
@@ -87,8 +102,8 @@ public final class ExportingServices extends PhysicalTenantScopedApiServices<Exp
    * PAUSE}, and a caller allowed to stop exporting must also be able to start it again — otherwise
    * they could leave the cluster in a paused state they cannot undo.
    */
-  private CompletableFuture<Void> withExporterPausePermission(
-      final CamundaAuthentication authentication, final Supplier<CompletableFuture<Void>> action) {
+  private <T> CompletableFuture<T> withExporterPausePermission(
+      final CamundaAuthentication authentication, final Supplier<CompletableFuture<T>> action) {
     if (!hasExporterPausePermission(authentication)) {
       return CompletableFuture.failedFuture(
           ErrorMapper.createForbiddenException(EXPORTER_PAUSE_AUTHORIZATION));

--- a/service/src/test/java/io/camunda/service/ExportingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/ExportingServicesTest.java
@@ -28,6 +28,7 @@ import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.admin.ExportingRequestBroadcaster;
+import io.camunda.zeebe.gateway.admin.ExportingStatus;
 import io.camunda.zeebe.gateway.admin.IncompleteTopologyException;
 import java.util.Collections;
 import java.util.Set;
@@ -104,6 +105,41 @@ public class ExportingServicesTest {
     // then
     assertThat(future).succeedsWithin(ofSeconds(1));
     verify(exportingRequestBroadcaster).resumeExporting(PHYSICAL_TENANT_ID);
+  }
+
+  @Test
+  public void shouldDelegateStatusQuery() {
+    // given
+    when(exportingRequestBroadcaster.getExportingStatus(PHYSICAL_TENANT_ID))
+        .thenReturn(CompletableFuture.completedFuture(ExportingStatus.SOFT_PAUSED));
+
+    // when
+    final var future = services.getExportingStatus(authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1)).isEqualTo(ExportingStatus.SOFT_PAUSED);
+    verify(exportingRequestBroadcaster).getExportingStatus(PHYSICAL_TENANT_ID);
+  }
+
+  @Test
+  public void shouldFailStatusQueryWithForbiddenWhenUserHasNoAuthorizations() {
+    // given
+    authorizationsConfig.setEnabled(true);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Collections.emptySet());
+
+    // when
+    final var future = services.getExportingStatus(authentication);
+
+    // then
+    assertThat(future)
+        .failsWithin(ofSeconds(1))
+        .withThrowableOfType(ExecutionException.class)
+        .havingCause()
+        .asInstanceOf(type(ServiceException.class))
+        .extracting(ServiceException::getStatus)
+        .isEqualTo(Status.FORBIDDEN);
+    verify(exportingRequestBroadcaster, never()).getExportingStatus(any());
   }
 
   @Test

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/NoOpPartitionAdminAccess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/NoOpPartitionAdminAccess.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.partitioning;
 
 import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import io.camunda.zeebe.broker.system.configuration.FlowControlCfg;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControlLimits;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -74,6 +75,12 @@ public final class NoOpPartitionAdminAccess implements PartitionAdminAccess {
 
   @Override
   public ActorFuture<FlowControlLimits> getFlowControlConfiguration() {
+    logCall();
+    return CompletableActorFuture.completed(null);
+  }
+
+  @Override
+  public ActorFuture<ExporterPhase> getExporterPhase() {
     logCall();
     return CompletableActorFuture.completed(null);
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.partitioning;
 
+import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import io.camunda.zeebe.broker.system.configuration.FlowControlCfg;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControlLimits;
@@ -46,4 +47,11 @@ public interface PartitionAdminAccess {
   ActorFuture<Void> configureFlowControl(final FlowControlCfg flowControlCfg);
 
   ActorFuture<FlowControlLimits> getFlowControlConfiguration();
+
+  /**
+   * The exporter phase currently persisted for this partition. Every replica answers from its own
+   * persisted state, so callers can verify that a pause took effect on all replicas and not only on
+   * the leader.
+   */
+  ActorFuture<ExporterPhase> getExporterPhase();
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.partitions;
 
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
+import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
@@ -37,4 +38,11 @@ public interface PartitionAdminControl {
   boolean softPauseExporting() throws IOException;
 
   boolean resumeExporting() throws IOException;
+
+  /**
+   * The exporter phase persisted for this partition. It is readable on every replica, not only the
+   * leader, because the phase is persisted alongside the partition data rather than held by the
+   * (leader-only) exporter director.
+   */
+  ExporterPhase getExporterPhase();
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.partitions;
 
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
+import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionProcessingState;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -98,5 +99,10 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
   @Override
   public boolean resumeExporting() throws IOException {
     return partitionProcessingStateSupplier.get().resumeExporting();
+  }
+
+  @Override
+  public ExporterPhase getExporterPhase() {
+    return partitionProcessingStateSupplier.get().getExporterPhase();
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.system.partitions;
 import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
 import io.camunda.zeebe.broker.system.configuration.FlowControlCfg;
 import io.camunda.zeebe.engine.state.processing.DbBannedInstanceState;
@@ -236,6 +237,22 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
             future.complete(limits);
           } catch (final Exception e) {
             LOG.error("Failure on getting the limit configuration of flow control.", e);
+            future.completeExceptionally(e);
+          }
+        });
+    return future;
+  }
+
+  @Override
+  public ActorFuture<ExporterPhase> getExporterPhase() {
+    final ActorFuture<ExporterPhase> future = concurrencyControl.createFuture();
+
+    concurrencyControl.run(
+        () -> {
+          try {
+            future.complete(adminControl.getExporterPhase());
+          } catch (final Exception e) {
+            LOG.error("Failure on getting the exporter phase.", e);
             future.completeExceptionally(e);
           }
         });

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.Either;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 public class AdminApiRequestHandler
     extends AsyncApiRequestHandler<ApiRequestReader, ApiResponseWriter> {
@@ -76,6 +77,7 @@ public class AdminApiRequestHandler
       case BAN_INSTANCE -> banInstance(requestReader, responseWriter, partitionId, errorWriter);
       case GET_FLOW_CONTROL -> getFlowControl(responseWriter, errorWriter);
       case SET_FLOW_CONTROL -> setFlowControl(requestReader, responseWriter, errorWriter);
+      case GET_EXPORTING_STATE -> getExportingState(responseWriter, partitionId, errorWriter);
       default -> unknownRequest(errorWriter, requestReader.getMessageDecoder().type());
     };
   }
@@ -135,6 +137,40 @@ public class AdminApiRequestHandler
                     Either.left(
                         errorWriter.internalError(
                             "Failed to get the flow control configuration.")));
+              }
+            });
+
+    return result;
+  }
+
+  private ActorFuture<Either<ErrorResponseWriter, ApiResponseWriter>> getExportingState(
+      final ApiResponseWriter responseWriter,
+      final int partitionId,
+      final ErrorResponseWriter errorWriter) {
+    final var partitionAdminAccess = adminAccess.forPartition(partitionId);
+    if (partitionAdminAccess.isEmpty()) {
+      return CompletableActorFuture.completed(
+          Either.left(
+              errorWriter.internalError(
+                  "Partition %s failed to report its exporting state. Could not find the partition.",
+                  partitionId)));
+    }
+
+    final ActorFuture<Either<ErrorResponseWriter, ApiResponseWriter>> result = actor.createFuture();
+    partitionAdminAccess
+        .orElseThrow()
+        .getExporterPhase()
+        .onComplete(
+            (phase, t) -> {
+              if (t == null) {
+                responseWriter.setPayload(phase.name().getBytes(StandardCharsets.UTF_8));
+                result.complete(Either.right(responseWriter));
+              } else {
+                LOG.error("Failed to get the exporting state on partition {}", partitionId, t);
+                result.complete(
+                    Either.left(
+                        errorWriter.internalError(
+                            "Failed to get the exporting state on partition %s", partitionId)));
               }
             });
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/backups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/backups.yaml
@@ -8,7 +8,7 @@ paths:
         - Backup
       operationId: takeRuntimeBackup
       x-required-permissions:
-        - { resourceType: SYSTEM, permissionType: UPDATE }
+        - { resourceType: BACKUP, permissionType: CREATE }
       security:
         - bearerAuth: []
         - basicAuth: []
@@ -61,7 +61,7 @@ paths:
         - Backup
       operationId: listRuntimeBackups
       x-required-permissions:
-        - { resourceType: SYSTEM, permissionType: READ }
+        - { resourceType: BACKUP, permissionType: READ }
       security:
         - bearerAuth: []
         - basicAuth: []
@@ -106,7 +106,7 @@ paths:
         - Backup
       operationId: getRuntimeBackupState
       x-required-permissions:
-        - { resourceType: SYSTEM, permissionType: READ }
+        - { resourceType: BACKUP, permissionType: READ }
       security:
         - bearerAuth: []
         - basicAuth: []
@@ -138,7 +138,7 @@ paths:
         - Backup
       operationId: deleteRuntimeBackupState
       x-required-permissions:
-        - { resourceType: SYSTEM, permissionType: UPDATE }
+        - { resourceType: BACKUP, permissionType: DELETE }
       security:
         - bearerAuth: []
         - basicAuth: []
@@ -167,7 +167,7 @@ paths:
         - Backup
       operationId: syncRuntimeBackupState
       x-required-permissions:
-        - { resourceType: SYSTEM, permissionType: UPDATE }
+        - { resourceType: BACKUP, permissionType: CREATE }
       security:
         - bearerAuth: []
         - basicAuth: []
@@ -206,7 +206,7 @@ paths:
         - Backup
       operationId: getRuntimeBackup
       x-required-permissions:
-        - { resourceType: SYSTEM, permissionType: READ }
+        - { resourceType: BACKUP, permissionType: READ }
       security:
         - bearerAuth: []
         - basicAuth: []
@@ -247,7 +247,7 @@ paths:
         - Backup
       operationId: deleteRuntimeBackup
       x-required-permissions:
-        - { resourceType: SYSTEM, permissionType: UPDATE }
+        - { resourceType: BACKUP, permissionType: DELETE }
       security:
         - bearerAuth: []
         - basicAuth: []

--- a/zeebe/gateway-protocol/src/main/proto/v2/exporting.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/exporting.yaml
@@ -1,6 +1,43 @@
 ## Endpoint definitions
 
 paths:
+  /exporting:
+    get:
+      x-eventually-consistent: false
+      tags:
+        - Exporting
+      operationId: getExportingStatus
+      x-required-permissions:
+        - { resourceType: EXPORTER, permissionType: PAUSE }
+      security:
+        - bearerAuth: []
+        - basicAuth: []
+      summary: Get exporting status
+      description: |
+        Returns the exporting status of the physical tenant, aggregated over every replica of
+        every one of its partitions.
+
+        Because pause and resume are applied to all replicas, the status is only a single phase
+        if every replica reports that phase; otherwise it is `MIXED`, which means a pause or
+        resume is still in flight or was only partially applied. Backup tooling should treat
+        only `PAUSED` and `SOFT_PAUSED` as confirmation that exporting is paused.
+      responses:
+        "200":
+          description: The current exporting status of the physical tenant.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExportingStatusResponse'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+
   /exporting/pause:
     post:
       x-eventually-consistent: false
@@ -68,3 +105,35 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+
+components:
+  schemas:
+    ExportingStatusCode:
+      title: Exporting Status Code
+      description: |
+        The exporting status of a physical tenant, aggregated over every replica of every one of
+        its partitions:
+        - `EXPORTING`: all replicas are exporting and committing their position.
+        - `PAUSED`: all replicas are paused, nothing is being exported.
+        - `SOFT_PAUSED`: all replicas keep exporting but do not commit their position.
+        - `MIXED`: replicas report different phases, so the tenant is in no single phase.
+      type: string
+      enum:
+        - EXPORTING
+        - PAUSED
+        - SOFT_PAUSED
+        - MIXED
+      example: PAUSED
+
+    ExportingStatusResponse:
+      title: ExportingStatusResponse
+      description: Response body for the exporting status of a physical tenant.
+      type: object
+      properties:
+        status:
+          description: The aggregated exporting status of the physical tenant.
+          readOnly: true
+          allOf:
+            - $ref: '#/components/schemas/ExportingStatusCode'
+      required:
+        - status

--- a/zeebe/gateway-protocol/src/main/proto/v2/exporting.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/exporting.yaml
@@ -116,8 +116,7 @@ components:
         - `EXPORTING`: all replicas are exporting and committing their position.
         - `PAUSED`: all replicas are paused, nothing is being exported.
         - `SOFT_PAUSED`: all replicas keep exporting but do not commit their position.
-        - `MIXED`: the tenant is in no single phase, because replicas report different phases or
-          one of them reports a phase this version does not recognise.
+        - `MIXED`: replicas report different phases, so the tenant is in no single phase.
       type: string
       enum:
         - EXPORTING

--- a/zeebe/gateway-protocol/src/main/proto/v2/exporting.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/exporting.yaml
@@ -116,7 +116,8 @@ components:
         - `EXPORTING`: all replicas are exporting and committing their position.
         - `PAUSED`: all replicas are paused, nothing is being exported.
         - `SOFT_PAUSED`: all replicas keep exporting but do not commit their position.
-        - `MIXED`: replicas report different phases, so the tenant is in no single phase.
+        - `MIXED`: the tenant is in no single phase, because replicas report different phases or
+          one of them reports a phase this version does not recognise.
       type: string
       enum:
         - EXPORTING

--- a/zeebe/gateway-protocol/src/main/proto/v2/exporting.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/exporting.yaml
@@ -45,7 +45,7 @@ paths:
         - Exporting
       operationId: pauseExporting
       x-required-permissions:
-        - { resourceType: SYSTEM, permissionType: UPDATE }
+        - { resourceType: EXPORTER, permissionType: PAUSE }
       security:
         - bearerAuth: []
         - basicAuth: []
@@ -86,7 +86,7 @@ paths:
         - Exporting
       operationId: resumeExporting
       x-required-permissions:
-        - { resourceType: SYSTEM, permissionType: UPDATE }
+        - { resourceType: EXPORTER, permissionType: PAUSE }
       security:
         - bearerAuth: []
         - basicAuth: []

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -221,6 +221,8 @@ paths:
     $ref: 'element-instances.yaml#/paths/~1element-instances~1{elementInstanceKey}~1variables'
 
   # Exporting endpoints
+  /exporting:
+    $ref: 'exporting.yaml#/paths/~1exporting'
   /exporting/pause:
     $ref: 'exporting.yaml#/paths/~1exporting~1pause'
   /exporting/resume:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ExportingController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ExportingController.java
@@ -9,11 +9,14 @@ package io.camunda.zeebe.gateway.rest.controller;
 
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
+import io.camunda.zeebe.gateway.rest.mapper.ExportingResponseMapper;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import java.util.concurrent.CompletableFuture;
 import org.jspecify.annotations.NullMarked;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,6 +34,17 @@ public final class ExportingController {
       final CamundaAuthenticationProvider authenticationProvider) {
     this.serviceRegistry = serviceRegistry;
     this.authenticationProvider = authenticationProvider;
+  }
+
+  @CamundaGetMapping
+  public CompletableFuture<ResponseEntity<Object>> getExportingStatus(
+      @PhysicalTenantId final String physicalTenantId) {
+    final var authentication = authenticationProvider.getCamundaAuthentication();
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            serviceRegistry.exportingServices(physicalTenantId).getExportingStatus(authentication),
+        ExportingResponseMapper::toExportingStatusResponse,
+        HttpStatus.OK);
   }
 
   @CamundaPostMapping(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/ExportingResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/ExportingResponseMapper.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.mapper;
+
+import io.camunda.gateway.protocol.model.ExportingStatusCode;
+import io.camunda.gateway.protocol.model.ExportingStatusResponse;
+import io.camunda.zeebe.gateway.admin.ExportingStatus;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public final class ExportingResponseMapper {
+
+  private ExportingResponseMapper() {}
+
+  public static ExportingStatusResponse toExportingStatusResponse(final ExportingStatus status) {
+    return ExportingStatusResponse.Builder.create().status(toStatusCode(status)).build();
+  }
+
+  private static ExportingStatusCode toStatusCode(final ExportingStatus status) {
+    return switch (status) {
+      case EXPORTING -> ExportingStatusCode.EXPORTING;
+      case PAUSED -> ExportingStatusCode.PAUSED;
+      case SOFT_PAUSED -> ExportingStatusCode.SOFT_PAUSED;
+      case MIXED -> ExportingStatusCode.MIXED;
+    };
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ExportingControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ExportingControllerTest.java
@@ -19,6 +19,7 @@ import io.camunda.service.ExportingServices;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.gateway.admin.ExportingStatus;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +33,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 @WebMvcTest(ExportingController.class)
 public class ExportingControllerTest extends RestControllerTest {
 
+  private static final String STATUS_PATH = "/exporting";
   private static final String PAUSE_PATH = "/exporting/pause";
   private static final String RESUME_PATH = "/exporting/resume";
 
@@ -177,6 +179,67 @@ public class ExportingControllerTest extends RestControllerTest {
     webClient
         .post()
         .uri(baseUrl + RESUME_PATH)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isForbidden();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/v2", "/physical-tenants/default/v2"})
+  void getExportingStatusShouldReturnStatusAndTargetDefaultTenant(final String baseUrl) {
+    // given
+    when(exportingServices.getExportingStatus(any()))
+        .thenReturn(CompletableFuture.completedFuture(ExportingStatus.SOFT_PAUSED));
+
+    // when - then
+    webClient
+        .get()
+        .uri(baseUrl + STATUS_PATH)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json("{\"status\":\"SOFT_PAUSED\"}");
+
+    // the unprefixed and the /physical-tenants/default/ routes both resolve to the default PT
+    verify(serviceRegistry).exportingServices(DEFAULT_PHYSICAL_TENANT_ID);
+    verify(exportingServices).getExportingStatus(any());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/v2", "/physical-tenants/default/v2"})
+  void getExportingStatusShouldReturnServiceUnavailableOnIncompleteTopology(final String baseUrl) {
+    // given
+    when(exportingServices.getExportingStatus(any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("Topology is incomplete", Status.UNAVAILABLE)));
+
+    // when - then
+    webClient
+        .get()
+        .uri(baseUrl + STATUS_PATH)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/v2", "/physical-tenants/default/v2"})
+  void getExportingStatusShouldReturnForbiddenWhenUnauthorized(final String baseUrl) {
+    // given
+    when(exportingServices.getExportingStatus(any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("Unauthorized to perform operation", Status.FORBIDDEN)));
+
+    // when - then
+    webClient
+        .get()
+        .uri(baseUrl + STATUS_PATH)
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ExportingControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ExportingControllerTest.java
@@ -29,6 +29,7 @@ import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(ExportingController.class)
 public class ExportingControllerTest extends RestControllerTest {
@@ -201,7 +202,7 @@ public class ExportingControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .json("{\"status\":\"SOFT_PAUSED\"}");
+        .json("{\"status\":\"SOFT_PAUSED\"}", JsonCompareMode.STRICT);
 
     // the unprefixed and the /physical-tenants/default/ routes both resolve to the default PT
     verify(serviceRegistry).exportingServices(DEFAULT_PHYSICAL_TENANT_ID);

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
@@ -45,6 +45,10 @@ public class BrokerAdminRequest extends BrokerRequest<AdminResponse> {
     request.setType(AdminRequestType.RESUME_EXPORTING);
   }
 
+  public void getExportingState() {
+    request.setType(AdminRequestType.GET_EXPORTING_STATE);
+  }
+
   public void getFLowControlConfiguration() {
     request.setType(AdminRequestType.GET_FLOW_CONTROL);
   }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ExportingRequestBroadcaster.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ExportingRequestBroadcaster.java
@@ -11,9 +11,12 @@ import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +53,45 @@ public class ExportingRequestBroadcaster {
     return broadcastOnTopology(physicalTenantId, topology, BrokerAdminRequest::resumeExporting);
   }
 
+  /**
+   * Queries every replica of every partition of the physical tenant and aggregates the reported
+   * exporter phases into a single status. Every replica is queried, not just the leaders, because
+   * pause and resume are applied to all replicas: backup tooling needs to know that the pause took
+   * effect everywhere, not only where exporting currently runs.
+   */
+  public CompletableFuture<ExportingStatus> getExportingStatus(final String physicalTenantId) {
+    final var topology = brokerClient.getTopologyManager().getTopology(physicalTenantId);
+    validateTopology(topology);
+
+    final var responses =
+        topology.getPartitions().stream()
+            .flatMap(
+                partitionId ->
+                    membersOfPartition(topology, partitionId).stream()
+                        .map(
+                            brokerId -> {
+                              final var request = new BrokerAdminRequest();
+                              request.setPartitionGroup(physicalTenantId);
+                              request.setBrokerId(brokerId);
+                              request.setPartitionId(partitionId);
+                              request.getExportingState();
+                              return brokerClient
+                                  .sendRequest(request)
+                                  .thenApply(
+                                      response ->
+                                          new String(
+                                              response.getResponseOrThrow().getPayload(),
+                                              StandardCharsets.UTF_8));
+                            }))
+            .toList();
+
+    return CompletableFuture.allOf(responses.toArray(CompletableFuture<?>[]::new))
+        .thenApply(
+            ignored ->
+                ExportingStatus.aggregate(
+                    responses.stream().map(CompletableFuture::join).collect(Collectors.toSet())));
+  }
+
   private CompletableFuture<Void> broadcastOnTopology(
       final String physicalTenantId,
       final BrokerClusterState topology,
@@ -71,16 +113,7 @@ public class ExportingRequestBroadcaster {
       final Integer partitionId,
       final Consumer<BrokerAdminRequest> configureRequest) {
 
-    final var leader = topology.getLeaderForPartition(partitionId);
-    final var followers = topology.getFollowersForPartition(partitionId);
-    final var inactive = topology.getInactiveNodesForPartition(partitionId);
-
-    final var members = new HashSet<BrokerMemberId>(topology.getReplicationFactor());
-    if (leader != null) {
-      members.add(leader);
-    }
-    members.addAll(followers);
-    members.addAll(inactive);
+    final var members = membersOfPartition(topology, partitionId);
 
     final var requests =
         members.stream()
@@ -97,6 +130,21 @@ public class ExportingRequestBroadcaster {
                 })
             .toArray(CompletableFuture<?>[]::new);
     return CompletableFuture.allOf(requests);
+  }
+
+  private Set<BrokerMemberId> membersOfPartition(
+      final BrokerClusterState topology, final Integer partitionId) {
+    final var leader = topology.getLeaderForPartition(partitionId);
+    final var followers = topology.getFollowersForPartition(partitionId);
+    final var inactive = topology.getInactiveNodesForPartition(partitionId);
+
+    final var members = new HashSet<BrokerMemberId>(topology.getReplicationFactor());
+    if (leader != null) {
+      members.add(leader);
+    }
+    members.addAll(followers);
+    members.addAll(inactive);
+    return members;
   }
 
   private void validateTopology(final BrokerClusterState topology) {

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ExportingRequestBroadcaster.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ExportingRequestBroadcaster.java
@@ -54,10 +54,10 @@ public class ExportingRequestBroadcaster {
   }
 
   /**
-   * Queries the leader and every follower of every partition of the physical tenant and aggregates
-   * the reported exporter phases into a single status. Followers are queried too, not just the
-   * leaders, because pause and resume are applied to every active member: backup tooling needs to
-   * know the pause took effect everywhere, not only where exporting currently runs.
+   * Queries every member of every partition of the physical tenant and aggregates the reported
+   * exporter phases into a single status. Every member is queried, not just the leaders, because
+   * pause and resume are applied to all of them: backup tooling needs to know the pause took effect
+   * everywhere, not only where exporting currently runs.
    */
   public CompletableFuture<ExportingStatus> getExportingStatus(final String physicalTenantId) {
     final var topology = brokerClient.getTopologyManager().getTopology(physicalTenantId);
@@ -114,9 +114,6 @@ public class ExportingRequestBroadcaster {
       final Consumer<BrokerAdminRequest> configureRequest) {
 
     final var members = membersOfPartition(topology, partitionId);
-    // pause and resume additionally target inactive members: they hold partition data, so they
-    // must not resume exporting on their own once they become active again
-    members.addAll(topology.getInactiveNodesForPartition(partitionId));
 
     final var requests =
         members.stream()
@@ -135,17 +132,24 @@ public class ExportingRequestBroadcaster {
     return CompletableFuture.allOf(requests);
   }
 
-  /** The active members of a partition, i.e. its leader and followers. */
+  /**
+   * Every member holding a copy of the partition: its leader, its followers and its inactive
+   * members. Inactive members are included because they are only temporarily unhealthy -- they keep
+   * their partition data and become active again after recovering, so their exporter phase is as
+   * relevant as any other replica's, both when pausing and when reporting the status.
+   */
   private Set<BrokerMemberId> membersOfPartition(
       final BrokerClusterState topology, final Integer partitionId) {
     final var leader = topology.getLeaderForPartition(partitionId);
     final var followers = topology.getFollowersForPartition(partitionId);
+    final var inactive = topology.getInactiveNodesForPartition(partitionId);
 
     final var members = new HashSet<BrokerMemberId>(topology.getReplicationFactor());
     if (leader != null) {
       members.add(leader);
     }
     members.addAll(followers);
+    members.addAll(inactive);
     return members;
   }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ExportingRequestBroadcaster.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ExportingRequestBroadcaster.java
@@ -54,10 +54,10 @@ public class ExportingRequestBroadcaster {
   }
 
   /**
-   * Queries every replica of every partition of the physical tenant and aggregates the reported
-   * exporter phases into a single status. Every replica is queried, not just the leaders, because
-   * pause and resume are applied to all replicas: backup tooling needs to know that the pause took
-   * effect everywhere, not only where exporting currently runs.
+   * Queries the leader and every follower of every partition of the physical tenant and aggregates
+   * the reported exporter phases into a single status. Followers are queried too, not just the
+   * leaders, because pause and resume are applied to every active member: backup tooling needs to
+   * know the pause took effect everywhere, not only where exporting currently runs.
    */
   public CompletableFuture<ExportingStatus> getExportingStatus(final String physicalTenantId) {
     final var topology = brokerClient.getTopologyManager().getTopology(physicalTenantId);
@@ -114,6 +114,9 @@ public class ExportingRequestBroadcaster {
       final Consumer<BrokerAdminRequest> configureRequest) {
 
     final var members = membersOfPartition(topology, partitionId);
+    // pause and resume additionally target inactive members: they hold partition data, so they
+    // must not resume exporting on their own once they become active again
+    members.addAll(topology.getInactiveNodesForPartition(partitionId));
 
     final var requests =
         members.stream()
@@ -132,18 +135,17 @@ public class ExportingRequestBroadcaster {
     return CompletableFuture.allOf(requests);
   }
 
+  /** The active members of a partition, i.e. its leader and followers. */
   private Set<BrokerMemberId> membersOfPartition(
       final BrokerClusterState topology, final Integer partitionId) {
     final var leader = topology.getLeaderForPartition(partitionId);
     final var followers = topology.getFollowersForPartition(partitionId);
-    final var inactive = topology.getInactiveNodesForPartition(partitionId);
 
     final var members = new HashSet<BrokerMemberId>(topology.getReplicationFactor());
     if (leader != null) {
       members.add(leader);
     }
     members.addAll(followers);
-    members.addAll(inactive);
     return members;
   }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ExportingStatus.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ExportingStatus.java
@@ -25,12 +25,25 @@ public enum ExportingStatus {
   PAUSED,
   /** All replicas keep exporting but do not commit their position. */
   SOFT_PAUSED,
-  /** Replicas report different phases, so the tenant is in no single well-defined phase. */
+  /**
+   * The tenant is in no single well-defined phase: either the replicas report different phases, or
+   * at least one of them reports a phase this gateway does not recognise.
+   */
   MIXED;
 
   /**
-   * Aggregates the phases reported by the individual replicas: a single phase if they all agree,
-   * {@link #MIXED} otherwise.
+   * Aggregates the phases reported by the individual replicas: a single phase if they all agree on
+   * one this gateway recognises, {@link #MIXED} otherwise.
+   *
+   * <p>An unrecognised phase yields {@link #MIXED} rather than a dedicated status because {@link
+   * #MIXED} already carries the only meaning a caller can safely act on -- "this is not a confirmed
+   * pause". Distinguishing it would oblige every caller to handle a second indistinguishable
+   * non-answer for no gain in what they can do about it. In practice the branch is unreachable: the
+   * phase is read from the replica's persisted partition state, which only ever holds {@code
+   * EXPORTING}, {@code PAUSED} or {@code SOFT_PAUSED} -- the broker's fourth {@code ExporterPhase},
+   * {@code CLOSED}, is held by the exporter director and never persisted. It is kept so a future
+   * phase added on the broker side degrades to a safe answer instead of being mistaken for a pause
+   * on an older gateway.
    */
   public static ExportingStatus aggregate(final Set<String> reportedPhases) {
     if (reportedPhases.size() != 1) {

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ExportingStatus.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ExportingStatus.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.admin;
+
+import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * The exporting status aggregated over every replica of every partition of a physical tenant.
+ *
+ * <p>Pause and resume are applied to all replicas, so a status is only meaningful for backup
+ * tooling if all replicas agree; when they don't, the tenant is {@link #MIXED} and the operation is
+ * still in flight or was only partially applied.
+ */
+@NullMarked
+public enum ExportingStatus {
+  /** All replicas are actively exporting and committing their position. */
+  EXPORTING,
+  /** All replicas are paused, nothing is being exported. */
+  PAUSED,
+  /** All replicas keep exporting but do not commit their position. */
+  SOFT_PAUSED,
+  /** Replicas report different phases, so the tenant is in no single well-defined phase. */
+  MIXED;
+
+  /**
+   * Aggregates the phases reported by the individual replicas: a single phase if they all agree,
+   * {@link #MIXED} otherwise.
+   */
+  public static ExportingStatus aggregate(final Set<String> reportedPhases) {
+    if (reportedPhases.size() != 1) {
+      return MIXED;
+    }
+
+    final var phase = reportedPhases.iterator().next();
+    return switch (phase) {
+      case "EXPORTING" -> EXPORTING;
+      case "PAUSED" -> PAUSED;
+      case "SOFT_PAUSED" -> SOFT_PAUSED;
+      default -> MIXED;
+    };
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ExportingStatus.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ExportingStatus.java
@@ -25,25 +25,18 @@ public enum ExportingStatus {
   PAUSED,
   /** All replicas keep exporting but do not commit their position. */
   SOFT_PAUSED,
-  /**
-   * The tenant is in no single well-defined phase: either the replicas report different phases, or
-   * at least one of them reports a phase this gateway does not recognise.
-   */
+  /** Replicas report different phases, so the tenant is in no single well-defined phase. */
   MIXED;
 
   /**
-   * Aggregates the phases reported by the individual replicas: a single phase if they all agree on
-   * one this gateway recognises, {@link #MIXED} otherwise.
+   * Aggregates the phases reported by the individual replicas: a single phase if they all agree,
+   * {@link #MIXED} otherwise.
    *
-   * <p>An unrecognised phase yields {@link #MIXED} rather than a dedicated status because {@link
-   * #MIXED} already carries the only meaning a caller can safely act on -- "this is not a confirmed
-   * pause". Distinguishing it would oblige every caller to handle a second indistinguishable
-   * non-answer for no gain in what they can do about it. In practice the branch is unreachable: the
-   * phase is read from the replica's persisted partition state, which only ever holds {@code
-   * EXPORTING}, {@code PAUSED} or {@code SOFT_PAUSED} -- the broker's fourth {@code ExporterPhase},
-   * {@code CLOSED}, is held by the exporter director and never persisted. It is kept so a future
-   * phase added on the broker side degrades to a safe answer instead of being mistaken for a pause
-   * on an older gateway.
+   * <p>Throws on a phase this gateway does not know rather than folding it into {@link #MIXED}: a
+   * phase added to the broker's {@code ExporterPhase} would otherwise be reported as a benign
+   * "pause still in flight" forever, and the mismatch would never surface. Failing the request
+   * makes it a visible error instead. This gateway is not the only thing that would need updating
+   * anyway -- a new phase also needs a status to map onto in the REST response.
    */
   public static ExportingStatus aggregate(final Set<String> reportedPhases) {
     if (reportedPhases.size() != 1) {
@@ -55,7 +48,10 @@ public enum ExportingStatus {
       case "EXPORTING" -> EXPORTING;
       case "PAUSED" -> PAUSED;
       case "SOFT_PAUSED" -> SOFT_PAUSED;
-      default -> MIXED;
+      default ->
+          throw new IllegalArgumentException(
+              "Expected a broker replica to report a known exporter phase, but got '%s'"
+                  .formatted(phase));
     };
   }
 }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/admin/ExportingRequestBroadcasterTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/admin/ExportingRequestBroadcasterTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
 import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -111,6 +112,57 @@ public class ExportingRequestBroadcasterTest {
     // then
     assertThatExceptionOfType(Throwable.class)
         .isThrownBy(() -> service.pauseExporting(DEFAULT_PHYSICAL_TENANT_ID));
+  }
+
+  @ParameterizedTest
+  @MethodSource("validTopologies")
+  void shouldReportSinglePhaseWhenAllReplicasAgree(final BrokerClusterState topology) {
+    // given
+    final var client = setupBrokerClient(topology);
+    final var service = new ExportingRequestBroadcaster(client);
+    when(client.sendRequest(any())).thenAnswer(invocation -> respondWithPhase("PAUSED"));
+
+    // when
+    final var status = service.getExportingStatus(DEFAULT_PHYSICAL_TENANT_ID);
+
+    // then
+    assertThat(status).succeedsWithin(Duration.ofSeconds(10)).isEqualTo(ExportingStatus.PAUSED);
+  }
+
+  @ParameterizedTest
+  @MethodSource("validTopologies")
+  void shouldReportMixedWhenReplicasDisagree(final BrokerClusterState topology) {
+    // given a single replica that has not caught up with the pause yet
+    final var client = setupBrokerClient(topology);
+    final var service = new ExportingRequestBroadcaster(client);
+    when(client.sendRequest(any())).thenAnswer(invocation -> respondWithPhase("PAUSED"));
+    when(client.sendRequest(requestTo(1, topology.getLeaderForPartition(1))))
+        .thenAnswer(invocation -> respondWithPhase("EXPORTING"));
+
+    // when
+    final var status = service.getExportingStatus(DEFAULT_PHYSICAL_TENANT_ID);
+
+    // then
+    assertThat(status).succeedsWithin(Duration.ofSeconds(10)).isEqualTo(ExportingStatus.MIXED);
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidTopologies")
+  void shouldFailToReportStatusOnIncompleteTopology(final BrokerClusterState topology) {
+    // given
+    final var client = setupBrokerClient(topology);
+    final var service = new ExportingRequestBroadcaster(client);
+
+    // then
+    assertThatExceptionOfType(IncompleteTopologyException.class)
+        .isThrownBy(() -> service.getExportingStatus(DEFAULT_PHYSICAL_TENANT_ID));
+  }
+
+  private static CompletableFuture<BrokerResponse<AdminResponse>> respondWithPhase(
+      final String phase) {
+    final var response = mock(AdminResponse.class);
+    when(response.getPayload()).thenReturn(phase.getBytes(StandardCharsets.UTF_8));
+    return CompletableFuture.completedFuture(new BrokerResponse<>(response));
   }
 
   private BrokerClient setupBrokerClient(final BrokerClusterState topology) {

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/admin/ExportingRequestBroadcasterTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/admin/ExportingRequestBroadcasterTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -38,6 +39,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jspecify.annotations.NonNull;
@@ -148,9 +150,9 @@ public class ExportingRequestBroadcasterTest {
 
   @ParameterizedTest
   @MethodSource("validTopologies")
-  void shouldReportMixedWhenReplicasAgreeOnAnUnrecognisedPhase(final BrokerClusterState topology) {
+  void shouldFailWhenReplicasReportAnUnknownPhase(final BrokerClusterState topology) {
     // given every replica agrees, but on a phase this gateway does not know -- as would happen if
-    // a newer broker gained a phase; it must not be mistaken for a confirmed pause
+    // a phase were added to the broker without updating the aggregation
     final var client = setupBrokerClient(topology);
     final var service = new ExportingRequestBroadcaster(client);
     when(client.sendRequest(any())).thenAnswer(invocation -> respondWithPhase("SOME_FUTURE_PHASE"));
@@ -158,8 +160,33 @@ public class ExportingRequestBroadcasterTest {
     // when
     final var status = service.getExportingStatus(DEFAULT_PHYSICAL_TENANT_ID);
 
-    // then
-    assertThat(status).succeedsWithin(Duration.ofSeconds(10)).isEqualTo(ExportingStatus.MIXED);
+    // then it must not be silently reported as MIXED, which would read as a benign "in flight"
+    assertThat(status)
+        .failsWithin(Duration.ofSeconds(10))
+        .withThrowableOfType(ExecutionException.class)
+        .havingCause()
+        .isInstanceOf(IllegalArgumentException.class)
+        .withMessageContaining("SOME_FUTURE_PHASE");
+  }
+
+  @ParameterizedTest
+  @MethodSource("validTopologies")
+  void shouldNotQueryInactiveMembersForStatus(final BrokerClusterState topology) {
+    // given
+    final var client = setupBrokerClient(topology);
+    final var service = new ExportingRequestBroadcaster(client);
+    when(client.sendRequest(any())).thenAnswer(invocation -> respondWithPhase("PAUSED"));
+
+    // when
+    service.getExportingStatus(DEFAULT_PHYSICAL_TENANT_ID).join();
+
+    // then only members that actually hold the partition are asked -- an inactive member has no
+    // exporter phase to report
+    for (final var partition : topology.getPartitions()) {
+      for (final var inactive : topology.getInactiveNodesForPartition(partition)) {
+        verify(client, never()).sendRequest(requestTo(partition, inactive));
+      }
+    }
   }
 
   @ParameterizedTest

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/admin/ExportingRequestBroadcasterTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/admin/ExportingRequestBroadcasterTest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -171,7 +170,7 @@ public class ExportingRequestBroadcasterTest {
 
   @ParameterizedTest
   @MethodSource("validTopologies")
-  void shouldNotQueryInactiveMembersForStatus(final BrokerClusterState topology) {
+  void shouldQueryInactiveMembersForStatus(final BrokerClusterState topology) {
     // given
     final var client = setupBrokerClient(topology);
     final var service = new ExportingRequestBroadcaster(client);
@@ -180,11 +179,11 @@ public class ExportingRequestBroadcasterTest {
     // when
     service.getExportingStatus(DEFAULT_PHYSICAL_TENANT_ID).join();
 
-    // then only members that actually hold the partition are asked -- an inactive member has no
-    // exporter phase to report
+    // then inactive members are asked too: they are only temporarily unhealthy and keep their
+    // partition data, so a pause that did not reach them is not a complete pause
     for (final var partition : topology.getPartitions()) {
       for (final var inactive : topology.getInactiveNodesForPartition(partition)) {
-        verify(client, never()).sendRequest(requestTo(partition, inactive));
+        verify(client).sendRequest(requestTo(partition, inactive));
       }
     }
   }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/admin/ExportingRequestBroadcasterTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/admin/ExportingRequestBroadcasterTest.java
@@ -147,6 +147,22 @@ public class ExportingRequestBroadcasterTest {
   }
 
   @ParameterizedTest
+  @MethodSource("validTopologies")
+  void shouldReportMixedWhenReplicasAgreeOnAnUnrecognisedPhase(final BrokerClusterState topology) {
+    // given every replica agrees, but on a phase this gateway does not know -- as would happen if
+    // a newer broker gained a phase; it must not be mistaken for a confirmed pause
+    final var client = setupBrokerClient(topology);
+    final var service = new ExportingRequestBroadcaster(client);
+    when(client.sendRequest(any())).thenAnswer(invocation -> respondWithPhase("SOME_FUTURE_PHASE"));
+
+    // when
+    final var status = service.getExportingStatus(DEFAULT_PHYSICAL_TENANT_ID);
+
+    // then
+    assertThat(status).succeedsWithin(Duration.ofSeconds(10)).isEqualTo(ExportingStatus.MIXED);
+  }
+
+  @ParameterizedTest
   @MethodSource("invalidTopologies")
   void shouldFailToReportStatusOnIncompleteTopology(final BrokerClusterState topology) {
     // given

--- a/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
@@ -15,6 +15,7 @@
       <validValue name="SOFT_PAUSE_EXPORTING">4</validValue>
       <validValue name="SET_FLOW_CONTROL">5</validValue>
       <validValue name="GET_FLOW_CONTROL">6</validValue>
+      <validValue name="GET_EXPORTING_STATE">7</validValue>
     </enum>
 
     <enum name="BackupRequestType" encodingType="uint8">


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds `GET /v2/exporting`, returning the aggregated exporting status of a physical tenant. Backup tooling can currently pause exporting but has no way to confirm the pause actually took effect on every replica before it starts a backup — it has to assume the `204` from `POST /v2/exporting/pause` means the whole tenant is quiet.

The endpoint reports a single status aggregated over every replica of every partition in the tenant:

| Status        | Meaning                                                     |
|---------------|-------------------------------------------------------------|
| `EXPORTING`   | all replicas are exporting and committing their position     |
| `PAUSED`      | all replicas are paused                                      |
| `SOFT_PAUSED` | all replicas keep exporting but do not commit their position |
| `MIXED`       | replicas disagree — a pause/resume is still in flight        |

`MIXED` is the important case: it means the tenant is in *no* single phase, so callers should retry rather than treat it as paused. Only `PAUSED` and `SOFT_PAUSED` confirm exporting has stopped.

The read path spans all four layers, which is why the commits are split that way: a new `GET_EXPORTING_STATE` admin request exposes the exporter phase from each broker replica, and the gateway fans out to every replica and folds the responses.
The phase is readable on followers too, not just the leader, because it is persisted alongside partition data rather than held by the leader-only exporter director.

Available on both routing forms: `/v2/exporting` (default physical tenant) and `/physical-tenants/{id}/v2/exporting`.

## Related issues

closes #58653