### PR TITLE
docs: clarify scope of exporter failure isolation and backpressure coupling

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
@@ -19,6 +19,16 @@ import org.agrona.collections.LongArrayList;
 import org.agrona.collections.MutableLong;
 import org.agrona.concurrent.UnsafeBuffer;
 
+/**
+ * Each {@link io.camunda.zeebe.broker.exporter.stream.ExporterActor} constructs its own instance of
+ * this class over its own independent {@link TransactionContext} against the partition's shared
+ * {@link ZeebeDb} - safe only because every instance touches exclusively the {@link
+ * ZbColumnFamilies#EXPORTER} column family, keyed by exporter id. {@link TransactionContext}s are
+ * not RocksDB transactions with conflict detection: two contexts writing the same key would
+ * silently lose one write. Do not extend this class (or anything reachable from an exporter actor's
+ * own context) to read or write any column family whose keys could collide with another exporter's
+ * or the engine's own state.
+ */
 public final class ExportersState {
 
   public static final long VALUE_NOT_FOUND = -1;

--- a/zeebe/docs/adr/0007-TBD-concurrent-exporters.md
+++ b/zeebe/docs/adr/0007-TBD-concurrent-exporters.md
@@ -60,11 +60,21 @@ record of each other, so retained log volume stays small; once exporters progres
 stalled exporter can fall arbitrarily far behind its siblings, and retained log volume grows with
 that gap until the stalled exporter recovers, is paused, or is removed.
 
-**D5. Failure isolation replaces shared failure.**
+**D5. Failure isolation replaces shared failure — scoped to throughput and liveness, not fatal
+errors.**
 An unrecoverable error in one exporter today halts exporting for the entire partition. Under this
 decision, it parks only that exporter — preserving its position for a later restart — while
 siblings continue unaffected. Partition-level health becomes an aggregate (worst-of) over
 individual exporter health, not a single shared state.
+
+This isolation has a deliberate boundary: because the aggregate is worst-of, one exporter reporting
+an unrecoverable (dead) failure still makes the partition's own health report dead, which — via the
+broker's existing health-monitoring wiring — still stops the partition as a whole (not just
+exporting), exactly as a fatal error in today's single shared actor does. What changes is scoped to
+the *slow-or-stuck-but-retrying* case: such an exporter no longer blocks its siblings' throughput or
+degrades partition health at all. A *fatal* error in one exporter remains, by design, a
+partition-wide event — decoupling exporters from each other does not decouple the partition's
+availability from any single exporter's correctness.
 
 **D6. No public API changes.**
 The `Exporter`/`Controller`/`Context` SPI exporter implementations are built against is untouched.
@@ -84,8 +94,9 @@ each other, not a change to what an exporter implementation does or receives.
 
 - Multi-exporter deployments gain real throughput and latency improvements: exporters no longer
   wait on each other.
-- One exporter's fatal error, network partition, or backlog no longer stops exporting for the
-  whole partition.
+- One exporter's stall, backlog, or transient (retryable) failure no longer stops exporting for the
+  whole partition or degrades partition health at all. A *fatal* (unrecoverable) error in one
+  exporter still stops the partition as a whole, same as today — see D5.
 - The number of actors scheduled per partition grows from one to one-per-configured-exporter;
   in practice this is small (deployments typically configure a handful of exporters), but it is a
   real increase in scheduled units on the broker's IO-bound actor pool.

--- a/zeebe/docs/design/0007-concurrent-exporters-design.md
+++ b/zeebe/docs/design/0007-concurrent-exporters-design.md
@@ -382,3 +382,35 @@ The three branches above are the entire failure-isolation story: a permanently-t
 just keeps retrying (with backoff) on its own actor forever, on a log reader no other exporter
 shares, without any other exporter's loop ever being aware it's happening.
 
+## 9. Backpressure interaction with `FlowControl`
+
+Neither this document nor the ADR originally accounted for `LogStream`'s write-rate throttle
+(`io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl`), which slows down new appends based on
+how far writing has outpaced exporting (`lastWrittenPosition - lastExportedPosition`). Before this
+refactor, `FlowControl.onExported(position)` was only ever called once every configured exporter had
+accepted a record, so the throttle was implicitly gated by the slowest exporter.
+
+Moving each exporter onto its own actor broke that implicit gating: each `ExporterActor` began
+calling `onExported` independently with its own position, and since `FlowControl` simply overwrites
+its tracked position on each call (no per-exporter awareness), the throttle ended up reflecting
+whichever exporter happened to report *last* — typically the fastest one — silently weakening
+backpressure exactly when a lagging exporter should have been triggering it.
+
+This is fixed by `ExporterExportedPositions`
+(`zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterExportedPositions.java`),
+a small class shared by every `ExporterActor` on a partition (the same "one instance passed to every
+actor" pattern already used for `ExporterMetrics`): it tracks each exporter's own last-known
+position and reports the *minimum* across all of them to `FlowControl`, restoring the pre-refactor
+throttling behavior.
+
+**This intentionally restores a coupling, not just a bug fix.** With the fix in place, if any one
+configured exporter stalls (e.g. its downstream store is down), the partition's write-rate throttle
+engages exactly as it did before this refactor — new command/record appends slow down or are
+rejected (`WriteRateLimitExhausted`, surfaced to clients as `RESOURCE_EXHAUSTED`) based on that
+exporter's lag, not just that exporter's own throughput. Decoupling exporters from each other does
+not, and was never intended to, decouple the engine's write throughput from the slowest exporter —
+that coupling exists for a correctness reason independent of this refactor (bounding how far writing
+can outpace exporting) and predates the per-exporter-actor design entirely. Operators should not
+expect this refactor to change how a single stalled exporter affects overall write throughput; it
+only changes whether that exporter also blocks *other exporters*.
+


### PR DESCRIPTION
## Summary

Docs-only follow-up split out of #57912. Clarifies claims in the concurrent-exporters ADR and design doc that were broader than what the implementation actually guarantees, and documents an invariant that isn't obvious from the code alone.

- **ADR D5 / Consequences**: narrows the failure-isolation claim. Health aggregation is worst-of across per-exporter actors, so one exporter reporting an unrecoverable (dead) failure still marks the partition's own health as dead and stops the partition as a whole via the existing health-monitoring wiring — not just exporting. Isolation applies to transient failures/backlogs, not fatal ones.
- **Design doc §9 (new)**: documents that the `FlowControl` backpressure fix (gating the exporting-lag throttle by the slowest exporter, from #57912) intentionally restores a coupling between exporting and engine write throughput — this is deliberate, not an oversight.
- **`ExportersState`**: adds a class-level javadoc documenting the disjoint-key invariant each per-exporter `ExporterActor` instance relies on (each touches only the `EXPORTER` column family keyed by its own exporter id) and warns against extending this pattern to any column family whose keys could collide across exporters or with engine state.

No behavioral changes — documentation only.

## Test plan

- [x] `./mvnw license:format spotless:apply -T1C` (docs + javadoc only, no test impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)