### PR TITLE
test: cover log compaction after exporter deletion

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceImpl.java
@@ -167,6 +167,10 @@ public final class BrokerAdminServiceImpl extends Actor implements BrokerAdminSe
         snapshotId
             .map(id -> FileBasedSnapshotId.ofFileName(id).getOrThrow().getProcessedPosition())
             .orElse(null);
+    final var exportedPositionInSnapshot =
+        snapshotId
+            .map(id -> FileBasedSnapshotId.ofFileName(id).getOrThrow().getExportedPosition())
+            .orElse(null);
     final var clockFuture = streamProcessor.getClock();
 
     final var partitionHealth = getPartitionHealth().get(partition.getPartitionId());
@@ -198,7 +202,8 @@ public final class BrokerAdminServiceImpl extends Actor implements BrokerAdminSe
                   exporterPhase,
                   exporterPosition,
                   clock,
-                  HealthTree.fromHealthReport(partitionHealth));
+                  HealthTree.fromHealthReport(partitionHealth),
+                  exportedPositionInSnapshot);
           partitionStatus.complete(status);
         });
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/PartitionStatus.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/PartitionStatus.java
@@ -22,7 +22,8 @@ public record PartitionStatus(
     ExporterPhase exporterPhase,
     Long exportedPosition,
     ClockStatus clock,
-    HealthTree health) {
+    HealthTree health,
+    Long exportedPositionInSnapshot) {
   // without the modificationType, you need to interpret the modification based on its fields, which
   // may not always be obvious
   public record ClockStatus(Instant instant, String modificationType, Modification modification) {}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/SingleBrokerDataDeletionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/SingleBrokerDataDeletionTest.java
@@ -39,7 +39,6 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.util.unit.DataSize;
@@ -173,46 +172,6 @@ public class SingleBrokerDataDeletionTest {
     }
   }
 
-  @Ignore("until https://github.com/camunda/camunda/issues/35321")
-  @Test
-  public void shouldCompactWhenExporterHasBeenRemoved() {
-    // given - an exporter which updates its position and accepts all records
-    final int nodeId = 0;
-    LogStreamReader reader = clusteringRule.getLogStream(1).newLogStreamReader();
-    final Broker broker = clusteringRule.getBroker(nodeId);
-    ControllableExporter.updatePosition(true);
-
-    // when - filling the log with messages, and a single deployment command for which we will not
-    // update the position
-    publishEnoughMessagesForCompaction();
-    ControllableExporter.updatePosition(false);
-    deployDummyProcess();
-
-    // then - force compaction and ensure we compacted only things before our sentinel command
-    reader.seekToFirstEvent();
-    final long firstPositionPreCompaction = reader.getPosition();
-    clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
-    final var firstSnapshot = clusteringRule.waitForSnapshotAtBroker(broker);
-    awaitUntilCompaction(reader, firstPositionPreCompaction);
-    assertContainsDeploymentCommand(reader);
-
-    // when - restarting without the exporter
-    final var brokerCfg = clusteringRule.getBrokerCfg(nodeId);
-    brokerCfg.setExporters(Collections.emptyMap());
-    clusteringRule.stopBroker(nodeId);
-    clusteringRule.startBroker(nodeId);
-    publishEnoughMessagesForCompaction();
-
-    // then - force compaction, and expect the deployment command to have been removed
-    reader = clusteringRule.getLogStream(1).newLogStreamReader();
-    final long newFirstPositionPreCompaction = reader.getPosition();
-    clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
-    clusteringRule.waitForNewSnapshotAtBroker(clusteringRule.getBroker(0), firstSnapshot);
-    assertThat(newFirstPositionPreCompaction).isGreaterThan(firstPositionPreCompaction);
-    awaitUntilCompaction(reader, newFirstPositionPreCompaction);
-    assertDoesNotContainDeploymentCommand(reader);
-  }
-
   @Test
   public void shouldNotCompactWhenExporterHasBeenRemovedFromConfig() {
     // given - an exporter which updates its position and accepts all records
@@ -300,15 +259,6 @@ public class SingleBrokerDataDeletionTest {
         Spliterators.spliteratorUnknownSize(reader, Spliterator.ORDERED);
     return StreamSupport.stream(spliterator, false)
         .map(event -> (CopiedRecord<?>) CopiedRecords.createCopiedRecord(1, event));
-  }
-
-  private void assertDoesNotContainDeploymentCommand(final LogStreamReader reader) {
-    assertThat(newRecordStream(reader))
-        .noneSatisfy(
-            r ->
-                RecordAssert.assertThat(r)
-                    .hasRecordType(RecordType.COMMAND)
-                    .hasValueType(ValueType.DEPLOYMENT));
   }
 
   private void assertContainsDeploymentCommand(final LogStreamReader reader) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/exporter/ExporterDeleteTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/exporter/ExporterDeleteTest.java
@@ -11,117 +11,231 @@ import static io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker.RECORDING_EX
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.client.CamundaClient;
 import io.camunda.zeebe.management.cluster.ExporterStatus;
 import io.camunda.zeebe.management.cluster.Operation;
 import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.qa.util.actuator.ExportersActuator;
+import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Objects;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
-@Timeout(2 * 60) // 2 minutes
 @ZeebeIntegration
 final class ExporterDeleteTest {
-  private static final int PARTITIONS_COUNT = 3;
-  private static final int BROKERS_COUNT = 3;
-  private static final int REPLICATION_FACTOR = 3;
 
-  @TempDir private Path baseWorkingDir;
-
-  private TestCluster cluster;
-
-  private ExportersActuator actuator;
-
-  @BeforeEach
-  void setup() {
-    cluster =
-        TestCluster.builder()
-            .useRecordingExporter(true)
-            .withBrokersCount(BROKERS_COUNT)
-            .withPartitionsCount(PARTITIONS_COUNT)
-            .withReplicationFactor(REPLICATION_FACTOR)
-            .withEmbeddedGateway(true)
-            .withBrokerConfig(
-                (memberId, broker) ->
-                    broker.withWorkingDirectory(resolveBrokerDir(baseWorkingDir, memberId)))
-            .build();
-
-    cluster.start().awaitCompleteTopology();
-
-    actuator = ExportersActuator.of(cluster.availableGateway());
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (cluster != null) {
-      cluster.shutdown();
-    }
-  }
-
-  @Test
-  void shouldDeleteExporterFromAllPartitions() {
-    // given - verify exporter is initially enabled on all partitions
-    assertThat(actuator.getExporters())
-        .hasSize(1)
-        .first()
-        .extracting(ExporterStatus::getStatus)
-        .isEqualTo(ExporterStatus.StatusEnum.ENABLED);
-
-    // restart cluster without exporter config to simulate CONFIG_NOT_FOUND state
-    cluster.shutdown();
-
-    cluster.brokers().values().forEach(b -> b.withRecordingExporter(false));
-    final var restartedCluster = cluster.start().awaitCompleteTopology();
-
-    final var restartedActuator = ExportersActuator.of(restartedCluster.availableGateway());
-
-    // verify exporter shows up as CONFIG_NOT_FOUND across all partitions
-    assertThat(restartedActuator.getExporters())
-        .hasSize(1)
-        .first()
-        .satisfies(
-            status -> {
-              assertThat(status.getExporterId()).isEqualTo(RECORDING_EXPORTER_ID);
-              assertThat(status.getStatus()).isEqualTo(ExporterStatus.StatusEnum.CONFIG_NOT_FOUND);
-            });
-
-    // when - delete exporter
-    final var deleteResponse = restartedActuator.deleteExporter(RECORDING_EXPORTER_ID);
-
-    assertThat(deleteResponse.getPlannedChanges())
-        .hasSize(PARTITIONS_COUNT * REPLICATION_FACTOR)
-        .allMatch(
-            operation ->
-                operation.getOperation() == Operation.OperationEnum.PARTITION_DELETE_EXPORTER);
-
-    waitUntilOperationIsApplied(restartedCluster, deleteResponse);
-
-    // then - verify exporter is deleted from all partitions
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .untilAsserted(
-            () ->
-                assertThat(restartedActuator.getExporters())
-                    .describedAs("Exporter is deleted from all partitions")
-                    .isEmpty());
-  }
-
-  private Path resolveBrokerDir(final Path base, final MemberId memberId) {
+  private static Path resolveBrokerDir(final Path base, final MemberId memberId) {
     return base.resolve("broker-" + memberId.id());
   }
 
-  private void waitUntilOperationIsApplied(
+  private static void waitUntilOperationIsApplied(
       final TestCluster cluster, final PlannedOperationsResponse response) {
     Awaitility.await()
         .timeout(Duration.ofSeconds(30))
         .untilAsserted(() -> ClusterActuatorAssert.assertThat(cluster).hasAppliedChanges(response));
+  }
+
+  @Nested
+  @Timeout(2 * 60) // 2 minutes
+  final class DeleteFromAllPartitionsTest {
+    private static final int PARTITIONS_COUNT = 3;
+    private static final int BROKERS_COUNT = 3;
+    private static final int REPLICATION_FACTOR = 3;
+
+    @TempDir private Path baseWorkingDir;
+
+    private TestCluster cluster;
+
+    private ExportersActuator actuator;
+
+    @BeforeEach
+    void setup() {
+      cluster =
+          TestCluster.builder()
+              .useRecordingExporter(true)
+              .withBrokersCount(BROKERS_COUNT)
+              .withPartitionsCount(PARTITIONS_COUNT)
+              .withReplicationFactor(REPLICATION_FACTOR)
+              .withEmbeddedGateway(true)
+              .withBrokerConfig(
+                  (memberId, broker) ->
+                      broker.withWorkingDirectory(resolveBrokerDir(baseWorkingDir, memberId)))
+              .build();
+
+      cluster.start().awaitCompleteTopology();
+
+      actuator = ExportersActuator.of(cluster.availableGateway());
+    }
+
+    @AfterEach
+    void tearDown() {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+
+    @Test
+    void shouldDeleteExporterFromAllPartitions() {
+      // given - verify exporter is initially enabled on all partitions
+      assertThat(actuator.getExporters())
+          .hasSize(1)
+          .first()
+          .extracting(ExporterStatus::getStatus)
+          .isEqualTo(ExporterStatus.StatusEnum.ENABLED);
+
+      // restart cluster without exporter config to simulate CONFIG_NOT_FOUND state
+      cluster.shutdown();
+
+      cluster.brokers().values().forEach(b -> b.withRecordingExporter(false));
+      final var restartedCluster = cluster.start().awaitCompleteTopology();
+
+      final var restartedActuator = ExportersActuator.of(restartedCluster.availableGateway());
+
+      // verify exporter shows up as CONFIG_NOT_FOUND across all partitions
+      assertThat(restartedActuator.getExporters())
+          .hasSize(1)
+          .first()
+          .satisfies(
+              status -> {
+                assertThat(status.getExporterId()).isEqualTo(RECORDING_EXPORTER_ID);
+                assertThat(status.getStatus())
+                    .isEqualTo(ExporterStatus.StatusEnum.CONFIG_NOT_FOUND);
+              });
+
+      // when - delete exporter
+      final var deleteResponse = restartedActuator.deleteExporter(RECORDING_EXPORTER_ID);
+
+      assertThat(deleteResponse.getPlannedChanges())
+          .hasSize(PARTITIONS_COUNT * REPLICATION_FACTOR)
+          .allMatch(
+              operation ->
+                  operation.getOperation() == Operation.OperationEnum.PARTITION_DELETE_EXPORTER);
+
+      waitUntilOperationIsApplied(restartedCluster, deleteResponse);
+
+      // then - verify exporter is deleted from all partitions
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(30))
+          .untilAsserted(
+              () ->
+                  assertThat(restartedActuator.getExporters())
+                      .describedAs("Exporter is deleted from all partitions")
+                      .isEmpty());
+    }
+  }
+
+  @Nested
+  final class CompactionAfterExporterDeletedTest {
+    private static final String PARTITION_DATA_DIRECTORY = "data/default/partitions/1";
+
+    @TempDir private Path baseWorkingDir;
+
+    private TestCluster cluster;
+
+    @BeforeEach
+    void setup() {
+      // an exporter which never acknowledges any record pins the exported position, which blocks
+      // log compaction until the exporter itself is deleted
+      RecordingExporter.autoAcknowledge(false);
+
+      cluster =
+          TestCluster.builder()
+              .useRecordingExporter(true)
+              .withBrokersCount(1)
+              .withPartitionsCount(1)
+              .withReplicationFactor(1)
+              .withEmbeddedGateway(true)
+              .withBrokerConfig(
+                  (memberId, broker) ->
+                      broker
+                          .withWorkingDirectory(resolveBrokerDir(baseWorkingDir, memberId))
+                          .withDataConfig(
+                              data -> {
+                                data.setSnapshotPeriod(Duration.ofMinutes(5));
+                              }))
+              .build();
+
+      cluster.start().awaitCompleteTopology();
+    }
+
+    @AfterEach
+    void tearDown() {
+      RecordingExporter.autoAcknowledge(true);
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+
+    @Test
+    @Timeout(3 * 60)
+    void shouldCompactLogAfterExporterIsDeletedEvenIfItNeverAcknowledgedRecords() {
+      // given - fill up the log and take a snapshot; since the exporter never acknowledges
+      // anything, its exported position stays pinned at 0 and nothing can be compacted yet
+      final var broker = cluster.brokers().values().iterator().next();
+      final var partitions = PartitionsActuator.of(broker);
+
+      try (final var client = cluster.newClientBuilder().build()) {
+        publish(broker, client, 10);
+      }
+      partitions.takeSnapshot();
+      final long exportedPositionInSnapshot = awaitSnapshotTaken(partitions);
+      assertThat(exportedPositionInSnapshot)
+          .describedAs("Exporter is configured and not exporting")
+          .isZero();
+
+      // when - restarting without the exporter config (CONFIG_NOT_FOUND), then deleting the
+      // exporter through the actuator endpoint
+      cluster.shutdown();
+      cluster.brokers().values().forEach(b -> b.withRecordingExporter(false));
+      cluster.start().awaitCompleteTopology();
+
+      final var restartedActuator = ExportersActuator.of(cluster.availableGateway());
+      final var deleteResponse = restartedActuator.deleteExporter(RECORDING_EXPORTER_ID);
+      waitUntilOperationIsApplied(cluster, deleteResponse);
+
+      try (final var client = cluster.newClientBuilder().build()) {
+        publish(broker, client, 10);
+      }
+
+      partitions.takeSnapshot();
+      final var exportedPositionAfterDeletion = awaitSnapshotTaken(partitions);
+
+      // then - the log is compacted now that the exporter's pinned position is gone
+      assertThat(exportedPositionAfterDeletion).isGreaterThan(0);
+    }
+
+    private long awaitSnapshotTaken(final PartitionsActuator partitions) {
+      Awaitility.await("until a snapshot is taken")
+          .atMost(Duration.ofSeconds(30))
+          .until(() -> partitions.query().get(1).snapshotId(), Objects::nonNull);
+      final var partitionStatus = partitions.query().get(1);
+      return partitionStatus.exportedPositionInSnapshot();
+    }
+
+    private void publish(
+        final TestStandaloneBroker broker, final CamundaClient client, final long numMessages) {
+      for (int i = 0; i < numMessages; i++) {
+        client
+            .newPublishMessageCommand()
+            .messageName("msg")
+            .correlationKey("compaction-test")
+            .variable("foo", RandomStringUtils.insecure().nextAscii(1024))
+            .send()
+            .join();
+      }
+    }
   }
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
@@ -142,7 +142,8 @@ public interface PartitionsActuator {
       String streamProcessorPhase,
       Long exportedPosition,
       String exporterPhase,
-      ClockStatus clock) {}
+      ClockStatus clock,
+      Long exportedPositionInSnapshot) {}
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   record ClockStatus(Instant instant, String modificationType, Map<String, Object> modification) {}


### PR DESCRIPTION
## Summary
- `SingleBrokerDataDeletionTest#shouldCompactWhenExporterHasBeenRemoved` was `@Ignore`d pending #35321, and also encoded the wrong contract (it asserted that removing an exporter's config alone triggers compaction, which its sibling test correctly says it should not).
- #35321 is closed on main: exporters can now be fully removed via the delete-exporter actuator endpoint. Added a new nested test to `ExporterDeleteTest` (`CompactionAfterExporterDeletedTest`) that pins the exporter's exported position (so compaction is genuinely blocked), then verifies log segments are compacted once the exporter is deleted through that endpoint.
- Removed the stale ignored test and its now-unused helper from `SingleBrokerDataDeletionTest`.