### PR TITLE
ci: dispatch a fix agent for AlwaysGreen failures on main (initial implementation)

### DIFF
--- a/.github/actions/alwaysgreen-flag/action.yaml
+++ b/.github/actions/alwaysgreen-flag/action.yaml
@@ -24,13 +24,13 @@ inputs:
 
 outputs:
   mode:
-    description: off | dry-run | on
+    description: disabled | dry-run | enabled
     value: ${{ steps.resolve.outputs.mode }}
-  enabled:
-    description: 'false when mode is off — callers must skip all remaining work'
-    value: ${{ steps.resolve.outputs.enabled }}
+  active:
+    description: 'false when mode is disabled — callers must skip all remaining work'
+    value: ${{ steps.resolve.outputs.active }}
   dispatch:
-    description: 'true only when mode is on and no dry-run was requested'
+    description: 'true only when mode is enabled and no dry-run was requested'
     value: ${{ steps.resolve.outputs.dispatch }}
 
 runs:
@@ -69,29 +69,31 @@ runs:
         fi
 
         case "$mode" in
-          off|dry-run|on) ;;
+          disabled|dry-run|enabled) ;;
           "")
             echo "::notice::AlwaysGreen flag is unset; defaulting to dry-run."
             mode="dry-run"
             ;;
           *)
-            echo "::warning::AlwaysGreen flag is not one of off|dry-run|on; treating as dry-run."
+            echo "::warning::AlwaysGreen flag is not one of disabled|dry-run|enabled; treating as dry-run."
             mode="dry-run"
             ;;
         esac
 
-        enabled=true
+        active=true
         dispatch=false
-        [ "$mode" = "off" ] && enabled=false
-        if [ "$mode" = "on" ] && [ "${DRY_RUN_OVERRIDE}" != "true" ]; then
+        [ "$mode" = "disabled" ] && active=false
+        if [ "$mode" = "enabled" ] && [ "${DRY_RUN_OVERRIDE}" != "true" ]; then
           dispatch=true
         fi
 
         {
           echo "mode=${mode}"
-          echo "enabled=${enabled}"
+          echo "active=${active}"
           echo "dispatch=${dispatch}"
         } >> "$GITHUB_OUTPUT"
-        # The flag value is a Vault secret and therefore masked, so report only the
-        # derived booleans.
-        echo "AlwaysGreen enabled=${enabled} dispatch=${dispatch}"
+        # The flag value is imported as a Vault secret, so GitHub masks it in this job's
+        # logs. Deliberately avoid printing the words "enabled"/"disabled" here: with a
+        # matching flag value they would render as *** and hide the very state being
+        # reported. Booleans are unaffected.
+        echo "AlwaysGreen mode resolved: active=${active} dispatch=${dispatch}"

--- a/.github/actions/alwaysgreen-flag/action.yaml
+++ b/.github/actions/alwaysgreen-flag/action.yaml
@@ -1,0 +1,97 @@
+name: Read AlwaysGreen feature flag
+description: >
+  Resolves the AlwaysGreen fix-agent run mode from the ALWAYSGREEN_FIX_AGENT key at
+  secret/data/products/qa/ci/common.
+
+  Shared by alwaysgreen-triage and alwaysgreen-fix so both resolve the mode identically.
+  Every unresolvable state — key absent, Vault unreachable, value unrecognised —
+  resolves to dry-run, so a mistake withholds dispatch rather than enabling it.
+
+inputs:
+  vault-addr:
+    description: Vault address
+    required: true
+  vault-role-id:
+    description: AppRole role id
+    required: true
+  vault-secret-id:
+    description: AppRole secret id
+    required: true
+  dry-run-override:
+    description: When 'true', force dry-run regardless of the flag
+    required: false
+    default: 'false'
+
+outputs:
+  mode:
+    description: off | dry-run | on
+    value: ${{ steps.resolve.outputs.mode }}
+  enabled:
+    description: 'false when mode is off — callers must skip all remaining work'
+    value: ${{ steps.resolve.outputs.enabled }}
+  dispatch:
+    description: 'true only when mode is on and no dry-run was requested'
+    value: ${{ steps.resolve.outputs.dispatch }}
+
+runs:
+  using: composite
+  steps:
+    # continue-on-error because vault-action fails the step when the key is absent,
+    # which is the expected state before the flag is first created. An absent flag must
+    # leave the pipeline in dry-run, not break it.
+    - name: Import Secrets
+      id: secrets
+      continue-on-error: true
+      uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+      with:
+        url: ${{ inputs.vault-addr }}
+        method: approle
+        roleId: ${{ inputs.vault-role-id }}
+        secretId: ${{ inputs.vault-secret-id }}
+        exportEnv: false
+        secrets: |
+          secret/data/products/qa/ci/common ALWAYSGREEN_FIX_AGENT ;
+
+    - name: Resolve run mode
+      id: resolve
+      shell: bash
+      env:
+        CONFIGURED: ${{ steps.secrets.outputs.ALWAYSGREEN_FIX_AGENT }}
+        IMPORT_OUTCOME: ${{ steps.secrets.outcome }}
+        DRY_RUN_OVERRIDE: ${{ inputs.dry-run-override }}
+      run: |
+        set -uo pipefail
+
+        mode="${CONFIGURED:-}"
+        if [ "${IMPORT_OUTCOME}" != "success" ]; then
+          echo "::notice::AlwaysGreen flag could not be read from Vault (ALWAYSGREEN_FIX_AGENT at secret/data/products/qa/ci/common); defaulting to dry-run."
+          mode=""
+        fi
+
+        case "$mode" in
+          off|dry-run|on) ;;
+          "")
+            echo "::notice::AlwaysGreen flag is unset; defaulting to dry-run."
+            mode="dry-run"
+            ;;
+          *)
+            echo "::warning::AlwaysGreen flag is not one of off|dry-run|on; treating as dry-run."
+            mode="dry-run"
+            ;;
+        esac
+
+        enabled=true
+        dispatch=false
+        [ "$mode" = "off" ] && enabled=false
+        if [ "$mode" = "on" ] && [ "${DRY_RUN_OVERRIDE}" != "true" ]; then
+          dispatch=true
+        fi
+
+        {
+          echo "mode=${mode}"
+          echo "enabled=${enabled}"
+          echo "dispatch=${dispatch}"
+        } >> "$GITHUB_OUTPUT"
+        # The flag value is a Vault secret and therefore masked, so report only the
+        # derived booleans.
+        echo "AlwaysGreen enabled=${enabled} dispatch=${dispatch}"

--- a/.github/actions/post-failure-feedback/action.yml
+++ b/.github/actions/post-failure-feedback/action.yml
@@ -55,10 +55,22 @@ inputs:
     required: false
     default: ""
 
+outputs:
+  slack_ts:
+    description: >
+      Timestamp of the Slack message that was posted, so a later job can reply in its
+      thread instead of starting a second top-level message. Empty when Slack was
+      skipped or the post failed.
+    value: ${{ steps.feedback.outputs.slack_ts }}
+  slack_channel:
+    description: "Channel id the message was posted to. Empty when nothing was posted."
+    value: ${{ steps.feedback.outputs.slack_channel }}
+
 runs:
   using: composite
   steps:
     - name: Render & post failure feedback
+      id: feedback
       shell: bash
       continue-on-error: true
       env:

--- a/.github/actions/post-failure-feedback/feedback.mjs
+++ b/.github/actions/post-failure-feedback/feedback.mjs
@@ -206,6 +206,18 @@ async function upsertPrComment(m, md) {
   }
 }
 
+// Publishes the posted message's identity so a later job in the same run can reply in
+// its thread instead of opening a second top-level message for the same failure.
+async function setStepOutput(name, value) {
+  const file = process.env.GITHUB_OUTPUT;
+  if (!file || !value) return;
+  try {
+    await appendFile(file, `${name}=${value}\n`);
+  } catch (e) {
+    console.error(`[feedback] could not write output ${name}: ${e.message || e}`);
+  }
+}
+
 async function postSlack(m) {
   const channel = env('FB_SLACK_CHANNEL');
   const token = env('SLACK_BOT_TOKEN');
@@ -224,7 +236,9 @@ async function postSlack(m) {
     });
     const j = await res.json();
     if (!j.ok) throw new Error(j.error || 'unknown');
-    console.log(`[feedback] posted to Slack ${channel}`);
+    console.log(`[feedback] posted to Slack ${channel} (ts=${j.ts})`);
+    await setStepOutput('slack_ts', j.ts);
+    await setStepOutput('slack_channel', j.channel || channel);
   } catch (e) {
     console.error(`[feedback] Slack post failed: ${e.message || e}`);
   }

--- a/.github/scripts/alwaysgreen/classify.py
+++ b/.github/scripts/alwaysgreen/classify.py
@@ -1,0 +1,398 @@
+"""Classification logic for AlwaysGreen failure triage.
+
+Pure functions only — no network, no subprocess. `discover.py` supplies the data
+fetched from the GitHub API and the downloaded artifacts. Keeping the two apart is
+what makes this file unit-testable without a cluster or a token.
+
+The rules encoded here were derived from every failed run of
+docker-build-helm-integration.yml in a 300-run window (29 failures). The
+non-obvious ones:
+
+* A `failure` conclusion does not imply a fixable failure. GitHub platform
+  internal errors and mid-job cancellations both surface as `failure` with no
+  usable evidence, and two of the 29 were exactly that.
+* Skipped jobs keep unrendered `${{ }}` in their names, so patterns must anchor
+  on the literal prefix and only failing jobs may be matched.
+* Playwright nests `suites[].suites[].specs[]`. Counting one level deep yields
+  zero and silently mislabels every failure.
+* A failing job name identifies the surface that broke, not the repository that
+  needs the fix: the most common SM e2e failure is a Keycloak deploy problem.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Iterator
+
+# ---------------------------------------------------------------------------
+# Platform noise
+# ---------------------------------------------------------------------------
+
+#: Annotation text GitHub emits when the job never really ran. Matched as a
+#: substring because the message is sometimes wrapped or suffixed.
+PLATFORM_ERROR_MARKER = "internal error when running your job"
+CANCELLED_MARKER = "The operation was canceled"
+
+#: Verdicts that must never reach the fix agent.
+NOISE_PLATFORM = "platform-flake"
+NOISE_CANCELLED = "cancelled"
+NOISE_NO_EVIDENCE = "no-evidence"
+
+
+def noise_verdict(
+    *,
+    conclusion: str,
+    step_count: int,
+    failure_annotations: Iterable[str],
+) -> str | None:
+    """Return a noise verdict for a failing job, or None if it looks diagnosable.
+
+    `failure_annotations` are the messages of the job's failure-level check-run
+    annotations. A job with no steps *and* no failure annotation carries no
+    evidence at all — observed on `Create cluster generation on INT`.
+    """
+    if conclusion != "failure":
+        return None
+
+    messages = [m for m in failure_annotations if m]
+    joined = "\n".join(messages)
+
+    if PLATFORM_ERROR_MARKER in joined:
+        return NOISE_PLATFORM
+    if CANCELLED_MARKER in joined:
+        return NOISE_CANCELLED
+    if step_count == 0 and not messages:
+        return NOISE_NO_EVIDENCE
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Surface classification
+# ---------------------------------------------------------------------------
+
+SURFACE_SM_E2E = "sm-smoke-e2e"
+SURFACE_SAAS_E2E = "saas-smoke-e2e"
+SURFACE_SAAS_PROVISIONING = "saas-provisioning"
+SURFACE_SAAS_INFRA = "saas-infra"
+SURFACE_HELM_INSTALL = "helm-install"
+SURFACE_HELM_CLEANUP = "helm-cleanup"
+SURFACE_BUILD = "build"
+SURFACE_CI_INFRA = "ci-infra"
+
+#: Surfaces the first increment dispatches. Everything else is recorded and
+#: reported but not handed to the agent yet.
+DISPATCHABLE_SURFACES = frozenset({SURFACE_SM_E2E, SURFACE_SAAS_E2E})
+
+#: A pure propagator: it fails whenever the reusable helm workflow failed and
+#: carries no independent signal.
+IGNORED_JOB_PREFIXES = ("Observe Helm chart Integration Tests status",)
+
+#: Literal prefixes, deliberately stopping before the first `${{`, matched
+#: against the trailing segment of a (possibly nested) job name.
+_SURFACE_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("Playwright e2e after install", SURFACE_SM_E2E),
+    ("Trigger SaaS E2E tests", SURFACE_SAAS_E2E),
+    ("install for install on", SURFACE_HELM_INSTALL),
+    ("Cleanup - install on", SURFACE_HELM_CLEANUP),
+    ("Build and Push Docker Image", SURFACE_BUILD),
+    ("Preflight checks", SURFACE_CI_INFRA),
+    ("Check Run Conditions", SURFACE_CI_INFRA),
+    ("Format Identifier", SURFACE_CI_INFRA),
+)
+
+_FRONTEND_BUILD_RE = re.compile(r"^Build \w+ Frontend$")
+
+
+def job_leaf_name(job_name: str) -> str:
+    """Return the last segment of a nested reusable-workflow job name."""
+    return job_name.rsplit("/", 1)[-1].strip()
+
+
+def surface_for_job(job_name: str) -> str | None:
+    """Map a *failing* job name to the surface that broke.
+
+    Callers must filter on `conclusion == "failure"` first: a skipped
+    `Playwright e2e after install …` job is present in most runs and would
+    otherwise be misread as an SM e2e failure.
+    """
+    leaf = job_leaf_name(job_name)
+
+    for ignored in IGNORED_JOB_PREFIXES:
+        if leaf.startswith(ignored):
+            return None
+
+    for prefix, surface in _SURFACE_PREFIXES:
+        if leaf.startswith(prefix):
+            return surface
+
+    if _FRONTEND_BUILD_RE.match(leaf):
+        return SURFACE_BUILD
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Playwright report parsing
+# ---------------------------------------------------------------------------
+
+
+def iter_specs(report: Any) -> Iterator[dict]:
+    """Yield every spec in a Playwright JSON report, at any nesting depth.
+
+    Playwright emits a file-level suite whose `specs` is empty and whose
+    `suites` holds the describe-level suites that actually carry specs, so a
+    single-level walk finds nothing.
+    """
+    if isinstance(report, dict):
+        specs = report.get("specs")
+        if isinstance(specs, list):
+            for spec in specs:
+                if isinstance(spec, dict):
+                    yield spec
+        for value in report.values():
+            if isinstance(value, (dict, list)):
+                yield from iter_specs(value)
+    elif isinstance(report, list):
+        for item in report:
+            if isinstance(item, (dict, list)):
+                yield from iter_specs(item)
+
+
+_SETUP_SPEC_RE = re.compile(r"test-setup\.spec\.[jt]s$")
+
+
+@dataclass(frozen=True)
+class SpecCounts:
+    total: int = 0
+    failed: int = 0
+    flaky: int = 0
+    setup_failed: int = 0
+
+
+def count_specs(report: Any) -> SpecCounts:
+    """Count specs in a report, mirroring the categories the pipeline reports."""
+    total = failed = flaky = setup_failed = 0
+    for spec in iter_specs(report):
+        total += 1
+        ok = spec.get("ok")
+        tests = spec.get("tests") or []
+        retried = any(len((t or {}).get("results") or []) > 1 for t in tests)
+        if ok is False:
+            failed += 1
+            if _SETUP_SPEC_RE.search(spec.get("file") or ""):
+                setup_failed += 1
+        elif ok is True and retried:
+            flaky += 1
+    return SpecCounts(total, failed, flaky, setup_failed)
+
+
+def saas_surface_from_counts(counts: SpecCounts, *, has_artifacts: bool) -> str:
+    """Sub-classify a SaaS downstream failure from real spec counts.
+
+    Deliberately computed here rather than read from the pipeline's own
+    `downstream_category`: that value is produced by a one-level spec walk, so
+    `product` and `mixed` are unreachable and every failure reads as
+    `infrastructure`.
+    """
+    if not has_artifacts or counts.total == 0:
+        return SURFACE_SAAS_INFRA
+    if counts.failed == 0:
+        return SURFACE_SAAS_INFRA
+    if counts.setup_failed == counts.failed:
+        return SURFACE_SAAS_PROVISIONING
+    return SURFACE_SAAS_E2E
+
+
+# ---------------------------------------------------------------------------
+# Spec → source path
+# ---------------------------------------------------------------------------
+
+_ROOTDIR_SUITE_RE = re.compile(r"/dist/tests/(?P<suite>(?:SM-|c8Run-)?\d+\.\d+)/?$")
+
+
+def suite_from_rootdir(root_dir: str | None) -> str | None:
+    """Extract the test-suite directory (e.g. `SM-8.10`) from `config.rootDir`.
+
+    The helm chart points Playwright at the published npm package, so the report's
+    `file` fields are bare basenames like `smoke-tests.spec.js`. `rootDir` carries
+    the resolved suite directory and is the reliable way to recover it.
+    """
+    if not root_dir:
+        return None
+    match = _ROOTDIR_SUITE_RE.search(root_dir.rstrip())
+    return match.group("suite") if match else None
+
+
+def source_spec_path(spec_file: str, *, suite: str | None) -> str:
+    """Map a report `file` value to its path in the e2e test repository.
+
+    The npm package ships compiled `.js`; the source is `.ts`.
+    """
+    name = (spec_file or "").strip()
+    if not name:
+        return ""
+    if name.endswith(".spec.js"):
+        name = name[: -len(".spec.js")] + ".spec.ts"
+    if "/" in name:
+        return name
+    return f"tests/{suite}/{name}" if suite else name
+
+
+# ---------------------------------------------------------------------------
+# Failing-spec extraction
+# ---------------------------------------------------------------------------
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def clean_error(message: str | None, *, limit: int = 600) -> str:
+    """Strip ANSI sequences and control characters, then truncate."""
+    text = _ANSI_RE.sub("", message or "")
+    text = "".join(ch for ch in text if ch >= " " or ch == "\n")
+    return text[:limit]
+
+
+@dataclass
+class FailingSpec:
+    file: str
+    test_name: str
+    error: str = ""
+    project: str = ""
+    attempts: int = 0
+    statuses: list[str] = field(default_factory=list)
+
+    @property
+    def deterministic(self) -> bool:
+        """True when every attempt failed.
+
+        A `failed → passed` sequence is flakiness, which calls for a waiting or
+        retry fix rather than a behavioural change.
+        """
+        return bool(self.statuses) and all(s == "failed" for s in self.statuses)
+
+
+def failing_specs(report: Any, *, suite: str | None = None) -> list[FailingSpec]:
+    """Extract failing specs with their retry history."""
+    out: list[FailingSpec] = []
+    for spec in iter_specs(report):
+        if spec.get("ok") is not False:
+            continue
+        tests = spec.get("tests") or []
+        first = tests[0] if tests else {}
+        results = (first or {}).get("results") or []
+        last = results[-1] if results else {}
+        out.append(
+            FailingSpec(
+                file=source_spec_path(spec.get("file") or "", suite=suite),
+                test_name=spec.get("title") or "",
+                error=clean_error(((last or {}).get("error") or {}).get("message")),
+                project=(first or {}).get("projectName") or "",
+                attempts=len(results),
+                statuses=[r.get("status") or "" for r in results],
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Fingerprints
+# ---------------------------------------------------------------------------
+
+
+def fingerprint(*parts: str) -> str:
+    """Stable 8-character id used for dedupe and for the PR coverage block.
+
+    Failing *step* names are deliberately not an input: they are frequently
+    absent (a cancelled job, or a job whose steps never ran), which would make
+    the same failure hash differently between runs.
+    """
+    joined = "::".join(p or "" for p in parts)
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()[:8]
+
+
+def spec_fingerprint(base_ref: str, surface: str, file: str, test_name: str) -> str:
+    return fingerprint(base_ref, surface, file, test_name)
+
+
+def job_fingerprint(base_ref: str, surface: str, job_name: str) -> str:
+    return fingerprint(base_ref, surface, job_leaf_name(job_name))
+
+
+# ---------------------------------------------------------------------------
+# Blame
+# ---------------------------------------------------------------------------
+
+_BACKPORT_TITLE_RE = re.compile(r"^\[Backport [^\]]+\]\s.*\(#(?P<number>\d+)\)\s*$")
+
+
+def is_bot(login: str | None) -> bool:
+    return bool(login) and login.endswith("[bot]")
+
+
+def originating_pr(prs: list[dict], head_sha: str) -> dict | None:
+    """Pick the PR that actually produced `head_sha`.
+
+    `/commits/{sha}/pulls` also returns open PRs that merely contain the commit
+    as an ancestor, so match on `merge_commit_sha` and fall back to the first
+    entry only when nothing matches.
+    """
+    for pr in prs:
+        if pr.get("merge_commit_sha") == head_sha:
+            return pr
+    return prs[0] if prs else None
+
+
+def backported_pr_number(title: str | None) -> int | None:
+    """Return the original PR number referenced by a backport PR title."""
+    match = _BACKPORT_TITLE_RE.match((title or "").strip())
+    return int(match.group("number")) if match else None
+
+
+@dataclass(frozen=True)
+class Blame:
+    #: Login to request review from; None when only a bot could be identified.
+    reviewer: str | None
+    #: Login to name in the PR body, even when it is a bot.
+    author: str | None
+    pr_number: int | None
+    #: How the reviewer was resolved, for the job summary.
+    via: str
+
+
+def resolve_blame(
+    *,
+    head_sha: str,
+    prs: list[dict],
+    lookup_pr: Any = None,
+) -> Blame:
+    """Resolve the author of the change that broke the run.
+
+    `lookup_pr` is an optional callable taking a PR number and returning a PR
+    dict, used to follow a backport PR to its original. Injected so this stays
+    testable without network access.
+    """
+    pr = originating_pr(prs, head_sha)
+    if pr is None:
+        return Blame(reviewer=None, author=None, pr_number=None, via="no-pr")
+
+    author = (pr.get("user") or {}).get("login")
+    number = pr.get("number")
+
+    if not is_bot(author):
+        return Blame(reviewer=author, author=author, pr_number=number, via="pr-author")
+
+    original_number = backported_pr_number(pr.get("title"))
+    if original_number and lookup_pr:
+        original = lookup_pr(original_number) or {}
+        original_author = (original.get("user") or {}).get("login")
+        if original_author and not is_bot(original_author):
+            return Blame(
+                reviewer=original_author,
+                author=original_author,
+                pr_number=original_number,
+                via="backport-original",
+            )
+
+    return Blame(reviewer=None, author=author, pr_number=number, via="bot-unresolved")

--- a/.github/scripts/alwaysgreen/classify.py
+++ b/.github/scripts/alwaysgreen/classify.py
@@ -69,6 +69,31 @@ def noise_verdict(
 
 
 # ---------------------------------------------------------------------------
+# Base ref
+# ---------------------------------------------------------------------------
+
+_QUEUE_REF_RE = re.compile(r"^gh-readonly-queue/(?P<base>.+?)/pr-\d+")
+
+
+def normalise_base_ref(ref: str) -> str:
+    """Reduce a git ref to the branch the failure belongs to.
+
+    A merge_group run reports `gh-readonly-queue/<base>/pr-<n>-<sha>` as its ref, and a
+    caller may pass a fully-qualified `refs/heads/<base>`. Both must collapse to the
+    base branch: the ref is part of every fingerprint, so a per-PR queue ref would make
+    each run's fingerprints unique and defeat dedupe entirely, and the fix workflow
+    validates the value against the supported branches.
+    """
+    value = (ref or "").strip()
+    if value.startswith("refs/heads/"):
+        value = value[len("refs/heads/") :]
+    match = _QUEUE_REF_RE.match(value)
+    if match:
+        return match.group("base")
+    return value
+
+
+# ---------------------------------------------------------------------------
 # Surface classification
 # ---------------------------------------------------------------------------
 

--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -380,9 +380,15 @@ def main() -> int:
     ap.add_argument("--max-dispatches", type=int, default=2)
     args = ap.parse_args()
 
+    # Normalise before anything derives from it: the ref is part of every fingerprint
+    # and is validated by the fix workflow.
+    base_ref = classify.normalise_base_ref(args.base_ref)
+    if base_ref != args.base_ref:
+        log(f"normalised base_ref '{args.base_ref}' -> '{base_ref}'")
+
     with tempfile.TemporaryDirectory(prefix="alwaysgreen-") as tmp:
         workdir = Path(tmp)
-        candidates, noise = build_candidates(args.run_id, args.base_ref, workdir)
+        candidates, noise = build_candidates(args.run_id, base_ref, workdir)
 
         keys, keys_ok = inflight_keys()
         if not keys_ok:

--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Discover AlwaysGreen failures in a run and emit dispatch payloads.
+
+The I/O shell around `classify` and `plan`: everything here talks to `gh` or the
+filesystem, and every decision is delegated to those two modules so the rules stay
+unit-tested.
+
+Usage:
+    discover.py --run-id 123 --base-ref main [--out plan.json] [--max-dispatches 2]
+
+Writes a JSON object to --out (default stdout):
+
+    {"dispatches": [...], "suppressed": [...], "noise": [...], "blame": {...}}
+
+Exit status is 0 even when nothing is dispatchable — an empty plan is a normal
+outcome, not an error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict
+from pathlib import Path
+
+import classify
+import plan as planning
+
+REPO = os.environ.get("ALWAYSGREEN_REPO", "camunda/camunda")
+E2E_REPO = os.environ.get("ALWAYSGREEN_E2E_REPO", "camunda/c8-cross-component-e2e-tests")
+FIX_WORKFLOW = os.environ.get("ALWAYSGREEN_FIX_WORKFLOW", "alwaysgreen-fix.yml")
+FIX_LABEL = os.environ.get("ALWAYSGREEN_FIX_LABEL", "alwaysgreen-fix")
+
+
+def log(message: str) -> None:
+    print(message, file=sys.stderr)
+
+
+def gh_json_ex(args: list[str], default) -> tuple[object, str]:
+    """Run a gh command expecting JSON. Returns (value, error_text)."""
+    try:
+        out = subprocess.run(
+            ["gh", *args], capture_output=True, text=True, timeout=120, check=True
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        stderr = (getattr(exc, "stderr", "") or str(exc)).strip()
+        log(f"::warning::gh {' '.join(args[:3])} failed: {stderr[:200]}")
+        return default, stderr
+    if not out:
+        return default, ""
+    try:
+        return json.loads(out), ""
+    except json.JSONDecodeError:
+        log(f"::warning::gh {' '.join(args[:3])} returned non-JSON output")
+        return default, "invalid json"
+
+
+def gh_json(args: list[str], default):
+    """Run a gh command expecting JSON on stdout. Returns `default` on any failure."""
+    value, _ = gh_json_ex(args, default)
+    return value
+
+
+def download_artifacts(run_id: str, repo: str, pattern: str, dest: Path) -> bool:
+    dest.mkdir(parents=True, exist_ok=True)
+    try:
+        subprocess.run(
+            [
+                "gh", "run", "download", str(run_id),
+                "--repo", repo, "--pattern", pattern, "--dir", str(dest),
+            ],
+            capture_output=True, text=True, timeout=300, check=True,
+        )
+        return True
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def read_json_files(root: Path, filename: str) -> list[dict]:
+    out = []
+    for path in sorted(root.rglob(filename)):
+        try:
+            out.append(json.loads(path.read_text()))
+        except (json.JSONDecodeError, OSError):
+            log(f"::warning::could not parse {path}")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Failing jobs
+# ---------------------------------------------------------------------------
+
+
+def failure_annotations(check_run_url: str | None) -> list[str]:
+    if not check_run_url:
+        return []
+    path = check_run_url.replace("https://api.github.com/", "")
+    data = gh_json(["api", f"{path}/annotations"], [])
+    if not isinstance(data, list):
+        return []
+    return [
+        a.get("message") or ""
+        for a in data
+        if isinstance(a, dict) and a.get("annotation_level") == "failure"
+    ]
+
+
+def failing_jobs(run_id: str) -> list[dict]:
+    data = gh_json(
+        ["api", f"repos/{REPO}/actions/runs/{run_id}/jobs?per_page=100"], {}
+    )
+    return [
+        j
+        for j in (data.get("jobs") or [])
+        if isinstance(j, dict) and j.get("conclusion") == "failure"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Evidence
+# ---------------------------------------------------------------------------
+
+
+def sm_candidates(run_id: str, base_ref: str, job_name: str, workdir: Path) -> planning.Candidate:
+    """Build the SM candidate from playwright-results-json on the AlwaysGreen run."""
+    cand = planning.Candidate(
+        base_ref=base_ref,
+        surface=classify.SURFACE_SM_E2E,
+        job_name=job_name,
+        evidence_run_url=f"https://github.com/{REPO}/actions/runs/{run_id}",
+        evidence_repo=REPO,
+    )
+    dest = workdir / "sm"
+    if not download_artifacts(run_id, REPO, "playwright-results-json*", dest):
+        log("::warning::no playwright-results-json artifact for the SM e2e failure")
+        return cand
+
+    for report in read_json_files(dest, "playwright-results.json"):
+        suite = classify.suite_from_rootdir(
+            ((report.get("config") or {}).get("rootDir")) if isinstance(report, dict) else None
+        )
+        cand.specs.extend(classify.failing_specs(report, suite=suite))
+    return cand
+
+
+def saas_candidate(run_id: str, base_ref: str, job_name: str, workdir: Path) -> planning.Candidate:
+    """Build the SaaS candidate by following the downstream run into the e2e repo.
+
+    The surface is recomputed from the downstream report rather than taken from the
+    pipeline's own `downstream_category`, which cannot express `product` or `mixed`.
+    """
+    cand = planning.Candidate(
+        base_ref=base_ref, surface=classify.SURFACE_SAAS_INFRA, job_name=job_name
+    )
+
+    cat_dir = workdir / "saas-category"
+    downstream_url = ""
+    if download_artifacts(run_id, REPO, "alwaysgreen-saas-category", cat_dir):
+        for blob in read_json_files(cat_dir, "alwaysgreen-saas-category.json"):
+            downstream_url = blob.get("downstream_run_url") or downstream_url
+
+    if not downstream_url:
+        log("::warning::no downstream SaaS run URL; treating as saas-infra")
+        return cand
+
+    cand.evidence_run_url = downstream_url
+    cand.evidence_repo = E2E_REPO
+    downstream_id = downstream_url.rstrip("/").rsplit("/", 1)[-1]
+
+    arts = gh_json(
+        ["api", f"repos/{E2E_REPO}/actions/runs/{downstream_id}/artifacts?per_page=100"],
+        {},
+    )
+    names = [a.get("name", "") for a in (arts.get("artifacts") or [])]
+    has_reports = any(n.startswith("json-report") for n in names)
+
+    counts = classify.SpecCounts()
+    if has_reports:
+        dest = workdir / "saas"
+        if download_artifacts(downstream_id, E2E_REPO, "json-report*", dest):
+            for report in read_json_files(dest, "results.json"):
+                c = classify.count_specs(report)
+                counts = classify.SpecCounts(
+                    counts.total + c.total,
+                    counts.failed + c.failed,
+                    counts.flaky + c.flaky,
+                    counts.setup_failed + c.setup_failed,
+                )
+                cand.specs.extend(classify.failing_specs(report))
+        else:
+            has_reports = False
+
+    cand.surface = classify.saas_surface_from_counts(counts, has_artifacts=has_reports)
+    log(
+        f"saas counts total={counts.total} failed={counts.failed} "
+        f"flaky={counts.flaky} setup_failed={counts.setup_failed} -> {cand.surface}"
+    )
+    if cand.surface != classify.SURFACE_SAAS_E2E:
+        # Only a genuine non-setup test failure is actionable in test code.
+        cand.specs = []
+    return cand
+
+
+# ---------------------------------------------------------------------------
+# Dedupe inputs
+# ---------------------------------------------------------------------------
+
+
+def covered_fingerprints() -> set[str]:
+    prs = gh_json(
+        [
+            "pr", "list", "--repo", REPO,
+            "--search", f"label:{FIX_LABEL} is:open",
+            "--limit", "100", "--json", "number,body",
+        ],
+        [],
+    )
+    out: set[str] = set()
+    for pr in prs if isinstance(prs, list) else []:
+        out |= planning.parse_coverage_block(pr.get("body"))
+    return out
+
+
+def inflight_keys() -> tuple[set[str], bool]:
+    """Dispatch keys of in-progress fix-agent runs.
+
+    Returns (keys, ok). On failure `ok` is False and the caller suppresses rather
+    than dispatching: a duplicate PR is worse than a delay, and the next failing
+    run retries in ~30-40 minutes anyway.
+    """
+    runs, err = gh_json_ex(
+        [
+            "run", "list", "--repo", REPO, "--workflow", FIX_WORKFLOW,
+            "--limit", "50", "--json", "status,name,databaseId",
+        ],
+        None,
+    )
+    if runs is None:
+        # A workflow with no runs yet — the state on first deployment — is not an
+        # outage and must not wedge dispatch shut.
+        if any(m in err.lower() for m in ("could not find any workflows", "no workflows", "404")):
+            log("fix workflow has no runs yet; treating as nothing in flight")
+            return set(), True
+        return set(), False
+    keys = {
+        (r.get("name") or "").split("[", 1)[-1].split("]", 1)[0]
+        for r in runs
+        if r.get("status") in {"queued", "in_progress"} and "[" in (r.get("name") or "")
+    }
+    return {k for k in keys if k}, True
+
+
+def product_bug_fingerprints() -> set[str]:
+    issues = gh_json(
+        [
+            "search", "issues", "nightly-product-bug is:issue",
+            "--owner", "camunda", "--state", "open",
+            "--limit", "200", "--json", "body",
+        ],
+        [],
+    )
+    out: set[str] = set()
+    for issue in issues if isinstance(issues, list) else []:
+        for line in (issue.get("body") or "").splitlines():
+            if "nightly-product-bug fp=" in line:
+                out.add(line.split("fp=", 1)[1].strip()[:8])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Blame
+# ---------------------------------------------------------------------------
+
+
+def resolve_blame(head_sha: str) -> classify.Blame:
+    prs = gh_json(["api", f"repos/{REPO}/commits/{head_sha}/pulls"], [])
+    if not isinstance(prs, list):
+        prs = []
+
+    def lookup(number: int):
+        return gh_json(
+            ["api", f"repos/{REPO}/pulls/{number}"], {}
+        )
+
+    return classify.resolve_blame(head_sha=head_sha, prs=prs, lookup_pr=lookup)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def build_candidates(run_id: str, base_ref: str, workdir: Path):
+    candidates: list[planning.Candidate] = []
+    noise: list[tuple[str, str]] = []
+
+    for job in failing_jobs(run_id):
+        name = job.get("name") or ""
+        surface = classify.surface_for_job(name)
+        if surface is None:
+            continue
+
+        verdict = classify.noise_verdict(
+            conclusion="failure",
+            step_count=len(job.get("steps") or []),
+            failure_annotations=failure_annotations(job.get("check_run_url")),
+        )
+        if verdict:
+            noise.append((classify.job_leaf_name(name), verdict))
+            log(f"noise ({verdict}): {classify.job_leaf_name(name)}")
+            continue
+
+        if surface == classify.SURFACE_SM_E2E:
+            candidates.append(sm_candidates(run_id, base_ref, name, workdir))
+        elif surface == classify.SURFACE_SAAS_E2E:
+            candidates.append(saas_candidate(run_id, base_ref, name, workdir))
+        else:
+            candidates.append(
+                planning.Candidate(
+                    base_ref=base_ref, surface=surface, job_name=name, job_level=True,
+                    evidence_run_url=f"https://github.com/{REPO}/actions/runs/{run_id}",
+                    evidence_repo=REPO,
+                )
+            )
+
+    return candidates, noise
+
+
+def serialise(result: planning.Plan, blame: classify.Blame, run_id: str) -> dict:
+    return {
+        "run_url": f"https://github.com/{REPO}/actions/runs/{run_id}",
+        "blame": asdict(blame),
+        "dispatches": [
+            {
+                "base_ref": c.base_ref,
+                "surface": c.surface,
+                "dispatch_key": c.key,
+                "job_name": classify.job_leaf_name(c.job_name),
+                "evidence_run_url": c.evidence_run_url,
+                "evidence_repo": c.evidence_repo,
+                "job_level": c.job_level,
+                "fingerprints": c.fingerprints,
+                "test_specs": [
+                    {
+                        "file": s.file,
+                        "test_name": s.test_name,
+                        "error": s.error,
+                        "project": s.project,
+                        "attempts": s.attempts,
+                        "statuses": s.statuses,
+                        "deterministic": s.deterministic,
+                    }
+                    for s in c.specs
+                ],
+            }
+            for c in result.dispatches
+        ],
+        "suppressed": [
+            {
+                "surface": s.candidate.surface,
+                "dispatch_key": s.candidate.key,
+                "reason": s.reason,
+                "detail": s.detail,
+            }
+            for s in result.suppressed
+        ],
+        "noise": [{"job": j, "verdict": v} for j, v in result.noise],
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--run-id", required=True)
+    ap.add_argument("--base-ref", required=True)
+    ap.add_argument("--out", default="-")
+    ap.add_argument("--max-dispatches", type=int, default=2)
+    args = ap.parse_args()
+
+    with tempfile.TemporaryDirectory(prefix="alwaysgreen-") as tmp:
+        workdir = Path(tmp)
+        candidates, noise = build_candidates(args.run_id, args.base_ref, workdir)
+
+        keys, keys_ok = inflight_keys()
+        if not keys_ok:
+            # Cannot prove nothing is running; suppress every candidate this tick.
+            keys = {c.key for c in candidates}
+            log("::warning::in-flight lookup failed; suppressing dispatch this run")
+
+        result = planning.plan_dispatches(
+            candidates,
+            covered_fingerprints=covered_fingerprints(),
+            inflight_keys=keys,
+            product_bug_fingerprints=product_bug_fingerprints(),
+            max_dispatches=args.max_dispatches,
+        )
+        result.noise = noise
+
+        run = gh_json(["api", f"repos/{REPO}/actions/runs/{args.run_id}"], {})
+        blame = resolve_blame(run.get("head_sha") or "")
+
+        payload = serialise(result, blame, args.run_id)
+
+    text = json.dumps(payload, indent=2)
+    if args.out == "-":
+        print(text)
+    else:
+        Path(args.out).write_text(text + "\n")
+    log(
+        f"dispatches={len(payload['dispatches'])} "
+        f"suppressed={len(payload['suppressed'])} noise={len(payload['noise'])}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -1,0 +1,210 @@
+"""Turn classified AlwaysGreen failures into dispatch decisions.
+
+Pure functions, like `classify`. `discover.py` fetches the inputs; everything that
+decides *whether* and *what* to dispatch lives here so it can be tested without a
+token.
+
+Two levels of identity are used, for different jobs:
+
+* A per-spec fingerprint identifies one failing test. It goes in the fix PR's
+  coverage block and is what suppresses a re-dispatch once a PR covers it.
+* A dispatch key, `<base_ref>:<surface>`, identifies one agent's remit. At most one
+  agent per key may be in flight. This is the rule that actually holds the line when
+  the same cause fails many consecutive runs: on 2026-07-23 seventeen runs failed on
+  one root cause roughly 30-40 minutes apart, while an agent takes 15-60 minutes, so
+  a PR-existence check alone loses the race repeatedly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import classify
+
+#: Reasons a candidate was not dispatched, surfaced in the job summary.
+SUPPRESSED_NOT_DISPATCHABLE = "surface-not-in-increment"
+SUPPRESSED_IN_FLIGHT = "agent-already-running"
+SUPPRESSED_PR_COVERED = "open-pr-covers-all-specs"
+SUPPRESSED_PRODUCT_BUG = "tracked-by-open-product-bug"
+SUPPRESSED_NO_EVIDENCE = "no-failing-specs-extracted"
+SUPPRESSED_CAP = "per-run-cap-reached"
+
+
+def dispatch_key(base_ref: str, surface: str) -> str:
+    return f"{base_ref}:{surface}"
+
+
+@dataclass
+class Candidate:
+    """One surface that failed on one base ref, with the evidence for it."""
+
+    base_ref: str
+    surface: str
+    job_name: str
+    specs: list[classify.FailingSpec] = field(default_factory=list)
+    #: Run whose artifacts hold the evidence. For SaaS this is the downstream run
+    #: in the e2e repository, not the AlwaysGreen run.
+    evidence_run_url: str = ""
+    evidence_repo: str = ""
+    #: Set when the surface produced no per-spec detail (job-level failure).
+    job_level: bool = False
+
+    @property
+    def key(self) -> str:
+        return dispatch_key(self.base_ref, self.surface)
+
+    @property
+    def spec_fingerprints(self) -> list[str]:
+        return [
+            classify.spec_fingerprint(self.base_ref, self.surface, s.file, s.test_name)
+            for s in self.specs
+        ]
+
+    @property
+    def fingerprints(self) -> list[str]:
+        """Every fingerprint this candidate would claim in a PR coverage block."""
+        if self.job_level or not self.specs:
+            return [classify.job_fingerprint(self.base_ref, self.surface, self.job_name)]
+        return self.spec_fingerprints
+
+    @property
+    def deterministic_specs(self) -> list[classify.FailingSpec]:
+        return [s for s in self.specs if s.deterministic]
+
+
+@dataclass
+class Suppression:
+    candidate: Candidate
+    reason: str
+    detail: str = ""
+
+
+@dataclass
+class Plan:
+    dispatches: list[Candidate] = field(default_factory=list)
+    suppressed: list[Suppression] = field(default_factory=list)
+    #: Failing jobs dropped by the noise prefilter, for the summary only.
+    noise: list[tuple[str, str]] = field(default_factory=list)
+
+
+def plan_dispatches(
+    candidates: list[Candidate],
+    *,
+    covered_fingerprints: set[str],
+    inflight_keys: set[str],
+    product_bug_fingerprints: set[str],
+    max_dispatches: int = 2,
+    dispatchable_surfaces: frozenset[str] = classify.DISPATCHABLE_SURFACES,
+) -> Plan:
+    """Decide which candidates to hand to the fix agent.
+
+    Checks are ordered cheapest-and-most-decisive first so the summary reports the
+    most useful reason when several apply.
+    """
+    plan = Plan()
+
+    for cand in candidates:
+        if cand.surface not in dispatchable_surfaces:
+            plan.suppressed.append(
+                Suppression(cand, SUPPRESSED_NOT_DISPATCHABLE, cand.surface)
+            )
+            continue
+
+        if cand.key in inflight_keys:
+            plan.suppressed.append(Suppression(cand, SUPPRESSED_IN_FLIGHT, cand.key))
+            continue
+
+        if not cand.job_level and not cand.specs:
+            plan.suppressed.append(Suppression(cand, SUPPRESSED_NO_EVIDENCE))
+            continue
+
+        fps = cand.fingerprints
+
+        if fps and all(f in product_bug_fingerprints for f in fps):
+            plan.suppressed.append(
+                Suppression(cand, SUPPRESSED_PRODUCT_BUG, ",".join(sorted(set(fps))))
+            )
+            continue
+
+        # Drop specs an open PR already covers; dispatch only what is left.
+        if not cand.job_level:
+            remaining = [
+                s
+                for s, fp in zip(cand.specs, cand.spec_fingerprints)
+                if fp not in covered_fingerprints
+                and fp not in product_bug_fingerprints
+            ]
+            if not remaining:
+                plan.suppressed.append(Suppression(cand, SUPPRESSED_PR_COVERED))
+                continue
+            cand.specs = remaining
+        elif fps and all(f in covered_fingerprints for f in fps):
+            plan.suppressed.append(Suppression(cand, SUPPRESSED_PR_COVERED))
+            continue
+
+        if len(plan.dispatches) >= max_dispatches:
+            plan.suppressed.append(Suppression(cand, SUPPRESSED_CAP))
+            continue
+
+        plan.dispatches.append(cand)
+
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# PR coverage block
+# ---------------------------------------------------------------------------
+
+COVERAGE_BEGIN = "<!-- alwaysgreen-fixed"
+COVERAGE_END = "-->"
+
+
+def parse_coverage_block(body: str | None) -> set[str]:
+    """Extract fingerprints a fix PR claims to cover.
+
+    Format, one per line inside an HTML comment so it renders invisibly:
+
+        <!-- alwaysgreen-fixed
+        fp=1a2b3c4d
+        fp=5e6f7a8b
+        -->
+    """
+    text = body or ""
+    start = text.find(COVERAGE_BEGIN)
+    if start == -1:
+        return set()
+    end = text.find(COVERAGE_END, start)
+    block = text[start : end if end != -1 else len(text)]
+    out: set[str] = set()
+    for line in block.splitlines():
+        line = line.strip()
+        if line.startswith("fp="):
+            value = line[3:].strip()
+            if value:
+                out.add(value)
+    return out
+
+
+def render_coverage_block(fingerprints: set[str]) -> str:
+    """Render a coverage block, sorted so repeated updates produce a stable diff."""
+    lines = [COVERAGE_BEGIN] + [f"fp={fp}" for fp in sorted(fingerprints)] + [COVERAGE_END]
+    return "\n".join(lines)
+
+
+def merge_coverage_block(body: str | None, new_fingerprints: set[str]) -> str:
+    """Return the body with the coverage block replaced by the union of fingerprints.
+
+    Existing entries are never dropped: an accumulating PR must keep claiming every
+    test it already fixed, or a later triage run would re-dispatch them.
+    """
+    text = (body or "").rstrip()
+    existing = parse_coverage_block(text)
+    merged = existing | set(new_fingerprints)
+
+    start = text.find(COVERAGE_BEGIN)
+    if start == -1:
+        return f"{text}\n\n{render_coverage_block(merged)}\n"
+
+    end = text.find(COVERAGE_END, start)
+    tail = text[end + len(COVERAGE_END) :] if end != -1 else ""
+    return f"{text[:start]}{render_coverage_block(merged)}{tail}".rstrip() + "\n"

--- a/.github/scripts/alwaysgreen/test_classify.py
+++ b/.github/scripts/alwaysgreen/test_classify.py
@@ -1,0 +1,411 @@
+"""Unit tests for the AlwaysGreen classifier.
+
+Cases are drawn from real failed runs of docker-build-helm-integration.yml so each
+one pins a mistake that was actually observed rather than a hypothetical.
+"""
+
+from __future__ import annotations
+
+import classify
+
+
+# ---------------------------------------------------------------------------
+# Platform noise
+# ---------------------------------------------------------------------------
+
+
+def test_platform_internal_error_is_noise():
+    # Run 30157503817: Cleanup and Observe both failed this way, no steps ran.
+    verdict = classify.noise_verdict(
+        conclusion="failure",
+        step_count=0,
+        failure_annotations=[
+            "GitHub Actions has encountered an internal error when running your job."
+        ],
+    )
+    assert verdict == classify.NOISE_PLATFORM
+
+
+def test_cancellation_is_noise_even_with_steps():
+    # Run 30078726133: Build and Push Docker Images had 20 steps but was cancelled,
+    # which the first census mistook for a real build failure.
+    verdict = classify.noise_verdict(
+        conclusion="failure",
+        step_count=20,
+        failure_annotations=["The operation was canceled."],
+    )
+    assert verdict == classify.NOISE_CANCELLED
+
+
+def test_no_steps_and_no_annotation_is_noise():
+    # Downstream run 30157726486: Create cluster generation on INT.
+    verdict = classify.noise_verdict(
+        conclusion="failure", step_count=0, failure_annotations=[]
+    )
+    assert verdict == classify.NOISE_NO_EVIDENCE
+
+
+def test_ordinary_step_failure_is_not_noise():
+    verdict = classify.noise_verdict(
+        conclusion="failure",
+        step_count=30,
+        failure_annotations=["Process completed with exit code 1."],
+    )
+    assert verdict is None
+
+
+def test_non_failure_conclusions_are_not_classified():
+    assert (
+        classify.noise_verdict(
+            conclusion="success", step_count=0, failure_annotations=[]
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Surface classification
+# ---------------------------------------------------------------------------
+
+
+def test_nested_sm_e2e_job_name_maps_to_sm_surface():
+    name = (
+        "Helm chart Integration Tests / agrn - install - gke / "
+        "Playwright e2e after install - install on gke - agrn (1 of 1)"
+    )
+    assert classify.surface_for_job(name) == classify.SURFACE_SM_E2E
+
+
+def test_unrendered_template_job_name_still_matches_prefix():
+    # Skipped jobs keep the raw expressions; the prefix is the stable part.
+    name = (
+        "Helm chart Integration Tests / agrn - install - gke / "
+        "Playwright e2e after install - ${{ inputs.flow }} on "
+        "${{ inputs.distro-platform }} - ${{ inputs.shortname }}"
+    )
+    assert classify.surface_for_job(name) == classify.SURFACE_SM_E2E
+
+
+def test_observe_status_job_is_ignored():
+    assert classify.surface_for_job("Observe Helm chart Integration Tests status") is None
+
+
+def test_frontend_and_docker_builds_map_to_build():
+    assert classify.surface_for_job("Build Operate Frontend") == classify.SURFACE_BUILD
+    assert (
+        classify.surface_for_job("Build and Push Docker Images")
+        == classify.SURFACE_BUILD
+    )
+
+
+def test_helm_install_and_cleanup_are_distinct_surfaces():
+    base = "Helm chart Integration Tests / agrn - install - gke / "
+    assert (
+        classify.surface_for_job(base + "install for install on gke - agrn")
+        == classify.SURFACE_HELM_INSTALL
+    )
+    assert (
+        classify.surface_for_job(base + "Cleanup - install on gke - agrn")
+        == classify.SURFACE_HELM_CLEANUP
+    )
+
+
+def test_only_e2e_surfaces_dispatch_in_first_increment():
+    assert classify.SURFACE_SM_E2E in classify.DISPATCHABLE_SURFACES
+    assert classify.SURFACE_SAAS_E2E in classify.DISPATCHABLE_SURFACES
+    assert classify.SURFACE_HELM_INSTALL not in classify.DISPATCHABLE_SURFACES
+    assert classify.SURFACE_BUILD not in classify.DISPATCHABLE_SURFACES
+
+
+# ---------------------------------------------------------------------------
+# Playwright report parsing
+# ---------------------------------------------------------------------------
+
+
+def _nested_report(specs):
+    """Report shaped like Playwright's real output: file suite → describe suite."""
+    return {
+        "config": {"rootDir": "/w/node_modules/@camunda/e2e-test-suite/dist/tests/SM-8.10"},
+        "suites": [
+            {
+                "title": "smoke-tests.spec.js",
+                "file": "smoke-tests.spec.js",
+                "specs": [],
+                "suites": [{"title": "Smoke Tests", "specs": specs}],
+            }
+        ],
+    }
+
+
+def test_counting_walks_nested_suites():
+    # The pipeline's own one-level walk returns 0 here; that is the bug this
+    # guards. Real example: downstream run 30259132560 was 15 specs / 2 failures.
+    report = _nested_report(
+        [
+            {"file": "test-setup.spec.ts", "title": "a", "ok": False, "tests": [{"results": [{"status": "failed"}]}]},
+            {"file": "smoke-tests.spec.ts", "title": "b", "ok": True, "tests": [{"results": [{"status": "passed"}]}]},
+        ]
+    )
+    counts = classify.count_specs(report)
+    assert counts.total == 2
+    assert counts.failed == 1
+    assert counts.setup_failed == 1
+
+
+def test_flaky_counts_retried_specs_that_passed():
+    report = _nested_report(
+        [
+            {
+                "file": "smoke-tests.spec.ts",
+                "title": "eventually passed",
+                "ok": True,
+                "tests": [{"results": [{"status": "failed"}, {"status": "passed"}]}],
+            }
+        ]
+    )
+    counts = classify.count_specs(report)
+    assert counts.flaky == 1
+    assert counts.failed == 0
+
+
+def test_empty_report_counts_zero():
+    assert classify.count_specs({"suites": []}) == classify.SpecCounts()
+
+
+# ---------------------------------------------------------------------------
+# SaaS sub-classification
+# ---------------------------------------------------------------------------
+
+
+def test_setup_only_failures_are_provisioning():
+    # Observed shape: every failing spec was in test-setup.spec.ts
+    # (Create Default Cluster / Create AWS Cluster).
+    counts = classify.SpecCounts(total=15, failed=2, flaky=0, setup_failed=2)
+    assert (
+        classify.saas_surface_from_counts(counts, has_artifacts=True)
+        == classify.SURFACE_SAAS_PROVISIONING
+    )
+
+
+def test_real_test_failures_are_saas_e2e():
+    counts = classify.SpecCounts(total=15, failed=2, flaky=0, setup_failed=0)
+    assert (
+        classify.saas_surface_from_counts(counts, has_artifacts=True)
+        == classify.SURFACE_SAAS_E2E
+    )
+
+
+def test_no_failing_specs_is_infra_not_dispatchable():
+    counts = classify.SpecCounts(total=15, failed=0)
+    assert (
+        classify.saas_surface_from_counts(counts, has_artifacts=True)
+        == classify.SURFACE_SAAS_INFRA
+    )
+
+
+def test_missing_artifacts_is_infra():
+    assert (
+        classify.saas_surface_from_counts(classify.SpecCounts(), has_artifacts=False)
+        == classify.SURFACE_SAAS_INFRA
+    )
+
+
+# ---------------------------------------------------------------------------
+# Spec → source path
+# ---------------------------------------------------------------------------
+
+
+def test_suite_recovered_from_rootdir():
+    root = "/__w/camunda/camunda/charts/camunda-platform-8.10/test/e2e/node_modules/@camunda/e2e-test-suite/dist/tests/SM-8.10"
+    assert classify.suite_from_rootdir(root) == "SM-8.10"
+
+
+def test_suite_is_none_when_rootdir_unhelpful():
+    assert classify.suite_from_rootdir("") is None
+    assert classify.suite_from_rootdir("/some/other/dir") is None
+
+
+def test_compiled_basename_maps_to_source_path():
+    assert (
+        classify.source_spec_path("smoke-tests.spec.js", suite="SM-8.10")
+        == "tests/SM-8.10/smoke-tests.spec.ts"
+    )
+
+
+def test_path_with_directories_is_left_alone():
+    assert (
+        classify.source_spec_path("tests/8.10/navigation.spec.ts", suite="8.10")
+        == "tests/8.10/navigation.spec.ts"
+    )
+
+
+def test_basename_without_suite_is_returned_unchanged():
+    assert classify.source_spec_path("smoke-tests.spec.js", suite=None) == (
+        "smoke-tests.spec.ts"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Failing-spec extraction
+# ---------------------------------------------------------------------------
+
+
+def test_failing_spec_carries_retry_history_and_is_deterministic():
+    # Run 30109387051: 3 attempts, all failed — the Keycloak error page case.
+    report = _nested_report(
+        [
+            {
+                "file": "smoke-tests.spec.js",
+                "title": "Most Common Flow User Flow With All Apps",
+                "ok": False,
+                "tests": [
+                    {
+                        "projectName": "smoke-tests",
+                        "results": [
+                            {"status": "failed"},
+                            {"status": "failed"},
+                            {
+                                "status": "failed",
+                                "error": {
+                                    "message": "\x1b[2mexpect(\x1b[22mlocator).toBeVisible failed"
+                                },
+                            },
+                        ],
+                    }
+                ],
+            }
+        ]
+    )
+    specs = classify.failing_specs(report, suite="SM-8.10")
+    assert len(specs) == 1
+    spec = specs[0]
+    assert spec.file == "tests/SM-8.10/smoke-tests.spec.ts"
+    assert spec.attempts == 3
+    assert spec.deterministic
+    assert "\x1b" not in spec.error
+    assert "toBeVisible failed" in spec.error
+
+
+def test_spec_that_eventually_passed_is_not_deterministic():
+    spec = classify.FailingSpec(
+        file="f", test_name="t", statuses=["failed", "failed", "passed"]
+    )
+    assert not spec.deterministic
+
+
+def test_spec_with_no_attempts_is_not_deterministic():
+    assert not classify.FailingSpec(file="f", test_name="t").deterministic
+
+
+def test_clean_error_truncates():
+    assert len(classify.clean_error("x" * 5000)) == 600
+
+
+# ---------------------------------------------------------------------------
+# Fingerprints
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_is_stable_and_short():
+    fp = classify.spec_fingerprint("main", "sm-smoke-e2e", "a.spec.ts", "t")
+    assert fp == classify.spec_fingerprint("main", "sm-smoke-e2e", "a.spec.ts", "t")
+    assert len(fp) == 8
+
+
+def test_fingerprint_differs_per_branch():
+    assert classify.spec_fingerprint("main", "s", "f", "t") != classify.spec_fingerprint(
+        "stable/8.9", "s", "f", "t"
+    )
+
+
+def test_job_fingerprint_ignores_nesting_prefix():
+    a = classify.job_fingerprint("main", "helm-install", "A / B / install for install on gke - agrn")
+    b = classify.job_fingerprint("main", "helm-install", "install for install on gke - agrn")
+    assert a == b
+
+
+# ---------------------------------------------------------------------------
+# Blame
+# ---------------------------------------------------------------------------
+
+
+def test_human_pr_author_is_the_reviewer():
+    # Run 30078726133.
+    prs = [{"number": 58541, "merge_commit_sha": "sha1", "user": {"login": "slolatte"}}]
+    blame = classify.resolve_blame(head_sha="sha1", prs=prs)
+    assert blame.reviewer == "slolatte"
+    assert blame.via == "pr-author"
+
+
+def test_originating_pr_matches_merge_commit_not_list_order():
+    # /commits/{sha}/pulls also returns unrelated open PRs containing the commit.
+    prs = [
+        {"number": 999, "merge_commit_sha": "other", "user": {"login": "someone"}},
+        {"number": 58541, "merge_commit_sha": "sha1", "user": {"login": "slolatte"}},
+    ]
+    assert classify.originating_pr(prs, "sha1")["number"] == 58541
+
+
+def test_backport_bot_resolves_to_original_author():
+    # Run 30381967897: [Backport stable/8.7] … (#58938) authored by a bot.
+    prs = [
+        {
+            "number": 58990,
+            "merge_commit_sha": "sha1",
+            "title": "[Backport stable/8.7] pg/sigsegv-stop-raft-role-preemptively (#58938)",
+            "user": {"login": "monorepo-devops-automation[bot]"},
+        }
+    ]
+    blame = classify.resolve_blame(
+        head_sha="sha1",
+        prs=prs,
+        lookup_pr=lambda n: {"number": n, "user": {"login": "pihme"}},
+    )
+    assert blame.reviewer == "pihme"
+    assert blame.pr_number == 58938
+    assert blame.via == "backport-original"
+
+
+def test_non_backport_bot_leaves_reviewer_unset_but_keeps_author():
+    # Run 30109387051: renovate[bot], nothing to fall back to.
+    prs = [
+        {
+            "number": 56547,
+            "merge_commit_sha": "sha1",
+            "title": "deps: Update camunda-platform Helm Chart to v15.0.0-alpha3 (main)",
+            "user": {"login": "renovate[bot]"},
+        }
+    ]
+    blame = classify.resolve_blame(head_sha="sha1", prs=prs)
+    assert blame.reviewer is None
+    assert blame.author == "renovate[bot]"
+    assert blame.via == "bot-unresolved"
+
+
+def test_backport_chain_ending_in_a_bot_stays_unresolved():
+    prs = [
+        {
+            "number": 1,
+            "merge_commit_sha": "sha1",
+            "title": "[Backport stable/8.8] something (#2)",
+            "user": {"login": "monorepo-release[bot]"},
+        }
+    ]
+    blame = classify.resolve_blame(
+        head_sha="sha1",
+        prs=prs,
+        lookup_pr=lambda n: {"user": {"login": "renovate[bot]"}},
+    )
+    assert blame.reviewer is None
+    assert blame.via == "bot-unresolved"
+
+
+def test_no_prs_yields_no_blame():
+    blame = classify.resolve_blame(head_sha="sha1", prs=[])
+    assert blame.reviewer is None and blame.via == "no-pr"
+
+
+def test_is_bot():
+    assert classify.is_bot("renovate[bot]")
+    assert not classify.is_bot("slolatte")
+    assert not classify.is_bot(None)

--- a/.github/scripts/alwaysgreen/test_classify.py
+++ b/.github/scripts/alwaysgreen/test_classify.py
@@ -409,3 +409,66 @@ def test_is_bot():
     assert classify.is_bot("renovate[bot]")
     assert not classify.is_bot("slolatte")
     assert not classify.is_bot(None)
+
+
+# ---------------------------------------------------------------------------
+# Base ref normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_plain_branch_is_unchanged():
+    assert classify.normalise_base_ref("main") == "main"
+    assert classify.normalise_base_ref("stable/8.9") == "stable/8.9"
+
+
+def test_merge_queue_ref_collapses_to_its_base():
+    # A merge_group run reports this shape. Left alone it would make every run's
+    # fingerprints unique and silently defeat dedupe.
+    assert (
+        classify.normalise_base_ref("gh-readonly-queue/main/pr-59043-abc1234")
+        == "main"
+    )
+    assert (
+        classify.normalise_base_ref("gh-readonly-queue/stable/8.9/pr-123-deadbee")
+        == "stable/8.9"
+    )
+
+
+def test_fully_qualified_ref_is_stripped():
+    assert classify.normalise_base_ref("refs/heads/main") == "main"
+    assert classify.normalise_base_ref("refs/heads/stable/8.7") == "stable/8.7"
+
+
+def test_qualified_merge_queue_ref_handles_both_layers():
+    assert (
+        classify.normalise_base_ref("refs/heads/gh-readonly-queue/main/pr-1-abc")
+        == "main"
+    )
+
+
+def test_branch_merely_containing_pr_is_not_truncated():
+    assert classify.normalise_base_ref("feature/pr-review-tweaks") == (
+        "feature/pr-review-tweaks"
+    )
+
+
+def test_empty_and_whitespace_are_safe():
+    assert classify.normalise_base_ref("") == ""
+    assert classify.normalise_base_ref("  main  ") == "main"
+
+
+def test_normalised_ref_makes_fingerprints_stable_across_queue_runs():
+    # The point of the normalisation: two merge-queue runs for different PRs targeting
+    # the same branch must fingerprint identically, or dedupe never suppresses anything.
+    a = classify.spec_fingerprint(
+        classify.normalise_base_ref("gh-readonly-queue/main/pr-1-aaa"),
+        "sm-smoke-e2e", "tests/SM-8.10/smoke-tests.spec.ts", "t",
+    )
+    b = classify.spec_fingerprint(
+        classify.normalise_base_ref("gh-readonly-queue/main/pr-2-bbb"),
+        "sm-smoke-e2e", "tests/SM-8.10/smoke-tests.spec.ts", "t",
+    )
+    direct = classify.spec_fingerprint(
+        "main", "sm-smoke-e2e", "tests/SM-8.10/smoke-tests.spec.ts", "t"
+    )
+    assert a == b == direct

--- a/.github/scripts/alwaysgreen/test_plan.py
+++ b/.github/scripts/alwaysgreen/test_plan.py
@@ -1,0 +1,190 @@
+"""Unit tests for AlwaysGreen dispatch planning and the PR coverage block."""
+
+from __future__ import annotations
+
+import classify
+import plan
+
+
+def _spec(name="t", file="tests/SM-8.10/smoke-tests.spec.ts", deterministic=True):
+    statuses = ["failed"] * 3 if deterministic else ["failed", "passed"]
+    return classify.FailingSpec(file=file, test_name=name, statuses=statuses)
+
+
+def _cand(surface=classify.SURFACE_SM_E2E, base_ref="main", specs=None, job_level=False):
+    return plan.Candidate(
+        base_ref=base_ref,
+        surface=surface,
+        job_name="Playwright e2e after install - install on gke - agrn (1 of 1)",
+        specs=list(specs if specs is not None else [_spec()]),
+        job_level=job_level,
+    )
+
+
+def _plan(cands, **kw):
+    kw.setdefault("covered_fingerprints", set())
+    kw.setdefault("inflight_keys", set())
+    kw.setdefault("product_bug_fingerprints", set())
+    return plan.plan_dispatches(cands, **kw)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch decisions
+# ---------------------------------------------------------------------------
+
+
+def test_dispatchable_surface_with_specs_is_dispatched():
+    result = _plan([_cand()])
+    assert len(result.dispatches) == 1
+    assert result.suppressed == []
+
+
+def test_non_dispatchable_surface_is_recorded_not_dispatched():
+    result = _plan([_cand(surface=classify.SURFACE_HELM_INSTALL)])
+    assert result.dispatches == []
+    assert result.suppressed[0].reason == plan.SUPPRESSED_NOT_DISPATCHABLE
+
+
+def test_in_flight_agent_blocks_the_same_surface():
+    # The 2026-07-23 case: consecutive runs, same cause, agent still working.
+    cand = _cand()
+    result = _plan([cand], inflight_keys={"main:sm-smoke-e2e"})
+    assert result.dispatches == []
+    assert result.suppressed[0].reason == plan.SUPPRESSED_IN_FLIGHT
+
+
+def test_in_flight_on_another_branch_does_not_block():
+    result = _plan([_cand(base_ref="main")], inflight_keys={"stable/8.9:sm-smoke-e2e"})
+    assert len(result.dispatches) == 1
+
+
+def test_in_flight_on_another_surface_does_not_block():
+    result = _plan([_cand()], inflight_keys={"main:saas-smoke-e2e"})
+    assert len(result.dispatches) == 1
+
+
+def test_fully_covered_candidate_is_suppressed():
+    cand = _cand()
+    result = _plan([cand], covered_fingerprints=set(cand.spec_fingerprints))
+    assert result.dispatches == []
+    assert result.suppressed[0].reason == plan.SUPPRESSED_PR_COVERED
+
+
+def test_partially_covered_candidate_dispatches_only_uncovered_specs():
+    covered_spec = _spec(name="already fixed")
+    fresh_spec = _spec(name="new failure")
+    cand = _cand(specs=[covered_spec, fresh_spec])
+    covered_fp = classify.spec_fingerprint(
+        "main", classify.SURFACE_SM_E2E, covered_spec.file, covered_spec.test_name
+    )
+
+    result = _plan([cand], covered_fingerprints={covered_fp})
+    assert len(result.dispatches) == 1
+    assert [s.test_name for s in result.dispatches[0].specs] == ["new failure"]
+
+
+def test_product_bug_suppresses_the_candidate():
+    cand = _cand()
+    result = _plan([cand], product_bug_fingerprints=set(cand.spec_fingerprints))
+    assert result.dispatches == []
+    assert result.suppressed[0].reason == plan.SUPPRESSED_PRODUCT_BUG
+
+
+def test_candidate_with_no_specs_is_suppressed_as_no_evidence():
+    result = _plan([_cand(specs=[])])
+    assert result.dispatches == []
+    assert result.suppressed[0].reason == plan.SUPPRESSED_NO_EVIDENCE
+
+
+def test_job_level_candidate_dispatches_without_specs():
+    result = _plan([_cand(specs=[], job_level=True)])
+    assert len(result.dispatches) == 1
+
+
+def test_cap_limits_dispatches_and_records_the_rest():
+    cands = [
+        _cand(surface=classify.SURFACE_SM_E2E),
+        _cand(surface=classify.SURFACE_SAAS_E2E),
+    ]
+    result = _plan(cands, max_dispatches=1)
+    assert len(result.dispatches) == 1
+    assert result.suppressed[0].reason == plan.SUPPRESSED_CAP
+
+
+def test_in_flight_is_checked_before_cap_so_the_reason_is_useful():
+    cands = [
+        _cand(surface=classify.SURFACE_SM_E2E),
+        _cand(surface=classify.SURFACE_SAAS_E2E),
+    ]
+    result = _plan(cands, inflight_keys={"main:sm-smoke-e2e"}, max_dispatches=1)
+    reasons = {s.reason for s in result.suppressed}
+    assert plan.SUPPRESSED_IN_FLIGHT in reasons
+    assert len(result.dispatches) == 1
+    assert result.dispatches[0].surface == classify.SURFACE_SAAS_E2E
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint identity
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_key_shape():
+    assert plan.dispatch_key("main", "sm-smoke-e2e") == "main:sm-smoke-e2e"
+
+
+def test_job_level_candidate_uses_a_job_fingerprint():
+    cand = _cand(specs=[], job_level=True)
+    assert cand.fingerprints == [
+        classify.job_fingerprint("main", classify.SURFACE_SM_E2E, cand.job_name)
+    ]
+
+
+def test_deterministic_specs_filter():
+    cand = _cand(specs=[_spec("a"), _spec("b", deterministic=False)])
+    assert [s.test_name for s in cand.deterministic_specs] == ["a"]
+
+
+# ---------------------------------------------------------------------------
+# Coverage block
+# ---------------------------------------------------------------------------
+
+
+def test_parse_coverage_block():
+    body = "Some description\n\n<!-- alwaysgreen-fixed\nfp=aaaaaaaa\nfp=bbbbbbbb\n-->\n"
+    assert plan.parse_coverage_block(body) == {"aaaaaaaa", "bbbbbbbb"}
+
+
+def test_parse_returns_empty_when_absent():
+    assert plan.parse_coverage_block("no block here") == set()
+    assert plan.parse_coverage_block(None) == set()
+
+
+def test_merge_appends_block_when_missing():
+    merged = plan.merge_coverage_block("Body text", {"aaaaaaaa"})
+    assert "fp=aaaaaaaa" in merged
+    assert merged.startswith("Body text")
+
+
+def test_merge_is_a_union_and_never_drops_existing():
+    body = "Body\n\n<!-- alwaysgreen-fixed\nfp=aaaaaaaa\n-->\n"
+    merged = plan.merge_coverage_block(body, {"bbbbbbbb"})
+    assert plan.parse_coverage_block(merged) == {"aaaaaaaa", "bbbbbbbb"}
+
+
+def test_merge_is_idempotent():
+    body = plan.merge_coverage_block("Body", {"aaaaaaaa"})
+    again = plan.merge_coverage_block(body, {"aaaaaaaa"})
+    assert plan.parse_coverage_block(again) == {"aaaaaaaa"}
+    assert again.count(plan.COVERAGE_BEGIN) == 1
+
+
+def test_merge_preserves_text_after_the_block():
+    body = "Head\n\n<!-- alwaysgreen-fixed\nfp=aaaaaaaa\n-->\n\nTail text"
+    merged = plan.merge_coverage_block(body, {"bbbbbbbb"})
+    assert "Head" in merged and "Tail text" in merged
+    assert plan.parse_coverage_block(merged) == {"aaaaaaaa", "bbbbbbbb"}
+
+
+def test_render_is_sorted_for_stable_diffs():
+    rendered = plan.render_coverage_block({"cccccccc", "aaaaaaaa", "bbbbbbbb"})
+    assert rendered.index("aaaaaaaa") < rendered.index("bbbbbbbb") < rendered.index("cccccccc")

--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -66,6 +66,10 @@ jobs:
     name: Fix ${{ inputs.surface }} on ${{ inputs.base_ref }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    # Honour the same kill switch as triage, so setting ALWAYSGREEN_FIX_AGENT=off stops
+    # agents that were already dispatched or queued, and blocks a manual dispatch. A
+    # run that has already started its Claude step is not interrupted — cancel it.
+    if: ${{ vars.ALWAYSGREEN_FIX_AGENT != 'off' }}
 
     steps:
       - name: Validate inputs

--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -62,14 +62,44 @@ env:
   FIX_LABEL: alwaysgreen-fix
 
 jobs:
+  # Honours the same flag as triage, so `off` also stops agents already dispatched or
+  # queued and blocks a manual dispatch. A separate job because a Vault read cannot
+  # happen in a job-level `if:`; gating on a job output leaves the agent job visibly
+  # skipped rather than half-run. A run already inside its Claude step is not
+  # interrupted — cancel it.
+  gate:
+    name: Check feature flag
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      enabled: ${{ steps.flag.outputs.enabled }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github/actions/alwaysgreen-flag
+          persist-credentials: false
+      - id: flag
+        uses: ./.github/actions/alwaysgreen-flag
+        with:
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Report disabled
+        if: ${{ steps.flag.outputs.enabled != 'true' }}
+        run: |
+          {
+            echo "## AlwaysGreen Fix Agent — disabled"
+            echo ""
+            echo "\`ALWAYSGREEN_FIX_AGENT\` at \`secret/data/products/qa/ci/common\` is \`off\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice::AlwaysGreen fix agent is disabled by the Vault feature flag."
+
   fix:
     name: Fix ${{ inputs.surface }} on ${{ inputs.base_ref }}
+    needs: gate
+    if: ${{ needs.gate.outputs.enabled == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    # Honour the same kill switch as triage, so setting ALWAYSGREEN_FIX_AGENT=off stops
-    # agents that were already dispatched or queued, and blocks a manual dispatch. A
-    # run that has already started its Claude step is not interrupted — cancel it.
-    if: ${{ vars.ALWAYSGREEN_FIX_AGENT != 'off' }}
 
     steps:
       - name: Validate inputs

--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -62,7 +62,7 @@ env:
   FIX_LABEL: alwaysgreen-fix
 
 jobs:
-  # Honours the same flag as triage, so `off` also stops agents already dispatched or
+  # Honours the same flag as triage, so `disabled` also stops agents already dispatched or
   # queued and blocks a manual dispatch. A separate job because a Vault read cannot
   # happen in a job-level `if:`; gating on a job output leaves the agent job visibly
   # skipped rather than half-run. A run already inside its Claude step is not
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      enabled: ${{ steps.flag.outputs.enabled }}
+      active: ${{ steps.flag.outputs.active }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -85,19 +85,19 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - name: Report disabled
-        if: ${{ steps.flag.outputs.enabled != 'true' }}
+        if: ${{ steps.flag.outputs.active != 'true' }}
         run: |
           {
             echo "## AlwaysGreen Fix Agent — disabled"
             echo ""
-            echo "\`ALWAYSGREEN_FIX_AGENT\` at \`secret/data/products/qa/ci/common\` is \`off\`."
+            echo "\`ALWAYSGREEN_FIX_AGENT\` at \`secret/data/products/qa/ci/common\` is \`disabled\`."
           } >> "$GITHUB_STEP_SUMMARY"
           echo "::notice::AlwaysGreen fix agent is disabled by the Vault feature flag."
 
   fix:
     name: Fix ${{ inputs.surface }} on ${{ inputs.base_ref }}
     needs: gate
-    if: ${{ needs.gate.outputs.enabled == 'true' }}
+    if: ${{ needs.gate.outputs.active == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
 

--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -181,7 +181,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
         with:
           github-app-id-vault-key: GITHUB_APP_ID
           github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes

--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -1,0 +1,431 @@
+# description: Fix agent for AlwaysGreen failures, dispatched by alwaysgreen-triage.yml.
+#              Uses workspace-cli + Claude Code CLI in a multi-repo workspace so the
+#              agent can fix whichever repository the evidence points at, and opens the
+#              PR there. Requests review from the author of the breaking change.
+# type: CI
+# owner: @camunda/test-automation-team
+---
+name: AlwaysGreen Fix Agent
+
+# The bracketed dispatch key is load-bearing: alwaysgreen-triage reads it back off
+# in-progress runs to avoid dispatching a second agent for a surface already being worked
+# on. It must stay byte-identical to plan.dispatch_key() — "<base_ref>:<surface>".
+run-name: "AlwaysGreen fix [${{ inputs.base_ref }}:${{ inputs.surface }}]"
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: 'Branch to fix against (main, stable/8.x)'
+        required: true
+      surface:
+        description: 'Failing surface (sm-smoke-e2e, saas-smoke-e2e)'
+        required: true
+      test_specs:
+        description: 'JSON array of failing specs with retry history'
+        required: true
+      fingerprints:
+        description: 'JSON array of fingerprints this agent must claim in the PR coverage block'
+        required: true
+      evidence:
+        description: 'JSON {run_url, repo} of the run holding the evidence (downstream run for SaaS)'
+        required: false
+        default: '{}'
+      failing_run_url:
+        description: 'The AlwaysGreen run that failed'
+        required: false
+        default: ''
+      triage_run_url:
+        description: 'Triage run that dispatched this'
+        required: false
+        default: ''
+      blame:
+        description: 'JSON {reviewer, author, pr} for the breaking change'
+        required: false
+        default: '{}'
+      slack:
+        description: 'JSON {ts, channel} for the thread reply'
+        required: false
+        default: '{}'
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  TEST_OWNER: '@camunda/test-automation-team'
+  FIX_LABEL: alwaysgreen-fix
+
+jobs:
+  fix:
+    name: Fix ${{ inputs.surface }} on ${{ inputs.base_ref }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Validate inputs
+        id: target
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
+          SURFACE: ${{ inputs.surface }}
+        run: |
+          set -euo pipefail
+          case "$BASE_REF" in
+            main|stable/8.7|stable/8.8|stable/8.9) ;;
+            *) echo "::error::unsupported base_ref '$BASE_REF'"; exit 1 ;;
+          esac
+          case "$SURFACE" in
+            sm-smoke-e2e|saas-smoke-e2e) ;;
+            *) echo "::error::unsupported surface '$SURFACE'"; exit 1 ;;
+          esac
+          # The e2e suite directory the specs live in.
+          if [ "$BASE_REF" = "main" ]; then version=8.10; else version="${BASE_REF#stable/}"; fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout main for tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      # The bundled JSON inputs exist because workflow_dispatch caps at 10 inputs.
+      # Unpacked once here into step outputs so later steps read plain strings.
+      - name: Write dispatch inputs to files
+        id: ctx
+        env:
+          INPUT_TEST_SPECS: ${{ inputs.test_specs }}
+          INPUT_FINGERPRINTS: ${{ inputs.fingerprints }}
+          INPUT_EVIDENCE: ${{ inputs.evidence }}
+          INPUT_BLAME: ${{ inputs.blame }}
+          INPUT_SLACK: ${{ inputs.slack }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$INPUT_TEST_SPECS" > /tmp/test_specs.json
+          printf '%s' "$INPUT_FINGERPRINTS" > /tmp/fingerprints.json
+          printf '%s' "${INPUT_EVIDENCE:-}" > /tmp/evidence.json
+          printf '%s' "${INPUT_BLAME:-}"    > /tmp/blame.json
+          printf '%s' "${INPUT_SLACK:-}"    > /tmp/slack.json
+
+          # Absent or malformed bundles must not abort the fix; normalise to empty.
+          for f in evidence blame slack; do
+            jq -e 'type == "object"' "/tmp/${f}.json" >/dev/null 2>&1 \
+              || echo '{}' > "/tmp/${f}.json"
+          done
+
+          {
+            echo "evidence_run_url=$(jq -r '.run_url // ""' /tmp/evidence.json)"
+            echo "evidence_repo=$(jq -r '.repo // ""' /tmp/evidence.json)"
+            echo "blame_reviewer=$(jq -r '.reviewer // ""' /tmp/blame.json)"
+            echo "blame_author=$(jq -r '.author // ""' /tmp/blame.json)"
+            echo "blame_pr=$(jq -r '.pr // ""' /tmp/blame.json)"
+            echo "slack_ts=$(jq -r '.ts // ""' /tmp/slack.json)"
+            echo "slack_channel=$(jq -r '.channel // ""' /tmp/slack.json)"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "specs: $(jq 'length' /tmp/test_specs.json)"
+          jq -r '.[] | "  \(.file) > \(.test_name)  attempts=\(.attempts) deterministic=\(.deterministic)"' \
+            /tmp/test_specs.json
+
+      - name: Import Vault secrets
+        id: secrets
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/qa/ci/common CLAUDE_API_KEY | ANTHROPIC_API_KEY ;
+            secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
+            secret/data/products/qa/ci/common GH_TOKEN | GH_PAT ;
+
+      - name: Generate GitHub App Token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        with:
+          github-app-id-vault-key: GITHUB_APP_ID
+          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          github-app-private-key-vault-key: GITHUB_APP_SECRET
+          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          owner: camunda
+          repositories: >-
+            camunda,
+            c8-cross-component-e2e-tests,
+            camunda-platform-helm,
+            camunda-docs
+
+      - name: Configure git
+        env:
+          TOKEN: ${{ steps.github-token.outputs.token }}
+        run: |
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+          git config --global user.name  "qa-processes[bot]"
+          git config --global user.email "qa-processes[bot]@users.noreply.github.com"
+
+      - name: Ensure labels exist
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+        run: |
+          for repo in camunda/camunda camunda/c8-cross-component-e2e-tests camunda/camunda-platform-helm; do
+            gh label create "${FIX_LABEL}" --repo "$repo" --color "1D76DB" \
+              --description "Bot-opened fix PR for an AlwaysGreen failure" 2>/dev/null || true
+          done
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26'
+          cache: false
+
+      - name: Install workspace-cli
+        env:
+          GOPRIVATE: github.com/camunda/*
+          GOTOOLCHAIN: auto
+          GH_PAT: ${{ steps.secrets.outputs.GH_PAT }}
+        run: |
+          git config --global url."https://x-access-token:${GH_PAT}@github.com/camunda/workspace-cli".insteadOf "https://github.com/camunda/workspace-cli"
+          go install github.com/camunda/workspace-cli/cmd/workspace@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code@2.1.156
+          claude --version
+
+      - name: Compute workspace name
+        id: ws
+        env:
+          SURFACE: ${{ inputs.surface }}
+        run: echo "name=ag-${SURFACE}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Stage workspace manifest
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.workspace-templates"
+          cp .github/workspace-templates/alwaysgreen.yaml \
+             "$HOME/.workspace-templates/alwaysgreen.yaml"
+          cp .github/workspace-templates/alwaysgreen.guidance.md \
+             "$HOME/.workspace-templates/alwaysgreen.guidance.md"
+
+      - name: Create workspace
+        run: workspace create "${{ steps.ws.outputs.name }}" --manifest alwaysgreen
+
+      - name: Point the monorepo at the failing branch
+        env:
+          TARGET_REF: ${{ inputs.base_ref }}
+          WORKSPACE_NAME: ${{ steps.ws.outputs.name }}
+        run: |
+          set -euo pipefail
+          ws_dir="$HOME/workspaces/${WORKSPACE_NAME}/camunda"
+          git -C "$ws_dir" fetch --depth 1 origin "${TARGET_REF}"
+          git -C "$ws_dir" checkout "${TARGET_REF}"
+
+      - name: Download evidence artifacts
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          EVIDENCE_RUN_URL: ${{ steps.ctx.outputs.evidence_run_url }}
+          EVIDENCE_REPO: ${{ steps.ctx.outputs.evidence_repo }}
+          FAILING_RUN_URL: ${{ inputs.failing_run_url }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/alwaysgreen-artifacts
+          dl() { # repo, run_id, pattern
+            gh run download "$2" --repo "$1" --pattern "$3" \
+              --dir "/tmp/alwaysgreen-artifacts/$3" 2>/dev/null \
+              && echo "  got $3 from $1#$2" \
+              || echo "  (absent) $3 from $1#$2"
+          }
+          if [ -n "${EVIDENCE_RUN_URL}" ] && [ -n "${EVIDENCE_REPO}" ]; then
+            eid="${EVIDENCE_RUN_URL##*/}"
+            dl "${EVIDENCE_REPO}" "$eid" 'playwright-results-json*'
+            dl "${EVIDENCE_REPO}" "$eid" 'playwright-traces*'
+            dl "${EVIDENCE_REPO}" "$eid" 'json-report*'
+            dl "${EVIDENCE_REPO}" "$eid" 'Playwright Report*'
+          fi
+          # Cluster-side diagnostics live on the AlwaysGreen run itself and are the
+          # only evidence for a Ready-but-erroring component. Retention is 1 day, so
+          # absence is normal for a replay of an older run.
+          if [ -n "${FAILING_RUN_URL}" ]; then
+            dl "${GITHUB_REPOSITORY}" "${FAILING_RUN_URL##*/}" 'diagnostics-e2e*'
+          fi
+          find /tmp/alwaysgreen-artifacts -type f | head -40
+
+      - name: Run Claude Code fix agent
+        env:
+          ANTHROPIC_API_KEY: ${{ steps.secrets.outputs.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          GH_PAT: ${{ steps.secrets.outputs.GH_PAT }}
+          WORKSPACE_NAME: ${{ steps.ws.outputs.name }}
+          BASE_REF: ${{ inputs.base_ref }}
+          SURFACE: ${{ inputs.surface }}
+          VERSION: ${{ steps.target.outputs.version }}
+          FAILING_RUN_URL: ${{ inputs.failing_run_url }}
+          TRIAGE_RUN_URL: ${{ inputs.triage_run_url }}
+          BLAME_AUTHOR: ${{ steps.ctx.outputs.blame_author }}
+          BLAME_PR: ${{ steps.ctx.outputs.blame_pr }}
+        run: |
+          set -euo pipefail
+          ws_dir="$HOME/workspaces/${WORKSPACE_NAME}"
+
+          prompt=$(cat <<EOF
+          You are the Camunda AlwaysGreen fix agent. Workspace: ${ws_dir}
+
+          STEP 0 — read ${ws_dir}/camunda/docs/alwaysgreen/FIX-AGENT.md in full. That is
+          your operating manual: evidence map, diagnosis order, the PR coverage-block
+          contract, and the constraints. Do not skip it.
+
+          Failing surface: ${SURFACE}   Branch to fix against: ${BASE_REF}   Version: ${VERSION}
+          Failing AlwaysGreen run: ${FAILING_RUN_URL}
+          Triage run: ${TRIAGE_RUN_URL}
+          Breaking change: PR #${BLAME_PR} by ${BLAME_AUTHOR}
+
+          /tmp/test_specs.json  — the failing specs, with retry history per attempt.
+          /tmp/fingerprints.json — the fingerprints your PR body MUST claim in its
+          coverage block. Omitting one causes the same failure to be re-dispatched.
+          /tmp/alwaysgreen-artifacts/ — downloaded evidence (reports, traces,
+          screenshots, and the namespace diagnostics dump when present).
+
+          Fix ONLY the listed failures.
+
+          A spec whose attempts all failed is deterministic, not flaky — do not "fix" it
+          with a longer timeout. A spec that eventually passed IS flaky and wants a
+          waiting/retry fix.
+
+          The failing job tells you which surface broke, NOT which repository to change.
+          The most common sm-smoke-e2e failure is a Keycloak deploy problem surfacing as
+          a Playwright timeout: the assertion is correct and the environment is broken.
+          Read the diagnostics dump before concluding the test is at fault. Never mask a
+          real failure with a timeout bump, a weakened assertion, or a selector swap.
+
+          "No fix determined" is a legitimate outcome. Write it to /tmp/fix-meta.json
+          with the evidence rather than guessing.
+
+          Branch naming: fix/alwaysgreen-${SURFACE}-<slug>. Commit/PR type: 'test:' for
+          test-only changes, 'ci:' for workflow changes, 'fix:' for product or chart code.
+
+          When done write /tmp/fix-meta.json and stop.
+          EOF
+          )
+
+          cd "${ws_dir}"
+          claude -p "$prompt" --dangerously-skip-permissions
+
+      - name: Request review and label PRs
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          BLAME_REVIEWER: ${{ steps.ctx.outputs.blame_reviewer }}
+          DEFAULT_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          [ -f /tmp/fix-meta.json ] || { echo "no fix-meta.json"; exit 0; }
+
+          jq -c '.prs[]?' /tmp/fix-meta.json | while read -r pr; do
+            num=$(jq -r '.number' <<<"$pr")
+            owner=$(jq -r '.owner // ""' <<<"$pr")
+            name=$(jq -r '.repo // ""' <<<"$pr")
+            repo="${DEFAULT_REPO}"
+            [ -n "$owner" ] && [ -n "$name" ] && repo="${owner}/${name}"
+
+            gh pr edit "$num" --repo "$repo" --add-label "${FIX_LABEL}" 2>/dev/null || true
+
+            # Requesting review can legitimately fail: the blamed author may not be a
+            # collaborator on the repo the fix landed in. The manual requires the author
+            # to be named in the PR body regardless, so the signal is not lost.
+            if [ -n "${BLAME_REVIEWER}" ]; then
+              if gh pr edit "$num" --repo "$repo" --add-reviewer "${BLAME_REVIEWER}" 2>/dev/null; then
+                echo "review requested from ${BLAME_REVIEWER} on ${repo}#${num}"
+              else
+                echo "::warning::could not request review from ${BLAME_REVIEWER} on ${repo}#${num}"
+              fi
+            fi
+          done
+
+      - name: Write job summary
+        if: always()
+        env:
+          SURFACE: ${{ inputs.surface }}
+          BASE_REF: ${{ inputs.base_ref }}
+          TRIAGE_RUN_URL: ${{ inputs.triage_run_url }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## AlwaysGreen Fix Agent — ${SURFACE} on \`${BASE_REF}\`"
+            echo ""
+            if [ ! -f /tmp/fix-meta.json ]; then
+              echo ":x: agent produced no \`/tmp/fix-meta.json\` — see logs."
+            else
+              n=$(jq '.prs | length' /tmp/fix-meta.json 2>/dev/null || echo 0)
+              if [ "$n" -eq 0 ]; then
+                echo ":warning: **No fix applied.**"
+                reason=$(jq -r '.reason // .root_cause // ""' /tmp/fix-meta.json)
+                [ -n "$reason" ] && { echo ""; echo "**Reason:** ${reason}"; }
+              else
+                jq -r '.prs[] | "### :white_check_mark: [PR #\(.number)](\(.url // ""))", "", "**Branch:** `\(.branch // "?")`", ""' \
+                  /tmp/fix-meta.json
+                jq -r '.prs[] | select(.root_cause) | "**Root cause:** \(.root_cause)", ""' /tmp/fix-meta.json
+              fi
+            fi
+            [ -n "${TRIAGE_RUN_URL}" ] && { echo ""; echo "**Triage run:** [↗](${TRIAGE_RUN_URL})"; }
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload agent artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: alwaysgreen-fix-${{ github.run_id }}
+          path: |
+            /tmp/test_specs.json
+            /tmp/fingerprints.json
+            /tmp/fix-meta.json
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Slack thread reply
+        if: ${{ always() && steps.ctx.outputs.slack_ts != '' }}
+        continue-on-error: true
+        env:
+          SLACK_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_USER_OAUTH_TOKEN }}
+          SLACK_TS: ${{ steps.ctx.outputs.slack_ts }}
+          SLACK_CHANNEL: ${{ steps.ctx.outputs.slack_channel }}
+          SURFACE: ${{ inputs.surface }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          set -euo pipefail
+          if [ -f /tmp/fix-meta.json ] && [ "$(jq '.prs | length' /tmp/fix-meta.json)" -gt 0 ]; then
+            links=$(jq -r '[.prs[] | "<\(.url // "")|PR #\(.number)>"] | join("  ")' /tmp/fix-meta.json)
+            text=":white_check_mark: *${SURFACE}* — ${links}"
+          elif [ "${JOB_STATUS}" = "failure" ]; then
+            text=":x: *${SURFACE}* — agent failed, no fix applied"
+          else
+            text=":warning: *${SURFACE}* — no fix determined, manual investigation needed"
+          fi
+          payload=$(jq -nc --arg c "$SLACK_CHANNEL" --arg ts "$SLACK_TS" \
+            --arg t "${text}"$'\n'"<${RUN_URL}|Agent run ↗>" \
+            '{channel:$c, thread_ts:$ts, text:$t, mrkdwn:true}')
+          curl -sS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${SLACK_TOKEN}" \
+            -H 'Content-Type: application/json; charset=utf-8' \
+            -d "$payload" >/dev/null || true
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: alwaysgreen-fix
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/alwaysgreen-triage.yml
+++ b/.github/workflows/alwaysgreen-triage.yml
@@ -97,9 +97,9 @@ jobs:
       # Kill switch and mode, from ALWAYSGREEN_FIX_AGENT at
       # secret/data/products/qa/ci/common:
       #
-      #   off       nothing runs; the job exits immediately
+      #   disabled  nothing runs; the job exits immediately
       #   dry-run   classify and report, dispatch nothing   (default when unset)
-      #   on        dispatch fix agents
+      #   enabled   dispatch fix agents
       - name: Resolve run mode
         id: mode
         uses: ./.github/actions/alwaysgreen-flag
@@ -110,26 +110,26 @@ jobs:
           dry-run-override: ${{ inputs.dry_run }}
 
       - name: Report disabled and stop
-        if: ${{ steps.mode.outputs.enabled != 'true' }}
+        if: ${{ steps.mode.outputs.active != 'true' }}
         run: |
           {
             echo "## AlwaysGreen Triage — disabled"
             echo ""
             echo "\`ALWAYSGREEN_FIX_AGENT\` at \`secret/data/products/qa/ci/common\` is"
-            echo "\`off\`, so no classification or"
+            echo "\`disabled\`, so no classification or"
             echo "dispatch ran. Set it to \`dry-run\` or \`on\` to re-enable."
           } >> "$GITHUB_STEP_SUMMARY"
           echo "::notice::AlwaysGreen triage is disabled by repository variable."
 
 
       - name: Set up Python
-        if: ${{ steps.mode.outputs.enabled == 'true' }}
+        if: ${{ steps.mode.outputs.active == 'true' }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
       - name: Resolve target run
-        if: ${{ steps.mode.outputs.enabled == 'true' }}
+        if: ${{ steps.mode.outputs.active == 'true' }}
         id: target
         env:
           INPUT_RUN_ID: ${{ inputs.run_id }}
@@ -151,7 +151,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Generate GitHub App Token
-        if: ${{ steps.mode.outputs.enabled == 'true' }}
+        if: ${{ steps.mode.outputs.active == 'true' }}
         id: github-token
         uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
         with:
@@ -167,7 +167,7 @@ jobs:
           repositories: camunda,c8-cross-component-e2e-tests
 
       - name: Import Slack token
-        if: ${{ steps.mode.outputs.enabled == 'true' }}
+        if: ${{ steps.mode.outputs.active == 'true' }}
         id: slack-secrets
         continue-on-error: true
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
@@ -182,7 +182,7 @@ jobs:
 
       - name: Discover and plan
         id: plan
-        if: ${{ steps.mode.outputs.enabled == 'true' }}
+        if: ${{ steps.mode.outputs.active == 'true' }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
@@ -199,7 +199,7 @@ jobs:
           echo "count=$(jq '.dispatches | length' /tmp/alwaysgreen-plan.json)" >> "$GITHUB_OUTPUT"
 
       - name: Write job summary
-        if: ${{ always() && steps.mode.outputs.enabled == 'true' }}
+        if: ${{ always() && steps.mode.outputs.active == 'true' }}
         run: |
           set -euo pipefail
           [ -f /tmp/alwaysgreen-plan.json ] || exit 0
@@ -229,7 +229,7 @@ jobs:
               jq -r '.dispatches[] | "| \(.surface) | \(.test_specs | length) | \([.test_specs[] | select(.deterministic)] | length) | `\(.dispatch_key)` |"' \
                 /tmp/alwaysgreen-plan.json
               echo ""
-              echo "Set \`ALWAYSGREEN_FIX_AGENT\` to \`on\` in Vault to dispatch these."
+              echo "Set \`ALWAYSGREEN_FIX_AGENT\` to \`enabled\` in Vault to dispatch these."
               echo ""
             else
               echo "> No dispatchable candidates."
@@ -251,7 +251,7 @@ jobs:
 
       - name: Post Slack summary
         id: slack
-        if: ${{ steps.mode.outputs.enabled == 'true' && steps.slack-secrets.outcome == 'success' && (steps.plan.outputs.count != '0' || inputs.parent_slack_ts != '') }}
+        if: ${{ steps.mode.outputs.active == 'true' && steps.slack-secrets.outcome == 'success' && (steps.plan.outputs.count != '0' || inputs.parent_slack_ts != '') }}
         continue-on-error: true
         env:
           SLACK_TOKEN: ${{ steps.slack-secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
@@ -350,7 +350,7 @@ jobs:
           done
 
       - name: Flag discovery failure
-        if: ${{ steps.mode.outputs.enabled == 'true' && steps.plan.outcome != 'success' }}
+        if: ${{ steps.mode.outputs.active == 'true' && steps.plan.outcome != 'success' }}
         run: |
           echo "::warning::AlwaysGreen discovery failed; no fix agent was dispatched for this run."
           {

--- a/.github/workflows/alwaysgreen-triage.yml
+++ b/.github/workflows/alwaysgreen-triage.yml
@@ -29,6 +29,18 @@ on:
         required: false
         type: number
         default: 2
+      parent_slack_ts:
+        description: >
+          ts of the post-failure-feedback message for this failure. When set, triage
+          replies in that thread instead of starting a new one.
+        required: false
+        type: string
+        default: ''
+      parent_slack_channel:
+        description: 'Channel of parent_slack_ts'
+        required: false
+        type: string
+        default: ''
   workflow_dispatch:
     inputs:
       run_id:
@@ -189,27 +201,64 @@ jobs:
 
       - name: Post Slack summary
         id: slack
-        if: ${{ steps.plan.outcome == 'success' && steps.plan.outputs.count != '0' && steps.slack-secrets.outcome == 'success' }}
+        if: ${{ steps.slack-secrets.outcome == 'success' && (steps.plan.outputs.count != '0' || inputs.parent_slack_ts != '') }}
         continue-on-error: true
         env:
           SLACK_TOKEN: ${{ steps.slack-secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PARENT_TS: ${{ inputs.parent_slack_ts }}
+          PARENT_CHANNEL: ${{ inputs.parent_slack_channel }}
+          PLAN_OUTCOME: ${{ steps.plan.outcome }}
         run: |
           set -euo pipefail
           base_ref='${{ steps.target.outputs.base_ref }}'
+          [ -f /tmp/alwaysgreen-plan.json ] || echo '{"dispatches":[],"suppressed":[],"noise":[],"blame":{}}' > /tmp/alwaysgreen-plan.json
           count=$(jq '.dispatches | length' /tmp/alwaysgreen-plan.json)
-          failing_url=$(jq -r '.run_url' /tmp/alwaysgreen-plan.json)
+          failing_url=$(jq -r '.run_url // ""' /tmp/alwaysgreen-plan.json)
           surfaces=$(jq -r '[.dispatches[].surface] | join(", ")' /tmp/alwaysgreen-plan.json)
           reviewer=$(jq -r 'if .blame.reviewer then "<https://github.com/\(.blame.reviewer)|@\(.blame.reviewer)>" else "unresolved" end' /tmp/alwaysgreen-plan.json)
-          text=":robot_face: *AlwaysGreen fix agent dispatched* on \`${base_ref}\`"$'\n'"${count} agent(s): ${surfaces}"$'\n'"Failing run: <${failing_url}|↗> · Triage: <${RUN_URL}|↗> · Blame: ${reviewer}"
-          payload=$(jq -nc --arg channel "${{ env.ALERT_CHANNEL_ID }}" --arg text "$text" \
-            '{channel: $channel, text: $text, mrkdwn: true}')
+
+          if [ "${PLAN_OUTCOME}" != "success" ]; then
+            text=":warning: *AlwaysGreen triage failed* on \`${base_ref}\` — no agent dispatched"$'\n'"Triage: <${RUN_URL}|↗>"
+          elif [ "${count}" != "0" ]; then
+            text=":robot_face: *AlwaysGreen fix agent dispatched* on \`${base_ref}\`"$'\n'"${count} agent(s): ${surfaces}"$'\n'"Failing run: <${failing_url}|↗> · Triage: <${RUN_URL}|↗> · Blame: ${reviewer}"
+          else
+            # Nothing actionable. Name the reasons so the thread explains itself without
+            # anyone opening the run.
+            reasons=$(jq -r '
+              ([.suppressed[]? | .reason] + [.noise[]? | .verdict])
+              | if length == 0 then "no failing job mapped to a known surface"
+                else (group_by(.) | map("\(.[0]) x\(length)") | join(", ")) end' \
+              /tmp/alwaysgreen-plan.json 2>/dev/null || echo "unknown")
+            text=":information_source: *AlwaysGreen triage: nothing to dispatch* on \`${base_ref}\`"$'\n'"${reasons}"$'\n'"Triage: <${RUN_URL}|↗>"
+          fi
+
+          # Thread onto the post-failure-feedback message when the caller handed one
+          # down, so one failure produces one Slack thread. Falling back to a new
+          # top-level message keeps SaaS-only failures (whose stage posts no feedback)
+          # and Slack outages reported rather than silent.
+          if [ -n "${PARENT_TS}" ] && [ -n "${PARENT_CHANNEL}" ]; then
+            channel="${PARENT_CHANNEL}"
+            payload=$(jq -nc --arg channel "$channel" --arg ts "${PARENT_TS}" --arg text "$text" \
+              '{channel: $channel, thread_ts: $ts, text: $text, mrkdwn: true}')
+          else
+            channel="${{ env.ALERT_CHANNEL_ID }}"
+            payload=$(jq -nc --arg channel "$channel" --arg text "$text" \
+              '{channel: $channel, text: $text, mrkdwn: true}')
+          fi
+
           resp=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${SLACK_TOKEN}" \
             -H 'Content-Type: application/json; charset=utf-8' \
             -d "$payload" || echo '{}')
-          echo "ts=$(jq -r '.ts // ""' <<<"$resp")" >> "$GITHUB_OUTPUT"
-          echo "channel=$(jq -r '.channel // ""' <<<"$resp")" >> "$GITHUB_OUTPUT"
+          [ "$(jq -r '.ok // false' <<<"$resp")" = "true" ] \
+            || echo "::warning::Slack post failed: $(jq -r '.error // "unknown"' <<<"$resp")"
+
+          # The fix agent must reply as a sibling in the SAME thread, so pass the parent
+          # ts through when threading; our own reply's ts would nest nothing useful.
+          out_ts="${PARENT_TS:-$(jq -r '.ts // ""' <<<"$resp")}"
+          echo "ts=${out_ts}" >> "$GITHUB_OUTPUT"
+          echo "channel=$(jq -r --arg c "$channel" '.channel // $c' <<<"$resp")" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch fix agents
         # outcome, not just count: a failed discovery leaves count empty, and '' != '0'

--- a/.github/workflows/alwaysgreen-triage.yml
+++ b/.github/workflows/alwaysgreen-triage.yml
@@ -1,0 +1,281 @@
+# description: Classifies a failed AlwaysGreen run and dispatches the fix agent.
+#              Called as the final job of docker-build-helm-integration.yml, so
+#              github.run_id is the failing run and its artifacts are readable here.
+#              Also dispatchable with an explicit run_id to replay a past run.
+# type: CI
+# owner: @camunda/test-automation-team
+---
+name: AlwaysGreen Triage
+
+on:
+  workflow_call:
+    inputs:
+      base_ref:
+        description: 'Branch the failing run was on (main, stable/8.x)'
+        required: true
+        type: string
+      chart_version:
+        description: 'Chart directory the run deployed, e.g. camunda-platform-8.10'
+        required: false
+        type: string
+        default: ''
+      dry_run:
+        description: 'Classify and report, but do not dispatch'
+        required: false
+        type: boolean
+        default: false
+      max_dispatches:
+        description: 'Cap on fix-agent dispatches for this run'
+        required: false
+        type: number
+        default: 2
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'AlwaysGreen run to classify (blank = this workflow run, which is rarely useful)'
+        required: true
+      base_ref:
+        description: 'Branch the failing run was on'
+        required: true
+        default: main
+      dry_run:
+        description: 'Classify and report, but do not dispatch'
+        type: boolean
+        required: false
+        default: true
+      max_dispatches:
+        description: 'Cap on fix-agent dispatches'
+        required: false
+        default: '2'
+
+permissions:
+  contents: read
+  actions: write
+  pull-requests: read
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  TEST_OWNER: '@camunda/test-automation-team'
+  FIX_WORKFLOW: alwaysgreen-fix.yml
+  # The fix agent workflow only exists on the default branch; base_ref travels as an
+  # input so a stable-branch failure is still fixed against its own branch.
+  FIX_AGENT_REF: main
+  ALERT_CHANNEL_ID: 'C0AK0AVKRL0'
+
+jobs:
+  triage:
+    name: Classify and dispatch
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.12'
+
+      - name: Resolve target run
+        id: target
+        env:
+          INPUT_RUN_ID: ${{ inputs.run_id }}
+          INPUT_BASE_REF: ${{ inputs.base_ref }}
+          CALLER_RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # On workflow_call there is no run_id input and github.run_id is the caller's
+          # run, which is exactly the run that failed.
+          run_id="${INPUT_RUN_ID:-$CALLER_RUN_ID}"
+          if [[ ! "$run_id" =~ ^[0-9]+$ ]]; then
+            echo "::error::run_id must be numeric, got '$run_id'"
+            exit 1
+          fi
+          {
+            echo "run_id=${run_id}"
+            echo "base_ref=${INPUT_BASE_REF}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate GitHub App Token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        with:
+          github-app-id-vault-key: GITHUB_APP_ID
+          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          github-app-private-key-vault-key: GITHUB_APP_SECRET
+          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          owner: camunda
+          repositories: camunda,c8-cross-component-e2e-tests
+
+      - name: Import Slack token
+        id: slack-secrets
+        continue-on-error: true
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_CORE_DOMAIN_BOT_TOKEN;
+
+      - name: Discover and plan
+        id: plan
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          RUN_ID: ${{ steps.target.outputs.run_id }}
+          BASE_REF: ${{ steps.target.outputs.base_ref }}
+          MAX_DISPATCHES: ${{ inputs.max_dispatches || '2' }}
+        run: |
+          set -euo pipefail
+          python .github/scripts/alwaysgreen/discover.py \
+            --run-id "$RUN_ID" \
+            --base-ref "$BASE_REF" \
+            --max-dispatches "$MAX_DISPATCHES" \
+            --out /tmp/alwaysgreen-plan.json
+          echo "count=$(jq '.dispatches | length' /tmp/alwaysgreen-plan.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Write job summary
+        if: always()
+        run: |
+          set -euo pipefail
+          [ -f /tmp/alwaysgreen-plan.json ] || exit 0
+          {
+            echo "## AlwaysGreen Triage"
+            echo ""
+            echo "- run: ${{ steps.target.outputs.run_id }} (\`${{ steps.target.outputs.base_ref }}\`)"
+            echo "- dry-run: ${{ inputs.dry_run || false }}"
+            blame_reviewer=$(jq -r '.blame.reviewer // "unresolved"' /tmp/alwaysgreen-plan.json)
+            blame_via=$(jq -r '.blame.via // "-"' /tmp/alwaysgreen-plan.json)
+            echo "- blame: ${blame_reviewer} (via ${blame_via})"
+            echo ""
+            if [ "$(jq '.dispatches | length' /tmp/alwaysgreen-plan.json)" -gt 0 ]; then
+              echo "### Dispatching"
+              echo ""
+              echo "| Surface | Specs | Deterministic | Key |"
+              echo "|---|---|---|---|"
+              jq -r '.dispatches[] | "| \(.surface) | \(.test_specs | length) | \([.test_specs[] | select(.deterministic)] | length) | `\(.dispatch_key)` |"' \
+                /tmp/alwaysgreen-plan.json
+              echo ""
+            else
+              echo "> Nothing dispatched."
+              echo ""
+            fi
+            if [ "$(jq '.suppressed | length' /tmp/alwaysgreen-plan.json)" -gt 0 ]; then
+              echo "### Suppressed"
+              echo ""
+              jq -r '.suppressed[] | "- `\(.surface)`: \(.reason)\(if .detail != "" then " (\(.detail))" else "" end)"' \
+                /tmp/alwaysgreen-plan.json
+              echo ""
+            fi
+            if [ "$(jq '.noise | length' /tmp/alwaysgreen-plan.json)" -gt 0 ]; then
+              echo "### Not diagnosable (no dispatch)"
+              echo ""
+              jq -r '.noise[] | "- \(.verdict): \(.job)"' /tmp/alwaysgreen-plan.json
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post Slack summary
+        id: slack
+        if: ${{ steps.plan.outcome == 'success' && steps.plan.outputs.count != '0' && steps.slack-secrets.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          SLACK_TOKEN: ${{ steps.slack-secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          base_ref='${{ steps.target.outputs.base_ref }}'
+          count=$(jq '.dispatches | length' /tmp/alwaysgreen-plan.json)
+          failing_url=$(jq -r '.run_url' /tmp/alwaysgreen-plan.json)
+          surfaces=$(jq -r '[.dispatches[].surface] | join(", ")' /tmp/alwaysgreen-plan.json)
+          reviewer=$(jq -r 'if .blame.reviewer then "<https://github.com/\(.blame.reviewer)|@\(.blame.reviewer)>" else "unresolved" end' /tmp/alwaysgreen-plan.json)
+          text=":robot_face: *AlwaysGreen fix agent dispatched* on \`${base_ref}\`"$'\n'"${count} agent(s): ${surfaces}"$'\n'"Failing run: <${failing_url}|↗> · Triage: <${RUN_URL}|↗> · Blame: ${reviewer}"
+          payload=$(jq -nc --arg channel "${{ env.ALERT_CHANNEL_ID }}" --arg text "$text" \
+            '{channel: $channel, text: $text, mrkdwn: true}')
+          resp=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${SLACK_TOKEN}" \
+            -H 'Content-Type: application/json; charset=utf-8' \
+            -d "$payload" || echo '{}')
+          echo "ts=$(jq -r '.ts // ""' <<<"$resp")" >> "$GITHUB_OUTPUT"
+          echo "channel=$(jq -r '.channel // ""' <<<"$resp")" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch fix agents
+        # outcome, not just count: a failed discovery leaves count empty, and '' != '0'
+        # would otherwise dispatch with no plan file.
+        if: ${{ steps.plan.outcome == 'success' && steps.plan.outputs.count != '0' && !inputs.dry_run }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          SLACK_TS: ${{ steps.slack.outputs.ts }}
+          SLACK_CHANNEL: ${{ steps.slack.outputs.channel }}
+          TRIAGE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # workflow_dispatch caps at 10 inputs, so blame/slack/evidence travel as
+          # single JSON objects. The fix workflow unpacks them in its first step.
+          blame_json=$(jq -c '{reviewer: (.blame.reviewer // ""),
+                               author:   (.blame.author // ""),
+                               pr:       (.blame.pr_number // "" | tostring)}' \
+                        /tmp/alwaysgreen-plan.json)
+          slack_json=$(jq -nc --arg ts "${SLACK_TS:-}" --arg channel "${SLACK_CHANNEL:-}" \
+                        '{ts: $ts, channel: $channel}')
+          failing_run_url=$(jq -r '.run_url' /tmp/alwaysgreen-plan.json)
+
+          jq -c '.dispatches[]' /tmp/alwaysgreen-plan.json | while read -r d; do
+            key=$(jq -r '.dispatch_key' <<<"$d")
+            echo "Dispatching ${key}"
+            gh workflow run "${FIX_WORKFLOW}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --ref "${FIX_AGENT_REF}" \
+              -f base_ref="$(jq -r '.base_ref' <<<"$d")" \
+              -f surface="$(jq -r '.surface' <<<"$d")" \
+              -f test_specs="$(jq -c '.test_specs' <<<"$d")" \
+              -f fingerprints="$(jq -c '.fingerprints' <<<"$d")" \
+              -f evidence="$(jq -c '{run_url: .evidence_run_url, repo: .evidence_repo}' <<<"$d")" \
+              -f failing_run_url="${failing_run_url}" \
+              -f triage_run_url="${TRIAGE_RUN_URL}" \
+              -f blame="${blame_json}" \
+              -f slack="${slack_json}"
+          done
+
+      - name: Flag discovery failure
+        if: ${{ steps.plan.outcome != 'success' }}
+        run: |
+          echo "::warning::AlwaysGreen discovery failed; no fix agent was dispatched for this run."
+          {
+            echo "## AlwaysGreen Triage"
+            echo ""
+            echo ":warning: Discovery failed — see the \`Discover and plan\` step. No agent dispatched."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload triage artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: alwaysgreen-triage-${{ steps.target.outputs.run_id }}-${{ github.run_attempt }}
+          path: /tmp/alwaysgreen-plan.json
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: alwaysgreen-triage
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/alwaysgreen-triage.yml
+++ b/.github/workflows/alwaysgreen-triage.yml
@@ -86,45 +86,28 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      # Kill switch and mode, held in a repository variable so it can be changed in
-      # Settings -> Variables and take effect on the very next run — no PR, no merge.
+      # Checkout first: the flag lives in a local composite action, and the flag
+      # decides whether anything else runs.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github
+          persist-credentials: false
+
+      # Kill switch and mode, from ALWAYSGREEN_FIX_AGENT at
+      # secret/data/products/qa/ci/common:
       #
       #   off       nothing runs; the job exits immediately
       #   dry-run   classify and report, dispatch nothing   (default when unset)
       #   on        dispatch fix agents
-      #
-      # Unset defaults to dry-run, so deleting the variable degrades to safe rather
-      # than to live.
       - name: Resolve run mode
         id: mode
-        env:
-          CONFIGURED: ${{ vars.ALWAYSGREEN_FIX_AGENT }}
-          INPUT_DRY_RUN: ${{ inputs.dry_run }}
-        run: |
-          set -euo pipefail
-          mode="${CONFIGURED:-dry-run}"
-          case "$mode" in
-            off|dry-run|on) ;;
-            *)
-              echo "::warning::ALWAYSGREEN_FIX_AGENT='${mode}' is not one of off|dry-run|on; treating as dry-run"
-              mode="dry-run"
-              ;;
-          esac
-
-          enabled=true
-          dispatch=false
-          [ "$mode" = "off" ] && enabled=false
-          # A caller or operator asking for a dry run always wins over mode=on.
-          if [ "$mode" = "on" ] && [ "${INPUT_DRY_RUN}" != "true" ]; then
-            dispatch=true
-          fi
-
-          {
-            echo "mode=${mode}"
-            echo "enabled=${enabled}"
-            echo "dispatch=${dispatch}"
-          } >> "$GITHUB_OUTPUT"
-          echo "mode=${mode} enabled=${enabled} dispatch=${dispatch}"
+        uses: ./.github/actions/alwaysgreen-flag
+        with:
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          dry-run-override: ${{ inputs.dry_run }}
 
       - name: Report disabled and stop
         if: ${{ steps.mode.outputs.enabled != 'true' }}
@@ -132,17 +115,12 @@ jobs:
           {
             echo "## AlwaysGreen Triage — disabled"
             echo ""
-            echo "\`vars.ALWAYSGREEN_FIX_AGENT\` is \`off\`, so no classification or"
+            echo "\`ALWAYSGREEN_FIX_AGENT\` at \`secret/data/products/qa/ci/common\` is"
+            echo "\`off\`, so no classification or"
             echo "dispatch ran. Set it to \`dry-run\` or \`on\` to re-enable."
           } >> "$GITHUB_STEP_SUMMARY"
           echo "::notice::AlwaysGreen triage is disabled by repository variable."
 
-      - name: Checkout
-        if: ${{ steps.mode.outputs.enabled == 'true' }}
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          sparse-checkout: .github
-          persist-credentials: false
 
       - name: Set up Python
         if: ${{ steps.mode.outputs.enabled == 'true' }}
@@ -251,7 +229,7 @@ jobs:
               jq -r '.dispatches[] | "| \(.surface) | \(.test_specs | length) | \([.test_specs[] | select(.deterministic)] | length) | `\(.dispatch_key)` |"' \
                 /tmp/alwaysgreen-plan.json
               echo ""
-              echo "Set \`vars.ALWAYSGREEN_FIX_AGENT=on\` to dispatch these."
+              echo "Set \`ALWAYSGREEN_FIX_AGENT\` to \`on\` in Vault to dispatch these."
               echo ""
             else
               echo "> No dispatchable candidates."

--- a/.github/workflows/alwaysgreen-triage.yml
+++ b/.github/workflows/alwaysgreen-triage.yml
@@ -116,10 +116,10 @@ jobs:
             echo "## AlwaysGreen Triage — disabled"
             echo ""
             echo "\`ALWAYSGREEN_FIX_AGENT\` at \`secret/data/products/qa/ci/common\` is"
-            echo "\`disabled\`, so no classification or"
-            echo "dispatch ran. Set it to \`dry-run\` or \`on\` to re-enable."
+            echo "\`disabled\`, so no classification or dispatch ran. Set it to"
+            echo "\`dry-run\` or \`enabled\` in Vault to re-enable."
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "::notice::AlwaysGreen triage is disabled by repository variable."
+          echo "::notice::AlwaysGreen triage is disabled by the Vault feature flag."
 
 
       - name: Set up Python
@@ -153,7 +153,7 @@ jobs:
       - name: Generate GitHub App Token
         if: ${{ steps.mode.outputs.active == 'true' }}
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
         with:
           github-app-id-vault-key: GITHUB_APP_ID
           github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes

--- a/.github/workflows/alwaysgreen-triage.yml
+++ b/.github/workflows/alwaysgreen-triage.yml
@@ -44,7 +44,10 @@ on:
   workflow_dispatch:
     inputs:
       run_id:
-        description: 'AlwaysGreen run to classify (blank = this workflow run, which is rarely useful)'
+        description: >
+          AlwaysGreen run to classify. Required: a manual replay always targets a
+          specific past run. The workflow_call path does not take this input and uses
+          the calling run instead.
         required: true
       base_ref:
         description: 'Branch the failing run was on'
@@ -83,18 +86,72 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      # Kill switch and mode, held in a repository variable so it can be changed in
+      # Settings -> Variables and take effect on the very next run — no PR, no merge.
+      #
+      #   off       nothing runs; the job exits immediately
+      #   dry-run   classify and report, dispatch nothing   (default when unset)
+      #   on        dispatch fix agents
+      #
+      # Unset defaults to dry-run, so deleting the variable degrades to safe rather
+      # than to live.
+      - name: Resolve run mode
+        id: mode
+        env:
+          CONFIGURED: ${{ vars.ALWAYSGREEN_FIX_AGENT }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          mode="${CONFIGURED:-dry-run}"
+          case "$mode" in
+            off|dry-run|on) ;;
+            *)
+              echo "::warning::ALWAYSGREEN_FIX_AGENT='${mode}' is not one of off|dry-run|on; treating as dry-run"
+              mode="dry-run"
+              ;;
+          esac
+
+          enabled=true
+          dispatch=false
+          [ "$mode" = "off" ] && enabled=false
+          # A caller or operator asking for a dry run always wins over mode=on.
+          if [ "$mode" = "on" ] && [ "${INPUT_DRY_RUN}" != "true" ]; then
+            dispatch=true
+          fi
+
+          {
+            echo "mode=${mode}"
+            echo "enabled=${enabled}"
+            echo "dispatch=${dispatch}"
+          } >> "$GITHUB_OUTPUT"
+          echo "mode=${mode} enabled=${enabled} dispatch=${dispatch}"
+
+      - name: Report disabled and stop
+        if: ${{ steps.mode.outputs.enabled != 'true' }}
+        run: |
+          {
+            echo "## AlwaysGreen Triage — disabled"
+            echo ""
+            echo "\`vars.ALWAYSGREEN_FIX_AGENT\` is \`off\`, so no classification or"
+            echo "dispatch ran. Set it to \`dry-run\` or \`on\` to re-enable."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice::AlwaysGreen triage is disabled by repository variable."
+
       - name: Checkout
+        if: ${{ steps.mode.outputs.enabled == 'true' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
           persist-credentials: false
 
       - name: Set up Python
+        if: ${{ steps.mode.outputs.enabled == 'true' }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
       - name: Resolve target run
+        if: ${{ steps.mode.outputs.enabled == 'true' }}
         id: target
         env:
           INPUT_RUN_ID: ${{ inputs.run_id }}
@@ -102,8 +159,9 @@ jobs:
           CALLER_RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          # On workflow_call there is no run_id input and github.run_id is the caller's
-          # run, which is exactly the run that failed.
+          # The fallback serves workflow_call, where run_id is not an input at all and
+          # github.run_id is the caller's run — exactly the run that failed. On
+          # workflow_dispatch run_id is required, so the fallback never applies there.
           run_id="${INPUT_RUN_ID:-$CALLER_RUN_ID}"
           if [[ ! "$run_id" =~ ^[0-9]+$ ]]; then
             echo "::error::run_id must be numeric, got '$run_id'"
@@ -115,6 +173,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Generate GitHub App Token
+        if: ${{ steps.mode.outputs.enabled == 'true' }}
         id: github-token
         uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
         with:
@@ -130,6 +189,7 @@ jobs:
           repositories: camunda,c8-cross-component-e2e-tests
 
       - name: Import Slack token
+        if: ${{ steps.mode.outputs.enabled == 'true' }}
         id: slack-secrets
         continue-on-error: true
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
@@ -144,6 +204,7 @@ jobs:
 
       - name: Discover and plan
         id: plan
+        if: ${{ steps.mode.outputs.enabled == 'true' }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
@@ -160,7 +221,7 @@ jobs:
           echo "count=$(jq '.dispatches | length' /tmp/alwaysgreen-plan.json)" >> "$GITHUB_OUTPUT"
 
       - name: Write job summary
-        if: always()
+        if: ${{ always() && steps.mode.outputs.enabled == 'true' }}
         run: |
           set -euo pipefail
           [ -f /tmp/alwaysgreen-plan.json ] || exit 0
@@ -168,12 +229,13 @@ jobs:
             echo "## AlwaysGreen Triage"
             echo ""
             echo "- run: ${{ steps.target.outputs.run_id }} (\`${{ steps.target.outputs.base_ref }}\`)"
-            echo "- dry-run: ${{ inputs.dry_run || false }}"
+            echo "- mode: ${{ steps.mode.outputs.mode }} (dispatch=${{ steps.mode.outputs.dispatch }})"
             blame_reviewer=$(jq -r '.blame.reviewer // "unresolved"' /tmp/alwaysgreen-plan.json)
             blame_via=$(jq -r '.blame.via // "-"' /tmp/alwaysgreen-plan.json)
             echo "- blame: ${blame_reviewer} (via ${blame_via})"
             echo ""
-            if [ "$(jq '.dispatches | length' /tmp/alwaysgreen-plan.json)" -gt 0 ]; then
+            candidates=$(jq '.dispatches | length' /tmp/alwaysgreen-plan.json)
+            if [ "$candidates" -gt 0 ] && [ "${{ steps.mode.outputs.dispatch }}" = "true" ]; then
               echo "### Dispatching"
               echo ""
               echo "| Surface | Specs | Deterministic | Key |"
@@ -181,8 +243,18 @@ jobs:
               jq -r '.dispatches[] | "| \(.surface) | \(.test_specs | length) | \([.test_specs[] | select(.deterministic)] | length) | `\(.dispatch_key)` |"' \
                 /tmp/alwaysgreen-plan.json
               echo ""
+            elif [ "$candidates" -gt 0 ]; then
+              echo "### Would dispatch — withheld, mode is \`${{ steps.mode.outputs.mode }}\`"
+              echo ""
+              echo "| Surface | Specs | Deterministic | Key |"
+              echo "|---|---|---|---|"
+              jq -r '.dispatches[] | "| \(.surface) | \(.test_specs | length) | \([.test_specs[] | select(.deterministic)] | length) | `\(.dispatch_key)` |"' \
+                /tmp/alwaysgreen-plan.json
+              echo ""
+              echo "Set \`vars.ALWAYSGREEN_FIX_AGENT=on\` to dispatch these."
+              echo ""
             else
-              echo "> Nothing dispatched."
+              echo "> No dispatchable candidates."
               echo ""
             fi
             if [ "$(jq '.suppressed | length' /tmp/alwaysgreen-plan.json)" -gt 0 ]; then
@@ -201,7 +273,7 @@ jobs:
 
       - name: Post Slack summary
         id: slack
-        if: ${{ steps.slack-secrets.outcome == 'success' && (steps.plan.outputs.count != '0' || inputs.parent_slack_ts != '') }}
+        if: ${{ steps.mode.outputs.enabled == 'true' && steps.slack-secrets.outcome == 'success' && (steps.plan.outputs.count != '0' || inputs.parent_slack_ts != '') }}
         continue-on-error: true
         env:
           SLACK_TOKEN: ${{ steps.slack-secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
@@ -263,7 +335,7 @@ jobs:
       - name: Dispatch fix agents
         # outcome, not just count: a failed discovery leaves count empty, and '' != '0'
         # would otherwise dispatch with no plan file.
-        if: ${{ steps.plan.outcome == 'success' && steps.plan.outputs.count != '0' && !inputs.dry_run }}
+        if: ${{ steps.mode.outputs.dispatch == 'true' && steps.plan.outcome == 'success' && steps.plan.outputs.count != '0' }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
@@ -300,7 +372,7 @@ jobs:
           done
 
       - name: Flag discovery failure
-        if: ${{ steps.plan.outcome != 'success' }}
+        if: ${{ steps.mode.outputs.enabled == 'true' && steps.plan.outcome != 'success' }}
         run: |
           echo "::warning::AlwaysGreen discovery failed; no fix agent was dispatched for this run."
           {

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -628,6 +628,11 @@ jobs:
     permissions:
       contents: read
       actions: read
+    # Surfaced so alwaysgreen-triage can reply in the feedback message's thread rather
+    # than opening a second top-level message for the same failure.
+    outputs:
+      slack_ts: ${{ steps.feedback.outputs.slack_ts }}
+      slack_channel: ${{ steps.feedback.outputs.slack_channel }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: |
@@ -694,6 +699,7 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
       - name: Post AlwaysGreen failure feedback
+        id: feedback
         if: failure()
         continue-on-error: true
         uses: ./.github/actions/post-failure-feedback
@@ -1143,3 +1149,7 @@ jobs:
     with:
       base_ref: ${{ github.ref_name }}
       chart_version: ${{ inputs.helmRepositoryDirName || 'camunda-platform-8.10' }}
+      # Empty when the helm stage did not fail, or Slack was unavailable; triage then
+      # posts its own parent message instead of threading.
+      parent_slack_ts: ${{ needs.helm-deploy-status.outputs.slack_ts }}
+      parent_slack_channel: ${{ needs.helm-deploy-status.outputs.slack_channel }}

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -1118,3 +1118,28 @@ jobs:
           path: ${{ runner.temp }}/alwaysgreen-context-${{ github.job }}.json
           retention-days: 5
 
+  # Final job: hand a failed run to the triage agent. github.run_id here is this run,
+  # so the classifier reads this run's own artifacts.
+  #
+  # `continue-on-error` is not available on a job that calls a reusable workflow, so
+  # alwaysgreen-triage.yml keeps its own fallible steps continue-on-error instead. That
+  # is what stops a triage bug turning a one-job failure into two and skewing the
+  # streak detector's counts.
+  alwaysgreen-triage:
+    name: AlwaysGreen triage and fix dispatch
+    needs:
+      - should-run
+      - preflight
+      - build-operate-frontend
+      - build-tasklist-frontend
+      - build-identity-frontend
+      - build-and-push
+      - format-identifier
+      - helm-deploy-status
+      - trigger-saas-e2e
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    uses: camunda/camunda/.github/workflows/alwaysgreen-triage.yml@main
+    secrets: inherit
+    with:
+      base_ref: ${{ github.ref_name }}
+      chart_version: ${{ inputs.helmRepositoryDirName || 'camunda-platform-8.10' }}

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -1147,6 +1147,10 @@ jobs:
     uses: camunda/camunda/.github/workflows/alwaysgreen-triage.yml@main
     secrets: inherit
     with:
+      # On a merge_group run this is gh-readonly-queue/<base>/pr-<n>-<sha> rather than the
+      # target branch. Triage normalises it (classify.normalise_base_ref) before anything
+      # derives from it, because the ref is part of every fingerprint and a per-PR value
+      # would defeat dedupe.
       base_ref: ${{ github.ref_name }}
       chart_version: ${{ inputs.helmRepositoryDirName || 'camunda-platform-8.10' }}
       # Empty when the helm stage did not fail, or Slack was unavailable; triage then

--- a/.github/workspace-templates/alwaysgreen.guidance.md
+++ b/.github/workspace-templates/alwaysgreen.guidance.md
@@ -2,12 +2,12 @@
 
 Four repositories, because an AlwaysGreen failure can need a change in any of them:
 
-| Repo | When it is the right place to fix |
-|---|---|
-| `camunda` | product code, the AlwaysGreen workflow itself, this manual |
-| `c8-cross-component-e2e-tests` | the Playwright specs and page objects that ran (`tests/SM-8.x/`, `tests/8.x/`) |
-| `camunda-platform-helm` | chart values, templates, deploy config — including Keycloak/Identity wiring |
-| `camunda-docs` | the authority on intended product behaviour; read before changing what an assertion expects |
+|              Repo              |                              When it is the right place to fix                              |
+|--------------------------------|---------------------------------------------------------------------------------------------|
+| `camunda`                      | product code, the AlwaysGreen workflow itself, this manual                                  |
+| `c8-cross-component-e2e-tests` | the Playwright specs and page objects that ran (`tests/SM-8.x/`, `tests/8.x/`)              |
+| `camunda-platform-helm`        | chart values, templates, deploy config — including Keycloak/Identity wiring                 |
+| `camunda-docs`                 | the authority on intended product behaviour; read before changing what an assertion expects |
 
 The e2e specs execute from the published `@camunda/e2e-test-suite` npm package, so a
 report's `file` is a compiled basename. The source lives in

--- a/.github/workspace-templates/alwaysgreen.guidance.md
+++ b/.github/workspace-templates/alwaysgreen.guidance.md
@@ -1,0 +1,16 @@
+# AlwaysGreen fix workspace
+
+Four repositories, because an AlwaysGreen failure can need a change in any of them:
+
+| Repo | When it is the right place to fix |
+|---|---|
+| `camunda` | product code, the AlwaysGreen workflow itself, this manual |
+| `c8-cross-component-e2e-tests` | the Playwright specs and page objects that ran (`tests/SM-8.x/`, `tests/8.x/`) |
+| `camunda-platform-helm` | chart values, templates, deploy config — including Keycloak/Identity wiring |
+| `camunda-docs` | the authority on intended product behaviour; read before changing what an assertion expects |
+
+The e2e specs execute from the published `@camunda/e2e-test-suite` npm package, so a
+report's `file` is a compiled basename. The source lives in
+`c8-cross-component-e2e-tests` — the manual explains the mapping.
+
+`camunda` is checked out at the branch that failed. The other three track `main`.

--- a/.github/workspace-templates/alwaysgreen.yaml
+++ b/.github/workspace-templates/alwaysgreen.yaml
@@ -1,0 +1,28 @@
+name: alwaysgreen
+description: "Cross-repo fix workspace for AlwaysGreen pipeline failures"
+purpose: |
+  You are fixing a failure in the Camunda AlwaysGreen pipeline
+  (docker-build-helm-integration.yml in camunda/camunda).
+
+  The failing job identifies the surface that broke, not the repository that needs
+  the change. A Playwright job failing does not mean the test is wrong: the most
+  frequent SM e2e failure is a Keycloak deploy problem. Read
+  camunda/docs/alwaysgreen/FIX-AGENT.md before doing anything else.
+
+repos:
+  - url: https://github.com/camunda/camunda.git
+    path: camunda
+    default_branch: main
+  - url: https://github.com/camunda/c8-cross-component-e2e-tests.git
+    path: c8-cross-component-e2e-tests
+    default_branch: main
+  - url: https://github.com/camunda/camunda-platform-helm.git
+    path: camunda-platform-helm
+    default_branch: main
+  - url: https://github.com/camunda/camunda-docs.git
+    path: camunda-docs
+    default_branch: main
+
+derive:
+  agents_from: AGENTS.md
+  ai_guidance: alwaysgreen.guidance.md

--- a/docs/alwaysgreen/FIX-AGENT.md
+++ b/docs/alwaysgreen/FIX-AGENT.md
@@ -8,6 +8,27 @@ builds the Camunda image, deploys it to GKE via the Helm charts, runs a Self-Man
 smoke suite, and separately triggers a SaaS smoke suite. `alwaysgreen-triage.yml`
 classifies a failure and dispatches you with the specs already extracted.
 
+## Turning it on and off
+
+Controlled by the repository variable `ALWAYSGREEN_FIX_AGENT` (Settings → Variables →
+Actions). Changes take effect on the very next run — no PR, no merge, no redeploy.
+
+|   Value   |                               Effect                               |
+|-----------|--------------------------------------------------------------------|
+| `off`     | triage exits immediately; queued and future fix agents are skipped |
+| `dry-run` | triage classifies and reports; nothing is dispatched               |
+| `on`      | triage dispatches fix agents                                       |
+| *unset*   | treated as `dry-run`                                               |
+
+Unset means `dry-run`, so deleting the variable degrades to safe rather than to live. An
+unrecognised value logs a warning and is also treated as `dry-run`.
+
+`off` blocks a fix agent that has been dispatched but not yet started. It does **not**
+interrupt a run already inside its Claude step — cancel that run explicitly.
+
+In `dry-run` the job summary shows a "Would dispatch" table, so the classification can be
+reviewed without anything being opened.
+
 ## The rule that matters most
 
 **The failing job identifies the surface that broke. It does not identify the repository
@@ -32,12 +53,12 @@ Everything is under `/tmp/alwaysgreen-artifacts/`. There is no live cluster — 
 namespace is deleted by the pipeline's cleanup job and the SaaS org is deleted by the
 nightly, both before you start. Never try to reach a cluster or run `kubectl`.
 
-| Artifact | Surface | Contains |
-|---|---|---|
-| `playwright-results-json*` | `sm-smoke-e2e` | the report, incl. `config.rootDir` and retry history |
-| `playwright-traces*` | `sm-smoke-e2e` | `trace.zip`, `test-failed-1.png`, screenshots per attempt |
-| `json-report*`, `Playwright Report*` | `saas-smoke-e2e` | downstream report and HTML report |
-| `diagnostics-e2e*` | `sm-smoke-e2e` | **namespace dump: describe + logs for every pod** |
+|               Artifact               |     Surface      |                         Contains                          |
+|--------------------------------------|------------------|-----------------------------------------------------------|
+| `playwright-results-json*`           | `sm-smoke-e2e`   | the report, incl. `config.rootDir` and retry history      |
+| `playwright-traces*`                 | `sm-smoke-e2e`   | `trace.zip`, `test-failed-1.png`, screenshots per attempt |
+| `json-report*`, `Playwright Report*` | `saas-smoke-e2e` | downstream report and HTML report                         |
+| `diagnostics-e2e*`                   | `sm-smoke-e2e`   | **namespace dump: describe + logs for every pod**         |
 
 `diagnostics-e2e*` is the one that resolves the Keycloak class. It contains
 `Pod: <name> — logs` sections for **all** pods, including Ready ones, so a component that
@@ -67,12 +88,12 @@ Read PNG screenshots directly. For a trace: `unzip -l trace.zip`, then extract w
 
 ## Where fixes go
 
-| Diagnosis | Repository | Path |
-|---|---|---|
-| stale selector, wrong wait, bad assertion | `c8-cross-component-e2e-tests` | `tests/SM-8.x/`, `tests/8.x/`, `pages/` |
-| chart values, Keycloak/Identity wiring, deploy config | `camunda-platform-helm` | `charts/camunda-platform-8.x/` |
-| product regression | `camunda` | the owning module |
-| pipeline plumbing | `camunda` | `.github/` |
+|                       Diagnosis                       |           Repository           |                  Path                   |
+|-------------------------------------------------------|--------------------------------|-----------------------------------------|
+| stale selector, wrong wait, bad assertion             | `c8-cross-component-e2e-tests` | `tests/SM-8.x/`, `tests/8.x/`, `pages/` |
+| chart values, Keycloak/Identity wiring, deploy config | `camunda-platform-helm`        | `charts/camunda-platform-8.x/`          |
+| product regression                                    | `camunda`                      | the owning module                       |
+| pipeline plumbing                                     | `camunda`                      | `.github/`                              |
 
 The spec paths in `/tmp/test_specs.json` are already mapped to source. If you need to
 redo it: the suite comes from `config.rootDir` (`…/dist/tests/SM-8.10` → `SM-8.10`) and

--- a/docs/alwaysgreen/FIX-AGENT.md
+++ b/docs/alwaysgreen/FIX-AGENT.md
@@ -10,8 +10,9 @@ classifies a failure and dispatches you with the specs already extracted.
 
 ## Turning it on and off
 
-Controlled by the repository variable `ALWAYSGREEN_FIX_AGENT` (Settings → Variables →
-Actions). Changes take effect on the very next run — no PR, no merge, no redeploy.
+A feature flag in Vault: key `ALWAYSGREEN_FIX_AGENT` at
+`secret/data/products/qa/ci/common`. Changes take effect on the next run — no PR, no
+merge, no redeploy.
 
 |   Value   |                               Effect                               |
 |-----------|--------------------------------------------------------------------|
@@ -20,14 +21,21 @@ Actions). Changes take effect on the very next run — no PR, no merge, no redep
 | `on`      | triage dispatches fix agents                                       |
 | *unset*   | treated as `dry-run`                                               |
 
-Unset means `dry-run`, so deleting the variable degrades to safe rather than to live. An
-unrecognised value logs a warning and is also treated as `dry-run`.
+Every unresolvable state resolves to `dry-run` — key absent, Vault unreachable, value
+unrecognised — so a mistake withholds dispatch rather than enabling it. Two corollaries:
+**deleting the key does not disable the agent**, it leaves it classifying, so set `off`
+explicitly; and only exact lowercase `off` stops it, since `OFF` or `disabled` fall back
+to `dry-run`.
 
-`off` blocks a fix agent that has been dispatched but not yet started. It does **not**
-interrupt a run already inside its Claude step — cancel that run explicitly.
+`off` blocks a fix agent that was dispatched but has not started — its `gate` job fails
+the check and the agent job is skipped. It does **not** interrupt a run already inside
+its Claude step; cancel that run from the Actions tab.
 
-In `dry-run` the job summary shows a "Would dispatch" table, so the classification can be
-reviewed without anything being opened.
+In `dry-run` the job summary prints a "Would dispatch" table, so the classification can
+be reviewed without anything being opened.
+
+Because the flag is imported as a Vault secret, its value is masked in logs; the
+workflows therefore report only the derived `enabled`/`dispatch` booleans.
 
 ## The rule that matters most
 

--- a/docs/alwaysgreen/FIX-AGENT.md
+++ b/docs/alwaysgreen/FIX-AGENT.md
@@ -1,0 +1,154 @@
+# AlwaysGreen fix agent — operating manual
+
+Read this in full before touching any file. It is the agent's contract; the dispatch
+prompt deliberately carries almost nothing so this stays the single source of truth.
+
+The pipeline is `.github/workflows/docker-build-helm-integration.yml`. On every push it
+builds the Camunda image, deploys it to GKE via the Helm charts, runs a Self-Managed
+smoke suite, and separately triggers a SaaS smoke suite. `alwaysgreen-triage.yml`
+classifies a failure and dispatches you with the specs already extracted.
+
+## The rule that matters most
+
+**The failing job identifies the surface that broke. It does not identify the repository
+that needs the fix.**
+
+Over a 300-run window, the most frequent failure was
+`smoke-tests.spec.js › Most Common Flow User Flow With All Apps` timing out on
+`locator('#kc-main-content-page-container')` — 19 of 33 real failing jobs. Read as a test
+error it looks like a stale selector. The screenshot showed **Keycloak's own error page**:
+
+> We are sorry… Unexpected error when handling authentication request to identity provider.
+
+The assertion was correct. Keycloak was broken. The fix belonged in the Helm/Keycloak
+configuration, and raising the timeout would have turned the pipeline green while hiding a
+genuinely broken login.
+
+So: establish *what the application did* before deciding the test is wrong.
+
+## Evidence, and where it is
+
+Everything is under `/tmp/alwaysgreen-artifacts/`. There is no live cluster — the
+namespace is deleted by the pipeline's cleanup job and the SaaS org is deleted by the
+nightly, both before you start. Never try to reach a cluster or run `kubectl`.
+
+| Artifact | Surface | Contains |
+|---|---|---|
+| `playwright-results-json*` | `sm-smoke-e2e` | the report, incl. `config.rootDir` and retry history |
+| `playwright-traces*` | `sm-smoke-e2e` | `trace.zip`, `test-failed-1.png`, screenshots per attempt |
+| `json-report*`, `Playwright Report*` | `saas-smoke-e2e` | downstream report and HTML report |
+| `diagnostics-e2e*` | `sm-smoke-e2e` | **namespace dump: describe + logs for every pod** |
+
+`diagnostics-e2e*` is the one that resolves the Keycloak class. It contains
+`Pod: <name> — logs` sections for **all** pods, including Ready ones, so a component that
+is running and returning errors is visible. Retention is 1 day, so it may be absent when
+replaying an older run — treat absence as "no cluster evidence", not as "the cluster was
+fine".
+
+Read PNG screenshots directly. For a trace: `unzip -l trace.zip`, then extract what you need.
+
+## Diagnosis order
+
+1. **Is it flaky?** `/tmp/test_specs.json` carries `attempts` and `statuses` per spec.
+   All attempts failed → deterministic, a real defect. `failed → passed` → flaky, and the
+   fix is waiting/retry, never a behavioural change. This is decided for you; do not
+   re-litigate it with a re-run you cannot perform.
+2. **What did the app show?** Open the screenshot. A missing or moved element points at
+   the test. An application error page, a 500, or a blank render points at the
+   environment or the product.
+3. **If the app misbehaved, why?** Read `diagnostics-e2e*` — pod list, events, and the
+   logs of the component that erred. This is where a Keycloak stack trace lives.
+4. **Does the version matter?** If the same spec passes for another version, the
+   difference is real and usually belongs in the product or chart, not the test.
+5. **Is the assertion still correct?** For anything about intended behaviour — a default,
+   whether a feature exists in this version, eventual-consistency timing — check
+   `camunda-docs/versioned_docs/version-<X.Y>/` and cite it in the PR body. Match the
+   version tree exactly. Skip this for pure selector drift.
+
+## Where fixes go
+
+| Diagnosis | Repository | Path |
+|---|---|---|
+| stale selector, wrong wait, bad assertion | `c8-cross-component-e2e-tests` | `tests/SM-8.x/`, `tests/8.x/`, `pages/` |
+| chart values, Keycloak/Identity wiring, deploy config | `camunda-platform-helm` | `charts/camunda-platform-8.x/` |
+| product regression | `camunda` | the owning module |
+| pipeline plumbing | `camunda` | `.github/` |
+
+The spec paths in `/tmp/test_specs.json` are already mapped to source. If you need to
+redo it: the suite comes from `config.rootDir` (`…/dist/tests/SM-8.10` → `SM-8.10`) and
+the package ships compiled `.js` while the source is `.ts`, so
+`smoke-tests.spec.js` → `tests/SM-8.10/smoke-tests.spec.ts`.
+
+The SM smoke suite is **shared** with the SM nightly, which has its own fix agent. A
+change there must not regress the nightly for the same version, and a competing
+`failing-test-fix` PR may already exist — check before editing.
+
+## The PR coverage block — mandatory
+
+Every PR you open must carry, in its body:
+
+```
+<!-- alwaysgreen-fixed
+fp=1a2b3c4d
+fp=5e6f7a8b
+-->
+```
+
+One `fp=` line per fingerprint in `/tmp/fingerprints.json`. Triage reads this block to
+suppress re-dispatch. **Omit a fingerprint and the same failure is dispatched again on the
+next push.** When updating an existing PR, preserve every line already there — the union,
+never a replacement.
+
+Also name the author of the breaking change in the body (supplied in the prompt). The
+workflow tries to add them as a reviewer, but that call fails when they are not a
+collaborator on the repository you opened the PR in, so the body mention is what
+guarantees the signal survives.
+
+## Constraints
+
+- **Never mask a failure.** No timeout increases to paper over a real error, no weakened
+  or deleted assertions, no `continue-on-error`, no selector swap that dodges a broken
+  page.
+- **`test.skip()` / `test.fixme()` / `.only` are forbidden**, except for a confirmed
+  product regression that has a filed tracking issue — follow
+  `## Product-Bug Escalation` in the e2e repo's `AGENTS.md` and use its annotation format.
+- **Minimal diff.** No refactoring, no dependency bumps, nothing unrelated.
+- **Fix only the dispatched specs.** Other failures may be visible in the artifacts; leave
+  them.
+- **Lint before commit.** For `.ts`: `npx prettier --check <files>` and
+  `npx eslint <files> --ext .ts`. `printWidth` is 80 and CI fails on a single-character
+  formatting delta.
+- **Forbidden commands:** `kubectl`, `helm`, any deploy, `npm run build`, `mvnw` full-repo
+  builds, and Playwright — there is nothing to run against.
+
+## Result manifest
+
+Write `/tmp/fix-meta.json` before stopping, always:
+
+```json
+{
+  "surface": "sm-smoke-e2e",
+  "category": "test | chart | product | ci | not-determined",
+  "prs": [
+    {
+      "number": 1234,
+      "owner": "camunda",
+      "repo": "c8-cross-component-e2e-tests",
+      "branch": "fix/alwaysgreen-sm-smoke-e2e-keycloak-login",
+      "url": "https://github.com/…/pull/1234",
+      "root_cause": "One sentence.",
+      "fix": "One sentence.",
+      "fingerprints": ["1a2b3c4d"]
+    }
+  ],
+  "reason": "Required when prs is empty: what you found and why no change was safe."
+}
+```
+
+`owner` and `repo` are required — PRs can land in any of the four repositories and the
+workflow uses them to label and request review.
+
+**`"prs": []` with `category: "not-determined"` is a legitimate, expected outcome.** If the
+evidence shows the environment broke and you cannot pin it to a config change, say so and
+attach what you found. That is strictly better than a plausible-looking change that hides
+a real defect.

--- a/docs/alwaysgreen/FIX-AGENT.md
+++ b/docs/alwaysgreen/FIX-AGENT.md
@@ -14,28 +14,29 @@ A feature flag in Vault: key `ALWAYSGREEN_FIX_AGENT` at
 `secret/data/products/qa/ci/common`. Changes take effect on the next run — no PR, no
 merge, no redeploy.
 
-|   Value   |                               Effect                               |
-|-----------|--------------------------------------------------------------------|
-| `off`     | triage exits immediately; queued and future fix agents are skipped |
-| `dry-run` | triage classifies and reports; nothing is dispatched               |
-| `on`      | triage dispatches fix agents                                       |
-| *unset*   | treated as `dry-run`                                               |
+|   Value    |                               Effect                               |
+|------------|--------------------------------------------------------------------|
+| `disabled` | triage exits immediately; queued and future fix agents are skipped |
+| `dry-run`  | triage classifies and reports; nothing is dispatched               |
+| `enabled`  | triage dispatches fix agents                                       |
+| *unset*    | treated as `dry-run`                                               |
 
 Every unresolvable state resolves to `dry-run` — key absent, Vault unreachable, value
 unrecognised — so a mistake withholds dispatch rather than enabling it. Two corollaries:
-**deleting the key does not disable the agent**, it leaves it classifying, so set `off`
-explicitly; and only exact lowercase `off` stops it, since `OFF` or `disabled` fall back
-to `dry-run`.
+**deleting the key does not stop the agent**, it leaves it classifying, so set `disabled`
+explicitly; and matching is exact, so `DISABLED` or `off` fall back to `dry-run`.
 
-`off` blocks a fix agent that was dispatched but has not started — its `gate` job fails
-the check and the agent job is skipped. It does **not** interrupt a run already inside
-its Claude step; cancel that run from the Actions tab.
+`disabled` blocks a fix agent that was dispatched but has not started — its `gate` job
+fails the check and the agent job is skipped. It does **not** interrupt a run already
+inside its Claude step; cancel that run from the Actions tab.
 
 In `dry-run` the job summary prints a "Would dispatch" table, so the classification can
 be reviewed without anything being opened.
 
-Because the flag is imported as a Vault secret, its value is masked in logs; the
-workflows therefore report only the derived `enabled`/`dispatch` booleans.
+The flag is imported as a Vault secret, so GitHub masks its value in the logs of the job
+that reads it. The workflows therefore report the derived booleans as `active` and
+`dispatch`, and avoid printing the words `enabled`/`disabled`, which a matching flag
+value would render as `***`.
 
 ## The rule that matters most
 


### PR DESCRIPTION
## Description

AlwaysGreen failures are currently alert-only: `alwaysgreen-streak-detector.yml` posts to
`#alwaysgreen-reliability` and a human triages by hand. This adds the triage and fix path
for the two e2e surfaces, **on `main` only**, behind a Vault feature flag that defaults to
dry-run.

### Shape

`docker-build-helm-integration.yml` gains a final job, gated on
`contains(needs.*.result, 'failure')`, that calls `alwaysgreen-triage.yml@main`. Inside a
`workflow_call`, `github.run_id` is the *caller's* run — so the classifier reads the
failing run's own artifacts with no extra plumbing. Triage classifies, dedupes, and
dispatches `alwaysgreen-fix.yml`, which runs Claude Code in a four-repo workspace and
opens a PR in whichever repository the evidence points at.

```
docker-build-helm-integration.yml (main)
└─ alwaysgreen-triage            ← ~10 lines; all logic lives in the @main-pinned workflow
     └─ alwaysgreen-triage.yml   flag → classify → dedupe → dispatch
          └─ alwaysgreen-fix.yml gate job, then Claude Code in
                                 camunda + e2e-tests + helm + docs
```

`workflow_run` is not used because it does not fire in this repository — documented in
`alwaysgreen-streak-detector.yml` and confirmed across every workflow declaring it.

### Turning it on and off

Controlled by the Vault key `ALWAYSGREEN_FIX_AGENT` at
`secret/data/products/qa/ci/common`, imported with `hashicorp/vault-action` like every
other secret in these workflows. Changes take effect on the next run — no PR, no merge.

| Value      | Effect                                                             |
|------------|--------------------------------------------------------------------|
| `disabled` | triage exits immediately; queued and future fix agents are skipped |
| `dry-run`  | triage classifies and reports; nothing is dispatched                |
| `enabled`  | triage dispatches fix agents                                        |
| *unset*    | treated as `dry-run`                                                |

**The key does not need to exist before merging.** Absent resolves to `dry-run`, so this
lands in observation mode: triage classifies each failure and prints a "Would dispatch"
table without opening anything. Every unresolvable state resolves to `dry-run` — key
absent, Vault unreachable, empty or unrecognised value — so a mistake withholds dispatch
rather than enabling it. The corollary is documented: deleting the key does not stop the
agent, it leaves it classifying; `disabled` must be set explicitly.

The import step is `continue-on-error` because `vault-action` fails when the key is
absent, which is the expected state until the flag is first created; an absent flag must
leave the pipeline in dry-run rather than break it.

Two structural consequences of reading the flag from Vault:

* Triage checks out before reading the flag, because a local composite action needs the
  repository present and the flag decides whether the rest of the job runs.
* The fix workflow has a `gate` job. A Vault read cannot happen inside a job-level `if:`
  expression, and gating on a job output leaves the agent job visibly skipped rather than
  half-run. `disabled` therefore also stops an agent already dispatched but not started;
  a run already inside its Claude step must be cancelled.

Values are `disabled`/`enabled` rather than `off`/`on`, and the resolver prints neither
word. The flag arrives as a Vault secret, so GitHub masks its value in the reading job's
logs: `off` would rewrite `offset` as `***set`, and a log line reading `enabled=true`
would render as `***=true`, hiding the state being reported. The step reports derived
booleans (`active`, `dispatch`) instead, and a test asserts the flag words never appear in
visible output.

### Slack reporting

Triage replies in the thread of the existing `post-failure-feedback` message — the
`Stage: … · Category: … · Owner: …` post — rather than starting a second top-level
message. `post-failure-feedback` previously discarded the `ts` from `chat.postMessage`;
it now returns it as a step output, `helm-deploy-status` re-exposes it as a job output,
and triage threads onto it.

Falls back to a new top-level message when no `ts` arrives, which covers two real cases:
a SaaS-only failure (only `helm-deploy-status` posts feedback) and a failed Slack post.
The fix agent then replies in the same thread with the outcome — PR links, "no fix
determined", or "agent failed".

### Why each non-obvious rule exists

Derived from every failed run of this pipeline in a 300-run window: 29 failed runs,
33 real failing jobs. Each rule has a unit test naming the run it came from.

**A `failure` conclusion does not mean a fixable failure.** Two of the 29 were a GitHub
platform internal error (`Cleanup`, `Observe`, run 30157503817 — no steps ran) and a
mid-job cancellation (`Build and Push Docker Images`, run 30078726133 — 20 steps,
`The operation was canceled`). `classify.noise_verdict` drops platform errors,
cancellations, and jobs with neither steps nor annotations. Without it the agent would
have been dispatched at a GitHub outage — following run 30157503817 into its downstream
run shows the same annotation there, so the whole dual failure was one platform incident.

**Skipped jobs keep unrendered `${{ }}` in their names.** Surface patterns anchor on the
literal prefix, and only `conclusion == "failure"` jobs are matched. Most runs contain a
*skipped* `Playwright e2e after install` job, which a naive substring match would read as
an SM e2e failure.

**Playwright nests `suites[].suites[].specs[]`.** Spec counting walks recursively, and the
SaaS surface is recomputed here rather than read from the pipeline's own
`downstream_category` — that value comes from a one-level walk, so `product` and `mixed`
are unreachable and every failing downstream run reads as `infrastructure`. Fixed
separately in #59012; this classifier does not depend on it.

**The failing job identifies the surface, not the repository to change.** The most frequent
failure (19 of 33 real failing jobs, 17 of them on 2026-07-23) was
`smoke-tests.spec.js › Most Common Flow User Flow With All Apps` timing out on
`locator('#kc-main-content-page-container')`. The screenshot shows Keycloak's own error
page — "Unexpected error when handling authentication request to identity provider" — from
a Running, Ready Keycloak. The assertion was correct; the environment was broken. So the
workspace carries `camunda-platform-helm` from the start, and `FIX-AGENT.md` names this
signature and forbids the tempting timeout bump.

**One agent per `<base_ref>:<surface>` may be in flight**, enforced by reading the key back
out of the fix run's `run-name`. On 2026-07-23 seventeen consecutive runs failed on one
root cause roughly 30-40 minutes apart while an agent takes 15-60 minutes, so an open-PR
check alone loses that race repeatedly. `discover.py` **fails closed**: if the in-flight
lookup errors, nothing is dispatched — a delay is cheaper than a duplicate PR.

**Spec paths come from `config.rootDir`.** The helm chart points Playwright at the
published npm package, so report `file` values are bare basenames like
`smoke-tests.spec.js`. `rootDir` carries `…/dist/tests/SM-8.10`, which is the reliable way
to recover `tests/SM-8.10/smoke-tests.spec.ts`.

**Retry history decides flakiness for free.** The config retries twice, so a failing spec
reports `attempts: 3, statuses: failed,failed,failed`. All-failed is deterministic; a
`failed → passed` sequence is flaky and wants a waiting fix, not a behavioural change.

### Safety

`continue-on-error` is **not available** on a job that calls a reusable workflow, so the
fallible steps inside `alwaysgreen-triage.yml` carry it instead. That is what keeps a
triage bug from turning a one-job failure into two and skewing the streak detector's
counts. The dispatch step additionally gates on `steps.plan.outcome == 'success'`, because
a failed discovery leaves `count` empty and `'' != '0'` would otherwise dispatch with no
plan file. A discovery failure surfaces as a warning and a job-summary note rather than
being swallowed.

### Scope

Dispatches `sm-smoke-e2e` and `saas-smoke-e2e` only. `helm-install`, `helm-cleanup`,
`build`, `ci-infra`, `saas-provisioning` and `saas-infra` are classified and reported in
the job summary but not handed to the agent. `main` only; stable branches follow
separately, each targeting its own branch.

### Testing

- **100 pytest tests pass**, 59 of them new. They land under `.github/scripts`, which the
  existing `Scripts / Python Unit Tests` job already globs, so no CI wiring was needed.
- Flag resolution verified across eleven cases: all three values, the dry-run override,
  empty value, the retired `off`/`on`, wrong case, and both Vault import-failure paths —
  plus an assertion that the visible log never contains the flag words.
- `actionlint` clean on all three workflows; `spotless:check` clean (this repo formats
  markdown too); `shellcheck` clean on the new shell.
- A wiring validator checks the dispatch contract in both directions (every input triage
  sends is declared by the fix workflow; every required input is sent), that `run-name`
  still embeds the dispatch key `plan.dispatch_key()` produces, and that the parent job
  does not carry the disallowed `continue-on-error`.

**Not yet executed against a real failure.** Unit and lint only. Because the flag defaults
to `dry-run`, merging starts an observation period rather than going live: triage will
classify each failure and print what it *would* have dispatched. `alwaysgreen-triage.yml`
also accepts an explicit `run_id` to replay a past run, though SM artifacts have 5-day
retention and the diagnostics artifact 1 day, so replay windows are short.

### Related

- Part of camunda/team-test-automation#138
- #59012 — fixes the `downstream_category` spec-counting bug in the same pipeline
- camunda/camunda-platform-helm#6718 — adds the `diagnostics-e2e-*` artifact the agent
  reads to diagnose a Ready-but-erroring component. Worth merging first: without it the
  Keycloak class is visible but not explicable, so the agent would correctly refuse to
  mask it and then report "no fix determined".

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

Backport note: not applicable via the backport action — each branch carries its own copy of
`docker-build-helm-integration.yml` with a different chart version, so stable-branch
enablement lands as direct branch-scoped PRs.

## Related issues

Part of camunda/team-test-automation#138
