### PR TITLE
fix: preserve batch operation reference when async cancel terminates process instance

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/AsyncRequestBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/AsyncRequestBehavior.java
@@ -39,6 +39,7 @@ public class AsyncRequestBehavior {
         .setValueType(command.getValueType())
         .setRequestId(command.getRequestId())
         .setRequestStreamId(command.getRequestStreamId())
-        .setOperationReference(command.getOperationReference());
+        .setOperationReference(command.getOperationReference())
+        .setBatchOperationReference(command.getBatchOperationReference());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -333,7 +333,12 @@ public final class BpmnStateTransitionBehavior {
 
     if (asyncRequest != null) {
       stateWriter.appendFollowUpEvent(
-          key, transition, value, m -> m.operationReference(asyncRequest.operationReference()));
+          key,
+          transition,
+          value,
+          m ->
+              m.operationReference(asyncRequest.operationReference())
+                  .batchOperationReference(asyncRequest.batchOperationReference()));
       stateWriter.appendFollowUpEvent(
           asyncRequest.key(), AsyncRequestIntent.PROCESSED, asyncRequest.record());
     } else {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AsyncRequestState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AsyncRequestState.java
@@ -46,5 +46,9 @@ public interface AsyncRequestState {
     public long operationReference() {
       return record.getOperationReference();
     }
+
+    public long batchOperationReference() {
+      return record.getBatchOperationReference();
+    }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -29,6 +30,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentUpdateSemantic;
@@ -692,6 +694,67 @@ public class TaskListenerBlockedTransitionTest {
             tuple(ValueType.USER_TASK, UserTaskIntent.CANCELED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.CONTINUE_TERMINATING_ELEMENT),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldPropagateBatchOperationReferenceToTerminatedEventAfterCancelingListener() {
+    // given
+    final long batchOperationReference = 42L;
+    final long processInstanceKey =
+        helper.createProcessInstance(
+            helper.createUserTaskWithTaskListeners(
+                ZeebeTaskListenerEventType.canceling, listenerType));
+    RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+
+    // when: cancel the instance as part of a batch operation, then let the canceling listener
+    // job complete so termination resumes in a later processing cycle
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .withBatchOperationReference(batchOperationReference)
+        .expectTerminating()
+        .cancel();
+    helper.completeJobs(processInstanceKey, listenerType);
+
+    // then: the terminal process ELEMENT_TERMINATED must retain the batchOperationReference so the
+    // batch operation item can be marked completed (regression for stuck batch cancel of user
+    // tasks with canceling listeners)
+    final var processTerminated =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+    assertThat(processTerminated.getBatchOperationReference()).isEqualTo(batchOperationReference);
+  }
+
+  @Test
+  public void shouldNotSetBatchOperationReferenceOnTerminatedEventWhenCancelWithoutBatch() {
+    // given
+    final long processInstanceKey =
+        helper.createProcessInstance(
+            helper.createUserTaskWithTaskListeners(
+                ZeebeTaskListenerEventType.canceling, listenerType));
+    RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+
+    // when: cancel the instance outside of any batch operation (no batchOperationReference), then
+    // let the canceling listener job complete so termination resumes in a later processing cycle
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+    helper.completeJobs(processInstanceKey, listenerType);
+
+    // then: the terminal process ELEMENT_TERMINATED must NOT carry a batchOperationReference. This
+    // is the negative counterpart to the batch-cancel regression: the reference appears on the
+    // terminal event only when propagated from the async request, never leaked onto plain cancels.
+    final var processTerminated =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+    assertThat(processTerminated.getBatchOperationReference())
+        .isEqualTo(RecordMetadataDecoder.batchOperationReferenceNullValue());
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -489,6 +489,11 @@ public final class TestStreams {
       return this;
     }
 
+    public FluentLogWriter batchOperationReference(final long batchOperationReference) {
+      metadata.batchOperationReference(batchOperationReference);
+      return this;
+    }
+
     public FluentLogWriter recordType(final RecordType recordType) {
       metadata.recordType(recordType);
       return this;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -368,6 +368,7 @@ public final class ProcessInstanceClient {
 
     private String[] authorizedTenants;
     private int partition = DEFAULT_PARTITION;
+    private long batchOperationReference = -1;
     private Function<Long, Record<ProcessInstanceRecordValue>> expectation = SUCCESS_EXPECTATION;
     private Function<Long, Record<ProcessInstanceRecordValue>> resumeExpectation =
         RESUMED_EXPECTATION;
@@ -382,6 +383,11 @@ public final class ProcessInstanceClient {
 
     public ExistingInstanceClient onPartition(final int partition) {
       this.partition = partition;
+      return this;
+    }
+
+    public ExistingInstanceClient withBatchOperationReference(final long batchOperationReference) {
+      this.batchOperationReference = batchOperationReference;
       return this;
     }
 
@@ -482,6 +488,19 @@ public final class ProcessInstanceClient {
                 .withProcessInstanceKey(processInstanceKey)
                 .getFirst()
                 .getPartitionId();
+      }
+
+      if (batchOperationReference != -1) {
+        writer.writeCommandOnPartition(
+            partition,
+            builder ->
+                builder
+                    .key(processInstanceKey)
+                    .intent(ProcessInstanceIntent.CANCEL)
+                    .authorizations(authorizedTenants)
+                    .batchOperationReference(batchOperationReference)
+                    .event(new ProcessInstanceRecord().setProcessInstanceKey(processInstanceKey)));
+        return;
       }
 
       writer.writeCommandOnPartition(

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-async-request-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-async-request-template.json
@@ -38,6 +38,9 @@
             },
             "operationReference": {
               "type": "long"
+            },
+            "batchOperationReference": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-async-request-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-async-request-template.json
@@ -44,6 +44,9 @@
             },
             "operationReference": {
               "type": "long"
+            },
+            "batchOperationReference": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/AsyncRequestRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/AsyncRequestRecord.java
@@ -27,15 +27,18 @@ public final class AsyncRequestRecord extends UnifiedRecordValue
       new IntegerProperty("requestStreamId", -1);
   private final LongProperty operationReferenceProperty =
       new LongProperty("operationReference", -1);
+  private final LongProperty batchOperationReferenceProperty =
+      new LongProperty("batchOperationReference", -1);
 
   public AsyncRequestRecord() {
-    super(6);
+    super(7);
     declareProperty(scopeKeyProperty)
         .declareProperty(valueTypeProperty)
         .declareProperty(intentProperty)
         .declareProperty(requestIdProperty)
         .declareProperty(requestStreamIdProperty)
-        .declareProperty(operationReferenceProperty);
+        .declareProperty(operationReferenceProperty)
+        .declareProperty(batchOperationReferenceProperty);
   }
 
   public void wrap(final AsyncRequestRecord record) {
@@ -45,6 +48,7 @@ public final class AsyncRequestRecord extends UnifiedRecordValue
     requestIdProperty.setValue(record.getRequestId());
     requestStreamIdProperty.setValue(record.getRequestStreamId());
     operationReferenceProperty.setValue(record.getOperationReference());
+    batchOperationReferenceProperty.setValue(record.getBatchOperationReference());
   }
 
   @Override
@@ -114,6 +118,16 @@ public final class AsyncRequestRecord extends UnifiedRecordValue
 
   public AsyncRequestRecord setOperationReference(final long operationReference) {
     operationReferenceProperty.setValue(operationReference);
+    return this;
+  }
+
+  @Override
+  public long getBatchOperationReference() {
+    return batchOperationReferenceProperty.getValue();
+  }
+
+  public AsyncRequestRecord setBatchOperationReference(final long batchOperationReference) {
+    batchOperationReferenceProperty.setValue(batchOperationReference);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AsyncRequestRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AsyncRequestRecord.golden
@@ -27,15 +27,18 @@ public final class AsyncRequestRecord extends UnifiedRecordValue
       new IntegerProperty("requestStreamId", -1);
   private final LongProperty operationReferenceProperty =
       new LongProperty("operationReference", -1);
+  private final LongProperty batchOperationReferenceProperty =
+      new LongProperty("batchOperationReference", -1);
 
   public AsyncRequestRecord() {
-    super(6);
+    super(7);
     declareProperty(scopeKeyProperty)
         .declareProperty(valueTypeProperty)
         .declareProperty(intentProperty)
         .declareProperty(requestIdProperty)
         .declareProperty(requestStreamIdProperty)
-        .declareProperty(operationReferenceProperty);
+        .declareProperty(operationReferenceProperty)
+        .declareProperty(batchOperationReferenceProperty);
   }
 
   public void wrap(final AsyncRequestRecord record) {
@@ -45,6 +48,7 @@ public final class AsyncRequestRecord extends UnifiedRecordValue
     requestIdProperty.setValue(record.getRequestId());
     requestStreamIdProperty.setValue(record.getRequestStreamId());
     operationReferenceProperty.setValue(record.getOperationReference());
+    batchOperationReferenceProperty.setValue(record.getBatchOperationReference());
   }
 
   @Override
@@ -114,6 +118,16 @@ public final class AsyncRequestRecord extends UnifiedRecordValue
 
   public AsyncRequestRecord setOperationReference(final long operationReference) {
     operationReferenceProperty.setValue(operationReference);
+    return this;
+  }
+
+  @Override
+  public long getBatchOperationReference() {
+    return batchOperationReferenceProperty.getValue();
+  }
+
+  public AsyncRequestRecord setBatchOperationReference(final long batchOperationReference) {
+    batchOperationReferenceProperty.setValue(batchOperationReference);
     return this;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AsyncRequestRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AsyncRequestRecordValue.java
@@ -56,4 +56,13 @@ public interface AsyncRequestRecordValue extends RecordValue {
 
   /** The operation reference associated with the original command, for traceability. */
   long getOperationReference();
+
+  /**
+   * The batch operation reference associated with the original command, for traceability.
+   *
+   * <p>This is needed so that follow-up events written after the request finishes (e.g. the
+   * terminal {@code ProcessInstance:ELEMENT_TERMINATED} of an asynchronously terminated process
+   * instance) can be correlated back to the batch operation that triggered them.
+   */
+  long getBatchOperationReference();
 }


### PR DESCRIPTION
## Problem

Bulk-cancelling process instances that wait on a **native user task** via Operate never completes: the batch items stay in the `Scheduled`/`ACTIVE` state forever. Cancelling a single instance, or bulk-cancelling instances without a user task, works fine.

## Root cause

When a native user task has a `canceling` task listener, terminating the process instance is **asynchronous**. The `CANCEL` command is persisted as an `AsyncRequest`, and the terminal process `ELEMENT_TERMINATED` event is only written later — after the listener job completes, driven by a `JOB:COMPLETE` command that does **not** carry the `batchOperationReference`.

`AsyncRequestRecord` persisted only the `operationReference`, so `BpmnStateTransitionBehavior` restored just that on the terminal event. The RDBMS batch-operation status handler requires a non-null `batchOperationReference` to mark the corresponding item completed, so the item never progressed past `Scheduled`.

## Solution

Carry the `batchOperationReference` through the async-request round trip:

- **Persist** it on `AsyncRequestRecord` (new `LongProperty`, defaults to `-1` — the null reference value — keeping the record backward compatible with already-persisted state; the golden file is updated accordingly).
- **Capture** it from the originating command in `AsyncRequestBehavior`.
- **Restore** it alongside the `operationReference` on the terminal event in `BpmnStateTransitionBehavior`.

- **Exporter schema:** because `batchOperationReference` is a new property on the record value, it is also serialized into the exported record `value`. The Elasticsearch and OpenSearch `async-request` index templates use a `dynamic: strict` value mapping, so the field is added to both templates; otherwise export fails with `strict_dynamic_mapping_exception`.

The `AsyncRequest` mechanism is shared by user-task assign/claim/update/complete and variable-document updates, so this fixes traceability for **all** async-request consumers uniformly rather than only cancel.

## Testing

Added an `EngineRule`-based engine test, `TaskListenerBlockedTransitionTest#shouldPropagateBatchOperationReferenceToTerminatedEventAfterCancelingListener`, that:

1. Creates a process with a native user task carrying a `canceling` task listener.
2. Cancels the instance with a `batchOperationReference`, expecting async termination.
3. Completes the listener job so termination resumes in a later processing cycle.
4. Asserts the terminal `PROCESS` `ELEMENT_TERMINATED` event still carries the `batchOperationReference`.

Verified the test **fails** without the fix (`expected: 42L but was: -1L`) and **passes** with it, so it genuinely gates the regression.

A negative counterpart, `shouldNotSetBatchOperationReferenceOnTerminatedEventWhenCancelWithoutBatch`, cancels the same canceling-listener instance **without** a batch reference and asserts the terminal event carries **none** (`-1`). This pins the boundary — the reference reaches the terminal event only when propagated from the async request — and guards against leaking a reference onto plain cancels.

To support the test, `ProcessInstanceClient` gains a `withBatchOperationReference(...)` helper and `TestStreams` propagates it.


## Known limitation

Because the old engine never persisted `batchOperationReference` on `AsyncRequestRecord`, batch-cancel operations already in flight across the exact upgrade boundary — where the async request was received on the pre-fix engine and its canceling listener completes on the post-fix engine — won't be retroactively corrected; those specific batch items remain stuck. This affects only that narrow upgrade window and is unavoidable (the value was never captured); newly triggered batch cancels are unaffected.


Closes  https://github.com/camunda/camunda/issues/58970

