### PR TITLE
test: ignore rows without a sort value in audit log sort assertions

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/audit-log/audit-log-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/audit-log/audit-log-search-api-tests.spec.ts
@@ -149,11 +149,9 @@ for (const {description, sort} of sortTestCases) {
       const values = body.items.map(
         (item: Record<string, unknown>) => item[sort.field],
       ) as Array<string | number | null>;
-      // Where the backend places rows whose sort field is null is not defined
-      // by the API, and the secondary storages disagree: ES/OS return them last
-      // on ASC, RDBMS returns them first (camunda#57579). Asserting on them
-      // would make this test backend-specific, so only the rows that actually
-      // carry a value are checked for ordering.
+      // Null placement is undefined by the API and differs per backend
+      // (ES/OS last on ASC, RDBMS first - camunda#57579), so assert ordering
+      // only over rows that carry a value.
       const present = values.filter((value) => value !== null);
       const sorted = [...present].sort();
       if (sort.order === 'DESC') {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/audit-log/audit-log-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/audit-log/audit-log-search-api-tests.spec.ts
@@ -148,12 +148,18 @@ for (const {description, sort} of sortTestCases) {
       const body = await res.json();
       const values = body.items.map(
         (item: Record<string, unknown>) => item[sort.field],
-      ) as Array<string | number>;
-      const sorted = [...values].sort();
+      ) as Array<string | number | null>;
+      // Where the backend places rows whose sort field is null is not defined
+      // by the API, and the secondary storages disagree: ES/OS return them last
+      // on ASC, RDBMS returns them first (camunda#57579). Asserting on them
+      // would make this test backend-specific, so only the rows that actually
+      // carry a value are checked for ordering.
+      const present = values.filter((value) => value !== null);
+      const sorted = [...present].sort();
       if (sort.order === 'DESC') {
         sorted.reverse();
       }
-      expect(values).toEqual(sorted);
+      expect(present).toEqual(sorted);
     }).toPass(defaultAssertionOptions);
   });
 }


### PR DESCRIPTION
## Description

The audit log sort assertions compare the server's ordering against a plain `Array.prototype.sort()`. That stringifies `null` to `"null"` and sorts it alphabetically, so the assertion only holds while every real value in the result sorts *before* the literal string `"null"`.

Existing fixtures use IDs like `dd-isLatest-…` (`d`), which sit before `"null"` — so the tests pass today. Any decision or process ID starting with a letter after `n` lands on the far side of the nulls and fails:

```
"null" < "dd-isLatest"   → false   passes
"null" < "versionTag..." → true    fails
```

Observed for real: [#58901](https://github.com/camunda/camunda/pull/58901) adds decisions named `versionTagDecision_*`, and `Sort by decisionDefinitionId ASC` and `Sort by decisionRequirementsId ASC` began failing on Elasticsearch — not because of anything that PR changed in the product, purely the first letter of its test data.

There is a second reason not to assert on those rows. Where a backend places rows whose sort field is null is not defined by the API, and the secondary storages disagree:

| Sort | ES / OS | RDBMS |
|---|---|---|
| ASC | nulls last | nulls first |
| DESC | nulls last | nulls last |

That divergence is known and owned by the DataLayer team (see [#57579](https://github.com/camunda/camunda/issues/57579) and the linked Slack thread; current leaning is to document rather than change it). Either way, a test that asserts null positions is asserting undefined, backend-specific behaviour.

## Change

Restrict the ordering assertion to rows that actually carry a value. Nine lines, no change to which fields are covered.

## Testing

Run against a local Elasticsearch cluster seeded with decisions whose IDs sort after `"null"`:

- before: `Sort by decisionDefinitionId ASC` and `Sort by decisionRequirementsId ASC` fail, 3 passed / 2 failed
- after: **44/44 pass**

The raw response confirms the server is behaving correctly — 10 values then 31 nulls, i.e. nulls last — and that the old expectation wanted a `null` at index 0.
