### PR TITLE
feat: allow tuning RDBMS pool keepalive and validation timeout

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/RdbmsConnectionPool.java
+++ b/configuration/src/main/java/io/camunda/configuration/RdbmsConnectionPool.java
@@ -33,6 +33,17 @@ public class RdbmsConnectionPool {
    */
   private Duration leakDetectionThreshold = Duration.ZERO;
 
+  /**
+   * Interval at which the pool probes idle connections for aliveness, evicting dead ones before
+   * they are handed out. Set to {@link Duration#ZERO} (the HikariCP default) to disable. Useful
+   * with failover-aware JDBC drivers (e.g. AWS Aurora) so connections bound to a demoted writer are
+   * discarded proactively instead of only on borrow.
+   */
+  private Duration keepaliveTime = Duration.ZERO;
+
+  /** Maximum time the pool waits for a connection to be validated as alive. */
+  private Duration validationTimeout = Duration.ofMillis(5_000);
+
   public int getMaximumPoolSize() {
     return maximumPoolSize;
   }
@@ -79,5 +90,21 @@ public class RdbmsConnectionPool {
 
   public void setLeakDetectionThreshold(final Duration leakDetectionThreshold) {
     this.leakDetectionThreshold = leakDetectionThreshold;
+  }
+
+  public Duration getKeepaliveTime() {
+    return keepaliveTime;
+  }
+
+  public void setKeepaliveTime(final Duration keepaliveTime) {
+    this.keepaliveTime = keepaliveTime;
+  }
+
+  public Duration getValidationTimeout() {
+    return validationTimeout;
+  }
+
+  public void setValidationTimeout(final Duration validationTimeout) {
+    this.validationTimeout = validationTimeout;
   }
 }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -198,10 +198,12 @@ data.secondary-storage.rdbms.batch-operation-cache
 data.secondary-storage.rdbms.batch-operation-item-insert-block-size
 data.secondary-storage.rdbms.connection-pool.connection-timeout
 data.secondary-storage.rdbms.connection-pool.idle-timeout
+data.secondary-storage.rdbms.connection-pool.keepalive-time
 data.secondary-storage.rdbms.connection-pool.leak-detection-threshold
 data.secondary-storage.rdbms.connection-pool.max-lifetime
 data.secondary-storage.rdbms.connection-pool.maximum-pool-size
 data.secondary-storage.rdbms.connection-pool.minimum-idle
+data.secondary-storage.rdbms.connection-pool.validation-timeout
 data.secondary-storage.rdbms.database-vendor-id
 data.secondary-storage.rdbms.ddl-lock-wait-timeout
 data.secondary-storage.rdbms.export-batch-operation-items-on-creation

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -806,6 +806,11 @@ camunda: # Type: io.camunda.configuration.Camunda
           connection-timeout: "30000ms" # Type: Duration, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_CONNECTIONPOOL_CONNECTIONTIMEOUT
           # Maximum time a connection is allowed to sit idle in the pool before being evicted.
           idle-timeout: "600000ms" # Type: Duration, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_CONNECTIONPOOL_IDLETIMEOUT
+          # Interval at which the pool probes idle connections for aliveness, evicting dead ones before they are
+          # handed out. Set to {@link Duration#ZERO} (the HikariCP default) to disable. Useful with
+          # failover-aware JDBC drivers (e.g. AWS Aurora) so connections bound to a demoted writer are discarded
+          # proactively instead of only on borrow.
+          keepalive-time: 0 # Type: Duration, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_CONNECTIONPOOL_KEEPALIVETIME
           # Threshold for logging a possible connection leak. Set to {@link Duration#ZERO} (the HikariCP
           # default) to disable leak detection.
           leak-detection-threshold: 0 # Type: Duration, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_CONNECTIONPOOL_LEAKDETECTIONTHRESHOLD
@@ -815,6 +820,8 @@ camunda: # Type: io.camunda.configuration.Camunda
           maximum-pool-size: 10 # Type: Integer, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_CONNECTIONPOOL_MAXIMUMPOOLSIZE
           # Minimum number of idle connections kept by the pool.
           minimum-idle: 2 # Type: Integer, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_CONNECTIONPOOL_MINIMUMIDLE
+          # Maximum time the pool waits for a connection to be validated as alive.
+          validation-timeout: "5000ms" # Type: Duration, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_CONNECTIONPOOL_VALIDATIONTIMEOUT
         
         # The database vendor id. It is used to determine the dialect to use for the database. If not set, the
         # dialect is determined automatically.

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsDataSources.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsDataSources.java
@@ -141,6 +141,8 @@ public final class RdbmsDataSources implements AutoCloseable {
     ds.setIdleTimeout(pool.getIdleTimeout().toMillis());
     ds.setMaxLifetime(pool.getMaxLifetime().toMillis());
     ds.setLeakDetectionThreshold(pool.getLeakDetectionThreshold().toMillis());
+    ds.setKeepaliveTime(pool.getKeepaliveTime().toMillis());
+    ds.setValidationTimeout(pool.getValidationTimeout().toMillis());
     ds.setAutoCommit(false);
     return ds;
   }

--- a/dist/src/test/java/io/camunda/application/commons/rdbms/RdbmsDataSourcesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/rdbms/RdbmsDataSourcesTest.java
@@ -62,6 +62,9 @@ class RdbmsDataSourcesTest {
     pool.setIdleTimeout(Duration.ofMillis(45_678));
     pool.setMaxLifetime(Duration.ofMillis(99_999));
     pool.setLeakDetectionThreshold(Duration.ofMillis(2_500));
+    // keepaliveTime must be >= 30s and < maxLifetime or HikariCP resets it to 0 on validation
+    pool.setKeepaliveTime(Duration.ofMillis(30_000));
+    pool.setValidationTimeout(Duration.ofMillis(3_000));
     rdbms.setConnectionPool(pool);
 
     try (final var registry =
@@ -75,6 +78,25 @@ class RdbmsDataSourcesTest {
       assertThat(ds.getIdleTimeout()).isEqualTo(45_678);
       assertThat(ds.getMaxLifetime()).isEqualTo(99_999);
       assertThat(ds.getLeakDetectionThreshold()).isEqualTo(2_500);
+      assertThat(ds.getKeepaliveTime()).isEqualTo(30_000);
+      assertThat(ds.getValidationTimeout()).isEqualTo(3_000);
+    }
+  }
+
+  @Test
+  void shouldApplyHikariDefaultsForKeepaliveAndValidationTimeoutWhenUnset() throws Exception {
+    // given: a pool with default keepalive (disabled) and validation timeout
+    final var rdbms = h2Rdbms();
+    rdbms.setConnectionPool(new RdbmsConnectionPool());
+
+    try (final var registry =
+        RdbmsDataSources.of(Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, rdbms))) {
+
+      // then: keepalive stays disabled and validation timeout keeps the HikariCP default
+      final var ds =
+          (HikariDataSource) registry.dataSourceFor(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+      assertThat(ds.getKeepaliveTime()).isZero();
+      assertThat(ds.getValidationTimeout()).isEqualTo(5_000);
     }
   }
 


### PR DESCRIPTION

## Description
When an Aurora writer fails over, HikariCP connections bound to the demoted writer stay in the pool until borrowed. The next flush that draws such a connection blocks inside the AWS Advanced JDBC Wrapper until it either fails over or hits failoverTimeoutMs (300s default), so a single exporter can stall for minutes while other exporters sharing the same per-tenant pool recover as soon as they happen to draw a healthy connection.

HikariCP can probe idle connections in the background and evict dead ones before they are handed out, but keepaliveTime and validationTimeout were not exposed, so operators had no way to enable it. Both are HikariCP pool properties and cannot be passed through the JDBC URL (which only reaches the driver), so they must be first-class config.

Expose both under camunda.data.secondary-storage.rdbms.connection-pool with HikariCP defaults (keepalive disabled, validation 5s), leaving behavior unchanged unless explicitly tuned. Aurora deployments can now set keepalive-time (e.g. 30s) to have stale connections discarded proactively; the driver-side failoverTimeoutMs remains tunable via the JDBC URL.

NOTE: Hikari w/ spring can be configured w/ spring properties, but we manually construct the pool, so this is required

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
