### PR TITLE
test: Skip Reindex Step Evaluation

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
@@ -104,8 +104,9 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
                 return CompletableFuture.completedFuture(0L);
               }
 
-              return reindex(response)
-                  .thenCompose(reindexedCount -> delete(response))
+//              return reindex(response)
+//                  .thenCompose(reindexedCount -> delete(response))
+              return delete(response)
                   .thenApply(
                       deletedCount -> {
                         // advance search position only after both archive steps completed


### PR DESCRIPTION

## Description

Quick test to see the impact of removing reindexing step and straight deleting docs.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
