### PR TITLE
refactor: remove dead global.image.tag/repository from load-test defaults

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -671,8 +671,7 @@ jobs:
           # optimize_repo is only consumed in the custom build path where orchestration-tag is empty
 
           # Build platform configuration
-          additional_platform_config="--set global.image.tag=${CALCULATED_IMAGE_TAG} \
-            --set orchestration.image.registry=${IMAGE_REGISTRY} \
+          additional_platform_config="--set orchestration.image.registry=${IMAGE_REGISTRY} \
             --set orchestration.image.repository=${CAMUNDA_REPO} \
             --set orchestration.image.tag=${CALCULATED_IMAGE_TAG}"
 

--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -265,16 +265,15 @@ docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz -t registry
 docker push registry.camunda.cloud/team-zeebe/camunda:SNAPSHOT-$(date +%Y-%m-%d)-$(git rev-parse --short=8 HEAD)
 ```
 
-Update the `camunda-platform-values-defaults.yaml` file in your namespace folder and set the newly created image tag.
+Update the `camunda-platform-values-defaults.yaml` file in your namespace folder and point `orchestration.image` at the newly pushed image. `global.image` only supplies a fallback `registry`/`pullPolicy`/`pullSecrets` for components that don't set their own image — `orchestration.image` already pins its own `registry`/`repository`/`tag` (to `docker.io`/`camunda/camunda` by default), so `global.image.tag` alone has no effect here and must not be relied on.
 
 The changes should look similar to this:
 
 ```yaml
-global:
-  image:
-    tag: SNAPSHOT-2024-01-15-abcd1234
 orchestration:
   image:
+    registry: registry.camunda.cloud
+    repository: team-zeebe/camunda
     tag: SNAPSHOT-2024-01-15-abcd1234
 ```
 

--- a/load-tests/setup/main/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-defaults.yaml
@@ -22,10 +22,6 @@ global:
   ingress:
     enabled: false
   image:
-    # Image.repository defines the repository from which to fetch the docker images
-    repository: "registry.camunda.cloud/team-zeebe"
-    # Image.tag defines the tag / version which should be used in the chart
-    tag: SNAPSHOT
     ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
     pullPolicy: Always
     ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod

--- a/load-tests/setup/stable-87/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-87/values/camunda-platform-values-defaults.yaml
@@ -22,10 +22,6 @@ global:
   ingress:
     enabled: false
   image:
-    # Image.repository defines the repository from which to fetch the docker images
-    repository: "registry.camunda.cloud/team-zeebe"
-    # Image.tag defines the tag / version which should be used in the chart
-    tag: 8.7.34
     ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
     pullPolicy: Always
     ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod

--- a/load-tests/setup/stable-88/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-88/values/camunda-platform-values-defaults.yaml
@@ -22,10 +22,6 @@ global:
   ingress:
     enabled: false
   image:
-    # Image.repository defines the repository from which to fetch the docker images
-    repository: "registry.camunda.cloud/team-zeebe"
-    # Image.tag defines the tag / version which should be used in the chart
-    tag: 8.8.29
     ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
     pullPolicy: Always
     ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod

--- a/load-tests/setup/stable-89/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-defaults.yaml
@@ -22,10 +22,6 @@ global:
   ingress:
     enabled: false
   image:
-    # Image.repository defines the repository from which to fetch the docker images
-    repository: "registry.camunda.cloud/team-zeebe"
-    # Image.tag defines the tag / version which should be used in the chart
-    tag: 8.9.11
     ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
     pullPolicy: Always
     ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod

--- a/load-tests/skills/load-test-ops/SKILL.md
+++ b/load-tests/skills/load-test-ops/SKILL.md
@@ -286,7 +286,7 @@ cd load-tests/setup
 # Upgrade platform Helm chart — pin the image tag explicitly
 cd <namespace>
 make max additional_platform_configuration="\
-  --set-string global.image.tag=<image-tag> \
+  --set-string orchestration.image.tag=<image-tag> \
   --set orchestration.resources.limits.memory=4Gi" \
   additional_load_test_configuration="--set starter.rate=200"
 ```


### PR DESCRIPTION
## Summary
- Every component (orchestration, zeebe, optimize, identity, connectors, etc.) ships its own non-empty, version-pinned `image.tag`/`image.repository` default in the `camunda-platform` chart, so `global.image.tag`/`global.image.repository` were never actually applied — confirmed via `helm template`.
- Removes the dead `global.image.tag`/`repository` entries from the load-test `camunda-platform-values-defaults.yaml` files (main, stable-87/88/89) and from `.github/workflows/camunda-load-test.yml`'s `additional_platform_config`, where `orchestration.image.tag` already set the same value right after.
- Updates `load-tests/setup/README.md` and `load-tests/skills/load-test-ops/SKILL.md` so the image-pinning instructions point at `orchestration.image` instead of the no-op `global.image.tag`.
- Upstream status of `global.image.tag` in `camunda-platform-helm`, checked per pinned chart version (`load-tests/setup/newLoadTest.sh`):
  - `main` (chart 15.0.0-alpha3, camunda-platform-8.10) and `stable-89` (chart 14.7.0, camunda-platform-8.9): the option was formally dropped from `values.yaml` in [camunda/camunda-platform-helm#5351](https://github.com/camunda/camunda-platform-helm/pull/5351).
  - `stable-87` (chart 12.10.0, camunda-platform-8.7) and `stable-88` (chart 13.12.3, camunda-platform-8.8): `global.image.tag` is still declared in `values.yaml` (upstream hasn't cleaned it up there yet), but it's dead for the same reason — the identical `imageByParams`/`imageTagByParams` merge helper (`.overlay.image.tag | default .base.image.tag`, e.g. [camunda-platform-8.7/templates/camunda/_helpers.tpl#L83-L85](https://github.com/camunda/camunda-platform-helm/blob/c52c6f06feaee0e8ff311898b8e2963e7aa5bf5f/charts/camunda-platform-8.7/templates/camunda/_helpers.tpl#L83-L85)) always prefers the non-empty component-level tag, which every component ships. This matches our own `helm template` verification across all 4 pinned versions.

## Related

* https://github.com/camunda/camunda/issues/55702


<sub>🤖 This PR was generated by Claude Code on behalf of @multani.</sub>
