### PR TITLE
feat: add Hikari metrics scoped per tenant

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -14,6 +14,7 @@ import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.zeebe.util.VersionUtil;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -68,11 +69,13 @@ public class MyBatisConfiguration {
   }
 
   @Bean
-  public RdbmsDataSources rdbmsDataSources(final PhysicalTenantResolver physicalTenantResolver)
+  public RdbmsDataSources rdbmsDataSources(
+      final PhysicalTenantResolver physicalTenantResolver, final MeterRegistry meterRegistry)
       throws IOException {
     return RdbmsDataSources.of(
         physicalTenantResolver.mapValues(
-            camunda -> camunda.getData().getSecondaryStorage().getRdbms()));
+            camunda -> camunda.getData().getSecondaryStorage().getRdbms()),
+        meterRegistry);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsDataSources.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsDataSources.java
@@ -12,6 +12,10 @@ import io.camunda.configuration.Rdbms;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.config.VendorDatabasePropertiesLoader;
 import io.camunda.zeebe.util.VisibleForTesting;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -38,49 +42,60 @@ public final class RdbmsDataSources implements AutoCloseable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RdbmsDataSources.class);
 
-  private final Map<String, HikariDataSource> dataSources;
-  private final Map<String, VendorDatabaseProperties> vendorProperties;
-  private final Map<String, DatabaseIdProvider> databaseIdProviders;
+  private final Map<String, HikariDataSource> dataSources = new LinkedHashMap<>();
+  private final Map<String, MeterRegistry> tenantMeterRegistries = new LinkedHashMap<>();
+  private final Map<String, VendorDatabaseProperties> vendorProperties = new LinkedHashMap<>();
+  private final Map<String, DatabaseIdProvider> databaseIdProviders = new LinkedHashMap<>();
 
-  private RdbmsDataSources(
-      final Map<String, HikariDataSource> dataSources,
-      final Map<String, VendorDatabaseProperties> vendorProperties,
-      final Map<String, DatabaseIdProvider> databaseIdProviders) {
-    this.dataSources = dataSources;
-    this.vendorProperties = vendorProperties;
-    this.databaseIdProviders = databaseIdProviders;
-  }
+  private RdbmsDataSources() {}
 
-  public static RdbmsDataSources of(final Map<String, Rdbms> physicalTenantConfigs)
+  /**
+   * @param meterRegistry the cluster-wide registry each physical tenant's HikariCP metrics are
+   *     forwarded to. Each tenant gets its own {@link MicrometerUtil#wrap wrapped registry} tagging
+   *     metrics with {@link PartitionKeyNames#PHYSICAL_TENANT}, consistent with the other
+   *     physical-tenant-scoped RDBMS metrics (e.g. {@code
+   *     PhysicalTenantsRdbmsTableRowCountMetrics}).
+   */
+  public static RdbmsDataSources of(
+      final Map<String, Rdbms> physicalTenantConfigs, final MeterRegistry meterRegistry)
       throws IOException {
-    final var dataSources = new LinkedHashMap<String, HikariDataSource>();
-    final var vendorProperties = new LinkedHashMap<String, VendorDatabaseProperties>();
-    final var databaseIdProviders = new LinkedHashMap<String, DatabaseIdProvider>();
+    final var result = new RdbmsDataSources();
     for (final var entry : physicalTenantConfigs.entrySet()) {
       final var currentPhysicalTenantId = entry.getKey();
       final var rdbms = entry.getValue();
       try {
-        final var ds = buildDataSource(currentPhysicalTenantId, rdbms);
-        dataSources.put(currentPhysicalTenantId, ds);
+        final var tenantMeterRegistry =
+            result.registerTenantMeterRegistry(currentPhysicalTenantId, meterRegistry);
+        final var ds = buildDataSource(currentPhysicalTenantId, rdbms, tenantMeterRegistry);
+        result.dataSources.put(currentPhysicalTenantId, ds);
         final var databaseIdProvider = new RdbmsDatabaseIdProvider(rdbms.getDatabaseVendorId());
-        databaseIdProviders.put(currentPhysicalTenantId, databaseIdProvider);
+        result.databaseIdProviders.put(currentPhysicalTenantId, databaseIdProvider);
         final var databaseId = databaseIdProvider.getDatabaseId(ds);
         LOGGER.info(
             "Detected databaseId '{}' for physical tenant '{}'",
             databaseId,
             currentPhysicalTenantId);
-        vendorProperties.put(
+        result.vendorProperties.put(
             currentPhysicalTenantId, VendorDatabasePropertiesLoader.load(databaseId));
       } catch (final IOException | RuntimeException e) {
         LOGGER.error(
             "Failed to initialize RDBMS datasource for physical tenant {}",
             currentPhysicalTenantId,
             e);
-        dataSources.values().forEach(RdbmsDataSources::closeQuietly);
+        result.close();
         throw e;
       }
     }
-    return new RdbmsDataSources(dataSources, vendorProperties, databaseIdProviders);
+    return result;
+  }
+
+  private MeterRegistry registerTenantMeterRegistry(
+      final String physicalTenantId, final MeterRegistry meterRegistry) {
+    final var tenantMeterRegistry =
+        MicrometerUtil.wrap(
+            meterRegistry, Tags.of(PartitionKeyNames.PHYSICAL_TENANT.asString(), physicalTenantId));
+    tenantMeterRegistries.put(physicalTenantId, tenantMeterRegistry);
+    return tenantMeterRegistry;
   }
 
   public Set<String> physicalTenantIds() {
@@ -120,11 +135,16 @@ public final class RdbmsDataSources implements AutoCloseable {
 
   @Override
   public void close() {
-    dataSources.values().forEach(RdbmsDataSources::closeQuietly);
+    // close each tenant's pool together with its wrapped registry so neither is left dangling
+    dataSources.forEach(
+        (tenantId, ds) -> {
+          closeQuietly(ds);
+          MicrometerUtil.close(tenantMeterRegistries.get(tenantId));
+        });
   }
 
   private static HikariDataSource buildDataSource(
-      final String physicalTenantId, final Rdbms rdbms) {
+      final String physicalTenantId, final Rdbms rdbms, final MeterRegistry meterRegistry) {
     final var ds = new HikariDataSource();
     ds.setPoolName("camunda-rdbms-" + physicalTenantId);
     ds.setJdbcUrl(rdbms.getUrl());
@@ -143,6 +163,7 @@ public final class RdbmsDataSources implements AutoCloseable {
     ds.setLeakDetectionThreshold(pool.getLeakDetectionThreshold().toMillis());
     ds.setKeepaliveTime(pool.getKeepaliveTime().toMillis());
     ds.setValidationTimeout(pool.getValidationTimeout().toMillis());
+    ds.setMetricRegistry(meterRegistry);
     ds.setAutoCommit(false);
     return ds;
   }

--- a/dist/src/test/java/io/camunda/application/commons/rdbms/MyBatisConfigurationPerTenantIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/rdbms/MyBatisConfigurationPerTenantIT.java
@@ -84,7 +84,9 @@ class MyBatisConfigurationPerTenantIT {
     env.getPropertySources().addFirst(new MapPropertySource("test", props));
     final var resolver = PhysicalTenantResolver.of(env, new Camunda());
     final var dataSources =
-        RdbmsDataSources.of(resolver.mapValues(c -> c.getData().getSecondaryStorage().getRdbms()));
+        RdbmsDataSources.of(
+            resolver.mapValues(c -> c.getData().getSecondaryStorage().getRdbms()),
+            new SimpleMeterRegistry());
     final var factories = MY_BATIS.sqlSessionFactories(dataSources, resolver);
     final var bundles = MY_BATIS.rdbmsMapperBundles(factories, dataSources);
     return new TenantFixture(dataSources, factories, bundles);

--- a/dist/src/test/java/io/camunda/application/commons/rdbms/RdbmsDataSourcesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/rdbms/RdbmsDataSourcesTest.java
@@ -17,6 +17,7 @@ import com.zaxxer.hikari.HikariDataSource;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.configuration.Rdbms;
 import io.camunda.configuration.RdbmsConnectionPool;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -40,7 +41,9 @@ class RdbmsDataSourcesTest {
   void shouldBuildDataSourceForSinglePhysicalTenant() throws Exception {
     final var rdbms = h2Rdbms();
     try (final var registry =
-        RdbmsDataSources.of(Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, rdbms))) {
+        RdbmsDataSources.of(
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, rdbms),
+            new SimpleMeterRegistry())) {
 
       // then
       final var ds =
@@ -68,7 +71,9 @@ class RdbmsDataSourcesTest {
     rdbms.setConnectionPool(pool);
 
     try (final var registry =
-        RdbmsDataSources.of(Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, rdbms))) {
+        RdbmsDataSources.of(
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, rdbms),
+            new SimpleMeterRegistry())) {
 
       final var ds =
           (HikariDataSource) registry.dataSourceFor(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
@@ -90,7 +95,9 @@ class RdbmsDataSourcesTest {
     rdbms.setConnectionPool(new RdbmsConnectionPool());
 
     try (final var registry =
-        RdbmsDataSources.of(Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, rdbms))) {
+        RdbmsDataSources.of(
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, rdbms),
+            new SimpleMeterRegistry())) {
 
       // then: keepalive stays disabled and validation timeout keeps the HikariCP default
       final var ds =
@@ -106,7 +113,7 @@ class RdbmsDataSourcesTest {
     configs.put("tenant-a", h2Rdbms());
     configs.put("tenant-b", h2Rdbms());
 
-    try (final var registry = RdbmsDataSources.of(configs)) {
+    try (final var registry = RdbmsDataSources.of(configs, new SimpleMeterRegistry())) {
       assertThat(registry.dataSourceFor("tenant-a")).isNotNull();
       assertThat(registry.dataSourceFor("tenant-b")).isNotNull();
       assertThat(registry.vendorPropertiesFor("tenant-a")).isNotNull();
@@ -117,7 +124,9 @@ class RdbmsDataSourcesTest {
   @Test
   void shouldThrowWhenLookingUpUnknownPhysicalTenantDataSource() throws Exception {
     try (final var registry =
-        RdbmsDataSources.of(Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, h2Rdbms()))) {
+        RdbmsDataSources.of(
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, h2Rdbms()),
+            new SimpleMeterRegistry())) {
       assertThatThrownBy(() -> registry.dataSourceFor("missing"))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("missing");
@@ -127,7 +136,9 @@ class RdbmsDataSourcesTest {
   @Test
   void shouldThrowWhenLookingUpUnknownPhysicalTenantVendorProperties() throws Exception {
     try (final var registry =
-        RdbmsDataSources.of(Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, h2Rdbms()))) {
+        RdbmsDataSources.of(
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, h2Rdbms()),
+            new SimpleMeterRegistry())) {
       assertThatThrownBy(() -> registry.vendorPropertiesFor("missing"))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("missing");
@@ -142,7 +153,7 @@ class RdbmsDataSourcesTest {
 
     final HikariDataSource dsA;
     final HikariDataSource dsB;
-    try (final var registry = RdbmsDataSources.of(configs)) {
+    try (final var registry = RdbmsDataSources.of(configs, new SimpleMeterRegistry())) {
       dsA = (HikariDataSource) registry.dataSourceFor("tenant-a");
       dsB = (HikariDataSource) registry.dataSourceFor("tenant-b");
       assertThat(dsA.isClosed()).isFalse();
@@ -167,7 +178,7 @@ class RdbmsDataSourcesTest {
       configs.put("tenant-b", tenantBRdbms);
 
       // when / then
-      assertThatThrownBy(() -> RdbmsDataSources.of(configs))
+      assertThatThrownBy(() -> RdbmsDataSources.of(configs, new SimpleMeterRegistry()))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("unsupported");
 


### PR DESCRIPTION
## Description

After Hikari pool was created manually we lost the metrics exported to meter registry.
Each tenant uses a composite meter registry always exporting the physical tenant label so it can be properly filtered in the dashboard. MeterRegistry is closed when all datasources are closed.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates #59050
