### PR TITLE
9648-mob-session

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/CandidateRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/CandidateRole.java
@@ -28,6 +28,7 @@ import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.utils.VoteQuorum;
+import io.atomix.raft.utils.VoteQuorum.VoteErrorStatus;
 import io.atomix.utils.concurrent.Scheduled;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -225,10 +226,10 @@ public final class CandidateRole extends ActiveRole {
         raft.transition(RaftServer.Role.FOLLOWER);
       } else if (!response.voted()) {
         log.debug("Received rejected vote from {}", member);
-        quorum.fail(member.memberId());
+        quorum.fail(member.memberId(), VoteErrorStatus.REJECTED);
       } else if (response.term() != raft.getTerm()) {
         log.debug("Received successful vote for a different term from {}", member);
-        quorum.fail(member.memberId());
+        quorum.fail(member.memberId(), VoteErrorStatus.INVALID_TERM);
       } else {
         log.debug("Received successful vote from {}", member);
         quorum.succeed(member.memberId());
@@ -253,7 +254,7 @@ public final class CandidateRole extends ActiveRole {
       }
     } else {
       log.warn(error.getMessage());
-      quorum.fail(member.memberId());
+      quorum.fail(member.memberId(), VoteErrorStatus.of(error));
     }
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/CandidateRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/CandidateRole.java
@@ -30,6 +30,7 @@ import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.utils.VoteQuorum;
 import io.atomix.raft.utils.VoteQuorum.VoteErrorStatus;
 import io.atomix.utils.concurrent.Scheduled;
+import io.camunda.zeebe.util.concurrency.FuturesUtil;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -243,7 +244,8 @@ public final class CandidateRole extends ActiveRole {
       final RaftMember member,
       final VoteRequest request,
       final Throwable error) {
-    if (error.getCause() instanceof NoRemoteHandler) {
+    final var cause = FuturesUtil.unwrapCompletionException(error);
+    if (cause instanceof NoRemoteHandler) {
       log.debug(
           "Member {} is not ready to receive vote requests, will retry later.", member, error);
       if (isRunning() && !complete.get()) {
@@ -253,8 +255,10 @@ public final class CandidateRole extends ActiveRole {
                 () -> sendVoteRequestToMember(complete, quorum, member, request));
       }
     } else {
-      log.warn(error.getMessage());
-      quorum.fail(member.memberId(), VoteErrorStatus.of(error));
+      final var status = VoteErrorStatus.of(cause);
+      log.atLevel(status.logLevel())
+          .log("Vote request to {} failed with {}: {}", member.memberId(), status, cause);
+      quorum.fail(member.memberId(), status);
     }
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -19,6 +19,7 @@ package io.atomix.raft.roles;
 import io.atomix.cluster.ClusterMembershipEvent;
 import io.atomix.cluster.ClusterMembershipEventListener;
 import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
 import io.atomix.raft.ElectionTimer;
 import io.atomix.raft.ElectionTimerFactory;
 import io.atomix.raft.RaftError;
@@ -41,9 +42,11 @@ import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.utils.VoteQuorum;
+import io.atomix.raft.utils.VoteQuorum.VoteErrorStatus;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.event.Level;
 
 /** Follower state. */
 public final class FollowerRole extends ActiveRole {
@@ -93,6 +96,16 @@ public final class FollowerRole extends ActiveRole {
       onHeartbeatFromLeader();
     }
     return future;
+  }
+
+  @Override
+  protected VoteResponse handleVote(final VoteRequest request) {
+    // Reset the heartbeat timeout if we voted for another candidate.
+    final VoteResponse response = super.handleVote(request);
+    if (response.voted()) {
+      onHeartbeatFromLeader();
+    }
+    return response;
   }
 
   /** Handles a cluster event. */
@@ -186,15 +199,6 @@ public final class FollowerRole extends ActiveRole {
   }
 
   @Override
-  public CompletableFuture<AppendResponse> onAppend(final InternalAppendRequest request) {
-    final CompletableFuture<AppendResponse> future = super.onAppend(request);
-    if (isRequestFromCurrentLeader(request.term(), request.leader())) {
-      onHeartbeatFromLeader();
-    }
-    return future;
-  }
-
-  @Override
   public CompletableFuture<TimeoutNowResponse> onTimeoutNow(final TimeoutNowRequest request) {
     logRequest(request);
 
@@ -220,13 +224,12 @@ public final class FollowerRole extends ActiveRole {
   }
 
   @Override
-  protected VoteResponse handleVote(final VoteRequest request) {
-    // Reset the heartbeat timeout if we voted for another candidate.
-    final VoteResponse response = super.handleVote(request);
-    if (response.voted()) {
+  public CompletableFuture<AppendResponse> onAppend(final InternalAppendRequest request) {
+    final CompletableFuture<AppendResponse> future = super.onAppend(request);
+    if (isRequestFromCurrentLeader(request.term(), request.leader())) {
       onHeartbeatFromLeader();
     }
-    return response;
+    return future;
   }
 
   /**
@@ -317,8 +320,8 @@ public final class FollowerRole extends ActiveRole {
 
     if (isRunning() && !complete.get()) {
       if (error != null) {
-        log.warn("Poll request to {} failed: {}", member.memberId(), error.getMessage());
-        quorum.fail(member.memberId());
+        logError(error, member);
+        quorum.fail(member.memberId(), VoteErrorStatus.of(error));
       } else {
         if (response.term() > raft.getTerm()) {
           raft.setTerm(response.term());
@@ -326,15 +329,20 @@ public final class FollowerRole extends ActiveRole {
 
         if (!response.accepted()) {
           log.debug("Received rejected poll from {}", member);
-          quorum.fail(member.memberId());
+          quorum.fail(member.memberId(), VoteErrorStatus.REJECTED);
         } else if (response.term() != raft.getTerm()) {
           log.debug("Received accepted poll for a different term from {}", member);
-          quorum.fail(member.memberId());
+          quorum.fail(member.memberId(), VoteErrorStatus.INVALID_TERM);
         } else {
           log.debug("Received accepted poll from {}", member);
           quorum.succeed(member.memberId());
         }
       }
     }
+  }
+
+  private void logError(final Throwable error, final RaftMember member) {
+    log.atLevel(error instanceof NoSuchMemberException ? Level.TRACE : Level.WARN)
+        .log("Poll request to {} failed: {}", member.memberId(), error.getMessage());
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -19,7 +19,6 @@ package io.atomix.raft.roles;
 import io.atomix.cluster.ClusterMembershipEvent;
 import io.atomix.cluster.ClusterMembershipEventListener;
 import io.atomix.cluster.MemberId;
-import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
 import io.atomix.raft.ElectionTimer;
 import io.atomix.raft.ElectionTimerFactory;
 import io.atomix.raft.RaftError;
@@ -43,11 +42,10 @@ import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.utils.VoteQuorum;
 import io.atomix.raft.utils.VoteQuorum.VoteErrorStatus;
+import io.camunda.zeebe.util.concurrency.FuturesUtil;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.slf4j.event.Level;
 
 /** Follower state. */
 public final class FollowerRole extends ActiveRole {
@@ -97,16 +95,6 @@ public final class FollowerRole extends ActiveRole {
       onHeartbeatFromLeader();
     }
     return future;
-  }
-
-  @Override
-  protected VoteResponse handleVote(final VoteRequest request) {
-    // Reset the heartbeat timeout if we voted for another candidate.
-    final VoteResponse response = super.handleVote(request);
-    if (response.voted()) {
-      onHeartbeatFromLeader();
-    }
-    return response;
   }
 
   /** Handles a cluster event. */
@@ -200,6 +188,15 @@ public final class FollowerRole extends ActiveRole {
   }
 
   @Override
+  public CompletableFuture<AppendResponse> onAppend(final InternalAppendRequest request) {
+    final CompletableFuture<AppendResponse> future = super.onAppend(request);
+    if (isRequestFromCurrentLeader(request.term(), request.leader())) {
+      onHeartbeatFromLeader();
+    }
+    return future;
+  }
+
+  @Override
   public CompletableFuture<TimeoutNowResponse> onTimeoutNow(final TimeoutNowRequest request) {
     logRequest(request);
 
@@ -225,12 +222,13 @@ public final class FollowerRole extends ActiveRole {
   }
 
   @Override
-  public CompletableFuture<AppendResponse> onAppend(final InternalAppendRequest request) {
-    final CompletableFuture<AppendResponse> future = super.onAppend(request);
-    if (isRequestFromCurrentLeader(request.term(), request.leader())) {
+  protected VoteResponse handleVote(final VoteRequest request) {
+    // Reset the heartbeat timeout if we voted for another candidate.
+    final VoteResponse response = super.handleVote(request);
+    if (response.voted()) {
       onHeartbeatFromLeader();
     }
-    return future;
+    return response;
   }
 
   /**
@@ -321,8 +319,11 @@ public final class FollowerRole extends ActiveRole {
 
     if (isRunning() && !complete.get()) {
       if (error != null) {
-        logError(error, member);
-        quorum.fail(member.memberId(), VoteErrorStatus.of(error));
+        final var cause = FuturesUtil.unwrapCompletionException(error);
+        final var status = VoteErrorStatus.of(cause);
+        log.atLevel(status.logLevel())
+            .log("Poll request to {} failed with {}: {}", member.memberId(), status, cause);
+        quorum.fail(member.memberId(), status);
       } else {
         if (response.term() > raft.getTerm()) {
           raft.setTerm(response.term());
@@ -340,13 +341,5 @@ public final class FollowerRole extends ActiveRole {
         }
       }
     }
-  }
-
-  private void logError(final Throwable error, final RaftMember member) {
-    final var cause =
-        error instanceof CompletionException && error.getCause() != null ? error.getCause() : error;
-    final var logLevel = cause instanceof NoSuchMemberException ? Level.TRACE : Level.WARN;
-    log.atLevel(logLevel)
-        .log("Poll request to {} failed: {}", member.memberId(), cause.getMessage());
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -45,6 +45,7 @@ import io.atomix.raft.utils.VoteQuorum;
 import io.atomix.raft.utils.VoteQuorum.VoteErrorStatus;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.event.Level;
 
@@ -342,7 +343,10 @@ public final class FollowerRole extends ActiveRole {
   }
 
   private void logError(final Throwable error, final RaftMember member) {
-    log.atLevel(error instanceof NoSuchMemberException ? Level.TRACE : Level.WARN)
-        .log("Poll request to {} failed: {}", member.memberId(), error.getMessage());
+    final var cause =
+        error instanceof CompletionException && error.getCause() != null ? error.getCause() : error;
+    final var logLevel = cause instanceof NoSuchMemberException ? Level.TRACE : Level.WARN;
+    log.atLevel(logLevel)
+        .log("Poll request to {} failed: {}", member.memberId(), cause.getMessage());
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/JointConsensusVoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/JointConsensusVoteQuorum.java
@@ -68,9 +68,9 @@ public class JointConsensusVoteQuorum implements VoteQuorum {
   }
 
   @Override
-  public void fail(final MemberId member) {
-    oldQuorum.fail(member);
-    newQuorum.fail(member);
+  public void fail(final MemberId member, final VoteErrorStatus statusCode) {
+    oldQuorum.fail(member, statusCode);
+    newQuorum.fail(member, statusCode);
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/SimpleVoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/SimpleVoteQuorum.java
@@ -40,7 +40,7 @@ public class SimpleVoteQuorum implements VoteQuorum {
   }
 
   @Override
-  public void fail(final MemberId member) {
+  public void fail(final MemberId member, final VoteErrorStatus statusCode) {
     if (members.remove(member)) {
       failed++;
       checkComplete();

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/SimpleVoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/SimpleVoteQuorum.java
@@ -9,17 +9,24 @@ package io.atomix.raft.utils;
 
 import io.atomix.cluster.MemberId;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SimpleVoteQuorum implements VoteQuorum {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SimpleVoteQuorum.class);
   private Consumer<Boolean> callback;
   private boolean complete;
   private final Set<MemberId> members;
   private int succeeded;
   private int failed;
   private final int quorum;
+  private final Map<MemberId, VoteErrorStatus> failedStatuses;
 
   /**
    * @param callback will be called with the result of the vote, either true or false.
@@ -28,6 +35,7 @@ public class SimpleVoteQuorum implements VoteQuorum {
   public SimpleVoteQuorum(final Consumer<Boolean> callback, final Collection<MemberId> members) {
     this.callback = callback;
     this.members = new HashSet<>(members);
+    failedStatuses = new HashMap<>();
     quorum = members.size() / 2 + 1;
   }
 
@@ -40,9 +48,10 @@ public class SimpleVoteQuorum implements VoteQuorum {
   }
 
   @Override
-  public void fail(final MemberId member, final VoteErrorStatus statusCode) {
+  public void fail(final MemberId member, final VoteErrorStatus status) {
     if (members.remove(member)) {
       failed++;
+      failedStatuses.put(member, status);
       checkComplete();
     }
   }
@@ -64,6 +73,9 @@ public class SimpleVoteQuorum implements VoteQuorum {
         callback.accept(true);
       } else if (failed >= quorum) {
         complete = true;
+        final int memberCount = succeeded + failed + members.size();
+        LOG.warn(
+            "Quorum failed with {}/{} failed members: {}", failed, memberCount, failedStatuses);
         callback.accept(false);
       }
     }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/VoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/VoteQuorum.java
@@ -12,6 +12,7 @@ import io.atomix.cluster.messaging.MessagingException.NoRemoteHandler;
 import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
 import java.net.ConnectException;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeoutException;
 
 public interface VoteQuorum {
 
@@ -23,6 +24,7 @@ public interface VoteQuorum {
 
   enum VoteErrorStatus {
     NO_SUCH_MEMBER,
+    MEMBER_TIMED_OUT,
     REJECTED,
     INVALID_TERM,
     UNKNOWN;
@@ -32,6 +34,7 @@ public interface VoteQuorum {
         case final NoSuchMemberException noSuchMemberException -> NO_SUCH_MEMBER;
         case final ConnectException connectException -> NO_SUCH_MEMBER;
         case final NoRemoteHandler noRemoteHandler -> NO_SUCH_MEMBER;
+        case final TimeoutException timeoutException -> MEMBER_TIMED_OUT;
         case final CompletionException completionException -> {
           if (completionException.getCause() != null) {
             yield of(completionException.getCause());

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/VoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/VoteQuorum.java
@@ -10,15 +10,16 @@ package io.atomix.raft.utils;
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.MessagingException.NoRemoteHandler;
 import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
+import io.camunda.zeebe.util.concurrency.FuturesUtil;
 import java.net.ConnectException;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeoutException;
+import org.slf4j.event.Level;
 
 public interface VoteQuorum {
 
   void succeed(MemberId member);
 
-  void fail(MemberId member, final VoteErrorStatus statusCode);
+  void fail(MemberId member, VoteErrorStatus status);
 
   void cancel();
 
@@ -30,20 +31,17 @@ public interface VoteQuorum {
     UNKNOWN;
 
     public static VoteErrorStatus of(final Throwable error) {
-      return switch (error) {
+      return switch (FuturesUtil.unwrapCompletionException(error)) {
         case final NoSuchMemberException noSuchMemberException -> NO_SUCH_MEMBER;
         case final ConnectException connectException -> NO_SUCH_MEMBER;
         case final NoRemoteHandler noRemoteHandler -> NO_SUCH_MEMBER;
         case final TimeoutException timeoutException -> MEMBER_TIMED_OUT;
-        case final CompletionException completionException -> {
-          if (completionException.getCause() != null) {
-            yield of(completionException.getCause());
-          } else {
-            yield UNKNOWN;
-          }
-        }
         default -> UNKNOWN;
       };
+    }
+
+    public Level logLevel() {
+      return this == NO_SUCH_MEMBER ? Level.TRACE : Level.WARN;
     }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/VoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/VoteQuorum.java
@@ -32,7 +32,13 @@ public interface VoteQuorum {
         case final NoSuchMemberException noSuchMemberException -> NO_SUCH_MEMBER;
         case final ConnectException connectException -> NO_SUCH_MEMBER;
         case final NoRemoteHandler noRemoteHandler -> NO_SUCH_MEMBER;
-        case final CompletionException completionException -> of(completionException.getCause());
+        case final CompletionException completionException -> {
+          if (completionException.getCause() != null) {
+            yield of(completionException.getCause());
+          } else {
+            yield UNKNOWN;
+          }
+        }
         default -> UNKNOWN;
       };
     }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/VoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/VoteQuorum.java
@@ -17,7 +17,7 @@ public interface VoteQuorum {
 
   void succeed(MemberId member);
 
-  void fail(MemberId member);
+  void fail(MemberId member, final VoteErrorStatus statusCode);
 
   void cancel();
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/VoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/VoteQuorum.java
@@ -8,6 +8,10 @@
 package io.atomix.raft.utils;
 
 import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.MessagingException.NoRemoteHandler;
+import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
+import java.net.ConnectException;
+import java.util.concurrent.CompletionException;
 
 public interface VoteQuorum {
 
@@ -16,4 +20,21 @@ public interface VoteQuorum {
   void fail(MemberId member);
 
   void cancel();
+
+  enum VoteErrorStatus {
+    NO_SUCH_MEMBER,
+    REJECTED,
+    INVALID_TERM,
+    UNKNOWN;
+
+    public static VoteErrorStatus of(final Throwable error) {
+      return switch (error) {
+        case final NoSuchMemberException noSuchMemberException -> NO_SUCH_MEMBER;
+        case final ConnectException connectException -> NO_SUCH_MEMBER;
+        case final NoRemoteHandler noRemoteHandler -> NO_SUCH_MEMBER;
+        case final CompletionException completionException -> of(completionException.getCause());
+        default -> UNKNOWN;
+      };
+    }
+  }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/utils/VoteErrorStatusTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/utils/VoteErrorStatusTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.event.Level;
 
 final class VoteErrorStatusTest {
 
@@ -72,19 +73,6 @@ final class VoteErrorStatusTest {
 
       // then
       assertThat(status).isEqualTo(expected);
-    }
-
-    @Test
-    void shouldClassifyTransportFailureWrappedMoreThanOnce() {
-      // given
-      final var error =
-          new CompletionException(new CompletionException(new ConnectException("refused")));
-
-      // when
-      final var status = VoteErrorStatus.of(error);
-
-      // then
-      assertThat(status).isEqualTo(VoteErrorStatus.NO_SUCH_MEMBER);
     }
   }
 
@@ -148,6 +136,48 @@ final class VoteErrorStatusTest {
 
       // then
       assertThat(status).isEqualTo(VoteErrorStatus.UNKNOWN);
+    }
+  }
+
+  @Nested
+  final class LogLevels {
+
+    static Stream<Arguments> unreachableMemberFailures() {
+      return Stream.of(
+          Arguments.of(
+              Named.of("member not in membership view", new NoSuchMemberException("member 2"))),
+          Arguments.of(Named.of("connection refused", new ConnectException("connection refused"))),
+          Arguments.of(
+              Named.of("partition handler not registered", new NoRemoteHandler("vote-subject"))));
+    }
+
+    /**
+     * Every failure classified as an unreachable member has to be demoted, not only the one
+     * exception type that names it.
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("unreachableMemberFailures")
+    void shouldDemoteEveryUnreachableMemberFailure(final Throwable error) {
+      // given
+      final var wrapped = new CompletionException(error);
+
+      // when
+      final var level = VoteErrorStatus.of(wrapped).logLevel();
+
+      // then
+      assertThat(level).isEqualTo(Level.TRACE);
+    }
+
+    @Test
+    void shouldKeepReportingOtherFailuresAtWarn() {
+      // given
+      final var error = new CompletionException(new IllegalStateException("boom"));
+
+      // when
+      final var level = VoteErrorStatus.of(error).logLevel();
+
+      // then
+      assertThat(level).isEqualTo(Level.WARN);
     }
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/utils/VoteErrorStatusTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/utils/VoteErrorStatusTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.messaging.MessagingException;
+import io.atomix.cluster.messaging.MessagingException.ConnectionClosed;
+import io.atomix.cluster.messaging.MessagingException.NoRemoteHandler;
+import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
+import io.atomix.cluster.messaging.MessagingException.RemoteHandlerFailure;
+import io.atomix.raft.utils.VoteQuorum.VoteErrorStatus;
+import java.net.ConnectException;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+final class VoteErrorStatusTest {
+
+  @Nested
+  final class TransportFailures {
+
+    static Stream<Arguments> transportFailures() {
+      return Stream.of(
+          Arguments.of(
+              Named.of("member not in membership view", new NoSuchMemberException("member 2")),
+              VoteErrorStatus.NO_SUCH_MEMBER),
+          Arguments.of(
+              Named.of("connection refused", new ConnectException("connection refused")),
+              VoteErrorStatus.NO_SUCH_MEMBER),
+          Arguments.of(
+              Named.of("partition handler not registered", new NoRemoteHandler("vote-subject")),
+              VoteErrorStatus.NO_SUCH_MEMBER),
+          Arguments.of(
+              Named.of(
+                  "no response within the request timeout",
+                  new TimeoutException("Request PollRequest to 0.0.0.0:26502 timed out in PT2.5S")),
+              VoteErrorStatus.MEMBER_TIMED_OUT));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("transportFailures")
+    void shouldClassifyBareTransportFailure(final Throwable error, final VoteErrorStatus expected) {
+      // given / when
+      final var status = VoteErrorStatus.of(error);
+
+      // then
+      assertThat(status).isEqualTo(expected);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("transportFailures")
+    void shouldClassifyTransportFailureWrappedByCompletionStage(
+        final Throwable error, final VoteErrorStatus expected) {
+      // given
+      final var wrapped = new CompletionException(error);
+
+      // when
+      final var status = VoteErrorStatus.of(wrapped);
+
+      // then
+      assertThat(status).isEqualTo(expected);
+    }
+
+    @Test
+    void shouldClassifyTransportFailureWrappedMoreThanOnce() {
+      // given
+      final var error =
+          new CompletionException(new CompletionException(new ConnectException("refused")));
+
+      // when
+      final var status = VoteErrorStatus.of(error);
+
+      // then
+      assertThat(status).isEqualTo(VoteErrorStatus.NO_SUCH_MEMBER);
+    }
+  }
+
+  @Nested
+  final class UnclassifiedFailures {
+
+    static Stream<Arguments> unclassifiedFailures() {
+      return Stream.of(
+          Arguments.of(
+              Named.of(
+                  "channel closed before the response arrived",
+                  new ConnectionClosed("channel was closed unexpectedly"))),
+          Arguments.of(
+              Named.of("remote handler threw", new RemoteHandlerFailure("handler failed"))),
+          Arguments.of(Named.of("malformed message", new MessagingException.ProtocolException())),
+          Arguments.of(Named.of("unrelated failure", new IllegalStateException("boom"))));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("unclassifiedFailures")
+    void shouldFallBackToUnknownForUnclassifiedFailure(final Throwable error) {
+      // given / when
+      final var status = VoteErrorStatus.of(error);
+
+      // then
+      assertThat(status).isEqualTo(VoteErrorStatus.UNKNOWN);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("unclassifiedFailures")
+    void shouldFallBackToUnknownWhenUnclassifiedFailureIsWrapped(final Throwable error) {
+      // given
+      final var wrapped = new CompletionException(error);
+
+      // when
+      final var status = VoteErrorStatus.of(wrapped);
+
+      // then
+      assertThat(status).isEqualTo(VoteErrorStatus.UNKNOWN);
+    }
+
+    @Test
+    void shouldFallBackToUnknownForAnExecutionExceptionAroundAKnownFailure() {
+      // given
+      final var error = new ExecutionException(new NoSuchMemberException("member 2"));
+
+      // when
+      final var status = VoteErrorStatus.of(error);
+
+      // then
+      assertThat(status).isEqualTo(VoteErrorStatus.UNKNOWN);
+    }
+
+    @Test
+    void shouldFallBackToUnknownForAWrapperWithoutACause() {
+      // given
+      final var error = new CompletionException(null);
+
+      // when
+      final var status = VoteErrorStatus.of(error);
+
+      // then
+      assertThat(status).isEqualTo(VoteErrorStatus.UNKNOWN);
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/utils/VoteQuorumTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/utils/VoteQuorumTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import io.atomix.cluster.MemberId;
+import io.atomix.raft.utils.VoteQuorum.VoteErrorStatus;
 import java.util.Set;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Nested;
@@ -117,8 +118,8 @@ final class VoteQuorumTest {
               callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
       // when
-      quorum.fail(new MemberId("1"));
-      quorum.fail(new MemberId("2"));
+      quorum.fail(new MemberId("1"), VoteErrorStatus.UNKNOWN);
+      quorum.fail(new MemberId("2"), VoteErrorStatus.UNKNOWN);
 
       // then
       verify(callback, only()).accept(false);
@@ -134,8 +135,8 @@ final class VoteQuorumTest {
               callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
       // when
-      quorum.fail(new MemberId("1"));
-      quorum.fail(new MemberId("2"));
+      quorum.fail(new MemberId("1"), VoteErrorStatus.UNKNOWN);
+      quorum.fail(new MemberId("2"), VoteErrorStatus.UNKNOWN);
       quorum.succeed(new MemberId("1"));
       quorum.succeed(new MemberId("2"));
 
@@ -236,8 +237,8 @@ final class VoteQuorumTest {
               Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
       // when
-      quorum.fail(new MemberId("1"));
-      quorum.fail(new MemberId("4"));
+      quorum.fail(new MemberId("1"), VoteErrorStatus.UNKNOWN);
+      quorum.fail(new MemberId("4"), VoteErrorStatus.UNKNOWN);
 
       // then
       verify(callback, only()).accept(false);
@@ -255,8 +256,8 @@ final class VoteQuorumTest {
               Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
       // when
-      quorum.fail(new MemberId("1"));
-      quorum.fail(new MemberId("4"));
+      quorum.fail(new MemberId("1"), VoteErrorStatus.UNKNOWN);
+      quorum.fail(new MemberId("4"), VoteErrorStatus.UNKNOWN);
       quorum.succeed(new MemberId("1"));
       quorum.succeed(new MemberId("2"));
       quorum.succeed(new MemberId("3"));


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Introduce a quorum vote status error mapping in order to be able to provide an aggregate of member states when the quorum vote request fails.

The original `NoSuchMemberException` noise, is dropped to a `TRACE` level, but all other error causes are still logged as `WARN`

Co-authored in the team's mob programming session by:
- @lenaschoenburg 
- @entangled90 
- @mkavanagh 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #9648
