### PR TITLE
test: add regression tests for DefaultExporterResourceProvider

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -31,6 +31,8 @@ import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerRegistry;
@@ -42,6 +44,8 @@ import io.camunda.zeebe.protocol.record.ValueTypeMapping;
 import java.lang.reflect.ParameterizedType;
 import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -385,6 +389,9 @@ public class DefaultExporterResourceProviderTest {
     final var decisionRequirementsCache = resourceProvider.getDecisionRequirementsCache();
     final var formCache = resourceProvider.getFormCache();
     final var processIndex = resourceProvider.getIndexDescriptor(ProcessIndex.class);
+    final var exportHandlersByIdentity =
+        Collections.newSetFromMap(new IdentityHashMap<ExportHandler<?, ?>, Boolean>());
+    exportHandlersByIdentity.addAll(resourceProvider.getExportHandlers());
 
     // when
     resourceProvider.reset();
@@ -405,27 +412,42 @@ public class DefaultExporterResourceProviderTest {
         .isNotSameAs(processIndex)
         .extracting(IndexDescriptor::getFullQualifiedName)
         .isEqualTo(processIndex.getFullQualifiedName());
-    assertThat(resourceProvider.getExportHandlers()).isNotEmpty();
+    assertThat(resourceProvider.getExportHandlers())
+        .isNotEmpty()
+        .noneMatch(exportHandlersByIdentity::contains);
   }
 
   @Test
-  void shouldIgnoreMissingDocumentErrorsOnlyForOperationIndex() {
+  void shouldIgnoreMissingDocumentErrorsOnlyForConfiguredIndices() {
     // given
     final var resourceProvider = initializedProvider(mock(ExporterEntityCacheProvider.class));
     final var operationIndex =
         resourceProvider.getIndexTemplateDescriptor(OperationTemplate.class).getFullQualifiedName();
+    final var batchOperationIndex =
+        resourceProvider
+            .getIndexTemplateDescriptor(BatchOperationTemplate.class)
+            .getFullQualifiedName();
+    final var listViewIndex =
+        resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class).getFullQualifiedName();
+    final var processIndex =
+        resourceProvider.getIndexDescriptor(ProcessIndex.class).getFullQualifiedName();
     final var formIndex =
         resourceProvider.getIndexDescriptor(FormIndex.class).getFullQualifiedName();
     final var customErrorHandlers = resourceProvider.getCustomErrorHandlers();
     final var missingDocument = new Error("missing", "document_missing_exception", 404);
     final var versionConflict = new Error("conflict", "version_conflict_engine_exception", 409);
 
-    // when
-    final var missingOperationError =
-        catchThrowable(() -> customErrorHandlers.accept(operationIndex, missingDocument));
-
     // then
-    assertThat(missingOperationError).isNull();
+    assertThat(catchThrowable(() -> customErrorHandlers.accept(operationIndex, missingDocument)))
+        .isNull();
+    assertThat(
+            catchThrowable(() -> customErrorHandlers.accept(batchOperationIndex, missingDocument)))
+        .isNull();
+    assertThat(catchThrowable(() -> customErrorHandlers.accept(listViewIndex, missingDocument)))
+        .isNull();
+    assertThat(catchThrowable(() -> customErrorHandlers.accept(processIndex, missingDocument)))
+        .isNull();
+
     assertThatThrownBy(() -> customErrorHandlers.accept(formIndex, missingDocument))
         .isInstanceOf(PersistenceException.class)
         .hasMessage("missing");

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -10,6 +10,7 @@ package io.camunda.exporter;
 import static io.camunda.exporter.DefaultExporterResourceProvider.PROCESS_DEFINITION_PARTITION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.Mockito.mock;
 
@@ -28,6 +29,9 @@ import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.ComponentNames;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.index.FormIndex;
+import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerRegistry;
 import io.camunda.zeebe.exporter.common.waitstate.transformers.WaitStateTransformerRegistry;
@@ -420,6 +424,82 @@ public class DefaultExporterResourceProviderTest {
 
     final var handlers = provider.getCustomErrorHandlers();
     return handlers;
+  }
+
+  @Test
+  void shouldRecreateStateAfterResetAndInit() {
+    // given
+    final var resourceProvider = initializedProvider(mock(ExporterEntityCacheProvider.class));
+    final var processCache = resourceProvider.getProcessCache();
+    final var decisionRequirementsCache = resourceProvider.getDecisionRequirementsCache();
+    final var formCache = resourceProvider.getFormCache();
+    final var processIndex = resourceProvider.getIndexDescriptor(ProcessIndex.class);
+
+    // when
+    resourceProvider.reset();
+    final var processCacheAfterReset = resourceProvider.getProcessCache();
+    final var decisionRequirementsCacheAfterReset = resourceProvider.getDecisionRequirementsCache();
+    final var formCacheAfterReset = resourceProvider.getFormCache();
+    initProvider(resourceProvider, mock(ExporterEntityCacheProvider.class));
+
+    // then
+    assertThat(processCacheAfterReset).isNull();
+    assertThat(decisionRequirementsCacheAfterReset).isNull();
+    assertThat(formCacheAfterReset).isNull();
+    assertThat(resourceProvider.getProcessCache()).isNotSameAs(processCache);
+    assertThat(resourceProvider.getDecisionRequirementsCache())
+        .isNotSameAs(decisionRequirementsCache);
+    assertThat(resourceProvider.getFormCache()).isNotSameAs(formCache);
+    assertThat(resourceProvider.getIndexDescriptor(ProcessIndex.class))
+        .isNotSameAs(processIndex)
+        .extracting(IndexDescriptor::getFullQualifiedName)
+        .isEqualTo(processIndex.getFullQualifiedName());
+    assertThat(resourceProvider.getExportHandlers()).isNotEmpty();
+  }
+
+  @Test
+  void shouldIgnoreMissingDocumentErrorsOnlyForOperationIndex() {
+    // given
+    final var resourceProvider = initializedProvider(mock(ExporterEntityCacheProvider.class));
+    final var operationIndex =
+        resourceProvider.getIndexTemplateDescriptor(OperationTemplate.class).getFullQualifiedName();
+    final var formIndex =
+        resourceProvider.getIndexDescriptor(FormIndex.class).getFullQualifiedName();
+    final var customErrorHandlers = resourceProvider.getCustomErrorHandlers();
+    final var missingDocument = new Error("missing", "document_missing_exception", 404);
+    final var versionConflict = new Error("conflict", "version_conflict_engine_exception", 409);
+
+    // when
+    final var missingOperationError =
+        catchThrowable(() -> customErrorHandlers.accept(operationIndex, missingDocument));
+
+    // then
+    assertThat(missingOperationError).isNull();
+    assertThatThrownBy(() -> customErrorHandlers.accept(formIndex, missingDocument))
+        .isInstanceOf(PersistenceException.class)
+        .hasMessage("missing");
+    assertThatThrownBy(() -> customErrorHandlers.accept(operationIndex, versionConflict))
+        .isInstanceOf(PersistenceException.class)
+        .hasMessage("conflict");
+  }
+
+  private DefaultExporterResourceProvider initializedProvider(
+      final ExporterEntityCacheProvider cacheProvider) {
+    final var resourceProvider = new DefaultExporterResourceProvider();
+    initProvider(resourceProvider, cacheProvider);
+    return resourceProvider;
+  }
+
+  private void initProvider(
+      final DefaultExporterResourceProvider resourceProvider,
+      final ExporterEntityCacheProvider cacheProvider) {
+    final var objectMapper = TestObjectMapper.objectMapper();
+    resourceProvider.init(
+        new ExporterConfiguration(),
+        cacheProvider,
+        new ExporterTestContext(),
+        new ExporterMetadata(objectMapper),
+        objectMapper);
   }
 
   /**

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -29,7 +29,6 @@ import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.ComponentNames;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
-import io.camunda.webapps.schema.descriptors.index.FormIndex;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
@@ -48,6 +47,7 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -431,26 +431,45 @@ public class DefaultExporterResourceProviderTest {
         resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class).getFullQualifiedName();
     final var processIndex =
         resourceProvider.getIndexDescriptor(ProcessIndex.class).getFullQualifiedName();
-    final var formIndex =
-        resourceProvider.getIndexDescriptor(FormIndex.class).getFullQualifiedName();
+    final var configuredIndices =
+        Set.of(operationIndex, batchOperationIndex, listViewIndex, processIndex);
     final var customErrorHandlers = resourceProvider.getCustomErrorHandlers();
-    final var missingDocument = new Error("missing", "document_missing_exception", 404);
+    // isolate each side of the production `status == 404 || type == document_missing_exception`
+    // check so a regression collapsing it to `&&` fails one of these, not just the combined case
+    final var missingDocumentByStatusOnly = new Error("missing", "some_other_exception_type", 404);
+    final var missingDocumentByTypeOnly = new Error("missing", "document_missing_exception", 400);
     final var versionConflict = new Error("conflict", "version_conflict_engine_exception", 409);
 
     // then
-    assertThat(catchThrowable(() -> customErrorHandlers.accept(operationIndex, missingDocument)))
-        .isNull();
-    assertThat(
-            catchThrowable(() -> customErrorHandlers.accept(batchOperationIndex, missingDocument)))
-        .isNull();
-    assertThat(catchThrowable(() -> customErrorHandlers.accept(listViewIndex, missingDocument)))
-        .isNull();
-    assertThat(catchThrowable(() -> customErrorHandlers.accept(processIndex, missingDocument)))
-        .isNull();
+    configuredIndices.forEach(
+        index -> {
+          assertThat(
+                  catchThrowable(
+                      () -> customErrorHandlers.accept(index, missingDocumentByStatusOnly)))
+              .isNull();
+          assertThat(
+                  catchThrowable(
+                      () -> customErrorHandlers.accept(index, missingDocumentByTypeOnly)))
+              .isNull();
+        });
 
-    assertThatThrownBy(() -> customErrorHandlers.accept(formIndex, missingDocument))
-        .isInstanceOf(PersistenceException.class)
-        .hasMessage("missing");
+    // exhaustively assert every other index/template still throws, so the "only" claim keeps
+    // holding even if a future index is added to the ignore list without updating this test
+    final var otherIndices =
+        Stream.concat(
+                resourceProvider.getIndexDescriptors().stream()
+                    .map(IndexDescriptor::getFullQualifiedName),
+                resourceProvider.getIndexTemplateDescriptors().stream()
+                    .map(IndexTemplateDescriptor::getFullQualifiedName))
+            .filter(index -> !configuredIndices.contains(index))
+            .toList();
+    assertThat(otherIndices).isNotEmpty();
+    otherIndices.forEach(
+        index ->
+            assertThatThrownBy(() -> customErrorHandlers.accept(index, missingDocumentByStatusOnly))
+                .isInstanceOf(PersistenceException.class)
+                .hasMessage("missing"));
+
     assertThatThrownBy(() -> customErrorHandlers.accept(operationIndex, versionConflict))
         .isInstanceOf(PersistenceException.class)
         .hasMessage("conflict");

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -31,6 +31,8 @@ import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerRegistry;
@@ -42,6 +44,8 @@ import io.camunda.zeebe.protocol.record.ValueTypeMapping;
 import java.lang.reflect.ParameterizedType;
 import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -434,6 +438,9 @@ public class DefaultExporterResourceProviderTest {
     final var decisionRequirementsCache = resourceProvider.getDecisionRequirementsCache();
     final var formCache = resourceProvider.getFormCache();
     final var processIndex = resourceProvider.getIndexDescriptor(ProcessIndex.class);
+    final var exportHandlersByIdentity =
+        Collections.newSetFromMap(new IdentityHashMap<ExportHandler<?, ?>, Boolean>());
+    exportHandlersByIdentity.addAll(resourceProvider.getExportHandlers());
 
     // when
     resourceProvider.reset();
@@ -454,27 +461,42 @@ public class DefaultExporterResourceProviderTest {
         .isNotSameAs(processIndex)
         .extracting(IndexDescriptor::getFullQualifiedName)
         .isEqualTo(processIndex.getFullQualifiedName());
-    assertThat(resourceProvider.getExportHandlers()).isNotEmpty();
+    assertThat(resourceProvider.getExportHandlers())
+        .isNotEmpty()
+        .noneMatch(exportHandlersByIdentity::contains);
   }
 
   @Test
-  void shouldIgnoreMissingDocumentErrorsOnlyForOperationIndex() {
+  void shouldIgnoreMissingDocumentErrorsOnlyForConfiguredIndices() {
     // given
     final var resourceProvider = initializedProvider(mock(ExporterEntityCacheProvider.class));
     final var operationIndex =
         resourceProvider.getIndexTemplateDescriptor(OperationTemplate.class).getFullQualifiedName();
+    final var batchOperationIndex =
+        resourceProvider
+            .getIndexTemplateDescriptor(BatchOperationTemplate.class)
+            .getFullQualifiedName();
+    final var listViewIndex =
+        resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class).getFullQualifiedName();
+    final var processIndex =
+        resourceProvider.getIndexDescriptor(ProcessIndex.class).getFullQualifiedName();
     final var formIndex =
         resourceProvider.getIndexDescriptor(FormIndex.class).getFullQualifiedName();
     final var customErrorHandlers = resourceProvider.getCustomErrorHandlers();
     final var missingDocument = new Error("missing", "document_missing_exception", 404);
     final var versionConflict = new Error("conflict", "version_conflict_engine_exception", 409);
 
-    // when
-    final var missingOperationError =
-        catchThrowable(() -> customErrorHandlers.accept(operationIndex, missingDocument));
-
     // then
-    assertThat(missingOperationError).isNull();
+    assertThat(catchThrowable(() -> customErrorHandlers.accept(operationIndex, missingDocument)))
+        .isNull();
+    assertThat(
+            catchThrowable(() -> customErrorHandlers.accept(batchOperationIndex, missingDocument)))
+        .isNull();
+    assertThat(catchThrowable(() -> customErrorHandlers.accept(listViewIndex, missingDocument)))
+        .isNull();
+    assertThat(catchThrowable(() -> customErrorHandlers.accept(processIndex, missingDocument)))
+        .isNull();
+
     assertThatThrownBy(() -> customErrorHandlers.accept(formIndex, missingDocument))
         .isInstanceOf(PersistenceException.class)
         .hasMessage("missing");

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -9,11 +9,15 @@ package io.camunda.exporter;
 
 import static io.camunda.exporter.DefaultExporterResourceProvider.PROCESS_DEFINITION_PARTITION;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.Mockito.mock;
 
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.errorhandling.Error;
+import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.handlers.auditlog.AuditLogCleanupHandler;
 import io.camunda.exporter.handlers.auditlog.AuditLogHandler;
@@ -25,6 +29,9 @@ import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.ComponentNames;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.index.FormIndex;
+import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerRegistry;
 import io.camunda.zeebe.exporter.common.waitstate.transformers.WaitStateTransformerRegistry;
@@ -368,6 +375,82 @@ public class DefaultExporterResourceProviderTest {
                 .isEqualTo(expectedValueType);
           }
         });
+  }
+
+  @Test
+  void shouldRecreateStateAfterResetAndInit() {
+    // given
+    final var resourceProvider = initializedProvider(mock(ExporterEntityCacheProvider.class));
+    final var processCache = resourceProvider.getProcessCache();
+    final var decisionRequirementsCache = resourceProvider.getDecisionRequirementsCache();
+    final var formCache = resourceProvider.getFormCache();
+    final var processIndex = resourceProvider.getIndexDescriptor(ProcessIndex.class);
+
+    // when
+    resourceProvider.reset();
+    final var processCacheAfterReset = resourceProvider.getProcessCache();
+    final var decisionRequirementsCacheAfterReset = resourceProvider.getDecisionRequirementsCache();
+    final var formCacheAfterReset = resourceProvider.getFormCache();
+    initProvider(resourceProvider, mock(ExporterEntityCacheProvider.class));
+
+    // then
+    assertThat(processCacheAfterReset).isNull();
+    assertThat(decisionRequirementsCacheAfterReset).isNull();
+    assertThat(formCacheAfterReset).isNull();
+    assertThat(resourceProvider.getProcessCache()).isNotSameAs(processCache);
+    assertThat(resourceProvider.getDecisionRequirementsCache())
+        .isNotSameAs(decisionRequirementsCache);
+    assertThat(resourceProvider.getFormCache()).isNotSameAs(formCache);
+    assertThat(resourceProvider.getIndexDescriptor(ProcessIndex.class))
+        .isNotSameAs(processIndex)
+        .extracting(IndexDescriptor::getFullQualifiedName)
+        .isEqualTo(processIndex.getFullQualifiedName());
+    assertThat(resourceProvider.getExportHandlers()).isNotEmpty();
+  }
+
+  @Test
+  void shouldIgnoreMissingDocumentErrorsOnlyForOperationIndex() {
+    // given
+    final var resourceProvider = initializedProvider(mock(ExporterEntityCacheProvider.class));
+    final var operationIndex =
+        resourceProvider.getIndexTemplateDescriptor(OperationTemplate.class).getFullQualifiedName();
+    final var formIndex =
+        resourceProvider.getIndexDescriptor(FormIndex.class).getFullQualifiedName();
+    final var customErrorHandlers = resourceProvider.getCustomErrorHandlers();
+    final var missingDocument = new Error("missing", "document_missing_exception", 404);
+    final var versionConflict = new Error("conflict", "version_conflict_engine_exception", 409);
+
+    // when
+    final var missingOperationError =
+        catchThrowable(() -> customErrorHandlers.accept(operationIndex, missingDocument));
+
+    // then
+    assertThat(missingOperationError).isNull();
+    assertThatThrownBy(() -> customErrorHandlers.accept(formIndex, missingDocument))
+        .isInstanceOf(PersistenceException.class)
+        .hasMessage("missing");
+    assertThatThrownBy(() -> customErrorHandlers.accept(operationIndex, versionConflict))
+        .isInstanceOf(PersistenceException.class)
+        .hasMessage("conflict");
+  }
+
+  private DefaultExporterResourceProvider initializedProvider(
+      final ExporterEntityCacheProvider cacheProvider) {
+    final var resourceProvider = new DefaultExporterResourceProvider();
+    initProvider(resourceProvider, cacheProvider);
+    return resourceProvider;
+  }
+
+  private void initProvider(
+      final DefaultExporterResourceProvider resourceProvider,
+      final ExporterEntityCacheProvider cacheProvider) {
+    final var objectMapper = TestObjectMapper.objectMapper();
+    resourceProvider.init(
+        new ExporterConfiguration(),
+        cacheProvider,
+        new ExporterTestContext(),
+        new ExporterMetadata(objectMapper),
+        objectMapper);
   }
 
   /**

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -29,7 +29,6 @@ import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.ComponentNames;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
-import io.camunda.webapps.schema.descriptors.index.FormIndex;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
@@ -48,6 +47,7 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -480,26 +480,45 @@ public class DefaultExporterResourceProviderTest {
         resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class).getFullQualifiedName();
     final var processIndex =
         resourceProvider.getIndexDescriptor(ProcessIndex.class).getFullQualifiedName();
-    final var formIndex =
-        resourceProvider.getIndexDescriptor(FormIndex.class).getFullQualifiedName();
+    final var configuredIndices =
+        Set.of(operationIndex, batchOperationIndex, listViewIndex, processIndex);
     final var customErrorHandlers = resourceProvider.getCustomErrorHandlers();
-    final var missingDocument = new Error("missing", "document_missing_exception", 404);
+    // isolate each side of the production `status == 404 || type == document_missing_exception`
+    // check so a regression collapsing it to `&&` fails one of these, not just the combined case
+    final var missingDocumentByStatusOnly = new Error("missing", "some_other_exception_type", 404);
+    final var missingDocumentByTypeOnly = new Error("missing", "document_missing_exception", 400);
     final var versionConflict = new Error("conflict", "version_conflict_engine_exception", 409);
 
     // then
-    assertThat(catchThrowable(() -> customErrorHandlers.accept(operationIndex, missingDocument)))
-        .isNull();
-    assertThat(
-            catchThrowable(() -> customErrorHandlers.accept(batchOperationIndex, missingDocument)))
-        .isNull();
-    assertThat(catchThrowable(() -> customErrorHandlers.accept(listViewIndex, missingDocument)))
-        .isNull();
-    assertThat(catchThrowable(() -> customErrorHandlers.accept(processIndex, missingDocument)))
-        .isNull();
+    configuredIndices.forEach(
+        index -> {
+          assertThat(
+                  catchThrowable(
+                      () -> customErrorHandlers.accept(index, missingDocumentByStatusOnly)))
+              .isNull();
+          assertThat(
+                  catchThrowable(
+                      () -> customErrorHandlers.accept(index, missingDocumentByTypeOnly)))
+              .isNull();
+        });
 
-    assertThatThrownBy(() -> customErrorHandlers.accept(formIndex, missingDocument))
-        .isInstanceOf(PersistenceException.class)
-        .hasMessage("missing");
+    // exhaustively assert every other index/template still throws, so the "only" claim keeps
+    // holding even if a future index is added to the ignore list without updating this test
+    final var otherIndices =
+        Stream.concat(
+                resourceProvider.getIndexDescriptors().stream()
+                    .map(IndexDescriptor::getFullQualifiedName),
+                resourceProvider.getIndexTemplateDescriptors().stream()
+                    .map(IndexTemplateDescriptor::getFullQualifiedName))
+            .filter(index -> !configuredIndices.contains(index))
+            .toList();
+    assertThat(otherIndices).isNotEmpty();
+    otherIndices.forEach(
+        index ->
+            assertThatThrownBy(() -> customErrorHandlers.accept(index, missingDocumentByStatusOnly))
+                .isInstanceOf(PersistenceException.class)
+                .hasMessage("missing"));
+
     assertThatThrownBy(() -> customErrorHandlers.accept(operationIndex, versionConflict))
         .isInstanceOf(PersistenceException.class)
         .hasMessage("conflict");


### PR DESCRIPTION
## Summary

Cherry-picks the commit from #55822 by @amirdeljouyi so it runs through full CI (external
contribution PRs don't trigger the required workflows), then adds a follow-up commit that
resolves the rebase against `main` and strengthens two assertions found during review.

- `3b04c09` (original, author preserved): adds `shouldRecreateStateAfterResetAndInit` and
  `shouldIgnoreMissingDocumentErrorsOnlyForOperationIndex` to
  `DefaultExporterResourceProviderTest`, covering `reset()`/`init()` state recreation and the
  custom error-handler ignore behavior.
- Follow-up commit: the recreation check only asserted `getExportHandlers()` was non-empty,
  which passes even without real recreation; switched to a reference-identity comparison since
  `UsageMetricExportedHandler` is a record with value equality. Also extended the error-handler
  test to cover all four indices currently configured to ignore missing-document errors
  (`OperationTemplate`, `BatchOperationTemplate`, `ListViewTemplate`, `ProcessIndex`), not just
  the operation index, so the "only" in the test actually holds.

Test-only change, no production code touched.