### PR TITLE
feat: adapt remaining cluster configuration initializers to the new model

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
@@ -456,6 +456,7 @@ public interface ClusterConfigurationInitializer<T extends InitializableClusterC
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void onClusterConfigurationUpdated(final ClusterConfiguration clusterConfiguration) {
       if (uninitialized instanceof ClusterConfiguration) {
         configurationUpdated((T) clusterConfiguration);
@@ -463,6 +464,7 @@ public interface ClusterConfigurationInitializer<T extends InitializableClusterC
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void onClusterConfigurationUpdated(
         final CurrentClusterConfiguration clusterConfiguration) {
       if (uninitialized instanceof CurrentClusterConfiguration) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
@@ -224,47 +224,67 @@ public interface ClusterConfigurationInitializer<T extends InitializableClusterC
    * any member. The future returned by initialize is never completed until a valid configuration is
    * received.
    */
-  class GossipInitializer
-      implements ClusterConfigurationInitializer<ClusterConfiguration>,
-          ClusterConfigurationUpdateListener {
+  class GossipInitializer<T extends InitializableClusterConfiguration>
+      implements ClusterConfigurationInitializer<T>, ClusterConfigurationUpdateListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GossipInitializer.class);
     private final ClusterConfigurationUpdateNotifier clusterConfigurationUpdateNotifier;
-    private final PersistedClusterConfiguration persistedClusterConfiguration;
-    private final Consumer<ClusterConfiguration> configurationGossiper;
-    private final ActorFuture<ClusterConfiguration> initialized;
-
+    private final Supplier<T> persistedConfigurationSupplier;
+    private final Consumer<T> configurationGossiper;
+    private final ActorFuture<T> initialized;
     private final ConcurrencyControl executor;
+    // Used only to discriminate, at runtime, which of the two onClusterConfigurationUpdated
+    // overloads carries a T (see SyncInitializer for the same pattern).
+    private final T uninitialized;
 
     public GossipInitializer(
         final ClusterConfigurationUpdateNotifier clusterConfigurationUpdateNotifier,
-        final PersistedClusterConfiguration persistedClusterConfiguration,
-        final Consumer<ClusterConfiguration> configurationGossiper,
-        final ConcurrencyControl executor) {
+        final Supplier<T> persistedConfigurationSupplier,
+        final Consumer<T> configurationGossiper,
+        final ConcurrencyControl executor,
+        final T uninitialized) {
       this.clusterConfigurationUpdateNotifier = clusterConfigurationUpdateNotifier;
-      this.persistedClusterConfiguration = persistedClusterConfiguration;
+      this.persistedConfigurationSupplier = persistedConfigurationSupplier;
       this.configurationGossiper = configurationGossiper;
       this.executor = executor;
+      this.uninitialized = uninitialized;
       initialized = new CompletableActorFuture<>();
     }
 
     @Override
-    public ActorFuture<ClusterConfiguration> initialize() {
+    public ActorFuture<T> initialize() {
       LOGGER.debug("Waiting for initial cluster configuration via gossip.");
       clusterConfigurationUpdateNotifier.addUpdateListener(this);
-      if (persistedClusterConfiguration.isUninitialized()) {
+      final var persistedConfiguration = persistedConfigurationSupplier.get();
+      if (persistedConfiguration.isUninitialized()) {
         // When uninitialized, the member should gossip uninitialized configuration so that the
         // coordinator is not waiting in SyncInitializer forever.
 
         // Check persisted cluster configuration directly, so as not to overwrite and concurrently
         // received gossip
-        configurationGossiper.accept(persistedClusterConfiguration.getConfiguration());
+        configurationGossiper.accept(persistedConfiguration);
       }
       return initialized;
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void onClusterConfigurationUpdated(final ClusterConfiguration clusterConfiguration) {
+      if (uninitialized instanceof ClusterConfiguration) {
+        configurationUpdated((T) clusterConfiguration);
+      }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void onClusterConfigurationUpdated(
+        final CurrentClusterConfiguration clusterConfiguration) {
+      if (uninitialized instanceof CurrentClusterConfiguration) {
+        configurationUpdated((T) clusterConfiguration);
+      }
+    }
+
+    private void configurationUpdated(final T clusterConfiguration) {
       executor.run(
           () -> {
             if (initialized.isDone()) {
@@ -285,14 +305,13 @@ public interface ClusterConfigurationInitializer<T extends InitializableClusterC
    * until the bootstrap timeout, after which this initializer completes with an uninitialized
    * configuration, letting the caller's initializer chain decide how to proceed.
    */
-  class SyncInitializer
-      implements ClusterConfigurationInitializer<ClusterConfiguration>,
-          ClusterConfigurationUpdateListener {
+  class SyncInitializer<T extends InitializableClusterConfiguration>
+      implements ClusterConfigurationInitializer<T>, ClusterConfigurationUpdateListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SyncInitializer.class);
     private final Duration syncDelay;
     private final ClusterConfigurationUpdateNotifier clusterConfigurationUpdateNotifier;
-    private final ActorFuture<ClusterConfiguration> initialized;
+    private final ActorFuture<T> initialized;
     private final Supplier<List<MemberId>> knownMembersToSync;
     private final Duration bootstrapTimeout;
     private final Set<MemberId> uninitializedMembers = new HashSet<>();
@@ -300,26 +319,29 @@ public interface ClusterConfigurationInitializer<T extends InitializableClusterC
     private boolean retryScheduled;
     private ScheduledTimer bootstrapTimeoutTimer;
     private final ConcurrencyControl executor;
-    private final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester;
+    private final Function<MemberId, ActorFuture<T>> syncRequester;
+    private final T uninitialized;
 
     SyncInitializer(
         final Duration syncDelay,
         final ClusterConfigurationUpdateNotifier clusterConfigurationUpdateNotifier,
         final Supplier<List<MemberId>> knownMembersToSync,
         final ConcurrencyControl executor,
-        final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester,
-        final Duration bootstrapTimeout) {
+        final Function<MemberId, ActorFuture<T>> syncRequester,
+        final Duration bootstrapTimeout,
+        final T uninitialized) {
       this.syncDelay = syncDelay;
       this.clusterConfigurationUpdateNotifier = clusterConfigurationUpdateNotifier;
       this.knownMembersToSync = knownMembersToSync;
       this.executor = executor;
       this.syncRequester = syncRequester;
       this.bootstrapTimeout = bootstrapTimeout;
+      this.uninitialized = uninitialized;
       initialized = new CompletableActorFuture<>();
     }
 
     @Override
-    public ActorFuture<ClusterConfiguration> initialize() {
+    public ActorFuture<T> initialize() {
       if (knownMembersToSync.get().isEmpty()) {
         completeAsUninitialized("no known members to sync");
       } else {
@@ -353,7 +375,7 @@ public interface ClusterConfigurationInitializer<T extends InitializableClusterC
     }
 
     private void handleSyncResponse(
-        final MemberId memberId, final ClusterConfiguration configuration, final Throwable error) {
+        final MemberId memberId, final T configuration, final Throwable error) {
       requestsInFlight.remove(memberId);
       if (initialized.isDone()) {
         return;
@@ -384,7 +406,7 @@ public interface ClusterConfigurationInitializer<T extends InitializableClusterC
         }
       } else {
         LOGGER.debug("Received cluster configuration {} from {}", configuration, memberId);
-        onClusterConfigurationUpdated(configuration);
+        configurationUpdated(configuration);
       }
     }
 
@@ -407,7 +429,7 @@ public interface ClusterConfigurationInitializer<T extends InitializableClusterC
             "No initialized cluster configuration found: {}. Completing as uninitialized; "
                 + "the initializer chain will decide how to proceed.",
             cause);
-        initialized.complete(ClusterConfiguration.uninitialized());
+        initialized.complete(uninitialized);
         cancelBootstrapTimeout();
         clusterConfigurationUpdateNotifier.removeUpdateListener(this);
       }
@@ -429,12 +451,26 @@ public interface ClusterConfigurationInitializer<T extends InitializableClusterC
       }
     }
 
-    private ActorFuture<ClusterConfiguration> requestSync(final MemberId memberId) {
+    private ActorFuture<T> requestSync(final MemberId memberId) {
       return syncRequester.apply(memberId);
     }
 
     @Override
     public void onClusterConfigurationUpdated(final ClusterConfiguration clusterConfiguration) {
+      if (uninitialized instanceof ClusterConfiguration) {
+        configurationUpdated((T) clusterConfiguration);
+      }
+    }
+
+    @Override
+    public void onClusterConfigurationUpdated(
+        final CurrentClusterConfiguration clusterConfiguration) {
+      if (uninitialized instanceof CurrentClusterConfiguration) {
+        configurationUpdated((T) clusterConfiguration);
+      }
+    }
+
+    private void configurationUpdated(final T clusterConfiguration) {
       executor.run(
           () -> {
             if (initialized.isDone()) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -279,7 +279,7 @@ public final class ClusterConfigurationManagerService
    * recover a broken file via sync, then wait on gossip from the coordinator; the coordinator-only
    * initializers below are still defined here (not skipped) because the actual coordinator, once
    * the configuration is initialized, might differ from what {@code staticConfiguration} assumes —
-   * see {@link PartitionDistributorInitializer.CoordinatorOnly}'s self-filtering.
+   * see {@link ClusterConfigurationModifier.CoordinatorOnly}'s self-filtering.
    */
   private ClusterConfigurationInitializer<CurrentClusterConfiguration>
       getCurrentClusterConfigurationNonCoordinatorInitializer(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -212,19 +212,21 @@ public final class ClusterConfigurationManagerService
         // of a serialization bug.
         .recover(
             PersistedConfigurationIsBroken.class,
-            new SyncInitializer(
+            new SyncInitializer<>(
                 gossiperConfig.syncInitializerDelay(),
                 clusterConfigurationGossiper,
                 otherKnownMembers,
                 managerActor,
                 clusterConfigurationGossiper::queryClusterConfiguration,
-                gossiperConfig.bootstrapTimeout()))
+                gossiperConfig.bootstrapTimeout(),
+                ClusterConfiguration.uninitialized()))
         .orThen(
-            new GossipInitializer(
+            new GossipInitializer<>(
                 clusterConfigurationGossiper,
-                persistedClusterConfiguration,
+                persistedClusterConfiguration::getConfiguration,
                 clusterConfigurationGossiper::updateClusterConfiguration,
-                managerActor))
+                managerActor,
+                ClusterConfiguration.uninitialized()))
         .andThen(
             new ExporterStateInitializer(
                 staticConfiguration.partitionConfig().exporting().exporters().keySet(),
@@ -249,13 +251,14 @@ public final class ClusterConfigurationManagerService
     final Supplier<List<MemberId>> otherKnownMembers = initializationMembers(staticConfiguration);
     return FileInitializer.legacyFileInitializer(configurationFile, new ProtoBufSerializer())
         .orThen(
-            new SyncInitializer(
+            new SyncInitializer<>(
                 gossiperConfig.syncInitializerDelay(),
                 clusterConfigurationGossiper,
                 otherKnownMembers,
                 managerActor,
                 clusterConfigurationGossiper::queryClusterConfiguration,
-                gossiperConfig.bootstrapTimeout()))
+                gossiperConfig.bootstrapTimeout(),
+                ClusterConfiguration.uninitialized()))
         .orThen(new StaticInitializer<>(staticConfiguration::generateTopology))
         .andThen(
             new ExporterStateInitializer(
@@ -272,25 +275,62 @@ public final class ClusterConfigurationManagerService
   }
 
   /**
-   * New-model counterpart of {@link #getCoordinatorInitializer}/{@link
-   * #getNonCoordinatorInitializer}. Unlike those, this is a single chain shared by coordinator and
-   * non-coordinator alike: {@link PartitionDistributorInitializer} is {@code CoordinatorOnly} and
-   * self-filters based on the initialized configuration's membership, exactly as it does in the
-   * legacy chains, so no separate coordinator/non-coordinator variant is needed here for it. {@link
-   * PartitionGroupExporterStateInitializer} runs the same for both roles since its post-restore,
-   * coordinator-driven branch does not exist for the new model yet (see {@link
-   * PartitionGroupExporterStateInitializer}'s javadoc).
-   *
-   * <p>{@link GossipInitializer}/{@link SyncInitializer} recovery for the new model is not migrated
-   * yet — the sync RPC ({@link
-   * io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiper#queryClusterConfiguration})
-   * only carries the legacy {@link ClusterConfiguration}. Until that is addressed, every member
-   * falls back to generating its own configuration from static configuration when the local file is
-   * empty.
+   * New-model counterpart of {@link #getNonCoordinatorInitializer}. Mirrors its shape exactly:
+   * recover a broken file via sync, then wait on gossip from the coordinator; the coordinator-only
+   * initializers below are still defined here (not skipped) because the actual coordinator, once
+   * the configuration is initialized, might differ from what {@code staticConfiguration} assumes —
+   * see {@link PartitionDistributorInitializer.CoordinatorOnly}'s self-filtering.
    */
   private ClusterConfigurationInitializer<CurrentClusterConfiguration>
-      getCurrentClusterConfigurationInitializer(final StaticConfiguration staticConfiguration) {
+      getCurrentClusterConfigurationNonCoordinatorInitializer(
+          final StaticConfiguration staticConfiguration) {
+    final Supplier<List<MemberId>> otherKnownMembers = initializationMembers(staticConfiguration);
     return FileInitializer.fromPersistedConfiguration(configurationFile, new ProtoBufSerializer())
+        .recover(
+            PersistedConfigurationIsBroken.class,
+            new SyncInitializer<>(
+                gossiperConfig.syncInitializerDelay(),
+                clusterConfigurationGossiper,
+                otherKnownMembers,
+                managerActor,
+                clusterConfigurationGossiper::queryCurrentClusterConfiguration,
+                gossiperConfig.bootstrapTimeout(),
+                CurrentClusterConfiguration.uninitialized()))
+        .orThen(
+            new GossipInitializer<>(
+                clusterConfigurationGossiper,
+                persistedCurrentClusterConfiguration::getConfiguration,
+                clusterConfigurationGossiper::updateCurrentClusterConfiguration,
+                managerActor,
+                CurrentClusterConfiguration.uninitialized()))
+        .andThen(
+            new PartitionGroupExporterStateInitializer(
+                staticConfiguration.partitionConfig().exporting().exporters().keySet(),
+                staticConfiguration.localMemberId()))
+        .andThen(
+            PartitionDistributorInitializer
+                .currentClusterConfigurationPartitionDistributorInitializer(staticConfiguration));
+  }
+
+  /**
+   * New-model counterpart of {@link #getCoordinatorInitializer}. Mirrors its shape exactly: sync
+   * from other members, and — unlike the non-coordinator chain — self-generate from static
+   * configuration as a last resort if sync times out uninitialized.
+   */
+  private ClusterConfigurationInitializer<CurrentClusterConfiguration>
+      getCurrentClusterConfigurationCoordinatorInitializer(
+          final StaticConfiguration staticConfiguration) {
+    final Supplier<List<MemberId>> otherKnownMembers = initializationMembers(staticConfiguration);
+    return FileInitializer.fromPersistedConfiguration(configurationFile, new ProtoBufSerializer())
+        .orThen(
+            new SyncInitializer<>(
+                gossiperConfig.syncInitializerDelay(),
+                clusterConfigurationGossiper,
+                otherKnownMembers,
+                managerActor,
+                clusterConfigurationGossiper::queryCurrentClusterConfiguration,
+                gossiperConfig.bootstrapTimeout(),
+                CurrentClusterConfiguration.uninitialized()))
         .orThen(new StaticInitializer<>(staticConfiguration::generateCurrentClusterConfiguration))
         .andThen(
             new PartitionGroupExporterStateInitializer(
@@ -354,8 +394,20 @@ public final class ClusterConfigurationManagerService
                 clusterConfigurationManager.registerGlobalChangeAppliers(
                     new GlobalConfigurationChangeAppliersImpl(
                         new NoopClusterMembershipChangeExecutor(), clusterChangeExecutor));
+                final var coordinatorMemberId =
+                    ClusterConfigurationCoordinatorSupplier.ofMembers(
+                            staticConfiguration.clusterMembers())
+                        .getDefaultCoordinator();
+                final var isCoordinator = coordinatorMemberId.equals(localMemberId);
+                final ClusterConfigurationInitializer<CurrentClusterConfiguration>
+                    currentClusterConfigurationInitializer =
+                        isCoordinator
+                            ? getCurrentClusterConfigurationCoordinatorInitializer(
+                                staticConfiguration)
+                            : getCurrentClusterConfigurationNonCoordinatorInitializer(
+                                staticConfiguration);
                 clusterConfigurationManager
-                    .start(getCurrentClusterConfigurationInitializer(staticConfiguration))
+                    .start(currentClusterConfigurationInitializer)
                     .onComplete(result);
               } else {
                 final var coordinatorMemberId =

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -238,7 +238,9 @@ public final class ClusterConfigurationManagerService
         // configuration.
         // These initializers will be skipped if they are not running on the latest coordinator
         // based on the initialized configuration.
-        .andThen(new PartitionDistributorInitializer(staticConfiguration))
+        .andThen(
+            PartitionDistributorInitializer.legacyPartitionDistributorInitializer(
+                staticConfiguration))
         .andThen(new ClusterIdInitializer(staticConfiguration.clusterId(), localMemberId));
   }
 
@@ -263,8 +265,40 @@ public final class ClusterConfigurationManagerService
                 true))
         .andThen(new RoutingStateInitializer(staticConfiguration.partitionCount()))
         // Must be initialized by the coordinator only
-        .andThen(new PartitionDistributorInitializer(staticConfiguration))
+        .andThen(
+            PartitionDistributorInitializer.legacyPartitionDistributorInitializer(
+                staticConfiguration))
         .andThen(new ClusterIdInitializer(staticConfiguration.clusterId(), localMemberId));
+  }
+
+  /**
+   * New-model counterpart of {@link #getCoordinatorInitializer}/{@link
+   * #getNonCoordinatorInitializer}. Unlike those, this is a single chain shared by coordinator and
+   * non-coordinator alike: {@link PartitionDistributorInitializer} is {@code CoordinatorOnly} and
+   * self-filters based on the initialized configuration's membership, exactly as it does in the
+   * legacy chains, so no separate coordinator/non-coordinator variant is needed here for it. {@link
+   * PartitionGroupExporterStateInitializer} runs the same for both roles since its post-restore,
+   * coordinator-driven branch does not exist for the new model yet (see {@link
+   * PartitionGroupExporterStateInitializer}'s javadoc).
+   *
+   * <p>{@link GossipInitializer}/{@link SyncInitializer} recovery for the new model is not migrated
+   * yet — the sync RPC ({@link
+   * io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiper#queryClusterConfiguration})
+   * only carries the legacy {@link ClusterConfiguration}. Until that is addressed, every member
+   * falls back to generating its own configuration from static configuration when the local file is
+   * empty.
+   */
+  private ClusterConfigurationInitializer<CurrentClusterConfiguration>
+      getCurrentClusterConfigurationInitializer(final StaticConfiguration staticConfiguration) {
+    return FileInitializer.fromPersistedConfiguration(configurationFile, new ProtoBufSerializer())
+        .orThen(new StaticInitializer<>(staticConfiguration::generateCurrentClusterConfiguration))
+        .andThen(
+            new PartitionGroupExporterStateInitializer(
+                staticConfiguration.partitionConfig().exporting().exporters().keySet(),
+                staticConfiguration.localMemberId()))
+        .andThen(
+            PartitionDistributorInitializer
+                .currentClusterConfigurationPartitionDistributorInitializer(staticConfiguration));
   }
 
   private Supplier<List<MemberId>> initializationMembers(
@@ -320,17 +354,9 @@ public final class ClusterConfigurationManagerService
                 clusterConfigurationManager.registerGlobalChangeAppliers(
                     new GlobalConfigurationChangeAppliersImpl(
                         new NoopClusterMembershipChangeExecutor(), clusterChangeExecutor));
-                // Intermediate migration step: only the file and static initializer exists for the
-                // new model, used unconditionally for both coordinator and non-coordinator role.
-                // File/gossip/sync recovery and the coordinator/non-coordinator split are a
-                // follow-up.
-                final ClusterConfigurationInitializer<CurrentClusterConfiguration> initializer =
-                    FileInitializer.fromPersistedConfiguration(
-                            configurationFile, new ProtoBufSerializer())
-                        .orThen(
-                            new StaticInitializer<>(
-                                staticConfiguration::generateCurrentClusterConfiguration));
-                clusterConfigurationManager.start(initializer).onComplete(result);
+                clusterConfigurationManager
+                    .start(getCurrentClusterConfigurationInitializer(staticConfiguration))
+                    .onComplete(result);
               } else {
                 final var coordinatorMemberId =
                     ClusterConfigurationCoordinatorSupplier.ofMembers(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ExporterStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ExporterStateInitializer.java
@@ -84,7 +84,8 @@ public class ExporterStateInitializer
     MemberState updatedMemberState = memberState;
     for (final var p : memberState.partitions().keySet()) {
       final PartitionState currentPartitionState = memberState.partitions().get(p);
-      final var updatedPartitionState = updateExporterStateInPartition(currentPartitionState);
+      final var updatedPartitionState =
+          updateExporterStateInPartition(currentPartitionState, configuredExporters);
       // Do not update the member state if the partition state is not changed, otherwise the
       // version will be updated during every restart and this could interfere with other
       // concurrent configuration changes.
@@ -96,7 +97,14 @@ public class ExporterStateInitializer
     return updatedMemberState;
   }
 
-  private PartitionState updateExporterStateInPartition(final PartitionState partitionState) {
+  /**
+   * Reconciles a single partition's exporter state against {@code configuredExporters}. Pure
+   * function of the partition state and the configured exporters — shared with {@link
+   * PartitionGroupExporterStateInitializer}, which applies the same reconciliation per partition
+   * group instead of per cluster-wide member.
+   */
+  static PartitionState updateExporterStateInPartition(
+      final PartitionState partitionState, final Set<String> configuredExporters) {
     final var initializedPartitionState =
         partitionState.config().isInitialized()
             ? partitionState
@@ -133,7 +141,7 @@ public class ExporterStateInitializer
         .updateConfig(c -> c.updateExporting(e -> e.addExporters(newlyAddedExporters)));
   }
 
-  private ExportingConfig reEnableExporters(
+  static ExportingConfig reEnableExporters(
       final ExportingConfig exportingConfig,
       final List<Entry<String, ExporterState>> configReaddedExporters) {
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PartitionDistributorInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PartitionDistributorInitializer.java
@@ -8,41 +8,77 @@
 package io.camunda.zeebe.dynamic.config;
 
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.dynamic.config.util.ZoneAwarePartitionDistributor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Initializes the {@link PartitionDistributorConfig} of the cluster configuration from the local
- * static configuration if it has not already been set. Once the cluster has agreed on a distributor
- * config via gossip, subsequent restarts read it from the persisted state instead of falling back
- * to static configuration.
+ * Initializes the {@link PartitionDistributorConfig} from the local static configuration if it has
+ * not already been set. Once the cluster has agreed on a distributor config via gossip, subsequent
+ * restarts read it from the persisted state instead of falling back to static configuration.
+ *
+ * <p>Works with either the legacy {@link ClusterConfiguration} (where the distributor config lives
+ * directly on the configuration) or the new {@link CurrentClusterConfiguration} (where it lives on
+ * the cluster-wide {@code GlobalConfiguration}, since the partition distributor is not scoped to
+ * any single partition group) via the injected accessor functions. See {@link
+ * #legacyPartitionDistributorInitializer(StaticConfiguration)} and {@link
+ * #currentClusterConfigurationPartitionDistributorInitializer(StaticConfiguration)}.
  */
 @NullMarked
-public class PartitionDistributorInitializer
-    extends ClusterConfigurationModifier.CoordinatorOnly<ClusterConfiguration> {
+public class PartitionDistributorInitializer<T extends InitializableClusterConfiguration>
+    extends ClusterConfigurationModifier.CoordinatorOnly<T> {
 
   private static final Logger LOG = LoggerFactory.getLogger(PartitionDistributorInitializer.class);
 
   private final StaticConfiguration staticConfiguration;
+  private final Function<T, Optional<PartitionDistributorConfig>> configGetter;
+  private final BiFunction<T, PartitionDistributorConfig, T> configSetter;
 
-  public PartitionDistributorInitializer(final StaticConfiguration staticConfiguration) {
+  public PartitionDistributorInitializer(
+      final StaticConfiguration staticConfiguration,
+      final Function<T, Optional<PartitionDistributorConfig>> configGetter,
+      final BiFunction<T, PartitionDistributorConfig, T> configSetter) {
     super(staticConfiguration.localMemberId());
     this.staticConfiguration = staticConfiguration;
+    this.configGetter = configGetter;
+    this.configSetter = configSetter;
+  }
+
+  public static PartitionDistributorInitializer<ClusterConfiguration>
+      legacyPartitionDistributorInitializer(final StaticConfiguration staticConfiguration) {
+    return new PartitionDistributorInitializer<>(
+        staticConfiguration,
+        ClusterConfiguration::partitionDistributorConfig,
+        ClusterConfiguration::setPartitionDistributorConfig);
+  }
+
+  public static PartitionDistributorInitializer<CurrentClusterConfiguration>
+      currentClusterConfigurationPartitionDistributorInitializer(
+          final StaticConfiguration staticConfiguration) {
+    return new PartitionDistributorInitializer<>(
+        staticConfiguration,
+        configuration -> configuration.globalConfiguration().partitionDistributorConfig(),
+        (configuration, config) ->
+            configuration.updateGlobalConfiguration(
+                global -> global.setPartitionDistributorConfig(config)));
   }
 
   @Override
-  public ActorFuture<ClusterConfiguration> modify(final ClusterConfiguration configuration) {
-    if (configuration.partitionDistributorConfig().isPresent()) {
+  public ActorFuture<T> modify(final T configuration) {
+    if (configGetter.apply(configuration).isPresent()) {
       return CompletableActorFuture.completed(configuration);
     }
     final var config = toConfig(staticConfiguration.partitionDistributor());
-    return CompletableActorFuture.completed(configuration.setPartitionDistributorConfig(config));
+    return CompletableActorFuture.completed(configSetter.apply(configuration, config));
   }
 
   private static PartitionDistributorConfig toConfig(final PartitionDistributor distributor) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.Set;
+
+/**
+ * New-model counterpart of {@link ExporterStateInitializer}, applying the same exporter-state
+ * reconciliation to the local member's partitions in <em>every</em> partition group, instead of
+ * once for the single default group. The per-partition reconciliation logic is shared with {@link
+ * ExporterStateInitializer} via its package-visible static helpers.
+ *
+ * <p>Unlike {@link ExporterStateInitializer}, this does not have a post-restore branch that updates
+ * every member's exporter state: nothing currently produces a restore change plan on {@link
+ * CurrentClusterConfiguration}, so that branch would be unreachable and untested. Revisit once
+ * restore is migrated to the new model.
+ */
+public class PartitionGroupExporterStateInitializer
+    implements ClusterConfigurationModifier<CurrentClusterConfiguration> {
+
+  private final Set<String> configuredExporters;
+  private final MemberId localMemberId;
+
+  public PartitionGroupExporterStateInitializer(
+      final Set<String> configuredExporters, final MemberId localMemberId) {
+    this.configuredExporters = configuredExporters;
+    this.localMemberId = localMemberId;
+  }
+
+  @Override
+  public ActorFuture<CurrentClusterConfiguration> modify(
+      final CurrentClusterConfiguration configuration) {
+    var updated = configuration;
+    for (final var groupId : configuration.partitionGroups().keySet()) {
+      if (updated.partitionGroup(groupId).hasMember(localMemberId)) {
+        updated =
+            updated.updatePartitionGroupConfig(
+                groupId, group -> group.updateMember(localMemberId, this::updateExporterState));
+      }
+    }
+    return CompletableActorFuture.completed(updated);
+  }
+
+  private BrokerPartitionState updateExporterState(
+      final BrokerPartitionState brokerPartitionState) {
+    BrokerPartitionState updated = brokerPartitionState;
+    for (final var p : brokerPartitionState.partitions().keySet()) {
+      final PartitionState currentPartitionState = brokerPartitionState.partitions().get(p);
+      final var updatedPartitionState =
+          ExporterStateInitializer.updateExporterStateInPartition(
+              currentPartitionState, configuredExporters);
+      // Do not update the partition state if it is unchanged, otherwise the version would be
+      // bumped during every restart and could interfere with other concurrent configuration
+      // changes.
+      if (!updatedPartitionState.equals(currentPartitionState)) {
+        updated = updated.updatePartition(p, partitionState -> updatedPartitionState);
+      }
+    }
+    return updated;
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiper.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiper.java
@@ -280,6 +280,22 @@ public final class ClusterConfigurationGossiper
     return responseFuture;
   }
 
+  public ActorFuture<CurrentClusterConfiguration> queryCurrentClusterConfiguration(
+      final MemberId memberId) {
+    final ActorFuture<CurrentClusterConfiguration> responseFuture = executor.createFuture();
+    sendSyncRequest(memberId)
+        .whenCompleteAsync(
+            (response, error) -> {
+              if (error == null) {
+                responseFuture.complete(response.getCurrentClusterConfiguration());
+              } else {
+                responseFuture.completeExceptionally(error);
+              }
+            },
+            executor::run);
+    return responseFuture;
+  }
+
   private CompletableFuture<ClusterConfigurationGossipState> sendSyncRequest(
       final MemberId memberId) {
     return communicationService.send(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.SyncIniti
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
@@ -134,11 +135,12 @@ final class ClusterConfigurationInitializerTest {
     final TestClusterConfigurationNotifier topologyNotifier =
         new TestClusterConfigurationNotifier();
     final var initializer =
-        new GossipInitializer(
+        new GossipInitializer<>(
             topologyNotifier,
-            persistedClusterConfiguration,
+            persistedClusterConfiguration::getConfiguration,
             ignore -> {},
-            new TestConcurrencyControl());
+            new TestConcurrencyControl(),
+            ClusterConfiguration.uninitialized());
 
     // when
     final var initializeFuture = initializer.initialize();
@@ -159,13 +161,14 @@ final class ClusterConfigurationInitializerTest {
     final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester =
         id -> syncResponseFuture;
     final var initializer =
-        new SyncInitializer(
+        new SyncInitializer<>(
             Duration.ofSeconds(5),
             new TestClusterConfigurationNotifier(),
             () -> knownMembers,
             new TestConcurrencyControl(true),
             syncRequester,
-            ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT);
+            ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT,
+            ClusterConfiguration.uninitialized());
 
     // when
     final var initializeFuture = initializer.initialize();
@@ -191,13 +194,14 @@ final class ClusterConfigurationInitializerTest {
         id -> syncResponseFuture;
     final var concurrencyControl = new TestConcurrencyControl(true);
     final var initializer =
-        new SyncInitializer(
+        new SyncInitializer<>(
             Duration.ofSeconds(5),
             new TestClusterConfigurationNotifier(),
             () -> knownMembers,
             concurrencyControl,
             syncRequester,
-            ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT);
+            ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT,
+            ClusterConfiguration.uninitialized());
 
     // when
     final var initializeFuture = initializer.initialize();
@@ -222,13 +226,14 @@ final class ClusterConfigurationInitializerTest {
     final var syncResponses =
         Map.of(uninitializedMember, uninitializedResponse, initializedMember, initializedResponse);
     final var initializer =
-        new SyncInitializer(
+        new SyncInitializer<>(
             Duration.ofSeconds(5),
             new TestClusterConfigurationNotifier(),
             () -> List.of(uninitializedMember, initializedMember),
             new TestConcurrencyControl(true),
             syncResponses::get,
-            ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT);
+            ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT,
+            ClusterConfiguration.uninitialized());
 
     // when
     final var initializeFuture = initializer.initialize();
@@ -251,13 +256,14 @@ final class ClusterConfigurationInitializerTest {
     final var concurrencyControl = new TestConcurrencyControl(true);
     final var bootstrapTimeout = Duration.ofSeconds(1);
     final var initializer =
-        new SyncInitializer(
+        new SyncInitializer<>(
             Duration.ofSeconds(1),
             new TestClusterConfigurationNotifier(),
             () -> List.of(unresponsiveMember),
             concurrencyControl,
             ignored -> new TestActorFuture<>(),
-            bootstrapTimeout);
+            bootstrapTimeout,
+            ClusterConfiguration.uninitialized());
 
     // when
     final var initializeFuture = initializer.initialize();
@@ -289,13 +295,14 @@ final class ClusterConfigurationInitializerTest {
     final var uninitializedResponse = new TestActorFuture<ClusterConfiguration>();
     final var syncResponses = Map.of(unresponsiveMember, uninitializedResponse);
     final var initializer =
-        new SyncInitializer(
+        new SyncInitializer<>(
             Duration.ofSeconds(5),
             new TestClusterConfigurationNotifier(),
             () -> List.of(unresponsiveMember),
             concurrencyControl,
             m -> syncResponses.getOrDefault(m, new TestActorFuture<>()),
-            Duration.ofSeconds(1));
+            Duration.ofSeconds(1),
+            ClusterConfiguration.uninitialized());
 
     // when
     final var initializeFuture = initializer.initialize();
@@ -329,13 +336,14 @@ final class ClusterConfigurationInitializerTest {
         };
     final var concurrencyControl = new TestConcurrencyControl(true);
     final var initializer =
-        new SyncInitializer(
+        new SyncInitializer<>(
             Duration.ofSeconds(5),
             new TestClusterConfigurationNotifier(),
             () -> List.of(unreachableMember, recoveringMember),
             concurrencyControl,
             syncRequester,
-            ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT);
+            ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT,
+            ClusterConfiguration.uninitialized());
 
     // when - first round: one member fails, the other is uninitialized -> stays pending
     final var initializeFuture = initializer.initialize();
@@ -352,7 +360,7 @@ final class ClusterConfigurationInitializerTest {
   void shouldCompleteImmediatelyWithNoKnownMembersToSync() {
     // given - a single-node cluster: the coordinator has no other members to sync with
     final var initializer =
-        new SyncInitializer(
+        new SyncInitializer<>(
             Duration.ofSeconds(5),
             new TestClusterConfigurationNotifier(),
             List::of,
@@ -360,7 +368,8 @@ final class ClusterConfigurationInitializerTest {
             id -> {
               throw new AssertionError("should not query any member when the cluster has none");
             },
-            ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT);
+            ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT,
+            ClusterConfiguration.uninitialized());
 
     // when
     final var initializeFuture = initializer.initialize();
@@ -379,13 +388,14 @@ final class ClusterConfigurationInitializerTest {
     final var concurrencyControl = new TestConcurrencyControl(true);
     final var bootstrapTimeout = Duration.ofSeconds(1);
     final var initializer =
-        new SyncInitializer(
+        new SyncInitializer<>(
             Duration.ofMillis(50),
             new TestClusterConfigurationNotifier(),
             () -> List.of(nullRespondingMember),
             concurrencyControl,
             ignored -> CompletableActorFuture.completed(null),
-            bootstrapTimeout);
+            bootstrapTimeout,
+            ClusterConfiguration.uninitialized());
 
     // when
     final var initializeFuture = initializer.initialize();
@@ -420,13 +430,14 @@ final class ClusterConfigurationInitializerTest {
     final var concurrencyControl = new TestConcurrencyControl(true);
     final var bootstrapTimeout = Duration.ofSeconds(30);
     final var initializer =
-        new SyncInitializer(
+        new SyncInitializer<>(
             Duration.ofMillis(50),
             new TestClusterConfigurationNotifier(),
             () -> List.of(slowMember, fastMember),
             concurrencyControl,
             syncRequester,
-            bootstrapTimeout);
+            bootstrapTimeout,
+            ClusterConfiguration.uninitialized());
 
     // when
     final var initializeFuture = initializer.initialize();
@@ -482,6 +493,10 @@ final class ClusterConfigurationInitializerTest {
     void updateTopology(final ClusterConfiguration topology) {
       listener.onClusterConfigurationUpdated(topology);
     }
+
+    void updateCurrentClusterConfiguration(final CurrentClusterConfiguration configuration) {
+      listener.onClusterConfigurationUpdated(configuration);
+    }
   }
 
   @Nested
@@ -492,11 +507,12 @@ final class ClusterConfigurationInitializerTest {
       final var fileInitializer =
           FileInitializer.legacyFileInitializer(topologyFile, new ProtoBufSerializer())
               .orThen(
-                  new GossipInitializer(
+                  new GossipInitializer<>(
                       new TestClusterConfigurationNotifier(),
-                      persistedClusterConfiguration,
+                      persistedClusterConfiguration::getConfiguration,
                       ignore -> {},
-                      new TestConcurrencyControl()));
+                      new TestConcurrencyControl(),
+                      ClusterConfiguration.uninitialized()));
       // write initial topology to the file
       persistedClusterConfiguration.update(initialClusterConfiguration);
       // when
@@ -515,11 +531,12 @@ final class ClusterConfigurationInitializerTest {
       final var initializer =
           FileInitializer.legacyFileInitializer(topologyFile, new ProtoBufSerializer())
               .orThen(
-                  new GossipInitializer(
+                  new GossipInitializer<>(
                       topologyUpdateNotifier,
-                      persistedClusterConfiguration,
+                      persistedClusterConfiguration::getConfiguration,
                       gossipedTopology::set,
-                      new TestConcurrencyControl()));
+                      new TestConcurrencyControl(),
+                      ClusterConfiguration.uninitialized()));
 
       // when
       final var initializeFuture = initializer.initialize();
@@ -544,11 +561,12 @@ final class ClusterConfigurationInitializerTest {
       final var initializer =
           FileInitializer.legacyFileInitializer(topologyFile, new ProtoBufSerializer())
               .orThen(
-                  new GossipInitializer(
+                  new GossipInitializer<>(
                       topologyUpdateNotifier,
-                      persistedClusterConfiguration,
+                      persistedClusterConfiguration::getConfiguration,
                       gossipedTopology::set,
-                      new TestConcurrencyControl()));
+                      new TestConcurrencyControl(),
+                      ClusterConfiguration.uninitialized()));
       // Corrupt file
       Files.write(
           topologyFile, "random".getBytes(), StandardOpenOption.WRITE, StandardOpenOption.CREATE);
@@ -568,13 +586,14 @@ final class ClusterConfigurationInitializerTest {
       final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester =
           id -> syncResponseFuture;
       final var syncInitializer =
-          new SyncInitializer(
+          new SyncInitializer<>(
               Duration.ofSeconds(5),
               new TestClusterConfigurationNotifier(),
               () -> knownMembers,
               new TestConcurrencyControl(true),
               syncRequester,
-              ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT);
+              ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT,
+              ClusterConfiguration.uninitialized());
 
       final var initializer =
           FileInitializer.legacyFileInitializer(topologyFile, new ProtoBufSerializer())
@@ -600,13 +619,14 @@ final class ClusterConfigurationInitializerTest {
           id -> syncResponseFuture;
       final var concurrencyControl = new TestConcurrencyControl(true);
       final var syncInitializer =
-          new SyncInitializer(
+          new SyncInitializer<>(
               Duration.ofSeconds(5),
               new TestClusterConfigurationNotifier(),
               () -> knownMembers,
               concurrencyControl,
               syncRequester,
-              ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT);
+              ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT,
+              ClusterConfiguration.uninitialized());
 
       final var initializer =
           FileInitializer.legacyFileInitializer(topologyFile, new ProtoBufSerializer())
@@ -623,6 +643,112 @@ final class ClusterConfigurationInitializerTest {
 
       // then
       assertThatClusterTopology(initializeFuture.join()).isInitialized();
+    }
+  }
+
+  @Nested
+  class NewModelSyncAndGossipInitializerTest {
+
+    private final CurrentClusterConfiguration initialCurrentClusterConfiguration =
+        CurrentClusterConfiguration.init();
+
+    @Test
+    void shouldInitializeFromGossip() {
+      // given
+      final var topologyNotifier = new TestClusterConfigurationNotifier();
+      final var persistedCurrentClusterConfiguration =
+          PersistedCurrentClusterConfiguration.ofFile(topologyFile, new ProtoBufSerializer());
+      final var initializer =
+          new GossipInitializer<>(
+              topologyNotifier,
+              persistedCurrentClusterConfiguration::getConfiguration,
+              ignore -> {},
+              new TestConcurrencyControl(),
+              CurrentClusterConfiguration.uninitialized());
+
+      // when
+      final var initializeFuture = initializer.initialize();
+      assertThat(initializeFuture.isDone()).isFalse();
+
+      // Simulate gossip received
+      topologyNotifier.updateCurrentClusterConfiguration(initialCurrentClusterConfiguration);
+
+      // then
+      assertThat(initializeFuture.join()).isEqualTo(initialCurrentClusterConfiguration);
+    }
+
+    @Test
+    void shouldIgnoreLegacyUpdatesWhileWaitingForNewModelGossip() {
+      // given
+      final var topologyNotifier = new TestClusterConfigurationNotifier();
+      final var persistedCurrentClusterConfiguration =
+          PersistedCurrentClusterConfiguration.ofFile(topologyFile, new ProtoBufSerializer());
+      final var initializer =
+          new GossipInitializer<>(
+              topologyNotifier,
+              persistedCurrentClusterConfiguration::getConfiguration,
+              ignore -> {},
+              new TestConcurrencyControl(),
+              CurrentClusterConfiguration.uninitialized());
+
+      // when
+      final var initializeFuture = initializer.initialize();
+      topologyNotifier.updateTopology(initialClusterConfiguration);
+
+      // then — the legacy overload is ignored; only a CurrentClusterConfiguration completes it
+      assertThat(initializeFuture.isDone()).isFalse();
+    }
+
+    @Test
+    void shouldInitializeFromSync() {
+      // given
+      final var member = MemberId.from("1");
+      final ActorFuture<CurrentClusterConfiguration> syncResponseFuture = new TestActorFuture<>();
+      final Function<MemberId, ActorFuture<CurrentClusterConfiguration>> syncRequester =
+          id -> syncResponseFuture;
+      final var initializer =
+          new SyncInitializer<>(
+              Duration.ofSeconds(5),
+              new TestClusterConfigurationNotifier(),
+              () -> List.of(member),
+              new TestConcurrencyControl(true),
+              syncRequester,
+              ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT,
+              CurrentClusterConfiguration.uninitialized());
+
+      // when
+      final var initializeFuture = initializer.initialize();
+      assertThat(initializeFuture.isDone()).isFalse();
+      syncResponseFuture.complete(initialCurrentClusterConfiguration);
+
+      // then
+      assertThat(initializeFuture.join()).isEqualTo(initialCurrentClusterConfiguration);
+    }
+
+    @Test
+    void shouldCompleteAsUninitializedAfterBootstrapTimeout() {
+      // given - a member that always answers with null, e.g. a gateway member which is part of
+      // cluster membership but never gossips an explicit uninitialized configuration
+      final var nullRespondingMember = MemberId.from("gateway-0");
+      final var concurrencyControl = new TestConcurrencyControl(true);
+      final var bootstrapTimeout = Duration.ofSeconds(1);
+      final var initializer =
+          new SyncInitializer<>(
+              Duration.ofMillis(50),
+              new TestClusterConfigurationNotifier(),
+              () -> List.of(nullRespondingMember),
+              concurrencyControl,
+              ignored -> CompletableActorFuture.completed(null),
+              bootstrapTimeout,
+              CurrentClusterConfiguration.uninitialized());
+
+      // when
+      final var initializeFuture = initializer.initialize();
+      assertThat(initializeFuture.isDone()).isFalse();
+      concurrencyControl.runAll();
+
+      // then - falls back to uninitialized instead of polling forever
+      assertThat(initializeFuture.join().isUninitialized()).isTrue();
     }
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
@@ -639,7 +639,9 @@ final class ClusterConfigurationInitializerTest {
           getStaticConfiguration(MemberId.from("1"), Set.of(MemberId.from("1")));
       final var initializer =
           StaticInitializer.legacyStaticInitializer(updatedConfiguration)
-              .andThen(new PartitionDistributorInitializer(staticConfiguration));
+              .andThen(
+                  PartitionDistributorInitializer.legacyPartitionDistributorInitializer(
+                      staticConfiguration));
 
       // when
       final var initializeFuture = initializer.initialize();
@@ -658,7 +660,9 @@ final class ClusterConfigurationInitializerTest {
               MemberId.from("1"), Set.of(MemberId.from("0"), MemberId.from("1")));
       final var initializer =
           StaticInitializer.legacyStaticInitializer(staticConfiguration)
-              .andThen(new PartitionDistributorInitializer(staticConfiguration));
+              .andThen(
+                  PartitionDistributorInitializer.legacyPartitionDistributorInitializer(
+                      staticConfiguration));
 
       // when
       final var initializeFuture = initializer.initialize();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionDistributorInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionDistributorInitializerTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
@@ -41,7 +42,8 @@ final class PartitionDistributorInitializerTest {
         ClusterConfiguration.init()
             .setPartitionDistributorConfig(new PartitionDistributorConfig.RoundRobinConfig());
     final var initializer =
-        new PartitionDistributorInitializer(staticConfigWith(new RoundRobinPartitionDistributor()));
+        PartitionDistributorInitializer.legacyPartitionDistributorInitializer(
+            staticConfigWith(new RoundRobinPartitionDistributor()));
 
     // when
     final var result = initializer.modify(config).join();
@@ -55,7 +57,8 @@ final class PartitionDistributorInitializerTest {
     // given
     final var config = ClusterConfiguration.init();
     final var initializer =
-        new PartitionDistributorInitializer(staticConfigWith(new RoundRobinPartitionDistributor()));
+        PartitionDistributorInitializer.legacyPartitionDistributorInitializer(
+            staticConfigWith(new RoundRobinPartitionDistributor()));
 
     // when
     final var result = initializer.modify(config).join();
@@ -71,7 +74,7 @@ final class PartitionDistributorInitializerTest {
     final var zoneSpecs = List.of(new ZoneSpec("zone-a", 2, 1000), new ZoneSpec("zone-b", 1, 500));
     final var config = ClusterConfiguration.init();
     final var initializer =
-        new PartitionDistributorInitializer(
+        PartitionDistributorInitializer.legacyPartitionDistributorInitializer(
             staticConfigWith(new ZoneAwarePartitionDistributor(zoneSpecs)));
 
     // when
@@ -98,7 +101,8 @@ final class PartitionDistributorInitializerTest {
         (members, partitionIds, replicationFactor) -> Set.of();
     final var config = ClusterConfiguration.init();
     final var initializer =
-        new PartitionDistributorInitializer(staticConfigWith(unknownDistributor));
+        PartitionDistributorInitializer.legacyPartitionDistributorInitializer(
+            staticConfigWith(unknownDistributor));
 
     // when
     final var result = initializer.modify(config).join();
@@ -106,5 +110,41 @@ final class PartitionDistributorInitializerTest {
     // then
     assertThat(result.partitionDistributorConfig())
         .hasValue(new PartitionDistributorConfig.FixedConfig());
+  }
+
+  @Test
+  void shouldSkipIfAlreadySetOnGlobalConfiguration() {
+    // given
+    final var configuration =
+        CurrentClusterConfiguration.init()
+            .updateGlobalConfiguration(
+                global ->
+                    global.setPartitionDistributorConfig(
+                        new PartitionDistributorConfig.RoundRobinConfig()));
+    final var initializer =
+        PartitionDistributorInitializer.currentClusterConfigurationPartitionDistributorInitializer(
+            staticConfigWith(new ZoneAwarePartitionDistributor(List.of())));
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then
+    assertThat(result).isEqualTo(configuration);
+  }
+
+  @Test
+  void shouldDeriveConfigOnGlobalConfigurationWhenAbsent() {
+    // given
+    final var configuration = CurrentClusterConfiguration.init();
+    final var initializer =
+        PartitionDistributorInitializer.currentClusterConfigurationPartitionDistributorInitializer(
+            staticConfigWith(new RoundRobinPartitionDistributor()));
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then
+    assertThat(result.globalConfiguration().partitionDistributorConfig())
+        .hasValue(new PartitionDistributorConfig.RoundRobinConfig());
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializerTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class PartitionGroupExporterStateInitializerTest {
+
+  private static final MemberId LOCAL_MEMBER_ID = MemberId.from("0");
+
+  @Test
+  void shouldUpdateLocalMemberExporterStateInEveryGroup() {
+    // given — local member replicates a partition in two different groups
+    final var config = DynamicPartitionConfig.init();
+    final var configuration =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of(
+                "tenant-a", groupWithMember(LOCAL_MEMBER_ID, config),
+                "tenant-b", groupWithMember(LOCAL_MEMBER_ID, config)),
+            PhasedChangeState.empty());
+
+    // when
+    final var result =
+        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID)
+            .modify(configuration)
+            .join();
+
+    // then
+    for (final var groupId : Set.of("tenant-a", "tenant-b")) {
+      final var partitionState =
+          result.partitionGroup(groupId).getMember(LOCAL_MEMBER_ID).getPartition(1);
+      assertThat(partitionState.config().exporting().exporters()).containsKey("expA");
+    }
+  }
+
+  @Test
+  void shouldNotUpdateOtherMembersInAGroup() {
+    // given
+    final var config = DynamicPartitionConfig.init();
+    final var otherMember = MemberId.from("1");
+    final var group =
+        groupWithMember(LOCAL_MEMBER_ID, config)
+            .addMember(otherMember, initialPartitionState(config));
+    final var configuration =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of("tenant-a", group),
+            PhasedChangeState.empty());
+
+    // when
+    final var result =
+        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID)
+            .modify(configuration)
+            .join();
+
+    // then
+    assertThat(
+            result
+                .partitionGroup("tenant-a")
+                .getMember(LOCAL_MEMBER_ID)
+                .getPartition(1)
+                .config()
+                .exporting()
+                .exporters())
+        .containsKey("expA");
+    assertThat(
+            result
+                .partitionGroup("tenant-a")
+                .getMember(otherMember)
+                .getPartition(1)
+                .config()
+                .exporting()
+                .exporters())
+        .doesNotContainKey("expA");
+  }
+
+  @Test
+  void shouldNotChangeGroupWhereLocalMemberIsAbsent() {
+    // given — local member does not replicate any partition in this group
+    final var otherMember = MemberId.from("1");
+    final var config = DynamicPartitionConfig.init();
+    final var group = groupWithMember(otherMember, config);
+    final var configuration =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of("tenant-a", group),
+            PhasedChangeState.empty());
+
+    // when
+    final var result =
+        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID)
+            .modify(configuration)
+            .join();
+
+    // then
+    assertThat(result).isEqualTo(configuration);
+  }
+
+  @Test
+  void shouldNotUpdateWhenNoExporterChanges() {
+    // given
+    final var config =
+        new DynamicPartitionConfig(
+            new ExportingConfig(
+                ExportingState.EXPORTING,
+                Map.of("expA", new ExporterState(0, State.ENABLED, Optional.empty()))));
+    final var configuration =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of("tenant-a", groupWithMember(LOCAL_MEMBER_ID, config)),
+            PhasedChangeState.empty());
+
+    // when
+    final var result =
+        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID)
+            .modify(configuration)
+            .join();
+
+    // then
+    assertThat(result).isEqualTo(configuration);
+  }
+
+  private static PartitionGroupConfiguration groupWithMember(
+      final MemberId memberId, final DynamicPartitionConfig partitionConfig) {
+    return PartitionGroupConfiguration.empty(PartitionGroupConfiguration.INITIAL_VERSION)
+        .addMember(memberId, initialPartitionState(partitionConfig));
+  }
+
+  private static BrokerPartitionState initialPartitionState(
+      final DynamicPartitionConfig partitionConfig) {
+    return BrokerPartitionState.initialize(Map.of(1, PartitionState.active(1, partitionConfig)));
+  }
+}


### PR DESCRIPTION
## Summary

Migrates the remaining `ClusterConfigurationInitializer`/`ClusterConfigurationModifier` implementations to also work with `CurrentClusterConfiguration` (the new multi-partition-group model), and wires them into `ClusterConfigurationManagerService`'s bootstrap chain for coordinator and non-coordinator when `USE_NEW_CONFIG` is `true`.

- `ExporterStateInitializer`: extracted shared per-partition reconciliation helpers, and added `PartitionGroupExporterStateInitializer`, applying the same reconciliation per partition group instead of once for a single default group. The post-restore, coordinator-driven "update every member" branch is intentionally not ported — nothing currently produces a restore change plan on `CurrentClusterConfiguration`, so it would be unreachable and untestable today.
- `PartitionDistributorInitializer`: generified over the config type (mirroring `FileInitializer`/`StaticInitializer`), since the distributor config lives on `GlobalConfiguration` in the new model instead of directly on the top-level configuration.
- `SyncInitializer`/`GossipInitializer`: generified the same way, closing the previous gap where the new model had no way to recover an initialized configuration from other members via sync or gossip (bootstrap could only read the local file or self-generate, risking divergent configs across members).
- Added `ClusterConfigurationGossiper.queryCurrentClusterConfiguration`, the new-model counterpart of the sync RPC (no protocol change needed — the sync response already dual-carries both models via the existing gossip dual-write).
- `RoutingStateInitializer` and `ClusterIdInitializer` are intentionally **not** migrated, per the issue — they only mattered for the very first migration.
- `ClusterConfigurationManagerService`'s new-model chain now mirrors the legacy coordinator/non-coordinator split exactly: coordinator falls back to self-generating from static configuration after sync times out; non-coordinator never self-generates, instead waiting on gossip.

closes #58533.
