### PR TITLE
fix: sort decision instance ids by numeric segments

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/DecisionInstanceFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/DecisionInstanceFieldSortingTransformer.java
@@ -17,6 +17,7 @@ import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTem
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.EVALUATION_DATE;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.EVALUATION_FAILURE;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.EVALUATION_FAILURE_MESSAGE;
+import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.EXECUTION_INDEX;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.ID;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.KEY;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.PROCESS_DEFINITION_KEY;
@@ -24,6 +25,8 @@ import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTem
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.ROOT_DECISION_DEFINITION_ID;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.STATE;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.TENANT_ID;
+
+import java.util.List;
 
 public class DecisionInstanceFieldSortingTransformer implements FieldSortingTransformer {
 
@@ -48,6 +51,14 @@ public class DecisionInstanceFieldSortingTransformer implements FieldSortingTran
       case "rootDecisionDefinitionKey" -> ROOT_DECISION_DEFINITION_ID;
       case "tenantId" -> TENANT_ID;
       default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
+    };
+  }
+
+  @Override
+  public List<String> applyAll(final String domainField) {
+    return switch (domainField) {
+      case "decisionInstanceId" -> List.of(KEY, EXECUTION_INDEX);
+      default -> FieldSortingTransformer.super.applyAll(domainField);
     };
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/FieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/FieldSortingTransformer.java
@@ -8,11 +8,16 @@
 package io.camunda.search.clients.transformers.sort;
 
 import io.camunda.search.clients.transformers.ServiceTransformer;
+import java.util.List;
 
 public interface FieldSortingTransformer extends ServiceTransformer<String, String> {
 
   @Override
   String apply(final String domainField);
+
+  default List<String> applyAll(final String domainField) {
+    return List.of(apply(domainField));
+  }
 
   default String defaultSortField() {
     return "key";

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/SortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/SortingTransformer.java
@@ -43,7 +43,7 @@ public final class SortingTransformer
     if (orderings != null && !orderings.isEmpty()) {
       sorting =
           orderings.stream()
-              .map((f) -> toSearchSortOption(f, reverse))
+              .flatMap((f) -> toSearchSortOptions(f, reverse).stream())
               .collect(Collectors.toList());
     } else {
       sorting = new ArrayList<>();
@@ -51,14 +51,19 @@ public final class SortingTransformer
     return sorting;
   }
 
-  private SearchSortOptions toSearchSortOption(final FieldSorting value, final boolean reverse) {
-    final var field = fieldSortingTransformer.apply(value.field());
+  private List<SearchSortOptions> toSearchSortOptions(
+      final FieldSorting value, final boolean reverse) {
     final var order = value.order();
-    if (!reverse) {
-      return sortOptions(field, order, "_last");
-    } else {
-      return sortOptions(field, reverseOrder(order), "_first");
-    }
+    return fieldSortingTransformer.applyAll(value.field()).stream()
+        .map(field -> toSearchSortOption(field, order, reverse))
+        .toList();
+  }
+
+  private SearchSortOptions toSearchSortOption(
+      final String field, final SortOrder order, final boolean reverse) {
+    return !reverse
+        ? sortOptions(field, order, "_last")
+        : sortOptions(field, reverseOrder(order), "_first");
   }
 
   private SearchSortOptions getDefaultSearchSortOption(final boolean reverse) {

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/DecisionInstanceSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/DecisionInstanceSortTest.java
@@ -16,6 +16,7 @@ import io.camunda.search.sort.SortOrder;
 import io.camunda.util.ObjectBuilder;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -25,7 +26,6 @@ class DecisionInstanceSortTest extends AbstractSortTransformerTest {
   private static Stream<Arguments> provideSortParameters() {
     return Stream.of(
         new TestArguments("key", SortOrder.ASC, s -> s.decisionInstanceKey().asc()),
-        new TestArguments("id", SortOrder.ASC, s -> s.decisionInstanceId().asc()),
         new TestArguments("decisionId", SortOrder.ASC, s -> s.decisionDefinitionId().asc()),
         new TestArguments(
             "decisionDefinitionId", SortOrder.DESC, s -> s.decisionDefinitionKey().desc()),
@@ -69,6 +69,23 @@ class DecisionInstanceSortTest extends AbstractSortTransformerTest {
               assertThat(t.field().field()).isEqualTo("id");
               assertThat(t.field().order()).isEqualTo(SortOrder.ASC);
             });
+  }
+
+  @Test
+  void shouldSortDecisionInstanceIdByKeyAndExecutionIndex() {
+    // when
+    final var request =
+        SearchQueryBuilders.decisionInstanceSearchQuery(
+            q -> q.sort(s -> s.decisionInstanceId().desc()));
+    final var sort = transformRequest(request);
+
+    // then
+    assertThat(sort)
+        .extracting(searchSort -> searchSort.field().field())
+        .containsExactly("key", "executionIndex", "id");
+    assertThat(sort)
+        .extracting(searchSort -> searchSort.field().order())
+        .containsExactly(SortOrder.DESC, SortOrder.DESC, SortOrder.ASC);
   }
 
   private record TestArguments(

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/DecisionInstanceSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/DecisionInstanceSortTest.java
@@ -16,9 +16,9 @@ import io.camunda.search.sort.SortOrder;
 import io.camunda.util.ObjectBuilder;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class DecisionInstanceSortTest extends AbstractSortTransformerTest {
@@ -71,12 +71,18 @@ class DecisionInstanceSortTest extends AbstractSortTransformerTest {
             });
   }
 
-  @Test
-  void shouldSortDecisionInstanceIdByKeyAndExecutionIndex() {
+  @ParameterizedTest
+  @EnumSource(SortOrder.class)
+  void shouldSortDecisionInstanceIdByKeyAndExecutionIndex(final SortOrder sortOrder) {
     // when
     final var request =
         SearchQueryBuilders.decisionInstanceSearchQuery(
-            q -> q.sort(s -> s.decisionInstanceId().desc()));
+            q ->
+                q.sort(
+                    s ->
+                        sortOrder == SortOrder.ASC
+                            ? s.decisionInstanceId().asc()
+                            : s.decisionInstanceId().desc()));
     final var sort = transformRequest(request);
 
     // then
@@ -85,7 +91,7 @@ class DecisionInstanceSortTest extends AbstractSortTransformerTest {
         .containsExactly("key", "executionIndex", "id");
     assertThat(sort)
         .extracting(searchSort -> searchSort.field().order())
-        .containsExactly(SortOrder.DESC, SortOrder.DESC, SortOrder.ASC);
+        .containsExactly(sortOrder, sortOrder, SortOrder.ASC);
   }
 
   private record TestArguments(


### PR DESCRIPTION
## Summary

Cherry-picks the commit from #55868 by @singhvishalkr so it runs through full CI (external
contribution PRs don't trigger the required workflows), then adds a follow-up commit that
strengthens test coverage found during review.

- `1494859` (original, author preserved): decision instance IDs are stored as `<key>-<executionIndex>`.
  Sorting by the stored ID string orders suffixes lexicographically, so a descending sort places
  `...-10` before `...-2`. This expands the `decisionInstanceId` sort into the numeric `key` and
  `executionIndex` fields before the existing `id` tie-breaker, via a new
  `FieldSortingTransformer.applyAll()` hook that only `DecisionInstanceFieldSortingTransformer`
  overrides — every other entity's sort transformer is unaffected. Closes #32993.
- Follow-up commit: the new regression test only covered the `DESC` direction. Parameterized it over
  `SortOrder` (ASC/DESC) so both directions are asserted.

### Scope note: RDBMS backend not covered

This only fixes the Elasticsearch/OpenSearch backend. The RDBMS backend (H2 / PostgreSQL) stores
`DECISION_INSTANCE_ID` as a plain string column with no separate numeric execution-index column, and
has the identical sort bug — tracked separately in #59040, deliberately descoped from this PR
(fixing it needs a schema addition and an extension to the RDBMS keyset-pagination abstraction, a
different risk profile than this contained ES/OS change).

### Review note for whoever picks this up

`FieldSortingTransformer.applyAll()` returns `List<String>` with a single `order`/`reverse` applied
uniformly to every expanded field (see `SortingTransformer.toSearchSortOptions`). That's correct here
because `key` and `executionIndex` both move in the same direction as the concatenated ID string, but
the interface has no way to express a composite sort where two physical fields need opposite
directions. Not an issue for this PR, but worth knowing if this pattern gets reused for another
entity.