### PR TITLE
ci: retry image pull in compose action on transient registry errors

### DIFF
--- a/.github/actions/compose/action.yml
+++ b/.github/actions/compose/action.yml
@@ -15,9 +15,31 @@ inputs:
     description: "Timeout for the healthcheck (in seconds)"
     required: false
     default: "300"
+  max_attempts:
+    description: "Maximum number of image-pull attempts before giving up"
+    required: false
+    default: "3"
+  retry_wait_seconds:
+    description: "Seconds to wait between pull retry attempts"
+    required: false
+    default: "15"
 runs:
   using: composite
   steps:
+    # Pre-pull images with a retry so a transient registry hiccup (e.g. Docker Hub
+    # 502s, see INC-6810) does not fail the whole job. Once images are cached locally,
+    # the compose "up" below does not need to hit the registry again.
+    - name: Pull ${{ inputs.project_name }} images with retry
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      with:
+        max_attempts: ${{ inputs.max_attempts }}
+        retry_wait_seconds: ${{ inputs.retry_wait_seconds }}
+        timeout_minutes: 10
+        shell: bash
+        command: |
+          docker compose -f "${{ inputs.compose_file }}" \
+            --project-name "${{ inputs.project_name }}" ${{ inputs.additional_flags }} pull
+
     - name: Run ${{ inputs.project_name }} compose
       uses: hoverkraft-tech/compose-action@11beaa1c2dae4e8ed7b1665aa074723b6cecb0e4 # v3.0.0
       with:


### PR DESCRIPTION
## What

Wrap image pulling in the shared `compose` action ([.github/actions/compose/action.yml](../../.github/actions/compose/action.yml)) in a retry, so a transient Docker Hub registry hiccup no longer fails the whole job.

A new pre-pull step runs `docker compose ... pull` through [`nick-fields/retry@v4`](https://github.com/nick-fields/retry) (the retry action already used across this repo, e.g. `setup-build` and `npm-ci-with-retry`). Once the images are cached locally, the existing `hoverkraft-tech/compose-action` bring-up and `healthy.sh` run unchanged.

Two optional inputs were added, both with defaults so **no existing caller needs to change**:

- `max_attempts` (default `3`)
- `retry_wait_seconds` (default `15`)

## Why

CI jobs using this action intermittently fail when Docker Hub returns a transient error (e.g. `502 Bad Gateway`) while `docker compose up` pulls images — most recently INC-6810, on the `camunda/keycloak` pull in `optimize-e2e-smoke`. There is no native `--retry` for `docker pull` / `docker compose pull`, and `hoverkraft-tech/compose-action` exposes no retry option, so retry has to be added around it.

## Design notes

**Why a separate pre-pull step instead of wrapping the existing bring-up?**
`nick-fields/retry` wraps a shell `command`, but the compose bring-up is a `uses:` step (`hoverkraft-tech/compose-action`), which cannot be wrapped by the retry action. Retrying a pre-pull is therefore the least invasive fix: it isolates the network-flaky operation (the pull) and leaves the working `hoverkraft` + `healthy.sh` flow untouched. The alternative — replacing `hoverkraft` with a plain retry-wrapped `docker compose up --pull always --wait` — is cleaner but a larger behavioral change to a shared action used by ~6 workflows, so it was intentionally avoided here.

**Why a blind retry (not scoped to 502/connection-reset only)?**
A compose pull is cheap and idempotent, so retrying on any pull failure is acceptable — the downside of an occasional extra pull attempt is negligible. Error-pattern scoping matters more for expensive operations like `docker buildx build`, where a blind retry can mask a genuine build failure and waste minutes; that is tracked separately for the `build-platform-docker` action and is **not** part of this PR.

## Scope

This PR covers only the `compose` action path (INC-6810).
## Testing

- `shellcheck` / `actionlint` / `spotless` do not apply to composite `action.yml` files in this repo (actionlint lints only `.github/workflows/*.yml`; spotless formats only Markdown/Java). No embedded bash remains after switching to `nick-fields/retry`.
- `nick-fields/retry` is pinned to the same SHA already used elsewhere in the repo, so the action-pin policy check passes.
