### PR TITLE
fix: transitive fs backups dependency for RestoreAppTest

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -793,12 +793,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-backup-store-filesystem</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
       <scope>runtime</scope>
@@ -1092,6 +1086,7 @@
             <ignoredNonTestScopedDependency>org.springframework.security:spring-security-web</ignoredNonTestScopedDependency>
             <ignoredNonTestScopedDependency>org.springframework.security:spring-security-config</ignoredNonTestScopedDependency>
             <ignoredNonTestScopedDependency>io.camunda:camunda-search-domain</ignoredNonTestScopedDependency>
+            <ignoredNonTestScopedDependency>io.camunda:zeebe-backup-store-filesystem</ignoredNonTestScopedDependency>
           </ignoredNonTestScopedDependencies>
           <!-- dependencies only packaged but not explicitly used -->
           <usedDependencies>
@@ -1143,6 +1138,7 @@
           <ignoredUsedUndeclaredDependencies>
             <dep>org.springframework.security:spring-security-web</dep>
             <dep>org.springframework.security:spring-security-config</dep>
+            <dep>io.camunda:zeebe-backup-store-filesystem</dep>
           </ignoredUsedUndeclaredDependencies>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Fix transitive dependency for FS Backup stores required for the `RestoreAppTest`. Introduced from https://github.com/camunda/camunda/pull/58979 changes.

The broker right now fails to start with FS Backups enabled.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
