### PR TITLE
ci: prevent npm-ci-with-retry from being killed by job timeouts

### DIFF
--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -120,7 +120,7 @@ jobs:
     if: inputs.runFeTests
     name: "Unit - Front End [${{ matrix.shardIndex }}/${{ matrix.shardTotal }}]"
     runs-on: gcp-perf-core-8-default
-    timeout-minutes: 10
+    timeout-minutes: 12
     permissions: {} # GITHUB_TOKEN unused in this job
     strategy:
       fail-fast: false
@@ -144,6 +144,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "3"
       - run: npm run test -- --no-file-parallelism --maxWorkers 1 --reporter=blob --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         name: Unit & Integration tests
         env:
@@ -173,7 +175,7 @@ jobs:
     needs: [fe-unit-tests]
     name: "Unit - Front End - Merge Reports"
     runs-on: gcp-perf-core-8-default
-    timeout-minutes: 5
+    timeout-minutes: 7
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Unit
@@ -191,6 +193,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "2"
       - name: Download blob reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -205,7 +209,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - TypeScript Type Check"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 7
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -225,6 +229,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "2"
       - run: npm run ts-check
         name: Type checks
       - name: Observe build status
@@ -242,7 +248,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - ESLint"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 7
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -262,6 +268,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "2"
       - run: npm run lint:eslint
         name: ESLint
       - name: Observe build status
@@ -278,7 +286,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - Prettier"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 7
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -298,6 +306,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "2"
       - run: npm run lint:prettier
         name: Prettier
       - name: Observe build status
@@ -315,7 +325,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - a11y"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 12
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -339,6 +349,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "3"
       - name: Build frontend
         run: npm run build
       - name: Run A11y tests
@@ -363,7 +375,7 @@ jobs:
     if: inputs.runFeTests
     name: "Unit / Front End - Visual Regression [${{ matrix.shardIndex }}/${{ matrix.shardTotal }}]"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 12
     permissions: {} # GITHUB_TOKEN unused in this job
     strategy:
       fail-fast: false
@@ -392,6 +404,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "3"
       - name: Build frontend
         run: npm run build:visual-regression
       - name: Run Visual regression tests
@@ -419,7 +433,7 @@ jobs:
     needs: [operate-fe-visual-regression-tests]
     name: "Unit / Front End - Visual Regression - Merge Reports"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 7
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: visual-regression
@@ -440,6 +454,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "2"
       - name: Download blob reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -475,7 +475,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - Update Screenshots"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 12
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: screenshot-update
@@ -497,6 +497,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "3"
       - name: Build frontend
         run: npm run build
       - name: Run Playwright

--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -82,7 +82,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool /  Front End - Type check"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 7
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -102,6 +102,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "2"
       - run: npm run ts-check
         name: Type checks
       - name: Observe build status
@@ -118,7 +120,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - ESLint"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 7
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -138,6 +140,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "2"
       - run: npm run lint:eslint
         name: ESLint
       - name: Observe build status
@@ -154,7 +158,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - Stylelint"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 7
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -173,6 +177,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "2"
       - run: npm run lint:stylelint
         name: Stylelint
       - name: Observe build status
@@ -189,7 +195,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - Prettier"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 7
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -209,6 +215,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "2"
       - run: npm run lint:prettier
         name: Prettier
       - name: Observe build status
@@ -260,7 +268,7 @@ jobs:
     if: inputs.runFeTests
     name: "Unit - Front End - Visual Regression"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 12
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: visual-regression
@@ -284,6 +292,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "3"
       - name: Build frontend
         run: npm run build:visual-regression
       - name: Run Playwright tests
@@ -308,7 +318,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - a11y"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 12
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -332,6 +342,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "3"
       - name: Build frontend
         run: npm run build
       - name: Run A11y tests

--- a/.github/workflows/ci-webapp-client.yml
+++ b/.github/workflows/ci-webapp-client.yml
@@ -18,7 +18,7 @@ jobs:
   typecheck:
     name: "Type check"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 7
     permissions: {} # GITHUB_TOKEN unused in this job
     defaults:
       run:
@@ -33,6 +33,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "2"
       - name: Type check
         run: npm run typecheck
       - name: Observe build status
@@ -48,7 +50,7 @@ jobs:
   eslint:
     name: "ESLint"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 7
     permissions: {} # GITHUB_TOKEN unused in this job
     defaults:
       run:
@@ -63,6 +65,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "2"
       - name: ESLint
         run: npm run lint:eslint
       - name: Observe build status
@@ -78,7 +82,7 @@ jobs:
   knip:
     name: "Knip"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 7
     permissions: {} # GITHUB_TOKEN unused in this job
     defaults:
       run:
@@ -93,6 +97,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "2"
       - name: Knip
         run: npm run lint:knip
       - name: Observe build status
@@ -108,7 +114,7 @@ jobs:
   prettier:
     name: "Prettier"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 7
     permissions: {} # GITHUB_TOKEN unused in this job
     defaults:
       run:
@@ -123,6 +129,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "2"
       - name: Prettier
         run: npm run lint:prettier
       - name: Observe build status
@@ -138,7 +146,7 @@ jobs:
   build:
     name: "Build"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 12
     permissions: {} # GITHUB_TOKEN unused in this job
     defaults:
       run:
@@ -153,6 +161,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "3"
       - name: Build packages
         run: npm run build
       - name: Observe build status
@@ -170,7 +180,7 @@ jobs:
     env:
       TEST_TYPE: Unit
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 12
     permissions: {} # GITHUB_TOKEN unused in this job
     container:
       image: mcr.microsoft.com/playwright:v1.61.1
@@ -190,6 +200,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "3"
       - name: Unit tests
         run: npm run test:unit -w @camunda/orchestration-cluster-webapp
       - name: Upload blob report
@@ -265,7 +277,7 @@ jobs:
     env:
       TEST_TYPE: Accessibility
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 12
     permissions: {} # GITHUB_TOKEN unused in this job
     container:
       image: mcr.microsoft.com/playwright:v1.61.1
@@ -285,6 +297,8 @@ jobs:
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
+          max_attempts: "2"
+          timeout_minutes: "3"
       - name: Build frontend
         run: npm run build -w @camunda/orchestration-cluster-webapp
       - name: Accessibility tests


### PR DESCRIPTION
## Summary

- Several fast frontend lint/type-check/build jobs (Operate, Tasklist, unified webapp client) set `timeout-minutes: 5` or `10`, well below the `npm-ci-with-retry` action's default retry budget (3 attempts × 10 min each).
- When `npm ci` runs slow on the first attempt, GitHub Actions kills the whole job via its own `timeout-minutes` before the retry action can time out, wait, and retry — surfacing as `"The operation was canceled"` instead of a clean retry-exhausted failure, and never actually retrying.
- This is the confirmed root cause of INC-6830 and INC-6834.
- Fix: for each affected job, override the retry action's `max_attempts`/`timeout_minutes` to a smaller worst case (2 attempts × 2–3 min) and bump the job's own `timeout-minutes` just enough to leave headroom for the job's real work afterward. Jobs that already have comfortable headroom (`fe-tests`, `integration`, `visual` — 15min+) and the retry action's own defaults are left untouched, to avoid changing behavior for other callers (Optimize, Zeebe, load-tests) not exposed to this issue.

Closes INC-6830, INC-6834

## Test plan

- [ ] `actionlint` passes on the 3 changed workflow files (verified locally, pre-existing unrelated runner-label warnings only)
- [ ] Push/merge-queue run of `ci-operate.yml`, `ci-tasklist.yml`, `ci-webapp-client.yml` completes green
- [ ] Spot-check one of the retried jobs (e.g. `eslint` in `ci-webapp-client.yml`) to confirm a transient `npm ci` blip now retries cleanly instead of being cancelled by the job timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)