### PR TITLE
fix: refresh RDBMS table-row-count metrics asynchronously

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/PhysicalTenantsRdbmsTableRowCountMetrics.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/PhysicalTenantsRdbmsTableRowCountMetrics.java
@@ -12,7 +12,9 @@ import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Registers metrics for the number of rows in each RDBMS table, per physical tenant. Each physical
@@ -21,12 +23,13 @@ import java.util.Map;
  * metrics. The actual (cached) row counts are provided by a per-tenant {@link
  * RdbmsTableRowCountProvider}.
  */
-public class PhysicalTenantsRdbmsTableRowCountMetrics implements MeterBinder {
+public class PhysicalTenantsRdbmsTableRowCountMetrics implements MeterBinder, AutoCloseable {
 
   private static final String NAMESPACE = "zeebe.rdbms";
   private static final String METRIC_NAME = NAMESPACE + ".table.row.count";
 
   private final Map<String, RdbmsTableRowCountProvider> rowCountProviders;
+  private final List<ExecutorService> executors;
 
   /**
    * @param rowCountProviders the row count provider for each physical tenant, keyed by physical
@@ -34,7 +37,19 @@ public class PhysicalTenantsRdbmsTableRowCountMetrics implements MeterBinder {
    */
   public PhysicalTenantsRdbmsTableRowCountMetrics(
       final Map<String, RdbmsTableRowCountProvider> rowCountProviders) {
+    this(rowCountProviders, List.of());
+  }
+
+  /**
+   * @param rowCountProviders the row count provider for each physical tenant, keyed by physical
+   *     tenant id
+   * @param executors executors owned by these metrics and closed with the metrics bean
+   */
+  public PhysicalTenantsRdbmsTableRowCountMetrics(
+      final Map<String, RdbmsTableRowCountProvider> rowCountProviders,
+      final List<ExecutorService> executors) {
     this.rowCountProviders = Map.copyOf(rowCountProviders);
+    this.executors = List.copyOf(executors);
   }
 
   @Override
@@ -49,5 +64,10 @@ public class PhysicalTenantsRdbmsTableRowCountMetrics implements MeterBinder {
                 .register(registry);
           }
         });
+  }
+
+  @Override
+  public void close() {
+    executors.forEach(ExecutorService::shutdown);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RdbmsTableRowCountProvider.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RdbmsTableRowCountProvider.java
@@ -7,11 +7,13 @@
  */
 package io.camunda.db.rdbms.read.service;
 
-import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.CacheLoader;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.camunda.db.rdbms.RdbmsTableNames;
 import io.camunda.db.rdbms.sql.TableMetricsMapper;
 import java.time.Duration;
+import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,37 +22,74 @@ import org.slf4j.LoggerFactory;
  * has its own database (backed by its own {@link TableMetricsMapper}) and its own cache duration,
  * so one provider is created per physical tenant. Row counts are cached to avoid performance impact
  * on the database.
+ *
+ * <p>{@link #getRowCount(String)} never blocks: it always returns immediately, either the last
+ * successfully loaded value or {@link #UNKNOWN_ROW_COUNT} if none has completed loading yet.
  */
 public class RdbmsTableRowCountProvider {
 
   private static final Logger LOG = LoggerFactory.getLogger(RdbmsTableRowCountProvider.class);
 
+  /**
+   * Returned for an unknown table name, a failed row count query, or a table whose first load
+   * hasn't completed yet.
+   */
+  private static final long UNKNOWN_ROW_COUNT = -1;
+
   private final TableMetricsMapper tableMetricsMapper;
-  private final Cache<String, Long> rowCountCache;
+  private final AsyncLoadingCache<String, Long> rowCountCache;
 
   /**
    * @param tableMetricsMapper the mapper backing the physical tenant's database
-   * @param cacheDuration how long row counts are cached before being fetched again
+   * @param cacheDuration how long a row count is served before a refresh is triggered
+   * @param executor runs the (potentially slow or blocking) database reload off the caller's thread
    */
   public RdbmsTableRowCountProvider(
-      final TableMetricsMapper tableMetricsMapper, final Duration cacheDuration) {
+      final TableMetricsMapper tableMetricsMapper,
+      final Duration cacheDuration,
+      final Executor executor) {
     this.tableMetricsMapper = tableMetricsMapper;
-    rowCountCache = Caffeine.newBuilder().expireAfterWrite(cacheDuration).build();
+    rowCountCache =
+        Caffeine.newBuilder()
+            .refreshAfterWrite(cacheDuration)
+            .executor(executor)
+            .buildAsync(
+                new CacheLoader<>() {
+                  @Override
+                  public Long load(final String tableName) {
+                    return fetchRowCount(tableName);
+                  }
+
+                  @Override
+                  public Long reload(final String tableName, final Long oldValue) throws Exception {
+                    if (!isAllowedTableName(tableName)) {
+                      LOG.warn("Attempted to reload row count for unknown table: {}", tableName);
+                      return oldValue;
+                    }
+                    return tableMetricsMapper.countTableRows(tableName);
+                  }
+                });
   }
 
   /**
    * Gets the row count for a specific table, using the cache if available.
    *
    * @param tableName the name of the table
-   * @return the number of rows in the table, or -1 if the table is not in the allowed list
+   * @return the row count; {@link #UNKNOWN_ROW_COUNT} if the table is unknown or its first load
+   *     hasn't completed yet or failed; the previously cached value if a subsequent refresh failed
    */
   public long getRowCount(final String tableName) {
     if (!isAllowedTableName(tableName)) {
       LOG.warn("Attempted to get row count for unknown table: {}", tableName);
-      return -1;
+      return UNKNOWN_ROW_COUNT;
     }
 
-    return rowCountCache.get(tableName, this::fetchRowCount);
+    try {
+      return rowCountCache.get(tableName).getNow(UNKNOWN_ROW_COUNT);
+    } catch (final Exception e) {
+      LOG.warn("Failed to read cached row count for table {}", tableName, e);
+      return UNKNOWN_ROW_COUNT;
+    }
   }
 
   /**
@@ -63,18 +102,18 @@ public class RdbmsTableRowCountProvider {
     return RdbmsTableNames.TABLE_NAMES.contains(tableName);
   }
 
-  private long fetchRowCount(final String tableName) {
+  private Long fetchRowCount(final String tableName) {
     // Only fetch row counts for allowed table names to prevent SQL injection
     if (!isAllowedTableName(tableName)) {
       LOG.warn("Attempted to fetch row count for unknown table: {}", tableName);
-      return -1;
+      return UNKNOWN_ROW_COUNT;
     }
 
     try {
       return tableMetricsMapper.countTableRows(tableName);
     } catch (final Exception e) {
       LOG.warn("Failed to fetch row count for table {}", tableName, e);
-      return -1;
+      return UNKNOWN_ROW_COUNT;
     }
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/PhysicalTenantsRdbmsTableRowCountMetricsTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/PhysicalTenantsRdbmsTableRowCountMetricsTest.java
@@ -18,6 +18,7 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -124,5 +125,20 @@ class PhysicalTenantsRdbmsTableRowCountMetricsTest {
     // then
     assertThat(gaugeA.value()).isEqualTo(42.0);
     assertThat(gaugeB.value()).isEqualTo(7.0);
+  }
+
+  @Test
+  void shouldCloseOwnedExecutors() {
+    // given
+    final var executorA = Executors.newSingleThreadExecutor();
+    final var executorB = Executors.newSingleThreadExecutor();
+    metrics = new PhysicalTenantsRdbmsTableRowCountMetrics(Map.of(), List.of(executorA, executorB));
+
+    // when
+    metrics.close();
+
+    // then
+    assertThat(executorA.isShutdown()).isTrue();
+    assertThat(executorB.isShutdown()).isTrue();
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/PhysicalTenantsRdbmsTableRowCountMetricsTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/PhysicalTenantsRdbmsTableRowCountMetricsTest.java
@@ -19,6 +19,10 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +35,7 @@ class PhysicalTenantsRdbmsTableRowCountMetricsTest {
   private TableMetricsMapper mapperA;
   private TableMetricsMapper mapperB;
   private MeterRegistry meterRegistry;
+  private ExecutorService executor;
   private PhysicalTenantsRdbmsTableRowCountMetrics metrics;
 
   @BeforeEach
@@ -38,11 +43,23 @@ class PhysicalTenantsRdbmsTableRowCountMetricsTest {
     mapperA = mock(TableMetricsMapper.class);
     mapperB = mock(TableMetricsMapper.class);
     meterRegistry = new SimpleMeterRegistry();
+    // Single-threaded so a no-op task submitted after triggering a load can be used as a barrier:
+    // once that no-op task completes, the earlier (async) load is guaranteed to have finished too.
+    executor = Executors.newSingleThreadExecutor();
   }
 
-  private static RdbmsTableRowCountProvider provider(
+  @AfterEach
+  void tearDown() {
+    executor.shutdownNow();
+  }
+
+  private void awaitPendingLoads() throws Exception {
+    executor.submit(() -> {}).get(5, TimeUnit.SECONDS);
+  }
+
+  private RdbmsTableRowCountProvider provider(
       final TableMetricsMapper mapper, final Duration cacheDuration) {
-    return new RdbmsTableRowCountProvider(mapper, cacheDuration);
+    return new RdbmsTableRowCountProvider(mapper, cacheDuration, executor);
   }
 
   @Test
@@ -76,7 +93,7 @@ class PhysicalTenantsRdbmsTableRowCountMetricsTest {
   }
 
   @Test
-  void shouldReportRowCountsPerPhysicalTenantIndependently() {
+  void shouldReportRowCountsPerPhysicalTenantIndependently() throws Exception {
     // given
     when(mapperA.countTableRows("PROCESS_INSTANCE")).thenReturn(42L);
     when(mapperB.countTableRows("PROCESS_INSTANCE")).thenReturn(7L);
@@ -87,7 +104,7 @@ class PhysicalTenantsRdbmsTableRowCountMetricsTest {
                 TENANT_B, provider(mapperB, DEFAULT_CACHE_DURATION)));
     metrics.bindTo(meterRegistry);
 
-    // when
+    // when - the first read of each gauge only triggers the (async) load; wait for it to finish
     final Gauge gaugeA =
         meterRegistry
             .find("zeebe.rdbms.table.row.count")
@@ -100,6 +117,9 @@ class PhysicalTenantsRdbmsTableRowCountMetricsTest {
             .tag("physicalTenant", TENANT_B)
             .tag("table", "PROCESS_INSTANCE")
             .gauge();
+    gaugeA.value();
+    gaugeB.value();
+    awaitPendingLoads();
 
     // then
     assertThat(gaugeA.value()).isEqualTo(42.0);

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/RdbmsTableRowCountProviderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/RdbmsTableRowCountProviderTest.java
@@ -15,6 +15,11 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.sql.TableMetricsMapper;
 import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -23,33 +28,78 @@ class RdbmsTableRowCountProviderTest {
   private static final Duration DEFAULT_CACHE_DURATION = Duration.ofMinutes(15);
 
   private TableMetricsMapper mapper;
+  private ExecutorService executor;
 
   @BeforeEach
   void setUp() {
     mapper = mock(TableMetricsMapper.class);
+    // Single-threaded so a no-op task submitted after triggering a load can be used as a barrier:
+    // once that no-op task completes, the earlier load is guaranteed to have finished too.
+    executor = Executors.newSingleThreadExecutor();
+  }
+
+  @AfterEach
+  void tearDown() {
+    executor.shutdownNow();
+  }
+
+  private void awaitPendingLoad() throws Exception {
+    executor.submit(() -> {}).get(5, TimeUnit.SECONDS);
   }
 
   @Test
-  void shouldReturnRowCountFromMapper() {
+  void shouldReturnRowCountFromMapper() throws Exception {
     // given
     when(mapper.countTableRows("PROCESS_INSTANCE")).thenReturn(42L);
-    final var provider = new RdbmsTableRowCountProvider(mapper, DEFAULT_CACHE_DURATION);
+    final var provider = new RdbmsTableRowCountProvider(mapper, DEFAULT_CACHE_DURATION, executor);
 
-    // when
-    final long rowCount = provider.getRowCount("PROCESS_INSTANCE");
+    // when - the first load happens asynchronously, off this thread
+    provider.getRowCount("PROCESS_INSTANCE");
+    awaitPendingLoad();
 
     // then
-    assertThat(rowCount).isEqualTo(42L);
+    assertThat(provider.getRowCount("PROCESS_INSTANCE")).isEqualTo(42L);
   }
 
   @Test
-  void shouldCacheRowCountWithinCacheDuration() {
+  void shouldReturnNegativeOneWhileFirstLoadIsStillInFlight() throws Exception {
+    // given - the mapper call is parked until the test releases it, simulating a slow/stuck
+    // database
+    final var loadStarted = new CountDownLatch(1);
+    final var releaseLoad = new CountDownLatch(1);
+    when(mapper.countTableRows("PROCESS_INSTANCE"))
+        .thenAnswer(
+            invocation -> {
+              loadStarted.countDown();
+              releaseLoad.await();
+              return 42L;
+            });
+    final var provider = new RdbmsTableRowCountProvider(mapper, DEFAULT_CACHE_DURATION, executor);
+
+    // when - the very first read triggers the load but must never block on it
+    final long rowCountWhileLoading = provider.getRowCount("PROCESS_INSTANCE");
+    assertThat(loadStarted.await(5, TimeUnit.SECONDS))
+        .as("the async load should have started")
+        .isTrue();
+
+    // then
+    assertThat(rowCountWhileLoading).isEqualTo(-1L);
+
+    // and - once the load completes, the real value becomes available
+    releaseLoad.countDown();
+    awaitPendingLoad();
+    assertThat(provider.getRowCount("PROCESS_INSTANCE")).isEqualTo(42L);
+  }
+
+  @Test
+  void shouldCacheRowCountWithinCacheDuration() throws Exception {
     // given
     when(mapper.countTableRows("PROCESS_INSTANCE")).thenReturn(42L);
-    final var provider = new RdbmsTableRowCountProvider(mapper, Duration.ofHours(1));
+    final var provider = new RdbmsTableRowCountProvider(mapper, Duration.ofHours(1), executor);
 
-    // when - request the row count multiple times
+    // when - wait for the first (async) load, then request the row count multiple times
     provider.getRowCount("PROCESS_INSTANCE");
+    awaitPendingLoad();
     provider.getRowCount("PROCESS_INSTANCE");
     provider.getRowCount("PROCESS_INSTANCE");
 
@@ -58,23 +108,59 @@ class RdbmsTableRowCountProviderTest {
   }
 
   @Test
-  void shouldReturnNegativeOneOnMapperException() {
+  void shouldReturnNegativeOneOnMapperException() throws Exception {
     // given
     when(mapper.countTableRows("PROCESS_INSTANCE"))
         .thenThrow(new RuntimeException("Database error"));
-    final var provider = new RdbmsTableRowCountProvider(mapper, DEFAULT_CACHE_DURATION);
+    final var provider = new RdbmsTableRowCountProvider(mapper, DEFAULT_CACHE_DURATION, executor);
 
-    // when
-    final long rowCount = provider.getRowCount("PROCESS_INSTANCE");
+    // when - the exception is caught during the async load, not just the initial default
+    provider.getRowCount("PROCESS_INSTANCE");
+    awaitPendingLoad();
 
     // then
-    assertThat(rowCount).isEqualTo(-1L);
+    assertThat(provider.getRowCount("PROCESS_INSTANCE")).isEqualTo(-1L);
+    verify(mapper, times(1)).countTableRows("PROCESS_INSTANCE");
+  }
+
+  @Test
+  void shouldKeepPreviousValueWhenRefreshFails() throws Exception {
+    // given - the initial load succeeds; the subsequent refresh (triggered after cache expiry)
+    // fails; the previously cached value must continue to be served
+    final var refreshStarted = new CountDownLatch(1);
+    final var releaseRefresh = new CountDownLatch(1);
+    when(mapper.countTableRows("PROCESS_INSTANCE"))
+        .thenReturn(42L)
+        .thenAnswer(
+            invocation -> {
+              refreshStarted.countDown();
+              releaseRefresh.await();
+              throw new RuntimeException("Database error during refresh");
+            });
+    final var provider = new RdbmsTableRowCountProvider(mapper, Duration.ofMillis(1), executor);
+
+    // load the initial value
+    provider.getRowCount("PROCESS_INSTANCE");
+    awaitPendingLoad();
+    assertThat(provider.getRowCount("PROCESS_INSTANCE")).isEqualTo(42L);
+
+    // when - let the cache entry become stale, then trigger the async refresh
+    Thread.sleep(5); // 5× the 1 ms cache duration; ensures the entry is due for refresh
+    provider.getRowCount("PROCESS_INSTANCE"); // triggers the async refresh off this thread
+    assertThat(refreshStarted.await(5, TimeUnit.SECONDS))
+        .as("the async refresh should have started")
+        .isTrue();
+    releaseRefresh.countDown(); // release the refresh, which then throws
+    awaitPendingLoad(); // wait for the refresh task to finish
+
+    // then - Caffeine retains the previous good value when reload() throws; must not return -1
+    assertThat(provider.getRowCount("PROCESS_INSTANCE")).isEqualTo(42L);
   }
 
   @Test
   void shouldReturnNegativeOneForUnknownTable() {
     // given
-    final var provider = new RdbmsTableRowCountProvider(mapper, DEFAULT_CACHE_DURATION);
+    final var provider = new RdbmsTableRowCountProvider(mapper, DEFAULT_CACHE_DURATION, executor);
 
     // when
     final long rowCount = provider.getRowCount("UNKNOWN_TABLE");

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.util.error.FatalErrorHandler;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,21 +52,20 @@ public class RdbmsConfiguration {
 
   private static final Logger LOG = LoggerFactory.getLogger(RdbmsConfiguration.class);
 
-  @Bean(destroyMethod = "shutdown")
-  public ExecutorService rdbmsMetricsRefreshExecutor() {
+  private static ExecutorService rdbmsMetricsRefreshExecutor(final String physicalTenantId) {
     final var threadFactory =
         Thread.ofPlatform()
-            .name("rdbms-metrics-refresh-", 0)
+            .name("rdbms-metrics-refresh-" + physicalTenantId + "-", 0)
             .uncaughtExceptionHandler(FatalErrorHandler.uncaughtExceptionHandler(LOG))
             .factory();
-    return Executors.newFixedThreadPool(2, threadFactory);
+    return Executors.newFixedThreadPool(1, threadFactory);
   }
 
-  @Bean
+  @Bean(destroyMethod = "close")
   public PhysicalTenantsRdbmsTableRowCountMetrics rdbmsTableRowCountMetrics(
       final Map<String, RdbmsMapperBundle> rdbmsMapperBundles,
-      final PhysicalTenantResolver physicalTenantResolver,
-      final ExecutorService rdbmsMetricsRefreshExecutor) {
+      final PhysicalTenantResolver physicalTenantResolver) {
+    final var executors = new ArrayList<ExecutorService>();
     final var rowCountProviders =
         rdbmsMapperBundles.entrySet().stream()
             .collect(
@@ -80,12 +80,12 @@ public class RdbmsConfiguration {
                               .getRdbms()
                               .getMetrics()
                               .getTableRowCountCacheDuration();
+                      final var executor = rdbmsMetricsRefreshExecutor(e.getKey());
+                      executors.add(executor);
                       return new RdbmsTableRowCountProvider(
-                          e.getValue().tableMetricsMapper(),
-                          cacheDuration,
-                          rdbmsMetricsRefreshExecutor);
+                          e.getValue().tableMetricsMapper(), cacheDuration, executor);
                     }));
-    return new PhysicalTenantsRdbmsTableRowCountMetrics(rowCountProviders);
+    return new PhysicalTenantsRdbmsTableRowCountMetrics(rowCountProviders, executors);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -24,6 +24,7 @@ import io.camunda.search.clients.reader.AuthorizationReader;
 import io.camunda.search.clients.reader.PhysicalTenantSearchClientReaders;
 import io.camunda.search.clients.reader.SearchClientReaders;
 import io.camunda.security.core.authz.ResourceAccessController;
+import io.camunda.zeebe.util.error.FatalErrorHandler;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
@@ -31,6 +32,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,10 +51,21 @@ public class RdbmsConfiguration {
 
   private static final Logger LOG = LoggerFactory.getLogger(RdbmsConfiguration.class);
 
+  @Bean(destroyMethod = "shutdown")
+  public ExecutorService rdbmsMetricsRefreshExecutor() {
+    final var threadFactory =
+        Thread.ofPlatform()
+            .name("rdbms-metrics-refresh-", 0)
+            .uncaughtExceptionHandler(FatalErrorHandler.uncaughtExceptionHandler(LOG))
+            .factory();
+    return Executors.newFixedThreadPool(2, threadFactory);
+  }
+
   @Bean
   public PhysicalTenantsRdbmsTableRowCountMetrics rdbmsTableRowCountMetrics(
       final Map<String, RdbmsMapperBundle> rdbmsMapperBundles,
-      final PhysicalTenantResolver physicalTenantResolver) {
+      final PhysicalTenantResolver physicalTenantResolver,
+      final ExecutorService rdbmsMetricsRefreshExecutor) {
     final var rowCountProviders =
         rdbmsMapperBundles.entrySet().stream()
             .collect(
@@ -67,7 +81,9 @@ public class RdbmsConfiguration {
                               .getMetrics()
                               .getTableRowCountCacheDuration();
                       return new RdbmsTableRowCountProvider(
-                          e.getValue().tableMetricsMapper(), cacheDuration);
+                          e.getValue().tableMetricsMapper(),
+                          cacheDuration,
+                          rdbmsMetricsRefreshExecutor);
                     }));
     return new PhysicalTenantsRdbmsTableRowCountMetrics(rowCountProviders);
   }


### PR DESCRIPTION
## Summary

`PhysicalTenantsRdbmsTableRowCountMetrics` exposes a Prometheus gauge per RDBMS table whose value supplier (`RdbmsTableRowCountProvider.getRowCount`) ran a synchronous, unbounded `COUNT(*)` query against the database on every scrape, cached for a fixed duration (default 15 min) via a plain Caffeine `expireAfterWrite` cache.

If the database becomes slow or unreachable, the *first* scrape after the cache entry expires blocks the scrape-handling thread indefinitely (no query timeout is configured for RDBMS anywhere in this codebase). Reproduced in a load test: after killing the backing Postgres instance, Prometheus metrics for the whole cluster silently stopped ~5 minutes later (matching the cache duration) even though the broker/engine kept running — because the scrape endpoint thread was stuck waiting on a dead connection.

- **Motivation**: this metrics endpoint should never be able to block on the database, regardless of DB health.
- **Fix**: switch `RdbmsTableRowCountProvider` to Caffeine's `refreshAfterWrite` + `buildAsync`, backed by a small bounded, dedicated executor. `getRowCount` now always returns immediately — either the last successfully loaded value, or `-1` if no load has completed yet (e.g. first call, or a load currently in flight) — while the (potentially slow/blocking) reload runs off-thread.
- The executor is shared across all physical tenants' providers and bounded to 2 threads, so even if every table's refresh across every tenant hangs simultaneously, this can never grow unbounded or starve the connection pool used by other read paths.