### PR TITLE
test: harden worker login and flow-node filter in nightly E2E tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test as base, type Cookie} from '@playwright/test';
+import {test as base, expect, type Cookie} from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 import {OperateHomePage} from '@pages/OperateHomePage';
 import {TaskPanelPage} from '@pages/TaskPanelPage';
@@ -230,11 +230,23 @@ const test = publicTest.extend<NonNullable<unknown>, AuthWorkerFixtures>({
       const baseURL =
         process.env.CORE_APPLICATION_URL ?? 'http://localhost:8080';
       const context = await browser.newContext();
-      const response = await context.request.post(`${baseURL}/login`, {
-        form: loginUser,
-      });
-      const csrfToken = response.headers()['x-csrf-token'] ?? '';
-      const cookies = await context.cookies();
+      let csrfToken = '';
+      let cookies: Cookie[] = [];
+      // loginState is worker-scoped, so a login that silently fails would send
+      // every test on this worker (and its retries) to the login screen. Retry
+      // the login until the session cookie is actually established, and fail
+      // loudly if it never is, instead of proceeding unauthenticated.
+      await expect(async () => {
+        const response = await context.request.post(`${baseURL}/login`, {
+          form: loginUser,
+        });
+        expect(response.status()).toBe(204);
+        csrfToken = response.headers()['x-csrf-token'] ?? '';
+        cookies = await context.cookies();
+        expect(
+          cookies.some((cookie) => cookie.name === 'camunda-session'),
+        ).toBe(true);
+      }).toPass({timeout: 30_000});
       await context.close();
       await use({cookies, csrfToken});
     },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
@@ -215,8 +215,16 @@ export class OperateFiltersPanelPage {
   }
 
   async selectFlowNode(option: string) {
-    await this.flowNodeFilter.click();
-    await this.getOptionByName(option, false).click();
+    // The flow-node dropdown can fail to open, or render before its options
+    // have loaded; retry opening it until the target option is present (same
+    // approach as selectVersion).
+    await expect(async () => {
+      await this.flowNodeFilter.click();
+      await expect(this.getOptionByName(option, false)).toBeVisible({
+        timeout: 5_000,
+      });
+    }).toPass({timeout: 30_000});
+    await this.getOptionByName(option, false).click({timeout: 30000});
   }
 
   async fillBusinessIdFilter(value: string) {


### PR DESCRIPTION
## Description

Follow-up hardening for two more orchestration-cluster nightly E2E flakes that
surfaced after the previous batch merged (#58907). Both are root-cause fixes —
no assertions weakened, no retry counts inflated.

### `operations.spec.ts:77` "Retry and cancel single instance" (and similar nav timeouts)

The worker-scoped `loginState` fixture posted to `/login` once and used whatever
cookies came back, without verifying a session was created. When that login
silently failed (no `camunda-session` cookie), every test on the worker — and
its retries — ran unauthenticated and landed on the login screen, so navigation
elements never rendered. It surfaced as a 30s timeout waiting for the
"Processes" nav link (confirmed from the nightly artifact for
[run 30456656149](https://github.com/camunda/camunda/actions/runs/30456656149)).

Fix: retry the login until the response is `204` and a `camunda-session` cookie
is present, failing loudly otherwise, so a transient login blip no longer
poisons the whole worker's session.

### `processInstancesFilters.spec.ts:104` "Interaction between diagram and filters"

`selectFlowNode` opened the flow-node dropdown and clicked the option in one
pass with no retry; under load the dropdown can render before its options load
(or the open click is dropped), so the option click times out waiting for
`StartEvent_1`. Fix: reopen the dropdown until the option is present before
clicking, mirroring the existing `selectVersion` pattern.

## Validation

- Root causes identified from the nightly artifacts/traces (not assumptions).
- Local `prettier`/`eslint`/`tsc` clean on both changed files.
- **Green on-demand E2E run:** https://github.com/camunda/camunda/actions/runs/30480816456
  — both E2E jobs (Tasklist v2, `profiles` + `all-in-one`) and all API jobs
  passed, with `operations.spec.ts:77` and `processInstancesFilters.spec.ts:104`
  green in both jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
