### PR TITLE
fix: remove flaky time-fill race in DateRangeField tests

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.test.tsx
@@ -102,26 +102,15 @@ describe('<DateRangeField />', () => {
 		const screen = await render(<MockDateRangeField />, {wrapper: getWrapper()});
 
 		await screen.getByLabelText('Start Date Range').click();
+		// Times before dates, on purpose. Setting a date leaves flatpickr with a deferred range
+		// commit that only runs once focus leaves the date input, and that commit fills any time
+		// field it finds empty with the default. Writing the times first means the fields are
+		// never empty when it runs, so it cannot overwrite them — the ordering is what makes this
+		// deterministic. Dates first needs a retry to survive that race (INC-6825, INC-6762).
+		await screen.getByTestId('fromTime').fill('12:30:00');
+		await screen.getByTestId('toTime').fill('17:15:00');
 		await screen.getByLabelText('From date').fill('2022-01-01');
 		await screen.getByLabelText('To date').fill('2022-12-01');
-		// Typing a date asynchronously resets the time fields to their defaults via the
-		// calendar's onChange (ported 1:1 from legacy). Under CI/parallel-test CPU pressure
-		// that reset can race a same-tick time fill, so retry the fill until it sticks —
-		// a real user's fill is never fast enough to hit this window.
-		await expect.element(screen.getByLabelText('From date')).toHaveValue('2022-01-01');
-		await expect.element(screen.getByLabelText('To date')).toHaveValue('2022-12-01');
-		await expect
-			.poll(async () => {
-				await screen.getByTestId('fromTime').fill('12:30:00');
-				return (screen.getByTestId('fromTime').element() as HTMLInputElement).value;
-			})
-			.toBe('12:30:00');
-		await expect
-			.poll(async () => {
-				await screen.getByTestId('toTime').fill('17:15:00');
-				return (screen.getByTestId('toTime').element() as HTMLInputElement).value;
-			})
-			.toBe('17:15:00');
 		await applyDateRange(screen);
 
 		await expect

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.tracking.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.tracking.test.tsx
@@ -89,25 +89,11 @@ describe('<DateRangeField /> tracking', () => {
 			filterName: 'startDateRange',
 		});
 
+		// Times before dates — see DateRangeField.test.tsx for why the order matters.
+		await screen.getByTestId('fromTime').fill('12:30:00');
+		await screen.getByTestId('toTime').fill('17:15:00');
 		await screen.getByLabelText('From date').fill('2022-01-01');
 		await screen.getByLabelText('To date').fill('2022-12-01');
-		// Typing a date asynchronously resets the time fields to their defaults via the
-		// calendar's onChange; under CI/parallel-test CPU pressure that reset can race a
-		// same-tick time fill, so retry the fill until it sticks (see DateRangeField.test.tsx).
-		await expect.element(screen.getByLabelText('From date')).toHaveValue('2022-01-01');
-		await expect.element(screen.getByLabelText('To date')).toHaveValue('2022-12-01');
-		await expect
-			.poll(async () => {
-				await screen.getByTestId('fromTime').fill('12:30:00');
-				return (screen.getByTestId('fromTime').element() as HTMLInputElement).value;
-			})
-			.toBe('12:30:00');
-		await expect
-			.poll(async () => {
-				await screen.getByTestId('toTime').fill('17:15:00');
-				return (screen.getByTestId('toTime').element() as HTMLInputElement).value;
-			})
-			.toBe('17:15:00');
 		await applyDateRange(screen);
 
 		expect(trackSpy).toHaveBeenNthCalledWith(2, {


### PR DESCRIPTION
## Description

Fixes the flaky test behind [INC-6825](https://app.incident.io/camunda/incidents/6825): `should apply from and to dates` in `DateRangeField.test.tsx` occasionally applied `00:00:00`/`23:59:59` instead of the typed time.

Setting a date in `DateRangeModal` leaves flatpickr with a deferred range commit that only runs once focus leaves the date input, and that commit fills any time field it finds empty with its default. Both affected tests typed dates first, so under CI/parallel-test CPU pressure the deferred commit could land after the typed time and overwrite it.

The previous fix for the same root cause ([INC-6762](https://app.incident.io/camunda/incidents/6762), #58808) retried the time fill until it stuck. That doesn't remove the race, it just rerolls it — it held for two days before this incident recurred.

Fix: type the times before the dates. The fields are then never empty when the deferred commit runs, so it has nothing to overwrite — this removes the precondition of the race instead of retrying against it. Test-only change, no product code touched.

## Related issues

closes [INC-6825](https://app.incident.io/camunda/incidents/6825)
