### PR TITLE
refactor: extract CslTenantCheck from CslAuthorizationCheck

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
-import io.camunda.zeebe.engine.processing.identity.AuthorizedTenantsResolver;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
@@ -40,6 +39,9 @@ import org.slf4j.LoggerFactory;
  * <p>Use {@link #check} for single-check sites (one {@link RequiredAuthorization} per command). Use
  * {@link #resolveForCheck} for multi-check sites (e.g. UserTask processors) that run several CSL
  * checks after the skip-logic resolves the principal.
+ *
+ * <p>Tenant-membership checks are delegated to {@link CslTenantCheck}; this class exposes them
+ * under their original method names so existing callers are unaffected.
  */
 @NullMarked
 public final class CslAuthorizationCheck {
@@ -49,6 +51,7 @@ public final class CslAuthorizationCheck {
   private final AuthorizationCheckPort authzService;
   private final TokenClaimsAuthenticationResolver claimsConverter;
   private final EngineSecurityConfig securityConfig;
+  private final CslTenantCheck tenantCheck;
 
   public CslAuthorizationCheck(
       final AuthorizationCheckPort authzService,
@@ -57,6 +60,7 @@ public final class CslAuthorizationCheck {
     this.authzService = authzService;
     this.claimsConverter = claimsConverter;
     this.securityConfig = securityConfig;
+    tenantCheck = new CslTenantCheck(claimsConverter, securityConfig);
   }
 
   /**
@@ -110,45 +114,22 @@ public final class CslAuthorizationCheck {
   }
 
   /**
-   * Resolves the {@link AuthorizedTenants} for a command from its authorization claims, reusing
-   * this component's claims converter and security configuration. Centralizes the converter here so
-   * command processors depend only on {@code CslAuthorizationCheck} instead of threading the
-   * converter through their construction chains.
+   * Resolves the {@link AuthorizedTenants} for a command from its authorization claims. Delegates
+   * to {@link CslTenantCheck#resolveAuthorizedTenants}.
    */
   public AuthorizedTenants resolveAuthorizedTenants(final Map<String, Object> authorizations) {
-    return AuthorizedTenantsResolver.resolve(authorizations, securityConfig, claimsConverter);
+    return tenantCheck.resolveAuthorizedTenants(authorizations);
   }
 
   public boolean isMultiTenancyChecksEnabled() {
-    return securityConfig.isMultiTenancyChecksEnabled();
+    return tenantCheck.isMultiTenancyChecksEnabled();
   }
 
   /**
    * Tenant-assignment check for command sites that must verify tenant membership independently of a
    * resource {@link #check} — e.g. a command-level tenant gate, or a site whose RBAC check runs at
-   * a different granularity (one tenant, many resource checks).
-   *
-   * <p>Encapsulates the skip-logic hand-rolled across engine processors: when multi-tenancy checks
-   * are disabled the check is a no-op; when no username or clientId claim is present the check is
-   * also a no-op (mirrors {@link #resolveForCheck} — a no-principal command is either an internal
-   * command already exempted upstream, or authorizations are disabled and the primary permission
-   * check already let it through; either way there is no principal to hold a tenant assignment
-   * requirement against). Otherwise the authorized tenants are resolved from the command's claims
-   * (anonymous access is authorized for every tenant) and {@code tenantId} must be among them.
-   *
-   * <p>This no-principal skip is load-bearing: every caller runs {@link #check} first — either
-   * directly, composed via {@link #checkAuthorizationAndTenant}, or (for the sole remaining direct
-   * caller) via an equivalent {@code check(...).flatMap(v -> checkTenant(...))} of its own — before
-   * this method is ever reached. When authorizations are enabled, {@code check} itself rejects a
-   * no-principal command before this method runs; when authorizations are disabled, letting a
-   * claims-free command through here (e.g. deployment/process lifecycle commands issued without an
-   * explicit user, common in tests and tooling) is the established, relied-upon behavior. Do not
-   * call this method directly without a preceding {@link #check}, and do not remove this skip
-   * without auditing every caller.
-   *
-   * <p>Callers own the rejection semantics: {@code notAssignedRejection} carries the {@link
-   * io.camunda.zeebe.protocol.record.RejectionType} — {@code FORBIDDEN} to signal "not assigned to
-   * tenant", or {@code NOT_FOUND} to mask an existing resource — and the message.
+   * a different granularity (one tenant, many resource checks). Delegates to {@link
+   * CslTenantCheck#checkTenant}; see that method's javadoc for the full skip-logic contract.
    *
    * @param value the value to return on success (mirrors {@link #check}; enables {@code flatMap}
    *     composition with it)
@@ -160,38 +141,14 @@ public final class CslAuthorizationCheck {
       final String tenantId,
       final T value,
       final Rejection notAssignedRejection) {
-    if (!securityConfig.isMultiTenancyChecksEnabled()) {
-      return Either.right(value);
-    }
-    final var authorizations = command.getAuthorizations();
-    if (authorizations.get(Authorization.AUTHORIZED_USERNAME) == null
-        && authorizations.get(Authorization.AUTHORIZED_CLIENT_ID) == null) {
-      return Either.right(value);
-    }
-    if (resolveAuthorizedTenants(authorizations).isAuthorizedForTenantId(tenantId)) {
-      return Either.right(value);
-    }
-    return Either.left(notAssignedRejection);
+    return tenantCheck.checkTenant(command, tenantId, value, notAssignedRejection);
   }
 
   /**
-   * Unlike {@link #checkTenant}, this method has no no-principal skip: a claims-free caller is
-   * rejected for every tenant it names, rather than vacuously authorized. (The
-   * multi-tenancy-disabled and anonymous-caller skips still apply, same as {@link #checkTenant}.)
-   * Use it only for command sites that call the tenant check directly, with no preceding {@link
-   * #check}, and that verify membership across a list of tenant IDs at once, using {@link
-   * AuthorizedTenants#isAuthorizedForTenantIds}.
-   *
-   * <p>Without a preceding {@link #check} to reject a claims-free command first, sharing {@link
-   * #checkTenant}'s no-principal skip here would silently authorize a claims-free caller for every
-   * tenant it names instead of rejecting it — hence the guarantee is deliberate, not an oversight.
-   *
-   * <p>Also unlike {@link #checkTenant}, takes an already-resolved {@link AuthorizedTenants} and a
-   * lazy {@code Supplier<Rejection>} rather than resolving internally and building the rejection
-   * eagerly — callers that already resolved tenants for the same command don't pay to resolve
-   * twice, and the rejection message is only built on the rejected path. The supplier is only
-   * invoked on rejection, which never happens for an anonymous principal, so it's always safe to
-   * call {@code authorizedTenants.getAuthorizedTenantIds()} inside it.
+   * Tenant-assignment check across a list of tenant IDs at once, for command sites that call it
+   * directly with no preceding {@link #check}. Delegates to {@link
+   * CslTenantCheck#checkTenantsRequiringPrincipal}; see that method's javadoc for the full
+   * skip-logic contract, including why it has no no-principal skip (unlike {@link #checkTenant}).
    *
    * @param authorizedTenants the tenants the command's principal is authorized for, as resolved by
    *     {@link #resolveAuthorizedTenants} from the same command's claims
@@ -203,21 +160,17 @@ public final class CslAuthorizationCheck {
       final AuthorizedTenants authorizedTenants,
       final T value,
       final Supplier<Rejection> notAssignedRejection) {
-    if (!securityConfig.isMultiTenancyChecksEnabled()) {
-      return Either.right(value);
-    }
-    if (authorizedTenants.isAuthorizedForTenantIds(tenantIds)) {
-      return Either.right(value);
-    }
-    return Either.left(notAssignedRejection.get());
+    return tenantCheck.checkTenantsRequiringPrincipal(
+        tenantIds, authorizedTenants, value, notAssignedRejection);
   }
 
   /**
-   * Combines {@link #check} and {@link #checkTenant} into the single call most command sites need:
-   * RBAC permission first, tenant membership second. Mirrors the priority {@code main}'s {@code
-   * AuthorizationCheckBehavior} aggregation gives when both checks would fail on the same command
-   * (permission rejection wins) — so a principal with no permission at all always sees {@code
-   * FORBIDDEN}, never a tenant-shaped rejection that could hint at the resource's existence.
+   * Combines {@link #check} and {@link CslTenantCheck#checkTenant} into the single call most
+   * command sites need: RBAC permission first, tenant membership second. Mirrors the priority
+   * {@code main}'s {@code AuthorizationCheckBehavior} aggregation gives when both checks would fail
+   * on the same command (permission rejection wins) — so a principal with no permission at all
+   * always sees {@code FORBIDDEN}, never a tenant-shaped rejection that could hint at the
+   * resource's existence.
    *
    * <p>Only runs the tenant check once the permission check passes; a permission failure never
    * bothers a tenant lookup, and vice versa a resource-not-permitted-here principal never learns

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslTenantCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslTenantCheck.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity.authorization;
+
+import io.camunda.security.api.context.TokenClaimsAuthenticationResolver;
+import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.zeebe.auth.Authorization;
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
+import io.camunda.zeebe.engine.processing.identity.AuthorizedTenantsResolver;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Encapsulates the tenant-membership checks used across engine command processors.
+ *
+ * <p>Most callers reach these methods via {@link
+ * CslAuthorizationCheck#checkAuthorizationAndTenant}, which runs {@link
+ * CslAuthorizationCheck#check} first. Do not call {@link #checkTenant} or {@link
+ * #checkTenantsRequiringPrincipal} directly without a preceding authorization check, and do not
+ * remove the no-principal skip in either method without auditing every caller.
+ */
+@NullMarked
+public final class CslTenantCheck {
+
+  private final TokenClaimsAuthenticationResolver claimsConverter;
+  private final EngineSecurityConfig securityConfig;
+
+  public CslTenantCheck(
+      final TokenClaimsAuthenticationResolver claimsConverter,
+      final EngineSecurityConfig securityConfig) {
+    this.claimsConverter = claimsConverter;
+    this.securityConfig = securityConfig;
+  }
+
+  /**
+   * Resolves the {@link AuthorizedTenants} for a command from its authorization claims, reusing
+   * this component's claims converter and security configuration. Centralizes the converter here so
+   * command processors depend only on {@code CslTenantCheck} instead of threading the converter
+   * through their construction chains.
+   */
+  public AuthorizedTenants resolveAuthorizedTenants(final Map<String, Object> authorizations) {
+    return AuthorizedTenantsResolver.resolve(authorizations, securityConfig, claimsConverter);
+  }
+
+  public boolean isMultiTenancyChecksEnabled() {
+    return securityConfig.isMultiTenancyChecksEnabled();
+  }
+
+  /**
+   * Tenant-assignment check for command sites that must verify tenant membership independently of a
+   * resource {@link CslAuthorizationCheck#check} — e.g. a command-level tenant gate, or a site
+   * whose RBAC check runs at a different granularity (one tenant, many resource checks).
+   *
+   * <p>Encapsulates the skip-logic hand-rolled across engine processors: when multi-tenancy checks
+   * are disabled the check is a no-op; when no username or clientId claim is present the check is
+   * also a no-op (mirrors {@link CslAuthorizationCheck#resolveForCheck} — a no-principal command is
+   * either an internal command already exempted upstream, or authorizations are disabled and the
+   * primary permission check already let it through; either way there is no principal to hold a
+   * tenant assignment requirement against). Otherwise the authorized tenants are resolved from the
+   * command's claims (anonymous access is authorized for every tenant) and {@code tenantId} must be
+   * among them.
+   *
+   * <p>This no-principal skip is load-bearing: every caller runs {@link
+   * CslAuthorizationCheck#check} first — either directly, composed via {@link
+   * CslAuthorizationCheck#checkAuthorizationAndTenant}, or (for the sole remaining direct caller)
+   * via an equivalent {@code check(...).flatMap(v -> checkTenant(...))} of its own — before this
+   * method is ever reached. When authorizations are enabled, {@code check} itself rejects a
+   * no-principal command before this method runs; when authorizations are disabled, letting a
+   * claims-free command through here (e.g. deployment/process lifecycle commands issued without an
+   * explicit user, common in tests and tooling) is the established, relied-upon behavior. Do not
+   * call this method directly without a preceding {@link CslAuthorizationCheck#check}, and do not
+   * remove this skip without auditing every caller.
+   *
+   * <p>Callers own the rejection semantics: {@code notAssignedRejection} carries the {@link
+   * io.camunda.zeebe.protocol.record.RejectionType} — {@code FORBIDDEN} to signal "not assigned to
+   * tenant", or {@code NOT_FOUND} to mask an existing resource — and the message.
+   *
+   * @param value the value to return on success (mirrors {@link CslAuthorizationCheck#check};
+   *     enables {@code flatMap} composition with it)
+   */
+  public <T> Either<Rejection, T> checkTenant(
+      final TypedRecord<?> command,
+      final String tenantId,
+      final T value,
+      final Rejection notAssignedRejection) {
+    if (!securityConfig.isMultiTenancyChecksEnabled()) {
+      return Either.right(value);
+    }
+    final var authorizations = command.getAuthorizations();
+    if (authorizations.get(Authorization.AUTHORIZED_USERNAME) == null
+        && authorizations.get(Authorization.AUTHORIZED_CLIENT_ID) == null) {
+      return Either.right(value);
+    }
+    if (resolveAuthorizedTenants(authorizations).isAuthorizedForTenantId(tenantId)) {
+      return Either.right(value);
+    }
+    return Either.left(notAssignedRejection);
+  }
+
+  /**
+   * Unlike {@link #checkTenant}, this method has no no-principal skip: a claims-free caller is
+   * rejected for every tenant it names, rather than vacuously authorized. (The
+   * multi-tenancy-disabled and anonymous-caller skips still apply, same as {@link #checkTenant}.)
+   * Use it only for command sites that call the tenant check directly, with no preceding {@link
+   * CslAuthorizationCheck#check}, and that verify membership across a list of tenant IDs at once,
+   * using {@link AuthorizedTenants#isAuthorizedForTenantIds}.
+   *
+   * <p>Without a preceding {@link CslAuthorizationCheck#check} to reject a claims-free command
+   * first, sharing {@link #checkTenant}'s no-principal skip here would silently authorize a
+   * claims-free caller for every tenant it names instead of rejecting it — hence the guarantee is
+   * deliberate, not an oversight.
+   *
+   * <p>Also unlike {@link #checkTenant}, takes an already-resolved {@link AuthorizedTenants} and a
+   * lazy {@code Supplier<Rejection>} rather than resolving internally and building the rejection
+   * eagerly — callers that already resolved tenants for the same command don't pay to resolve
+   * twice, and the rejection message is only built on the rejected path. The supplier is only
+   * invoked on rejection, which never happens for an anonymous principal, so it's always safe to
+   * call {@code authorizedTenants.getAuthorizedTenantIds()} inside it.
+   *
+   * @param authorizedTenants the tenants the command's principal is authorized for, as resolved by
+   *     {@link #resolveAuthorizedTenants} from the same command's claims
+   */
+  public <T> Either<Rejection, T> checkTenantsRequiringPrincipal(
+      final List<String> tenantIds,
+      final AuthorizedTenants authorizedTenants,
+      final T value,
+      final Supplier<Rejection> notAssignedRejection) {
+    if (!securityConfig.isMultiTenancyChecksEnabled()) {
+      return Either.right(value);
+    }
+    if (authorizedTenants.isAuthorizedForTenantIds(tenantIds)) {
+      return Either.right(value);
+    }
+    return Either.left(notAssignedRejection.get());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslTenantCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslTenantCheck.java
@@ -23,11 +23,11 @@ import org.jspecify.annotations.NullMarked;
 /**
  * Encapsulates the tenant-membership checks used across engine command processors.
  *
- * <p>Most callers reach these methods via {@link
+ * <p>Most callers reach {@link #checkTenant} via {@link
  * CslAuthorizationCheck#checkAuthorizationAndTenant}, which runs {@link
- * CslAuthorizationCheck#check} first. Do not call {@link #checkTenant} or {@link
- * #checkTenantsRequiringPrincipal} directly without a preceding authorization check, and do not
- * remove the no-principal skip in either method without auditing every caller.
+ * CslAuthorizationCheck#check} first. Do not call {@link #checkTenant} directly without a preceding
+ * authorization check, and do not remove its no-principal skip without auditing every caller.
+ * {@link #checkTenantsRequiringPrincipal} has a different contract — see its own javadoc.
  */
 @NullMarked
 public final class CslTenantCheck {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheckTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheckTest.java
@@ -12,20 +12,15 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.api.context.TokenClaimsAuthenticationResolver;
-import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.api.model.config.initialization.InitializationConfiguration;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.auth.Authorization;
-import io.camunda.zeebe.engine.processing.Rejection;
-import io.camunda.zeebe.engine.processing.identity.AuthenticatedAuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
-import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,7 +34,6 @@ final class CslAuthorizationCheckTest {
   @Mock private TokenClaimsAuthenticationResolver claimsConverter;
   @Mock private AuthenticationConfiguration authConfig;
   @Mock private TypedRecord<?> command;
-  @Mock private CamundaAuthentication authentication;
 
   @Test
   void shouldReturnNoPrincipalRejectionWhenNoIdentityClaimsAndAuthorizationsEnabled() {
@@ -110,192 +104,6 @@ final class CslAuthorizationCheckTest {
     assertThat(result.isRight()).isTrue();
     assertThat(result.get()).isEmpty();
     verifyNoInteractions(claimsConverter, authCheckPort);
-  }
-
-  @Test
-  void shouldSkipTenantCheckWhenMultiTenancyDisabled() {
-    // given — multi-tenancy checks disabled
-    final var cslCheck = cslCheck(/* authorizationsEnabled= */ true, false);
-    final var rejection = new Rejection(RejectionType.FORBIDDEN, "not assigned");
-
-    // when
-    final var result = cslCheck.checkTenant(command, "tenant-a", "ok", rejection);
-
-    // then — no tenant resolution happens; the claims converter is never invoked
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.get()).isEqualTo("ok");
-    verifyNoInteractions(claimsConverter, authCheckPort);
-  }
-
-  @Test
-  void shouldAllowWhenPrincipalIsAssignedToTenant() {
-    // given — multi-tenancy on and a principal assigned to tenant-a
-    final var cslCheck = cslCheck(/* authorizationsEnabled= */ true, true);
-    when(command.getAuthorizations()).thenReturn(Map.of(Authorization.AUTHORIZED_USERNAME, "user"));
-    when(authentication.anonymousUser()).thenReturn(false);
-    when(authentication.authenticatedTenantIds()).thenReturn(List.of("tenant-a"));
-    when(claimsConverter.resolve(Map.of(Authorization.AUTHORIZED_USERNAME, "user")))
-        .thenReturn(authentication);
-
-    // when
-    final var result =
-        cslCheck.checkTenant(
-            command, "tenant-a", "ok", new Rejection(RejectionType.FORBIDDEN, "denied"));
-
-    // then
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.get()).isEqualTo("ok");
-  }
-
-  @Test
-  void shouldRejectWhenPrincipalIsNotAssignedToTenant() {
-    // given — multi-tenancy on and a principal assigned only to tenant-a
-    final var cslCheck = cslCheck(/* authorizationsEnabled= */ true, true);
-    when(command.getAuthorizations()).thenReturn(Map.of(Authorization.AUTHORIZED_USERNAME, "user"));
-    when(authentication.anonymousUser()).thenReturn(false);
-    when(authentication.authenticatedTenantIds()).thenReturn(List.of("tenant-a"));
-    when(claimsConverter.resolve(Map.of(Authorization.AUTHORIZED_USERNAME, "user")))
-        .thenReturn(authentication);
-    final var rejection = new Rejection(RejectionType.FORBIDDEN, "not assigned to tenant-b");
-
-    // when — a different tenant is requested
-    final var result = cslCheck.checkTenant(command, "tenant-b", "ok", rejection);
-
-    // then — the caller-supplied rejection is returned verbatim
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft()).isEqualTo(rejection);
-  }
-
-  @Test
-  void shouldAllowAnonymousUserForAnyTenant() {
-    // given — multi-tenancy on but the request is anonymous
-    final var cslCheck = cslCheck(/* authorizationsEnabled= */ true, true);
-    when(command.getAuthorizations())
-        .thenReturn(Map.of(Authorization.AUTHORIZED_ANONYMOUS_USER, true));
-
-    // when
-    final var result =
-        cslCheck.checkTenant(
-            command, "tenant-a", "ok", new Rejection(RejectionType.FORBIDDEN, "denied"));
-
-    // then — anonymous access is authorized for every tenant; no claims conversion needed
-    assertThat(result.isRight()).isTrue();
-    verifyNoInteractions(claimsConverter, authCheckPort);
-  }
-
-  @Test
-  void shouldSkipTenantCheckWhenNoIdentityClaims() {
-    // given — multi-tenancy on but the command carries neither a username nor a clientId claim;
-    // most callers reach checkTenant via checkAuthorizationAndTenant, which already runs `check`
-    // first and rejects a no-principal command when authorizations are enabled — so by the time
-    // checkTenant sees a no-principal command, either authorizations are disabled (and this skip
-    // is the established behavior many callers rely on) or the command was already rejected
-    // upstream
-    final var cslCheck = cslCheck(/* authorizationsEnabled= */ false, true);
-    when(command.getAuthorizations()).thenReturn(Map.of());
-    final var rejection = new Rejection(RejectionType.FORBIDDEN, "not assigned");
-
-    // when
-    final var result = cslCheck.checkTenant(command, "tenant-a", "ok", rejection);
-
-    // then
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.get()).isEqualTo("ok");
-    verifyNoInteractions(claimsConverter);
-  }
-
-  @Test
-  void shouldSkipTenantsCheckWhenMultiTenancyDisabled() {
-    // given — multi-tenancy checks disabled, and a non-anonymous, empty authorized-tenants set
-    // that would fail isAuthorizedForTenantIds if the multi-tenancy gate didn't short-circuit
-    // first — so a pass here can only be explained by the gate, not by trivial authorization
-    final var cslCheck = cslCheck(/* authorizationsEnabled= */ true, false);
-    final var rejection = new Rejection(RejectionType.UNAUTHORIZED, "not authorized");
-
-    // when
-    final var result =
-        cslCheck.checkTenantsRequiringPrincipal(
-            List.of("tenant-a", "tenant-b"),
-            new AuthenticatedAuthorizedTenants(List.of()),
-            "ok",
-            () -> rejection);
-
-    // then
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.get()).isEqualTo("ok");
-  }
-
-  @Test
-  void shouldAllowWhenPrincipalIsAssignedToAllTenants() {
-    // given — a principal pre-resolved as assigned to tenant-a and tenant-b
-    final var cslCheck = cslCheck(/* authorizationsEnabled= */ true, true);
-    final var authorizedTenants =
-        new AuthenticatedAuthorizedTenants(List.of("tenant-a", "tenant-b"));
-
-    // when
-    final var result =
-        cslCheck.checkTenantsRequiringPrincipal(
-            List.of("tenant-a", "tenant-b"),
-            authorizedTenants,
-            "ok",
-            () -> new Rejection(RejectionType.UNAUTHORIZED, "denied"));
-
-    // then
-    assertThat(result.isRight()).isTrue();
-    assertThat(result.get()).isEqualTo("ok");
-  }
-
-  @Test
-  void shouldRejectWhenPrincipalIsNotAssignedToAllTenants() {
-    // given — a principal pre-resolved as assigned only to tenant-a
-    final var cslCheck = cslCheck(/* authorizationsEnabled= */ true, true);
-    final var authorizedTenants = new AuthenticatedAuthorizedTenants(List.of("tenant-a"));
-    final var rejection = new Rejection(RejectionType.UNAUTHORIZED, "not authorized for tenant-b");
-
-    // when — tenant-b is requested in addition to tenant-a
-    final var result =
-        cslCheck.checkTenantsRequiringPrincipal(
-            List.of("tenant-a", "tenant-b"), authorizedTenants, "ok", () -> rejection);
-
-    // then — the caller-supplied rejection is returned verbatim
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft()).isEqualTo(rejection);
-  }
-
-  @Test
-  void shouldAllowAnonymousUserForAnyTenants() {
-    // given — the pre-resolved tenants represent an anonymous caller
-    final var cslCheck = cslCheck(/* authorizationsEnabled= */ true, true);
-
-    // when
-    final var result =
-        cslCheck.checkTenantsRequiringPrincipal(
-            List.of("tenant-a", "tenant-b"),
-            AuthorizedTenants.ANONYMOUS,
-            "ok",
-            () -> new Rejection(RejectionType.UNAUTHORIZED, "denied"));
-
-    // then — anonymous access is authorized for every tenant
-    assertThat(result.isRight()).isTrue();
-  }
-
-  @Test
-  void shouldRejectWhenNoPrincipalAssignedToAnyTenants() {
-    // given — a pre-resolved empty-tenant set (what AuthorizedTenantsResolver returns for a
-    // no-principal, non-anonymous command when multi-tenancy is enabled); the rejection supplier
-    // must be safely callable here since the check failed for a non-anonymous result
-    final var cslCheck = cslCheck(/* authorizationsEnabled= */ true, true);
-    final var authorizedTenants = new AuthenticatedAuthorizedTenants(List.of());
-    final var rejection = new Rejection(RejectionType.UNAUTHORIZED, "not authorized");
-
-    // when
-    final var result =
-        cslCheck.checkTenantsRequiringPrincipal(
-            List.of("tenant-a"), authorizedTenants, "ok", () -> rejection);
-
-    // then
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft()).isEqualTo(rejection);
   }
 
   private CslAuthorizationCheck cslCheck(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/CslTenantCheckTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/CslTenantCheckTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity.authorization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.api.context.TokenClaimsAuthenticationResolver;
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.api.model.config.AuthenticationConfiguration;
+import io.camunda.security.api.model.config.initialization.InitializationConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
+import io.camunda.zeebe.auth.Authorization;
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.identity.AuthenticatedAuthorizedTenants;
+import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+final class CslTenantCheckTest {
+
+  @Mock private TokenClaimsAuthenticationResolver claimsConverter;
+  @Mock private AuthenticationConfiguration authConfig;
+  @Mock private TypedRecord<?> command;
+  @Mock private CamundaAuthentication authentication;
+
+  @Test
+  void shouldSkipTenantCheckWhenMultiTenancyDisabled() {
+    // given — multi-tenancy checks disabled
+    final var tenantCheck = tenantCheck(false);
+    final var rejection = new Rejection(RejectionType.FORBIDDEN, "not assigned");
+
+    // when
+    final var result = tenantCheck.checkTenant(command, "tenant-a", "ok", rejection);
+
+    // then — no tenant resolution happens; the claims converter is never invoked
+    assertThat(result.isRight()).isTrue();
+    assertThat(result.get()).isEqualTo("ok");
+    verifyNoInteractions(claimsConverter);
+  }
+
+  @Test
+  void shouldAllowWhenPrincipalIsAssignedToTenant() {
+    // given — multi-tenancy on and a principal assigned to tenant-a
+    final var tenantCheck = tenantCheck(true);
+    when(command.getAuthorizations()).thenReturn(Map.of(Authorization.AUTHORIZED_USERNAME, "user"));
+    when(authentication.anonymousUser()).thenReturn(false);
+    when(authentication.authenticatedTenantIds()).thenReturn(List.of("tenant-a"));
+    when(claimsConverter.resolve(Map.of(Authorization.AUTHORIZED_USERNAME, "user")))
+        .thenReturn(authentication);
+
+    // when
+    final var result =
+        tenantCheck.checkTenant(
+            command, "tenant-a", "ok", new Rejection(RejectionType.FORBIDDEN, "denied"));
+
+    // then
+    assertThat(result.isRight()).isTrue();
+    assertThat(result.get()).isEqualTo("ok");
+  }
+
+  @Test
+  void shouldRejectWhenPrincipalIsNotAssignedToTenant() {
+    // given — multi-tenancy on and a principal assigned only to tenant-a
+    final var tenantCheck = tenantCheck(true);
+    when(command.getAuthorizations()).thenReturn(Map.of(Authorization.AUTHORIZED_USERNAME, "user"));
+    when(authentication.anonymousUser()).thenReturn(false);
+    when(authentication.authenticatedTenantIds()).thenReturn(List.of("tenant-a"));
+    when(claimsConverter.resolve(Map.of(Authorization.AUTHORIZED_USERNAME, "user")))
+        .thenReturn(authentication);
+    final var rejection = new Rejection(RejectionType.FORBIDDEN, "not assigned to tenant-b");
+
+    // when — a different tenant is requested
+    final var result = tenantCheck.checkTenant(command, "tenant-b", "ok", rejection);
+
+    // then — the caller-supplied rejection is returned verbatim
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo(rejection);
+  }
+
+  @Test
+  void shouldAllowAnonymousUserForAnyTenant() {
+    // given — multi-tenancy on but the request is anonymous
+    final var tenantCheck = tenantCheck(true);
+    when(command.getAuthorizations())
+        .thenReturn(Map.of(Authorization.AUTHORIZED_ANONYMOUS_USER, true));
+
+    // when
+    final var result =
+        tenantCheck.checkTenant(
+            command, "tenant-a", "ok", new Rejection(RejectionType.FORBIDDEN, "denied"));
+
+    // then — anonymous access is authorized for every tenant; no claims conversion needed
+    assertThat(result.isRight()).isTrue();
+    verifyNoInteractions(claimsConverter);
+  }
+
+  @Test
+  void shouldSkipTenantCheckWhenNoIdentityClaims() {
+    // given — multi-tenancy on but the command carries neither a username nor a clientId claim;
+    // most callers reach checkTenant via checkAuthorizationAndTenant, which already runs `check`
+    // first and rejects a no-principal command when authorizations are enabled — so by the time
+    // checkTenant sees a no-principal command, either authorizations are disabled (and this skip
+    // is the established behavior many callers rely on) or the command was already rejected
+    // upstream
+    final var tenantCheck = tenantCheck(true);
+    when(command.getAuthorizations()).thenReturn(Map.of());
+    final var rejection = new Rejection(RejectionType.FORBIDDEN, "not assigned");
+
+    // when
+    final var result = tenantCheck.checkTenant(command, "tenant-a", "ok", rejection);
+
+    // then
+    assertThat(result.isRight()).isTrue();
+    assertThat(result.get()).isEqualTo("ok");
+    verifyNoInteractions(claimsConverter);
+  }
+
+  @Test
+  void shouldSkipTenantsCheckWhenMultiTenancyDisabled() {
+    // given — multi-tenancy checks disabled, and a non-anonymous, empty authorized-tenants set
+    // that would fail isAuthorizedForTenantIds if the multi-tenancy gate didn't short-circuit
+    // first — so a pass here can only be explained by the gate, not by trivial authorization
+    final var tenantCheck = tenantCheck(false);
+    final var rejection = new Rejection(RejectionType.UNAUTHORIZED, "not authorized");
+
+    // when
+    final var result =
+        tenantCheck.checkTenantsRequiringPrincipal(
+            List.of("tenant-a", "tenant-b"),
+            new AuthenticatedAuthorizedTenants(List.of()),
+            "ok",
+            () -> rejection);
+
+    // then
+    assertThat(result.isRight()).isTrue();
+    assertThat(result.get()).isEqualTo("ok");
+  }
+
+  @Test
+  void shouldAllowWhenPrincipalIsAssignedToAllTenants() {
+    // given — a principal pre-resolved as assigned to tenant-a and tenant-b
+    final var tenantCheck = tenantCheck(true);
+    final var authorizedTenants =
+        new AuthenticatedAuthorizedTenants(List.of("tenant-a", "tenant-b"));
+
+    // when
+    final var result =
+        tenantCheck.checkTenantsRequiringPrincipal(
+            List.of("tenant-a", "tenant-b"),
+            authorizedTenants,
+            "ok",
+            () -> new Rejection(RejectionType.UNAUTHORIZED, "denied"));
+
+    // then
+    assertThat(result.isRight()).isTrue();
+    assertThat(result.get()).isEqualTo("ok");
+  }
+
+  @Test
+  void shouldRejectWhenPrincipalIsNotAssignedToAllTenants() {
+    // given — a principal pre-resolved as assigned only to tenant-a
+    final var tenantCheck = tenantCheck(true);
+    final var authorizedTenants = new AuthenticatedAuthorizedTenants(List.of("tenant-a"));
+    final var rejection = new Rejection(RejectionType.UNAUTHORIZED, "not authorized for tenant-b");
+
+    // when — tenant-b is requested in addition to tenant-a
+    final var result =
+        tenantCheck.checkTenantsRequiringPrincipal(
+            List.of("tenant-a", "tenant-b"), authorizedTenants, "ok", () -> rejection);
+
+    // then — the caller-supplied rejection is returned verbatim
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo(rejection);
+  }
+
+  @Test
+  void shouldAllowAnonymousUserForAnyTenants() {
+    // given — the pre-resolved tenants represent an anonymous caller
+    final var tenantCheck = tenantCheck(true);
+
+    // when
+    final var result =
+        tenantCheck.checkTenantsRequiringPrincipal(
+            List.of("tenant-a", "tenant-b"),
+            AuthorizedTenants.ANONYMOUS,
+            "ok",
+            () -> new Rejection(RejectionType.UNAUTHORIZED, "denied"));
+
+    // then — anonymous access is authorized for every tenant
+    assertThat(result.isRight()).isTrue();
+  }
+
+  @Test
+  void shouldRejectWhenNoPrincipalAssignedToAnyTenants() {
+    // given — a pre-resolved empty-tenant set (what AuthorizedTenantsResolver returns for a
+    // no-principal, non-anonymous command when multi-tenancy is enabled); the rejection supplier
+    // must be safely callable here since the check failed for a non-anonymous result
+    final var tenantCheck = tenantCheck(true);
+    final var authorizedTenants = new AuthenticatedAuthorizedTenants(List.of());
+    final var rejection = new Rejection(RejectionType.UNAUTHORIZED, "not authorized");
+
+    // when
+    final var result =
+        tenantCheck.checkTenantsRequiringPrincipal(
+            List.of("tenant-a"), authorizedTenants, "ok", () -> rejection);
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo(rejection);
+  }
+
+  private CslTenantCheck tenantCheck(final boolean multiTenancyChecksEnabled) {
+    final var securityConfig =
+        new EngineSecurityConfig(
+            authConfig,
+            /* authorizationsEnabled= */ true,
+            multiTenancyChecksEnabled,
+            new InitializationConfiguration(),
+            EngineSecurityConfigurations.ID_VALIDATION_PATTERN,
+            EngineSecurityConfigurations.GROUP_ID_VALIDATION_PATTERN);
+    return new CslTenantCheck(claimsConverter, securityConfig);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/CslTenantCheckTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/CslTenantCheckTest.java
@@ -112,11 +112,9 @@ final class CslTenantCheckTest {
   @Test
   void shouldSkipTenantCheckWhenNoIdentityClaims() {
     // given — multi-tenancy on but the command carries neither a username nor a clientId claim;
-    // most callers reach checkTenant via checkAuthorizationAndTenant, which already runs `check`
-    // first and rejects a no-principal command when authorizations are enabled — so by the time
-    // checkTenant sees a no-principal command, either authorizations are disabled (and this skip
-    // is the established behavior many callers rely on) or the command was already rejected
-    // upstream
+    // checkTenant treats this as vacuously authorized regardless of authorizationsEnabled, which it
+    // never reads for this check — the skip is deliberate and load-bearing, see checkTenant's
+    // javadoc
     final var tenantCheck = tenantCheck(true);
     when(command.getAuthorizations()).thenReturn(Map.of());
     final var rejection = new Rejection(RejectionType.FORBIDDEN, "not assigned");


### PR DESCRIPTION
## Summary

`CslAuthorizationCheck` bundled four concerns in one class: principal
skip-logic, RBAC checks against the CSL `AuthorizationCheckPort`,
tenant-membership checks against `AuthorizedTenantsResolver`, and
combined RBAC+tenant convenience methods. This splits tenant-membership
checks into a new `CslTenantCheck` class to keep the authz class from
growing into a god class.

- New `CslTenantCheck` holds `resolveAuthorizedTenants`,
  `isMultiTenancyChecksEnabled`, `checkTenant`, and
  `checkTenantsRequiringPrincipal`, moved verbatim (no behavior
  change). It's constructed from only `TokenClaimsAuthenticationResolver`
  and `EngineSecurityConfig` — never touches the authz port, confirming
  this is a clean concern boundary.
- `CslAuthorizationCheck` keeps its existing constructor signature and
  all four public tenant methods as thin delegates to an internally-held
  `CslTenantCheck`, so none of the ~14 existing call sites or the two DI
  construction sites (`EngineProcessors`, `MessageEventProcessors`) need
  to change.
- Javadoc cross-references were re-qualified to point at the class each
  method now lives on, without altering the wording of their behavioral
  contracts.
- Split `CslAuthorizationCheckTest`'s tenant-related tests into a new
  `CslTenantCheckTest`.

No issue tracks this — pure internal refactor, no behavior change.

### Follow-up

Today nothing outside `CslAuthorizationCheck` can reach `CslTenantCheck` directly — it has no
accessor, is only constructed in `CslAuthorizationCheck`'s constructor, all four tenant methods
stay there as delegates, and `AuthorizationArchTest` whitelists `CslAuthorizationCheck` only.
Migrating call sites directly onto `CslTenantCheck` (and dropping the delegates) is tracked as
camunda-security-library#585, a sub-issue of camunda-security-library#388.

## Test plan

- [x] `./mvnw license:format spotless:apply -T1C`
- [x] `./mvnw verify -pl zeebe/engine -Dtest=CslAuthorizationCheckTest,CslTenantCheckTest -DskipTests=false -DskipITs -Dquickly` — 14/14 passing
- [x] `./mvnw verify -pl qa/archunit-tests -Dtest=AuthorizationArchTest -DskipTests=false -DskipITs -Dquickly` — 2/2 passing, no arch impact
- [x] `./mvnw install -Dquickly -T1C` — full repo compiles, no call sites broken
- [x] `./mvnw verify -pl zeebe/engine -DskipTests=false -Dquickly` — 7352 tests, 0 failures/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
