### PR TITLE
feat: add client commands for resolving and listing secrets

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -69,6 +69,7 @@ import io.camunda.client.api.command.EvaluateExpressionCommandStep1;
 import io.camunda.client.api.command.GloballyScopedClusterVariableCreationCommandStep1;
 import io.camunda.client.api.command.GloballyScopedClusterVariableDeletionCommandStep1;
 import io.camunda.client.api.command.GloballyScopedClusterVariableUpdateCommandStep1;
+import io.camunda.client.api.command.ListSecretsCommandStep1;
 import io.camunda.client.api.command.MigrateProcessInstanceCommandStep1;
 import io.camunda.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.client.api.command.PinClockCommandStep1;
@@ -76,6 +77,7 @@ import io.camunda.client.api.command.PublishMessageCommandStep1;
 import io.camunda.client.api.command.ResetClockCommandStep1;
 import io.camunda.client.api.command.ResolveIncidentCommandStep1;
 import io.camunda.client.api.command.ResolveProcessInstanceIncidentsCommandStep1;
+import io.camunda.client.api.command.ResolveSecretsCommandStep1;
 import io.camunda.client.api.command.ResumeBatchOperationStep1;
 import io.camunda.client.api.command.ResumeProcessInstanceCommandStep1;
 import io.camunda.client.api.command.SetVariablesCommandStep1;
@@ -3751,4 +3753,51 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for searching agent instance history
    */
   AgentInstanceHistorySearchRequest newAgentInstanceHistorySearchRequest(long agentInstanceKey);
+
+  /**
+   * Command to resolve a batch of secret references in a single round-trip.
+   *
+   * <p><strong>Experimental: This method is under development. The respective API on compatible
+   * clusters cannot be considered production-ready. Thus, this method doesn't work out of the box
+   * with all clusters. Until this warning is removed, anything described below may not yet have
+   * taken effect, and the interface and its description are subject to change.</strong>
+   *
+   * <p>Each reference is authorized and resolved independently, so a reference that cannot be
+   * resolved never fails the others. Such a failure is returned as data on the response, not as an
+   * exception: the resolved references are available on {@link
+   * io.camunda.client.api.response.ResolveSecretsResponse#getResolved()} and the failed ones on
+   * {@link io.camunda.client.api.response.ResolveSecretsResponse#getErrors()}. Only a rejected
+   * request, for example one exceeding the maximum batch size, completes the command exceptionally.
+   *
+   * <pre>
+   *   camundaClient
+   *       .newResolveSecretsCommand()
+   *       .references(List.of("camunda.secrets.token"))
+   *       .send();
+   * </pre>
+   *
+   * @return a builder for the command
+   */
+  @ExperimentalApi("https://github.com/camunda/camunda/issues/56661")
+  ResolveSecretsCommandStep1 newResolveSecretsCommand();
+
+  /**
+   * Command to list the secret reference names the caller is authorized to see. It never returns
+   * secret values, only the reference names.
+   *
+   * <p><strong>Experimental: This method is under development. The respective API on compatible
+   * clusters cannot be considered production-ready. Thus, this method doesn't work out of the box
+   * with all clusters. Until this warning is removed, anything described below may not yet have
+   * taken effect, and the interface and its description are subject to change.</strong>
+   *
+   * <pre>
+   *   camundaClient
+   *       .newListSecretsCommand()
+   *       .send();
+   * </pre>
+   *
+   * @return a builder for the command
+   */
+  @ExperimentalApi("https://github.com/camunda/camunda/issues/56661")
+  ListSecretsCommandStep1 newListSecretsCommand();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/ListSecretsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ListSecretsCommandStep1.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.ListSecretsResponse;
+import java.time.Duration;
+
+/**
+ * Command to list the secret reference names the caller is authorized to see. The command takes no
+ * input; filtering options are reserved for a future release.
+ */
+public interface ListSecretsCommandStep1 extends FinalCommandStep<ListSecretsResponse> {
+
+  @Override
+  ListSecretsCommandStep1 requestTimeout(Duration requestTimeout);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/command/ResolveSecretsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ResolveSecretsCommandStep1.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.ResolveSecretsResponse;
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * Command to resolve a batch of secret references in a single round-trip.
+ *
+ * <p>At least one reference must be set before the command is sent. Duplicate references are
+ * deduplicated by the cluster, and the cluster also rejects a batch that exceeds its maximum size,
+ * so neither is enforced here.
+ */
+public interface ResolveSecretsCommandStep1 extends FinalCommandStep<ResolveSecretsResponse> {
+
+  /**
+   * Sets the references to resolve, replacing any previously set references.
+   *
+   * @param references the secret references to resolve
+   * @return the builder for this command
+   */
+  ResolveSecretsCommandStep1 references(List<String> references);
+
+  /**
+   * Sets the references to resolve, replacing any previously set references.
+   *
+   * @param references the secret references to resolve
+   * @return the builder for this command
+   */
+  ResolveSecretsCommandStep1 references(String... references);
+
+  /**
+   * Adds a single reference to resolve, keeping any previously set references.
+   *
+   * @param reference the secret reference to resolve
+   * @return the builder for this command
+   */
+  ResolveSecretsCommandStep1 reference(String reference);
+
+  @Override
+  ResolveSecretsCommandStep1 requestTimeout(Duration requestTimeout);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/response/ListSecretsResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ListSecretsResponse.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+import java.util.List;
+
+/** The secret references the caller is authorized to see. Reference names only, never values. */
+public interface ListSecretsResponse {
+
+  /**
+   * @return the secret reference names the caller is authorized to see, never null, unmodifiable
+   */
+  List<String> getReferences();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/response/ResolveSecretsResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ResolveSecretsResponse.java
@@ -17,6 +17,7 @@ package io.camunda.client.api.response;
 
 import io.camunda.client.api.search.enums.SecretErrorCode;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * The per-reference outcome of a resolve secrets command.
@@ -42,6 +43,21 @@ public interface ResolveSecretsResponse {
    * @return the references that could not be resolved, never null, unmodifiable
    */
   List<ResolutionError> getErrors();
+
+  /**
+   * Looks up a single resolved value by reference, so that a caller does not have to scan {@link
+   * #getResolved()} itself. A map is deliberately not exposed instead, since {@code Map.toString()}
+   * would print every value and undo the masking {@link ResolvedSecret} carries.
+   *
+   * @param reference the requested secret reference
+   * @return the resolved value, or empty if the reference was not resolved
+   */
+  default Optional<String> getValue(final String reference) {
+    return getResolved().stream()
+        .filter(resolved -> resolved.getReference().equals(reference))
+        .map(ResolvedSecret::getValue)
+        .findFirst();
+  }
 
   /** A reference that was resolved, together with its value. */
   interface ResolvedSecret {

--- a/clients/java/src/main/java/io/camunda/client/api/response/ResolveSecretsResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ResolveSecretsResponse.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+import io.camunda.client.api.search.enums.SecretErrorCode;
+import java.util.List;
+
+/**
+ * The per-reference outcome of a resolve secrets command.
+ *
+ * <p>Each requested reference is authorized and resolved independently: a reference that could not
+ * be resolved appears in {@link #getErrors()} and never fails the rest of the batch. Per-reference
+ * failures are therefore response data, not exceptions.
+ */
+public interface ResolveSecretsResponse {
+
+  /**
+   * @return true if every requested reference was resolved, that is if there are no errors and
+   *     every distinct requested reference appears in {@link #getResolved()}
+   */
+  boolean isFullyResolved();
+
+  /**
+   * @return the references that were resolved, never null, unmodifiable
+   */
+  List<ResolvedSecret> getResolved();
+
+  /**
+   * @return the references that could not be resolved, never null, unmodifiable
+   */
+  List<ResolutionError> getErrors();
+
+  /** A reference that was resolved, together with its value. */
+  interface ResolvedSecret {
+
+    /**
+     * @return the resolved secret reference
+     */
+    String getReference();
+
+    /**
+     * @return the resolved secret value
+     */
+    String getValue();
+  }
+
+  /** A reference that could not be resolved, together with its typed reason. */
+  interface ResolutionError {
+
+    /**
+     * @return the secret reference that could not be resolved
+     */
+    String getReference();
+
+    /**
+     * @return the typed reason the reference could not be resolved
+     */
+    SecretErrorCode getCode();
+
+    /**
+     * The cluster documents this message as error metadata only, so it does not carry the secret
+     * value. The client cannot enforce that, so treat it as server-provided text: it is left out of
+     * {@code toString()} and reaches a log only where a caller puts it there.
+     *
+     * @return a human-readable description of the failure
+     */
+    String getMessage();
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/SecretErrorCode.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/SecretErrorCode.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.enums;
+
+/** The typed reason a secret reference could not be resolved. */
+public enum SecretErrorCode {
+  /** No secret exists for the reference. */
+  NOT_FOUND,
+  /** The caller lacks the reveal permission on the reference. */
+  ACCESS_DENIED,
+  /** The reference is malformed. */
+  INVALID_REFERENCE,
+  UNKNOWN_ENUM_VALUE;
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/SecretErrorCode.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/SecretErrorCode.java
@@ -23,5 +23,7 @@ public enum SecretErrorCode {
   ACCESS_DENIED,
   /** The reference is malformed. */
   INVALID_REFERENCE,
+  /** The configured store could not return a value for the reference. */
+  UNREADABLE,
   UNKNOWN_ENUM_VALUE;
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -78,6 +78,7 @@ import io.camunda.client.api.command.FailJobCommandStep1;
 import io.camunda.client.api.command.GloballyScopedClusterVariableCreationCommandStep1;
 import io.camunda.client.api.command.GloballyScopedClusterVariableDeletionCommandStep1;
 import io.camunda.client.api.command.GloballyScopedClusterVariableUpdateCommandStep1;
+import io.camunda.client.api.command.ListSecretsCommandStep1;
 import io.camunda.client.api.command.MigrateProcessInstanceCommandStep1;
 import io.camunda.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.client.api.command.PinClockCommandStep1;
@@ -85,6 +86,7 @@ import io.camunda.client.api.command.PublishMessageCommandStep1;
 import io.camunda.client.api.command.ResetClockCommandStep1;
 import io.camunda.client.api.command.ResolveIncidentCommandStep1;
 import io.camunda.client.api.command.ResolveProcessInstanceIncidentsCommandStep1;
+import io.camunda.client.api.command.ResolveSecretsCommandStep1;
 import io.camunda.client.api.command.ResumeBatchOperationStep1;
 import io.camunda.client.api.command.ResumeProcessInstanceCommandStep1;
 import io.camunda.client.api.command.SetVariablesCommandStep1;
@@ -274,6 +276,7 @@ import io.camunda.client.impl.command.GloballyScopedUpdateClusterVariableImpl;
 import io.camunda.client.impl.command.JobUpdatePriorityCommandImpl;
 import io.camunda.client.impl.command.JobUpdateRetriesCommandImpl;
 import io.camunda.client.impl.command.JobUpdateTimeoutCommandImpl;
+import io.camunda.client.impl.command.ListSecretsCommandImpl;
 import io.camunda.client.impl.command.MigrateProcessInstanceCommandImpl;
 import io.camunda.client.impl.command.ModifyProcessInstanceCommandImpl;
 import io.camunda.client.impl.command.PinClockCommandImpl;
@@ -281,6 +284,7 @@ import io.camunda.client.impl.command.PublishMessageCommandImpl;
 import io.camunda.client.impl.command.ResetClockCommandImpl;
 import io.camunda.client.impl.command.ResolveIncidentCommandImpl;
 import io.camunda.client.impl.command.ResolveProcessInstanceIncidentsCommandImpl;
+import io.camunda.client.impl.command.ResolveSecretsCommandImpl;
 import io.camunda.client.impl.command.ResumeBatchOperationCommandImpl;
 import io.camunda.client.impl.command.ResumeProcessInstanceCommandImpl;
 import io.camunda.client.impl.command.SetVariablesCommandImpl;
@@ -1858,6 +1862,16 @@ public final class CamundaClientImpl implements CamundaClient {
   public AgentInstanceHistorySearchRequest newAgentInstanceHistorySearchRequest(
       final long agentInstanceKey) {
     return new AgentInstanceHistorySearchRequestImpl(agentInstanceKey, httpClient, jsonMapper);
+  }
+
+  @Override
+  public ResolveSecretsCommandStep1 newResolveSecretsCommand() {
+    return new ResolveSecretsCommandImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public ListSecretsCommandStep1 newListSecretsCommand() {
+    return new ListSecretsCommandImpl(httpClient);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ListSecretsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ListSecretsCommandImpl.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.ListSecretsCommandStep1;
+import io.camunda.client.api.response.ListSecretsResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.ListSecretsResponseImpl;
+import io.camunda.client.protocol.rest.SecretListResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class ListSecretsCommandImpl implements ListSecretsCommandStep1 {
+
+  /**
+   * The endpoint takes no input, but it only accepts JSON. An empty object is sent rather than no
+   * body at all, because a request without a body carries no content type and is rejected as an
+   * unsupported media type.
+   */
+  private static final String EMPTY_JSON_BODY = "{}";
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public ListSecretsCommandImpl(final HttpClient httpClient) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public ListSecretsCommandStep1 requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<ListSecretsResponse> send() {
+    final HttpCamundaFuture<ListSecretsResponse> result = new HttpCamundaFuture<>();
+    final String path = "/secrets/list";
+    httpClient.post(
+        path,
+        EMPTY_JSON_BODY,
+        httpRequestConfig.build(),
+        SecretListResult.class,
+        ListSecretsResponseImpl::new,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ResolveSecretsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ResolveSecretsCommandImpl.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.ResolveSecretsCommandStep1;
+import io.camunda.client.api.response.ResolveSecretsResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.ResolveSecretsResponseImpl;
+import io.camunda.client.protocol.rest.SecretResolveRequest;
+import io.camunda.client.protocol.rest.SecretResolveResult;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class ResolveSecretsCommandImpl implements ResolveSecretsCommandStep1 {
+
+  private final SecretResolveRequest request;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public ResolveSecretsCommandImpl(final HttpClient httpClient, final JsonMapper jsonMapper) {
+    this.jsonMapper = jsonMapper;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new SecretResolveRequest();
+  }
+
+  @Override
+  public ResolveSecretsCommandStep1 references(final List<String> references) {
+    ArgumentUtil.ensureNotNull("references", references);
+    // Null entries are rejected here because the cluster rejects the whole request for them, so
+    // sending one would fail the batch anyway. Everything else — the batch size, the reference
+    // length, duplicates and the reference format, an empty reference included — is owned by the
+    // cluster: a malformed reference comes back as a resolution error, not as an exception, and
+    // must therefore not fail the references alongside it.
+    references.forEach(reference -> ArgumentUtil.ensureNotNull("reference", reference));
+    request.setReferences(new ArrayList<>(references));
+    return this;
+  }
+
+  @Override
+  public ResolveSecretsCommandStep1 references(final String... references) {
+    ArgumentUtil.ensureNotNull("references", references);
+    return references(Arrays.asList(references));
+  }
+
+  @Override
+  public ResolveSecretsCommandStep1 reference(final String reference) {
+    ArgumentUtil.ensureNotNull("reference", reference);
+    request.addReferencesItem(reference);
+    return this;
+  }
+
+  @Override
+  public ResolveSecretsCommandStep1 requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<ResolveSecretsResponse> send() {
+    ArgumentUtil.ensureNotNullOrEmpty("references", request.getReferences());
+    // Deduplicated because the cluster deduplicates before resolving, so a duplicate reference
+    // comes back once. The response needs the requested references to tell a fully resolved batch
+    // apart from one whose references were dropped on the way back.
+    final Set<String> requestedReferences = new LinkedHashSet<>(request.getReferences());
+    final HttpCamundaFuture<ResolveSecretsResponse> result = new HttpCamundaFuture<>();
+    final String path = "/secrets/resolve";
+    httpClient.post(
+        path,
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        SecretResolveResult.class,
+        response -> new ResolveSecretsResponseImpl(response, requestedReferences),
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ResolveSecretsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ResolveSecretsCommandImpl.java
@@ -88,7 +88,10 @@ public class ResolveSecretsCommandImpl implements ResolveSecretsCommandStep1 {
     final Set<String> requestedReferences = new LinkedHashSet<>(request.getReferences());
     final HttpCamundaFuture<ResolveSecretsResponse> result = new HttpCamundaFuture<>();
     final String path = "/secrets/resolve";
-    httpClient.post(
+    // Sent as a sensitive response so that a response the client cannot make sense of is reported
+    // without echoing the body: the resolved values are only kept out of logs by
+    // ResolveSecretsResponseImpl, whereas the wire representation prints them.
+    httpClient.postWithSensitiveResponse(
         path,
         jsonMapper.toJson(request),
         httpRequestConfig.build(),

--- a/clients/java/src/main/java/io/camunda/client/impl/http/ApiCallback.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/ApiCallback.java
@@ -34,12 +34,14 @@ import org.apache.hc.core5.concurrent.FutureCallback;
 final class ApiCallback<HttpT, RespT> implements FutureCallback<ApiResponse<HttpT>> {
   private static final Predicate<Integer> DEFAULT_SUCCESS_PREDICATE =
       code -> code >= 200 && code < 400;
+  private static final String REDACTED_BODY = "<redacted: may contain secret values>";
   private final CompletableFuture<RespT> response;
   private final JsonResponseAndStatusCodeTransformer<HttpT, RespT> transformer;
   private final Predicate<Integer> successPredicate;
   private final Predicate<StatusCode> retryPredicate;
   private final Runnable retryAction;
   private final AtomicInteger remainingRetries;
+  private final boolean sensitiveResponseBody;
 
   public ApiCallback(
       final CompletableFuture<RespT> response,
@@ -47,7 +49,8 @@ final class ApiCallback<HttpT, RespT> implements FutureCallback<ApiResponse<Http
       final Predicate<Integer> successPredicate,
       final Predicate<StatusCode> retryPredicate,
       final Runnable retryAction,
-      final int maxRetries) {
+      final int maxRetries,
+      final boolean sensitiveResponseBody) {
     this.response = response;
     this.transformer = transformer;
     if (successPredicate != null) {
@@ -58,6 +61,7 @@ final class ApiCallback<HttpT, RespT> implements FutureCallback<ApiResponse<Http
     this.retryPredicate = retryPredicate;
     this.retryAction = retryAction;
     remainingRetries = new AtomicInteger(maxRetries);
+    this.sensitiveResponseBody = sensitiveResponseBody;
   }
 
   @Override
@@ -106,7 +110,7 @@ final class ApiCallback<HttpT, RespT> implements FutureCallback<ApiResponse<Http
           new MalformedResponseException(
               String.format(
                   "Expected to receive a problem body, but got an unknown body type: %s",
-                  StandardCharsets.UTF_8.decode(body.unknown())),
+                  describeUnknownBody(body)),
               code,
               reason));
       return;
@@ -117,7 +121,7 @@ final class ApiCallback<HttpT, RespT> implements FutureCallback<ApiResponse<Http
           new MalformedResponseException(
               String.format(
                   "Expected to receive a problem body, but got an actual response: %s",
-                  body.response()),
+                  describeResponseBody(body)),
               code,
               reason));
       return;
@@ -161,7 +165,7 @@ final class ApiCallback<HttpT, RespT> implements FutureCallback<ApiResponse<Http
           new MalformedResponseException(
               String.format(
                   "Expected to receive a response body, but got an unknown body type: %s",
-                  StandardCharsets.UTF_8.decode(body.unknown())),
+                  describeUnknownBody(body)),
               code,
               reason));
       return;
@@ -178,6 +182,27 @@ final class ApiCallback<HttpT, RespT> implements FutureCallback<ApiResponse<Http
     }
 
     completeResponse(code, reason, body.response());
+  }
+
+  /**
+   * A body that the server sent under an unexpected content type is echoed to make the mismatch
+   * debuggable, unless the endpoint answers with secret material: a cluster or proxy breaking the
+   * content type contract would otherwise put every secret in the batch into an exception message,
+   * and from there into the caller's logs.
+   */
+  private String describeUnknownBody(final ApiEntity<HttpT> body) {
+    return sensitiveResponseBody
+        ? REDACTED_BODY
+        : StandardCharsets.UTF_8.decode(body.unknown()).toString();
+  }
+
+  /**
+   * Same reasoning as {@link #describeUnknownBody(ApiEntity)}: the parsed body is only printable
+   * when it cannot carry secret material, because the generated response types print all of their
+   * fields.
+   */
+  private String describeResponseBody(final ApiEntity<HttpT> body) {
+    return sensitiveResponseBody ? REDACTED_BODY : String.valueOf(body.response());
   }
 
   private void completeResponse(final int code, final String reason, final HttpT httpResponse) {

--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClient.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClient.java
@@ -190,7 +190,8 @@ public final class HttpClient implements AutoCloseable {
         successPredicate,
         transformer,
         result,
-        null);
+        null,
+        false);
   }
 
   public <RespT> void post(
@@ -223,6 +224,34 @@ public final class HttpClient implements AutoCloseable {
 
     sendRequest(
         Method.POST, path, queryParams, body, requestConfig, responseType, transformer, result);
+  }
+
+  /**
+   * Same as {@link #post(String, String, RequestConfig, Class, JsonResponseTransformer,
+   * HttpCamundaFuture)}, except that the response body is never echoed into an error message. Use
+   * it for endpoints that answer with secret material: a response the client cannot make sense of —
+   * an unexpected content type, or a response body under an error status — is otherwise reported by
+   * dumping the body, which would leak the secrets it carries into the caller's logs.
+   */
+  public <HttpT, RespT> void postWithSensitiveResponse(
+      final String path,
+      final String body,
+      final RequestConfig requestConfig,
+      final Class<HttpT> responseType,
+      final JsonResponseTransformer<HttpT, RespT> transformer,
+      final HttpCamundaFuture<RespT> result) {
+    sendRequest(
+        Method.POST,
+        path,
+        Collections.emptyMap(),
+        body,
+        requestConfig,
+        MAX_RETRY_ATTEMPTS,
+        responseType,
+        transformer,
+        result,
+        null,
+        true);
   }
 
   public <HttpT, RespT> void postMultipart(
@@ -355,7 +384,8 @@ public final class HttpClient implements AutoCloseable {
         responseType,
         transformer,
         result,
-        null);
+        null,
+        false);
   }
 
   private <HttpT, RespT> void sendRequest(
@@ -368,7 +398,8 @@ public final class HttpClient implements AutoCloseable {
       final Class<HttpT> responseType,
       final JsonResponseTransformer<HttpT, RespT> transformer,
       final HttpCamundaFuture<RespT> result,
-      final ApiCallback<HttpT, RespT> callback) {
+      final ApiCallback<HttpT, RespT> callback,
+      final boolean sensitiveResponseBody) {
     sendRequest(
         httpMethod,
         path,
@@ -380,7 +411,8 @@ public final class HttpClient implements AutoCloseable {
         null,
         (response, statusCode) -> transformer.transform(response),
         result,
-        callback);
+        callback,
+        sensitiveResponseBody);
   }
 
   private <RespT> void sendRequest(
@@ -405,7 +437,8 @@ public final class HttpClient implements AutoCloseable {
         successPredicate,
         transformer,
         result,
-        callback);
+        callback,
+        false);
   }
 
   private <HttpT, RespT> void sendRequest(
@@ -419,7 +452,8 @@ public final class HttpClient implements AutoCloseable {
       final Predicate<Integer> successPredicate,
       final JsonResponseAndStatusCodeTransformer<HttpT, RespT> transformer,
       final HttpCamundaFuture<RespT> result,
-      final ApiCallback<HttpT, RespT> callback) {
+      final ApiCallback<HttpT, RespT> callback,
+      final boolean sensitiveResponseBody) {
     sendRequest(
         httpMethod,
         address,
@@ -432,7 +466,8 @@ public final class HttpClient implements AutoCloseable {
         successPredicate,
         transformer,
         result,
-        callback);
+        callback,
+        sensitiveResponseBody);
   }
 
   private <HttpT, RespT> void sendRequest(
@@ -447,7 +482,8 @@ public final class HttpClient implements AutoCloseable {
       final Predicate<Integer> successPredicate,
       final JsonResponseAndStatusCodeTransformer<HttpT, RespT> transformer,
       final HttpCamundaFuture<RespT> result,
-      final ApiCallback<HttpT, RespT> callback) {
+      final ApiCallback<HttpT, RespT> callback,
+      final boolean sensitiveResponseBody) {
     final AtomicReference<ApiCallback<HttpT, RespT>> apiCallback = new AtomicReference<>(callback);
     // Create retry action to re-execute the same request
     final Runnable retryAction =
@@ -467,7 +503,8 @@ public final class HttpClient implements AutoCloseable {
               successPredicate,
               transformer,
               result,
-              apiCallback.get());
+              apiCallback.get(),
+              sensitiveResponseBody);
         };
 
     final SimpleHttpRequest request =
@@ -487,7 +524,8 @@ public final class HttpClient implements AutoCloseable {
               successPredicate,
               credentialsProvider::shouldRetryRequest,
               retryAction,
-              maxRetries));
+              maxRetries,
+              sensitiveResponseBody));
     }
 
     result.transportFuture(

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ListSecretsResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ListSecretsResponseImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.ListSecretsResponse;
+import io.camunda.client.impl.util.CollectionUtil;
+import io.camunda.client.protocol.rest.SecretListResult;
+import java.util.List;
+
+public class ListSecretsResponseImpl implements ListSecretsResponse {
+
+  private final List<String> references;
+
+  public ListSecretsResponseImpl(final SecretListResult result) {
+    references = CollectionUtil.toUnmodifiableList(result.getReferences());
+  }
+
+  @Override
+  public List<String> getReferences() {
+    return references;
+  }
+
+  /** Reference names are metadata, never values, so they are safe to print. */
+  @Override
+  public String toString() {
+    return "ListSecretsResponse{references=" + references + '}';
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ResolveSecretsResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ResolveSecretsResponseImpl.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.ResolveSecretsResponse;
+import io.camunda.client.api.search.enums.SecretErrorCode;
+import io.camunda.client.impl.util.CollectionUtil;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.SecretResolveResult;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Copies the response eagerly instead of holding the wire representation, so that the resolved
+ * values are only reachable through the getters below and cannot be printed by a generated {@code
+ * toString()}.
+ */
+public class ResolveSecretsResponseImpl implements ResolveSecretsResponse {
+
+  private final List<ResolvedSecret> resolved;
+  private final List<ResolutionError> errors;
+  private final boolean fullyResolved;
+
+  public ResolveSecretsResponseImpl(
+      final SecretResolveResult result, final Set<String> requestedReferences) {
+    resolved =
+        CollectionUtil.mapToUnmodifiableList(
+            result.getResolved(),
+            item -> new ResolvedSecretImpl(item.getReference(), item.getValue()));
+    errors =
+        CollectionUtil.mapToUnmodifiableList(
+            result.getErrors(),
+            item ->
+                new ResolutionErrorImpl(
+                    item.getReference(), errorCode(item.getCode()), item.getMessage()));
+    fullyResolved = errors.isEmpty() && resolvedReferences().containsAll(requestedReferences);
+  }
+
+  /**
+   * An absent code is reported as {@link SecretErrorCode#UNKNOWN_ENUM_VALUE} rather than as null,
+   * so that a caller switching on the code never has to null-check it. The field is required by the
+   * API contract, so this only guards against a cluster or proxy that omits it anyway.
+   */
+  private static SecretErrorCode errorCode(
+      final io.camunda.client.protocol.rest.SecretErrorCode code) {
+    return code == null
+        ? SecretErrorCode.UNKNOWN_ENUM_VALUE
+        : EnumUtil.convert(code, SecretErrorCode.class);
+  }
+
+  private Set<String> resolvedReferences() {
+    return resolved.stream().map(ResolvedSecret::getReference).collect(Collectors.toSet());
+  }
+
+  /**
+   * Requires every requested reference to be present in {@link #getResolved()}, not merely that no
+   * error was reported: a response that dropped a reference has no errors either, and calling that
+   * fully resolved would send a caller to a resolved entry that is not there. Matching the
+   * references themselves rather than counting them also holds when the response repeats one
+   * reference and omits another.
+   */
+  @Override
+  public boolean isFullyResolved() {
+    return fullyResolved;
+  }
+
+  @Override
+  public List<ResolvedSecret> getResolved() {
+    return resolved;
+  }
+
+  @Override
+  public List<ResolutionError> getErrors() {
+    return errors;
+  }
+
+  /**
+   * Prints the resolved references but never their values, so that logging cannot leak a secret.
+   */
+  @Override
+  public String toString() {
+    return "ResolveSecretsResponse{resolved=" + resolved + ", errors=" + errors + '}';
+  }
+
+  public static final class ResolvedSecretImpl implements ResolvedSecret {
+
+    private final String reference;
+    private final String value;
+
+    public ResolvedSecretImpl(final String reference, final String value) {
+      this.reference = reference;
+      this.value = value;
+    }
+
+    @Override
+    public String getReference() {
+      return reference;
+    }
+
+    @Override
+    public String getValue() {
+      return value;
+    }
+
+    /** Deliberately omits the value, so that logging cannot leak a secret. */
+    @Override
+    public String toString() {
+      return "ResolvedSecret{reference='" + reference + "'}";
+    }
+  }
+
+  public static final class ResolutionErrorImpl implements ResolutionError {
+
+    private final String reference;
+    private final SecretErrorCode code;
+    private final String message;
+
+    public ResolutionErrorImpl(
+        final String reference, final SecretErrorCode code, final String message) {
+      this.reference = reference;
+      this.code = code;
+      this.message = message;
+    }
+
+    @Override
+    public String getReference() {
+      return reference;
+    }
+
+    @Override
+    public SecretErrorCode getCode() {
+      return code;
+    }
+
+    @Override
+    public String getMessage() {
+      return message;
+    }
+
+    /**
+     * Deliberately omits the message, so that logging cannot leak a secret. The reference and the
+     * typed code are enough to triage a failure, whereas the message is server-provided free text
+     * the client cannot vet. It stays available through {@link #getMessage()}.
+     */
+    @Override
+    public String toString() {
+      return "ResolutionError{reference='" + reference + "', code=" + code + '}';
+    }
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ResolveSecretsResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ResolveSecretsResponseImpl.java
@@ -51,15 +51,29 @@ public class ResolveSecretsResponseImpl implements ResolveSecretsResponse {
   }
 
   /**
-   * An absent code is reported as {@link SecretErrorCode#UNKNOWN_ENUM_VALUE} rather than as null,
-   * so that a caller switching on the code never has to null-check it. The field is required by the
-   * API contract, so this only guards against a cluster or proxy that omits it anyway.
+   * An absent or unrecognized code is reported as {@link SecretErrorCode#UNKNOWN_ENUM_VALUE} rather
+   * than thrown, so that a spec addition the client does not know about yet is reported per
+   * reference instead of failing the whole batch with a {@code RuntimeException}.
    */
   private static SecretErrorCode errorCode(
       final io.camunda.client.protocol.rest.SecretErrorCode code) {
-    return code == null
-        ? SecretErrorCode.UNKNOWN_ENUM_VALUE
-        : EnumUtil.convert(code, SecretErrorCode.class);
+    if (code == null) {
+      return SecretErrorCode.UNKNOWN_ENUM_VALUE;
+    }
+    switch (code) {
+      case NOT_FOUND:
+        return SecretErrorCode.NOT_FOUND;
+      case ACCESS_DENIED:
+        return SecretErrorCode.ACCESS_DENIED;
+      case INVALID_REFERENCE:
+        return SecretErrorCode.INVALID_REFERENCE;
+      case UNREADABLE:
+        return SecretErrorCode.UNREADABLE;
+      case UNKNOWN_DEFAULT_OPEN_API:
+      default:
+        EnumUtil.logUnknownEnumValue(code, "secret error code", SecretErrorCode.values());
+        return SecretErrorCode.UNKNOWN_ENUM_VALUE;
+    }
   }
 
   private Set<String> resolvedReferences() {

--- a/clients/java/src/main/java/io/camunda/client/impl/util/CollectionUtil.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/CollectionUtil.java
@@ -17,12 +17,34 @@ package io.camunda.client.impl.util;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public final class CollectionUtil {
 
   private CollectionUtil() {}
+
+  /**
+   * Copies a list that may be absent into an unmodifiable one, mapping every element. An absent
+   * list becomes an empty list, so that a response getter never hands a caller null.
+   */
+  public static <S, T> List<T> mapToUnmodifiableList(
+      final List<S> source, final Function<S, T> mapper) {
+    return source == null
+        ? Collections.emptyList()
+        : Collections.unmodifiableList(source.stream().map(mapper).collect(Collectors.toList()));
+  }
+
+  /**
+   * Copies a list that may be absent into an unmodifiable one. An absent list becomes an empty
+   * list, so that a response getter never hands a caller null.
+   */
+  public static <T> List<T> toUnmodifiableList(final List<T> source) {
+    return mapToUnmodifiableList(source, Function.identity());
+  }
 
   public static <T> List<T> addValuesToList(final List<T> list, final List<T> values) {
     final List<T> result;

--- a/clients/java/src/test/java/io/camunda/client/PhysicalTenantRestPathTest.java
+++ b/clients/java/src/test/java/io/camunda/client/PhysicalTenantRestPathTest.java
@@ -16,6 +16,7 @@
 package io.camunda.client;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 
@@ -46,8 +47,23 @@ final class PhysicalTenantRestPathTest {
   }
 
   private static void sendTopologyRequest(final CamundaClient client) {
+    send(() -> client.newTopologyRequest().send().join());
+  }
+
+  private static void sendPublishMessageCommand(final CamundaClient client) {
+    send(
+        () ->
+            client
+                .newPublishMessageCommand()
+                .messageName("message")
+                .correlationKey("key")
+                .send()
+                .join());
+  }
+
+  private static void send(final Runnable request) {
     try {
-      client.newTopologyRequest().send().join();
+      request.run();
     } catch (final Exception ignored) {
       // only the outgoing request URL is under test; the (unstubbed) response is irrelevant
     }
@@ -103,6 +119,19 @@ final class PhysicalTenantRestPathTest {
     // then the gateway serves the cluster status outside the per-tenant path, so keeping the
     // prefix would produce an unroutable URL
     verify(getRequestedFor(urlEqualTo("/cluster/v2/status")));
+  }
+
+  @Test
+  void shouldPrefixRestBasePathOfRequestWithBody(final WireMockRuntimeInfo mockInfo) {
+    // given
+    try (final CamundaClient client = client(mockInfo, true)) {
+      // when a request carrying a body is sent
+      sendPublishMessageCommand(client);
+    }
+
+    // then
+    verify(
+        postRequestedFor(urlEqualTo("/physical-tenants/riskproduction/v2/messages/publication")));
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/PhysicalTenantRestPathTest.java
+++ b/clients/java/src/test/java/io/camunda/client/PhysicalTenantRestPathTest.java
@@ -61,6 +61,10 @@ final class PhysicalTenantRestPathTest {
                 .join());
   }
 
+  private static void sendResolveSecretsCommand(final CamundaClient client) {
+    send(() -> client.newResolveSecretsCommand().reference("secrets.some-secret").send().join());
+  }
+
   private static void send(final Runnable request) {
     try {
       request.run();
@@ -132,6 +136,18 @@ final class PhysicalTenantRestPathTest {
     // then
     verify(
         postRequestedFor(urlEqualTo("/physical-tenants/riskproduction/v2/messages/publication")));
+  }
+
+  @Test
+  void shouldPrefixRestBasePathOfResolveSecretsCommand(final WireMockRuntimeInfo mockInfo) {
+    // given
+    try (final CamundaClient client = client(mockInfo, true)) {
+      // when
+      sendResolveSecretsCommand(client);
+    }
+
+    // then
+    verify(postRequestedFor(urlEqualTo("/physical-tenants/riskproduction/v2/secrets/resolve")));
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/impl/http/ApiCallbackTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/http/ApiCallbackTest.java
@@ -198,6 +198,34 @@ class ApiCallbackTest {
   }
 
   @Test
+  void shouldRedactResponseBodyWhenSensitiveAndServerReturnsErrorStatusWithAResponseBody()
+      throws Exception {
+    // given a sensitive command whose server sent a response body alongside an error status,
+    // which case ApiCallback treats as malformed since only a problem body is expected there
+    apiCallback =
+        new ApiCallback<>(
+            response,
+            transformer,
+            null,
+            retryPredicate,
+            retryAction,
+            DEFAULT_REMAINING_RETRIES,
+            true);
+    final ApiResponse<String> apiResponse = mock(ApiResponse.class);
+    when(apiResponse.getCode()).thenReturn(500);
+    when(apiResponse.entity()).thenReturn(ApiEntity.of("super-secret-value"));
+
+    // when
+    apiCallback.completed(apiResponse);
+
+    // then
+    assertThat(response.isCompletedExceptionally()).isTrue();
+    final Throwable error =
+        org.assertj.core.api.Assertions.catchThrowable(response::get).getCause();
+    assertThat(error.getMessage()).doesNotContain("super-secret-value").contains("redacted");
+  }
+
+  @Test
   void shouldFailWithStatusCodeTransformerWhenRetryPredicateIsFalse() {
     // given
     when(successPredicate.test(400)).thenReturn(false);

--- a/clients/java/src/test/java/io/camunda/client/impl/http/ApiCallbackTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/http/ApiCallbackTest.java
@@ -44,7 +44,13 @@ class ApiCallbackTest {
     retryAction = mock(Runnable.class);
     apiCallback =
         new ApiCallback<>(
-            response, transformer, null, retryPredicate, retryAction, DEFAULT_REMAINING_RETRIES);
+            response,
+            transformer,
+            null,
+            retryPredicate,
+            retryAction,
+            DEFAULT_REMAINING_RETRIES,
+            false);
   }
 
   @Test
@@ -147,7 +153,8 @@ class ApiCallbackTest {
             successPredicate,
             retryPredicate,
             retryAction,
-            DEFAULT_REMAINING_RETRIES);
+            DEFAULT_REMAINING_RETRIES,
+            false);
 
     final ApiResponse<String> apiResponse = mock(ApiResponse.class);
     when(apiResponse.getCode()).thenReturn(503);
@@ -175,7 +182,8 @@ class ApiCallbackTest {
             successPredicate,
             retryPredicate,
             retryAction,
-            DEFAULT_REMAINING_RETRIES);
+            DEFAULT_REMAINING_RETRIES,
+            false);
 
     final ApiResponse<String> apiResponse = mock(ApiResponse.class);
     when(apiResponse.getCode()).thenReturn(500);
@@ -202,7 +210,8 @@ class ApiCallbackTest {
             successPredicate,
             retryPredicate,
             retryAction,
-            DEFAULT_REMAINING_RETRIES);
+            DEFAULT_REMAINING_RETRIES,
+            false);
 
     final ApiResponse<String> apiResponse = mock(ApiResponse.class);
     when(apiResponse.getCode()).thenReturn(400);

--- a/clients/java/src/test/java/io/camunda/client/secret/ListSecretsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/secret/ListSecretsTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.secret;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.ListSecretsResponse;
+import io.camunda.client.protocol.rest.ProblemDetail;
+import io.camunda.client.protocol.rest.SecretListResult;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import io.camunda.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public class ListSecretsTest extends ClientRestTest {
+
+  private static final String REFERENCE = "camunda.secrets.token";
+  private static final String OTHER_REFERENCE = "camunda.secrets.a";
+
+  @Test
+  void shouldPostToListEndpoint() {
+    // given
+    gatewayService.onSecretsListRequest(new SecretListResult());
+
+    // when
+    client.newListSecretsCommand().send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getSecretsListUrl());
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+  }
+
+  @Test
+  void shouldSendEmptyJsonObjectAsBody() {
+    // given
+    gatewayService.onSecretsListRequest(new SecretListResult());
+
+    // when
+    client.newListSecretsCommand().send().join();
+
+    // then
+    assertThat(RestGatewayService.getLastRequest().getBodyAsString()).isEqualTo("{}");
+  }
+
+  @Test
+  void shouldSendJsonContentType() {
+    // given the endpoint only accepts JSON, so a body-less request would be rejected
+    gatewayService.onSecretsListRequest(new SecretListResult());
+
+    // when
+    client.newListSecretsCommand().send().join();
+
+    // then
+    assertThat(RestGatewayService.getLastRequest().getHeader("Content-Type"))
+        .contains("application/json");
+  }
+
+  @Test
+  void shouldReturnReferences() {
+    // given
+    gatewayService.onSecretsListRequest(
+        new SecretListResult().addReferencesItem(REFERENCE).addReferencesItem(OTHER_REFERENCE));
+
+    // when
+    final ListSecretsResponse response = client.newListSecretsCommand().send().join();
+
+    // then
+    assertThat(response.getReferences()).containsExactly(REFERENCE, OTHER_REFERENCE);
+  }
+
+  @Test
+  void shouldReturnUnmodifiableReferences() {
+    // given
+    gatewayService.onSecretsListRequest(new SecretListResult().addReferencesItem(REFERENCE));
+
+    // when
+    final ListSecretsResponse response = client.newListSecretsCommand().send().join();
+
+    // then the response cannot be altered through the list it hands out
+    assertThat(response.getReferences()).isUnmodifiable();
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenResponseOmitsReferences() {
+    // given
+    gatewayService.onSecretsListRequest(new SecretListResult());
+
+    // when
+    final ListSecretsResponse response = client.newListSecretsCommand().send().join();
+
+    // then
+    assertThat(response.getReferences()).isEmpty();
+  }
+
+  @Test
+  void shouldRaiseExceptionOnRejectedRequest() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getSecretsListUrl(),
+        () -> new ProblemDetail().title("Invalid data").status(400));
+
+    // when / then
+    assertThatThrownBy(() -> client.newListSecretsCommand().send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 400")
+        .hasMessageContaining("Invalid data");
+  }
+
+  @Test
+  void shouldRaiseExceptionWhenUnauthenticated() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getSecretsListUrl(),
+        () -> new ProblemDetail().title("Unauthorized").status(401));
+
+    // when / then
+    assertThatThrownBy(() -> client.newListSecretsCommand().send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 401: 'Unauthorized'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnServerError() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getSecretsListUrl(),
+        () -> new ProblemDetail().title("Internal Server Error").status(500));
+
+    // when / then
+    assertThatThrownBy(() -> client.newListSecretsCommand().send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/secret/ResolveSecretsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/secret/ResolveSecretsTest.java
@@ -251,9 +251,11 @@ public class ResolveSecretsTest extends ClientRestTest {
   /**
    * Drives every code the generated protocol enum knows, excluding only the generator's unknown
    * default, which {@link #shouldMapUnknownErrorCodeToUnknownEnumValue} covers. Deliberately not an
-   * explicit name list: should the API contract gain a code that {@link SecretErrorCode} does not
-   * mirror, {@code EnumUtil.convert} throws and fails the whole batch at runtime, so this test has
-   * to fail on the added code rather than silently keep testing the old three.
+   * explicit name list: a code the API contract gains is picked up by the enum source, and the
+   * assertion's {@code SecretErrorCode.valueOf(code.name())} then fails until {@link
+   * SecretErrorCode} mirrors it. An unmirrored code does not fail the batch at runtime any more, it
+   * degrades to {@link SecretErrorCode#UNKNOWN_ENUM_VALUE}, so this test is what keeps the two
+   * enums from drifting apart unnoticed.
    */
   @ParameterizedTest
   @EnumSource(

--- a/clients/java/src/test/java/io/camunda/client/secret/ResolveSecretsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/secret/ResolveSecretsTest.java
@@ -19,8 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.command.MalformedResponseException;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.ResolveSecretsResponse;
 import io.camunda.client.api.response.ResolveSecretsResponse.ResolutionError;
@@ -481,6 +483,30 @@ public class ResolveSecretsTest extends ClientRestTest {
   }
 
   @Test
+  void shouldNotExposeSecretValuesOfAResponseSentUnderAnErrorStatus() {
+    // given a cluster or proxy breaking the contract by answering with secrets and an error status
+    stubResolveResponse(502, "application/json", secretsBody());
+
+    // when / then the mismatch is reported without the body it could not make sense of
+    assertThatThrownBy(() -> client.newResolveSecretsCommand().reference(REFERENCE).send().join())
+        .isInstanceOf(MalformedResponseException.class)
+        .hasMessageContaining("redacted")
+        .hasMessageNotContaining(VALUE);
+  }
+
+  @Test
+  void shouldNotExposeSecretValuesOfAResponseSentUnderAnUnexpectedContentType() {
+    // given a cluster or proxy breaking the contract by answering with a non-JSON content type
+    stubResolveResponse(200, "text/plain", secretsBody());
+
+    // when / then the raw body is not echoed, as it carries the resolved values verbatim
+    assertThatThrownBy(() -> client.newResolveSecretsCommand().reference(REFERENCE).send().join())
+        .isInstanceOf(MalformedResponseException.class)
+        .hasMessageContaining("redacted")
+        .hasMessageNotContaining(VALUE);
+  }
+
+  @Test
   void shouldRaiseExceptionOnNullReferences() {
     // when / then
     assertThatThrownBy(() -> client.newResolveSecretsCommand().references((List<String>) null))
@@ -511,6 +537,21 @@ public class ResolveSecretsTest extends ClientRestTest {
     assertThatThrownBy(() -> client.newResolveSecretsCommand().send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("references");
+  }
+
+  private static void stubResolveResponse(
+      final int status, final String contentType, final String body) {
+    WireMock.stubFor(
+        WireMock.post(WireMock.urlEqualTo(RestGatewayPaths.getSecretsResolveUrl()))
+            .willReturn(
+                WireMock.aResponse()
+                    .withStatus(status)
+                    .withHeader("Content-Type", contentType)
+                    .withBody(body)));
+  }
+
+  private static String secretsBody() {
+    return "{\"resolved\":[{\"reference\":\"" + REFERENCE + "\",\"value\":\"" + VALUE + "\"}]}";
   }
 
   private static ResolvedSecret resolved(final String reference, final String value) {

--- a/clients/java/src/test/java/io/camunda/client/secret/ResolveSecretsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/secret/ResolveSecretsTest.java
@@ -1,0 +1,526 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.secret;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.ResolveSecretsResponse;
+import io.camunda.client.api.response.ResolveSecretsResponse.ResolutionError;
+import io.camunda.client.api.search.enums.SecretErrorCode;
+import io.camunda.client.protocol.rest.ProblemDetail;
+import io.camunda.client.protocol.rest.ResolvedSecret;
+import io.camunda.client.protocol.rest.SecretResolutionError;
+import io.camunda.client.protocol.rest.SecretResolveRequest;
+import io.camunda.client.protocol.rest.SecretResolveResult;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import io.camunda.client.util.RestGatewayService;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class ResolveSecretsTest extends ClientRestTest {
+
+  private static final String REFERENCE = "camunda.secrets.token";
+  private static final String OTHER_REFERENCE = "camunda.secrets.a";
+  private static final String VALUE = "s3cr3t-value";
+
+  @Test
+  void shouldPostToResolveEndpoint() {
+    // given
+    gatewayService.onSecretsResolveRequest(new SecretResolveResult());
+
+    // when
+    client.newResolveSecretsCommand().reference(REFERENCE).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getSecretsResolveUrl());
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+  }
+
+  @Test
+  void shouldSendAllReferencesInRequestBody() {
+    // given
+    gatewayService.onSecretsResolveRequest(new SecretResolveResult());
+
+    // when
+    client
+        .newResolveSecretsCommand()
+        .references(Arrays.asList(REFERENCE, OTHER_REFERENCE))
+        .send()
+        .join();
+
+    // then
+    final SecretResolveRequest request = gatewayService.getLastRequest(SecretResolveRequest.class);
+    assertThat(request.getReferences()).containsExactly(REFERENCE, OTHER_REFERENCE);
+  }
+
+  @Test
+  void shouldSendReferencesGivenAsVarargs() {
+    // given
+    gatewayService.onSecretsResolveRequest(new SecretResolveResult());
+
+    // when
+    client.newResolveSecretsCommand().references(REFERENCE, OTHER_REFERENCE).send().join();
+
+    // then
+    final SecretResolveRequest request = gatewayService.getLastRequest(SecretResolveRequest.class);
+    assertThat(request.getReferences()).containsExactly(REFERENCE, OTHER_REFERENCE);
+  }
+
+  @Test
+  void shouldAppendSingleReferences() {
+    // given
+    gatewayService.onSecretsResolveRequest(new SecretResolveResult());
+
+    // when
+    client.newResolveSecretsCommand().reference(REFERENCE).reference(OTHER_REFERENCE).send().join();
+
+    // then
+    final SecretResolveRequest request = gatewayService.getLastRequest(SecretResolveRequest.class);
+    assertThat(request.getReferences()).containsExactly(REFERENCE, OTHER_REFERENCE);
+  }
+
+  @Test
+  void shouldReplacePreviouslySetReferences() {
+    // given
+    gatewayService.onSecretsResolveRequest(new SecretResolveResult());
+
+    // when
+    client
+        .newResolveSecretsCommand()
+        .references(Collections.singletonList(REFERENCE))
+        .references(Collections.singletonList(OTHER_REFERENCE))
+        .send()
+        .join();
+
+    // then
+    final SecretResolveRequest request = gatewayService.getLastRequest(SecretResolveRequest.class);
+    assertThat(request.getReferences()).containsExactly(OTHER_REFERENCE);
+  }
+
+  @Test
+  void shouldSendDuplicateReferencesUnchanged() {
+    // given deduplication is owned by the cluster
+    gatewayService.onSecretsResolveRequest(new SecretResolveResult());
+
+    // when
+    client.newResolveSecretsCommand().references(REFERENCE, REFERENCE).send().join();
+
+    // then
+    final SecretResolveRequest request = gatewayService.getLastRequest(SecretResolveRequest.class);
+    assertThat(request.getReferences()).containsExactly(REFERENCE, REFERENCE);
+  }
+
+  @Test
+  void shouldSendMoreReferencesThanTheClusterAccepts() {
+    // given the batch size limit is owned by the cluster, which rejects an over-long batch
+    gatewayService.onSecretsResolveRequest(new SecretResolveResult());
+    final List<String> references =
+        IntStream.range(0, 25)
+            .mapToObj(index -> "camunda.secrets.reference-" + index)
+            .collect(Collectors.toList());
+
+    // when
+    client.newResolveSecretsCommand().references(references).send().join();
+
+    // then
+    final SecretResolveRequest request = gatewayService.getLastRequest(SecretResolveRequest.class);
+    assertThat(request.getReferences()).hasSize(25);
+  }
+
+  @Test
+  void shouldSendMalformedReferenceUnchanged() {
+    // given a malformed reference is a resolution error, not a client-side failure
+    gatewayService.onSecretsResolveRequest(new SecretResolveResult());
+
+    // when
+    client.newResolveSecretsCommand().reference("not-a-secret-reference").send().join();
+
+    // then
+    final SecretResolveRequest request = gatewayService.getLastRequest(SecretResolveRequest.class);
+    assertThat(request.getReferences()).containsExactly("not-a-secret-reference");
+  }
+
+  @Test
+  void shouldMapResolvedSecrets() {
+    // given
+    gatewayService.onSecretsResolveRequest(
+        new SecretResolveResult().addResolvedItem(resolved(REFERENCE, VALUE)));
+
+    // when
+    final ResolveSecretsResponse response =
+        client.newResolveSecretsCommand().reference(REFERENCE).send().join();
+
+    // then
+    assertThat(response.isFullyResolved()).isTrue();
+    assertThat(response.getErrors()).isEmpty();
+    assertThat(response.getResolved()).hasSize(1);
+    assertThat(response.getResolved().get(0).getReference()).isEqualTo(REFERENCE);
+    assertThat(response.getResolved().get(0).getValue()).isEqualTo(VALUE);
+  }
+
+  @Test
+  void shouldNotThrowOnPartialFailure() {
+    // given one reference resolves and one is denied
+    gatewayService.onSecretsResolveRequest(
+        new SecretResolveResult()
+            .addResolvedItem(resolved(REFERENCE, VALUE))
+            .addErrorsItem(
+                error(
+                    OTHER_REFERENCE,
+                    io.camunda.client.protocol.rest.SecretErrorCode.ACCESS_DENIED,
+                    "not authorized")));
+
+    // when
+    final AtomicReference<ResolveSecretsResponse> sent = new AtomicReference<>();
+    assertThatCode(
+            () ->
+                sent.set(
+                    client
+                        .newResolveSecretsCommand()
+                        .references(REFERENCE, OTHER_REFERENCE)
+                        .send()
+                        .join()))
+        .doesNotThrowAnyException();
+
+    // then the failure is response data, not an exception
+    final ResolveSecretsResponse response = sent.get();
+    assertThat(response.isFullyResolved()).isFalse();
+    assertThat(response.getResolved()).hasSize(1);
+    assertThat(response.getResolved().get(0).getReference()).isEqualTo(REFERENCE);
+    assertThat(response.getErrors()).hasSize(1);
+    assertThat(response.getErrors().get(0).getReference()).isEqualTo(OTHER_REFERENCE);
+    assertThat(response.getErrors().get(0).getCode()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+    assertThat(response.getErrors().get(0).getMessage()).isEqualTo("not authorized");
+  }
+
+  @Test
+  void shouldNotThrowWhenAllReferencesFail() {
+    // given
+    gatewayService.onSecretsResolveRequest(
+        new SecretResolveResult()
+            .addErrorsItem(
+                error(
+                    REFERENCE,
+                    io.camunda.client.protocol.rest.SecretErrorCode.NOT_FOUND,
+                    "no secret"))
+            .addErrorsItem(
+                error(
+                    OTHER_REFERENCE,
+                    io.camunda.client.protocol.rest.SecretErrorCode.ACCESS_DENIED,
+                    "not authorized")));
+
+    // when
+    final ResolveSecretsResponse response =
+        client.newResolveSecretsCommand().references(REFERENCE, OTHER_REFERENCE).send().join();
+
+    // then
+    assertThat(response.isFullyResolved()).isFalse();
+    assertThat(response.getResolved()).isEmpty();
+    assertThat(response.getErrors()).hasSize(2);
+  }
+
+  /**
+   * Drives every code the generated protocol enum knows, excluding only the generator's unknown
+   * default, which {@link #shouldMapUnknownErrorCodeToUnknownEnumValue} covers. Deliberately not an
+   * explicit name list: should the API contract gain a code that {@link SecretErrorCode} does not
+   * mirror, {@code EnumUtil.convert} throws and fails the whole batch at runtime, so this test has
+   * to fail on the added code rather than silently keep testing the old three.
+   */
+  @ParameterizedTest
+  @EnumSource(
+      value = io.camunda.client.protocol.rest.SecretErrorCode.class,
+      mode = EnumSource.Mode.EXCLUDE,
+      names = {"UNKNOWN_DEFAULT_OPEN_API"})
+  void shouldMapEveryErrorCode(final io.camunda.client.protocol.rest.SecretErrorCode code) {
+    // given
+    gatewayService.onSecretsResolveRequest(
+        new SecretResolveResult().addErrorsItem(error(REFERENCE, code, "failed")));
+
+    // when
+    final ResolveSecretsResponse response =
+        client.newResolveSecretsCommand().reference(REFERENCE).send().join();
+
+    // then
+    assertThat(response.getErrors().get(0).getCode())
+        .isEqualTo(SecretErrorCode.valueOf(code.name()));
+  }
+
+  @Test
+  void shouldMapUnknownErrorCodeToUnknownEnumValue() {
+    // given an error code this client version does not know
+    gatewayService.onSecretsResolveRequest(
+        new SecretResolveResult()
+            .addErrorsItem(
+                error(
+                    REFERENCE,
+                    io.camunda.client.protocol.rest.SecretErrorCode.UNKNOWN_DEFAULT_OPEN_API,
+                    "failed")));
+
+    // when
+    final ResolveSecretsResponse response =
+        client.newResolveSecretsCommand().reference(REFERENCE).send().join();
+
+    // then it is reported rather than failing the command
+    assertThat(response.getErrors().get(0).getCode()).isEqualTo(SecretErrorCode.UNKNOWN_ENUM_VALUE);
+  }
+
+  @Test
+  void shouldReturnEmptyListsWhenResponseOmitsArrays() {
+    // given
+    gatewayService.onSecretsResolveRequest(new SecretResolveResult());
+
+    // when
+    final ResolveSecretsResponse response =
+        client.newResolveSecretsCommand().reference(REFERENCE).send().join();
+
+    // then
+    assertThat(response.getResolved()).isEmpty();
+    assertThat(response.getErrors()).isEmpty();
+  }
+
+  @Test
+  void shouldNotReportFullyResolvedWhenResponseDropsReference() {
+    // given a response that accounts for neither the requested reference nor an error for it
+    gatewayService.onSecretsResolveRequest(new SecretResolveResult());
+
+    // when
+    final ResolveSecretsResponse response =
+        client.newResolveSecretsCommand().reference(REFERENCE).send().join();
+
+    // then the caller is not sent to a resolved entry that is not there
+    assertThat(response.isFullyResolved()).isFalse();
+  }
+
+  @Test
+  void shouldNotReportFullyResolvedWhenResponseRepeatsOneReferenceAndDropsAnother() {
+    // given a response that returns as many entries as were requested, but for one reference twice
+    // and for the other not at all
+    gatewayService.onSecretsResolveRequest(
+        new SecretResolveResult()
+            .addResolvedItem(resolved(REFERENCE, VALUE))
+            .addResolvedItem(resolved(REFERENCE, VALUE)));
+
+    // when
+    final ResolveSecretsResponse response =
+        client.newResolveSecretsCommand().references(REFERENCE, OTHER_REFERENCE).send().join();
+
+    // then the missing reference is detected, rather than masked by the matching entry count
+    assertThat(response.isFullyResolved()).isFalse();
+  }
+
+  @Test
+  void shouldReportFullyResolvedWhenDuplicateReferenceIsResolvedOnce() {
+    // given the cluster deduplicates, so a reference requested twice comes back once
+    gatewayService.onSecretsResolveRequest(
+        new SecretResolveResult().addResolvedItem(resolved(REFERENCE, VALUE)));
+
+    // when
+    final ResolveSecretsResponse response =
+        client.newResolveSecretsCommand().references(REFERENCE, REFERENCE).send().join();
+
+    // then
+    assertThat(response.isFullyResolved()).isTrue();
+  }
+
+  @Test
+  void shouldReportUnknownEnumValueWhenErrorCodeIsAbsent() {
+    // given an error entry without a code
+    gatewayService.onSecretsResolveRequest(
+        new SecretResolveResult().addErrorsItem(error(REFERENCE, null, "failed")));
+
+    // when
+    final ResolveSecretsResponse response =
+        client.newResolveSecretsCommand().reference(REFERENCE).send().join();
+
+    // then the code is reported rather than left null for the caller to trip over
+    assertThat(response.getErrors().get(0).getCode()).isEqualTo(SecretErrorCode.UNKNOWN_ENUM_VALUE);
+  }
+
+  @Test
+  void shouldSendEmptyReferenceUnchanged() {
+    // given an empty reference is a resolution error like any other malformed one, so it must not
+    // fail the references alongside it
+    gatewayService.onSecretsResolveRequest(new SecretResolveResult());
+
+    // when
+    client.newResolveSecretsCommand().references(REFERENCE, "").send().join();
+
+    // then
+    final SecretResolveRequest request = gatewayService.getLastRequest(SecretResolveRequest.class);
+    assertThat(request.getReferences()).containsExactly(REFERENCE, "");
+  }
+
+  @Test
+  void shouldReturnUnmodifiableLists() {
+    // given
+    gatewayService.onSecretsResolveRequest(
+        new SecretResolveResult()
+            .addResolvedItem(resolved(REFERENCE, VALUE))
+            .addErrorsItem(
+                error(
+                    OTHER_REFERENCE,
+                    io.camunda.client.protocol.rest.SecretErrorCode.NOT_FOUND,
+                    "no secret")));
+
+    // when
+    final ResolveSecretsResponse response =
+        client.newResolveSecretsCommand().references(REFERENCE, OTHER_REFERENCE).send().join();
+
+    // then the response cannot be altered through the lists it hands out
+    assertThat(response.getResolved()).isUnmodifiable();
+    assertThat(response.getErrors()).isUnmodifiable();
+  }
+
+  @Test
+  void shouldNotExposeSecretValueInToString() {
+    // given
+    gatewayService.onSecretsResolveRequest(
+        new SecretResolveResult().addResolvedItem(resolved(REFERENCE, VALUE)));
+
+    // when
+    final ResolveSecretsResponse response =
+        client.newResolveSecretsCommand().reference(REFERENCE).send().join();
+
+    // then
+    assertThat(response.toString()).contains(REFERENCE).doesNotContain(VALUE);
+    assertThat(response.getResolved().get(0).toString()).contains(REFERENCE).doesNotContain(VALUE);
+  }
+
+  @Test
+  void shouldNotExposeErrorMessageInToString() {
+    // given an error message, which is server-provided free text the client cannot vet
+    gatewayService.onSecretsResolveRequest(
+        new SecretResolveResult()
+            .addErrorsItem(
+                error(
+                    REFERENCE,
+                    io.camunda.client.protocol.rest.SecretErrorCode.NOT_FOUND,
+                    "no secret for " + VALUE)));
+
+    // when
+    final ResolveSecretsResponse response =
+        client.newResolveSecretsCommand().reference(REFERENCE).send().join();
+
+    // then the reference and the typed code remain printable, but the message does not
+    final ResolutionError error = response.getErrors().get(0);
+    assertThat(error.toString())
+        .contains(REFERENCE)
+        .contains(SecretErrorCode.NOT_FOUND.name())
+        .doesNotContain(VALUE);
+    assertThat(response.toString()).doesNotContain(VALUE);
+
+    // and it stays reachable for a caller that wants it
+    assertThat(error.getMessage()).contains(VALUE);
+  }
+
+  @Test
+  void shouldRaiseExceptionOnRejectedRequest() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getSecretsResolveUrl(),
+        () -> new ProblemDetail().title("Invalid data").status(400));
+
+    // when / then
+    assertThatThrownBy(() -> client.newResolveSecretsCommand().reference(REFERENCE).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 400")
+        .hasMessageContaining("Invalid data");
+  }
+
+  @Test
+  void shouldRaiseExceptionWhenUnauthenticated() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getSecretsResolveUrl(),
+        () -> new ProblemDetail().title("Unauthorized").status(401));
+
+    // when / then
+    assertThatThrownBy(() -> client.newResolveSecretsCommand().reference(REFERENCE).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 401: 'Unauthorized'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnServerError() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getSecretsResolveUrl(),
+        () -> new ProblemDetail().title("Internal Server Error").status(500));
+
+    // when / then
+    assertThatThrownBy(() -> client.newResolveSecretsCommand().reference(REFERENCE).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullReferences() {
+    // when / then
+    assertThatThrownBy(() -> client.newResolveSecretsCommand().references((List<String>) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("references");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullReferencesArray() {
+    // when / then
+    assertThatThrownBy(() -> client.newResolveSecretsCommand().references((String[]) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("references");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullReferenceEntry() {
+    // when / then
+    assertThatThrownBy(
+            () -> client.newResolveSecretsCommand().references(Collections.singletonList(null)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("reference");
+  }
+
+  @Test
+  void shouldRaiseExceptionWhenNoReferenceIsSet() {
+    // when / then
+    assertThatThrownBy(() -> client.newResolveSecretsCommand().send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("references");
+  }
+
+  private static ResolvedSecret resolved(final String reference, final String value) {
+    return new ResolvedSecret().reference(reference).value(value);
+  }
+
+  private static SecretResolutionError error(
+      final String reference,
+      final io.camunda.client.protocol.rest.SecretErrorCode code,
+      final String message) {
+    return new SecretResolutionError().reference(reference).code(code).message(message);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -110,6 +110,9 @@ public class RestGatewayPaths {
   private static final String URL_RESOURCE_DELETION = REST_API_PATH + "/resources/%s/deletion";
   private static final String URL_ROLE = REST_API_PATH + "/roles/%s";
   private static final String URL_ROLES = REST_API_PATH + "/roles";
+  private static final String URL_SECRETS = REST_API_PATH + "/secrets";
+  private static final String URL_SECRETS_RESOLVE = URL_SECRETS + "/resolve";
+  private static final String URL_SECRETS_LIST = URL_SECRETS + "/list";
   private static final String URL_SIGNAL_BROADCAST = REST_API_PATH + "/signals/broadcast";
   private static final String URL_TENANT = REST_API_PATH + "/tenants/%s";
   private static final String URL_TENANTS = REST_API_PATH + "/tenants";
@@ -255,6 +258,14 @@ public class RestGatewayPaths {
 
   public static String getBroadcastSignalUrl() {
     return URL_SIGNAL_BROADCAST;
+  }
+
+  public static String getSecretsResolveUrl() {
+    return URL_SECRETS_RESOLVE;
+  }
+
+  public static String getSecretsListUrl() {
+    return URL_SECRETS_LIST;
   }
 
   public static String getEvaluateConditionalUrl() {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -74,6 +74,8 @@ import io.camunda.client.protocol.rest.RoleCreateResult;
 import io.camunda.client.protocol.rest.RoleResult;
 import io.camunda.client.protocol.rest.RoleUpdateResult;
 import io.camunda.client.protocol.rest.SearchQueryResponse;
+import io.camunda.client.protocol.rest.SecretListResult;
+import io.camunda.client.protocol.rest.SecretResolveResult;
 import io.camunda.client.protocol.rest.SignalBroadcastResult;
 import io.camunda.client.protocol.rest.TenantCreateResult;
 import io.camunda.client.protocol.rest.TenantResult;
@@ -232,6 +234,14 @@ public class RestGatewayService {
 
   public void onCreateUserRequest(final UserCreateResult response) {
     registerPost(RestGatewayPaths.getCreateUserUrl(), response);
+  }
+
+  public void onSecretsResolveRequest(final SecretResolveResult response) {
+    registerPost(RestGatewayPaths.getSecretsResolveUrl(), response);
+  }
+
+  public void onSecretsListRequest(final SecretListResult response) {
+    registerPost(RestGatewayPaths.getSecretsListUrl(), response);
   }
 
   public void onCorrelateMessageRequest(final MessageCorrelationResult response) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/SecretAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/SecretAuthorizationIT.java
@@ -358,8 +358,10 @@ class SecretAuthorizationIT {
   }
 
   /**
-   * Issues a raw HTTP call to {@code POST /v2/secrets/resolve} authenticated as the given user. The
-   * endpoint has no fluent Java client method yet.
+   * Issues a raw HTTP call to {@code POST /v2/secrets/resolve} authenticated as the given user.
+   * Deliberately not the fluent {@code newResolveSecretsCommand()}: the tests here assert the HTTP
+   * status code and response headers, neither of which the client exposes. The fluent command is
+   * covered by {@code SecretCommandIT}.
    */
   private static HttpResponse<String> resolve(
       final CamundaClient client, final String username, final List<String> references)
@@ -376,8 +378,9 @@ class SecretAuthorizationIT {
   }
 
   /**
-   * Issues a raw HTTP call to {@code POST /v2/secrets/list} authenticated as the given user. The
-   * endpoint has no fluent Java client method yet.
+   * Issues a raw HTTP call to {@code POST /v2/secrets/list} authenticated as the given user.
+   * Deliberately not the fluent {@code newListSecretsCommand()}, for the same reason as {@link
+   * #resolve}.
    */
   private static HttpResponse<String> list(final CamundaClient client, final String username)
       throws Exception {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/SecretCommandIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/SecretCommandIT.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.enums.SecretErrorCode;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the secret client commands against a real gateway: the wire format, the transport and the
+ * per-reference outcome mapping. It does not cover real secret resolution, because the backend is
+ * mocked in phase 1 and only resolves an explicit allow-list (see {@code
+ * SecretServices#MOCK_RESOLVABLE_REFERENCES}). Authorization enforcement is covered separately by
+ * {@code SecretAuthorizationIT}.
+ */
+@MultiDbTest
+public class SecretCommandIT {
+
+  // Resolvable by the mocked backend, mirroring SecretServices#MOCK_RESOLVABLE_REFERENCES. That
+  // constant is private, so the allow-list is repeated here; changing it fails these tests.
+  private static final String KNOWN_REFERENCE = "camunda.secrets.token";
+
+  private static final List<String> ALL_KNOWN_REFERENCES =
+      List.of(KNOWN_REFERENCE, "camunda.secrets.a", "camunda.secrets.b");
+
+  // Valid but not part of the mocked allow-list, so it resolves to NOT_FOUND.
+  private static final String UNKNOWN_REFERENCE = "camunda.secrets.doesnotexist";
+
+  /**
+   * The cluster's maximum batch size, mirroring {@code SecretRequestValidator#MAX_BATCH_SIZE}. It
+   * is repeated rather than imported because {@code gateway-mapping-http} is deliberately not a
+   * declared dependency of this module. Should the cluster's cap ever be raised, {@link
+   * #shouldRaiseExceptionWhenBatchExceedsTheClusterLimit} fails rather than silently no longer
+   * exceeding it.
+   */
+  private static final int MAX_BATCH_SIZE = 20;
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldResolveKnownReference() {
+    // when
+    final var response =
+        camundaClient.newResolveSecretsCommand().references(List.of(KNOWN_REFERENCE)).send().join();
+
+    // then
+    assertThat(response.isFullyResolved()).isTrue();
+    assertThat(response.getErrors()).isEmpty();
+    assertThat(response.getResolved()).hasSize(1);
+    assertThat(response.getResolved().get(0).getReference()).isEqualTo(KNOWN_REFERENCE);
+    assertThat(response.getResolved().get(0).getValue()).isNotBlank();
+  }
+
+  @Test
+  void shouldReportUnresolvedReferenceWithoutFailingTheBatch() {
+    // when a batch mixes a resolvable and an unresolvable reference
+    final var response =
+        camundaClient
+            .newResolveSecretsCommand()
+            .references(List.of(KNOWN_REFERENCE, UNKNOWN_REFERENCE))
+            .send()
+            .join();
+
+    // then the failure is reported as data rather than as an exception, and the other reference
+    // still resolves
+    assertThat(response.isFullyResolved()).isFalse();
+    assertThat(response.getResolved()).hasSize(1);
+    assertThat(response.getResolved().get(0).getReference()).isEqualTo(KNOWN_REFERENCE);
+    assertThat(response.getErrors()).hasSize(1);
+    assertThat(response.getErrors().get(0).getReference()).isEqualTo(UNKNOWN_REFERENCE);
+    assertThat(response.getErrors().get(0).getCode()).isEqualTo(SecretErrorCode.NOT_FOUND);
+  }
+
+  @Test
+  void shouldReportMalformedReference() {
+    // when
+    final var response =
+        camundaClient
+            .newResolveSecretsCommand()
+            .references(List.of("not-a-reference"))
+            .send()
+            .join();
+
+    // then the client passes the reference through and the cluster classifies it
+    assertThat(response.getResolved()).isEmpty();
+    assertThat(response.getErrors()).hasSize(1);
+    assertThat(response.getErrors().get(0).getCode()).isEqualTo(SecretErrorCode.INVALID_REFERENCE);
+  }
+
+  @Test
+  void shouldRaiseExceptionWhenBatchExceedsTheClusterLimit() {
+    // given a batch one over the cluster's cap, which the client deliberately does not enforce
+    final List<String> references =
+        IntStream.rangeClosed(0, MAX_BATCH_SIZE)
+            .mapToObj(index -> "camunda.secrets.reference" + index)
+            .toList();
+
+    // when / then a rejected request is the one outcome that completes the command exceptionally,
+    // rather than being reported as per-reference errors
+    assertThatExceptionOfType(ProblemException.class)
+        .isThrownBy(
+            () -> camundaClient.newResolveSecretsCommand().references(references).send().join())
+        .satisfies(exception -> assertThat(exception.details().getStatus()).isEqualTo(400));
+  }
+
+  @Test
+  void shouldListReferences() {
+    // when
+    final var response = camundaClient.newListSecretsCommand().send().join();
+
+    // then the references the mocked backend knows are returned, names only
+    assertThat(response.getReferences()).containsExactlyInAnyOrderElementsOf(ALL_KNOWN_REFERENCES);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/SecretCommandIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/SecretCommandIT.java
@@ -14,28 +14,41 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.enums.SecretErrorCode;
 import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
 /**
  * Covers the secret client commands against a real gateway: the wire format, the transport and the
- * per-reference outcome mapping. It does not cover real secret resolution, because the backend is
- * mocked in phase 1 and only resolves an explicit allow-list (see {@code
- * SecretServices#MOCK_RESOLVABLE_REFERENCES}). Authorization enforcement is covered separately by
- * {@code SecretAuthorizationIT}.
+ * per-reference outcome mapping, resolved from a real file-based secret store (#58497).
+ * Authorization enforcement is covered separately by {@code SecretAuthorizationIT}.
  */
 @MultiDbTest
 public class SecretCommandIT {
 
-  // Resolvable by the mocked backend, mirroring SecretServices#MOCK_RESOLVABLE_REFERENCES. That
-  // constant is private, so the allow-list is repeated here; changing it fails these tests.
+  private static final String TOKEN_VALUE = "token-file-value";
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withFileBasedSecretStore(
+              directory -> {
+                Files.writeString(directory.resolve("token"), TOKEN_VALUE, StandardCharsets.UTF_8);
+                Files.writeString(directory.resolve("a"), "a-file-value", StandardCharsets.UTF_8);
+                Files.writeString(directory.resolve("b"), "b-file-value", StandardCharsets.UTF_8);
+              });
+
+  // Held by the store (one file per secret, the file name being the bare secret name).
   private static final String KNOWN_REFERENCE = "camunda.secrets.token";
 
   private static final List<String> ALL_KNOWN_REFERENCES =
       List.of(KNOWN_REFERENCE, "camunda.secrets.a", "camunda.secrets.b");
 
-  // Valid but not part of the mocked allow-list, so it resolves to NOT_FOUND.
+  // Valid but no file of that name exists in the store, so it resolves to NOT_FOUND.
   private static final String UNKNOWN_REFERENCE = "camunda.secrets.doesnotexist";
 
   /**
@@ -60,7 +73,7 @@ public class SecretCommandIT {
     assertThat(response.getErrors()).isEmpty();
     assertThat(response.getResolved()).hasSize(1);
     assertThat(response.getResolved().get(0).getReference()).isEqualTo(KNOWN_REFERENCE);
-    assertThat(response.getResolved().get(0).getValue()).isNotBlank();
+    assertThat(response.getResolved().get(0).getValue()).isEqualTo(TOKEN_VALUE);
   }
 
   @Test
@@ -120,7 +133,7 @@ public class SecretCommandIT {
     // when
     final var response = camundaClient.newListSecretsCommand().send().join();
 
-    // then the references the mocked backend knows are returned, names only
+    // then the references the store knows are returned, names only
     assertThat(response.getReferences()).containsExactlyInAnyOrderElementsOf(ALL_KNOWN_REFERENCES);
   }
 }


### PR DESCRIPTION
## Description

Adds two fluent `CamundaClient` commands for the secret endpoints, so callers
stop hand-rolling HTTP:

- `newResolveSecretsCommand()` for `POST /v2/secrets/resolve`
- `newListSecretsCommand()` for `POST /v2/secrets/list`

Both are marked `@ExperimentalApi`, matching the alpha status of the endpoints.
The Spring Boot starter needs no change, since it exposes the whole
`CamundaClient` interface as a bean.

The part most easily got wrong by a hand-rolled caller is that resolve always
answers 200: a reference that cannot be resolved is response data, so it
appears in `getErrors()` and the command does not fail. Only a rejected
request, such as an over-long batch, completes exceptionally. Batch size,
reference length, deduplication and reference format stay server-side, so a
malformed reference is reported per reference rather than thrown. Physical
tenancy needs no per-command wiring: over REST it is a client-wide base-path
prefix that both commands inherit.

Testing:

- Unit tests against the mock REST gateway, including the partial-failure
  no-throw case and 400/401/500 mapping to `ProblemException`.
- `SecretCommandIT` against a real gateway. The secret backend is mocked in
  phase 1, so this proves wire format, transport and outcome mapping, not real
  secret resolution.
- `SecretAuthorizationIT` keeps its raw HTTP calls, since it asserts status
  codes and the `Cache-Control` header, which the fluent client does not
  expose.

Closes #56661

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56661 
