### PR TITLE
[Backport stable/8.8] test: fail fast when TestCluster startup hangs

### DIFF
--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
@@ -140,7 +140,12 @@ public final class TestCluster implements CloseableSilently {
         nodes().values().stream()
             .map(node -> CompletableFuture.runAsync(node::start))
             .toArray(CompletableFuture[]::new);
-    CompletableFuture.allOf(started).join();
+    try {
+      CompletableFuture.allOf(started).get(2, TimeUnit.MINUTES);
+    } catch (final Exception e) {
+      LOGGER.error("Failed to start cluster", e);
+      throw new RuntimeException(e);
+    }
     return this;
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
@@ -142,9 +142,11 @@ public final class TestCluster implements CloseableSilently {
             .toArray(CompletableFuture[]::new);
     try {
       CompletableFuture.allOf(started).get(2, TimeUnit.MINUTES);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while starting cluster " + name, e);
     } catch (final Exception e) {
-      LOGGER.error("Failed to start cluster", e);
-      throw new RuntimeException(e);
+      throw new RuntimeException("Failed to start cluster " + name, e);
     }
     return this;
   }


### PR DESCRIPTION
## Description

Partial backport of two commits that reached `main` inside #55588 (merged 2026-07-06), limited
to `TestCluster.start()`:

- `ca7496afffc9621caf620226265dc8d6ff00b5e3` test: in TestCluster do not join indefinitely, but timeout after 2 minutes
- `35c63f245693a856c0c0c802998276bb9a01d669` test: do not swallow interrupts in TestCluster start

`CompletableFuture.allOf(started).join()` becomes `.get(2, TimeUnit.MINUTES)`, with failures
wrapped in a `RuntimeException` and interrupts restored. This matches the already bounded
`shutdown()` a few lines below, and the resulting `start()` body is byte for byte identical to
`main`. Companion backport to `stable/8.9`: #59109.

### Why

Three CI incidents in four days in the `zeebe-ds-integration` job family share one signature: a
single IT class starts, produces zero further output, and stalls the job until the 30 minute GHA
`timeout-minutes` cancels it. The cancellation kills the runner before failsafe can write a
report, so the alert reports "Unsuccessful test cases: None captured", and
`failsafe.rerunFailingTestsCount=7` never engages because a hang is not a failure.

| Incident | Branch | Hung class | Issue |
|---|---|---|---|
| INC-6846 (2026-07-30) | `stable/8.8` | `PartitionLeaveTest` | #59097 |
| INC-6728 (2026-07-27) | `stable/8.9` | `AzureBackupRetentionAcceptanceIT` | #58822 |
| INC-6852 (2026-07-30) | `stable/8.9` | `ScaleUpPartitionsTest` | #59100 |

INC-6846 is the occurrence on this branch, and the lifecycle gap behind all three is identical
here. On `stable/8.8`, `start()` is the only unbounded wait left in the `TestCluster` lifecycle:
`shutdown()` already uses `get(2, TimeUnit.MINUTES)`, and `awaitCompleteTopology()`,
`awaitHealthyTopology()` and `await(probe)` are all Awaitility `atMost(...)` waits that throw.
`PartitionLeaveTest` builds its cluster with `.start().awaitCompleteTopology()`, so `start()`
runs before the bounded wait, and a broker whose Spring context blocks during boot waits forever
and never reaches it. That matches the observed zero output stall.

### Effect

A blocked broker startup becomes a failed test after 2 minutes: failsafe writes a report, the
failure carries a `TimeoutException` cause instead of "None captured", `rerunFailingTestsCount`
engages, and the job completes in minutes instead of being cancelled at 30.

This is a mitigation, not a root cause fix. The root cause is still unknown precisely because
every occurrence so far was killed before a stack trace could exist. #59097, #58822 and #59100
stay open as root cause trackers, and the first occurrence after this lands should finally carry
a usable exception.

### Scope

Cherry-picked with `-x`, so the original SHAs are recorded in the commit trailers. Nothing else
from #55588 is included: its multi-zone configuration work (`List<Zone> multiZoneConfig`,
constructor signature changes, `getMultiZoneConfig()`) is a feature and does not belong on a
stable branch. The net diff is 8 added and 1 removed line in one file. #55588 carried no
backport labels, which is why this never reached the stable branches.

## Related issues

Related to #59097, #58822, #59100 (deliberately left open as root cause trackers).
Original PR: #55588.
