### PR TITLE
fix: include NoSuchMemberException in connection issue check

### DIFF
--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixClientTransportAdapter.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixClientTransportAdapter.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.transport.impl;
 
 import io.atomix.cluster.messaging.MessagingException;
+import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
 import io.atomix.cluster.messaging.MessagingService;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -223,6 +224,7 @@ public final class AtomixClientTransportAdapter extends Actor implements ClientT
 
   private boolean exceptionShowsConnectionIssue(final @Nullable Throwable throwable) {
     return throwable instanceof ConnectException
+        || throwable instanceof NoSuchMemberException
         || throwable instanceof MessagingException.NoRemoteHandler;
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Include `NoSuchMemberException` in the generic network connection issue check. This was introduced to cover some of the `ConnectException` cases in 7fc0e1844782db351efd5a7dca4ec6db815601fc .

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
