### PR TITLE
Scan and store secret references on SECRET_REFERENCE cluster variables

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -40,18 +41,21 @@ public class ClusterVariableCreateProcessor
   private final CslAuthorizationCheck cslCheck;
   private final CommandDistributionBehavior commandDistributionBehavior;
   private final ClusterVariableRecordValidator clusterVariableRecordValidator;
+  private final ClusterVariableSecretReferenceScanner secretReferenceScanner;
 
   public ClusterVariableCreateProcessor(
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CslAuthorizationCheck cslCheck,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final ClusterVariableRecordValidator clusterVariableRecordValidator) {
+      final ClusterVariableRecordValidator clusterVariableRecordValidator,
+      final ClusterVariableSecretReferenceScanner secretReferenceScanner) {
     this.keyGenerator = keyGenerator;
     this.writers = writers;
     this.cslCheck = cslCheck;
     this.commandDistributionBehavior = commandDistributionBehavior;
     this.clusterVariableRecordValidator = clusterVariableRecordValidator;
+    this.secretReferenceScanner = secretReferenceScanner;
   }
 
   @Override
@@ -62,6 +66,7 @@ public class ClusterVariableCreateProcessor
         .flatMap(clusterVariableRecordValidator::ensureValidScope)
         .flatMap(record -> isAuthorized(record, command))
         .flatMap(clusterVariableRecordValidator::validateUniqueness)
+        .flatMap(this::applySecretReferences)
         .ifRightOrLeft(
             record -> {
               final var key = keyGenerator.nextKey();
@@ -99,6 +104,27 @@ public class ClusterVariableCreateProcessor
                 writers.rejection().appendRejection(command, rejection.type(), rejection.reason()));
 
     commandDistributionBehavior.acknowledgeCommand(command);
+  }
+
+  /**
+   * For a SECRET_REFERENCE-kind record, scans its value for secret references and sets them on the
+   * record; a non-SECRET_REFERENCE record passes through unchanged. Only ever called on the origin
+   * partition ({@link #processNewCommand}): the resulting refs are set on the same record that is
+   * appended, returned in the accepted response, and distributed, so a receiver's {@link
+   * #processDistributedCommand} carries them without re-scanning.
+   */
+  private Either<Rejection, ClusterVariableRecord> applySecretReferences(
+      final ClusterVariableRecord record) {
+    if (record.getKind() != ClusterVariableKind.SECRET_REFERENCE) {
+      return Either.right(record);
+    }
+    return secretReferenceScanner
+        .scan(record.getValueBuffer())
+        .map(
+            references -> {
+              references.forEach(ref -> record.addSecretReference("", ref.name(), ref.pointer()));
+              return record;
+            });
   }
 
   private Either<Rejection, ClusterVariableRecord> isAuthorized(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableProcessors.java
@@ -34,16 +34,27 @@ public class ClusterVariableProcessors {
             tenantState,
             new ClusterVariableValidationConfiguration(
                 engineConfiguration.getMaxNameFieldLength()));
+    final var secretReferenceScanner = new ClusterVariableSecretReferenceScanner();
     typedRecordProcessors.onCommand(
         ValueType.CLUSTER_VARIABLE,
         ClusterVariableIntent.CREATE,
         new ClusterVariableCreateProcessor(
-            keyGenerator, writers, cslCheck, distributionBehavior, clusterVariableRecordValidator));
+            keyGenerator,
+            writers,
+            cslCheck,
+            distributionBehavior,
+            clusterVariableRecordValidator,
+            secretReferenceScanner));
     typedRecordProcessors.onCommand(
         ValueType.CLUSTER_VARIABLE,
         ClusterVariableIntent.UPDATE,
         new ClusterVariableUpdateProcessor(
-            keyGenerator, writers, cslCheck, distributionBehavior, clusterVariableRecordValidator));
+            keyGenerator,
+            writers,
+            cslCheck,
+            distributionBehavior,
+            clusterVariableRecordValidator,
+            secretReferenceScanner));
     typedRecordProcessors.onCommand(
         ValueType.CLUSTER_VARIABLE,
         ClusterVariableIntent.DELETE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableSecretReferenceScanner.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableSecretReferenceScanner.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.clustervariable;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.util.Either;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import org.agrona.DirectBuffer;
+import org.agrona.io.DirectBufferInputStream;
+import org.msgpack.jackson.dataformat.MessagePackFactory;
+
+/**
+ * Scans a SECRET_REFERENCE cluster variable's msgpack value for {@code camunda.secrets.<name>}
+ * occurrences, walking every string leaf of the value (the root scalar, object field values, and
+ * array elements) and recording each distinct reference name together with the RFC 6901 JSON
+ * pointer of the leaf it was found in.
+ *
+ * <p>This only detects references; resolving them into activated job variables is a separate, later
+ * concern (see the job-join sub-issue tracked under #56563).
+ */
+public final class ClusterVariableSecretReferenceScanner {
+
+  private static final String PREFIX = "camunda.secrets.";
+
+  /** Reads the msgpack encoding of a cluster variable value as a Jackson tree. */
+  private final ObjectMapper mapper = new ObjectMapper(new MessagePackFactory());
+
+  /**
+   * Scans the msgpack value buffer, returning every secret reference with its leaf's JSON pointer.
+   * The value is valid msgpack by construction (it comes from a record already round-tripped
+   * through the protocol), so the parse failure this guards against is very likely unreachable —
+   * but a processor must never throw, so it is reported as a rejection rather than propagated.
+   */
+  public Either<Rejection, List<DetectedReference>> scan(final DirectBuffer valueBuffer) {
+    final JsonNode root;
+    try {
+      root = mapper.readTree(new DirectBufferInputStream(valueBuffer));
+    } catch (final IOException e) {
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_ARGUMENT,
+              "Expected to detect secret references in the cluster variable value, but the value "
+                  + "could not be parsed: "
+                  + e.getMessage()));
+    }
+    final List<DetectedReference> references = new ArrayList<>();
+    collect(root, new StringBuilder(), references);
+    return Either.right(references);
+  }
+
+  private void collect(
+      final JsonNode node, final StringBuilder pointer, final List<DetectedReference> out) {
+    if (node.isTextual()) {
+      collectFromLeaf(node.textValue(), pointer.toString(), out);
+    } else if (node.isObject()) {
+      node.fields()
+          .forEachRemaining(
+              field -> {
+                final int length = pointer.length();
+                pointer.append('/').append(escape(field.getKey()));
+                collect(field.getValue(), pointer, out);
+                pointer.setLength(length);
+              });
+    } else if (node.isArray()) {
+      for (int i = 0; i < node.size(); i++) {
+        final int length = pointer.length();
+        pointer.append('/').append(i);
+        collect(node.get(i), pointer, out);
+        pointer.setLength(length);
+      }
+    }
+    // number/bool/null/missing leaves cannot carry a reference
+  }
+
+  /** Dedupes repeated occurrences of the same reference within a single leaf. */
+  private static void collectFromLeaf(
+      final String text, final String pointer, final List<DetectedReference> out) {
+    final Matcher matcher = SecretReference.REFERENCE_PATTERN.matcher(text);
+    final Set<String> namesInLeaf = new LinkedHashSet<>();
+    while (matcher.find()) {
+      namesInLeaf.add(matcher.group().substring(PREFIX.length()));
+    }
+    namesInLeaf.forEach(name -> out.add(new DetectedReference(name, pointer)));
+  }
+
+  /**
+   * Escapes a JSON pointer segment per RFC 6901: {@code ~} is replaced first (to {@code ~0}), then
+   * {@code /} (to {@code ~1}) — the order matters, otherwise a segment containing {@code /} would
+   * produce a pointer that does not round-trip through {@code JsonPointer.compile}.
+   */
+  private static String escape(final String segment) {
+    return segment.replace("~", "~0").replace("/", "~1");
+  }
+
+  /** A detected reference: the secret name and the RFC 6901 pointer of the leaf it was found in. */
+  public record DetectedReference(String name, String pointer) {}
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableSecretReferenceScanner.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableSecretReferenceScanner.java
@@ -30,7 +30,7 @@ import org.msgpack.jackson.dataformat.MessagePackFactory;
  * pointer of the leaf it was found in.
  *
  * <p>This only detects references; resolving them into activated job variables is a separate, later
- * concern (see the job-join sub-issue tracked under #56563).
+ * concern.
  */
 public final class ClusterVariableSecretReferenceScanner {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -40,18 +41,21 @@ public class ClusterVariableUpdateProcessor
   private final CslAuthorizationCheck cslCheck;
   private final CommandDistributionBehavior commandDistributionBehavior;
   private final ClusterVariableRecordValidator clusterVariableRecordValidator;
+  private final ClusterVariableSecretReferenceScanner secretReferenceScanner;
 
   public ClusterVariableUpdateProcessor(
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CslAuthorizationCheck cslCheck,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final ClusterVariableRecordValidator clusterVariableRecordValidator) {
+      final ClusterVariableRecordValidator clusterVariableRecordValidator,
+      final ClusterVariableSecretReferenceScanner secretReferenceScanner) {
     this.keyGenerator = keyGenerator;
     this.writers = writers;
     this.cslCheck = cslCheck;
     this.commandDistributionBehavior = commandDistributionBehavior;
     this.clusterVariableRecordValidator = clusterVariableRecordValidator;
+    this.secretReferenceScanner = secretReferenceScanner;
   }
 
   @Override
@@ -60,7 +64,7 @@ public class ClusterVariableUpdateProcessor
     clusterVariableRecordValidator
         .ensureValidScope(commandRecord)
         .flatMap(clusterVariableRecordValidator::loadExisting)
-        .map(stored -> applyUpdate(stored, commandRecord))
+        .flatMap(stored -> applyUpdateWithSecretReferences(stored, commandRecord))
         .flatMap(record -> isAuthorized(record, command))
         .ifRightOrLeft(
             record -> {
@@ -99,10 +103,35 @@ public class ClusterVariableUpdateProcessor
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 
+  /**
+   * For a SECRET_REFERENCE-stored variable, scans the command's value for secret references and
+   * sets them on the command record before applying the update; a non-SECRET_REFERENCE variable
+   * skips the scan. Kind is immutable-from-stored on update (the command may omit it), so scanning
+   * keys off the stored kind, not the (possibly absent) command kind. Only ever called on the
+   * origin partition ({@link #processNewCommand}), on the command record: the resulting refs then
+   * ride the distributed command, and the receiver's {@link #processDistributedCommand} copies them
+   * onto its stored record via {@link #applyUpdate} without re-scanning.
+   */
+  private Either<Rejection, ClusterVariableRecord> applyUpdateWithSecretReferences(
+      final ClusterVariableRecord stored, final ClusterVariableRecord command) {
+    if (stored.getKind() != ClusterVariableKind.SECRET_REFERENCE) {
+      return Either.right(applyUpdate(stored, command));
+    }
+    return secretReferenceScanner
+        .scan(command.getValueBuffer())
+        .map(
+            references -> {
+              references.forEach(ref -> command.addSecretReference("", ref.name(), ref.pointer()));
+              return applyUpdate(stored, command);
+            });
+  }
+
   private ClusterVariableRecord applyUpdate(
       final ClusterVariableRecord stored, final ClusterVariableRecord command) {
     stored.setValue(command.getValueBuffer());
     stored.setMetadata(command.getMetadataBuffer());
+    // reset-then-add so a value updated from secrets to none ends up empty rather than appended
+    stored.copySecretReferencesFrom(command);
     return stored;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
@@ -64,8 +64,8 @@ public class ClusterVariableUpdateProcessor
     clusterVariableRecordValidator
         .ensureValidScope(commandRecord)
         .flatMap(clusterVariableRecordValidator::loadExisting)
+        .flatMap(stored -> isAuthorized(stored, command))
         .flatMap(stored -> applyUpdateWithSecretReferences(stored, commandRecord))
-        .flatMap(record -> isAuthorized(record, command))
         .ifRightOrLeft(
             record -> {
               final long key = keyGenerator.nextKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
@@ -91,8 +91,7 @@ public class ClusterVariableUpdateProcessor
   public void processDistributedCommand(final TypedRecord<ClusterVariableRecord> command) {
     final var commandRecord = command.getValue();
     clusterVariableRecordValidator
-        .loadExisting(commandRecord)
-        .map(stored -> applyUpdate(stored, commandRecord))
+        .validateExistence(commandRecord)
         .ifRightOrLeft(
             record ->
                 writers
@@ -104,35 +103,28 @@ public class ClusterVariableUpdateProcessor
   }
 
   /**
-   * For a SECRET_REFERENCE-stored variable, scans the command's value for secret references and
-   * sets them on the command record before applying the update; a non-SECRET_REFERENCE variable
-   * skips the scan. Kind is immutable-from-stored on update (the command may omit it), so scanning
-   * keys off the stored kind, not the (possibly absent) command kind. Only ever called on the
-   * origin partition ({@link #processNewCommand}), on the command record: the resulting refs then
-   * ride the distributed command, and the receiver's {@link #processDistributedCommand} copies them
-   * onto its stored record via {@link #applyUpdate} without re-scanning.
+   * Kind is immutable-from-stored on update (the command may omit or misreport it), so this pins
+   * the stored kind onto the command record first. For a SECRET_REFERENCE-stored variable, it then
+   * scans the command's (new) value for secret references and sets them on the command record; a
+   * non-SECRET_REFERENCE variable skips the scan. Only ever called on the origin partition ({@link
+   * #processNewCommand}): the command record already carries the new value/metadata, and now kind
+   * and secretReferences too, making it a complete stand-in for the merged record. That same
+   * command then rides the distribution, so the receiver's {@link #processDistributedCommand} only
+   * needs to confirm the variable still exists and can append the command record as-is.
    */
   private Either<Rejection, ClusterVariableRecord> applyUpdateWithSecretReferences(
       final ClusterVariableRecord stored, final ClusterVariableRecord command) {
+    command.setKind(stored.getKind());
     if (stored.getKind() != ClusterVariableKind.SECRET_REFERENCE) {
-      return Either.right(applyUpdate(stored, command));
+      return Either.right(command);
     }
     return secretReferenceScanner
         .scan(command.getValueBuffer())
         .map(
             references -> {
               references.forEach(ref -> command.addSecretReference("", ref.name(), ref.pointer()));
-              return applyUpdate(stored, command);
+              return command;
             });
-  }
-
-  private ClusterVariableRecord applyUpdate(
-      final ClusterVariableRecord stored, final ClusterVariableRecord command) {
-    stored.setValue(command.getValueBuffer());
-    stored.setMetadata(command.getMetadataBuffer());
-    // reset-then-add so a value updated from secrets to none ends up empty rather than appended
-    stored.copySecretReferencesFrom(command);
-    return stored;
   }
 
   private Either<Rejection, ClusterVariableRecord> isAuthorized(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
@@ -13,6 +13,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.camunda.feel.syntaxtree.ConstContext;
 import org.camunda.feel.syntaxtree.Exp;
 import org.camunda.feel.syntaxtree.ParsedExpression;
@@ -43,6 +44,16 @@ import scala.jdk.javaapi.CollectionConverters;
  */
 @NullMarked
 public record SecretReference(String storeId, String name) {
+
+  /**
+   * Matches a {@code camunda.secrets.<name>} occurrence in raw text, shared by callers that scan
+   * text rather than a parsed FEEL AST (e.g. {@link
+   * io.camunda.zeebe.engine.processing.deployment.model.validation.SecretReferenceLiteralValidator}
+   * and {@link
+   * io.camunda.zeebe.engine.processing.clustervariable.ClusterVariableSecretReferenceScanner}).
+   */
+  public static final Pattern REFERENCE_PATTERN =
+      Pattern.compile("camunda\\.secrets\\.[\\p{Alnum}_]+");
 
   private static final String ROOT = "camunda";
   private static final String NAMESPACE = "secrets";

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidator.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.deployment.model.validation;
 
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
 import java.util.LinkedHashSet;
 import java.util.regex.MatchResult;
@@ -33,9 +34,6 @@ import org.jspecify.annotations.NullMarked;
  */
 @NullMarked
 final class SecretReferenceLiteralValidator implements ModelElementValidator<ZeebeInput> {
-
-  private static final Pattern SECRET_REFERENCE =
-      Pattern.compile("camunda\\.secrets\\.[\\p{Alnum}_]+");
 
   // Matches one whole double-quoted string literal, so only quoted text is scanned for a reference.
   // As a regex (after Java unescaping): "(?:\\.|[^"\\])*"
@@ -75,7 +73,7 @@ final class SecretReferenceLiteralValidator implements ModelElementValidator<Zee
     // a static value is a literal in full; a FEEL expression is a literal only where it is quoted
     final String literalText = expression.isStatic() ? source : stringLiterals(source.substring(1));
 
-    final var matcher = SECRET_REFERENCE.matcher(literalText);
+    final var matcher = SecretReference.REFERENCE_PATTERN.matcher(literalText);
     final var references = new LinkedHashSet<String>();
     while (matcher.find()) {
       references.add(matcher.group());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableSecretReferenceMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableSecretReferenceMultiPartitionTest.java
@@ -117,6 +117,7 @@ public final class ClusterVariableSecretReferenceMultiPartitionTest {
             ClusterVariableSecretReferenceValue::getSecretReference,
             ClusterVariableSecretReferenceValue::getPath)
         .containsExactly(tuple("", "rotated", "/auth"));
+    assertThat(updated.getValue().getKind()).isEqualTo(ClusterVariableKind.SECRET_REFERENCE);
 
     // and every distributed partition's UPDATED event carries the identical reference
     for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
@@ -133,6 +134,8 @@ public final class ClusterVariableSecretReferenceMultiPartitionTest {
               ClusterVariableSecretReferenceValue::getSecretReference,
               ClusterVariableSecretReferenceValue::getPath)
           .containsExactly(tuple("", "rotated", "/auth"));
+      assertThat(updatedOnReceiver.getValue().getKind())
+          .isEqualTo(ClusterVariableKind.SECRET_REFERENCE);
     }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableSecretReferenceMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableSecretReferenceMultiPartitionTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.clustervariable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue.ClusterVariableSecretReferenceValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Verifies that secret references, detected once on the origin partition, are carried
+ * deterministically to the distributed partitions on the {@link ClusterVariableRecord} value
+ * itself, without the receiver re-scanning the value.
+ */
+public final class ClusterVariableSecretReferenceMultiPartitionTest {
+
+  private static final int PARTITION_COUNT = 3;
+
+  @ClassRule
+  public static final EngineRule ENGINE_RULE = EngineRule.multiplePartition(PARTITION_COUNT);
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCarrySecretReferencesToDistributedPartitionsOnCreate() {
+    // given
+    final Record<ClusterVariableRecordValue> origin =
+        ENGINE_RULE
+            .clusterVariables()
+            .withName("secret-create-multi")
+            .setGlobalScope()
+            .withKind(ClusterVariableKind.SECRET_REFERENCE)
+            .withValue(Map.of("auth", "camunda.secrets.token"))
+            .create();
+
+    RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
+        .withDistributionIntent(ClusterVariableIntent.CREATE)
+        .await();
+
+    // then the origin partition (1) carries the scanned reference
+    assertThat(origin.getValue().getSecretReferences())
+        .extracting(
+            ClusterVariableSecretReferenceValue::getStoreId,
+            ClusterVariableSecretReferenceValue::getSecretReference,
+            ClusterVariableSecretReferenceValue::getPath)
+        .containsExactly(tuple("", "token", "/auth"));
+
+    // and every distributed partition's CREATED event carries the identical reference
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      final var created =
+          RecordingExporter.clusterVariableRecords()
+              .withIntent(ClusterVariableIntent.CREATED)
+              .withPartitionId(partitionId)
+              .withName("secret-create-multi")
+              .getFirst();
+
+      assertThat(created.getValue().getSecretReferences())
+          .extracting(
+              ClusterVariableSecretReferenceValue::getStoreId,
+              ClusterVariableSecretReferenceValue::getSecretReference,
+              ClusterVariableSecretReferenceValue::getPath)
+          .containsExactly(tuple("", "token", "/auth"));
+    }
+  }
+
+  @Test
+  public void shouldCarrySecretReferencesToDistributedPartitionsOnUpdate() {
+    // given
+    ENGINE_RULE
+        .clusterVariables()
+        .withName("secret-update-multi")
+        .setGlobalScope()
+        .withKind(ClusterVariableKind.SECRET_REFERENCE)
+        .withValue(Map.of("auth", "camunda.secrets.token"))
+        .create();
+
+    RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
+        .withDistributionIntent(ClusterVariableIntent.CREATE)
+        .await();
+
+    // when the value is updated to reference a different secret
+    final Record<ClusterVariableRecordValue> updated =
+        ENGINE_RULE
+            .clusterVariables()
+            .withName("secret-update-multi")
+            .setGlobalScope()
+            .withValue(Map.of("auth", "camunda.secrets.rotated"))
+            .update();
+
+    RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
+        .withDistributionIntent(ClusterVariableIntent.UPDATE)
+        .await();
+
+    // then the origin partition (1) carries the newly scanned reference
+    assertThat(updated.getValue().getSecretReferences())
+        .extracting(
+            ClusterVariableSecretReferenceValue::getStoreId,
+            ClusterVariableSecretReferenceValue::getSecretReference,
+            ClusterVariableSecretReferenceValue::getPath)
+        .containsExactly(tuple("", "rotated", "/auth"));
+
+    // and every distributed partition's UPDATED event carries the identical reference
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      final var updatedOnReceiver =
+          RecordingExporter.clusterVariableRecords()
+              .withIntent(ClusterVariableIntent.UPDATED)
+              .withPartitionId(partitionId)
+              .withName("secret-update-multi")
+              .getFirst();
+
+      assertThat(updatedOnReceiver.getValue().getSecretReferences())
+          .extracting(
+              ClusterVariableSecretReferenceValue::getStoreId,
+              ClusterVariableSecretReferenceValue::getSecretReference,
+              ClusterVariableSecretReferenceValue::getPath)
+          .containsExactly(tuple("", "rotated", "/auth"));
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableSecretReferenceScannerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableSecretReferenceScannerTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.clustervariable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import io.camunda.zeebe.engine.processing.clustervariable.ClusterVariableSecretReferenceScanner.DetectedReference;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import java.util.List;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure unit tests for {@link ClusterVariableSecretReferenceScanner}, covering the same transferable
+ * scenarios as {@link
+ * io.camunda.zeebe.engine.processing.deployment.model.element.SecretReferenceTest} (the FEEL-only
+ * ones, such as string-literal-vs-expression and iterator shadowing, do not apply here since the
+ * scanner walks a plain msgpack value, not a parsed FEEL AST).
+ */
+final class ClusterVariableSecretReferenceScannerTest {
+
+  private final ClusterVariableSecretReferenceScanner scanner =
+      new ClusterVariableSecretReferenceScanner();
+
+  @Test
+  void shouldDetectReferenceAtRootScalar() {
+    // given a value that is the string itself, not nested in an object
+    final var references = scan("\"camunda.secrets.token\"");
+
+    // then the pointer of a root-level leaf is the empty string
+    assertThat(references)
+        .extracting(DetectedReference::name, DetectedReference::pointer)
+        .containsExactly(tuple("token", ""));
+  }
+
+  @Test
+  void shouldDetectReferenceInObjectField() {
+    // given
+    final var references = scan("{\"auth\": \"camunda.secrets.token\"}");
+
+    // then
+    assertThat(references)
+        .extracting(DetectedReference::name, DetectedReference::pointer)
+        .containsExactly(tuple("token", "/auth"));
+  }
+
+  @Test
+  void shouldDetectReferenceInArrayElement() {
+    // given
+    final var references = scan("{\"list\": [\"camunda.secrets.token\"]}");
+
+    // then
+    assertThat(references)
+        .extracting(DetectedReference::name, DetectedReference::pointer)
+        .containsExactly(tuple("token", "/list/0"));
+  }
+
+  @Test
+  void shouldDetectReferenceInNestedObject() {
+    // given
+    final var references = scan("{\"a\": {\"b\": \"camunda.secrets.token\"}}");
+
+    // then
+    assertThat(references)
+        .extracting(DetectedReference::name, DetectedReference::pointer)
+        .containsExactly(tuple("token", "/a/b"));
+  }
+
+  @Test
+  void shouldReturnEmptyWhenValueHasNoSecretReference() {
+    // given a SECRET_REFERENCE-shaped value that does not contain any camunda.secrets.* text
+    final var references = scan("{\"auth\": \"plain value\"}");
+
+    // then
+    assertThat(references).isEmpty();
+  }
+
+  @Test
+  void shouldDetectTwoDistinctReferencesInOneLeaf() {
+    // given
+    final var references = scan("\"camunda.secrets.a and camunda.secrets.b\"");
+
+    // then
+    assertThat(references)
+        .extracting(DetectedReference::name, DetectedReference::pointer)
+        .containsExactlyInAnyOrder(tuple("a", ""), tuple("b", ""));
+  }
+
+  @Test
+  void shouldDedupeRepeatedReferenceWithinOneLeaf() {
+    // given the same reference occurring twice in a single leaf
+    final var references = scan("\"camunda.secrets.a and camunda.secrets.a\"");
+
+    // then it collapses into a single entry
+    assertThat(references)
+        .extracting(DetectedReference::name, DetectedReference::pointer)
+        .containsExactly(tuple("a", ""));
+  }
+
+  @Test
+  void shouldReportSameReferenceNameAtTwoDifferentLeavesSeparately() {
+    // given the same reference name used at two different leaves
+    final var references =
+        scan("{\"a\": \"camunda.secrets.token\", \"b\": \"camunda.secrets.token\"}");
+
+    // then both leaves are reported, each with its own pointer
+    assertThat(references)
+        .extracting(DetectedReference::name, DetectedReference::pointer)
+        .containsExactlyInAnyOrder(tuple("token", "/a"), tuple("token", "/b"));
+  }
+
+  @Test
+  void shouldNotFusePrefixCollidingReferences() {
+    // given a leaf where one reference name is a prefix of another
+    final var references = scan("\"camunda.secrets.token and camunda.secrets.token2\"");
+
+    // then both distinct names are reported, not just the longer one
+    assertThat(references)
+        .extracting(DetectedReference::name)
+        .containsExactlyInAnyOrder("token", "token2");
+  }
+
+  @Test
+  void shouldStopNameAtFirstNonAlphanumericCharacter() {
+    // given a name containing a hyphen, which is not \p{Alnum}
+    final var references = scan("\"camunda.secrets.my-name\"");
+
+    // then only the alphanumeric run up to the hyphen is captured, documenting the charset
+    // boundary of the shared reference pattern (SecretReference.REFERENCE_PATTERN)
+    assertThat(references).extracting(DetectedReference::name).containsExactly("my");
+  }
+
+  @Test
+  void shouldProduceAPointerThatRoundTripsForFieldNamesNeedingRfc6901Escaping() {
+    // given a field name containing both '/' and '~', the two characters RFC 6901 requires
+    // escaping for
+    final var references = scan("{\"a/b~c\": \"camunda.secrets.token\"}");
+
+    // then
+    assertThat(references)
+        .extracting(DetectedReference::name, DetectedReference::pointer)
+        .containsExactly(tuple("token", "/a~1b~0c"));
+
+    // and the pointer round-trips back to the original field name
+    final var pointer = JsonPointer.compile(references.get(0).pointer());
+    assertThat(pointer.getMatchingProperty()).isEqualTo("a/b~c");
+  }
+
+  private List<DetectedReference> scan(final String json) {
+    final var result = scanner.scan(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(json)));
+    assertThat(result.isRight()).describedAs("scan result: %s", result).isTrue();
+    return result.get();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableSecretReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableSecretReferenceTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.clustervariable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue.ClusterVariableSecretReferenceValue;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.Map;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class ClusterVariableSecretReferenceTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldStoreSecretReferenceOnCreate() {
+    // given
+    final Record<ClusterVariableRecordValue> created =
+        ENGINE
+            .clusterVariables()
+            .withName("var-create")
+            .setGlobalScope()
+            .withKind(ClusterVariableKind.SECRET_REFERENCE)
+            .withValue(Map.of("auth", "camunda.secrets.token"))
+            .create();
+
+    // then
+    assertThat(created.getValue().getSecretReferences())
+        .extracting(
+            ClusterVariableSecretReferenceValue::getStoreId,
+            ClusterVariableSecretReferenceValue::getSecretReference,
+            ClusterVariableSecretReferenceValue::getPath)
+        .containsExactly(tuple("", "token", "/auth"));
+  }
+
+  @Test
+  public void shouldStoreSecretReferenceForRootScalarValue() {
+    // given a value that is the string itself, not nested in an object
+    final Record<ClusterVariableRecordValue> created =
+        ENGINE
+            .clusterVariables()
+            .withName("var-root-scalar")
+            .setGlobalScope()
+            .withKind(ClusterVariableKind.SECRET_REFERENCE)
+            .withValue("\"camunda.secrets.token\"")
+            .create();
+
+    // then the pointer of a root-level leaf is the empty string
+    assertThat(created.getValue().getSecretReferences())
+        .extracting(
+            ClusterVariableSecretReferenceValue::getStoreId,
+            ClusterVariableSecretReferenceValue::getSecretReference,
+            ClusterVariableSecretReferenceValue::getPath)
+        .containsExactly(tuple("", "token", ""));
+  }
+
+  @Test
+  public void shouldStoreSecretReferencesInNestedObjectsAndArrays() {
+    // given
+    final Record<ClusterVariableRecordValue> created =
+        ENGINE
+            .clusterVariables()
+            .withName("var-nested")
+            .setGlobalScope()
+            .withKind(ClusterVariableKind.SECRET_REFERENCE)
+            .withValue(
+                Map.of(
+                    "a", Map.of("b", "camunda.secrets.x"),
+                    "list", List.of("camunda.secrets.y")))
+            .create();
+
+    // then
+    assertThat(created.getValue().getSecretReferences())
+        .extracting(
+            ClusterVariableSecretReferenceValue::getStoreId,
+            ClusterVariableSecretReferenceValue::getSecretReference,
+            ClusterVariableSecretReferenceValue::getPath)
+        .containsExactlyInAnyOrder(tuple("", "x", "/a/b"), tuple("", "y", "/list/0"));
+  }
+
+  @Test
+  public void shouldDedupeRepeatedReferenceWithinSameLeaf() {
+    // given a leaf with two distinct references, one of them repeated
+    final Record<ClusterVariableRecordValue> created =
+        ENGINE
+            .clusterVariables()
+            .withName("var-multi-ref-leaf")
+            .setGlobalScope()
+            .withKind(ClusterVariableKind.SECRET_REFERENCE)
+            .withValue("\"camunda.secrets.a and camunda.secrets.b and camunda.secrets.a\"")
+            .create();
+
+    // then the repeated occurrence of "a" collapses into a single entry
+    assertThat(created.getValue().getSecretReferences())
+        .extracting(
+            ClusterVariableSecretReferenceValue::getStoreId,
+            ClusterVariableSecretReferenceValue::getSecretReference,
+            ClusterVariableSecretReferenceValue::getPath)
+        .containsExactly(tuple("", "a", ""), tuple("", "b", ""));
+  }
+
+  @Test
+  public void shouldNotScanJsonKindValue() {
+    // given a JSON-kind value that happens to contain a secret-reference-shaped string
+    final Record<ClusterVariableRecordValue> created =
+        ENGINE
+            .clusterVariables()
+            .withName("var-json-kind")
+            .setGlobalScope()
+            .withValue("\"camunda.secrets.token\"")
+            .create();
+
+    // then
+    assertThat(created.getValue().getKind()).isEqualTo(ClusterVariableKind.JSON);
+    assertThat(created.getValue().getSecretReferences()).isEmpty();
+  }
+
+  @Test
+  public void shouldReplaceStoredSecretReferencesOnUpdate() {
+    // given a SECRET_REFERENCE variable with a reference
+    ENGINE
+        .clusterVariables()
+        .withName("var-update-replace")
+        .setGlobalScope()
+        .withKind(ClusterVariableKind.SECRET_REFERENCE)
+        .withValue(Map.of("auth", "camunda.secrets.token"))
+        .create();
+
+    // when updated to a value without any secret reference
+    final Record<ClusterVariableRecordValue> updated =
+        ENGINE
+            .clusterVariables()
+            .withName("var-update-replace")
+            .setGlobalScope()
+            .withKind(ClusterVariableKind.SECRET_REFERENCE)
+            .withValue(Map.of("plain", "value"))
+            .update();
+
+    // then the stored references end up empty, not appended to the old ones
+    assertThat(updated.getValue().getSecretReferences()).isEmpty();
+  }
+
+  @Test
+  public void shouldScanOnUpdateUsingStoredKindWhenCommandOmitsKind() {
+    // given a SECRET_REFERENCE variable without any reference yet
+    ENGINE
+        .clusterVariables()
+        .withName("var-update-omit-kind")
+        .setGlobalScope()
+        .withKind(ClusterVariableKind.SECRET_REFERENCE)
+        .withValue("\"none\"")
+        .create();
+
+    // when updated without specifying a kind (the command's kind defaults to JSON)
+    final Record<ClusterVariableRecordValue> updated =
+        ENGINE
+            .clusterVariables()
+            .withName("var-update-omit-kind")
+            .setGlobalScope()
+            .withValue(Map.of("auth", "camunda.secrets.token"))
+            .update();
+
+    // then the update still scans, since the stored kind (SECRET_REFERENCE) is used, not the
+    // command's (omitted, defaulting to JSON)
+    assertThat(updated.getValue().getSecretReferences())
+        .extracting(
+            ClusterVariableSecretReferenceValue::getStoreId,
+            ClusterVariableSecretReferenceValue::getSecretReference,
+            ClusterVariableSecretReferenceValue::getPath)
+        .containsExactly(tuple("", "token", "/auth"));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/UpdateClusterVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/UpdateClusterVariableTest.java
@@ -463,4 +463,36 @@ public final class UpdateClusterVariableTest {
         .hasRecordType(RecordType.EVENT);
     assertThat(record.getValue().getKind()).isEqualTo(ClusterVariableKind.JSON);
   }
+
+  @Test
+  public void shouldOnlyPreserveKindFromStoredStateOnUpdate() {
+    // given — variable created with a non-default kind and non-empty metadata
+    final Map<String, Object> originalMetadata = Map.of("owner", "team-a");
+    ENGINE_RULE
+        .clusterVariables()
+        .withName("KEY_ONLY_KIND_PRESERVED")
+        .setGlobalScope()
+        .withValue("\"VALUE\"")
+        .withMetadata(originalMetadata)
+        .withKind(ClusterVariableKind.SECRET_REFERENCE)
+        .create();
+
+    // when — update command carries a new value but no metadata and no kind
+    final var record =
+        ENGINE_RULE
+            .clusterVariables()
+            .withName("KEY_ONLY_KIND_PRESERVED")
+            .setGlobalScope()
+            .withValue("\"UPDATED_VALUE\"")
+            .update();
+
+    // then — kind is recovered from stored state; every other field takes exactly what the
+    // command carried, none of it recovered from stored state
+    Assertions.assertThat(record)
+        .hasIntent(ClusterVariableIntent.UPDATED)
+        .hasRecordType(RecordType.EVENT);
+    Assertions.assertThat(record.getValue()).hasValue("\"UPDATED_VALUE\"");
+    assertThat(record.getValue().getKind()).isEqualTo(ClusterVariableKind.SECRET_REFERENCE);
+    assertThat(record.getValue().getMetadata()).isEmpty();
+  }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonAppend;
 import io.camunda.zeebe.exporter.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
@@ -48,6 +49,7 @@ final class BulkIndexRequest {
           .addMixIn(JobBatchRecordValue.class, JobBatchMixin.class)
           .addMixIn(UserTaskRecordValue.class, BusinessIdMixin.class)
           .addMixIn(DecisionEvaluationRecordValue.class, BusinessIdMixin.class)
+          .addMixIn(ClusterVariableRecordValue.class, ClusterVariableMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -65,6 +67,8 @@ final class BulkIndexRequest {
   private static final String LEASE_TOKEN_PROPERTY = "leaseToken";
   private static final String SECRET_REFERENCES_PROPERTY = "secretReferences";
   private static final String WITH_LEASE_PROPERTY = "withLease";
+  private static final String METADATA_PROPERTY = "metadata";
+  private static final String KIND_PROPERTY = "kind";
   private final List<IndexOperation> operations = new ArrayList<>();
   private BulkIndexAction lastIndexedMetadata;
   private int memoryUsageBytes = 0;
@@ -199,4 +203,7 @@ final class BulkIndexRequest {
   /** Shared by record values that only need to strip {@code businessId} for previous versions. */
   @JsonIgnoreProperties({BUSINESS_ID_PROPERTY})
   private static final class BusinessIdMixin {}
+
+  @JsonIgnoreProperties({METADATA_PROPERTY, KIND_PROPERTY, SECRET_REFERENCES_PROPERTY})
+  private static final class ClusterVariableMixin {}
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-cluster-variable-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-cluster-variable-template.json
@@ -39,6 +39,19 @@
             },
             "metadata": {
               "enabled": false
+            },
+            "secretReferences": {
+              "properties": {
+                "storeId": {
+                  "type": "keyword"
+                },
+                "secretReference": {
+                  "type": "keyword"
+                },
+                "path": {
+                  "type": "keyword"
+                }
+              }
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -14,6 +14,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.exporter.BulkIndexRequest.IndexOperation;
 import io.camunda.zeebe.exporter.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
@@ -23,6 +25,7 @@ import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -30,6 +33,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -766,6 +770,88 @@ final class BulkIndexRequestTest {
           .describedAs(
               "Expect that decision evaluation records are serialized with businessId on current version")
           .containsExactly("order-123");
+    }
+
+    @Test
+    void shouldIndexClusterVariableRecordWithoutMetadataKindAndSecretReferencesOnPreviousVersion() {
+      // given
+      final var metadata = Map.of("credentialType", "OAUTH2");
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.CLUSTER_VARIABLE,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new ClusterVariableRecord()
+                              .setName("cluster-variable")
+                              .setMetadata(
+                                  new UnsafeBuffer(MsgPackConverter.convertToMsgPack(metadata)))
+                              .setKind(ClusterVariableKind.SECRET_REFERENCE)
+                              .addSecretReference("store", "secret", "/customHeaders")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .describedAs(
+              "Expect that cluster variable records are NOT serialized with metadata, kind, or"
+                  + " secretReferences on previous version")
+          .allSatisfy(
+              value ->
+                  assertThat((Map<String, Object>) value)
+                      .doesNotContainKeys("metadata", "kind", "secretReferences"));
+    }
+
+    @Test
+    void shouldIndexClusterVariableRecordWithMetadataKindAndSecretReferencesOnCurrentVersion() {
+      // given
+      final var metadata = Map.of("credentialType", "OAUTH2");
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.CLUSTER_VARIABLE,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new ClusterVariableRecord()
+                              .setName("cluster-variable")
+                              .setMetadata(
+                                  new UnsafeBuffer(MsgPackConverter.convertToMsgPack(metadata)))
+                              .setKind(ClusterVariableKind.SECRET_REFERENCE)
+                              .addSecretReference("store", "secret", "/customHeaders")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .describedAs(
+              "Expect that cluster variable records are serialized with metadata, kind, and"
+                  + " secretReferences on current version")
+          .allSatisfy(
+              value -> {
+                final var valueMap = (Map<String, Object>) value;
+                assertThat(valueMap).containsKey("metadata");
+                assertThat((Map<String, Object>) valueMap.get("metadata"))
+                    .containsExactlyInAnyOrderEntriesOf(metadata);
+                assertThat(valueMap.get("kind")).isEqualTo("SECRET_REFERENCE");
+                assertThat((List<Map<String, Object>>) valueMap.get("secretReferences"))
+                    .containsExactly(
+                        Map.of(
+                            "storeId", "store",
+                            "secretReference", "secret",
+                            "path", "/customHeaders"));
+              });
     }
 
     private Record<?> deserializeSource(final IndexOperation operation) {

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonAppend;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
@@ -48,6 +49,7 @@ final class BulkIndexRequest {
           .addMixIn(JobBatchRecordValue.class, JobBatchMixin.class)
           .addMixIn(UserTaskRecordValue.class, BusinessIdMixin.class)
           .addMixIn(DecisionEvaluationRecordValue.class, BusinessIdMixin.class)
+          .addMixIn(ClusterVariableRecordValue.class, ClusterVariableMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -65,6 +67,8 @@ final class BulkIndexRequest {
   private static final String LEASE_TOKEN_PROPERTY = "leaseToken";
   private static final String SECRET_REFERENCES_PROPERTY = "secretReferences";
   private static final String WITH_LEASE_PROPERTY = "withLease";
+  private static final String METADATA_PROPERTY = "metadata";
+  private static final String KIND_PROPERTY = "kind";
   private final List<IndexOperation> operations = new ArrayList<>();
   private BulkIndexAction lastIndexedMetadata;
   private int memoryUsageBytes = 0;
@@ -199,4 +203,7 @@ final class BulkIndexRequest {
   /** Shared by record values that only need to strip {@code businessId} for previous versions. */
   @JsonIgnoreProperties({BUSINESS_ID_PROPERTY})
   private static final class BusinessIdMixin {}
+
+  @JsonIgnoreProperties({METADATA_PROPERTY, KIND_PROPERTY, SECRET_REFERENCES_PROPERTY})
+  private static final class ClusterVariableMixin {}
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-cluster-variable-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-cluster-variable-template.json
@@ -45,6 +45,19 @@
             },
             "metadata": {
               "enabled": false
+            },
+            "secretReferences": {
+              "properties": {
+                "storeId": {
+                  "type": "keyword"
+                },
+                "secretReference": {
+                  "type": "keyword"
+                },
+                "path": {
+                  "type": "keyword"
+                }
+              }
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -14,6 +14,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.exporter.opensearch.BulkIndexRequest.IndexOperation;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
@@ -23,6 +25,7 @@ import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -30,6 +33,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -780,6 +784,90 @@ final class BulkIndexRequestTest {
           .describedAs(
               "Expect that decision evaluation records are serialized with businessId on current version")
           .containsExactly("order-123");
+    }
+
+    @Test
+    void shouldIndexClusterVariableRecordWithoutMetadataKindAndSecretReferencesOnPreviousVersion()
+        throws IOException {
+      // given
+      final var metadata = Map.of("credentialType", "OAUTH2");
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.CLUSTER_VARIABLE,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new ClusterVariableRecord()
+                              .setName("cluster-variable")
+                              .setMetadata(
+                                  new UnsafeBuffer(MsgPackConverter.convertToMsgPack(metadata)))
+                              .setKind(ClusterVariableKind.SECRET_REFERENCE)
+                              .addSecretReference("store", "secret", "/customHeaders")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .describedAs(
+              "Expect that cluster variable records are NOT serialized with metadata, kind, or"
+                  + " secretReferences on previous version")
+          .allSatisfy(
+              value ->
+                  assertThat((Map<String, Object>) value)
+                      .doesNotContainKeys("metadata", "kind", "secretReferences"));
+    }
+
+    @Test
+    void shouldIndexClusterVariableRecordWithMetadataKindAndSecretReferencesOnCurrentVersion()
+        throws IOException {
+      // given
+      final var metadata = Map.of("credentialType", "OAUTH2");
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.CLUSTER_VARIABLE,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new ClusterVariableRecord()
+                              .setName("cluster-variable")
+                              .setMetadata(
+                                  new UnsafeBuffer(MsgPackConverter.convertToMsgPack(metadata)))
+                              .setKind(ClusterVariableKind.SECRET_REFERENCE)
+                              .addSecretReference("store", "secret", "/customHeaders")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .describedAs(
+              "Expect that cluster variable records are serialized with metadata, kind, and"
+                  + " secretReferences on current version")
+          .allSatisfy(
+              value -> {
+                final var valueMap = (Map<String, Object>) value;
+                assertThat(valueMap).containsKey("metadata");
+                assertThat((Map<String, Object>) valueMap.get("metadata"))
+                    .containsExactlyInAnyOrderEntriesOf(metadata);
+                assertThat(valueMap.get("kind")).isEqualTo("SECRET_REFERENCE");
+                assertThat((List<Map<String, Object>>) valueMap.get("secretReferences"))
+                    .containsExactly(
+                        Map.of(
+                            "storeId", "store",
+                            "secretReference", "secret",
+                            "path", "/customHeaders"));
+              });
     }
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecord.java
@@ -8,17 +8,21 @@
 package io.camunda.zeebe.protocol.impl.record.value.clustervariable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue.ClusterVariableSecretReferenceValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -32,6 +36,7 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   private static final StringValue SCOPE_KEY = new StringValue("scope");
   private static final StringValue METADATA_KEY = new StringValue("metadata");
   private static final StringValue KIND_KEY = new StringValue("kind");
+  private static final StringValue SECRET_REFERENCES_KEY = new StringValue("secretReferences");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final BinaryProperty valueProp =
@@ -42,15 +47,18 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   private final DocumentProperty metadataProp = new DocumentProperty(METADATA_KEY);
   private final EnumProperty<ClusterVariableKind> kindProp =
       new EnumProperty<>(KIND_KEY, ClusterVariableKind.class, ClusterVariableKind.JSON);
+  private final ArrayProperty<ClusterVariableSecretReference> secretReferencesProp =
+      new ArrayProperty<>(SECRET_REFERENCES_KEY, ClusterVariableSecretReference::new);
 
   public ClusterVariableRecord() {
-    super(6);
+    super(7);
     declareProperty(nameProp)
         .declareProperty(valueProp)
         .declareProperty(scopeProp)
         .declareProperty(tenantIdProp)
         .declareProperty(metadataProp)
-        .declareProperty(kindProp);
+        .declareProperty(kindProp)
+        .declareProperty(secretReferencesProp);
   }
 
   @Override
@@ -144,5 +152,52 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   @JsonIgnore
   public boolean isGloballyScoped() {
     return ClusterVariableScope.GLOBAL.equals(scopeProp.getValue());
+  }
+
+  @Override
+  public List<ClusterVariableSecretReferenceValue> getSecretReferences() {
+    // detach copies so the returned list stays valid if this record is reused or reset later
+    return secretReferencesProp.stream()
+        .map(
+            element -> {
+              final var copy = new ClusterVariableSecretReference();
+              copy.copy(element);
+              return (ClusterVariableSecretReferenceValue) copy;
+            })
+        .toList();
+  }
+
+  /**
+   * Direct access to the secret reference elements, without the detached copies of {@link
+   * #getSecretReferences()}. The elements stay owned by this record; do not hold on to them.
+   */
+  @JsonIgnore
+  public ValueArray<ClusterVariableSecretReference> secretReferences() {
+    return secretReferencesProp;
+  }
+
+  @JsonIgnore
+  public boolean hasSecretReferences() {
+    return !secretReferencesProp.isEmpty();
+  }
+
+  public ClusterVariableRecord addSecretReference(
+      final String storeId, final String secretReference, final String path) {
+    secretReferencesProp
+        .add()
+        .setStoreId(storeId)
+        .setSecretReference(secretReference)
+        .setPath(path);
+    return this;
+  }
+
+  /**
+   * Copies the values buffer-to-buffer, avoiding the String round-trip of {@link
+   * #addSecretReference}.
+   */
+  public ClusterVariableRecord copySecretReferencesFrom(final ClusterVariableRecord other) {
+    secretReferencesProp.reset();
+    other.secretReferencesProp.forEach(reference -> secretReferencesProp.add().wrap(reference));
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecord.java
@@ -190,14 +190,4 @@ public class ClusterVariableRecord extends UnifiedRecordValue
         .setPath(path);
     return this;
   }
-
-  /**
-   * Copies the values buffer-to-buffer, avoiding the String round-trip of {@link
-   * #addSecretReference}.
-   */
-  public ClusterVariableRecord copySecretReferencesFrom(final ClusterVariableRecord other) {
-    secretReferencesProp.reset();
-    other.secretReferencesProp.forEach(reference -> secretReferencesProp.add().wrap(reference));
-    return this;
-  }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableSecretReference.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableSecretReference.java
@@ -7,14 +7,12 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.clustervariable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue.ClusterVariableSecretReferenceValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import org.agrona.DirectBuffer;
 
 @JsonIgnoreProperties({
   /* Inherited from ObjectValue. They have no purpose in exported JSON records. */
@@ -69,32 +67,9 @@ public final class ClusterVariableSecretReference extends ObjectValue
     return this;
   }
 
-  @JsonIgnore
-  public DirectBuffer getStoreIdBuffer() {
-    return storeIdProp.getValue();
-  }
-
-  @JsonIgnore
-  public DirectBuffer getSecretReferenceBuffer() {
-    return secretReferenceProp.getValue();
-  }
-
-  @JsonIgnore
-  public DirectBuffer getPathBuffer() {
-    return pathProp.getValue();
-  }
-
   public void copy(final ClusterVariableSecretReferenceValue secretReference) {
     setStoreId(secretReference.getStoreId());
     setSecretReference(secretReference.getSecretReference());
     setPath(secretReference.getPath());
-  }
-
-  /** Copies the values buffer-to-buffer, avoiding the String round-trip of {@link #copy}. */
-  public ClusterVariableSecretReference wrap(final ClusterVariableSecretReference other) {
-    storeIdProp.setValue(other.getStoreIdBuffer());
-    secretReferenceProp.setValue(other.getSecretReferenceBuffer());
-    pathProp.setValue(other.getPathBuffer());
-    return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableSecretReference.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableSecretReference.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.clustervariable;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue.ClusterVariableSecretReferenceValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
+
+@JsonIgnoreProperties({
+  /* Inherited from ObjectValue. They have no purpose in exported JSON records. */
+  "encodedLength",
+  "empty"
+})
+public final class ClusterVariableSecretReference extends ObjectValue
+    implements ClusterVariableSecretReferenceValue {
+
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue STORE_ID_KEY = new StringValue("storeId");
+  private static final StringValue SECRET_REFERENCE_KEY = new StringValue("secretReference");
+  private static final StringValue PATH_KEY = new StringValue("path");
+
+  private final StringProperty storeIdProp = new StringProperty(STORE_ID_KEY, "");
+  private final StringProperty secretReferenceProp = new StringProperty(SECRET_REFERENCE_KEY, "");
+  // RFC 6901 JSON pointer of the value leaf the reference was found in
+  private final StringProperty pathProp = new StringProperty(PATH_KEY, "");
+
+  public ClusterVariableSecretReference() {
+    super(3);
+    declareProperty(storeIdProp).declareProperty(secretReferenceProp).declareProperty(pathProp);
+  }
+
+  @Override
+  public String getStoreId() {
+    return BufferUtil.bufferAsString(storeIdProp.getValue());
+  }
+
+  public ClusterVariableSecretReference setStoreId(final String storeId) {
+    storeIdProp.setValue(storeId);
+    return this;
+  }
+
+  @Override
+  public String getSecretReference() {
+    return BufferUtil.bufferAsString(secretReferenceProp.getValue());
+  }
+
+  public ClusterVariableSecretReference setSecretReference(final String secretReference) {
+    secretReferenceProp.setValue(secretReference);
+    return this;
+  }
+
+  @Override
+  public String getPath() {
+    return BufferUtil.bufferAsString(pathProp.getValue());
+  }
+
+  public ClusterVariableSecretReference setPath(final String path) {
+    pathProp.setValue(path);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getStoreIdBuffer() {
+    return storeIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getSecretReferenceBuffer() {
+    return secretReferenceProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getPathBuffer() {
+    return pathProp.getValue();
+  }
+
+  public void copy(final ClusterVariableSecretReferenceValue secretReference) {
+    setStoreId(secretReference.getStoreId());
+    setSecretReference(secretReference.getSecretReference());
+    setPath(secretReference.getPath());
+  }
+
+  /** Copies the values buffer-to-buffer, avoiding the String round-trip of {@link #copy}. */
+  public ClusterVariableSecretReference wrap(final ClusterVariableSecretReference other) {
+    storeIdProp.setValue(other.getStoreIdBuffer());
+    secretReferenceProp.setValue(other.getSecretReferenceBuffer());
+    pathProp.setValue(other.getPathBuffer());
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3461,31 +3461,7 @@ final class JsonSerializableToJsonTest {
       // ////////////////////////////////////
       /////////////////////////////////////////////////////////////////////////////////////////////
       {
-        "ClusterVariableRecord (global scope with metadata)",
-        (Supplier<ClusterVariableRecord>)
-            () ->
-                new ClusterVariableRecord()
-                    .setName("myVar")
-                    .setGlobalScope()
-                    .setTenantId("<default>")
-                    .setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack("42")))
-                    .setMetadata(
-                        new UnsafeBuffer(
-                            MsgPackConverter.convertToMsgPack(Map.of("credentialType", "OAUTH2"))))
-                    .setKind(ClusterVariableKind.SECRET_REFERENCE),
-        """
-                {
-                  "name": "myVar",
-                  "value": "42",
-                  "scope": "GLOBAL",
-                  "tenantId": "<default>",
-                  "metadata": { "credentialType": "OAUTH2" },
-                  "kind": "SECRET_REFERENCE"
-                }
-                """
-      },
-      {
-        "ClusterVariableRecord (tenant scope without metadata)",
+        "ClusterVariableRecord (minimal)",
         (Supplier<ClusterVariableRecord>)
             () ->
                 new ClusterVariableRecord()
@@ -3500,7 +3476,43 @@ final class JsonSerializableToJsonTest {
                   "scope": "TENANT",
                   "tenantId": "tenant-1",
                   "metadata": {},
-                  "kind": "JSON"
+                  "kind": "JSON",
+                  "secretReferences": []
+                }
+                """
+      },
+      {
+        "ClusterVariableRecord (fully populated)",
+        (Supplier<ClusterVariableRecord>)
+            () ->
+                new ClusterVariableRecord()
+                    .setName("secretVar")
+                    .setGlobalScope()
+                    .setTenantId("<default>")
+                    .setValue(
+                        new UnsafeBuffer(
+                            MsgPackConverter.convertToMsgPack(
+                                Map.of("auth", "camunda.secrets.token"))))
+                    .setMetadata(
+                        new UnsafeBuffer(
+                            MsgPackConverter.convertToMsgPack(Map.of("credentialType", "OAUTH2"))))
+                    .setKind(ClusterVariableKind.SECRET_REFERENCE)
+                    .addSecretReference("", "token", "/auth"),
+        """
+                {
+                  "name": "secretVar",
+                  "value": "{\\"auth\\":\\"camunda.secrets.token\\"}",
+                  "scope": "GLOBAL",
+                  "tenantId": "<default>",
+                  "metadata": { "credentialType": "OAUTH2" },
+                  "kind": "SECRET_REFERENCE",
+                  "secretReferences": [
+                    {
+                      "storeId": "",
+                      "secretReference": "token",
+                      "path": "/auth"
+                    }
+                  ]
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableRecord.golden
@@ -8,17 +8,21 @@
 package io.camunda.zeebe.protocol.impl.record.value.clustervariable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue.ClusterVariableSecretReferenceValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -32,6 +36,7 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   private static final StringValue SCOPE_KEY = new StringValue("scope");
   private static final StringValue METADATA_KEY = new StringValue("metadata");
   private static final StringValue KIND_KEY = new StringValue("kind");
+  private static final StringValue SECRET_REFERENCES_KEY = new StringValue("secretReferences");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final BinaryProperty valueProp =
@@ -42,15 +47,18 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   private final DocumentProperty metadataProp = new DocumentProperty(METADATA_KEY);
   private final EnumProperty<ClusterVariableKind> kindProp =
       new EnumProperty<>(KIND_KEY, ClusterVariableKind.class, ClusterVariableKind.JSON);
+  private final ArrayProperty<ClusterVariableSecretReference> secretReferencesProp =
+      new ArrayProperty<>(SECRET_REFERENCES_KEY, ClusterVariableSecretReference::new);
 
   public ClusterVariableRecord() {
-    super(6);
+    super(7);
     declareProperty(nameProp)
         .declareProperty(valueProp)
         .declareProperty(scopeProp)
         .declareProperty(tenantIdProp)
         .declareProperty(metadataProp)
-        .declareProperty(kindProp);
+        .declareProperty(kindProp)
+        .declareProperty(secretReferencesProp);
   }
 
   @Override
@@ -144,5 +152,52 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   @JsonIgnore
   public boolean isGloballyScoped() {
     return ClusterVariableScope.GLOBAL.equals(scopeProp.getValue());
+  }
+
+  @Override
+  public List<ClusterVariableSecretReferenceValue> getSecretReferences() {
+    // detach copies so the returned list stays valid if this record is reused or reset later
+    return secretReferencesProp.stream()
+        .map(
+            element -> {
+              final var copy = new ClusterVariableSecretReference();
+              copy.copy(element);
+              return (ClusterVariableSecretReferenceValue) copy;
+            })
+        .toList();
+  }
+
+  /**
+   * Direct access to the secret reference elements, without the detached copies of {@link
+   * #getSecretReferences()}. The elements stay owned by this record; do not hold on to them.
+   */
+  @JsonIgnore
+  public ValueArray<ClusterVariableSecretReference> secretReferences() {
+    return secretReferencesProp;
+  }
+
+  @JsonIgnore
+  public boolean hasSecretReferences() {
+    return !secretReferencesProp.isEmpty();
+  }
+
+  public ClusterVariableRecord addSecretReference(
+      final String storeId, final String secretReference, final String path) {
+    secretReferencesProp
+        .add()
+        .setStoreId(storeId)
+        .setSecretReference(secretReference)
+        .setPath(path);
+    return this;
+  }
+
+  /**
+   * Copies the values buffer-to-buffer, avoiding the String round-trip of {@link
+   * #addSecretReference}.
+   */
+  public ClusterVariableRecord copySecretReferencesFrom(final ClusterVariableRecord other) {
+    secretReferencesProp.reset();
+    other.secretReferencesProp.forEach(reference -> secretReferencesProp.add().wrap(reference));
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableRecord.golden
@@ -190,14 +190,4 @@ public class ClusterVariableRecord extends UnifiedRecordValue
         .setPath(path);
     return this;
   }
-
-  /**
-   * Copies the values buffer-to-buffer, avoiding the String round-trip of {@link
-   * #addSecretReference}.
-   */
-  public ClusterVariableRecord copySecretReferencesFrom(final ClusterVariableRecord other) {
-    secretReferencesProp.reset();
-    other.secretReferencesProp.forEach(reference -> secretReferencesProp.add().wrap(reference));
-    return this;
-  }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableSecretReference.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableSecretReference.golden
@@ -7,14 +7,12 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.clustervariable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue.ClusterVariableSecretReferenceValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import org.agrona.DirectBuffer;
 
 @JsonIgnoreProperties({
   /* Inherited from ObjectValue. They have no purpose in exported JSON records. */
@@ -69,32 +67,9 @@ public final class ClusterVariableSecretReference extends ObjectValue
     return this;
   }
 
-  @JsonIgnore
-  public DirectBuffer getStoreIdBuffer() {
-    return storeIdProp.getValue();
-  }
-
-  @JsonIgnore
-  public DirectBuffer getSecretReferenceBuffer() {
-    return secretReferenceProp.getValue();
-  }
-
-  @JsonIgnore
-  public DirectBuffer getPathBuffer() {
-    return pathProp.getValue();
-  }
-
   public void copy(final ClusterVariableSecretReferenceValue secretReference) {
     setStoreId(secretReference.getStoreId());
     setSecretReference(secretReference.getSecretReference());
     setPath(secretReference.getPath());
-  }
-
-  /** Copies the values buffer-to-buffer, avoiding the String round-trip of {@link #copy}. */
-  public ClusterVariableSecretReference wrap(final ClusterVariableSecretReference other) {
-    storeIdProp.setValue(other.getStoreIdBuffer());
-    secretReferenceProp.setValue(other.getSecretReferenceBuffer());
-    pathProp.setValue(other.getPathBuffer());
-    return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableSecretReference.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableSecretReference.golden
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.clustervariable;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue.ClusterVariableSecretReferenceValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
+
+@JsonIgnoreProperties({
+  /* Inherited from ObjectValue. They have no purpose in exported JSON records. */
+  "encodedLength",
+  "empty"
+})
+public final class ClusterVariableSecretReference extends ObjectValue
+    implements ClusterVariableSecretReferenceValue {
+
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue STORE_ID_KEY = new StringValue("storeId");
+  private static final StringValue SECRET_REFERENCE_KEY = new StringValue("secretReference");
+  private static final StringValue PATH_KEY = new StringValue("path");
+
+  private final StringProperty storeIdProp = new StringProperty(STORE_ID_KEY, "");
+  private final StringProperty secretReferenceProp = new StringProperty(SECRET_REFERENCE_KEY, "");
+  // RFC 6901 JSON pointer of the value leaf the reference was found in
+  private final StringProperty pathProp = new StringProperty(PATH_KEY, "");
+
+  public ClusterVariableSecretReference() {
+    super(3);
+    declareProperty(storeIdProp).declareProperty(secretReferenceProp).declareProperty(pathProp);
+  }
+
+  @Override
+  public String getStoreId() {
+    return BufferUtil.bufferAsString(storeIdProp.getValue());
+  }
+
+  public ClusterVariableSecretReference setStoreId(final String storeId) {
+    storeIdProp.setValue(storeId);
+    return this;
+  }
+
+  @Override
+  public String getSecretReference() {
+    return BufferUtil.bufferAsString(secretReferenceProp.getValue());
+  }
+
+  public ClusterVariableSecretReference setSecretReference(final String secretReference) {
+    secretReferenceProp.setValue(secretReference);
+    return this;
+  }
+
+  @Override
+  public String getPath() {
+    return BufferUtil.bufferAsString(pathProp.getValue());
+  }
+
+  public ClusterVariableSecretReference setPath(final String path) {
+    pathProp.setValue(path);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getStoreIdBuffer() {
+    return storeIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getSecretReferenceBuffer() {
+    return secretReferenceProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getPathBuffer() {
+    return pathProp.getValue();
+  }
+
+  public void copy(final ClusterVariableSecretReferenceValue secretReference) {
+    setStoreId(secretReference.getStoreId());
+    setSecretReference(secretReference.getSecretReference());
+    setPath(secretReference.getPath());
+  }
+
+  /** Copies the values buffer-to-buffer, avoiding the String round-trip of {@link #copy}. */
+  public ClusterVariableSecretReference wrap(final ClusterVariableSecretReference other) {
+    storeIdProp.setValue(other.getStoreIdBuffer());
+    secretReferenceProp.setValue(other.getSecretReferenceBuffer());
+    pathProp.setValue(other.getPathBuffer());
+    return this;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
@@ -97,7 +97,7 @@ public interface ClusterVariableRecordValue extends RecordValue, TenantOwned {
   /**
    * Returns the secret references detected in a SECRET_REFERENCE value: for each {@code
    * camunda.secrets.<name>} occurrence, the reference name and the RFC 6901 JSON pointer of the
-   * value leaf it was found in. Empty for JSON-kind variables. Defaults to an empty list.
+   * value leaf it was found in. Empty for JSON-kind variables.
    *
    * @return the secret references detected in this variable's value
    */

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.protocol.record.value;
 
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import java.util.List;
 import java.util.Map;
 import org.immutables.value.Value;
 
@@ -34,6 +35,8 @@ import org.immutables.value.Value;
  *   <li>{@link #getScope()} – the current scope of the cluster variable.
  *   <li>{@link #getMetadata()} – the metadata attached to this cluster variable.
  *   <li>{@link #getKind()} – the kind of value stored in this cluster variable.
+ *   <li>{@link #getSecretReferences()} – the secret references detected in a SECRET_REFERENCE
+ *       value.
  * </ul>
  *
  * @see RecordValue;
@@ -89,5 +92,38 @@ public interface ClusterVariableRecordValue extends RecordValue, TenantOwned {
   @Value.Default
   default ClusterVariableKind getKind() {
     return ClusterVariableKind.JSON;
+  }
+
+  /**
+   * Returns the secret references detected in a SECRET_REFERENCE value: for each {@code
+   * camunda.secrets.<name>} occurrence, the reference name and the RFC 6901 JSON pointer of the
+   * value leaf it was found in. Empty for JSON-kind variables. Defaults to an empty list.
+   *
+   * @return the secret references detected in this variable's value
+   */
+  List<ClusterVariableSecretReferenceValue> getSecretReferences();
+
+  /**
+   * A secret reference detected in a SECRET_REFERENCE cluster variable value. Carries the reference
+   * identifier and the JSON pointer of the leaf it occurs in, never the resolved secret value.
+   */
+  @Value.Immutable
+  @ImmutableProtocol(builder = ImmutableClusterVariableSecretReferenceValue.Builder.class)
+  interface ClusterVariableSecretReferenceValue {
+
+    /**
+     * @return the identifier of the secret store that holds the referenced secret (empty for now)
+     */
+    String getStoreId();
+
+    /**
+     * @return the secret name, e.g. {@code token} for {@code camunda.secrets.token}; not the value
+     */
+    String getSecretReference();
+
+    /**
+     * @return the RFC 6901 JSON pointer of the value leaf the reference was found in
+     */
+    String getPath();
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Second of the three pieces of #56559. When a `SECRET_REFERENCE` cluster variable is created or updated, this scans the value for embedded `camunda.secrets.<name>` references and stores them on the `ClusterVariableRecord` — the secret name plus the RFC 6901 JSON pointer of the leaf it was found in. Doing it at write time keeps the eventual job-creation lookup cheap: the scan runs once on the origin partition and the result rides the distributed command/event to the other partitions unchanged, so receivers never re-scan. `JSON`-kind variables are never scanned.

A couple of things worth calling out:
1. On update the `kind` is read from the stored record (the update command may omit it), and `applyUpdate` copies the references onto the stored record with a reset-then-add — so a value updated from secrets to none ends up empty rather than accumulating stale references.
2. Both cluster-variable exporter index templates are `dynamic: strict`, so I extended them with the new `secretReferences` mapping in the same change — otherwise the new field would break the exporter.

The protocol value and record property mirror the existing `JobSecretReference` feature. The new msgpack property is an empty-by-default array, so it's backwards compatible and the golden was regenerated. Consumption (folding these references onto a job at creation) is the next sub-issue and out of scope here.

Implemented by Claude against a plan I reviewed; unit tests (scanner behavior, create/update scanning, single- and multi-partition carry) and the golden regeneration are included.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #58931
