### PR TITLE
fix: evaluate output mappings one by one in modeling order

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Engine.java
+++ b/configuration/src/main/java/io/camunda/configuration/Engine.java
@@ -19,6 +19,8 @@ public class Engine {
   private static final Set<String> LEGACY_MAX_PROCESS_DEPTH_PROPERTIES =
       Set.of("zeebe.broker.experimental.engine.maxProcessDepth");
 
+  private static final boolean DEFAULT_EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER = true;
+
   /** Configuration properties for the engine's distribution settings. */
   @NestedConfigurationProperty private Distribution distribution = new Distribution();
 
@@ -48,6 +50,19 @@ public class Engine {
    * guard against unbounded process recursion.
    */
   private int maxProcessDepth = DEFAULT_MAX_PROCESS_DEPTH;
+
+  /**
+   * Controls how output-variable mappings with colliding targets (the same target, or one target a
+   * prefix of another, e.g. {@code a} and {@code a.b}) are evaluated when a process has more than
+   * one mapping writing to such a target. When enabled (default), every mapping's source is
+   * evaluated, in modeling order, and a failing source raises an incident. When disabled, the
+   * earlier colliding mapping's source is silently skipped, never evaluated, reproducing the
+   * behavior prior to this change. Disabling this can suppress an incident from a source that would
+   * otherwise now fail on an already-deployed process, but is a compatibility escape hatch, not
+   * something to reach for by default.
+   */
+  private boolean evaluateDuplicateOutputMappingTargetsInOrder =
+      DEFAULT_EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER;
 
   public Distribution getDistribution() {
     return distribution;
@@ -124,5 +139,15 @@ public class Engine {
 
   public void setMaxProcessDepth(final int maxProcessDepth) {
     this.maxProcessDepth = maxProcessDepth;
+  }
+
+  public boolean isEvaluateDuplicateOutputMappingTargetsInOrder() {
+    return evaluateDuplicateOutputMappingTargetsInOrder;
+  }
+
+  public void setEvaluateDuplicateOutputMappingTargetsInOrder(
+      final boolean evaluateDuplicateOutputMappingTargetsInOrder) {
+    this.evaluateDuplicateOutputMappingTargetsInOrder =
+        evaluateDuplicateOutputMappingTargetsInOrder;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -266,6 +266,12 @@ public class BrokerBasedPropertiesOverride {
 
     override
         .getExperimental()
+        .getFeatures()
+        .setEvaluateDuplicateOutputMappingTargetsInOrder(
+            camunda.getProcessing().getEngine().isEvaluateDuplicateOutputMappingTargetsInOrder());
+
+    override
+        .getExperimental()
         .getEngine()
         .setMaxProcessDepth(camunda.getProcessing().getEngine().getMaxProcessDepth());
   }

--- a/configuration/src/test/java/io/camunda/configuration/EngineTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.FeatureFlagsCfg;
 import io.camunda.zeebe.broker.system.configuration.engine.EngineCfg;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -74,6 +75,41 @@ public class EngineTest {
     @Test
     void shouldSetMaxProcessDepthFromNew() {
       assertThat(brokerCfg.getExperimental().getEngine()).returns(5, EngineCfg::getMaxProcessDepth);
+    }
+  }
+
+  @Nested
+  class WithNothingSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNothingSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldEvaluateDuplicateOutputMappingTargetsInOrderByDefault() {
+      assertThat(brokerCfg.getExperimental().getFeatures())
+          .returns(true, FeatureFlagsCfg::isEvaluateDuplicateOutputMappingTargetsInOrder);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.engine.evaluate-duplicate-output-mapping-targets-in-order=false"
+      })
+  class WithEvaluateDuplicateOutputMappingTargetsInOrderConfigured {
+    final BrokerBasedProperties brokerCfg;
+
+    WithEvaluateDuplicateOutputMappingTargetsInOrderConfigured(
+        @Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetEvaluateDuplicateOutputMappingTargetsInOrder() {
+      assertThat(brokerCfg.getExperimental().getFeatures())
+          .returns(false, FeatureFlagsCfg::isEvaluateDuplicateOutputMappingTargetsInOrder);
     }
   }
 }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -285,6 +285,7 @@ processing.engine.caches.resource-cache-capacity
 processing.engine.distribution.max-backoff-duration
 processing.engine.distribution.pause-command-distribution
 processing.engine.distribution.redistribution-interval
+processing.engine.evaluate-duplicate-output-mapping-targets-in-order
 processing.engine.job.include-variables-in-job-completed-event
 processing.engine.job.timeout-checker-batch-limit
 processing.engine.job.timeout-checker-polling-interval

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
@@ -40,6 +40,8 @@ public final class FeatureFlagsCfg {
   private boolean enableMessageBodyOnExpired = DEFAULT_SETTINGS.enableMessageBodyOnExpired();
   private boolean evaluateBoundaryEventCorrelationKeyInActivityScope =
       DEFAULT_SETTINGS.evaluateBoundaryEventCorrelationKeyInActivityScope();
+  private boolean evaluateDuplicateOutputMappingTargetsInOrder =
+      DEFAULT_SETTINGS.evaluateDuplicateOutputMappingTargetsInOrder();
 
   public boolean isEnableYieldingDueDateChecker() {
     return enableYieldingDueDateChecker;
@@ -100,6 +102,16 @@ public final class FeatureFlagsCfg {
         evaluateBoundaryEventCorrelationKeyInActivityScope;
   }
 
+  public boolean isEvaluateDuplicateOutputMappingTargetsInOrder() {
+    return evaluateDuplicateOutputMappingTargetsInOrder;
+  }
+
+  public void setEvaluateDuplicateOutputMappingTargetsInOrder(
+      final boolean evaluateDuplicateOutputMappingTargetsInOrder) {
+    this.evaluateDuplicateOutputMappingTargetsInOrder =
+        evaluateDuplicateOutputMappingTargetsInOrder;
+  }
+
   public FeatureFlags toFeatureFlags() {
     return new FeatureFlags(
         enableYieldingDueDateChecker,
@@ -108,7 +120,8 @@ public final class FeatureFlagsCfg {
         enableTimerDueDateCheckerAsync,
         enableStraightThroughProcessingLoopDetector,
         enableMessageBodyOnExpired,
-        evaluateBoundaryEventCorrelationKeyInActivityScope
+        evaluateBoundaryEventCorrelationKeyInActivityScope,
+        evaluateDuplicateOutputMappingTargetsInOrder
         /*, enableFoo*/ );
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -233,8 +233,8 @@ class PartitionManagerStepTest {
     @Test
     void shouldPassDistinctFeatureFlagsToEachPhysicalTenant() throws Exception {
       // given — two tenants each with a distinct FeatureFlags instance
-      final var flagsA = new FeatureFlags(true, false, false, false, false, false, true);
-      final var flagsB = new FeatureFlags(false, false, true, false, false, false, false);
+      final var flagsA = new FeatureFlags(true, false, false, false, false, false, true, true);
+      final var flagsB = new FeatureFlags(false, false, true, false, false, false, false, true);
       final var secondTenantId = "second";
 
       final var secCfg = EngineSecurityConfigurations.unauthenticatedAndUnauthorized();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -263,6 +263,7 @@ public final class EngineProcessors {
             config,
             incidentMetrics,
             featureFlags.evaluateBoundaryEventCorrelationKeyInActivityScope(),
+            featureFlags.evaluateDuplicateOutputMappingTargetsInOrder(),
             cslCheck);
 
     typedRecordProcessors.withListener(bpmnBehaviors.incidentBehavior());
@@ -609,6 +610,7 @@ public final class EngineProcessors {
       final EngineConfiguration config,
       final IncidentMetrics incidentMetrics,
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
+      final boolean evaluateDuplicateOutputMappingTargetsInOrder,
       final CslAuthorizationCheck cslCheck) {
     return new BpmnBehaviorsImpl(
         processingState,
@@ -625,6 +627,7 @@ public final class EngineProcessors {
         config,
         incidentMetrics,
         evaluateBoundaryEventCorrelationKeyInActivityScope,
+        evaluateDuplicateOutputMappingTargetsInOrder,
         cslCheck);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -85,6 +85,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final EngineConfiguration config,
       final IncidentMetrics incidentMetrics,
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
+      final boolean evaluateDuplicateOutputMappingTargetsInOrder,
       final CslAuthorizationCheck cslCheck) {
 
     final var tenantClusterScope =
@@ -188,7 +189,11 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
     variableMappingBehavior =
         new BpmnVariableMappingBehavior(
-            expressionProcessor, processingState, variableBehavior, eventTriggerBehavior);
+            expressionProcessor,
+            processingState,
+            variableBehavior,
+            eventTriggerBehavior,
+            evaluateDuplicateOutputMappingTargetsInOrder);
 
     eventSubscriptionBehavior =
         new BpmnEventSubscriptionBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -17,7 +17,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCat
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
 import io.camunda.zeebe.engine.processing.deployment.model.element.InputMapping;
 import io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings;
-import io.camunda.zeebe.engine.processing.variable.InputMappingResultBuilder;
+import io.camunda.zeebe.engine.processing.variable.MappingResultBuilder;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
@@ -80,7 +80,7 @@ public final class BpmnVariableMappingBehavior {
       return Either.right(null);
     }
 
-    final var resultBuilder = new InputMappingResultBuilder();
+    final var resultBuilder = new MappingResultBuilder();
     // secret references (camunda.secrets.<name>) are resolved to their placeholder string only
     // for input mappings, so a modeled reference survives evaluation instead of nulling
     final var processor =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -30,6 +30,8 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
@@ -46,12 +48,14 @@ public final class BpmnVariableMappingBehavior {
   private final EventScopeInstanceState eventScopeInstanceState;
 
   private final EventTriggerBehavior eventTriggerBehavior;
+  private final boolean evaluateDuplicateOutputMappingTargetsInOrder;
 
   public BpmnVariableMappingBehavior(
       final ExpressionProcessor expressionProcessor,
       final ProcessingState processingState,
       final VariableBehavior variableBehavior,
-      final EventTriggerBehavior eventTriggerBehavior) {
+      final EventTriggerBehavior eventTriggerBehavior,
+      final boolean evaluateDuplicateOutputMappingTargetsInOrder) {
     this.expressionProcessor = expressionProcessor;
     inputMappingExpressionProcessor = expressionProcessor.withSecretReferenceContext();
     elementInstanceState = processingState.getElementInstanceState();
@@ -59,6 +63,8 @@ public final class BpmnVariableMappingBehavior {
     this.variableBehavior = variableBehavior;
     eventScopeInstanceState = processingState.getEventScopeInstanceState();
     this.eventTriggerBehavior = eventTriggerBehavior;
+    this.evaluateDuplicateOutputMappingTargetsInOrder =
+        evaluateDuplicateOutputMappingTargetsInOrder;
   }
 
   /**
@@ -163,7 +169,12 @@ public final class BpmnVariableMappingBehavior {
       final var processor =
           expressionProcessor.prependContext(name -> Either.left(resultBuilder.getVariable(name)));
 
-      for (final OutputMapping mapping : outputMappings.get()) {
+      final var mappingsToEvaluate =
+          evaluateDuplicateOutputMappingTargetsInOrder
+              ? outputMappings.get()
+              : withoutSupersededDuplicateTargets(outputMappings.get());
+
+      for (final OutputMapping mapping : mappingsToEvaluate) {
         final var result =
             processor.evaluateVariableMappingExpression(
                 mapping.source(), elementInstanceKey, tenantId);
@@ -271,5 +282,40 @@ public final class BpmnVariableMappingBehavior {
     } else {
       return false;
     }
+  }
+
+  /**
+   * Reproduces the target-collision handling of the removed combined-FEEL-context builder, for the
+   * {@code evaluateDuplicateOutputMappingTargetsInOrder} kill-switch: a mapping whose target path
+   * collides with an earlier one (equal, or one a prefix of the other) replaces it outright,
+   * keeping the FIRST colliding mapping's position but the LAST one's value -- mirroring how
+   * re-inserting an existing key into a {@code LinkedHashMap} keeps its iteration position but
+   * replaces its value. The superseded mapping's source is dropped entirely and never evaluated.
+   */
+  static List<OutputMapping> withoutSupersededDuplicateTargets(final List<OutputMapping> mappings) {
+    record Survivor(int firstIndex, OutputMapping mapping) {}
+
+    final var survivors = new ArrayList<Survivor>();
+    for (int i = 0; i < mappings.size(); i++) {
+      final var mapping = mappings.get(i);
+      var firstIndex = i;
+      final var iterator = survivors.iterator();
+      while (iterator.hasNext()) {
+        final var existing = iterator.next();
+        if (collides(existing.mapping().targetPath(), mapping.targetPath())) {
+          firstIndex = Math.min(firstIndex, existing.firstIndex());
+          iterator.remove();
+        }
+      }
+      survivors.add(new Survivor(firstIndex, mapping));
+    }
+    survivors.sort(Comparator.comparingInt(Survivor::firstIndex));
+    return survivors.stream().map(Survivor::mapping).toList();
+  }
+
+  private static boolean collides(final List<String> a, final List<String> b) {
+    final var shorter = a.size() <= b.size() ? a : b;
+    final var longer = a.size() <= b.size() ? b : a;
+    return longer.subList(0, shorter.size()).equals(shorter);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -92,7 +92,7 @@ public final class BpmnVariableMappingBehavior {
 
     for (final InputMapping mapping : inputMappings.get().mappings()) {
       final var result =
-          processor.evaluateVariableMappingSourceExpression(mapping.source(), scopeKey, tenantId);
+          processor.evaluateVariableMappingExpression(mapping.source(), scopeKey, tenantId);
       if (result.isLeft()) {
         return Either.left(result.getLeft());
       }
@@ -165,7 +165,7 @@ public final class BpmnVariableMappingBehavior {
 
       for (final OutputMapping mapping : outputMappings.get()) {
         final var result =
-            processor.evaluateVariableMappingSourceExpression(
+            processor.evaluateVariableMappingExpression(
                 mapping.source(), elementInstanceKey, tenantId);
         if (result.isLeft()) {
           return Either.left(result.getLeft());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
-import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
@@ -17,7 +16,9 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCat
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
 import io.camunda.zeebe.engine.processing.deployment.model.element.InputMapping;
 import io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings;
+import io.camunda.zeebe.engine.processing.deployment.model.element.OutputMapping;
 import io.camunda.zeebe.engine.processing.variable.MappingResultBuilder;
+import io.camunda.zeebe.engine.processing.variable.MsgPackPath;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
@@ -28,6 +29,8 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
 import org.jspecify.annotations.NonNull;
@@ -101,6 +104,12 @@ public final class BpmnVariableMappingBehavior {
   /**
    * Apply the output mappings for a BPMN element. Generally called on completing of the element.
    *
+   * <p>The mappings are evaluated one by one in modeling order. Each mapping's source expression
+   * sees the results of the earlier mappings (they take priority over same-named scope variables)
+   * and falls back to the element's variable scope otherwise. A nested target merges with the
+   * existing scope value at every path level. Evaluation stops at the first failing mapping and no
+   * variables are applied in that case.
+   *
    * @param context The current bpmn element context
    * @param element The current bpmn element
    * @return either void if successful, otherwise a failure
@@ -112,7 +121,7 @@ public final class BpmnVariableMappingBehavior {
     final long processDefinitionKey = record.getProcessDefinitionKey();
     final long processInstanceKey = record.getProcessInstanceKey();
     final String tenantId = context.getTenantId();
-    final Optional<Expression> outputMappingExpression = element.getOutputMappings();
+    final Optional<List<OutputMapping>> outputMappings = element.getOutputMappings();
 
     final EventTrigger eventTrigger = eventScopeInstanceState.peekEventTrigger(elementInstanceKey);
     boolean hasVariables = false;
@@ -131,7 +140,7 @@ public final class BpmnVariableMappingBehavior {
           element.getId());
     }
 
-    if (outputMappingExpression.isPresent()) {
+    if (outputMappings.isPresent()) {
       // set as local variables
       if (hasVariables) {
         final Either<Failure, Void> variableEither = mapLocalVariables(context, element, variables);
@@ -140,11 +149,31 @@ public final class BpmnVariableMappingBehavior {
         }
       }
 
-      // apply the output mappings
-      return expressionProcessor
-          .evaluateVariableMappingExpression(
-              outputMappingExpression.get(), elementInstanceKey, tenantId)
-          .flatMap(result -> mapVariables(context, element, getVariableScopeKey(context), result));
+      // Resolves the current scope value at a nested target's path so the builder can merge into
+      // it and keep the existing sibling properties: look up the top-level variable in the element
+      // scope, then navigate into it along the remaining path segments (null when absent).
+      final var resultBuilder =
+          new MappingResultBuilder(
+              path ->
+                  Optional.ofNullable(
+                          variablesState.getVariable(
+                              elementInstanceKey, BufferUtil.wrapString(path.getFirst())))
+                      .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
+                      .orElse(null));
+      final var processor =
+          expressionProcessor.prependContext(name -> Either.left(resultBuilder.getVariable(name)));
+
+      for (final OutputMapping mapping : outputMappings.get()) {
+        final var result =
+            processor.evaluateVariableMappingSourceExpression(
+                mapping.source(), elementInstanceKey, tenantId);
+        if (result.isLeft()) {
+          return Either.left(result.getLeft());
+        }
+        resultBuilder.put(mapping.targetPath(), result.get());
+      }
+      return mapVariables(
+          context, element, getVariableScopeKey(context), resultBuilder.toDocument());
 
     } else if (hasVariables) {
       // merge/propagate the event variables by default

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
@@ -455,28 +455,9 @@ public final class ExpressionProcessor {
   }
 
   /**
-   * Evaluates the given expression of a variable mapping and returns the result as buffer. If the
-   * evaluation fails or the result is not a context then a failure is returned.
-   *
-   * @param expression the expression to evaluate
-   * @param scopeKey the scope to load the variables from (a negative key is intended to imply an
-   *     empty variable context)
-   * @return either the evaluation result as buffer, or a failure
-   * @throws EvaluationException if the evaluation is interrupted or fails unexpectedly
-   */
-  public Either<Failure, DirectBuffer> evaluateVariableMappingExpression(
-      final Expression expression, final long scopeKey, final String tenantId) {
-    return evaluateExpressionAsEither(expression, scopeKey, tenantId)
-        .flatMap(result -> typeCheck(result, ResultType.OBJECT, scopeKey))
-        .mapLeft(failure -> new Failure(failure.getMessage(), ErrorType.IO_MAPPING_ERROR, scopeKey))
-        .map(EvaluationResult::toBuffer);
-  }
-
-  /**
    * Evaluates the source expression of a single variable mapping and returns the result as buffer.
-   * Unlike {@link #evaluateVariableMappingExpression(Expression, long, String)}, the result is not
-   * required to be a context: a single mapping's source may produce a value of any type, which is
-   * then stored under the mapping's target path.
+   * A single mapping's source may produce a value of any type, which is then stored under the
+   * mapping's target path.
    *
    * @param expression the mapping's source expression to evaluate
    * @param scopeKey the scope to load the variables from (a negative key is intended to imply an
@@ -486,7 +467,7 @@ public final class ExpressionProcessor {
    *     ErrorType#IO_MAPPING_ERROR}
    * @throws EvaluationException if the evaluation is interrupted or fails unexpectedly
    */
-  public Either<Failure, DirectBuffer> evaluateVariableMappingSourceExpression(
+  public Either<Failure, DirectBuffer> evaluateVariableMappingExpression(
       final Expression expression, final long scopeKey, final String tenantId) {
     return evaluateExpressionAsEither(expression, scopeKey, tenantId)
         .mapLeft(failure -> new Failure(failure.getMessage(), ErrorType.IO_MAPPING_ERROR, scopeKey))

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
@@ -21,7 +21,7 @@ public class ExecutableFlowNode extends AbstractFlowElement {
   private final List<ExecutableSequenceFlow> outgoing = new ArrayList<>();
 
   private Optional<InputMappings> inputMappings = Optional.empty();
-  private Optional<Expression> outputMappings = Optional.empty();
+  private Optional<List<OutputMapping>> outputMappings = Optional.empty();
 
   private final List<ExecutionListener> executionListeners = new ArrayList<>();
 
@@ -53,11 +53,11 @@ public class ExecutableFlowNode extends AbstractFlowElement {
     this.inputMappings = Optional.of(inputMappings);
   }
 
-  public Optional<Expression> getOutputMappings() {
+  public Optional<List<OutputMapping>> getOutputMappings() {
     return outputMappings;
   }
 
-  public void setOutputMappings(final Expression outputMappings) {
+  public void setOutputMappings(final List<OutputMapping> outputMappings) {
     this.outputMappings = Optional.of(outputMappings);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/OutputMapping.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/OutputMapping.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.element;
+
+import io.camunda.zeebe.el.Expression;
+import java.util.List;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A single transformed output mapping: the parsed source expression and the target path it is
+ * stored under, split into its {@code '.'}-separated segments (e.g. target {@code a.b.c} becomes
+ * {@code [a, b, c]}). Output mappings are evaluated one by one in modeling order at runtime; a
+ * nested target merges with the existing scope value at every path level (see {@code
+ * MappingResultBuilder}).
+ */
+@NullMarked
+public record OutputMapping(Expression source, List<String> targetPath) {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ClusterVariab
 import io.camunda.zeebe.engine.processing.deployment.model.element.ClusterVariableReference.DetectedClusterVariable;
 import io.camunda.zeebe.engine.processing.deployment.model.element.InputMapping;
 import io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings;
+import io.camunda.zeebe.engine.processing.deployment.model.element.OutputMapping;
 import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
 import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference.DetectedSecret;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
@@ -30,58 +31,18 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 /**
- * Transform variable mappings into an expression.
+ * Transforms variable mappings.
  *
- * <p>The resulting expression is a FEEL context that has a similar structure as a JSON document.
- * Each target of a mapping is a key in the context and the source of this mapping is the context
- * value. The source expression can be any FEEL expression. A nested target expression is
- * transformed into a nested context.
+ * <p>Neither input nor output mappings are combined into a single context expression. Each mapping
+ * is kept as its own parsed source expression plus its split target path (e.g. target {@code a.b.c}
+ * becomes {@code [a, b, c]}), so that mappings can be evaluated one by one in modeling order at
+ * runtime, with each mapping's result visible to subsequent mappings (see {@link InputMapping},
+ * {@link OutputMapping} and {@code BpmnVariableMappingBehavior}).
  *
- * <p>Variable mappings:
- *
- * <pre>
- *   source | target
- *   =======|=======
- *    x     | a
- *    y     | b.c
- *    z     | b.d
- * </pre>
- *
- * FEEL context expression:
- *
- * <pre>
- *   {
- *     a: x,
- *     b: {
- *       c: y,
- *       d: z
- *     }
- *   }
- * </pre>
- *
- * <p>Output variable mappings differ from input mappings that the result variables needs to be
- * merged with the existing variables if the variable is a JSON object. The merging is done by
- * calling the FEEL function 'context merge()' and referencing the variable.
- *
- * <pre>
- *   {
- *     a: x,
- *     b: if (b = null)
- *        then {
- *          c: y,
- *          d: z
- *        }
- *        else context merge(b, {
- *          c: y,
- *          d: z
- *       })
- *   }
- * </pre>
- *
- * <p><b>Input mappings</b> are not combined into a single context expression. Each mapping is kept
- * as its own parsed source expression plus its split target path, so that mappings can be evaluated
- * one by one in modeling order at runtime, with each mapping's result visible to subsequent
- * mappings (see {@link InputMapping} and {@code BpmnVariableMappingBehavior}).
+ * <p>Output mappings differ from input mappings in how a nested target is merged at runtime: the
+ * result must be merged with the existing scope variable if that variable is a JSON object, at
+ * every nesting level. This merging is done by {@code MappingResultBuilder} while accumulating
+ * results.
  */
 public final class VariableMappingTransformer {
 
@@ -126,14 +87,19 @@ public final class VariableMappingTransformer {
     return source;
   }
 
-  public Expression transformOutputMappings(
+  /**
+   * Transforms the output mappings, keeping each mapping as its own source expression plus target
+   * path so they can be evaluated one by one in modeling order at runtime. A nested target merges
+   * with the existing scope value at every path level at runtime (see {@code
+   * MappingResultBuilder}).
+   */
+  public List<OutputMapping> transformOutputMappings(
       final Collection<? extends ZeebeMapping> outputMappings,
       final ExpressionLanguage expressionLanguage) {
 
-    final var mappings = toMappings(outputMappings, expressionLanguage);
-    final var context = asContext(mappings);
-    final var contextExpression = asFeelContextExpression(context, this::mergeContextExpression);
-    return parseExpression(contextExpression, expressionLanguage);
+    return toMappings(outputMappings, expressionLanguage).stream()
+        .map(mapping -> new OutputMapping(mapping.source, splitPathExpression(mapping.target)))
+        .toList();
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -27,7 +27,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 /**
@@ -294,69 +293,6 @@ public final class VariableMappingTransformer {
       final var nestedContext = context.getOrAddContext(target);
       createContextEntry(targetPathParts, sourceExpression, nestedContext);
     }
-  }
-
-  private String asFeelContextExpression(
-      final MappingContext context,
-      final BiFunction<String, List<String>, Object> contextValueVisitor) {
-    return context.visit(feelContextBuilder(contextValueVisitor));
-  }
-
-  private MappingContextVisitor<String> feelContextBuilder(
-      final BiFunction<String, List<String>, Object> contextValueVisitor) {
-    return new MappingContextVisitor<>() {
-      @Override
-      public String onEntry(final String targetKey, final Expression sourceExpression) {
-        final String expression;
-
-        if (sourceExpression instanceof StaticExpression) {
-          // due to a regression (https://github.com/camunda/camunda/issues/16043) all the double
-          // quotes inside the static expression must be escaped
-          expression =
-              String.format("\"%s\"", sourceExpression.getExpression().replaceAll("\"", "\\\\\""));
-        } else {
-          expression = sourceExpression.getExpression();
-        }
-
-        return targetKey + ":" + expression;
-      }
-
-      @Override
-      public String onContext(final List<String> entries) {
-        return "{" + String.join(",", entries) + "}";
-      }
-
-      @Override
-      public String onContextEntry(
-          final String targetKey, final String contextValue, final List<String> contextPath) {
-        return targetKey + ":" + contextValueVisitor.apply(contextValue, contextPath);
-      }
-    };
-  }
-
-  private String mergeContextExpression(
-      final String nestedContext, final List<String> contextPath) {
-    // for a nested target mapping 'x -> a.b', append the nested property 'b' to
-    // the existing context variable 'a' (instead of overriding 'a')
-    // example: x = 1 and a = {'c':2} results in a = {'b':1, 'c':2}
-    final var existingContext = String.join(".", contextPath);
-    return String.format(
-        "if (%s != null) then context merge(%s,%s) else %s",
-        existingContext, existingContext, nestedContext, nestedContext);
-  }
-
-  private Expression parseExpression(
-      final String contextExpression, final ExpressionLanguage expressionLanguage) {
-    final var expression =
-        expressionLanguage.parseExpression(EXPRESSION_MARKER + contextExpression);
-
-    if (!expression.isValid()) {
-      throw new IllegalStateException(
-          String.format(
-              "Failed to build variable mapping expression: %s", expression.getFailureMessage()));
-    }
-
-    return expression;
   }
 
   private static final class MappingContext {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilder.java
@@ -22,11 +22,11 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Accumulates the results of input mappings that are evaluated one by one in modeling order. Each
- * mapping's result is stored under its (possibly nested) target path, and can be looked up by its
- * top-level variable name so that subsequent mappings can reference the values produced by earlier
- * mappings. {@link #toDocument()} returns the accumulated results as a single MsgPack document to
- * be merged into the element's local scope.
+ * Accumulates the results of variable mappings that are evaluated one by one in modeling order.
+ * Each mapping's result is stored under its (possibly nested) target path, and can be looked up by
+ * its top-level variable name so that subsequent mappings can reference the values produced by
+ * earlier mappings. {@link #toDocument()} returns the accumulated results as a single MsgPack
+ * document to be merged into the element's local scope.
  *
  * <p>A mapping to a nested target descends into (or creates) intermediate objects; a mapping whose
  * target collides structurally with an earlier one (a value where an object is needed, or vice
@@ -34,7 +34,7 @@ import org.jspecify.annotations.Nullable;
  * expression had.
  */
 @NullMarked
-public final class InputMappingResultBuilder {
+public final class MappingResultBuilder {
 
   /** Values are either a nested {@code Map<String, Object>} or a MsgPack {@link DirectBuffer}. */
   private final Map<String, Object> entries = new LinkedHashMap<>();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilder.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.variable;
 
+import io.camunda.zeebe.msgpack.spec.MsgPackCodes;
+import io.camunda.zeebe.msgpack.spec.MsgPackReader;
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayDeque;
@@ -15,6 +17,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -28,18 +31,54 @@ import org.jspecify.annotations.Nullable;
  * earlier mappings. {@link #toDocument()} returns the accumulated results as a single MsgPack
  * document to be merged into the element's local scope.
  *
- * <p>A mapping to a nested target descends into (or creates) intermediate objects; a mapping whose
- * target collides structurally with an earlier one (a value where an object is needed, or vice
- * versa) replaces the earlier entry — the same last-wins behavior the previous combined mapping
- * expression had.
+ * <p>For input mappings (no-arg constructor), a mapping to a nested target descends into (or
+ * creates) intermediate objects; a mapping whose target collides structurally with an earlier one
+ * (a value where an object is needed, or vice versa) replaces the earlier entry — last-wins.
+ *
+ * <p>For output mappings (constructor with a {@code scopeValueResolver}), a nested target instead
+ * merges with the existing scope variable at every path level: a level that is absent or holds a
+ * plain value is seeded from the current scope value at that path. A non-context scope value
+ * poisons the level to null, matching FEEL's {@code context merge(<non-context>, {...})} behavior.
  */
 @NullMarked
 public final class MappingResultBuilder {
 
-  /** Values are either a nested {@code Map<String, Object>} or a MsgPack {@link DirectBuffer}. */
+  /**
+   * Marks a nested level whose existing scope value was not a context: the level evaluates to null,
+   * matching FEEL's {@code context merge(<non-context>, {...})}. Serialized as NIL.
+   */
+  private static final Object POISON = new Object();
+
+  private static final DirectBuffer NIL = new UnsafeBuffer(new byte[] {MsgPackCodes.NIL});
+
+  /**
+   * Values are either a nested {@code Map<String, Object>}, {@link #POISON}, or a MsgPack {@link
+   * DirectBuffer}.
+   */
   private final Map<String, Object> entries = new LinkedHashMap<>();
 
   private final MsgPackWriter writer = new MsgPackWriter();
+
+  private final Function<List<String>, @Nullable DirectBuffer> scopeValueResolver;
+
+  /** Builder for input mappings: nested targets never merge with existing scope values. */
+  public MappingResultBuilder() {
+    this(path -> null);
+  }
+
+  /**
+   * Builder for output mappings: when a nested target path needs a map at a level that is absent
+   * (or currently holds a plain value), the level is seeded from the existing scope value at that
+   * path. A non-context scope value poisons the level to null, matching FEEL's {@code context
+   * merge} behavior.
+   *
+   * @param scopeValueResolver resolves a target-path prefix to the current scope value at that
+   *     path, or {@code null} when there is none; invoked only when a level must be (re)created
+   */
+  public MappingResultBuilder(
+      final Function<List<String>, @Nullable DirectBuffer> scopeValueResolver) {
+    this.scopeValueResolver = scopeValueResolver;
+  }
 
   /**
    * Puts a copy of the given MsgPack value at the nested target path. The value buffer is copied
@@ -48,19 +87,27 @@ public final class MappingResultBuilder {
   public void put(final List<String> targetPath, final DirectBuffer value) {
     Map<String, Object> current = entries;
     for (int i = 0; i < targetPath.size() - 1; i++) {
-      current = getOrAddNested(current, targetPath.get(i));
+      final var next = getOrSeedNested(current, targetPath.subList(0, i + 1));
+      if (next == null) {
+        return; // level is poisoned: the mapped value is discarded, the level stays null
+      }
+      current = next;
     }
     current.put(targetPath.getLast(), BufferUtil.cloneBuffer(value));
   }
 
   /**
    * Returns the accumulated value of the given top-level variable, or {@code null} if no mapping
-   * has produced it yet. Nested structures are serialized to a MsgPack document on lookup.
+   * has produced it yet. Nested structures are serialized to a MsgPack document on lookup. A
+   * poisoned top-level entry returns a NIL buffer (not Java {@code null}, which would let the
+   * caller fall back to the scope lookup instead of seeing the poisoned null).
    */
   public @Nullable DirectBuffer getVariable(final String name) {
     final var entry = entries.get(name);
     if (entry == null) {
       return null;
+    } else if (entry == POISON) {
+      return NIL;
     } else if (entry instanceof final DirectBuffer value) {
       return value;
     } else {
@@ -73,14 +120,57 @@ public final class MappingResultBuilder {
     return serialize(entries);
   }
 
-  private static Map<String, Object> getOrAddNested(
-      final Map<String, Object> parent, final String key) {
-    if (parent.get(key) instanceof Map<?, ?>) {
-      return asNestedMap(parent.get(key));
+  /**
+   * Returns the map at the given path prefix, creating it if the current entry is absent or a plain
+   * value. A newly created map is seeded with the top-level entries of the existing scope value at
+   * that path (children stay opaque buffers); a non-context scope value poisons the level instead.
+   * Returns {@code null} when the level is (or becomes) poisoned.
+   */
+  private @Nullable Map<String, Object> getOrSeedNested(
+      final Map<String, Object> parent, final List<String> pathPrefix) {
+    final var key = pathPrefix.getLast();
+    final var entry = parent.get(key);
+    if (entry == POISON) {
+      return null;
     }
-    final var nested = new LinkedHashMap<String, Object>();
-    parent.put(key, nested);
-    return nested;
+    if (entry instanceof Map<?, ?>) {
+      return asNestedMap(entry);
+    }
+    // absent, or a plain value from an earlier mapping: re-seed the (re)created level from the
+    // scope value at this path, dropping the earlier plain value
+    final var scopeValue = scopeValueResolver.apply(pathPrefix);
+    if (scopeValue == null || isNil(scopeValue)) {
+      final var fresh = new LinkedHashMap<String, Object>();
+      parent.put(key, fresh);
+      return fresh;
+    }
+    if (!MsgPackCodes.isMap(scopeValue.getByte(0))) {
+      parent.put(key, POISON);
+      return null;
+    }
+    final var seeded = deserializeTopLevel(scopeValue);
+    parent.put(key, seeded);
+    return seeded;
+  }
+
+  private static boolean isNil(final DirectBuffer value) {
+    return value.capacity() == 1 && value.getByte(0) == MsgPackCodes.NIL;
+  }
+
+  /** Reads the top level of a msgpack map into a builder map; values stay opaque cloned slices. */
+  private static Map<String, Object> deserializeTopLevel(final DirectBuffer map) {
+    final var result = new LinkedHashMap<String, Object>();
+    final var reader = new MsgPackReader();
+    reader.wrap(map, 0, map.capacity());
+    final int entryCount = reader.readMapHeader();
+    for (int i = 0; i < entryCount; i++) {
+      final var key = BufferUtil.bufferAsString(reader.readToken().getValueBuffer());
+      final int valueOffset = reader.getOffset();
+      reader.skipValue();
+      final var slice = new UnsafeBuffer(map, valueOffset, reader.getOffset() - valueOffset);
+      result.put(key, BufferUtil.cloneBuffer(slice));
+    }
+    return result;
   }
 
   @SuppressWarnings("unchecked")
@@ -121,6 +211,8 @@ public final class MappingResultBuilder {
         final var nested = asNestedMap(value);
         writer.writeMapHeader(nested.size());
         pending.push(nested.entrySet().iterator());
+      } else if (value == POISON) {
+        writer.writeNil();
       } else {
         writer.writeRaw((DirectBuffer) value);
       }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MsgPackPath.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MsgPackPath.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable;
+
+import io.camunda.zeebe.msgpack.spec.MsgPackCodes;
+import io.camunda.zeebe.msgpack.spec.MsgPackReader;
+import io.camunda.zeebe.msgpack.spec.MsgPackType;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Navigates a MsgPack document along the segments of a {@code '.'}-separated variable mapping
+ * target path, mirroring how a FEEL path expression (e.g. {@code a.b.c}) resolves: descending into
+ * nested maps by key. Used to look up the existing scope value that a nested output mapping target
+ * merges with.
+ */
+@NullMarked
+public final class MsgPackPath {
+
+  private MsgPackPath() {}
+
+  /**
+   * Returns the value of {@code document} at {@code path.subList(fromIndex, path.size())}, or
+   * {@code null} if any segment is missing or an intermediate value is not a map. The returned
+   * buffer is a view into {@code document} — callers must copy it if they retain it.
+   *
+   * @param document the MsgPack document to navigate (the value of the path's root variable)
+   * @param path the full target path; segments before {@code fromIndex} are already consumed
+   * @param fromIndex the index of the first segment to resolve within {@code document}
+   * @return the value at the path, or {@code null} if it cannot be resolved
+   */
+  public static @Nullable DirectBuffer navigate(
+      final DirectBuffer document, final List<String> path, final int fromIndex) {
+    var current = document;
+    final var reader = new MsgPackReader();
+    for (int i = fromIndex; i < path.size(); i++) {
+      current = valueOfKey(reader, current, path.get(i));
+      if (current == null) {
+        return null;
+      }
+    }
+    return current;
+  }
+
+  private static @Nullable DirectBuffer valueOfKey(
+      final MsgPackReader reader, final DirectBuffer map, final String key) {
+    if (map.capacity() == 0 || !MsgPackCodes.isMap(map.getByte(0))) {
+      return null;
+    }
+    reader.wrap(map, 0, map.capacity());
+    final int entries = reader.readMapHeader();
+    final var keyBuffer = BufferUtil.wrapString(key);
+    for (int i = 0; i < entries; i++) {
+      final var keyToken = reader.readToken();
+      final var isMatch =
+          keyToken.getType() == MsgPackType.STRING
+              && BufferUtil.equals(keyToken.getValueBuffer(), keyBuffer);
+      final int valueOffset = reader.getOffset();
+      reader.skipValue();
+      if (isMatch) {
+        return new UnsafeBuffer(map, valueOffset, reader.getOffset() - valueOffset);
+      }
+    }
+    return null;
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerTaskElementsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerTaskElementsTest.java
@@ -584,7 +584,7 @@ public class ExecutionListenerTaskElementsTest {
           .hasErrorType(ErrorType.IO_MAPPING_ERROR)
           .hasErrorMessage(
               """
-                Assertion failure on evaluate the expression '{o_var_1:assert(some_var, some_var != null)}': \
+                Assertion failure on evaluate the expression 'assert(some_var, some_var != null)': \
                 The condition is not fulfilled The evaluation reported the following warnings:
                 [NO_VARIABLE_FOUND] No variable found with name 'some_var'
                 [NO_VARIABLE_FOUND] No variable found with name 'some_var'

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/variables/ContainerElementVariablePropagationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/variables/ContainerElementVariablePropagationTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.test.util.JsonUtil;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Map;
@@ -142,6 +143,57 @@ public final class ContainerElementVariablePropagationTest {
     // then
     assertVariableIsNotPropagatedToProcessInstance(processInstanceKey, LOOP_COUNTER);
     assertVariableIsPropagatedToProcessInstance(processInstanceKey, LOCAL_VAR);
+  }
+
+  @Test
+  public void shouldMergeNestedTargetWhenPropagatingLocalVariablesFromMultiInstanceSubProcess() {
+    // given: a pre-existing "container" variable at the process instance scope, and the MI
+    // sub-process's own output mapping targets a nested path inside it, so the merge must
+    // preserve the pre-existing sibling key rather than overwrite the whole object
+    final var processId = "processId";
+    final var process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .subProcess(
+                "sp",
+                sp ->
+                    sp.multiInstance(
+                            mi ->
+                                mi.zeebeInputCollectionExpression("= [1]")
+                                    .zeebeInputElement("inputElement")
+                                    .zeebeOutputCollection("output")
+                                    .zeebeOutputElementExpression("outputElement"))
+                        .zeebeInputExpression("= \"foo\"", LOCAL_VAR)
+                        .embeddedSubProcess()
+                        .startEvent()
+                        .intermediateThrowEvent("nestedElement")
+                        .zeebeOutputExpression("= \"bar\"", LOCAL_VAR)
+                        .endEvent())
+            .zeebeOutputExpression(LOCAL_VAR, "container.nested")
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariables(Map.of("container", Map.of("existing", 1)))
+            .create();
+
+    // then
+    assertVariableIsNotPropagatedToProcessInstance(processInstanceKey, LOOP_COUNTER);
+    final var mergedContainer =
+        RecordingExporter.variableRecords(VariableIntent.UPDATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withScopeKey(processInstanceKey)
+            .withName("container")
+            .getFirst()
+            .getValue()
+            .getValue();
+    JsonUtil.assertEquality(mergedContainer, "{\"existing\":1,\"nested\":\"bar\"}");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
@@ -235,21 +235,6 @@ class ExpressionProcessorTest {
               The evaluation reported the following warnings:
               [NO_VARIABLE_FOUND] No variable found with name 'x'""");
     }
-
-    @Test
-    void testVariableMappingExpression() {
-      final var processor =
-          new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP, DEFAULT_TIMEOUT);
-      final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression("=x");
-      assertThat(processor.evaluateVariableMappingExpression(parsedExpression, -1L, "tenant_1"))
-          .isLeft()
-          .extracting(r -> r.getLeft().getMessage())
-          .isEqualTo(
-              """
-              Expected result of the expression 'x' to be 'OBJECT', but was 'NULL'. \
-              The evaluation reported the following warnings:
-              [NO_VARIABLE_FOUND] No variable found with name 'x'""");
-    }
   }
 
   @Nested
@@ -596,8 +581,7 @@ class ExpressionProcessorTest {
       final var expression = EXPRESSION_LANGUAGE.parseExpression("=\"abc\"");
 
       // when
-      final var result =
-          processor.evaluateVariableMappingSourceExpression(expression, 1L, "tenant");
+      final var result = processor.evaluateVariableMappingExpression(expression, 1L, "tenant");
 
       // then
       assertThat(result).isRight();
@@ -610,8 +594,7 @@ class ExpressionProcessorTest {
       final var expression = EXPRESSION_LANGUAGE.parseExpression("={y: x}");
 
       // when
-      final var result =
-          processor.evaluateVariableMappingSourceExpression(expression, 1L, "tenant");
+      final var result = processor.evaluateVariableMappingExpression(expression, 1L, "tenant");
 
       // then
       assertThat(result).isRight();
@@ -624,8 +607,7 @@ class ExpressionProcessorTest {
       final var expression = EXPRESSION_LANGUAGE.parseExpression("=null");
 
       // when
-      final var result =
-          processor.evaluateVariableMappingSourceExpression(expression, 1L, "tenant");
+      final var result = processor.evaluateVariableMappingExpression(expression, 1L, "tenant");
 
       // then
       assertThat(result).isRight();
@@ -641,8 +623,7 @@ class ExpressionProcessorTest {
       final var expression = EXPRESSION_LANGUAGE.parseExpression("=unknown_var");
 
       // when
-      final var result =
-          processor.evaluateVariableMappingSourceExpression(expression, 1L, "tenant");
+      final var result = processor.evaluateVariableMappingExpression(expression, 1L, "tenant");
 
       // then
       assertThat(result).isRight();
@@ -655,8 +636,7 @@ class ExpressionProcessorTest {
       final var expression = EXPRESSION_LANGUAGE.parseExpression("=assert(x, x != 1)");
 
       // when
-      final var result =
-          processor.evaluateVariableMappingSourceExpression(expression, 1L, "tenant");
+      final var result = processor.evaluateVariableMappingExpression(expression, 1L, "tenant");
 
       // then
       assertThat(result).isLeft();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MappingIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MappingIncidentTest.java
@@ -226,6 +226,78 @@ public final class MappingIncidentTest {
   }
 
   @Test
+  public void shouldNotApplyAnyOutputMappingIfOneFails() {
+    // given: three output mappings where the second one fails
+    final var process =
+        Bpmn.createExecutableProcess("process-atomic-output")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("test")
+                        .zeebeOutputExpression("1", "first")
+                        .zeebeOutputExpression("assert(missing, missing != null)", "second")
+                        .zeebeOutputExpression("2", "third"))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("process-atomic-output").create();
+    ENGINE.job().ofInstance(processInstanceKey).withType("test").complete();
+
+    // then: an incident is raised for the failing mapping and NO variable is created —
+    // neither 'first' (before the failing one) nor 'third' (after it)
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    Assertions.assertThat(incident.getValue()).hasErrorType(ErrorType.IO_MAPPING_ERROR);
+    assertThat(incident.getValue().getErrorMessage())
+        .contains("Assertion failure on evaluate the expression");
+
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                ignored ->
+                    RecordingExporter.variableRecords()
+                        .withProcessInstanceKey(processInstanceKey)
+                        .withName("first")
+                        .exists()))
+        .isFalse();
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                ignored ->
+                    RecordingExporter.variableRecords()
+                        .withProcessInstanceKey(processInstanceKey)
+                        .withName("third")
+                        .exists()))
+        .isFalse();
+
+    // when: the missing variable is provided and the incident is resolved
+    ENGINE.variables().ofScope(processInstanceKey).withDocument(Map.of("missing", 1)).update();
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+
+    // then: all mappings are re-evaluated from the start and applied
+    assertThat(
+            RecordingExporter.variableRecords(VariableIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withName("first")
+                .exists())
+        .isTrue();
+    assertThat(
+            RecordingExporter.variableRecords(VariableIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withName("second")
+                .exists())
+        .isTrue();
+    assertThat(
+            RecordingExporter.variableRecords(VariableIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withName("third")
+                .exists())
+        .isTrue();
+  }
+
+  @Test
   public void shouldResolveIncidentForInputMappingFailure() {
     // given
     ENGINE.deployment().withXmlResource(PROCESS_INPUT_MAPPING).deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MappingIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MappingIncidentTest.java
@@ -298,6 +298,46 @@ public final class MappingIncidentTest {
   }
 
   @Test
+  public void shouldRaiseIncidentForPreviouslyDroppedDuplicateOutputMappingSource() {
+    // given: two output mappings targeting the same key; under the OLD (pre-fix) behavior the
+    // first (an always-failing assert) would have been silently dropped as a superseded duplicate
+    // and never evaluated — now every source is evaluated in modeling order, so it fails first
+    final var process =
+        Bpmn.createExecutableProcess("process-duplicate-target-fail")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("test")
+                        .zeebeOutputExpression("assert(missing, missing != null)", "x")
+                        .zeebeOutputExpression("2", "x"))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("process-duplicate-target-fail").create();
+    ENGINE.job().ofInstance(processInstanceKey).withType("test").complete();
+
+    // then: an incident is raised for the first mapping's failing source, and 'x' is never
+    // created — the second, winning mapping is never reached
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    Assertions.assertThat(incident.getValue()).hasErrorType(ErrorType.IO_MAPPING_ERROR);
+    assertThat(incident.getValue().getErrorMessage())
+        .contains("Assertion failure on evaluate the expression");
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                ignored ->
+                    RecordingExporter.variableRecords()
+                        .withProcessInstanceKey(processInstanceKey)
+                        .withName("x")
+                        .exists()))
+        .isFalse();
+  }
+
+  @Test
   public void shouldResolveIncidentForInputMappingFailure() {
     // given
     ENGINE.deployment().withXmlResource(PROCESS_INPUT_MAPPING).deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilderTest.java
@@ -17,9 +17,9 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
-final class InputMappingResultBuilderTest {
+final class MappingResultBuilderTest {
 
-  private final InputMappingResultBuilder builder = new InputMappingResultBuilder();
+  private final MappingResultBuilder builder = new MappingResultBuilder();
 
   @Test
   void shouldBuildEmptyDocument() {
@@ -72,7 +72,7 @@ final class InputMappingResultBuilderTest {
     // when
     builder.put(List.of("a", "b"), asMsgPack("2"));
 
-    // then: structural last-wins, like the previous combined-expression transformer
+    // then: structural last-wins
     assertEquality(builder.toDocument(), "{'a': {'b': 2}}");
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilderTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
@@ -134,5 +135,102 @@ final class MappingResultBuilderTest {
 
     // when / then — must not throw
     assertThatCode(builder::toDocument).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldSeedNestedTargetFromScopeValue() {
+    // given: scope has a = {'c': 2}
+    final var builder =
+        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
+
+    // when
+    builder.put(List.of("a", "b"), asMsgPack("1"));
+
+    // then: existing sibling 'c' survives the merge
+    assertEquality(builder.toDocument(), "{'a': {'b': 1, 'c': 2}}");
+  }
+
+  @Test
+  void shouldSeedEveryPathLevelFromScopeValue() {
+    // given: scope has a = {'b': {'d': 2}, 'e': 3}
+    final var scope =
+        Map.of(
+            List.of("a"), asMsgPack("{'b': {'d': 2}, 'e': 3}"),
+            List.of("a", "b"), asMsgPack("{'d': 2}"));
+    final var builder = new MappingResultBuilder(scope::get);
+
+    // when
+    builder.put(List.of("a", "b", "c"), asMsgPack("1"));
+
+    // then: siblings survive at both levels
+    assertEquality(builder.toDocument(), "{'a': {'b': {'c': 1, 'd': 2}, 'e': 3}}");
+  }
+
+  @Test
+  void shouldPoisonLevelWhenScopeValueIsNotAMap() {
+    // given: scope has a = 5
+    final var builder =
+        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
+
+    // when
+    builder.put(List.of("a", "b"), asMsgPack("1"));
+
+    // then: the level is null, like FEEL's context merge(5, {...})
+    assertEquality(builder.toDocument(), "{'a': null}");
+    assertEquality(builder.getVariable("a"), "null");
+  }
+
+  @Test
+  void shouldDiscardFurtherPutsUnderPoisonedLevel() {
+    final var builder =
+        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
+
+    // when
+    builder.put(List.of("a", "b"), asMsgPack("1"));
+    builder.put(List.of("a", "c"), asMsgPack("2"));
+
+    // then
+    assertEquality(builder.toDocument(), "{'a': null}");
+  }
+
+  @Test
+  void shouldReplacePoisonedLevelWithPlainTargetPut() {
+    final var builder =
+        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
+
+    // when: a nested put poisons 'a', then a plain put replaces it
+    builder.put(List.of("a", "b"), asMsgPack("1"));
+    builder.put(List.of("a"), asMsgPack("7"));
+
+    // then
+    assertEquality(builder.toDocument(), "{'a': 7}");
+  }
+
+  @Test
+  void shouldReseedFromScopeWhenNestedPutFollowsPlainPut() {
+    // given: scope a = {'c': 2}; a plain put stored a value buffer for 'a'
+    final var builder =
+        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
+    builder.put(List.of("a"), asMsgPack("{'z': 9}"));
+
+    // when: the shape flips back to a map — the plain mapping's value is discarded and the fresh
+    // level is seeded from the SCOPE value, not the previously mapped value
+    builder.put(List.of("a", "b"), asMsgPack("1"));
+
+    // then
+    assertEquality(builder.toDocument(), "{'a': {'b': 1, 'c': 2}}");
+  }
+
+  @Test
+  void shouldSeedFreshMapWhenScopeValueIsNil() {
+    // given: scope has a = null — FEEL's `if (a != null)` takes the else branch
+    final var builder =
+        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("null") : null);
+
+    // when
+    builder.put(List.of("a", "b"), asMsgPack("1"));
+
+    // then
+    assertEquality(builder.toDocument(), "{'a': {'b': 1}}");
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/MsgPackPathTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/MsgPackPathTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable;
+
+import static io.camunda.zeebe.test.util.MsgPackUtil.asMsgPack;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.test.util.MsgPackUtil;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public final class MsgPackPathTest {
+
+  @Test
+  public void shouldReturnDocumentForEmptyPath() {
+    final var document = asMsgPack("{'a': 1}");
+    final var result = MsgPackPath.navigate(document, List.of(), 0);
+    MsgPackUtil.assertEquality(result, "{'a': 1}");
+  }
+
+  @Test
+  public void shouldNavigateNestedPath() {
+    final var document = asMsgPack("{'b': {'c': 42}, 'd': 2}");
+    MsgPackUtil.assertEquality(MsgPackPath.navigate(document, List.of("a", "b"), 1), "{'c': 42}");
+    MsgPackUtil.assertEquality(MsgPackPath.navigate(document, List.of("a", "b", "c"), 1), "42");
+  }
+
+  @Test
+  public void shouldReturnNullForMissingKey() {
+    final var document = asMsgPack("{'b': 1}");
+    assertThat(MsgPackPath.navigate(document, List.of("a", "x"), 1)).isNull();
+  }
+
+  @Test
+  public void shouldReturnNullWhenIntermediateValueIsNotAMap() {
+    final var document = asMsgPack("{'b': 5}");
+    assertThat(MsgPackPath.navigate(document, List.of("a", "b", "c"), 1)).isNull();
+  }
+
+  @Test
+  public void shouldReturnNullWhenDocumentIsNotAMap() {
+    final var document = asMsgPack("5");
+    assertThat(MsgPackPath.navigate(document, List.of("a", "b"), 1)).isNull();
+  }
+
+  @Test
+  public void shouldReturnNilValueAtPath() {
+    final var document = asMsgPack("{'b': null}");
+    MsgPackUtil.assertEquality(MsgPackPath.navigate(document, List.of("a", "b"), 1), "null");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/MsgPackPathTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/MsgPackPathTest.java
@@ -10,8 +10,12 @@ package io.camunda.zeebe.engine.processing.variable;
 import static io.camunda.zeebe.test.util.MsgPackUtil.asMsgPack;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.test.util.MsgPackUtil;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
 public final class MsgPackPathTest {
@@ -52,5 +56,29 @@ public final class MsgPackPathTest {
   public void shouldReturnNilValueAtPath() {
     final var document = asMsgPack("{'b': null}");
     MsgPackUtil.assertEquality(MsgPackPath.navigate(document, List.of("a", "b"), 1), "null");
+  }
+
+  @Test
+  public void shouldSkipPrecedingEntriesToFindKey() {
+    final var document = asMsgPack("{'a': 1, 'b': 2}");
+    MsgPackUtil.assertEquality(MsgPackPath.navigate(document, List.of("x", "b"), 1), "2");
+  }
+
+  @Test
+  public void shouldSkipNonStringMapKeys() {
+    final var writer = new MsgPackWriter();
+    final var buffer = new ExpandableArrayBuffer();
+    writer.wrap(buffer, 0);
+    // asMsgPack (JSON-based) can't produce a non-string map key, so build the map by hand: an
+    // integer key 1 -> 99, followed by a string key "1" -> 42 — same text as the integer key, to
+    // prove navigate() matches on key type, not just text
+    writer.writeMapHeader(2);
+    writer.writeInteger(1);
+    writer.writeInteger(99);
+    writer.writeString(BufferUtil.wrapString("1"));
+    writer.writeInteger(42);
+    final var document = new UnsafeBuffer(buffer, 0, writer.getOffset());
+
+    MsgPackUtil.assertEquality(MsgPackPath.navigate(document, List.of("x", "1"), 1), "42");
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityOutputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityOutputMappingTest.java
@@ -170,6 +170,46 @@ public final class ActivityOutputMappingTest {
         mapping(b -> b.zeebeInputExpression("x", "a").zeebeOutputExpression("y", "a.m")),
         scopeVariables(variable("a", "{\"l\":1,\"m\":2}"))
       },
+      {
+        // mappings are evaluated in modeling order, so a later mapping can reference the target
+        // of an earlier one even when nested targets are interleaved with plain ones
+        // regression test for https://github.com/camunda/camunda/issues/11789
+        "{}",
+        mapping(
+            b ->
+                b.zeebeOutputExpression("1", "obj.first")
+                    .zeebeOutputExpression("2", "flat")
+                    .zeebeOutputExpression("flat", "obj.second")
+                    .zeebeOutputExpression("flat", "flatCopy")),
+        scopeVariables(
+            variable("flat", "2"),
+            variable("obj", "{\"first\":1,\"second\":2}"),
+            variable("flatCopy", "2"))
+      },
+      {
+        // a mapping referencing a target produced by a LATER mapping sees it as not-yet-defined
+        // and resolves to null; the later mapping still produces its own value normally
+        "{}",
+        mapping(b -> b.zeebeOutputExpression("late", "early").zeebeOutputExpression("1", "late")),
+        scopeVariables(variable("early", "null"), variable("late", "1"))
+      },
+      {
+        // a mapping can reference the (merged) nested target of an earlier mapping
+        "{'x': 1}",
+        mapping(b -> b.zeebeOutputExpression("x", "a.b").zeebeOutputExpression("a.b + 1", "c")),
+        scopeVariables(variable("a", "{\"b\":1}"), variable("c", "2"))
+      },
+      {
+        // duplicate targets: every mapping is evaluated in order, the last value wins;
+        // an intermediate mapping sees the value that was current at its position
+        "{}",
+        mapping(
+            b ->
+                b.zeebeOutputExpression("1", "x")
+                    .zeebeOutputExpression("x", "y")
+                    .zeebeOutputExpression("2", "x")),
+        scopeVariables(variable("x", "2"), variable("y", "1"))
+      },
     };
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityOutputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityOutputMappingTest.java
@@ -141,7 +141,35 @@ public final class ActivityOutputMappingTest {
         "{'x': %s}".formatted(A_YEAR_MONTH_DURATION_VALUE),
         mapping(b -> b.zeebeOutputExpression("duration(x)", "y")),
         scopeVariables(variable("y", A_YEAR_MONTH_DURATION_VALUE))
-      }
+      },
+      {
+        // nested target merges with the existing variable at EVERY path level: siblings of both
+        // 'b' and 'c' survive
+        "{'x': 1, 'a': {'b': {'d': 2}, 'e': 3}}",
+        mapping(b -> b.zeebeOutputExpression("x", "a.b.c")),
+        scopeVariables(variable("a", "{\"b\":{\"c\":1,\"d\":2},\"e\":3}"))
+      },
+      {
+        // a nested target whose existing value at that path is not a context poisons the whole
+        // level to null: context merge(5, {...}) yields null in FEEL (pinned FEEL artifact)
+        "{'x': 1, 'a': 5}",
+        mapping(b -> b.zeebeOutputExpression("x", "a.b")),
+        scopeVariables(variable("a", "null"))
+      },
+      {
+        // ...same at a deeper level: only the non-context level is poisoned, siblings survive
+        "{'x': 1, 'a': {'b': 5, 'e': 3}}",
+        mapping(b -> b.zeebeOutputExpression("x", "a.b.c")),
+        scopeVariables(variable("a", "{\"b\":null,\"e\":3}"))
+      },
+      {
+        // the merge seed is read from the element-local scope walking up: a local variable
+        // created by an input mapping contributes its properties to the propagated result
+        // (#35251 behavior — intentionally preserved in this PR, fix tracked separately)
+        "{'x': {'l': 1}, 'y': 2}",
+        mapping(b -> b.zeebeInputExpression("x", "a").zeebeOutputExpression("y", "a.m")),
+        scopeVariables(variable("a", "{\"l\":1,\"m\":2}"))
+      },
     };
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/DuplicateOutputMappingTargetFeatureFlagTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/DuplicateOutputMappingTargetFeatureFlagTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable.mapping;
+
+import static io.camunda.zeebe.engine.processing.variable.mapping.VariableValue.variable;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Characterization tests for the {@code evaluateDuplicateOutputMappingTargetsInOrder} kill-switch:
+ * with the flag disabled, output mappings with colliding targets are handled the way the removed
+ * combined-FEEL-context builder used to handle them, not by the current one-by-one evaluation.
+ */
+public final class DuplicateOutputMappingTargetFeatureFlagTest {
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withFeatureFlags(f -> f.setEvaluateDuplicateOutputMappingTargetsInOrder(false));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldReproduceOldValuesForInterleavedDuplicateTargetsWhenDisabled() {
+    // given: the PR's canonical duplicate-target example (1 -> x, x -> y, 2 -> x); with the flag
+    // enabled this yields x=2, y=1 (see ActivityOutputMappingTest#shouldApplyOutputMappings), but
+    // the old combined-FEEL-context builder kept x's map position at its first occurrence while
+    // overwriting its value in place, so 'y's reference to 'x' resolved to the already-overwritten
+    // value
+    final var process =
+        Bpmn.createExecutableProcess("process-duplicate-target-old-semantics")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("test")
+                        .zeebeOutputExpression("1", "x")
+                        .zeebeOutputExpression("x", "y")
+                        .zeebeOutputExpression("2", "x"))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("process-duplicate-target-old-semantics").create();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("test").complete();
+
+    // then: x=2 (last write wins) and y=2 (not y=1, the flag-enabled value); the output mapping
+    // is applied while the task is completing, so its variable merge is exported before the
+    // task's own ELEMENT_COMPLETED record
+    assertThat(
+            RecordingExporter.variableRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withScopeKey(processInstanceKey)
+                .limit(2))
+        .extracting(Record::getValue)
+        .extracting(v -> variable(v.getName(), v.getValue()))
+        .containsExactlyInAnyOrder(variable("x", "2"), variable("y", "2"));
+  }
+
+  @Test
+  public void shouldSuppressIncidentFromSupersededDuplicateOutputMappingSourceWhenDisabled() {
+    // given: two output mappings targeting the same key; the first one's source always fails.
+    // With the flag enabled (default), every source is evaluated in modeling order, so this
+    // fails and raises an incident (see
+    // MappingIncidentTest#shouldRaiseIncidentForPreviouslyDroppedDuplicateOutputMappingSource).
+    // With the flag disabled, the first mapping is treated as a superseded duplicate target and
+    // its source is never evaluated, reproducing the old silent-drop behavior.
+    final var process =
+        Bpmn.createExecutableProcess("process-duplicate-target-fail-suppressed")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("test")
+                        .zeebeOutputExpression("assert(missing, missing != null)", "x")
+                        .zeebeOutputExpression("2", "x"))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId("process-duplicate-target-fail-suppressed")
+            .create();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("test").complete();
+
+    // then: no incident is raised, and the surviving (later) mapping's value wins
+    assertThat(
+            RecordingExporter.variableRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withScopeKey(processInstanceKey)
+                .limit(1))
+        .extracting(Record::getValue)
+        .extracting(v -> variable(v.getName(), v.getValue()))
+        .containsExactly(variable("x", "2"));
+
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                ignored ->
+                    RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+                        .withProcessInstanceKey(processInstanceKey)
+                        .exists()))
+        .isFalse();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.VariableMappingTransformer;
-import io.camunda.zeebe.engine.processing.variable.InputMappingResultBuilder;
+import io.camunda.zeebe.engine.processing.variable.MappingResultBuilder;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.util.Either;
@@ -200,7 +200,7 @@ final class VariableInputMappingTransformerTest {
     // when: evaluate the mappings one by one in modeling order, same as
     // BpmnVariableMappingBehavior.applyInputMappings does at runtime — accumulated results shadow
     // the base variables, which fall back for anything not mapped yet
-    final var resultBuilder = new InputMappingResultBuilder();
+    final var resultBuilder = new MappingResultBuilder();
     for (final var mapping : inputMappings.mappings()) {
       final EvaluationContext context =
           name -> {
@@ -233,7 +233,7 @@ final class VariableInputMappingTransformerTest {
                     .isTrue());
 
     // when
-    final var resultBuilder = new InputMappingResultBuilder();
+    final var resultBuilder = new MappingResultBuilder();
     for (final var mapping : inputMappings.mappings()) {
       final EvaluationContext context =
           name -> {
@@ -275,7 +275,7 @@ final class VariableInputMappingTransformerTest {
       final Map<String, DirectBuffer> variables,
       final ExpressionLanguage language) {
     final var inputMappings = transformer.transformInputMappings(mappings, language);
-    final var resultBuilder = new InputMappingResultBuilder();
+    final var resultBuilder = new MappingResultBuilder();
     for (final var mapping : inputMappings.mappings()) {
       final EvaluationContext context =
           name -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
@@ -138,6 +138,23 @@ public final class VariableOutputMappingTransformerTest {
         Map.of("x", asMsgPack("1"), "y", asMsgPack("2")),
         "{'a':1}"
       },
+      // declaration order preserved across regrouped nested targets (#11789 / #56387): an entry
+      // declared BETWEEN two entries of the same parent target sees the in-between assignment
+      {
+        List.of(mapping("1", "a.b"), mapping("x", "c"), mapping("c", "a.d")),
+        Map.of("x", asMsgPack("1")),
+        "{'a':{'b':1, 'd':1}, 'c':1}"
+      },
+      {
+        List.of(
+            mapping("\"some text\"", "nested.property"),
+            mapping("\"abc\"", "notNested"),
+            mapping("notNested", "nested.nested.property"),
+            mapping("notNested", "notNestedAssigned")),
+        Map.of(),
+        "{'nested':{'property':'some text', 'nested':{'property':'abc'}}, "
+            + "'notNested':'abc', 'notNestedAssigned':'abc'}"
+      },
       // source FEEL expression
       {List.of(mapping("1", "a")), Map.of(), "{'a':1}"},
       {List.of(mapping("\"foo\"", "a")), Map.of(), "{'a':'foo'}"},
@@ -246,85 +263,13 @@ public final class VariableOutputMappingTransformerTest {
 
   @Test
   @Disabled(
-      "Output-mapping target-regrouping still breaks declaration order - #58801 fixed "
-          + "this for input mappings only. Tracked under #56387 (mapping ordering). — once fixed, move into "
-          + "parametersSuccessfulEvaluationToObject.")
-  void shouldPreserveDeclarationOrderAcrossRegroupedTargets() {
-    // given: c is declared BETWEEN the two "a.*" entries, so the user reasonably expects a.d to
-    // see c's just-assigned value
-    final var mappings = List.of(mapping("1", "a.b"), mapping("x", "c"), mapping("c", "a.d"));
-    final Map<String, DirectBuffer> variables = Map.of("x", asMsgPack("1"));
-    final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
-
-    // when
-    final var resultBuilder =
-        new MappingResultBuilder(
-            path ->
-                Optional.ofNullable(variables.get(path.getFirst()))
-                    .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
-                    .orElse(null));
-    for (final var mapping : outputMappings) {
-      final EvaluationContext context =
-          name -> {
-            final var accumulated = resultBuilder.getVariable(name);
-            return Either.left(accumulated != null ? accumulated : variables.get(name));
-          };
-      final var result = expressionLanguage.evaluateExpression(mapping.source(), context);
-      resultBuilder.put(mapping.targetPath(), result.toBuffer());
-    }
-
-    // then
-    MsgPackUtil.assertEquality(resultBuilder.toDocument(), "{'a':{'b':1, 'd':1}, 'c':1}");
-  }
-
-  @Test
-  @Disabled(
-      "Same regrouping bug as shouldPreserveDeclarationOrderAcrossRegroupedTargets, reproducing "
-          + "#11789 (originally input mappings) for output mappings. Tracked under #56387 — once "
-          + "fixed, move into parametersSuccessfulEvaluationToObject.")
-  void shouldPreserveDeclarationOrderForRegroupedNestedTargets() {
-    // given: same mapping shape as issue #11789's "breaks" scriptTask, translated to output
-    // mappings - notNested is declared BETWEEN the two "nested.*" entries
-    final var mappings =
-        List.of(
-            mapping("\"some text\"", "nested.property"),
-            mapping("\"abc\"", "notNested"),
-            mapping("notNested", "nested.nested.property"),
-            mapping("notNested", "notNestedAssigned"));
-    final Map<String, DirectBuffer> variables = Map.of();
-    final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
-
-    // when
-    final var resultBuilder =
-        new MappingResultBuilder(
-            path ->
-                Optional.ofNullable(variables.get(path.getFirst()))
-                    .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
-                    .orElse(null));
-    for (final var mapping : outputMappings) {
-      final EvaluationContext context =
-          name -> {
-            final var accumulated = resultBuilder.getVariable(name);
-            return Either.left(accumulated != null ? accumulated : variables.get(name));
-          };
-      final var result = expressionLanguage.evaluateExpression(mapping.source(), context);
-      resultBuilder.put(mapping.targetPath(), result.toBuffer());
-    }
-
-    // then
-    MsgPackUtil.assertEquality(
-        resultBuilder.toDocument(),
-        "{'nested':{'property':'some text', 'nested':{'property':'abc'}}, "
-            + "'notNested':'abc', 'notNestedAssigned':'abc'}");
-  }
-
-  @Test
-  @Disabled(
       "context merge() with the current scope leaks an untouched sibling ('p') into the merge "
           + "target and a later back-reference to it, instead of building a mapping-only result "
-          + "(input mappings already do this post-#58801). Tracked under "
-          + "https://github.com/camunda/camunda/issues/35251 — once fixed, move into "
-          + "parametersSuccessfulEvaluationToObject.")
+          + "(input mappings already do this post-#58801). Cannot be enabled without the #35251 "
+          + "fix: the desired drop-the-sibling result conflicts with the pinned 'merge target "
+          + "with variable' case, which requires the sibling to be kept — both go through the "
+          + "same seed-from-scope path. Tracked under "
+          + "https://github.com/camunda/camunda/issues/35251.")
   void shouldNotLeakUntouchedSiblingIntoMergeTargetOrBackReference() {
     final var mappings = List.of(mapping("1", "a.b"), mapping("a", "d"));
     final Map<String, DirectBuffer> variables = Map.of("a", asMsgPack("{'p':0}"));
@@ -355,9 +300,9 @@ public final class VariableOutputMappingTransformerTest {
   @Disabled(
       "Same leak as shouldNotLeakUntouchedSiblingIntoMergeTargetOrBackReference, opposite "
           + "mapping order: the back-reference runs before 'a' is ever written, so it correctly "
-          + "keeps 'p'; only the later merge target should drop it. Tracked under "
-          + "https://github.com/camunda/camunda/issues/35251 — once fixed, move into "
-          + "parametersSuccessfulEvaluationToObject.")
+          + "keeps 'p'; only the later merge target should drop it. Cannot be enabled without "
+          + "the #35251 fix (see the sibling case). Tracked under "
+          + "https://github.com/camunda/camunda/issues/35251.")
   void shouldNotLeakUntouchedSiblingIntoMergeTargetOppositeOrder() {
     final var mappings = List.of(mapping("a", "d"), mapping("1", "a.b"));
     final Map<String, DirectBuffer> variables = Map.of("a", asMsgPack("{'p':0}"));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
@@ -10,19 +10,22 @@ package io.camunda.zeebe.engine.processing.variable.mapping;
 import static io.camunda.zeebe.test.util.MsgPackUtil.asMsgPack;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.el.EvaluationContext;
+import io.camunda.zeebe.el.EvaluationResult;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
-import io.camunda.zeebe.el.ResultType;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.VariableMappingTransformer;
+import io.camunda.zeebe.engine.processing.variable.MappingResultBuilder;
+import io.camunda.zeebe.engine.processing.variable.MsgPackPath;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.util.Either;
 import java.time.InstantSource;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.agrona.DirectBuffer;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -160,8 +163,7 @@ public final class VariableOutputMappingTransformerTest {
         Map.of(),
         """
         Assertion failure on evaluate the expression \
-        '{a:if (a != null) then context merge(a,{b: assert(x, x != null)}) else {b: assert(x, x != null)}}': \
-        The condition is not fulfilled"""
+        ' assert(x, x != null)': The condition is not fulfilled"""
       }, // #9543
     };
   }
@@ -173,20 +175,37 @@ public final class VariableOutputMappingTransformerTest {
       final Map<String, DirectBuffer> variables,
       final String expectedOutput) {
     // given
-    final var expression = transformer.transformOutputMappings(mappings, expressionLanguage);
+    final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
+    outputMappings.forEach(
+        mapping ->
+            assertThat(mapping.source().isValid())
+                .describedAs("Expected valid expression: %s", mapping.source().getFailureMessage())
+                .isTrue());
 
-    assertThat(expression.isValid())
-        .describedAs("Expected valid expression: %s", expression.getFailureMessage())
-        .isTrue();
-
-    // when
-    final var result =
-        expressionLanguage.evaluateExpression(expression, name -> Either.left(variables.get(name)));
+    // when: evaluate the mappings one by one in modeling order, same as
+    // BpmnVariableMappingBehavior.applyOutputMappings does at runtime — accumulated results
+    // shadow the scope variables, and nested targets merge with the scope value at every level
+    final var resultBuilder =
+        new MappingResultBuilder(
+            path ->
+                Optional.ofNullable(variables.get(path.getFirst()))
+                    .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
+                    .orElse(null));
+    for (final var mapping : outputMappings) {
+      final EvaluationContext context =
+          name -> {
+            final var accumulated = resultBuilder.getVariable(name);
+            return Either.left(accumulated != null ? accumulated : variables.get(name));
+          };
+      final var result = expressionLanguage.evaluateExpression(mapping.source(), context);
+      assertThat(result.isFailure())
+          .describedAs("Expected successful evaluation: %s", result.getFailureMessage())
+          .isFalse();
+      resultBuilder.put(mapping.targetPath(), result.toBuffer());
+    }
 
     // then
-    assertThat(result.getType()).isEqualTo(ResultType.OBJECT);
-
-    MsgPackUtil.assertEquality(result.toBuffer(), expectedOutput);
+    MsgPackUtil.assertEquality(resultBuilder.toDocument(), expectedOutput);
   }
 
   @ParameterizedTest(name = "{index}: mapping {0} fails with: {2}")
@@ -196,20 +215,33 @@ public final class VariableOutputMappingTransformerTest {
       final Map<String, DirectBuffer> variables,
       final String failureMessage) {
     // given
-    final var expression = transformer.transformOutputMappings(mappings, expressionLanguage);
+    final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
 
-    assertThat(expression.isValid())
-        .describedAs("Expected valid expression: %s", expression.getFailureMessage())
-        .isTrue();
-
-    // when
-    final var result =
-        expressionLanguage.evaluateExpression(expression, name -> Either.left(variables.get(name)));
+    // when: evaluate one by one, stopping at the first failure (mirrors runtime fail-fast)
+    final var resultBuilder =
+        new MappingResultBuilder(
+            path ->
+                Optional.ofNullable(variables.get(path.getFirst()))
+                    .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
+                    .orElse(null));
+    EvaluationResult failure = null;
+    for (final var mapping : outputMappings) {
+      final EvaluationContext context =
+          name -> {
+            final var accumulated = resultBuilder.getVariable(name);
+            return Either.left(accumulated != null ? accumulated : variables.get(name));
+          };
+      final var result = expressionLanguage.evaluateExpression(mapping.source(), context);
+      if (result.isFailure()) {
+        failure = result;
+        break;
+      }
+      resultBuilder.put(mapping.targetPath(), result.toBuffer());
+    }
 
     // then
-    assertThat(result.isFailure()).isTrue();
-
-    Assertions.assertThat(result.getFailureMessage()).isEqualTo(failureMessage);
+    assertThat(failure).isNotNull();
+    assertThat(failure.getFailureMessage()).isEqualTo(failureMessage);
   }
 
   @Test
@@ -222,19 +254,27 @@ public final class VariableOutputMappingTransformerTest {
     // see c's just-assigned value
     final var mappings = List.of(mapping("1", "a.b"), mapping("x", "c"), mapping("c", "a.d"));
     final Map<String, DirectBuffer> variables = Map.of("x", asMsgPack("1"));
-
-    final var expression = transformer.transformOutputMappings(mappings, expressionLanguage);
-    assertThat(expression.isValid())
-        .describedAs("Expected valid expression: %s", expression.getFailureMessage())
-        .isTrue();
+    final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
 
     // when
-    final var result =
-        expressionLanguage.evaluateExpression(expression, name -> Either.left(variables.get(name)));
+    final var resultBuilder =
+        new MappingResultBuilder(
+            path ->
+                Optional.ofNullable(variables.get(path.getFirst()))
+                    .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
+                    .orElse(null));
+    for (final var mapping : outputMappings) {
+      final EvaluationContext context =
+          name -> {
+            final var accumulated = resultBuilder.getVariable(name);
+            return Either.left(accumulated != null ? accumulated : variables.get(name));
+          };
+      final var result = expressionLanguage.evaluateExpression(mapping.source(), context);
+      resultBuilder.put(mapping.targetPath(), result.toBuffer());
+    }
 
     // then
-    assertThat(result.getType()).isEqualTo(ResultType.OBJECT);
-    MsgPackUtil.assertEquality(result.toBuffer(), "{'a':{'b':1, 'd':1}, 'c':1}");
+    MsgPackUtil.assertEquality(resultBuilder.toDocument(), "{'a':{'b':1, 'd':1}, 'c':1}");
   }
 
   @Test
@@ -251,19 +291,29 @@ public final class VariableOutputMappingTransformerTest {
             mapping("\"abc\"", "notNested"),
             mapping("notNested", "nested.nested.property"),
             mapping("notNested", "notNestedAssigned"));
-
-    final var expression = transformer.transformOutputMappings(mappings, expressionLanguage);
-    assertThat(expression.isValid())
-        .describedAs("Expected valid expression: %s", expression.getFailureMessage())
-        .isTrue();
+    final Map<String, DirectBuffer> variables = Map.of();
+    final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
 
     // when
-    final var result = expressionLanguage.evaluateExpression(expression, name -> Either.left(null));
+    final var resultBuilder =
+        new MappingResultBuilder(
+            path ->
+                Optional.ofNullable(variables.get(path.getFirst()))
+                    .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
+                    .orElse(null));
+    for (final var mapping : outputMappings) {
+      final EvaluationContext context =
+          name -> {
+            final var accumulated = resultBuilder.getVariable(name);
+            return Either.left(accumulated != null ? accumulated : variables.get(name));
+          };
+      final var result = expressionLanguage.evaluateExpression(mapping.source(), context);
+      resultBuilder.put(mapping.targetPath(), result.toBuffer());
+    }
 
     // then
-    assertThat(result.getType()).isEqualTo(ResultType.OBJECT);
     MsgPackUtil.assertEquality(
-        result.toBuffer(),
+        resultBuilder.toDocument(),
         "{'nested':{'property':'some text', 'nested':{'property':'abc'}}, "
             + "'notNested':'abc', 'notNestedAssigned':'abc'}");
   }
@@ -278,19 +328,27 @@ public final class VariableOutputMappingTransformerTest {
   void shouldNotLeakUntouchedSiblingIntoMergeTargetOrBackReference() {
     final var mappings = List.of(mapping("1", "a.b"), mapping("a", "d"));
     final Map<String, DirectBuffer> variables = Map.of("a", asMsgPack("{'p':0}"));
-
-    final var expression = transformer.transformOutputMappings(mappings, expressionLanguage);
-    assertThat(expression.isValid())
-        .describedAs("Expected valid expression: %s", expression.getFailureMessage())
-        .isTrue();
+    final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
 
     // when
-    final var result =
-        expressionLanguage.evaluateExpression(expression, name -> Either.left(variables.get(name)));
+    final var resultBuilder =
+        new MappingResultBuilder(
+            path ->
+                Optional.ofNullable(variables.get(path.getFirst()))
+                    .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
+                    .orElse(null));
+    for (final var mapping : outputMappings) {
+      final EvaluationContext context =
+          name -> {
+            final var accumulated = resultBuilder.getVariable(name);
+            return Either.left(accumulated != null ? accumulated : variables.get(name));
+          };
+      final var result = expressionLanguage.evaluateExpression(mapping.source(), context);
+      resultBuilder.put(mapping.targetPath(), result.toBuffer());
+    }
 
     // then
-    assertThat(result.getType()).isEqualTo(ResultType.OBJECT);
-    MsgPackUtil.assertEquality(result.toBuffer(), "{'a':{'b':1}, 'd':{'b':1}}");
+    MsgPackUtil.assertEquality(resultBuilder.toDocument(), "{'a':{'b':1}, 'd':{'b':1}}");
   }
 
   @Test
@@ -303,19 +361,27 @@ public final class VariableOutputMappingTransformerTest {
   void shouldNotLeakUntouchedSiblingIntoMergeTargetOppositeOrder() {
     final var mappings = List.of(mapping("a", "d"), mapping("1", "a.b"));
     final Map<String, DirectBuffer> variables = Map.of("a", asMsgPack("{'p':0}"));
-
-    final var expression = transformer.transformOutputMappings(mappings, expressionLanguage);
-    assertThat(expression.isValid())
-        .describedAs("Expected valid expression: %s", expression.getFailureMessage())
-        .isTrue();
+    final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
 
     // when
-    final var result =
-        expressionLanguage.evaluateExpression(expression, name -> Either.left(variables.get(name)));
+    final var resultBuilder =
+        new MappingResultBuilder(
+            path ->
+                Optional.ofNullable(variables.get(path.getFirst()))
+                    .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
+                    .orElse(null));
+    for (final var mapping : outputMappings) {
+      final EvaluationContext context =
+          name -> {
+            final var accumulated = resultBuilder.getVariable(name);
+            return Either.left(accumulated != null ? accumulated : variables.get(name));
+          };
+      final var result = expressionLanguage.evaluateExpression(mapping.source(), context);
+      resultBuilder.put(mapping.targetPath(), result.toBuffer());
+    }
 
     // then
-    assertThat(result.getType()).isEqualTo(ResultType.OBJECT);
-    MsgPackUtil.assertEquality(result.toBuffer(), "{'a':{'b':1}, 'd':{'p':0}}");
+    MsgPackUtil.assertEquality(resultBuilder.toDocument(), "{'a':{'b':1}, 'd':{'p':0}}");
   }
 
   private static ZeebeMapping mapping(final String source, final String target) {

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
@@ -49,6 +49,8 @@ public final class FeatureFlags {
   private static final boolean ENABLE_MESSAGE_BODY_ON_EXPIRED = false;
   // Kill-switch for a bug fix; intentionally enabled by default.
   private static final boolean EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE = true;
+  // Kill-switch for a bug fix; intentionally enabled by default.
+  private static final boolean EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER = true;
 
   private boolean yieldingDueDateChecker;
   private boolean enableActorMetrics;
@@ -57,6 +59,7 @@ public final class FeatureFlags {
   private boolean enableStraightThroughProcessingLoopDetector;
   private boolean enableMessageBodyOnExpired;
   private boolean evaluateBoundaryEventCorrelationKeyInActivityScope;
+  private boolean evaluateDuplicateOutputMappingTargetsInOrder;
 
   public FeatureFlags(
       final boolean yieldingDueDateChecker,
@@ -65,7 +68,8 @@ public final class FeatureFlags {
       final boolean enableTimerDueDateCheckerAsync,
       final boolean enableStraightThroughProcessingLoopDetector,
       final boolean enableMessageBodyOnExpired,
-      final boolean evaluateBoundaryEventCorrelationKeyInActivityScope
+      final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
+      final boolean evaluateDuplicateOutputMappingTargetsInOrder
       /*, boolean foo*/ ) {
     this.yieldingDueDateChecker = yieldingDueDateChecker;
     this.enableActorMetrics = enableActorMetrics;
@@ -75,6 +79,8 @@ public final class FeatureFlags {
     this.enableMessageBodyOnExpired = enableMessageBodyOnExpired;
     this.evaluateBoundaryEventCorrelationKeyInActivityScope =
         evaluateBoundaryEventCorrelationKeyInActivityScope;
+    this.evaluateDuplicateOutputMappingTargetsInOrder =
+        evaluateDuplicateOutputMappingTargetsInOrder;
   }
 
   public static FeatureFlags createDefault() {
@@ -85,7 +91,8 @@ public final class FeatureFlags {
         ENABLE_DUE_DATE_CHECKER_ASYNC,
         ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR,
         ENABLE_MESSAGE_BODY_ON_EXPIRED,
-        EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE
+        EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE,
+        EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER
         /*, FOO_DEFAULT*/ );
   }
 
@@ -102,7 +109,8 @@ public final class FeatureFlags {
         true, /* ENABLE_DUE_DATE_CHECKER_ASYNC */
         true, /* ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR */
         false, /* ENABLE_MESSAGE_BODY_ON_EXPIRED */
-        true /* EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE */
+        true, /* EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE */
+        true /* EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER */
         /*, FOO_DEFAULT*/ );
   }
 
@@ -134,6 +142,10 @@ public final class FeatureFlags {
     return evaluateBoundaryEventCorrelationKeyInActivityScope;
   }
 
+  public boolean evaluateDuplicateOutputMappingTargetsInOrder() {
+    return evaluateDuplicateOutputMappingTargetsInOrder;
+  }
+
   public void setYieldingDueDateChecker(final boolean yieldingDueDateChecker) {
     this.yieldingDueDateChecker = yieldingDueDateChecker;
   }
@@ -163,6 +175,12 @@ public final class FeatureFlags {
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope) {
     this.evaluateBoundaryEventCorrelationKeyInActivityScope =
         evaluateBoundaryEventCorrelationKeyInActivityScope;
+  }
+
+  public void setEvaluateDuplicateOutputMappingTargetsInOrder(
+      final boolean evaluateDuplicateOutputMappingTargetsInOrder) {
+    this.evaluateDuplicateOutputMappingTargetsInOrder =
+        evaluateDuplicateOutputMappingTargetsInOrder;
   }
 
   @Override

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
@@ -24,6 +24,7 @@ class FeatureFlagsTest {
     assertThat(sut.enableMessageTTLCheckerAsync()).isFalse();
     assertThat(sut.enableMessageBodyOnExpired()).isFalse();
     assertThat(sut.evaluateBoundaryEventCorrelationKeyInActivityScope()).isTrue();
+    assertThat(sut.evaluateDuplicateOutputMappingTargetsInOrder()).isTrue();
   }
 
   @Test
@@ -36,5 +37,6 @@ class FeatureFlagsTest {
     assertThat(sut.enableMessageTTLCheckerAsync()).isTrue();
     assertThat(sut.enableMessageBodyOnExpired()).isFalse();
     assertThat(sut.evaluateBoundaryEventCorrelationKeyInActivityScope()).isTrue();
+    assertThat(sut.evaluateDuplicateOutputMappingTargetsInOrder()).isTrue();
   }
 }


### PR DESCRIPTION
## Description

Output mappings (`zeebe:output`) are no longer merged into a single combined FEEL context expression at deployment time. Each mapping now keeps its own source expression and target path and is evaluated one by one, strictly in modeling (XML) order, at runtime — the same approach we applied to input mappings in #58801. Each mapping's source sees the accumulated results of the earlier mappings (shadowing same-named scope variables) and otherwise falls back to the element's variable scope, so a later mapping that references the target of an earlier one now resolves correctly instead of being reordered into a broken expression. This is the output half of #11789.

The tricky part was keeping the nested-target merge behavior byte-for-byte. The old combined expression wrapped every nesting level in `if (p != null) then context merge(p, {...})`, merging with the existing scope value at that path. I preserved this by seeding each (re)created level in the result builder from the scope value at its path — including the quirky FEEL artifact where a non-context existing value (`context merge(5, {...})`) poisons the whole level to `null`. So the merge semantics, and the pre-existing local-scope-seed behavior behind #35251, are unchanged; only the ordering is fixed. #35251 stays a separate follow-up.

A couple of intentional behavior changes fall out of evaluating each mapping instead of grouping them at deploy time:
1. Duplicate/overlapping targets now evaluate every source in order (e.g. `1 -> x, x -> y, 2 -> x` yields `x=2, y=1`), where the old grouping silently dropped earlier duplicates and never evaluated their sources. A source that fails (e.g. an `assert`) in a previously-dropped mapping now surfaces an incident.
2. Incident messages for a failing output mapping now name just that mapping's source expression instead of the whole combined context expression.

Evaluation is fail-fast and atomic: the first failing source stops evaluation, raises a single `IO_MAPPING_ERROR` incident, and applies no variables for that attempt; resolving the incident re-runs all mappings from the start, same as before. I added characterization tests up front to pin the existing merge/poison/local-seed behavior, then the ordering tests that reproduce the exact #11789 scenario for outputs.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #11789 
Relates to #56387
