### PR TITLE
feat: accept leadership transfer requests

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/LeadershipTransferPauseControl.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/LeadershipTransferPauseControl.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Broker-supplied control the leader uses to freeze and unfreeze a partition during a coordinated
+ * leadership transfer.
+ */
+public interface LeadershipTransferPauseControl {
+  /**
+   * Freezes the partition for a transfer and completes with the frozen last log index (the catch-up
+   * target the desired leader must reach). Arms a watchdog that steps the leader down if it is not
+   * resumed within {@code resumeTimeout}.
+   */
+  CompletableFuture<Long> pauseForTransfer(Duration resumeTimeout);
+
+  /** Resumes the partition after a transfer, undoing every restriction the pause applied. */
+  CompletableFuture<Void> resumeFromTransfer();
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/LeadershipTransferResult.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/LeadershipTransferResult.java
@@ -51,6 +51,8 @@ public enum LeadershipTransferResult {
    * to cannot be frozen.
    */
   CONFIGURATION_CHANGE_IN_PROGRESS,
+  /** The leader could not freeze the partition for the transfer. */
+  PAUSE_FAILED,
   /** The desired leader did not finish replicating within {@code replicationTimeout}. */
   REPLICATION_TIMED_OUT,
   /** TimeoutNow did not move leadership within {@code maxTransferAttempts}. */

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/LeadershipTransferResult.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/LeadershipTransferResult.java
@@ -44,6 +44,8 @@ public enum LeadershipTransferResult {
   TRANSFER_IN_PROGRESS,
   /** The desired leader's replication lag is above the configured threshold. */
   LAG_TOO_HIGH,
+  /** This leader has not committed the initial entry of its term yet. */
+  LEADER_INITIALIZING,
   /**
    * A Raft configuration change is in progress, so the log head the desired leader would catch up
    * to cannot be frozen.

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -47,6 +47,7 @@ import io.atomix.raft.protocol.ConfigureResponse;
 import io.atomix.raft.protocol.ForceConfigureResponse;
 import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.JoinResponse;
+import io.atomix.raft.protocol.LeadershipTransferInitiateResponse;
 import io.atomix.raft.protocol.LeaveResponse;
 import io.atomix.raft.protocol.PollResponse;
 import io.atomix.raft.protocol.ProtocolVersionHandler;
@@ -379,6 +380,12 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
         request ->
             handleRequestOnContext(
                 request, () -> role.onTimeoutNow(request), TimeoutNowResponse::builder));
+    protocol.registerLeadershipTransferInitiateHandler(
+        request ->
+            handleRequestOnContext(
+                request,
+                () -> role.onLeadershipTransferInitiate(request),
+                LeadershipTransferInitiateResponse::builder));
     protocol.registerAppendV1Handler(
         request ->
             handleRequestOnContext(
@@ -930,6 +937,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     protocol.unregisterLeaveHandler();
     protocol.unregisterTransferHandler();
     protocol.unregisterTimeoutNowHandler();
+    protocol.unregisterLeadershipTransferInitiateHandler();
     protocol.unregisterAppendHandler();
     protocol.unregisterPollHandler();
     protocol.unregisterVoteHandler();

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -24,6 +24,7 @@ import static io.atomix.utils.concurrent.Threads.namedThreads;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.ElectionTimer;
+import io.atomix.raft.LeadershipTransferPauseControl;
 import io.atomix.raft.RaftApplicationEntryCommittedPositionListener;
 import io.atomix.raft.RaftCommitListener;
 import io.atomix.raft.RaftException.CommitFailedException;
@@ -152,6 +153,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   private long firstCommitIndex;
   private volatile boolean started;
   private EntryValidator entryValidator;
+  private LeadershipTransferPauseControl leadershipTransferPauseControl;
   // Used for randomizing election timeout
   private final Random random;
   private PersistedSnapshot currentSnapshot;
@@ -1037,6 +1039,18 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
    */
   public void setEntryValidator(final EntryValidator validator) {
     entryValidator = validator;
+  }
+
+  /**
+   * The broker-supplied control the leader uses to freeze/unfreeze the partition during a
+   * coordinated leadership transfer, or {@code null} when none is registered.
+   */
+  public LeadershipTransferPauseControl getLeadershipTransferPauseControl() {
+    return leadershipTransferPauseControl;
+  }
+
+  public void setLeadershipTransferPauseControl(final LeadershipTransferPauseControl control) {
+    leadershipTransferPauseControl = control;
   }
 
   /**

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RebalanceMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RebalanceMetrics.java
@@ -7,20 +7,28 @@
  */
 package io.atomix.raft.metrics;
 
+import io.atomix.raft.LeadershipTransferResult;
+import io.atomix.raft.metrics.RebalanceMetricsDoc.RebalanceKeyNames;
 import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
 import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
+import java.util.EnumMap;
+import java.util.Map;
 
 /** Metrics for coordinated leadership transfer (rebalancing). */
 public class RebalanceMetrics extends RaftMetrics {
 
+  private final MeterRegistry meterRegistry;
   private final Timer partitionPauseDuration;
   private final StatefulGauge partitionPaused;
+  private final Map<LeadershipTransferResult, Timer> partitionTransferDuration =
+      new EnumMap<>(LeadershipTransferResult.class);
 
   public RebalanceMetrics(final String partitionName, final MeterRegistry meterRegistry) {
     super(partitionName);
+    this.meterRegistry = meterRegistry;
     partitionPauseDuration =
         Timer.builder(RebalanceMetricsDoc.PARTITION_PAUSE_DURATION.getName())
             .description(RebalanceMetricsDoc.PARTITION_PAUSE_DURATION.getDescription())
@@ -42,5 +50,22 @@ public class RebalanceMetrics extends RaftMetrics {
 
   public void setPartitionPaused(final boolean paused) {
     partitionPaused.set(paused ? 1 : 0);
+  }
+
+  public void observeTransferDuration(
+      final LeadershipTransferResult result, final Duration duration) {
+    partitionTransferDuration
+        .computeIfAbsent(result, this::registerTransferDuration)
+        .record(duration);
+  }
+
+  private Timer registerTransferDuration(final LeadershipTransferResult result) {
+    return Timer.builder(RebalanceMetricsDoc.PARTITION_TRANSFER_DURATION.getName())
+        .description(RebalanceMetricsDoc.PARTITION_TRANSFER_DURATION.getDescription())
+        .serviceLevelObjectives(RebalanceMetricsDoc.PARTITION_TRANSFER_DURATION.getTimerSLOs())
+        .tag(RebalanceKeyNames.RESULT.asString(), result.name())
+        .tag(PartitionKeyNames.PARTITION.asString(), partition)
+        .tag(PartitionKeyNames.PHYSICAL_TENANT.asString(), partitionGroupName)
+        .register(meterRegistry);
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RebalanceMetricsDoc.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RebalanceMetricsDoc.java
@@ -72,5 +72,44 @@ public enum RebalanceMetricsDoc implements ExtendedMeterDocumentation {
     public KeyName[] getKeyNames() {
       return new KeyName[] {PartitionKeyNames.PARTITION, PartitionKeyNames.PHYSICAL_TENANT};
     }
+  },
+
+  /** Duration of a per-partition coordinated leadership transfer attempt, tagged by result. */
+  PARTITION_TRANSFER_DURATION {
+    @Override
+    public String getBaseUnit() {
+      return "ms";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.cluster.rebalance.partition.duration";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Duration of a per-partition coordinated leadership transfer attempt, by result";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {
+        RebalanceKeyNames.RESULT, PartitionKeyNames.PARTITION, PartitionKeyNames.PHYSICAL_TENANT
+      };
+    }
+  };
+
+  public enum RebalanceKeyNames implements KeyName {
+    RESULT;
+
+    @Override
+    public String asString() {
+      return "result";
+    }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -23,6 +23,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.primitive.partition.Partition;
 import io.atomix.primitive.partition.PartitionMetadata;
+import io.atomix.raft.LeadershipTransferPauseControl;
 import io.atomix.raft.RaftApplicationEntryCommittedPositionListener;
 import io.atomix.raft.RaftCommitListener;
 import io.atomix.raft.RaftRoleChangeListener;
@@ -298,6 +299,15 @@ public class RaftPartitionServer implements HealthMonitorable {
     return runOnLeaderRole(leader -> leader.pauseForTransfer(resumeTimeout, pausedSinceMs));
   }
 
+  /**
+   * Registers the broker-supplied control the leader uses to freeze/unfreeze the partition during a
+   * coordinated leadership transfer.
+   */
+  public void setLeadershipTransferPauseControl(final LeadershipTransferPauseControl control) {
+    server.getContext().setLeadershipTransferPauseControl(control);
+  }
+
+  /** Resumes this partition after a coordinated leadership transfer, if it is still the leader. */
   public CompletableFuture<Void> resumeFromTransfer() {
     return runOnLeaderRole(
         leader -> {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/CatchUpWait.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/CatchUpWait.java
@@ -62,7 +62,7 @@ final class CatchUpWait {
   CompletableFuture<Optional<LeadershipTransferResult>> start() {
     raft.checkThread();
     if (isCaughtUp()) {
-      complete(Optional.empty());
+      succeed();
       return result;
     }
     final var pollInterval = raft.getHeartbeatInterval();
@@ -76,17 +76,17 @@ final class CatchUpWait {
       return;
     }
     LOG.debug("Lost leadership while catching up the desired leader; reporting LEADER_CHANGED");
-    complete(Optional.of(LeadershipTransferResult.LEADER_CHANGED));
+    failWith(LeadershipTransferResult.LEADER_CHANGED);
   }
 
   /** The freeze ended, so the desired leader can no longer catch up to a frozen log head. */
   void onPauseCleared() {
-    complete(Optional.of(LeadershipTransferResult.PAUSE_FAILED));
+    failWith(LeadershipTransferResult.PAUSE_FAILED);
   }
 
   /** The leader's freeze watchdog fired, so the desired leader is out of time to catch up. */
   void onPauseDeadlineExpired() {
-    complete(Optional.of(LeadershipTransferResult.REPLICATION_TIMED_OUT));
+    failWith(LeadershipTransferResult.REPLICATION_TIMED_OUT);
   }
 
   private void poll() {
@@ -94,11 +94,11 @@ final class CatchUpWait {
       return;
     }
     if (!leaderRunning.getAsBoolean()) {
-      complete(Optional.of(LeadershipTransferResult.LEADER_CHANGED));
+      failWith(LeadershipTransferResult.LEADER_CHANGED);
     } else if (raft.getCluster().getMemberContext(desiredLeader) == null) {
-      complete(Optional.of(LeadershipTransferResult.NOT_MEMBER));
+      failWith(LeadershipTransferResult.NOT_MEMBER);
     } else if (isCaughtUp()) {
-      complete(Optional.empty());
+      succeed();
     }
   }
 
@@ -107,11 +107,21 @@ final class CatchUpWait {
     return context != null && context.getMatchIndex() >= targetIndex;
   }
 
-  private void complete(final Optional<LeadershipTransferResult> outcome) {
+  /** The desired leader reached the frozen log head, so the transfer can carry on. */
+  private void succeed() {
+    complete(Optional.empty());
+  }
+
+  /** The desired leader will not catch up, so the transfer ends with {@code reason}. */
+  private void failWith(final LeadershipTransferResult reason) {
+    complete(Optional.of(reason));
+  }
+
+  private void complete(final Optional<LeadershipTransferResult> failureReason) {
     if (pollTimer != null) {
       pollTimer.cancel();
       pollTimer = null;
     }
-    result.complete(outcome);
+    result.complete(failureReason);
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/CatchUpWait.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/CatchUpWait.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.roles;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.LeadershipTransferResult;
+import io.atomix.raft.impl.RaftContext;
+import io.atomix.utils.concurrent.Scheduled;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BooleanSupplier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Waits until the desired leader's {@code matchIndex} reaches the frozen log head, polling on the
+ * Raft thread each heartbeat interval. The wait is bounded by the pause watchdog.
+ *
+ * <p>Owns its poll timer and completes the future returned by {@link #start()} exactly once, either
+ * with an empty {@link Optional} once the desired leader is fully caught up, or with a terminal
+ * reason if there was a failure/timeout. Role and pause events are only delivered while the wait is
+ * the transfer's active step.
+ */
+@NullMarked
+final class CatchUpWait {
+  private static final Logger LOG = LoggerFactory.getLogger(CatchUpWait.class);
+
+  private final RaftContext raft;
+  private final BooleanSupplier leaderRunning;
+  private final MemberId desiredLeader;
+  private final long targetIndex;
+  private final CompletableFuture<Optional<LeadershipTransferResult>> result =
+      new CompletableFuture<>();
+  private @Nullable Scheduled pollTimer;
+
+  CatchUpWait(
+      final RaftContext raft,
+      final BooleanSupplier leaderRunning,
+      final MemberId desiredLeader,
+      final long targetIndex) {
+    this.raft = raft;
+    this.leaderRunning = leaderRunning;
+    this.desiredLeader = desiredLeader;
+    this.targetIndex = targetIndex;
+  }
+
+  CompletableFuture<Optional<LeadershipTransferResult>> start() {
+    raft.checkThread();
+    if (isCaughtUp()) {
+      complete(Optional.empty());
+      return result;
+    }
+    final var pollInterval = raft.getHeartbeatInterval();
+    pollTimer = raft.getThreadContext().schedule(pollInterval, pollInterval, this::poll);
+    return result;
+  }
+
+  /** The leader role is stopping, e.g. because this node stepped down. */
+  void onLeaderStopped() {
+    if (result.isDone()) {
+      return;
+    }
+    LOG.debug("Lost leadership while catching up the desired leader; reporting LEADER_CHANGED");
+    complete(Optional.of(LeadershipTransferResult.LEADER_CHANGED));
+  }
+
+  /** The freeze ended, so the desired leader can no longer catch up to a frozen log head. */
+  void onPauseCleared() {
+    complete(Optional.of(LeadershipTransferResult.PAUSE_FAILED));
+  }
+
+  /** The leader's freeze watchdog fired, so the desired leader is out of time to catch up. */
+  void onPauseDeadlineExpired() {
+    complete(Optional.of(LeadershipTransferResult.REPLICATION_TIMED_OUT));
+  }
+
+  private void poll() {
+    if (result.isDone()) {
+      return;
+    }
+    if (!leaderRunning.getAsBoolean()) {
+      complete(Optional.of(LeadershipTransferResult.LEADER_CHANGED));
+    } else if (raft.getCluster().getMemberContext(desiredLeader) == null) {
+      complete(Optional.of(LeadershipTransferResult.NOT_MEMBER));
+    } else if (isCaughtUp()) {
+      complete(Optional.empty());
+    }
+  }
+
+  private boolean isCaughtUp() {
+    final var context = raft.getCluster().getMemberContext(desiredLeader);
+    return context != null && context.getMatchIndex() >= targetIndex;
+  }
+
+  private void complete(final Optional<LeadershipTransferResult> outcome) {
+    if (pollTimer != null) {
+      pollTimer.cancel();
+      pollTimer = null;
+    }
+    result.complete(outcome);
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/InactiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/InactiveRole.java
@@ -30,6 +30,8 @@ import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.InternalAppendRequest;
 import io.atomix.raft.protocol.JoinRequest;
 import io.atomix.raft.protocol.JoinResponse;
+import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
+import io.atomix.raft.protocol.LeadershipTransferInitiateResponse;
 import io.atomix.raft.protocol.LeaveRequest;
 import io.atomix.raft.protocol.LeaveResponse;
 import io.atomix.raft.protocol.PollRequest;
@@ -164,6 +166,19 @@ public class InactiveRole extends AbstractRole {
             TimeoutNowResponse.builder()
                 .withStatus(Status.ERROR)
                 .withError(RaftError.Type.UNAVAILABLE)
+                .build());
+    return CompletableFuture.completedFuture(result);
+  }
+
+  @Override
+  public CompletableFuture<LeadershipTransferInitiateResponse> onLeadershipTransferInitiate(
+      final LeadershipTransferInitiateRequest request) {
+    logRequest(request);
+    final var result =
+        logResponse(
+            LeadershipTransferInitiateResponse.builder()
+                .withStatus(Status.ERROR)
+                .withError(RaftError.Type.ILLEGAL_MEMBER_STATE)
                 .build());
     return CompletableFuture.completedFuture(result);
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -78,6 +78,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
 
   private static final int MAX_APPEND_ATTEMPTS = 5;
   private final LeaderAppender appender;
+  private final LeadershipTransferRunner leadershipTransferRunner;
   private Scheduled appendTimer;
   private long configuring;
   private CompletableFuture<Void> commitInitialEntriesFuture;
@@ -95,6 +96,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
   public LeaderRole(final RaftContext context) {
     super(context);
     appender = new LeaderAppender(this);
+    leadershipTransferRunner = new LeadershipTransferRunner(context, this);
   }
 
   @Override
@@ -430,6 +432,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
       log.trace("Cancelling append timer");
       appendTimer.cancel();
     }
+    leadershipTransferRunner.onLeaderStopped();
     // Paused mode always exits on a role transition (stop() runs when leadership is lost).
     clearTransferPause();
   }
@@ -502,6 +505,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
       return;
     }
     log.warn("Partition still paused after the resume deadline; stepping down to follower");
+    leadershipTransferRunner.onPauseDeadlineExpired();
     clearTransferPause();
     raft.transition(RaftServer.Role.FOLLOWER);
   }
@@ -518,6 +522,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
           .observePauseDuration(
               Duration.ofMillis(System.currentTimeMillis() - transferPauseStartMs));
     }
+    leadershipTransferRunner.onPauseCleared();
   }
 
   /**

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -544,6 +544,11 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     if (coordinatorRejection.isPresent()) {
       return coordinatorRejection;
     }
+    // Until this term's initial entry is committed the pause refuses to freeze the log head, so
+    // accepting here would freeze the partition only to roll it back again.
+    if (initializing()) {
+      return Optional.of(LeadershipTransferResult.LEADER_INITIALIZING);
+    }
     // A configuration entry would move the frozen log head the desired leader has to catch up to,
     // and can drop the desired leader from the replica set altogether, so a transfer cannot start
     // while one is in flight. We also check this again once paused.

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -810,20 +810,8 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
       final LeadershipTransferInitiateRequest request) {
     raft.checkThread();
     logRequest(request);
-    final var rejectionReason =
-        precheckTransfer(
-            request.desiredLeader(), request.coordinator(), request.coordinatorConfigIndex());
-    if (rejectionReason.isPresent()) {
-      return CompletableFuture.completedFuture(
-          logResponse(
-              LeadershipTransferInitiateResponse.builder()
-                  .withStatus(Status.OK)
-                  .withRejectionReason(rejectionReason.get())
-                  .build()));
-    }
-    leadershipTransferRunner.start(request);
     return CompletableFuture.completedFuture(
-        logResponse(LeadershipTransferInitiateResponse.builder().withStatus(Status.OK).build()));
+        logResponse(leadershipTransferRunner.handleInitiate(request)));
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -37,6 +37,8 @@ import io.atomix.raft.protocol.ForceConfigureResponse;
 import io.atomix.raft.protocol.InternalAppendRequest;
 import io.atomix.raft.protocol.JoinRequest;
 import io.atomix.raft.protocol.JoinResponse;
+import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
+import io.atomix.raft.protocol.LeadershipTransferInitiateResponse;
 import io.atomix.raft.protocol.LeaveRequest;
 import io.atomix.raft.protocol.LeaveResponse;
 import io.atomix.raft.protocol.PollRequest;
@@ -542,7 +544,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     if (desiredLeader.equals(localMember)) {
       return Optional.of(LeadershipTransferResult.ALREADY_LEADER);
     }
-    if (pausedForTransfer) {
+    if (leadershipTransferRunner.isInProgress() || pausedForTransfer) {
       return Optional.of(LeadershipTransferResult.TRANSFER_IN_PROGRESS);
     }
     final var coordinatorRejection = validateCoordinator(coordinator, coordinatorConfigIndex);
@@ -801,6 +803,27 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
               }
             });
     return future;
+  }
+
+  @Override
+  public CompletableFuture<LeadershipTransferInitiateResponse> onLeadershipTransferInitiate(
+      final LeadershipTransferInitiateRequest request) {
+    raft.checkThread();
+    logRequest(request);
+    final var rejectionReason =
+        precheckTransfer(
+            request.desiredLeader(), request.coordinator(), request.coordinatorConfigIndex());
+    if (rejectionReason.isPresent()) {
+      return CompletableFuture.completedFuture(
+          logResponse(
+              LeadershipTransferInitiateResponse.builder()
+                  .withStatus(Status.OK)
+                  .withRejectionReason(rejectionReason.get())
+                  .build()));
+    }
+    leadershipTransferRunner.start(request);
+    return CompletableFuture.completedFuture(
+        logResponse(LeadershipTransferInitiateResponse.builder().withStatus(Status.OK).build()));
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.roles;
+
+import com.google.common.base.Throwables;
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.LeadershipTransferResult;
+import io.atomix.raft.impl.RaftContext;
+import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
+import io.atomix.raft.protocol.LeadershipTransferResultRequest;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * One accepted coordinated leadership transfer, sequenced from freezing the partition to reporting
+ * the outcome: pause, wait for the desired leader to catch up, then resume. A fresh attempt is
+ * created per accepted transfer, so no state can leak from one transfer into the next.
+ *
+ * <p>Role and pause events are forwarded to the step currently in flight. Failures converge on
+ * {@link #finish}, which reports them to the coordinator; the transfer is not executed yet, so a
+ * desired leader that catches up simply ends the attempt.
+ */
+@NullMarked
+final class LeadershipTransferAttempt {
+  private static final Logger LOG = LoggerFactory.getLogger(LeadershipTransferAttempt.class);
+
+  private final RaftContext raft;
+  private final LeaderRole leader;
+  private final MemberId desiredLeader;
+  private final MemberId coordinator;
+  private final long correlationId;
+  private final Runnable finishListener;
+  private long startMs;
+  private @Nullable CatchUpWait activeCatchUp;
+
+  LeadershipTransferAttempt(
+      final RaftContext raft,
+      final LeaderRole leader,
+      final LeadershipTransferInitiateRequest request,
+      final Runnable finishListener) {
+    this.raft = raft;
+    this.leader = leader;
+    desiredLeader = request.desiredLeader();
+    coordinator = request.coordinator();
+    correlationId = request.correlationId();
+    this.finishListener = finishListener;
+  }
+
+  void start() {
+    raft.checkThread();
+    startMs = System.currentTimeMillis();
+    pause(raft.getRebalanceReplicationTimeout())
+        .whenCompleteAsync(
+            (targetIndex, error) -> {
+              if (error != null) {
+                final var result = pauseFailureResult(error);
+                LOG.warn(
+                    "Failed to pause partition for transfer to {}, reporting {}",
+                    desiredLeader,
+                    result,
+                    error);
+                finish(result);
+                return;
+              }
+              catchUp(targetIndex);
+            },
+            raft.getThreadContext());
+  }
+
+  void onLeaderStopped() {
+    if (activeCatchUp != null) {
+      activeCatchUp.onLeaderStopped();
+    }
+  }
+
+  /** The freeze ended. */
+  void onPauseCleared() {
+    if (activeCatchUp != null) {
+      activeCatchUp.onPauseCleared();
+    }
+  }
+
+  /** The leader's freeze watchdog fired: the pause outlived its resume deadline. */
+  void onPauseDeadlineExpired() {
+    if (activeCatchUp != null) {
+      activeCatchUp.onPauseDeadlineExpired();
+    }
+  }
+
+  private void catchUp(final long targetIndex) {
+    final var catchUpWait = new CatchUpWait(raft, leader::isRunning, desiredLeader, targetIndex);
+    activeCatchUp = catchUpWait;
+    catchUpWait
+        .start()
+        .whenComplete(
+            (outcome, ignored) -> {
+              activeCatchUp = null;
+              outcome.ifPresentOrElse(this::finish, () -> onCaughtUp(targetIndex));
+            });
+  }
+
+  /**
+   * The desired leader is caught up. We don't yet implement the actual transfer, so just resume:
+   * there is no terminal result to report to the coordinator.
+   */
+  private void onCaughtUp(final long targetIndex) {
+    LOG.info("Desired leader {} caught up to index {}", desiredLeader, targetIndex);
+    finishListener.run();
+    resume();
+  }
+
+  private void finish(final LeadershipTransferResult result) {
+    finishListener.run();
+    raft.getRebalanceMetrics()
+        .observeTransferDuration(result, Duration.ofMillis(System.currentTimeMillis() - startMs));
+    resume()
+        .whenComplete(
+            (ignored, resumeError) -> {
+              if (resumeError != null) {
+                // Cleanup failed: the partition may still be frozen. The pause watchdog is the
+                // safety net and steps the leader down once the resume deadline passes.
+                LOG.error(
+                    "Failed to resume partition after leadership transfer to {} (result {}); "
+                        + "relying on the pause watchdog to recover if still frozen",
+                    desiredLeader,
+                    result,
+                    resumeError);
+              }
+              final var notification =
+                  LeadershipTransferResultRequest.builder()
+                      .withLeader(raft.getCluster().getLocalMember().memberId())
+                      .withDesiredLeader(desiredLeader)
+                      .withResult(result)
+                      .withCorrelationId(correlationId)
+                      .build();
+              raft.getProtocol()
+                  .leadershipTransferResult(coordinator, notification)
+                  .whenComplete(
+                      (ack, notifyError) -> {
+                        if (notifyError != null) {
+                          LOG.debug(
+                              "Failed to notify coordinator {} of transfer result {}",
+                              coordinator,
+                              result,
+                              notifyError);
+                        }
+                      });
+            });
+  }
+
+  private CompletableFuture<Long> pause(final Duration resumeTimeout) {
+    final var control = raft.getLeadershipTransferPauseControl();
+    if (control != null) {
+      return control.pauseForTransfer(resumeTimeout);
+    }
+    // No broker control registered (e.g. Raft-only tests with no writes to freeze).
+    return CompletableFuture.completedFuture(
+        leader.pauseForTransfer(resumeTimeout, System.currentTimeMillis()));
+  }
+
+  private CompletableFuture<Void> resume() {
+    final var control = raft.getLeadershipTransferPauseControl();
+    if (control != null) {
+      return control.resumeFromTransfer();
+    }
+    leader.resumeFromTransfer();
+    return CompletableFuture.completedFuture(null);
+  }
+
+  /**
+   * Distinguishes a pause the leader refused because a configuration change started after the
+   * pre-check passed apart from one that failed with another exception.
+   */
+  private static LeadershipTransferResult pauseFailureResult(final Throwable error) {
+    return Throwables.getCausalChain(error).stream()
+            .anyMatch(LeaderRole.ConfigurationChangeInProgressException.class::isInstance)
+        ? LeadershipTransferResult.CONFIGURATION_CHANGE_IN_PROGRESS
+        : LeadershipTransferResult.PAUSE_FAILED;
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
@@ -110,9 +110,9 @@ final class LeadershipTransferAttempt {
     catchUpWait
         .start()
         .whenComplete(
-            (outcome, ignored) -> {
+            (failureReason, ignored) -> {
               activeCatchUp = null;
-              outcome.ifPresentOrElse(this::finish, () -> onCaughtUp(targetIndex));
+              failureReason.ifPresentOrElse(this::finish, () -> onCaughtUp(targetIndex));
             });
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
@@ -131,44 +131,34 @@ final class LeadershipTransferAttempt {
   private void finish(final LeadershipTransferResult result) {
     finishListener.run();
     observeDuration(result);
-    resume()
-        .whenComplete(
-            (ignored, resumeError) -> {
-              if (resumeError != null) {
-                // Cleanup failed: the partition may still be frozen. The pause watchdog is the
-                // safety net and steps the leader down once the resume deadline passes.
-                LOG.error(
-                    "Failed to resume partition after leadership transfer to {} (result {}); "
-                        + "relying on the pause watchdog to recover if still frozen",
-                    desiredLeader,
-                    result,
-                    resumeError);
-              }
-              final var notification =
-                  LeadershipTransferResultRequest.builder()
-                      .withLeader(raft.getCluster().getLocalMember().memberId())
-                      .withDesiredLeader(desiredLeader)
-                      .withResult(result)
-                      .withCorrelationId(correlationId)
-                      .build();
-              raft.getProtocol()
-                  .leadershipTransferResult(coordinator, notification)
-                  .whenComplete(
-                      (ack, notifyError) -> {
-                        if (notifyError != null) {
-                          LOG.debug(
-                              "Failed to notify coordinator {} of transfer result {}",
-                              coordinator,
-                              result,
-                              notifyError);
-                        }
-                      });
-            });
+    resume().whenComplete((ignored, resumeError) -> reportResult(result));
   }
 
   private void observeDuration(final LeadershipTransferResult result) {
     raft.getRebalanceMetrics()
         .observeTransferDuration(result, Duration.ofMillis(System.currentTimeMillis() - startMs));
+  }
+
+  private void reportResult(final LeadershipTransferResult result) {
+    final var notification =
+        LeadershipTransferResultRequest.builder()
+            .withLeader(raft.getCluster().getLocalMember().memberId())
+            .withDesiredLeader(desiredLeader)
+            .withResult(result)
+            .withCorrelationId(correlationId)
+            .build();
+    raft.getProtocol()
+        .leadershipTransferResult(coordinator, notification)
+        .whenComplete(
+            (ack, notifyError) -> {
+              if (notifyError != null) {
+                LOG.debug(
+                    "Failed to notify coordinator {} of transfer result {}",
+                    coordinator,
+                    result,
+                    notifyError);
+              }
+            });
   }
 
   private CompletableFuture<Long> pause(final Duration resumeTimeout) {
@@ -182,15 +172,32 @@ final class LeadershipTransferAttempt {
         leader.pauseForTransfer(resumeTimeout, System.currentTimeMillis()));
   }
 
+  /**
+   * Reopens the partition on every terminal path, whether the transfer failed or the desired leader
+   * caught up. A resume that fails can leave the partition frozen: the pause watchdog is the safety
+   * net and steps the leader down once the resume deadline passes.
+   */
   private CompletableFuture<Void> resume() {
     final var control = raft.getLeadershipTransferPauseControl();
+    final CompletableFuture<Void> resumed;
     if (control != null) {
-      return control.resumeFromTransfer();
+      resumed = control.resumeFromTransfer();
+    } else {
+      // e.g. Raft-only tests, where there are no writes to reopen
+      LOG.debug("No broker pause control registered, resuming the Raft side only");
+      leader.resumeFromTransfer();
+      resumed = CompletableFuture.completedFuture(null);
     }
-    // e.g. Raft-only tests, where there are no writes to reopen
-    LOG.debug("No broker pause control registered, resuming the Raft side only");
-    leader.resumeFromTransfer();
-    return CompletableFuture.completedFuture(null);
+    return resumed.whenComplete(
+        (ignored, error) -> {
+          if (error != null) {
+            LOG.error(
+                "Failed to resume partition after leadership transfer to {}; relying on the pause "
+                    + "watchdog to recover if still frozen",
+                desiredLeader,
+                error);
+          }
+        });
   }
 
   /**

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
@@ -117,19 +117,20 @@ final class LeadershipTransferAttempt {
   }
 
   /**
-   * The desired leader is caught up. We don't yet implement the actual transfer, so just resume:
-   * there is no terminal result to report to the coordinator.
+   * The desired leader is caught up, which is as far as a transfer gets until the promotion step
+   * exists: the attempt is measured as a success and the partition resumed, but there is no
+   * leadership change to report to the coordinator yet.
    */
   private void onCaughtUp(final long targetIndex) {
     LOG.info("Desired leader {} caught up to index {}", desiredLeader, targetIndex);
     finishListener.run();
+    observeDuration(LeadershipTransferResult.TRANSFERRED);
     resume();
   }
 
   private void finish(final LeadershipTransferResult result) {
     finishListener.run();
-    raft.getRebalanceMetrics()
-        .observeTransferDuration(result, Duration.ofMillis(System.currentTimeMillis() - startMs));
+    observeDuration(result);
     resume()
         .whenComplete(
             (ignored, resumeError) -> {
@@ -163,6 +164,11 @@ final class LeadershipTransferAttempt {
                         }
                       });
             });
+  }
+
+  private void observeDuration(final LeadershipTransferResult result) {
+    raft.getRebalanceMetrics()
+        .observeTransferDuration(result, Duration.ofMillis(System.currentTimeMillis() - startMs));
   }
 
   private CompletableFuture<Long> pause(final Duration resumeTimeout) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
@@ -170,7 +170,8 @@ final class LeadershipTransferAttempt {
     if (control != null) {
       return control.pauseForTransfer(resumeTimeout);
     }
-    // No broker control registered (e.g. Raft-only tests with no writes to freeze).
+    // e.g. Raft-only tests, where there are no writes to freeze
+    LOG.debug("No broker pause control registered, pausing the Raft side only");
     return CompletableFuture.completedFuture(
         leader.pauseForTransfer(resumeTimeout, System.currentTimeMillis()));
   }
@@ -180,6 +181,8 @@ final class LeadershipTransferAttempt {
     if (control != null) {
       return control.resumeFromTransfer();
     }
+    // e.g. Raft-only tests, where there are no writes to reopen
+    LOG.debug("No broker pause control registered, resuming the Raft side only");
     leader.resumeFromTransfer();
     return CompletableFuture.completedFuture(null);
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferRunner.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferRunner.java
@@ -15,181 +15,63 @@
  */
 package io.atomix.raft.roles;
 
-import com.google.common.base.Throwables;
-import io.atomix.cluster.MemberId;
-import io.atomix.raft.LeadershipTransferResult;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
-import io.atomix.raft.protocol.LeadershipTransferResultRequest;
-import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Runs the coordinated leadership transfers a {@link LeaderRole} accepts, one at a time. Shares the
  * role's lifecycle rather than being per-transfer: a leader that stays leader after a transfer
- * fails can run another.
+ * fails can run another. Each accepted transfer runs as its own one-shot {@link
+ * LeadershipTransferAttempt}, so no state survives from one transfer into the next.
  */
+@NullMarked
 final class LeadershipTransferRunner {
-  private static final Logger LOG = LoggerFactory.getLogger(LeadershipTransferRunner.class);
   private final RaftContext raft;
   private final LeaderRole leader;
-  // Set as soon as the transfer is accepted, before the pause is entered
-  private volatile boolean inProgress;
-  private CatchUpWait activeCatchUp;
+  // Set as soon as a transfer is accepted, before the pause is entered; cleared when the attempt
+  // finishes.
+  private volatile @Nullable LeadershipTransferAttempt currentAttempt;
 
   LeadershipTransferRunner(final RaftContext raft, final LeaderRole leader) {
     this.raft = raft;
     this.leader = leader;
   }
 
-  /** Whether a transfer is still running, i.e. has not reached {@link #finish}. */
+  /** Whether a transfer is still running, i.e. the accepted attempt has not finished. */
   boolean isInProgress() {
-    return inProgress;
+    return currentAttempt != null;
   }
 
   void start(final LeadershipTransferInitiateRequest request) {
     raft.checkThread();
-    inProgress = true;
-    final long startMs = System.currentTimeMillis();
-    final var desiredLeader = request.desiredLeader();
-    final var coordinator = request.coordinator();
-    final var correlationId = request.correlationId();
-    final var resumeTimeout = raft.getRebalanceReplicationTimeout();
-    pause(resumeTimeout)
-        .whenCompleteAsync(
-            (targetIndex, error) -> {
-              if (error != null) {
-                final var result = pauseFailureResult(error);
-                LOG.warn(
-                    "Failed to pause partition for transfer to {}, reporting {}",
-                    desiredLeader,
-                    result,
-                    error);
-                finish(coordinator, desiredLeader, correlationId, result, startMs);
-                return;
-              }
-              final var catchUp =
-                  new CatchUpWait(raft, leader::isRunning, desiredLeader, targetIndex);
-              activeCatchUp = catchUp;
-              catchUp
-                  .start()
-                  .whenComplete(
-                      (catchUpResult, ignored) -> {
-                        activeCatchUp = null;
-                        if (catchUpResult.isPresent()) {
-                          finish(
-                              coordinator,
-                              desiredLeader,
-                              correlationId,
-                              catchUpResult.get(),
-                              startMs);
-                          return;
-                        }
-                        // The desired leader is caught up. We don't yet implement the actual
-                        // transfer, so just resume. This run is over either way, so release the
-                        // runner for the next transfer the leader is asked to make.
-                        LOG.info(
-                            "Desired leader {} caught up to index {}", desiredLeader, targetIndex);
-                        inProgress = false;
-                        resume();
-                      });
-            },
-            raft.getThreadContext());
-  }
-
-  private void finish(
-      final MemberId coordinator,
-      final MemberId desiredLeader,
-      final long correlationId,
-      final LeadershipTransferResult result,
-      final long startMs) {
-    inProgress = false;
-    raft.getRebalanceMetrics()
-        .observeTransferDuration(result, Duration.ofMillis(System.currentTimeMillis() - startMs));
-    resume()
-        .whenComplete(
-            (ignored, resumeError) -> {
-              if (resumeError != null) {
-                // Cleanup failed: the partition may still be frozen. The pause watchdog is the
-                // safety net and steps the leader down once the resume deadline passes.
-                LOG.error(
-                    "Failed to resume partition after leadership transfer to {} (result {}); "
-                        + "relying on the pause watchdog to recover if still frozen",
-                    desiredLeader,
-                    result,
-                    resumeError);
-              }
-              final var notification =
-                  LeadershipTransferResultRequest.builder()
-                      .withLeader(raft.getCluster().getLocalMember().memberId())
-                      .withDesiredLeader(desiredLeader)
-                      .withResult(result)
-                      .withCorrelationId(correlationId)
-                      .build();
-              raft.getProtocol()
-                  .leadershipTransferResult(coordinator, notification)
-                  .whenComplete(
-                      (ack, notifyError) -> {
-                        if (notifyError != null) {
-                          LOG.debug(
-                              "Failed to notify coordinator {} of transfer result {}",
-                              coordinator,
-                              result,
-                              notifyError);
-                        }
-                      });
-            });
+    final var attempt =
+        new LeadershipTransferAttempt(raft, leader, request, () -> currentAttempt = null);
+    currentAttempt = attempt;
+    attempt.start();
   }
 
   void onLeaderStopped() {
-    if (activeCatchUp != null) {
-      activeCatchUp.onLeaderStopped();
+    final var attempt = currentAttempt;
+    if (attempt != null) {
+      attempt.onLeaderStopped();
     }
   }
 
   /** The freeze ended. */
   void onPauseCleared() {
-    if (activeCatchUp != null) {
-      activeCatchUp.onPauseCleared();
+    final var attempt = currentAttempt;
+    if (attempt != null) {
+      attempt.onPauseCleared();
     }
   }
 
   /** The leader's freeze watchdog fired: the pause outlived its resume deadline. */
   void onPauseDeadlineExpired() {
-    if (activeCatchUp != null) {
-      activeCatchUp.onPauseDeadlineExpired();
+    final var attempt = currentAttempt;
+    if (attempt != null) {
+      attempt.onPauseDeadlineExpired();
     }
-  }
-
-  private CompletableFuture<Long> pause(final Duration resumeTimeout) {
-    final var control = raft.getLeadershipTransferPauseControl();
-    if (control != null) {
-      return control.pauseForTransfer(resumeTimeout);
-    }
-    // No broker control registered (e.g. Raft-only tests with no writes to freeze).
-    return CompletableFuture.completedFuture(
-        leader.pauseForTransfer(resumeTimeout, System.currentTimeMillis()));
-  }
-
-  private CompletableFuture<Void> resume() {
-    final var control = raft.getLeadershipTransferPauseControl();
-    if (control != null) {
-      return control.resumeFromTransfer();
-    }
-    leader.resumeFromTransfer();
-    return CompletableFuture.completedFuture(null);
-  }
-
-  /**
-   * Distinguishes a pause the leader refused because a configuration change started after the
-   * pre-check passed apart from one that failed with another exception.
-   */
-  private static LeadershipTransferResult pauseFailureResult(final Throwable error) {
-    return Throwables.getCausalChain(error).stream()
-            .anyMatch(LeaderRole.ConfigurationChangeInProgressException.class::isInstance)
-        ? LeadershipTransferResult.CONFIGURATION_CHANGE_IN_PROGRESS
-        : LeadershipTransferResult.PAUSE_FAILED;
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferRunner.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferRunner.java
@@ -21,9 +21,7 @@ import io.atomix.raft.LeadershipTransferResult;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
 import io.atomix.raft.protocol.LeadershipTransferResultRequest;
-import io.atomix.utils.concurrent.Scheduled;
 import java.time.Duration;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,8 +37,7 @@ final class LeadershipTransferRunner {
   private final LeaderRole leader;
   // Set as soon as the transfer is accepted, before the pause is entered
   private volatile boolean inProgress;
-  private Scheduled catchUpPollTimer;
-  private CompletableFuture<Optional<LeadershipTransferResult>> catchUpFuture;
+  private CatchUpWait activeCatchUp;
 
   LeadershipTransferRunner(final RaftContext raft, final LeaderRole leader) {
     this.raft = raft;
@@ -73,9 +70,14 @@ final class LeadershipTransferRunner {
                 finish(coordinator, desiredLeader, correlationId, result, startMs);
                 return;
               }
-              awaitDesiredLeaderCaughtUp(desiredLeader, targetIndex)
+              final var catchUp =
+                  new CatchUpWait(raft, leader::isRunning, desiredLeader, targetIndex);
+              activeCatchUp = catchUp;
+              catchUp
+                  .start()
                   .whenComplete(
                       (catchUpResult, ignored) -> {
+                        activeCatchUp = null;
                         if (catchUpResult.isPresent()) {
                           finish(
                               coordinator,
@@ -142,91 +144,23 @@ final class LeadershipTransferRunner {
   }
 
   void onLeaderStopped() {
-    if (catchUpFuture != null) {
-      LOG.debug("Lost leadership while catching up the desired leader; reporting LEADER_CHANGED");
-      completeCatchUp(Optional.of(LeadershipTransferResult.LEADER_CHANGED));
+    if (activeCatchUp != null) {
+      activeCatchUp.onLeaderStopped();
     }
   }
 
-  /**
-   * The freeze ended, so a run still waiting for the desired leader to catch up can no longer
-   * succeed.
-   */
+  /** The freeze ended. */
   void onPauseCleared() {
-    if (catchUpFuture != null) {
-      completeCatchUp(Optional.of(LeadershipTransferResult.PAUSE_FAILED));
-    } else {
-      cancelCatchUp();
+    if (activeCatchUp != null) {
+      activeCatchUp.onPauseCleared();
     }
   }
 
-  /** The leader's freeze watchdog fired, so the desired leader is out of time to catch up. */
+  /** The leader's freeze watchdog fired: the pause outlived its resume deadline. */
   void onPauseDeadlineExpired() {
-    if (catchUpFuture != null) {
-      completeCatchUp(Optional.of(LeadershipTransferResult.REPLICATION_TIMED_OUT));
+    if (activeCatchUp != null) {
+      activeCatchUp.onPauseDeadlineExpired();
     }
-  }
-
-  /**
-   * Waits until {@code desiredLeader}'s {@code matchIndex} reaches {@code targetIndex}, polling on
-   * the Raft thread each {@code heartbeatInterval}. The wait is bounded by the pause watchdog.
-   *
-   * <p>The returned future completes with an empty {@link Optional} once the desired leader is
-   * fully caught up (proceed to promotion), or with a terminal reason if there was a
-   * failure/timeout.
-   */
-  CompletableFuture<Optional<LeadershipTransferResult>> awaitDesiredLeaderCaughtUp(
-      final MemberId desiredLeader, final long targetIndex) {
-    raft.checkThread();
-    catchUpFuture = new CompletableFuture<>();
-    // Hold a local reference: completeCatchUp() clears the field, so we must return this.
-    final var future = catchUpFuture;
-
-    if (isCaughtUp(desiredLeader, targetIndex)) {
-      completeCatchUp(Optional.empty());
-      return future;
-    }
-
-    final var pollInterval = raft.getHeartbeatInterval();
-    catchUpPollTimer =
-        raft.getThreadContext()
-            .schedule(
-                pollInterval,
-                pollInterval,
-                () -> {
-                  if (catchUpFuture == null) {
-                    return;
-                  }
-                  if (!leader.isRunning()) {
-                    completeCatchUp(Optional.of(LeadershipTransferResult.LEADER_CHANGED));
-                  } else if (raft.getCluster().getMemberContext(desiredLeader) == null) {
-                    completeCatchUp(Optional.of(LeadershipTransferResult.NOT_MEMBER));
-                  } else if (isCaughtUp(desiredLeader, targetIndex)) {
-                    completeCatchUp(Optional.empty());
-                  }
-                });
-    return future;
-  }
-
-  private boolean isCaughtUp(final MemberId desiredLeader, final long targetIndex) {
-    final var context = raft.getCluster().getMemberContext(desiredLeader);
-    return context != null && context.getMatchIndex() >= targetIndex;
-  }
-
-  private void completeCatchUp(final Optional<LeadershipTransferResult> result) {
-    final var future = catchUpFuture;
-    cancelCatchUp();
-    if (future != null) {
-      future.complete(result);
-    }
-  }
-
-  private void cancelCatchUp() {
-    if (catchUpPollTimer != null) {
-      catchUpPollTimer.cancel();
-      catchUpPollTimer = null;
-    }
-    catchUpFuture = null;
   }
 
   private CompletableFuture<Long> pause(final Duration resumeTimeout) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferRunner.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferRunner.java
@@ -15,10 +15,14 @@
  */
 package io.atomix.raft.roles;
 
+import com.google.common.base.Throwables;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.LeadershipTransferResult;
 import io.atomix.raft.impl.RaftContext;
+import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
+import io.atomix.raft.protocol.LeadershipTransferResultRequest;
 import io.atomix.utils.concurrent.Scheduled;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
@@ -33,12 +37,108 @@ final class LeadershipTransferRunner {
   private static final Logger LOG = LoggerFactory.getLogger(LeadershipTransferRunner.class);
   private final RaftContext raft;
   private final LeaderRole leader;
+  // Set as soon as the transfer is accepted, before the pause is entered
+  private volatile boolean inProgress;
   private Scheduled catchUpPollTimer;
   private CompletableFuture<Optional<LeadershipTransferResult>> catchUpFuture;
 
   LeadershipTransferRunner(final RaftContext raft, final LeaderRole leader) {
     this.raft = raft;
     this.leader = leader;
+  }
+
+  /** Whether a transfer is still running, i.e. has not reached {@link #finish}. */
+  boolean isInProgress() {
+    return inProgress;
+  }
+
+  void start(final LeadershipTransferInitiateRequest request) {
+    raft.checkThread();
+    inProgress = true;
+    final long startMs = System.currentTimeMillis();
+    final var desiredLeader = request.desiredLeader();
+    final var coordinator = request.coordinator();
+    final var correlationId = request.correlationId();
+    final var resumeTimeout = raft.getRebalanceReplicationTimeout();
+    pause(resumeTimeout)
+        .whenCompleteAsync(
+            (targetIndex, error) -> {
+              if (error != null) {
+                final var result = pauseFailureResult(error);
+                LOG.warn(
+                    "Failed to pause partition for transfer to {}, reporting {}",
+                    desiredLeader,
+                    result,
+                    error);
+                finish(coordinator, desiredLeader, correlationId, result, startMs);
+                return;
+              }
+              awaitDesiredLeaderCaughtUp(desiredLeader, targetIndex)
+                  .whenComplete(
+                      (catchUpResult, ignored) -> {
+                        if (catchUpResult.isPresent()) {
+                          finish(
+                              coordinator,
+                              desiredLeader,
+                              correlationId,
+                              catchUpResult.get(),
+                              startMs);
+                          return;
+                        }
+                        // The desired leader is caught up. We don't yet implement the actual
+                        // transfer, so just resume. This run is over either way, so release the
+                        // runner for the next transfer the leader is asked to make.
+                        LOG.info(
+                            "Desired leader {} caught up to index {}", desiredLeader, targetIndex);
+                        inProgress = false;
+                        resume();
+                      });
+            },
+            raft.getThreadContext());
+  }
+
+  private void finish(
+      final MemberId coordinator,
+      final MemberId desiredLeader,
+      final long correlationId,
+      final LeadershipTransferResult result,
+      final long startMs) {
+    inProgress = false;
+    raft.getRebalanceMetrics()
+        .observeTransferDuration(result, Duration.ofMillis(System.currentTimeMillis() - startMs));
+    resume()
+        .whenComplete(
+            (ignored, resumeError) -> {
+              if (resumeError != null) {
+                // Cleanup failed: the partition may still be frozen. The pause watchdog is the
+                // safety net and steps the leader down once the resume deadline passes.
+                LOG.error(
+                    "Failed to resume partition after leadership transfer to {} (result {}); "
+                        + "relying on the pause watchdog to recover if still frozen",
+                    desiredLeader,
+                    result,
+                    resumeError);
+              }
+              final var notification =
+                  LeadershipTransferResultRequest.builder()
+                      .withLeader(raft.getCluster().getLocalMember().memberId())
+                      .withDesiredLeader(desiredLeader)
+                      .withResult(result)
+                      .withCorrelationId(correlationId)
+                      .build();
+              raft.getProtocol()
+                  .leadershipTransferResult(coordinator, notification)
+                  .whenComplete(
+                      (ack, notifyError) -> {
+                        if (notifyError != null) {
+                          LOG.debug(
+                              "Failed to notify coordinator {} of transfer result {}",
+                              coordinator,
+                              result,
+                              notifyError);
+                        }
+                      });
+            });
   }
 
   void onLeaderStopped() {
@@ -127,5 +227,35 @@ final class LeadershipTransferRunner {
       catchUpPollTimer = null;
     }
     catchUpFuture = null;
+  }
+
+  private CompletableFuture<Long> pause(final Duration resumeTimeout) {
+    final var control = raft.getLeadershipTransferPauseControl();
+    if (control != null) {
+      return control.pauseForTransfer(resumeTimeout);
+    }
+    // No broker control registered (e.g. Raft-only tests with no writes to freeze).
+    return CompletableFuture.completedFuture(
+        leader.pauseForTransfer(resumeTimeout, System.currentTimeMillis()));
+  }
+
+  private CompletableFuture<Void> resume() {
+    final var control = raft.getLeadershipTransferPauseControl();
+    if (control != null) {
+      return control.resumeFromTransfer();
+    }
+    leader.resumeFromTransfer();
+    return CompletableFuture.completedFuture(null);
+  }
+
+  /**
+   * Distinguishes a pause the leader refused because a configuration change started after the
+   * pre-check passed apart from one that failed with another exception.
+   */
+  private static LeadershipTransferResult pauseFailureResult(final Throwable error) {
+    return Throwables.getCausalChain(error).stream()
+            .anyMatch(LeaderRole.ConfigurationChangeInProgressException.class::isInstance)
+        ? LeadershipTransferResult.CONFIGURATION_CHANGE_IN_PROGRESS
+        : LeadershipTransferResult.PAUSE_FAILED;
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferRunner.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferRunner.java
@@ -17,14 +17,16 @@ package io.atomix.raft.roles;
 
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
+import io.atomix.raft.protocol.LeadershipTransferInitiateResponse;
+import io.atomix.raft.protocol.RaftResponse.Status;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Runs the coordinated leadership transfers a {@link LeaderRole} accepts, one at a time. Shares the
- * role's lifecycle rather than being per-transfer: a leader that stays leader after a transfer
- * fails can run another. Each accepted transfer runs as its own one-shot {@link
- * LeadershipTransferAttempt}, so no state survives from one transfer into the next.
+ * Runs the coordinated leadership transfers the leader accepts, one at a time. Shares the role's
+ * lifecycle rather than being per-transfer: a leader that stays leader after a transfer fails can
+ * run another. Each accepted transfer runs as its own one-shot {@link LeadershipTransferAttempt},
+ * so no state survives from one transfer into the next.
  */
 @NullMarked
 final class LeadershipTransferRunner {
@@ -44,12 +46,28 @@ final class LeadershipTransferRunner {
     return currentAttempt != null;
   }
 
-  void start(final LeadershipTransferInitiateRequest request) {
+  /**
+   * Accepts or rejects an initiate request. A rejection carries its reason back in the response; an
+   * accepted request starts a one-shot attempt, whose outcome reaches the coordinator separately
+   * once the transfer finishes.
+   */
+  LeadershipTransferInitiateResponse handleInitiate(
+      final LeadershipTransferInitiateRequest request) {
     raft.checkThread();
+    final var rejectionReason =
+        leader.precheckTransfer(
+            request.desiredLeader(), request.coordinator(), request.coordinatorConfigIndex());
+    if (rejectionReason.isPresent()) {
+      return LeadershipTransferInitiateResponse.builder()
+          .withStatus(Status.OK)
+          .withRejectionReason(rejectionReason.get())
+          .build();
+    }
     final var attempt =
         new LeadershipTransferAttempt(raft, leader, request, () -> currentAttempt = null);
     currentAttempt = attempt;
     attempt.start();
+    return LeadershipTransferInitiateResponse.builder().withStatus(Status.OK).build();
   }
 
   void onLeaderStopped() {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferRunner.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferRunner.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.roles;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.LeadershipTransferResult;
+import io.atomix.raft.impl.RaftContext;
+import io.atomix.utils.concurrent.Scheduled;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs the coordinated leadership transfers a {@link LeaderRole} accepts, one at a time. Shares the
+ * role's lifecycle rather than being per-transfer: a leader that stays leader after a transfer
+ * fails can run another.
+ */
+final class LeadershipTransferRunner {
+  private static final Logger LOG = LoggerFactory.getLogger(LeadershipTransferRunner.class);
+  private final RaftContext raft;
+  private final LeaderRole leader;
+  private Scheduled catchUpPollTimer;
+  private CompletableFuture<Optional<LeadershipTransferResult>> catchUpFuture;
+
+  LeadershipTransferRunner(final RaftContext raft, final LeaderRole leader) {
+    this.raft = raft;
+    this.leader = leader;
+  }
+
+  void onLeaderStopped() {
+    if (catchUpFuture != null) {
+      LOG.debug("Lost leadership while catching up the desired leader; reporting LEADER_CHANGED");
+      completeCatchUp(Optional.of(LeadershipTransferResult.LEADER_CHANGED));
+    }
+  }
+
+  /**
+   * The freeze ended, so a run still waiting for the desired leader to catch up can no longer
+   * succeed.
+   */
+  void onPauseCleared() {
+    if (catchUpFuture != null) {
+      completeCatchUp(Optional.of(LeadershipTransferResult.PAUSE_FAILED));
+    } else {
+      cancelCatchUp();
+    }
+  }
+
+  /** The leader's freeze watchdog fired, so the desired leader is out of time to catch up. */
+  void onPauseDeadlineExpired() {
+    if (catchUpFuture != null) {
+      completeCatchUp(Optional.of(LeadershipTransferResult.REPLICATION_TIMED_OUT));
+    }
+  }
+
+  /**
+   * Waits until {@code desiredLeader}'s {@code matchIndex} reaches {@code targetIndex}, polling on
+   * the Raft thread each {@code heartbeatInterval}. The wait is bounded by the pause watchdog.
+   *
+   * <p>The returned future completes with an empty {@link Optional} once the desired leader is
+   * fully caught up (proceed to promotion), or with a terminal reason if there was a
+   * failure/timeout.
+   */
+  CompletableFuture<Optional<LeadershipTransferResult>> awaitDesiredLeaderCaughtUp(
+      final MemberId desiredLeader, final long targetIndex) {
+    raft.checkThread();
+    catchUpFuture = new CompletableFuture<>();
+    // Hold a local reference: completeCatchUp() clears the field, so we must return this.
+    final var future = catchUpFuture;
+
+    if (isCaughtUp(desiredLeader, targetIndex)) {
+      completeCatchUp(Optional.empty());
+      return future;
+    }
+
+    final var pollInterval = raft.getHeartbeatInterval();
+    catchUpPollTimer =
+        raft.getThreadContext()
+            .schedule(
+                pollInterval,
+                pollInterval,
+                () -> {
+                  if (catchUpFuture == null) {
+                    return;
+                  }
+                  if (!leader.isRunning()) {
+                    completeCatchUp(Optional.of(LeadershipTransferResult.LEADER_CHANGED));
+                  } else if (raft.getCluster().getMemberContext(desiredLeader) == null) {
+                    completeCatchUp(Optional.of(LeadershipTransferResult.NOT_MEMBER));
+                  } else if (isCaughtUp(desiredLeader, targetIndex)) {
+                    completeCatchUp(Optional.empty());
+                  }
+                });
+    return future;
+  }
+
+  private boolean isCaughtUp(final MemberId desiredLeader, final long targetIndex) {
+    final var context = raft.getCluster().getMemberContext(desiredLeader);
+    return context != null && context.getMatchIndex() >= targetIndex;
+  }
+
+  private void completeCatchUp(final Optional<LeadershipTransferResult> result) {
+    final var future = catchUpFuture;
+    cancelCatchUp();
+    if (future != null) {
+      future.complete(result);
+    }
+  }
+
+  private void cancelCatchUp() {
+    if (catchUpPollTimer != null) {
+      catchUpPollTimer.cancel();
+      catchUpPollTimer = null;
+    }
+    catchUpFuture = null;
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
@@ -28,6 +28,8 @@ import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.InternalAppendRequest;
 import io.atomix.raft.protocol.JoinRequest;
 import io.atomix.raft.protocol.JoinResponse;
+import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
+import io.atomix.raft.protocol.LeadershipTransferInitiateResponse;
 import io.atomix.raft.protocol.LeaveRequest;
 import io.atomix.raft.protocol.LeaveResponse;
 import io.atomix.raft.protocol.PollRequest;
@@ -108,6 +110,16 @@ public interface RaftRole extends Managed<RaftRole> {
    * @return A completable future to be completed with the request response.
    */
   CompletableFuture<TimeoutNowResponse> onTimeoutNow(TimeoutNowRequest request);
+
+  /**
+   * Handles a coordinated-leadership-transfer initiate request. Only the leader drives the
+   * transfer; every other role rejects it as misrouted.
+   *
+   * @param request The request to handle.
+   * @return A completable future to be completed with the acknowledgement.
+   */
+  CompletableFuture<LeadershipTransferInitiateResponse> onLeadershipTransferInitiate(
+      LeadershipTransferInitiateRequest request);
 
   /**
    * Handles an append request.

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/CoordinatedTransferDriver.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/CoordinatedTransferDriver.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.cluster.RaftMember;
+import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
+import io.atomix.raft.protocol.LeadershipTransferInitiateResponse;
+import io.atomix.raft.protocol.LeadershipTransferResultRequest;
+import io.atomix.raft.protocol.LeadershipTransferResultResponse;
+import io.atomix.raft.protocol.RaftResponse.Status;
+import io.atomix.raft.protocol.TestRaftServerProtocol;
+import java.util.Comparator;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/** Drives a coordinated leadership transfer the way a coordinator would. */
+final class CoordinatedTransferDriver {
+
+  private final RaftRule raftRule;
+  private final RaftServer leader;
+  private final MemberId coordinatorId;
+  private final CompletableFuture<LeadershipTransferResultRequest> reported =
+      new CompletableFuture<>();
+  private long nextCorrelationId = 0x5eed_0100L;
+
+  CoordinatedTransferDriver(final RaftRule raftRule, final RaftServer leader) {
+    this.raftRule = raftRule;
+    this.leader = leader;
+    coordinatorId =
+        leader.getContext().getCluster().getConfiguration().newMembers().stream()
+            .map(RaftMember::memberId)
+            .min(Comparator.comparing(MemberId::id))
+            .orElseThrow();
+    protocolOf(coordinatorId)
+        .registerLeadershipTransferResultHandler(
+            request -> {
+              reported.complete(request);
+              return CompletableFuture.completedFuture(
+                  LeadershipTransferResultResponse.builder().withStatus(Status.OK).build());
+            });
+  }
+
+  /**
+   * A follower other than the coordinator, so a test that cuts the desired leader off does not also
+   * cut off the coordinator the result is reported to.
+   */
+  RaftServer followerOutsideCoordinator() {
+    return raftRule.getServers().stream()
+        .filter(server -> server.getRole() == RaftServer.Role.FOLLOWER)
+        .filter(server -> !memberId(server).equals(coordinatorId))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  /** Requests a transfer to {@code desiredLeader} on the coordinator's behalf. */
+  LeadershipTransferInitiateResponse initiate(final RaftServer desiredLeader) throws Exception {
+    final var request =
+        LeadershipTransferInitiateRequest.builder()
+            .withDesiredLeader(memberId(desiredLeader))
+            .withCoordinator(coordinatorId)
+            .withCoordinatorConfigIndex(leader.getContext().getCluster().getConfiguration().index())
+            .withCorrelationId(nextCorrelationId++)
+            .build();
+    return leader
+        .getContext()
+        .getProtocol()
+        .leadershipTransferInitiate(memberId(leader), request)
+        .get(5, TimeUnit.SECONDS);
+  }
+
+  /** Completes with the terminal result the leader reports to the coordinator. */
+  CompletableFuture<LeadershipTransferResultRequest> reportedResult() {
+    return reported;
+  }
+
+  static MemberId memberId(final RaftServer server) {
+    return server.getContext().getCluster().getLocalMember().memberId();
+  }
+
+  private TestRaftServerProtocol protocolOf(final MemberId memberId) {
+    return raftRule.getServers().stream()
+        .filter(server -> memberId(server).equals(memberId))
+        .map(server -> (TestRaftServerProtocol) server.getContext().getProtocol())
+        .findFirst()
+        .orElseThrow();
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCoordinatedLeadershipTransferTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCoordinatedLeadershipTransferTest.java
@@ -23,10 +23,254 @@ import io.atomix.raft.partition.impl.RaftNamespaces;
 import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
 import io.atomix.raft.protocol.LeadershipTransferInitiateResponse;
 import io.atomix.raft.protocol.LeadershipTransferResultRequest;
+import io.atomix.raft.protocol.LeadershipTransferResultResponse;
 import io.atomix.raft.protocol.RaftResponse.Status;
+import io.atomix.raft.protocol.TestRaftServerProtocol;
+import io.atomix.raft.roles.LeaderRole;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class RaftCoordinatedLeadershipTransferTest {
+
+  @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);
+
+  @Test
+  public void shouldAcceptInitiateForCaughtUpFollower() throws Exception {
+    // given
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var targetId = memberId(raftRule.getFollower().orElseThrow());
+
+    // when
+    final var ack =
+        leader
+            .getContext()
+            .getProtocol()
+            .leadershipTransferInitiate(
+                memberId(leader),
+                initiate(targetId, coordinator(leader), configIndex(leader), 0x5eed_0001L))
+            .get(5, TimeUnit.SECONDS);
+
+    // then
+    assertThat(ack.accepted()).isTrue();
+  }
+
+  @Test
+  public void shouldAcceptAnotherTransferAfterOneFailed() throws Exception {
+    // given
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var targetId = memberId(raftRule.getFollower().orElseThrow());
+    final var coordinatorId = coordinator(leader);
+    final var reported = new ArrayBlockingQueue<LeadershipTransferResultRequest>(2);
+    protocolOf(coordinatorId)
+        .registerLeadershipTransferResultHandler(
+            request -> {
+              reported.add(request);
+              return CompletableFuture.completedFuture(
+                  LeadershipTransferResultResponse.builder().withStatus(Status.OK).build());
+            });
+    leader
+        .getContext()
+        .setLeadershipTransferPauseControl(
+            new LeadershipTransferPauseControl() {
+              @Override
+              public CompletableFuture<Long> pauseForTransfer(final Duration resumeTimeout) {
+                return CompletableFuture.failedFuture(
+                    new TimeoutException("Timed out arming the leadership-transfer pause barrier"));
+              }
+
+              @Override
+              public CompletableFuture<Void> resumeFromTransfer() {
+                return CompletableFuture.completedFuture(null);
+              }
+            });
+
+    // when
+    final var first =
+        leader
+            .getContext()
+            .getProtocol()
+            .leadershipTransferInitiate(
+                memberId(leader),
+                initiate(targetId, coordinatorId, configIndex(leader), 0x5eed_000cL))
+            .get(5, TimeUnit.SECONDS);
+    assertThat(reported.poll(10, TimeUnit.SECONDS))
+        .extracting(LeadershipTransferResultRequest::result)
+        .isEqualTo(LeadershipTransferResult.PAUSE_FAILED);
+    final var second =
+        leader
+            .getContext()
+            .getProtocol()
+            .leadershipTransferInitiate(
+                memberId(leader),
+                initiate(targetId, coordinatorId, configIndex(leader), 0x5eed_000dL))
+            .get(5, TimeUnit.SECONDS);
+
+    // then
+    assertThat(first.accepted()).isTrue();
+    assertThat(second.accepted())
+        .as("a leader that kept leadership is free to run another transfer")
+        .isTrue();
+    assertThat(reported.poll(10, TimeUnit.SECONDS))
+        .extracting(LeadershipTransferResultRequest::result)
+        .isEqualTo(LeadershipTransferResult.PAUSE_FAILED);
+  }
+
+  @Test
+  public void shouldRejectInitiateOnFollower() throws Exception {
+    // given
+    raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var follower = raftRule.getFollower().orElseThrow();
+    final var coordinatorId = coordinator(leader);
+
+    // when
+    final var ack =
+        follower
+            .getContext()
+            .getProtocol()
+            .leadershipTransferInitiate(
+                memberId(follower),
+                initiate(memberId(leader), coordinatorId, configIndex(leader), 0x5eed_0002L))
+            .get(5, TimeUnit.SECONDS);
+
+    // then
+    assertThat(ack.accepted()).isFalse();
+    assertThat(ack.error().type()).isEqualTo(RaftError.Type.ILLEGAL_MEMBER_STATE);
+  }
+
+  @Test
+  public void shouldAckImmediateSkipWhenDesiredLeaderIsAlreadyLeader() throws Exception {
+    // given
+    raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var coordinatorId = coordinator(leader);
+
+    // when
+    final var ack =
+        leader
+            .getContext()
+            .getProtocol()
+            .leadershipTransferInitiate(
+                memberId(leader),
+                initiate(memberId(leader), coordinatorId, configIndex(leader), 0x5eed_0003L))
+            .get(5, TimeUnit.SECONDS);
+
+    // then
+    assertThat(ack.accepted()).isFalse();
+    assertThat(ack.rejectionReason()).isEqualTo(LeadershipTransferResult.ALREADY_LEADER);
+  }
+
+  @Test
+  public void shouldReportConfigurationChangeWhenTheFreezeIsRefused() throws Exception {
+    // given
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var targetId = memberId(raftRule.getFollower().orElseThrow());
+    final var coordinatorId = coordinator(leader);
+    final CompletableFuture<LeadershipTransferResultRequest> reported = new CompletableFuture<>();
+    protocolOf(coordinatorId)
+        .registerLeadershipTransferResultHandler(
+            request -> {
+              reported.complete(request);
+              return CompletableFuture.completedFuture(
+                  LeadershipTransferResultResponse.builder().withStatus(Status.OK).build());
+            });
+
+    leader
+        .getContext()
+        .setLeadershipTransferPauseControl(
+            new LeadershipTransferPauseControl() {
+              @Override
+              public CompletableFuture<Long> pauseForTransfer(final Duration resumeTimeout) {
+                return CompletableFuture.failedFuture(
+                    new CompletionException(
+                        new LeaderRole.ConfigurationChangeInProgressException(
+                            "Cannot pause for leadership transfer: configuration change in"
+                                + " progress")));
+              }
+
+              @Override
+              public CompletableFuture<Void> resumeFromTransfer() {
+                return CompletableFuture.completedFuture(null);
+              }
+            });
+
+    // when
+    final var ack =
+        leader
+            .getContext()
+            .getProtocol()
+            .leadershipTransferInitiate(
+                memberId(leader),
+                initiate(targetId, coordinatorId, configIndex(leader), 0x5eed_0004L))
+            .get(5, TimeUnit.SECONDS);
+
+    // then
+    assertThat(ack.accepted()).isTrue();
+    final var notification = reported.get(10, TimeUnit.SECONDS);
+    assertThat(notification.result())
+        .isEqualTo(LeadershipTransferResult.CONFIGURATION_CHANGE_IN_PROGRESS);
+    assertThat(notification.correlationId())
+        .as("the failure notification echoes the initiate request's correlation id")
+        .isEqualTo(0x5eed_0004L);
+  }
+
+  @Test
+  public void shouldReportPauseFailureWhenTheFreezeFails() throws Exception {
+    // given
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var targetId = memberId(raftRule.getFollower().orElseThrow());
+    final var coordinatorId = coordinator(leader);
+    final CompletableFuture<LeadershipTransferResultRequest> reported = new CompletableFuture<>();
+    protocolOf(coordinatorId)
+        .registerLeadershipTransferResultHandler(
+            request -> {
+              reported.complete(request);
+              return CompletableFuture.completedFuture(
+                  LeadershipTransferResultResponse.builder().withStatus(Status.OK).build());
+            });
+
+    leader
+        .getContext()
+        .setLeadershipTransferPauseControl(
+            new LeadershipTransferPauseControl() {
+              @Override
+              public CompletableFuture<Long> pauseForTransfer(final Duration resumeTimeout) {
+                return CompletableFuture.failedFuture(
+                    new TimeoutException("Timed out arming the leadership-transfer pause barrier"));
+              }
+
+              @Override
+              public CompletableFuture<Void> resumeFromTransfer() {
+                return CompletableFuture.completedFuture(null);
+              }
+            });
+
+    // when
+    final var ack =
+        leader
+            .getContext()
+            .getProtocol()
+            .leadershipTransferInitiate(
+                memberId(leader),
+                initiate(targetId, coordinatorId, configIndex(leader), 0x5eed_000bL))
+            .get(5, TimeUnit.SECONDS);
+
+    // then
+    assertThat(ack.accepted()).isTrue();
+    assertThat(reported.get(10, TimeUnit.SECONDS).result())
+        .isEqualTo(LeadershipTransferResult.PAUSE_FAILED);
+  }
 
   @Test
   public void shouldRoundTripTransferMessagesThroughRaftNamespace() {
@@ -129,6 +373,74 @@ public class RaftCoordinatedLeadershipTransferTest {
         .hasMessageContaining("correlationId");
   }
 
+  @Test
+  public void shouldKeepAcceptedCorrelationIdWhenAnotherInitiateIsRejected() throws Exception {
+    // given
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var targetId = memberId(raftRule.getFollower().orElseThrow());
+    final var coordinatorId = coordinator(leader);
+    final CompletableFuture<LeadershipTransferResultRequest> reported = new CompletableFuture<>();
+    protocolOf(coordinatorId)
+        .registerLeadershipTransferResultHandler(
+            request -> {
+              reported.complete(request);
+              return CompletableFuture.completedFuture(
+                  LeadershipTransferResultResponse.builder().withStatus(Status.OK).build());
+            });
+
+    final var freeze = new CompletableFuture<Long>();
+    leader
+        .getContext()
+        .setLeadershipTransferPauseControl(
+            new LeadershipTransferPauseControl() {
+              @Override
+              public CompletableFuture<Long> pauseForTransfer(final Duration resumeTimeout) {
+                return freeze;
+              }
+
+              @Override
+              public CompletableFuture<Void> resumeFromTransfer() {
+                return CompletableFuture.completedFuture(null);
+              }
+            });
+
+    // when
+    final var accepted =
+        leader
+            .getContext()
+            .getProtocol()
+            .leadershipTransferInitiate(
+                memberId(leader),
+                initiate(targetId, coordinatorId, configIndex(leader), 0x5eed_0008L))
+            .get(5, TimeUnit.SECONDS);
+    final var rejected =
+        leader
+            .getContext()
+            .getProtocol()
+            .leadershipTransferInitiate(
+                memberId(leader),
+                initiate(targetId, coordinatorId, configIndex(leader), 0x5eed_0009L))
+            .get(5, TimeUnit.SECONDS);
+    freeze.completeExceptionally(new RuntimeException("freeze abandoned in test"));
+
+    // then
+    assertThat(accepted.accepted()).isTrue();
+    assertThat(rejected.accepted()).isFalse();
+    assertThat(rejected.rejectionReason()).isEqualTo(LeadershipTransferResult.TRANSFER_IN_PROGRESS);
+    assertThat(reported.get(10, TimeUnit.SECONDS).correlationId())
+        .as("the rejected request does not replace the in-flight attempt's correlation id")
+        .isEqualTo(0x5eed_0008L);
+  }
+
+  private TestRaftServerProtocol protocolOf(final MemberId memberId) {
+    return raftRule.getServers().stream()
+        .filter(server -> memberId(server).equals(memberId))
+        .map(server -> (TestRaftServerProtocol) server.getContext().getProtocol())
+        .findFirst()
+        .orElseThrow();
+  }
+
   private static <T> T roundTrip(final T message) {
     return RaftNamespaces.RAFT_PROTOCOL.deserialize(
         RaftNamespaces.RAFT_PROTOCOL.serialize(message));
@@ -158,5 +470,20 @@ public class RaftCoordinatedLeadershipTransferTest {
         .withResult(result)
         .withCorrelationId(correlationId)
         .build();
+  }
+
+  private static MemberId memberId(final RaftServer server) {
+    return server.getContext().getCluster().getLocalMember().memberId();
+  }
+
+  private static long configIndex(final RaftServer leader) {
+    return leader.getContext().getCluster().getConfiguration().index();
+  }
+
+  private static MemberId coordinator(final RaftServer leader) {
+    return leader.getContext().getCluster().getConfiguration().newMembers().stream()
+        .map(io.atomix.raft.cluster.RaftMember::memberId)
+        .min(Comparator.comparing(MemberId::id))
+        .orElseThrow();
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferCatchUpTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferCatchUpTest.java
@@ -48,6 +48,27 @@ public class RaftLeadershipTransferCatchUpTest {
           });
 
   @Test
+  public void shouldRecordTransferDurationWhenTheDesiredLeaderCatchesUp() throws Exception {
+    // given
+    raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var driver = new CoordinatedTransferDriver(raftRule, leader);
+    final var target = driver.followerOutsideCoordinator();
+
+    // when
+    final var ack = driver.initiate(target);
+
+    // then
+    assertThat(ack.accepted()).isTrue();
+    Awaitility.await("the attempt is measured once the desired leader is caught up")
+        .atMost(Duration.ofSeconds(15))
+        .untilAsserted(
+            () ->
+                assertThat(transferDurationCount(LeadershipTransferResult.TRANSFERRED))
+                    .isEqualTo(1));
+  }
+
+  @Test
   public void shouldReportLeaderChangedWhenLeadershipIsLostWhileCatchingUp() throws Exception {
     // given
     raftRule.appendEntries(5);
@@ -91,5 +112,15 @@ public class RaftLeadershipTransferCatchUpTest {
     Awaitility.await("the pause watchdog steps the leader down")
         .atMost(Duration.ofSeconds(15))
         .until(() -> leader.getRole() != Role.LEADER);
+  }
+
+  private long transferDurationCount(final LeadershipTransferResult result) {
+    final var timer =
+        raftRule
+            .getMeterRegistry()
+            .find("zeebe.cluster.rebalance.partition.duration")
+            .tag("result", result.name())
+            .timer();
+    return timer == null ? 0 : timer.count();
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferCatchUpTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferCatchUpTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.RaftServer.Role;
+import io.atomix.raft.partition.RaftPartitionConfig;
+import io.atomix.raft.protocol.LeadershipTransferResultRequest;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.Rule;
+import org.junit.Test;
+
+/** Coverage for the catch-up step of a coordinated leadership transfer. */
+public class RaftLeadershipTransferCatchUpTest {
+
+  private static final Duration REPLICATION_TIMEOUT = Duration.ofSeconds(2);
+
+  @Rule
+  public RaftRule raftRule =
+      RaftRule.withBootstrappedNodes(
+          3,
+          new RaftRule.Configurator() {
+            @Override
+            public void configure(final MemberId id, final RaftServer.Builder builder) {
+              final var config =
+                  new RaftPartitionConfig()
+                      .setElectionTimeout(Duration.ofSeconds(3))
+                      .setHeartbeatInterval(Duration.ofMillis(100));
+              config.setRebalanceReplicationTimeout(REPLICATION_TIMEOUT);
+              builder.withPartitionConfig(config);
+            }
+          });
+
+  @Test
+  public void shouldReportLeaderChangedWhenLeadershipIsLostWhileCatchingUp() throws Exception {
+    // given
+    raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var driver = new CoordinatedTransferDriver(raftRule, leader);
+    final var target = driver.followerOutsideCoordinator();
+    raftRule.partition(target);
+    raftRule.appendEntries(5);
+
+    // when
+    final var ack = driver.initiate(target);
+    leader.stepDown().get();
+
+    // then
+    assertThat(ack.accepted()).isTrue();
+    assertThat(driver.reportedResult())
+        .succeedsWithin(Duration.ofSeconds(15))
+        .extracting(LeadershipTransferResultRequest::result)
+        .isEqualTo(LeadershipTransferResult.LEADER_CHANGED);
+  }
+
+  @Test
+  public void shouldStepDownAndReportTimedOutWhenTheFreezeOutlivesItsDeadline() throws Exception {
+    // given
+    raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var driver = new CoordinatedTransferDriver(raftRule, leader);
+    final var target = driver.followerOutsideCoordinator();
+    raftRule.partition(target);
+    raftRule.appendEntries(5);
+
+    // when
+    final var ack = driver.initiate(target);
+
+    // then
+    assertThat(ack.accepted()).isTrue();
+    assertThat(driver.reportedResult())
+        .succeedsWithin(REPLICATION_TIMEOUT.plusSeconds(15))
+        .extracting(LeadershipTransferResultRequest::result)
+        .isEqualTo(LeadershipTransferResult.REPLICATION_TIMED_OUT);
+    Awaitility.await("the pause watchdog steps the leader down")
+        .atMost(Duration.ofSeconds(15))
+        .until(() -> leader.getRole() != Role.LEADER);
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferInitiateTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferInitiateTest.java
@@ -18,7 +18,12 @@ package io.atomix.raft;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
+import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.ReconfigureRequest;
+import io.atomix.raft.protocol.TestRaftServerProtocol;
+import io.atomix.raft.protocol.TimeoutNowRequest;
+import io.atomix.raft.protocol.VersionedAppendRequest;
+import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.roles.LeaderRole;
 import java.time.Duration;
 import java.util.Comparator;
@@ -268,6 +273,65 @@ public class RaftLeadershipTransferInitiateTest {
 
     // then
     assertThat(result).contains(LeadershipTransferResult.TRANSFER_IN_PROGRESS);
+  }
+
+  @Test
+  public void shouldRejectTransferWhileTheLeaderIsInitializing() throws Exception {
+    // given
+    raftRule.appendEntries(5);
+    final var oldLeader = raftRule.getLeader().orElseThrow();
+    final var newLeader = raftRule.getFollower().orElseThrow();
+
+    Awaitility.await("the new leader has the whole log")
+        .atMost(Duration.ofSeconds(15))
+        .until(
+            () ->
+                newLeader.getContext().getLog().getLastIndex()
+                    >= oldLeader.getContext().getLog().getLastIndex());
+
+    dropSends(newLeader, VersionedAppendRequest.class);
+    raftRule.getServers().stream()
+        .filter(server -> server != newLeader)
+        .forEach(
+            server -> {
+              dropSends(server, PollRequest.class);
+              dropSends(server, VoteRequest.class);
+            });
+    protocolOf(oldLeader)
+        .timeoutNow(
+            memberId(newLeader),
+            TimeoutNowRequest.builder()
+                .withTerm(oldLeader.getContext().getTerm())
+                .withLeader(memberId(oldLeader))
+                .build());
+    Awaitility.await("the new leader takes over")
+        .atMost(Duration.ofSeconds(15))
+        .until(() -> newLeader.getRole() == RaftServer.Role.LEADER);
+
+    // when
+    final var result =
+        onRaftThread(
+            newLeader,
+            () ->
+                leaderRole(newLeader)
+                    .precheckTransfer(
+                        memberId(oldLeader), coordinator(newLeader), index(newLeader)));
+
+    // then
+    assertThat(result).contains(LeadershipTransferResult.LEADER_INITIALIZING);
+  }
+
+  private static <T> void dropSends(final RaftServer server, final Class<T> requestType) {
+    protocolOf(server)
+        .interceptRequest(
+            requestType,
+            request -> {
+              return CompletableFuture.failedFuture(new RuntimeException("dropped in test"));
+            });
+  }
+
+  private static TestRaftServerProtocol protocolOf(final RaftServer server) {
+    return (TestRaftServerProtocol) server.getContext().getProtocol();
   }
 
   /** Builds a membership change that removes {@code follower}, so it is not a no-op. */

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -288,6 +288,11 @@ public final class RaftRule extends ExternalResource {
     return servers.get(id);
   }
 
+  /** The registry every server in the cluster reports its metrics to. */
+  public MeterRegistry getMeterRegistry() {
+    return meterRegistry;
+  }
+
   public void shutdownServer(final RaftServer raftServer) throws Exception {
     shutdownServer(raftServer.name());
   }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/CatchUpWaitTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/CatchUpWaitTest.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class LeadershipTransferCatchUpTest {
+public class CatchUpWaitTest {
 
   @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);
 
@@ -38,10 +38,9 @@ public class LeadershipTransferCatchUpTest {
     final long committed = raftRule.appendEntries(5);
     final var leader = raftRule.getLeader().orElseThrow();
     final var targetId = memberId(raftRule.getFollower().orElseThrow());
-    final var runner = new LeadershipTransferRunner(leader.getContext(), leaderRole(leader));
 
     // when
-    final var caughtUp = awaitCaughtUp(leader, runner, targetId, committed + 5);
+    final var caughtUp = awaitCaughtUp(leader, targetId, committed + 5);
     raftRule.appendEntries(5);
 
     // then
@@ -54,10 +53,9 @@ public class LeadershipTransferCatchUpTest {
     final long committed = raftRule.appendEntries(5);
     final var leader = raftRule.getLeader().orElseThrow();
     final var target = raftRule.getFollower().orElseThrow();
-    final var runner = new LeadershipTransferRunner(leader.getContext(), leaderRole(leader));
 
     // when
-    final var caughtUp = awaitCaughtUp(leader, runner, memberId(target), committed + 1_000);
+    final var caughtUp = awaitCaughtUp(leader, memberId(target), committed + 1_000);
     target.leave().get(30, TimeUnit.SECONDS);
 
     // then
@@ -67,18 +65,19 @@ public class LeadershipTransferCatchUpTest {
   }
 
   private static CompletableFuture<Optional<LeadershipTransferResult>> awaitCaughtUp(
-      final RaftServer leader,
-      final LeadershipTransferRunner runner,
-      final MemberId desiredLeader,
-      final long targetIndex) {
+      final RaftServer leader, final MemberId desiredLeader, final long targetIndex) {
     final var caughtUp = new CompletableFuture<Optional<LeadershipTransferResult>>();
     leader
         .getContext()
         .getThreadContext()
         .execute(
             () ->
-                runner
-                    .awaitDesiredLeaderCaughtUp(desiredLeader, targetIndex)
+                new CatchUpWait(
+                        leader.getContext(),
+                        leaderRole(leader)::isRunning,
+                        desiredLeader,
+                        targetIndex)
+                    .start()
                     .whenComplete(
                         (result, error) -> {
                           if (error != null) {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeadershipTransferCatchUpTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeadershipTransferCatchUpTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.roles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.LeadershipTransferResult;
+import io.atomix.raft.RaftRule;
+import io.atomix.raft.RaftServer;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class LeadershipTransferCatchUpTest {
+
+  @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);
+
+  @Test
+  public void shouldCompleteOnceTheDesiredLeaderReachesTheTargetIndex() throws Exception {
+    // given
+    final long committed = raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var targetId = memberId(raftRule.getFollower().orElseThrow());
+    final var runner = new LeadershipTransferRunner(leader.getContext(), leaderRole(leader));
+
+    // when
+    final var caughtUp = awaitCaughtUp(leader, runner, targetId, committed + 5);
+    raftRule.appendEntries(5);
+
+    // then
+    assertThat(caughtUp).succeedsWithin(Duration.ofSeconds(15)).isEqualTo(Optional.empty());
+  }
+
+  @Test
+  public void shouldReportNotMemberWhenTheDesiredLeaderLeavesThePartition() throws Exception {
+    // given
+    final long committed = raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+    final var runner = new LeadershipTransferRunner(leader.getContext(), leaderRole(leader));
+
+    // when
+    final var caughtUp = awaitCaughtUp(leader, runner, memberId(target), committed + 1_000);
+    target.leave().get(30, TimeUnit.SECONDS);
+
+    // then
+    assertThat(caughtUp)
+        .succeedsWithin(Duration.ofSeconds(15))
+        .isEqualTo(Optional.of(LeadershipTransferResult.NOT_MEMBER));
+  }
+
+  private static CompletableFuture<Optional<LeadershipTransferResult>> awaitCaughtUp(
+      final RaftServer leader,
+      final LeadershipTransferRunner runner,
+      final MemberId desiredLeader,
+      final long targetIndex) {
+    final var caughtUp = new CompletableFuture<Optional<LeadershipTransferResult>>();
+    leader
+        .getContext()
+        .getThreadContext()
+        .execute(
+            () ->
+                runner
+                    .awaitDesiredLeaderCaughtUp(desiredLeader, targetIndex)
+                    .whenComplete(
+                        (result, error) -> {
+                          if (error != null) {
+                            caughtUp.completeExceptionally(error);
+                          } else {
+                            caughtUp.complete(result);
+                          }
+                        }));
+    return caughtUp;
+  }
+
+  private static LeaderRole leaderRole(final RaftServer leader) {
+    return (LeaderRole) leader.getContext().getRaftRole();
+  }
+
+  private static MemberId memberId(final RaftServer server) {
+    return server.getContext().getCluster().getLocalMember().memberId();
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
+import io.atomix.raft.LeadershipTransferPauseControl;
 import io.atomix.raft.RaftRoleChangeListener;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.SnapshotReplicationListener;
@@ -36,6 +37,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 
@@ -63,6 +65,20 @@ public final class ZeebePartition extends Actor
 
   private CompletableActorFuture<Void> closeFuture;
   private boolean closing = false;
+
+  /** Bridges the actor-scheduled pause barrier to the {@link CompletableFuture}-based Raft hook. */
+  private final LeadershipTransferPauseControl pauseControl =
+      new LeadershipTransferPauseControl() {
+        @Override
+        public CompletableFuture<Long> pauseForTransfer(final Duration resumeTimeout) {
+          return toCompletableFuture(ZeebePartition.this.pauseForTransfer(resumeTimeout));
+        }
+
+        @Override
+        public CompletableFuture<Void> resumeFromTransfer() {
+          return toCompletableFuture(ZeebePartition.this.resumeFromTransfer());
+        }
+      };
 
   public ZeebePartition(
       final PartitionStartupAndTransitionContextImpl transitionContext,
@@ -145,6 +161,7 @@ public final class ZeebePartition extends Actor
     // criticalComponentsHealthMonitor can monitor the health of ZeebePartition similar to other
     // components.
     context.getComponentHealthMonitor().registerComponent(zeebePartitionHealth);
+    context.getRaftPartition().getServer().setLeadershipTransferPauseControl(pauseControl);
   }
 
   @Override
@@ -195,6 +212,19 @@ public final class ZeebePartition extends Actor
     // Most probably exception happened in the middle of installing leader or follower services
     // because this actor is not doing anything else
     onInstallFailure(failure);
+  }
+
+  private static <T> CompletableFuture<T> toCompletableFuture(final ActorFuture<T> actorFuture) {
+    final var future = new CompletableFuture<T>();
+    actorFuture.onComplete(
+        (result, error) -> {
+          if (error != null) {
+            future.completeExceptionally(error);
+          } else {
+            future.complete(result);
+          }
+        });
+    return future;
   }
 
   @Override


### PR DESCRIPTION
Handles accepted coordinated leadership-transfer requests through the pre-transfer catch-up phase. In addition to invoking the pause/freeze behaviour introduced already, we also wait until the desired leader's `matchIndex` reaches the frozen log index. Once it does, the partition is resumed (we don't yet send the TimeoutNow to actually execute the transfer).

Pause and catch-up failures are reported asynchronously to the coordinator. The partition is resumed after failures where possible. If resuming fails, or the pause watchdog expires before cleanup completes, the leader steps down.

The new `zeebe.cluster.rebalance.partition.duration` metric records each attempt's duration and terminal result.

Closes: #58909, #56758.