### PR TITLE
feat: include physical tenant prefix in the OpenAPI spec

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -29,7 +29,7 @@ externalDocs:
   description: Find out more
   url: https://docs.camunda.io/docs/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-overview/
 servers:
-  - url: "{schema}://{host}:{port}/v2"
+  - url: "{schema}://{host}:{port}/physical-tenants/{physicalTenantId}/v2"
     variables:
       host:
         default: localhost
@@ -40,6 +40,9 @@ servers:
       schema:
         default: http
         description: The schema of the Orchestration Cluster REST API server.
+      physicalTenantId:
+        default: default
+        description: The id of the physical tenant to use.
 tags:
   - name: Ad-hoc sub-process
   - name: Agent instance


### PR DESCRIPTION
This makes usage of the `default` tenant explicit and gives users an easy way to try out requests against non-default tenants.

The drawbacks are longer URLs for the common case where only the default tenant is used and that this version of the OpenAPI spec is only compatible with 8.10, and can't work at all for versions <8.10.

Part of https://github.com/camunda/camunda/issues/52027