### PR TITLE
ci: load-test: extract large GHA steps into dedicated scripts

### DIFF
--- a/.github/scripts/load-test-install-camunda-platform.sh
+++ b/.github/scripts/load-test-install-camunda-platform.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# owner: @camunda/reliability-testing
+#
+# Builds the Helm value overrides for both the Camunda platform and the load-tester
+# deployments from the workflow's inputs, then runs `make install`/`make install-stable`
+# against the rendered load-test folder. Centralized here because the override logic
+# branches on several independent, optional inputs (custom vs. Docker Hub images per
+# component, read benchmarks, Optimize metrics, user-supplied Helm values, whether the
+# metrics-exporter image was built this run).
+#
+# Usage: load-test-install-camunda-platform.sh <namespace> <install-target> <image-tag> \
+#          <image-repository> <image-registry> <camunda-repo> <optimize-repo> \
+#          <perform-read-benchmarks> <enable-optimize> <enable-optimize-metrics> \
+#          <metrics-exporter-built> <enable-chaos> <physical-tenants> [OPTIONS]
+#
+#   namespace                  Load-test namespace (also the setup folder name)
+#   install-target             Make target to run (install or install-stable)
+#   image-tag                  Calculated image tag for platform/starter/worker images
+#   image-repository           Repository for the load-tester (starter/worker) images
+#   image-registry             Registry for the orchestration/optimize images
+#   camunda-repo               Repository for the orchestration image
+#   optimize-repo              Repository for the optimize image (custom build path)
+#   perform-read-benchmarks    Run continuous read benchmarks (true/false)
+#   enable-optimize            Whether Optimize is part of this deployment (true/false)
+#   enable-optimize-metrics    Enable the load-tester Optimize report-evaluation meter (true/false)
+#   metrics-exporter-built     Whether build-metrics-exporter-image ran this run (true/false)
+#   enable-chaos               Enable chaos-killer (true/false)
+#   physical-tenants           Deploy a second physical tenant (true/false)
+#
+# Options (all optional, empty by default):
+#   --optimize-tag TAG            Explicit Optimize image tag (empty to use the built image)
+#   --orchestration-tag TAG       Docker Hub orchestration tag (empty when using a custom build)
+#   --identity-tag TAG            Explicit Identity image tag
+#   --connectors-tag TAG          Explicit Connectors image tag
+#   --load-test-load VALUE        Extra --set args for the load-tester Helm chart
+#   --platform-helm-values VALUE  Extra --set args for the platform Helm chart
+#   --scenario SCENARIO           Workload scenario to run
+
+set -euo pipefail
+
+namespace="$1"
+install_target="$2"
+image_tag="$3"
+image_repository="$4"
+image_registry="$5"
+camunda_repo="$6"
+optimize_repo="$7"
+perform_read_benchmarks="$8"
+enable_optimize="$9"
+enable_optimize_metrics="${10}"
+metrics_exporter_built="${11}"
+enable_chaos="${12}"
+physical_tenants="${13}"
+shift 13
+
+optimize_tag=""
+orchestration_tag=""
+identity_tag=""
+connectors_tag=""
+load_test_load=""
+platform_helm_values=""
+scenario=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --optimize-tag) optimize_tag="$2"; shift 2 ;;
+    --orchestration-tag) orchestration_tag="$2"; shift 2 ;;
+    --identity-tag) identity_tag="$2"; shift 2 ;;
+    --connectors-tag) connectors_tag="$2"; shift 2 ;;
+    --load-test-load) load_test_load="$2"; shift 2 ;;
+    --platform-helm-values) platform_helm_values="$2"; shift 2 ;;
+    --scenario) scenario="$2"; shift 2 ;;
+    *) echo "::error::Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+cd "load-tests/setup/${namespace}"
+
+# Build load test configuration
+load_test_config="--set global.image.tag=${image_tag} \
+                  --set global.image.repository=${image_repository} \
+                  --set global.image.pullSecrets[0].name=harbor-registry \
+                  --set global.performReadBenchmarks=${perform_read_benchmarks}"
+
+# Enable the load-tester Optimize report-evaluation meter via chart extraConfig
+# (binds to the Spring property load-tester.optimize.report-evaluation-enabled; off by default).
+if [[ "${enable_optimize_metrics}" == "true" ]]; then
+  load_test_config="$load_test_config --set global.extraConfig.load-tester.optimize.report-evaluation-enabled=true"
+fi
+
+# Append custom load test inputs
+load_test_config="$load_test_config ${load_test_load}"
+
+# Resolve image registry/repository: Docker Hub when orchestration-tag is set, internal registry otherwise
+# optimize_repo is only consumed in the custom build path where orchestration-tag is empty
+
+# Build platform configuration
+additional_platform_config="--set orchestration.image.registry=${image_registry} \
+  --set orchestration.image.repository=${camunda_repo} \
+  --set orchestration.image.tag=${image_tag}"
+
+additional_load_test_setup_configuration=""
+
+# Append optimize image config: optimize-tag wins if set, otherwise custom builds use internal registry
+if [[ "${enable_optimize}" == "true" ]]; then
+  if [[ -n "${optimize_tag}" ]]; then
+    # Explicit optimize tag provided: use it directly (Docker Hub image)
+    additional_platform_config+=" --set optimize.image.tag=${optimize_tag}"
+  elif [[ -z "${orchestration_tag}" ]]; then
+    # Custom build without explicit optimize tag: use the built image from internal registry
+    additional_platform_config+=" \
+      --set optimize.image.registry=${image_registry} \
+      --set optimize.image.repository=${optimize_repo} \
+      --set optimize.image.tag=${image_tag}"
+  fi
+fi
+
+# Append identity image config if a dedicated tag is provided
+if [[ -n "${identity_tag}" ]]; then
+  additional_platform_config+=" --set identity.image.tag=${identity_tag}"
+fi
+
+# Append connectors image config if a dedicated tag is provided
+if [[ -n "${connectors_tag}" ]]; then
+  additional_platform_config+=" --set connectors.image.tag=${connectors_tag}"
+fi
+
+# Append user-provided helm values if present
+if [[ -n "${platform_helm_values}" ]]; then
+  additional_platform_config+=" ${platform_helm_values}"
+fi
+
+# Pin the metrics-exporter image to the tag built by build-metrics-exporter-image.
+# If the image has been skipped, keep using the "latest" tag, which
+# is assuming to be always published by the dedicated CI running on
+# the main branch.
+if [[ "${metrics_exporter_built}" == "true" ]]; then
+  additional_load_test_setup_configuration+="--set metricsExporter.image.tag=${image_tag}"
+fi
+
+make "${install_target}" \
+  scenario="${scenario}" \
+  chaos="${enable_chaos}" \
+  physical_tenants="${physical_tenants}" \
+  additional_platform_configuration="$additional_platform_config" \
+  additional_load_test_configuration="$load_test_config" \
+  additional_load_test_setup_configuration="$additional_load_test_setup_configuration"

--- a/.github/scripts/load-test-print-tool-versions.sh
+++ b/.github/scripts/load-test-print-tool-versions.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# owner: @camunda/reliability-testing
+#
+# Prints the versions of the CLI tools used to deploy a load test cluster (helm, kubectl,
+# tsh, git, openssl, awk, jq), both as a step summary table and as a grouped log block.
+# Useful when a deploy behaves differently across runners due to a tool version drift.
+#
+# Writes to: $GITHUB_STEP_SUMMARY
+
+set -euo pipefail
+
+GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+helm_v=$(helm version --short 2>&1 || true)
+kubectl_v=$(kubectl version --client -o json 2>/dev/null | jq -r '.clientVersion.gitVersion' || true)
+tsh_v=$(tsh version --client --format=json 2>/dev/null | jq -r '.version' || tsh version 2>&1 | head -1)
+git_v=$(git --version)
+openssl_v=$(openssl version)
+awk_v=$(awk --version 2>/dev/null | head -1 || awk -W version 2>&1 | head -1)
+jq_v=$(jq --version)
+
+{
+  echo "## Tool versions"
+  echo ""
+  echo "| Tool | Version |"
+  echo "|------|---------|"
+  echo "| helm | \`${helm_v}\` |"
+  echo "| kubectl | \`${kubectl_v}\` |"
+  echo "| tsh | \`${tsh_v}\` |"
+  echo "| git | \`${git_v}\` |"
+  echo "| openssl | \`${openssl_v}\` |"
+  echo "| awk | \`${awk_v}\` |"
+  echo "| jq | \`${jq_v}\` |"
+} >> "$GITHUB_STEP_SUMMARY"
+
+echo "::group::Tool versions"
+printf '%-10s %s\n' helm "${helm_v}" kubectl "${kubectl_v}" tsh "${tsh_v}" \
+  git "${git_v}" openssl "${openssl_v}" awk "${awk_v}" jq "${jq_v}"
+echo "::endgroup::"

--- a/.github/scripts/load-test-summary.sh
+++ b/.github/scripts/load-test-summary.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -o errexit -o nounset -o pipefail
+IFS=$'\n\t'
+
+NAMESPACE="${1:?"Namespace is required as the first argument"}"
+
+echo "# Load test"
+echo
+echo "The test has been set up successfully. You can observe it [here](https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=${NAMESPACE})"
+echo
+
+echo "## Installed Helm Releases (namespace: \`${NAMESPACE}\`)"
+echo
+echo '```'
+helm list -n "${NAMESPACE}"
+echo '```'
+echo
+
+echo "### Helm Release Values"
+echo
+for release in $(helm list -n "${NAMESPACE}" -q); do
+    echo "### Helm Release \`${release}\` values"
+    echo '```yaml'
+    helm get values "${release}" -n "${NAMESPACE}"
+    echo '```'
+    echo
+done

--- a/.github/scripts/load-test-validate-docker-image-tags.sh
+++ b/.github/scripts/load-test-validate-docker-image-tags.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# owner: @camunda/reliability-testing
+#
+# Validates that the Docker Hub image tags requested for a load test (orchestration,
+# optimize, identity, connectors) actually exist before the deploy job wastes time on
+# a namespace that can never come up. Retries transient registry errors, but fails fast
+# on a genuinely missing manifest.
+#
+# Usage: load-test-validate-docker-image-tags.sh <orchestration-tag> <optimize-tag> <identity-tag> <connectors-tag> [enable-optimize]
+#   orchestration-tag   Docker Hub tag for camunda/camunda (empty to skip)
+#   optimize-tag        Docker Hub tag for camunda/optimize (empty to skip)
+#   identity-tag        Docker Hub tag for camunda/identity (empty to skip)
+#   connectors-tag      Docker Hub tag for camunda/connectors (empty to skip)
+#   enable-optimize     Whether Optimize is part of this deployment (true/false, default: false)
+
+set -euo pipefail
+
+orchestration_tag="$1"
+optimize_tag="$2"
+identity_tag="$3"
+connectors_tag="$4"
+enable_optimize="${5:-false}"
+
+validate_image() {
+  local image="$1"
+  local max_retries=3
+  local retry_delay=5
+  local attempt=1
+
+  while true; do
+    echo "Validating Docker image ${image} (attempt ${attempt}/${max_retries})"
+    manifest_output=$(docker manifest inspect "${image}" 2>&1 >/dev/null)
+    status=$?
+
+    if [ "${status}" -eq 0 ]; then
+      echo "Docker image ${image} exists"
+      return 0
+    fi
+
+    # Distinguish missing tag from transient errors
+    if echo "${manifest_output}" | grep -qiE "manifest unknown|no such manifest|not found"; then
+      echo "::error::Docker image ${image} does not exist on Docker Hub"
+      return 1
+    fi
+
+    if [ "${attempt}" -ge "${max_retries}" ]; then
+      echo "::error::Failed to validate Docker image ${image} after ${max_retries} attempts: ${manifest_output}"
+      return "${status}"
+    fi
+
+    echo "Transient error (attempt ${attempt}/${max_retries}), retrying in ${retry_delay}s..."
+    sleep "${retry_delay}"
+    attempt=$((attempt + 1))
+  done
+}
+
+if [[ -n "${orchestration_tag}" ]]; then
+  validate_image "camunda/camunda:${orchestration_tag}"
+fi
+
+if [[ "${enable_optimize}" == "true" && -n "${optimize_tag}" ]]; then
+  validate_image "camunda/optimize:${optimize_tag}"
+fi
+
+if [[ -n "${identity_tag}" ]]; then
+  validate_image "camunda/identity:${identity_tag}"
+fi
+
+if [[ -n "${connectors_tag}" ]]; then
+  validate_image "camunda/connectors:${connectors_tag}"
+fi

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -339,55 +339,15 @@ jobs:
 
       - name: Validate Docker image tags exist
         if: ${{ inputs.orchestration-tag != '' || inputs.optimize-tag != '' || inputs.identity-tag != '' || inputs.connectors-tag != '' }}
+        # Add -x to trace the call to the script and make it easier to reproduce it locally.
+        shell: bash --noprofile --norc -exo pipefail {0}
         run: |
-          validate_image() {
-            local image="$1"
-            local max_retries=3
-            local retry_delay=5
-            local attempt=1
-
-            while true; do
-              echo "Validating Docker image ${image} (attempt ${attempt}/${max_retries})"
-              manifest_output=$(docker manifest inspect "${image}" 2>&1 >/dev/null)
-              status=$?
-
-              if [ "${status}" -eq 0 ]; then
-                echo "Docker image ${image} exists"
-                return 0
-              fi
-
-              # Distinguish missing tag from transient errors
-              if echo "${manifest_output}" | grep -qiE "manifest unknown|no such manifest|not found"; then
-                echo "::error::Docker image ${image} does not exist on Docker Hub"
-                return 1
-              fi
-
-              if [ "${attempt}" -ge "${max_retries}" ]; then
-                echo "::error::Failed to validate Docker image ${image} after ${max_retries} attempts: ${manifest_output}"
-                return "${status}"
-              fi
-
-              echo "Transient error (attempt ${attempt}/${max_retries}), retrying in ${retry_delay}s..."
-              sleep "${retry_delay}"
-              attempt=$((attempt + 1))
-            done
-          }
-
-          if [[ -n "${ORCHESTRATION_TAG}" ]]; then
-            validate_image "camunda/camunda:${ORCHESTRATION_TAG}" || exit 1
-          fi
-
-          if [[ "${ENABLE_OPTIMIZE}" == "true" && -n "${OPTIMIZE_TAG}" ]]; then
-            validate_image "camunda/optimize:${OPTIMIZE_TAG}" || exit 1
-          fi
-
-          if [[ -n "${IDENTITY_TAG}" ]]; then
-            validate_image "camunda/identity:${IDENTITY_TAG}" || exit 1
-          fi
-
-          if [[ -n "${CONNECTORS_TAG}" ]]; then
-            validate_image "camunda/connectors:${CONNECTORS_TAG}" || exit 1
-          fi
+          .github/scripts/load-test-validate-docker-image-tags.sh \
+            "${ORCHESTRATION_TAG}" \
+            "${OPTIMIZE_TAG}" \
+            "${IDENTITY_TAG}" \
+            "${CONNECTORS_TAG}" \
+            "${ENABLE_OPTIMIZE}"
 
   build-camunda-image:
     name: Build Camunda
@@ -398,6 +358,8 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+    env:
+      CALCULATED_IMAGE_TAG: ${{ needs.calculate-image-tag.outputs.image-tag }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -450,7 +412,7 @@ jobs:
           repository: '${{ env.IMAGE_REPOSITORY }}/camunda'
           revision: ${{ inputs.ref }}
           push: true
-          version: ${{ needs.calculate-image-tag.outputs.image-tag }}
+          version: ${{ env.CALCULATED_IMAGE_TAG }}
           distball: ${{ steps.build-camunda.outputs.distball }}
           dockerfile: 'camunda.Dockerfile'
       - uses: ./.github/actions/build-platform-docker
@@ -460,7 +422,7 @@ jobs:
           repository: '${{ env.IMAGE_REPOSITORY }}/optimize'
           revision: ${{ inputs.ref }}
           push: true
-          version: ${{ needs.calculate-image-tag.outputs.image-tag }}
+          version: ${{ env.CALCULATED_IMAGE_TAG }}
           distball: 'optimize-distro/target/camunda-optimize-*.tar.gz'
           dockerfile: 'optimize.Dockerfile'
       - name: Observe build status
@@ -487,6 +449,7 @@ jobs:
       # intermittent failures pushing the load-test images; see discussion in
       # https://camunda.slack.com/archives/C5AHF1D8T/p1784723160353049
       JIB_HTTP_TIMEOUT: 60000
+      IMAGE_TAG: ${{ needs.calculate-image-tag.outputs.image-tag }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -502,12 +465,8 @@ jobs:
       - run: ./mvnw -B -D skipTests -D skipChecks -P\!include-optimize -pl load-tests/load-tester -am install
       - name: Build Starter Image
         run: ./mvnw -pl load-tests/load-tester jib:build -P starter -P\!include-optimize -D image="${IMAGE_REPOSITORY}/starter:${IMAGE_TAG}" -X -Djib.serialize=true -Djib.httpTimeout="${JIB_HTTP_TIMEOUT}"
-        env:
-          IMAGE_TAG: ${{ needs.calculate-image-tag.outputs.image-tag }}
       - name: Build Worker Image
         run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="${IMAGE_REPOSITORY}/worker:${IMAGE_TAG}" -X -Djib.serialize=true -Djib.httpTimeout="${JIB_HTTP_TIMEOUT}"
-        env:
-          IMAGE_TAG: ${{ needs.calculate-image-tag.outputs.image-tag }}
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -605,33 +564,7 @@ jobs:
             kubernetes-cluster: ${{ env.CLUSTER }}
 
       - name: Print tool versions
-        run: |
-          helm_v=$(helm version --short 2>&1 || true)
-          kubectl_v=$(kubectl version --client -o json 2>/dev/null | jq -r '.clientVersion.gitVersion' || true)
-          tsh_v=$(tsh version --client --format=json 2>/dev/null | jq -r '.version' || tsh version 2>&1 | head -1)
-          git_v=$(git --version)
-          openssl_v=$(openssl version)
-          awk_v=$(awk --version 2>/dev/null | head -1 || awk -W version 2>&1 | head -1)
-          jq_v=$(jq --version)
-
-          {
-            echo "## Tool versions"
-            echo ""
-            echo "| Tool | Version |"
-            echo "|------|---------|"
-            echo "| helm | \`${helm_v}\` |"
-            echo "| kubectl | \`${kubectl_v}\` |"
-            echo "| tsh | \`${tsh_v}\` |"
-            echo "| git | \`${git_v}\` |"
-            echo "| openssl | \`${openssl_v}\` |"
-            echo "| awk | \`${awk_v}\` |"
-            echo "| jq | \`${jq_v}\` |"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          echo "::group::Tool versions"
-          printf '%-10s %s\n' helm "${helm_v}" kubectl "${kubectl_v}" tsh "${tsh_v}" \
-            git "${git_v}" openssl "${openssl_v}" awk "${awk_v}" jq "${jq_v}"
-          echo "::endgroup::"
+        run: .github/scripts/load-test-print-tool-versions.sh
 
       - name: Scaffold load-test folder
         run: |
@@ -644,85 +577,36 @@ jobs:
           ./newLoadTest.sh --target-version "${TARGET_VERSION}" "${NAMESPACE}" "${SECONDARY_STORAGE_TYPE}" "${TTL}" "${ENABLE_OPTIMIZE}"
 
       - name: Install latest Camunda Platform
+        shell: bash --noprofile --norc -exo pipefail {0}
         env:
-          BUILD_METRICS_EXPORTER_RESULT: ${{ needs.build-metrics-exporter-image.result }}
-          CALCULATED_IMAGE_TAG: ${{ needs.calculate-image-tag.outputs.image-tag }}
-          CAMUNDA_REPO: ${{ inputs.orchestration-tag != '' && 'camunda/camunda' || 'team-zeebe/camunda' }}
-          IMAGE_REGISTRY: ${{ inputs.orchestration-tag != '' && 'docker.io' || 'registry.camunda.cloud' }}
           INSTALL_TARGET: ${{ inputs.stable-vms && 'install-stable' || 'install' }}
+          CALCULATED_IMAGE_TAG: ${{ needs.calculate-image-tag.outputs.image-tag }}
+          RESOLVED_IMAGE_REGISTRY: ${{ inputs.orchestration-tag != '' && 'docker.io' || 'registry.camunda.cloud' }}
+          CAMUNDA_REPO: ${{ inputs.orchestration-tag != '' && 'camunda/camunda' || 'team-zeebe/camunda' }}
           OPTIMIZE_REPO: ${{ inputs.orchestration-tag != '' && 'camunda/optimize' || 'team-zeebe/optimize' }}
-        run: |
-          cd "load-tests/setup/${NAMESPACE}"
-
-          # Build load test configuration
-          load_test_config="--set global.image.tag=${CALCULATED_IMAGE_TAG} \
-                            --set global.image.repository=${IMAGE_REPOSITORY} \
-                            --set global.image.pullSecrets[0].name=harbor-registry \
-                            --set global.performReadBenchmarks=${PERFORM_READ_BENCHMARKS}"
-
-          # Enable the load-tester Optimize report-evaluation meter via chart extraConfig
-          # (binds to the Spring property load-tester.optimize.report-evaluation-enabled; off by default).
-          if [[ "${ENABLE_OPTIMIZE_METRICS}" == "true" ]]; then
-            load_test_config="$load_test_config --set global.extraConfig.load-tester.optimize.report-evaluation-enabled=true"
-          fi
-
-          # Append custom load test inputs
-          load_test_config="$load_test_config ${LOAD_TEST_LOAD}"
-
-          # Resolve image registry/repository: Docker Hub when orchestration-tag is set, internal registry otherwise
-          # optimize_repo is only consumed in the custom build path where orchestration-tag is empty
-
-          # Build platform configuration
-          additional_platform_config="--set orchestration.image.registry=${IMAGE_REGISTRY} \
-            --set orchestration.image.repository=${CAMUNDA_REPO} \
-            --set orchestration.image.tag=${CALCULATED_IMAGE_TAG}"
-
-          additional_load_test_setup_configuration=""
-
-          # Append optimize image config: optimize-tag wins if set, otherwise custom builds use internal registry
-          if [[ "${ENABLE_OPTIMIZE}" == "true" ]]; then
-            if [[ -n "${OPTIMIZE_TAG}" ]]; then
-              # Explicit optimize tag provided: use it directly (Docker Hub image)
-              additional_platform_config+=" --set optimize.image.tag=${OPTIMIZE_TAG}"
-            elif [[ -z "${ORCHESTRATION_TAG}" ]]; then
-              # Custom build without explicit optimize tag: use the built image from internal registry
-              additional_platform_config+=" \
-                --set optimize.image.registry=${IMAGE_REGISTRY} \
-                --set optimize.image.repository=${OPTIMIZE_REPO} \
-                --set optimize.image.tag=${CALCULATED_IMAGE_TAG}"
-            fi
-          fi
-
-          # Append identity image config if a dedicated tag is provided
-          if [[ -n "${IDENTITY_TAG}" ]]; then
-            additional_platform_config+=" --set identity.image.tag=${IDENTITY_TAG}"
-          fi
-
-          # Append connectors image config if a dedicated tag is provided
-          if [[ -n "${CONNECTORS_TAG}" ]]; then
-            additional_platform_config+=" --set connectors.image.tag=${CONNECTORS_TAG}"
-          fi
-
-          # Append user-provided helm values if present
-          if [[ -n "${PLATFORM_HELM_VALUES}" ]]; then
-            additional_platform_config+=" ${PLATFORM_HELM_VALUES}"
-          fi
-
-          # Pin the metrics-exporter image to the tag built by build-metrics-exporter-image.
-          # If the image has been skipped, keep using the "latest" tag, which
-          # is assuming to be always published by the dedicated CI running on
-          # the main branch.
-          if [[ "${BUILD_METRICS_EXPORTER_RESULT}" == "success" ]]; then
-            additional_load_test_setup_configuration+="--set metricsExporter.image.tag=${CALCULATED_IMAGE_TAG}"
-          fi
-
-          make "${INSTALL_TARGET}" \
-            scenario="${SCENARIO}" \
-            chaos="${ENABLE_CHAOS}" \
-            physical_tenants="${PHYSICAL_TENANTS}" \
-            additional_platform_configuration="$additional_platform_config" \
-            additional_load_test_configuration="$load_test_config" \
-            additional_load_test_setup_configuration="$additional_load_test_setup_configuration"
+          METRICS_EXPORTER_BUILT: ${{ needs.build-metrics-exporter-image.result == 'success' }}
+        run: |-
+          .github/scripts/load-test-install-camunda-platform.sh \
+            "${NAMESPACE}" \
+            "${INSTALL_TARGET}" \
+            "${CALCULATED_IMAGE_TAG}" \
+            "${IMAGE_REPOSITORY}" \
+            "${RESOLVED_IMAGE_REGISTRY}" \
+            "${CAMUNDA_REPO}" \
+            "${OPTIMIZE_REPO}" \
+            "${PERFORM_READ_BENCHMARKS}" \
+            "${ENABLE_OPTIMIZE}" \
+            "${ENABLE_OPTIMIZE_METRICS}" \
+            "${METRICS_EXPORTER_BUILT}" \
+            "${ENABLE_CHAOS}" \
+            "${PHYSICAL_TENANTS}" \
+            --optimize-tag "${OPTIMIZE_TAG}" \
+            --orchestration-tag "${ORCHESTRATION_TAG}" \
+            --identity-tag "${IDENTITY_TAG}" \
+            --connectors-tag "${CONNECTORS_TAG}" \
+            --load-test-load "${LOAD_TEST_LOAD}" \
+            --platform-helm-values "${PLATFORM_HELM_VALUES}" \
+            --scenario "${SCENARIO}"
 
       - name: Annotate namespace with workflow run URL
         run: |
@@ -731,27 +615,9 @@ jobs:
             "github.com/workflow-run-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --overwrite
 
-      - name: Summarize platform deployment
-        if: success()
-        run: |
-          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Camunda platform \`${NAME}\` values
-            \`\`\`yaml
-            $(helm get values "${NAMESPACE}" -n "${NAMESPACE}")
-            \`\`\`
-          EOF
-
       - name: Summarize load test deployment
         if: success()
-        run: |
-          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            # Load test
-            The test has been set up successfully. You can observe it [here](https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=${NAMESPACE})
-            ## Load test \`${NAME}\` values
-            \`\`\`yaml
-            $(helm get values "${NAMESPACE}-test" -n "${NAMESPACE}")
-            \`\`\`
-          EOF
+        run: .github/scripts/load-test-summary.sh "${NAMESPACE}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Observe build status
         if: always()


### PR DESCRIPTION
## Description

Last week, when investigating why [a release load tests was not redeploying as expected](https://github.com/camunda/camunda/actions/runs/30102215166/job/90295609266), it was difficult to be sure that i was reproducing the same locally as GitHub Actions runs a large set of commands interleaved with env vars, locally computed values without providing a clear output of what it did (until the make commands).

This extracts the large inline GitHub Actions steps into dedicated scripts and "log" the actual calls to the scripts, making it easier to reproduce them locally.

* The large "install Camunda Platform" step is now reproducible more easily by checking out the logged call in GitHub Actions and pasting it locally
* The summary after the deployment now summarizes all the installed releases


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
