### PR TITLE
Switch on the feature flag for new config model

### DIFF
--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -17,6 +17,8 @@ import io.atomix.cluster.Member;
 import io.atomix.cluster.MemberConfig;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.impl.BrokerTopologyManagerImpl;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
@@ -24,6 +26,7 @@ import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
@@ -31,6 +34,7 @@ import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +42,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -769,37 +774,150 @@ final class BrokerTopologyManagerTest {
   }
 
   @Test
-  void shouldApplyDefaultGroupConfigurationToAllTenantsWhileNewConfigDisabled() {
+  void shouldResolveEachGroupsOwnConfiguredClusterState() {
     // given -- a broker joins a non-default tenant group
     final var brokerId = BrokerMemberId.from(0);
     final var tenant1Info = createBrokerWithGroup(brokerId, "tenant1");
     notifyEvent(createMemberAddedEvent(tenant1Info));
 
-    // when -- the cluster configuration (single, legacy group) is updated with partition
-    // assignments
-    final var clusterTopologyWithTwoBrokers =
-        ClusterConfiguration.init()
-            .addMember(
+    // when -- the new-model cluster configuration carries distinct partition groups for
+    // "default" and "tenant1", each with a different partition assignment
+    final var defaultGroup =
+        new PartitionGroupConfiguration(
+            PartitionGroupConfiguration.INITIAL_VERSION,
+            PartitionGroupConfiguration.INITIAL_INCARNATION_NUMBER,
+            Map.of(
                 MemberId.from("1"),
-                MemberState.initializeAsActive(
+                BrokerPartitionState.initialize(
                     Map.of(
                         1,
                         PartitionState.active(1, DynamicPartitionConfig.init()),
                         2,
-                        PartitionState.active(2, DynamicPartitionConfig.init()))))
-            .addMember(MemberId.from("2"), MemberState.initializeAsActive(Map.of()));
-    topologyManager.onClusterConfigurationUpdated(clusterTopologyWithTwoBrokers);
+                        PartitionState.active(1, DynamicPartitionConfig.init())))),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var tenant1Group =
+        new PartitionGroupConfiguration(
+            PartitionGroupConfiguration.INITIAL_VERSION,
+            PartitionGroupConfiguration.INITIAL_INCARNATION_NUMBER,
+            Map.of(
+                MemberId.from("2"),
+                BrokerPartitionState.initialize(
+                    Map.of(5, PartitionState.active(1, DynamicPartitionConfig.init())))),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var clusterConfiguration =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            new GlobalConfiguration(
+                GlobalConfiguration.INITIAL_VERSION,
+                Optional.empty(),
+                Map.of(
+                    MemberId.from("1"), BrokerState.initializeAsActive(),
+                    MemberId.from("2"), BrokerState.initializeAsActive()),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty()),
+            Map.of(DEFAULT_PHYSICAL_TENANT_ID, defaultGroup, "tenant1", tenant1Group),
+            PhasedChangeState.empty());
+    topologyManager.onClusterConfigurationUpdated(clusterConfiguration);
     actorSchedulerRule.workUntilDone();
 
-    // then -- tenant1's configured cluster state mirrors the default group's: with
-    // USE_NEW_CONFIG disabled, updateConfiguredClusterState always resolves the default group's
-    // configuration regardless of which tenant is being updated. This does not yet exercise
-    // per-tenant configuration resolution, which is unreachable while the flag is off.
+    // then -- the default group resolves its own partitions, not tenant1's
     Awaitility.await()
         .untilAsserted(
-            () -> assertThat(topologyManager.getTopology("tenant1").getClusterSize()).isEqualTo(2));
+            () -> assertThat(topologyManager.getTopology().getClusterSize()).isEqualTo(2));
+    assertThat(topologyManager.getTopology().getPartitionsCount()).isEqualTo(2);
+    assertThat(topologyManager.getTopology().getPartitions()).isEqualTo(List.of(1, 2));
+
+    // and -- tenant1 resolves its own partitions, not the default group's
+    assertThat(topologyManager.getTopology("tenant1").getClusterSize()).isEqualTo(2);
+    assertThat(topologyManager.getTopology("tenant1").getPartitionsCount()).isEqualTo(1);
+    assertThat(topologyManager.getTopology("tenant1").getPartitions()).isEqualTo(List.of(5));
+  }
+
+  @Test
+  void shouldUpdateOnlyChangedGroupOnIncrementalConfigurationUpdate() {
+    // given -- default and tenant1 are both known locally and both configured
+    notifyEvent(createMemberAddedEvent(createBroker(BrokerMemberId.from(0))));
+    notifyEvent(createMemberAddedEvent(createBrokerWithGroup(BrokerMemberId.from(0), "tenant1")));
+
+    final var global = globalConfigWithMember(MemberId.from("1"));
+    final var defaultGroup = singleMemberGroup(MemberId.from("1"), Map.of(1, 1, 2, 1));
+    final var initialTenant1Group = singleMemberGroup(MemberId.from("1"), Map.of(5, 1));
+    topologyManager.onClusterConfigurationUpdated(
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            global,
+            Map.of(DEFAULT_PHYSICAL_TENANT_ID, defaultGroup, "tenant1", initialTenant1Group),
+            PhasedChangeState.empty()));
+    actorSchedulerRule.workUntilDone();
+    assertThat(topologyManager.getTopology().getPartitionsCount()).isEqualTo(2);
+    assertThat(topologyManager.getTopology("tenant1").getPartitionsCount()).isEqualTo(1);
+
+    // when -- a second update changes only tenant1's partition assignment; default's
+    // configuration object is passed unchanged
+    final var updatedTenant1Group = singleMemberGroup(MemberId.from("1"), Map.of(5, 1, 6, 1));
+    topologyManager.onClusterConfigurationUpdated(
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            global,
+            Map.of(DEFAULT_PHYSICAL_TENANT_ID, defaultGroup, "tenant1", updatedTenant1Group),
+            PhasedChangeState.empty()));
+    actorSchedulerRule.workUntilDone();
+
+    // then -- tenant1 reflects the new partition, default is unaffected by tenant1's change
     assertThat(topologyManager.getTopology("tenant1").getPartitionsCount()).isEqualTo(2);
-    assertThat(topologyManager.getTopology("tenant1").getPartitions()).isEqualTo(List.of(1, 2));
+    assertThat(topologyManager.getTopology().getPartitionsCount())
+        .describedAs("default group must be unaffected by tenant1's configuration change")
+        .isEqualTo(2);
+    assertThat(topologyManager.getTopology().getPartitions()).isEqualTo(List.of(1, 2));
+  }
+
+  @Test
+  void shouldFireIncarnationChangedOncePerGroupWhoseIncarnationNumberChanged() {
+    // given -- default and tenant1 are both configured at their initial incarnation number
+    notifyEvent(createMemberAddedEvent(createBroker(BrokerMemberId.from(0))));
+    notifyEvent(createMemberAddedEvent(createBrokerWithGroup(BrokerMemberId.from(0), "tenant1")));
+
+    final var global = globalConfigWithMember(MemberId.from("1"));
+    final var defaultGroup = singleMemberGroup(MemberId.from("1"), Map.of(1, 1));
+    final var tenant1Group = singleMemberGroup(MemberId.from("1"), Map.of(5, 1));
+    topologyManager.onClusterConfigurationUpdated(
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            global,
+            Map.of(DEFAULT_PHYSICAL_TENANT_ID, defaultGroup, "tenant1", tenant1Group),
+            PhasedChangeState.empty()));
+    actorSchedulerRule.workUntilDone();
+
+    final var incarnationChanges = new AtomicInteger();
+    addTopologyListener(
+        new BrokerTopologyListener() {
+          @Override
+          public void clusterIncarnationChanged() {
+            incarnationChanges.incrementAndGet();
+          }
+        });
+
+    // when -- only tenant1's incarnation number advances; default's configuration is unchanged
+    final var tenant1GroupWithNewIncarnation = incrementIncarnation(tenant1Group);
+    topologyManager.onClusterConfigurationUpdated(
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            global,
+            Map.of(
+                DEFAULT_PHYSICAL_TENANT_ID,
+                defaultGroup,
+                "tenant1",
+                tenant1GroupWithNewIncarnation),
+            PhasedChangeState.empty()));
+    actorSchedulerRule.workUntilDone();
+
+    // then -- the listener fires exactly once, for tenant1's incarnation bump, not for default
+    assertThat(incarnationChanges).hasValue(1);
   }
 
   @Test
@@ -850,6 +968,44 @@ final class BrokerTopologyManagerTest {
 
   private BrokerInfo createBrokerWithGroup(final BrokerMemberId brokerId, final String group) {
     return createBroker(brokerId).setPartitionGroup(group);
+  }
+
+  private static GlobalConfiguration globalConfigWithMember(final MemberId memberId) {
+    return new GlobalConfiguration(
+        GlobalConfiguration.INITIAL_VERSION,
+        Optional.empty(),
+        Map.of(memberId, BrokerState.initializeAsActive()),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  // builds a partition group configuration hosted by a single member, at the initial incarnation
+  private static PartitionGroupConfiguration singleMemberGroup(
+      final MemberId memberId, final Map<Integer, Integer> partitionIdToPriority) {
+    final Map<Integer, PartitionState> partitions = new HashMap<>();
+    partitionIdToPriority.forEach(
+        (partitionId, priority) ->
+            partitions.put(
+                partitionId, PartitionState.active(priority, DynamicPartitionConfig.init())));
+    return new PartitionGroupConfiguration(
+        PartitionGroupConfiguration.INITIAL_VERSION,
+        PartitionGroupConfiguration.INITIAL_INCARNATION_NUMBER,
+        Map.of(memberId, BrokerPartitionState.initialize(partitions)),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  private static PartitionGroupConfiguration incrementIncarnation(
+      final PartitionGroupConfiguration group) {
+    return new PartitionGroupConfiguration(
+        group.version(),
+        group.incarnationNumber() + 1,
+        group.members(),
+        group.routingState(),
+        group.pendingChanges(),
+        group.lastChange());
   }
 
   private ClusterMembershipEvent createMemberAddedEvent(final BrokerInfo broker) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -75,7 +75,7 @@ public final class ClusterConfigurationManagerService
    * exercised via the {@code useNewConfig} constructor parameter (see {@link #USE_NEW_CONFIG}).
    * When {@code false}, the legacy code path runs completely unchanged.
    */
-  public static final boolean USE_NEW_CONFIG = false;
+  public static final boolean USE_NEW_CONFIG = true;
 
   private final ClusterConfigurationManagerImpl clusterConfigurationManager;
   private final ClusterConfigurationGossiper clusterConfigurationGossiper;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/GatewayClusterConfigurationService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/GatewayClusterConfigurationService.java
@@ -14,10 +14,12 @@ import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig
 import io.camunda.zeebe.dynamic.config.metrics.TopologyMetrics;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +29,14 @@ import org.slf4j.LoggerFactory;
  * The Gateway only listens to ClusterConfiguration changes. It cannot make changes to the
  * configuration. So the service does not run ClusterConfigurationManager, but only contains the
  * ClusterConfigurationGossiper.
+ *
+ * <p>When {@link ClusterConfigurationManagerService#USE_NEW_CONFIG} is enabled, this service tracks
+ * and gossips the multi-partition-group {@link CurrentClusterConfiguration} instead of the legacy
+ * single-group {@link ClusterConfiguration}, mirroring what {@link ClusterConfigurationManagerImpl}
+ * does for brokers. This matters beyond the gateway's own view: before this, the gateway only ever
+ * gossiped the legacy field, so any real broker that fell back to {@code
+ * CurrentClusterConfiguration#fromLegacy} for a message relayed by the gateway could construct a
+ * lossy reconstruction of an in-progress plan that conflicted with its own, natively-tracked one.
  */
 public class GatewayClusterConfigurationService extends Actor
     implements ClusterConfigurationUpdateNotifier {
@@ -34,8 +44,11 @@ public class GatewayClusterConfigurationService extends Actor
       LoggerFactory.getLogger(GatewayClusterConfigurationService.class);
   private final ClusterConfigurationGossiper clusterConfigurationGossiper;
 
-  // Keep an in memory copy of the configuration. No need to persist it.
+  // Keep an in memory copy of the configuration. No need to persist it. Exactly one of the two
+  // fields below is actively updated, matching useNewConfig.
   private ClusterConfiguration clusterConfiguration = ClusterConfiguration.uninitialized();
+  private CurrentClusterConfiguration currentClusterConfiguration =
+      CurrentClusterConfiguration.uninitialized();
   private final TopologyMetrics topologyMetrics;
   private final CompletableActorFuture<Void> startedFuture = new CompletableActorFuture<>();
 
@@ -44,6 +57,26 @@ public class GatewayClusterConfigurationService extends Actor
       final ClusterMembershipService memberShipService,
       final ClusterConfigurationGossiperConfig config,
       final MeterRegistry meterRegistry) {
+    this(
+        communicationService,
+        memberShipService,
+        config,
+        meterRegistry,
+        ClusterConfigurationManagerService.USE_NEW_CONFIG);
+  }
+
+  /**
+   * @param useNewConfig overrides {@link ClusterConfigurationManagerService#USE_NEW_CONFIG} for
+   *     testing; production code always goes through the constructor above, which uses the
+   *     compile-time flag.
+   */
+  @VisibleForTesting
+  GatewayClusterConfigurationService(
+      final ClusterCommunicationService communicationService,
+      final ClusterMembershipService memberShipService,
+      final ClusterConfigurationGossiperConfig config,
+      final MeterRegistry meterRegistry,
+      final boolean useNewConfig) {
     topologyMetrics = new TopologyMetrics(meterRegistry);
     clusterConfigurationGossiper =
         new ClusterConfigurationGossiper(
@@ -52,8 +85,8 @@ public class GatewayClusterConfigurationService extends Actor
             memberShipService,
             new ProtoBufSerializer(),
             config,
-            this::updateClusterTopology,
-            null, // This should be handled in a follow up.
+            useNewConfig ? ignored -> {} : this::updateClusterTopology,
+            useNewConfig ? this::updateCurrentClusterTopology : null,
             topologyMetrics);
   }
 
@@ -104,6 +137,37 @@ public class GatewayClusterConfigurationService extends Actor
             LOG.warn(
                 "Failed to process received configuration update {}",
                 clusterConfiguration,
+                updateFailed);
+          }
+        });
+  }
+
+  private void updateCurrentClusterTopology(
+      final CurrentClusterConfiguration currentClusterConfiguration) {
+    actor.run(
+        () -> {
+          if (currentClusterConfiguration == null
+              || currentClusterConfiguration.isUninitialized()) {
+            return;
+          }
+
+          try {
+            final var mergedTopology =
+                this.currentClusterConfiguration.merge(currentClusterConfiguration);
+            if (mergedTopology.equals(this.currentClusterConfiguration)) {
+              return;
+            }
+            LOG.debug(
+                "Received new configuration {}. Updating local configuration to {}",
+                currentClusterConfiguration,
+                mergedTopology);
+            this.currentClusterConfiguration = mergedTopology;
+            clusterConfigurationGossiper.updateCurrentClusterConfiguration(
+                this.currentClusterConfiguration);
+          } catch (final Exception updateFailed) {
+            LOG.warn(
+                "Failed to process received configuration update {}",
+                currentClusterConfiguration,
                 updateFailed);
           }
         });

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiper.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiper.java
@@ -339,7 +339,15 @@ public final class ClusterConfigurationGossiper
     executor.run(
         () -> {
           configurationUpdateListeners.add(listener);
-          if (gossipState.getClusterConfiguration() != null) {
+          // Prefer the new-model view (field 2): it carries every partition group, whereas the
+          // legacy view (field 1) is always a single-group projection (see
+          // CurrentClusterConfiguration#toLegacyDefault) and would silently hide every
+          // non-default physical tenant group from a listener backfilled through it. Fall back to
+          // the legacy field only when the new-model one hasn't been populated yet.
+          final var currentConfiguration = gossipState.getCurrentClusterConfiguration();
+          if (currentConfiguration != null) {
+            listener.onClusterConfigurationUpdated(currentConfiguration);
+          } else if (gossipState.getClusterConfiguration() != null) {
             listener.onClusterConfigurationUpdated(gossipState.getClusterConfiguration());
           }
         });

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
@@ -23,10 +23,10 @@ import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor.NoopModeChange
 import io.camunda.zeebe.dynamic.config.changes.NoopPartitionChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor.NoopPartitionScalingChangeExecutor;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
-import io.camunda.zeebe.dynamic.config.state.MemberState.State;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
@@ -54,9 +54,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+/**
+ * Exercises {@link ClusterConfigurationManagerService} end-to-end against the new
+ * multi-partition-group model ({@code USE_NEW_CONFIG = true}). Assertions read the {@link
+ * CurrentClusterConfiguration} directly (via {@link
+ * ClusterConfigurationManagerService#getClusterConfiguration()}) rather than the legacy compat
+ * projection ({@code getClusterTopology()}/{@code toLegacyDefault()}), since that projection cannot
+ * distinguish "uninitialized" from "initialized but empty" for the new model.
+ */
 class ClusterConfigurationManagementIntegrationTest {
 
   private static final Duration INITIALIZATION_TIMEOUT = Duration.ofSeconds(30);
+  private static final MemberId MEMBER_0 = MemberId.from("0");
+  private static final MemberId MEMBER_1 = MemberId.from("1");
+  private static final MemberId MEMBER_2 = MemberId.from("2");
 
   @TempDir Path rootDir;
 
@@ -112,14 +123,9 @@ class ClusterConfigurationManagementIntegrationTest {
                     .timeout(INITIALIZATION_TIMEOUT)
                     .untilAsserted(
                         () ->
-                            assertThat(node.service().getClusterTopology())
+                            assertThat(node.service().getClusterConfiguration())
                                 .succeedsWithin(INITIALIZATION_TIMEOUT)
-                                .satisfies(
-                                    configuration ->
-                                        ClusterConfigurationAssert.assertThatClusterTopology(
-                                                configuration)
-                                            .isInitialized()
-                                            .hasOnlyMembers(Set.of(0, 1, 2)))));
+                                .satisfies(this::assertInitializedWithAllMembers)));
   }
 
   @Test
@@ -146,10 +152,8 @@ class ClusterConfigurationManagementIntegrationTest {
                     .timeout(INITIALIZATION_TIMEOUT)
                     .untilAsserted(
                         () ->
-                            ClusterConfigurationAssert.assertThatClusterTopology(
-                                    node.service().getClusterTopology().join())
-                                .isInitialized()
-                                .hasOnlyMembers(Set.of(0, 1, 2))));
+                            assertInitializedWithAllMembers(
+                                node.service().getClusterConfiguration().join())));
   }
 
   @Test
@@ -180,10 +184,8 @@ class ClusterConfigurationManagementIntegrationTest {
                     .timeout(INITIALIZATION_TIMEOUT)
                     .untilAsserted(
                         () ->
-                            ClusterConfigurationAssert.assertThatClusterTopology(
-                                    node.service().getClusterTopology().join())
-                                .isInitialized()
-                                .hasOnlyMembers(Set.of(0, 1, 2))));
+                            assertInitializedWithAllMembers(
+                                node.service().getClusterConfiguration().join())));
   }
 
   @Test
@@ -201,21 +203,20 @@ class ClusterConfigurationManagementIntegrationTest {
             ignore ->
                 Either.right(
                     List.of(
-                        new PartitionJoinOperation(MemberId.from("0"), 2, 1),
-                        new PartitionLeaveOperation(MemberId.from("1"), 1, 1))))
+                        new PartitionJoinOperation(MEMBER_0, 2, 1),
+                        new PartitionLeaveOperation(MEMBER_1, 1, 1))))
         .join();
 
     // then
     Awaitility.await("The topology change should complete.")
-        .untilAsserted(
-            () ->
-                ClusterConfigurationAssert.assertThatClusterTopology(
-                        service.getClusterTopology().join())
-                    .hasPendingOperationsWithSize(0));
-    ClusterConfigurationAssert.assertThatClusterTopology(service.getClusterTopology().join())
-        .describedAs("The cluster must have the expected topology after change.")
-        .hasMemberWithPartitions(0, Set.of(1, 2))
-        .hasMemberWithPartitions(1, Set.of());
+        .untilAsserted(() -> assertThat(defaultGroupOf(service).hasPendingChanges()).isFalse());
+    final var defaultGroup = defaultGroupOf(service);
+    assertThat(defaultGroup.getMember(MEMBER_0).partitions().keySet())
+        .describedAs("Member 0 must replicate both partitions after the change.")
+        .containsExactlyInAnyOrder(1, 2);
+    assertThat(defaultGroup.hasMember(MEMBER_1))
+        .describedAs("Member 1 replicates no partitions of the group anymore, so it is removed.")
+        .isFalse();
   }
 
   @Test
@@ -234,22 +235,18 @@ class ClusterConfigurationManagementIntegrationTest {
             ignore ->
                 Either.right(
                     List.of(
-                        new ModeChangeOperation(MemberId.from("0"), Mode.RECOVERING),
-                        new ModeChangeOperation(MemberId.from("1"), Mode.RECOVERING),
-                        new ModeChangeOperation(MemberId.from("2"), Mode.RECOVERING))))
+                        new ModeChangeOperation(MEMBER_0, Mode.RECOVERING),
+                        new ModeChangeOperation(MEMBER_1, Mode.RECOVERING),
+                        new ModeChangeOperation(MEMBER_2, Mode.RECOVERING))))
         .join();
 
     // then
     Awaitility.await("The enter-recovery operation should complete.")
-        .untilAsserted(
-            () ->
-                ClusterConfigurationAssert.assertThatClusterTopology(
-                        service.getClusterTopology().join())
-                    .hasPendingOperationsWithSize(0));
-    ClusterConfigurationAssert.assertThatClusterTopology(service.getClusterTopology().join())
-        .hasMemberWithState(0, State.RECOVERING)
-        .hasMemberWithState(1, State.RECOVERING)
-        .hasMemberWithState(2, State.RECOVERING);
+        .untilAsserted(() -> assertThat(defaultGroupOf(service).hasPendingChanges()).isFalse());
+    final var defaultGroup = defaultGroupOf(service);
+    assertThat(defaultGroup.getMember(MEMBER_0).mode()).isEqualTo(Mode.RECOVERING);
+    assertThat(defaultGroup.getMember(MEMBER_1).mode()).isEqualTo(Mode.RECOVERING);
+    assertThat(defaultGroup.getMember(MEMBER_2).mode()).isEqualTo(Mode.RECOVERING);
   }
 
   @Test
@@ -267,22 +264,43 @@ class ClusterConfigurationManagementIntegrationTest {
             ignore ->
                 Either.right(
                     List.of(
-                        new PartitionJoinOperation(MemberId.from("0"), 2, 1),
-                        new PartitionLeaveOperation(MemberId.from("1"), 1, 1),
-                        new PartitionJoinOperation(MemberId.from("1"), 1, 1))))
+                        new PartitionJoinOperation(MEMBER_0, 2, 1),
+                        new PartitionLeaveOperation(MEMBER_1, 1, 1),
+                        new PartitionJoinOperation(MEMBER_1, 1, 1))))
         .join();
 
     // then
     Awaitility.await("The topology change should complete.")
-        .untilAsserted(
-            () ->
-                ClusterConfigurationAssert.assertThatClusterTopology(
-                        service.getClusterTopology().join())
-                    .hasPendingOperationsWithSize(0));
-    ClusterConfigurationAssert.assertThatClusterTopology(service.getClusterTopology().join())
-        .describedAs("The cluster must have the expected topology after change.")
-        .hasMemberWithPartitions(0, Set.of(1, 2))
-        .hasMemberWithPartitions(1, Set.of(1));
+        .untilAsserted(() -> assertThat(defaultGroupOf(service).hasPendingChanges()).isFalse());
+    final var defaultGroup = defaultGroupOf(service);
+    assertThat(defaultGroup.getMember(MEMBER_0).partitions().keySet())
+        .describedAs("Member 0 must replicate both partitions after the change.")
+        .containsExactlyInAnyOrder(1, 2);
+    assertThat(defaultGroup.getMember(MEMBER_1).partitions().keySet())
+        .describedAs("Member 1 left and rejoined partition 1.")
+        .containsExactlyInAnyOrder(1);
+  }
+
+  /**
+   * Asserts that the configuration is initialized and every static cluster member is visible in
+   * {@link CurrentClusterConfiguration#globalConfiguration()}. Checking {@code
+   * globalConfiguration().members()} directly (rather than the legacy {@code toLegacyDefault()}
+   * projection) is required because that projection's derived {@code version} can never equal the
+   * legacy uninitialized sentinel, so {@code isUninitialized()} on the projection is always {@code
+   * false} — it cannot be used to detect that initialization hasn't happened yet.
+   */
+  private void assertInitializedWithAllMembers(final CurrentClusterConfiguration configuration) {
+    assertThat(configuration.isUninitialized()).isFalse();
+    assertThat(configuration.globalConfiguration().members().keySet())
+        .containsExactlyInAnyOrderElementsOf(clusterMemberIds);
+  }
+
+  private PartitionGroupConfiguration defaultGroupOf(
+      final ClusterConfigurationManagerService service) {
+    return service
+        .getClusterConfiguration()
+        .join()
+        .partitionGroup(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
   }
 
   private void awaitAllInitialized() {
@@ -293,9 +311,9 @@ class ClusterConfigurationManagementIntegrationTest {
                 assertThat(nodes.values())
                     .allSatisfy(
                         node ->
-                            assertThat(node.service().getClusterTopology())
+                            assertThat(node.service().getClusterConfiguration())
                                 .succeedsWithin(INITIALIZATION_TIMEOUT)
-                                .returns(false, ClusterConfiguration::isUninitialized)));
+                                .returns(false, CurrentClusterConfiguration::isUninitialized)));
   }
 
   private Node createNode(final String id) {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/GatewayClusterConfigurationServiceTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/GatewayClusterConfigurationServiceTest.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.AtomixCluster;
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.Node;
+import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
+import io.atomix.cluster.impl.DiscoveryMembershipProtocol;
+import io.camunda.zeebe.dynamic.config.ClusterConfigurationUpdateNotifier.ClusterConfigurationUpdateListener;
+import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiper;
+import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
+import io.camunda.zeebe.dynamic.config.metrics.TopologyMetrics;
+import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.testing.TestActorFuture;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.agrona.CloseHelper;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class GatewayClusterConfigurationServiceTest {
+
+  private final ActorScheduler actorScheduler = ActorScheduler.newActorScheduler().build();
+  private final List<Node> clusterNodes =
+      List.of(createNode("1"), createNode("2"), createNode("3"));
+  private final ClusterConfigurationGossiperConfig config =
+      new ClusterConfigurationGossiperConfig(
+          Duration.ofMillis(100),
+          Duration.ofSeconds(1),
+          0,
+          Duration.ofSeconds(1),
+          Duration.ofSeconds(1));
+  @AutoClose private MeterRegistry meterRegistry = new SimpleMeterRegistry();
+  private TestBroker broker1;
+  private TestBroker broker3;
+  private AtomixCluster gatewayCluster;
+  private GatewayClusterConfigurationService gateway;
+
+  @BeforeEach
+  void setup() {
+    actorScheduler.start();
+  }
+
+  @AfterEach
+  void afterEach() {
+    if (gateway != null) {
+      gateway.close();
+    }
+    if (gatewayCluster != null) {
+      gatewayCluster.stop().join();
+    }
+    CloseHelper.quietCloseAll(broker1, broker3, actorScheduler);
+  }
+
+  @Test
+  void shouldReceiveNewModelConfigurationWhenUseNewConfigIsEnabled() {
+    // given — a broker gossiping the new-model configuration, and a gateway wired for the new
+    // model
+    broker1 = new TestBroker(createClusterNode(clusterNodes.get(0), clusterNodes), true);
+    broker1.start();
+    startGateway(clusterNodes.get(1), true);
+
+    final var brokerConfiguration =
+        CurrentClusterConfiguration.fromLegacy(
+            ClusterConfiguration.init()
+                .addMember(broker1.id(), MemberState.initializeAsActive(Map.of())));
+
+    final var received = new AtomicReference<CurrentClusterConfiguration>();
+    gateway.addUpdateListener(
+        new ClusterConfigurationUpdateListener() {
+          @Override
+          public void onClusterConfigurationUpdated(
+              final ClusterConfiguration clusterConfiguration) {
+            // should not be reached: the new-model handler is wired, so field 2 is always
+            // preferred
+            throw new IllegalStateException(
+                "Legacy listener should not be called when new-model field is populated");
+          }
+
+          @Override
+          public void onClusterConfigurationUpdated(
+              final CurrentClusterConfiguration clusterConfiguration) {
+            received.set(clusterConfiguration);
+          }
+        });
+
+    // when
+    broker1.setCurrentClusterConfiguration(brokerConfiguration);
+
+    // then — the gateway receives and merges the full new-model configuration, not a legacy
+    // single-group projection
+    Awaitility.await("The gateway has received the new-model configuration via gossip")
+        .untilAsserted(() -> assertThat(received.get()).isEqualTo(brokerConfiguration));
+  }
+
+  @Test
+  void shouldRelayNewModelConfigurationToOtherBrokers() {
+    // given — a broker gossips a new-model configuration with a non-default physical tenant
+    // group; the gateway is wired for the new model and sits between the two brokers
+    broker1 = new TestBroker(createClusterNode(clusterNodes.get(0), clusterNodes), true);
+    broker3 = new TestBroker(createClusterNode(clusterNodes.get(2), clusterNodes), true);
+    broker1.start();
+    broker3.start();
+    startGateway(clusterNodes.get(1), true);
+
+    final var tenantGroup =
+        new PartitionGroupConfiguration(
+            PartitionGroupConfiguration.INITIAL_VERSION,
+            PartitionGroupConfiguration.INITIAL_INCARNATION_NUMBER,
+            Map.of(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var brokerConfiguration =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init().addMember(broker1.id(), BrokerState.initializeAsActive()),
+            Map.of("tenanta", tenantGroup),
+            PhasedChangeState.empty());
+
+    // when — broker1 gossips the new-model configuration; it must reach broker3 relayed through
+    // the gateway (before this fix, the gateway never populated field 2 at all, so it could only
+    // ever relay a lossy single-group legacy projection)
+    broker1.setCurrentClusterConfiguration(brokerConfiguration);
+
+    // then
+    Awaitility.await("Broker 3 has received the full new-model configuration via the gateway")
+        .untilAsserted(
+            () -> assertThat(broker3.currentClusterConfiguration).isEqualTo(brokerConfiguration));
+    assertThat(broker3.currentClusterConfiguration.hasPartitionGroup("tenanta")).isTrue();
+  }
+
+  @Test
+  void shouldRelayLegacyOnlyBrokerConfigurationWithoutCorruptingConvergence() {
+    // given — broker1 is not yet upgraded (legacy handler only, e.g. mid rolling-upgrade); the
+    // gateway and broker3 are both wired for the new model
+    broker1 = new TestBroker(createClusterNode(clusterNodes.get(0), clusterNodes), false);
+    broker3 = new TestBroker(createClusterNode(clusterNodes.get(2), clusterNodes), true);
+    broker1.start();
+    broker3.start();
+    startGateway(clusterNodes.get(1), true);
+
+    final var brokerTopology =
+        ClusterConfiguration.init()
+            .addMember(broker1.id(), MemberState.initializeAsActive(Map.of()));
+    final var reconstructed = CurrentClusterConfiguration.fromLegacy(brokerTopology);
+
+    // when — the not-yet-upgraded broker gossips only the legacy field; the gateway falls back to
+    // fromLegacy (same as any new-model peer would) and relays the result onward
+    broker1.setTopology(brokerTopology);
+
+    // then — broker3 converges on the reconstructed configuration via the gateway, with no merge
+    // exception and no runaway version growth from repeated re-derivation (the gateway now
+    // dual-writes and only re-gossips when the merged value actually changes, same as a real
+    // broker; see ClusterConfigurationGossiper#updateCurrentClusterConfiguration)
+    Awaitility.await("Broker 3 has received the reconstructed configuration via the gateway")
+        .untilAsserted(
+            () -> assertThat(broker3.currentClusterConfiguration).isEqualTo(reconstructed));
+
+    // and — the reconstruction is stable: waiting longer doesn't change the converged value (no
+    // endless re-derivation loop through the gateway)
+    Awaitility.await()
+        .during(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> assertThat(broker3.currentClusterConfiguration).isEqualTo(reconstructed));
+  }
+
+  @Test
+  void shouldStillReceiveLegacyConfigurationWhenUseNewConfigIsDisabled() {
+    // given — a broker gossiping only the legacy configuration, and a gateway wired for the
+    // legacy model only (useNewConfig=false), matching pre-fix behavior
+    broker1 = new TestBroker(createClusterNode(clusterNodes.get(0), clusterNodes), false);
+    broker1.start();
+    startGateway(clusterNodes.get(1), false);
+
+    final var brokerTopology =
+        ClusterConfiguration.init()
+            .addMember(broker1.id(), MemberState.initializeAsActive(Map.of()));
+
+    final var received = new AtomicReference<ClusterConfiguration>();
+    gateway.addUpdateListener(
+        new ClusterConfigurationUpdateListener() {
+          @Override
+          public void onClusterConfigurationUpdated(
+              final ClusterConfiguration clusterConfiguration) {
+            received.set(clusterConfiguration);
+          }
+        });
+
+    // when
+    broker1.setTopology(brokerTopology);
+
+    // then
+    Awaitility.await("The gateway has received the legacy configuration via gossip")
+        .untilAsserted(() -> assertThat(received.get()).isEqualTo(brokerTopology));
+  }
+
+  private void startGateway(final Node node, final boolean useNewConfig) {
+    gatewayCluster = createClusterNode(node, clusterNodes);
+    gatewayCluster.start().join();
+    gateway =
+        new GatewayClusterConfigurationService(
+            gatewayCluster.getCommunicationService(),
+            gatewayCluster.getMembershipService(),
+            config,
+            meterRegistry,
+            useNewConfig);
+    gateway.start(actorScheduler).join();
+  }
+
+  private Node createNode(final String id) {
+    return Node.builder().withId(id).withPort(SocketUtil.getNextAddress().getPort()).build();
+  }
+
+  private AtomixCluster createClusterNode(final Node localNode, final Collection<Node> nodes) {
+    return AtomixCluster.builder(meterRegistry)
+        .withAddress(localNode.address())
+        .withMemberId(localNode.id().id())
+        .withMembershipProvider(new BootstrapDiscoveryProvider(nodes))
+        .withMembershipProtocol(new DiscoveryMembershipProtocol())
+        .build();
+  }
+
+  /** Minimal stand-in for a broker's {@code ClusterConfigurationManagerImpl}-driven gossiping. */
+  private final class TestBroker extends Actor {
+    private final ClusterConfigurationGossiper gossiper;
+    private final AtomixCluster atomixCluster;
+    private ClusterConfiguration clusterConfiguration;
+    private CurrentClusterConfiguration currentClusterConfiguration;
+
+    private TestBroker(final AtomixCluster atomixCluster, final boolean useNewModelHandler) {
+      super("Node-" + atomixCluster.getMembershipService().getLocalMember().id());
+      gossiper =
+          new ClusterConfigurationGossiper(
+              this,
+              atomixCluster.getCommunicationService(),
+              atomixCluster.getMembershipService(),
+              new ProtoBufSerializer(),
+              config,
+              useNewModelHandler ? null : this::mergeTopology,
+              useNewModelHandler ? this::mergeCurrentClusterConfiguration : null,
+              new TopologyMetrics(meterRegistry));
+      this.atomixCluster = atomixCluster;
+    }
+
+    @Override
+    public void close() {
+      atomixCluster.stop().join();
+    }
+
+    private void start() {
+      atomixCluster.start().join();
+      actorScheduler.submitActor(this).join();
+      gossiper.start();
+    }
+
+    void setTopology(final ClusterConfiguration clusterConfiguration) {
+      this.clusterConfiguration = clusterConfiguration;
+      gossiper.updateClusterConfiguration(clusterConfiguration);
+    }
+
+    private ActorFuture<ClusterConfiguration> mergeTopology(final ClusterConfiguration t) {
+      clusterConfiguration = clusterConfiguration == null ? t : t.merge(clusterConfiguration);
+      return TestActorFuture.completedFuture(clusterConfiguration);
+    }
+
+    void setCurrentClusterConfiguration(
+        final CurrentClusterConfiguration currentClusterConfiguration) {
+      this.currentClusterConfiguration = currentClusterConfiguration;
+      gossiper.updateCurrentClusterConfiguration(currentClusterConfiguration);
+    }
+
+    private void mergeCurrentClusterConfiguration(final CurrentClusterConfiguration received) {
+      currentClusterConfiguration =
+          currentClusterConfiguration == null
+              ? received
+              : currentClusterConfiguration.merge(received);
+      gossiper.updateCurrentClusterConfiguration(currentClusterConfiguration);
+    }
+
+    public MemberId id() {
+      return atomixCluster.getMembershipService().getLocalMember().id();
+    }
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperTest.java
@@ -14,11 +14,16 @@ import io.atomix.cluster.MemberId;
 import io.atomix.cluster.Node;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.cluster.impl.DiscoveryMembershipProtocol;
+import io.camunda.zeebe.dynamic.config.ClusterConfigurationUpdateNotifier.ClusterConfigurationUpdateListener;
 import io.camunda.zeebe.dynamic.config.metrics.TopologyMetrics;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -30,6 +35,8 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import org.agrona.CloseHelper;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
@@ -206,6 +213,73 @@ final class ClusterConfigurationGossiperTest {
                     .isEqualTo(node1Configuration.toLegacyDefault()));
   }
 
+  @Test
+  void shouldBackfillNewListenerWithNewModelConfigurationNotLegacyProjection() {
+    // given — two upgraded brokers; node1 gossips a new-model configuration with a non-default
+    // physical tenant group ("tenanta"), which node2 receives and converges on
+    final var config =
+        new ClusterConfigurationGossiperConfig(
+            Duration.ofMillis(100),
+            Duration.ofSeconds(1),
+            0,
+            Duration.ofSeconds(1),
+            Duration.ofSeconds(1));
+    node1 =
+        new TestGossiper(
+            createClusterNode(clusterNodes.get(0), clusterNodes), config, topologyMetrics, true);
+    node2 =
+        new TestGossiper(
+            createClusterNode(clusterNodes.get(1), clusterNodes), config, topologyMetrics, true);
+    node1.start();
+    node2.start();
+
+    final var tenantGroup =
+        new PartitionGroupConfiguration(
+            PartitionGroupConfiguration.INITIAL_VERSION,
+            PartitionGroupConfiguration.INITIAL_INCARNATION_NUMBER,
+            Map.of(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var node1Configuration =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init().addMember(node1.id(), BrokerState.initializeAsActive()),
+            Map.of("tenanta", tenantGroup),
+            PhasedChangeState.empty());
+    node1.setCurrentClusterConfiguration(node1Configuration);
+    Awaitility.await("Node 2 has received the new-model configuration via gossip")
+        .untilAsserted(
+            () -> assertThat(node2.currentClusterConfiguration).isEqualTo(node1Configuration));
+
+    // when — a new listener registers on node2 only now, simulating a broker whose
+    // BrokerTopologyManagerImpl (re)registers after the gossip state is already populated (e.g.
+    // right after a restart)
+    final var backfilled = new AtomicReference<CurrentClusterConfiguration>();
+    node2.addUpdateListener(
+        new ClusterConfigurationUpdateListener() {
+          @Override
+          public void onClusterConfigurationUpdated(
+              final ClusterConfiguration clusterConfiguration) {
+            // should not be reached: the new-model field is populated, so it must be preferred
+            throw new IllegalStateException(
+                "Legacy listener should not be called when new-model field is populated");
+          }
+
+          @Override
+          public void onClusterConfigurationUpdated(
+              final CurrentClusterConfiguration clusterConfiguration) {
+            backfilled.set(clusterConfiguration);
+          }
+        });
+
+    // then — the backfill call carries the full new-model configuration, including "tenanta",
+    // not the legacy single-group projection (which would have silently dropped it)
+    Awaitility.await("The new listener was backfilled with the new-model configuration")
+        .untilAsserted(() -> assertThat(backfilled.get()).isEqualTo(node1Configuration));
+    assertThat(backfilled.get().hasPartitionGroup("tenanta")).isTrue();
+  }
+
   private Node createNode(final String id) {
     return Node.builder().withId(id).withPort(SocketUtil.getNextAddress().getPort()).build();
   }
@@ -276,10 +350,19 @@ final class ClusterConfigurationGossiperTest {
           currentClusterConfiguration == null
               ? received
               : currentClusterConfiguration.merge(received);
+      // Mirrors ClusterConfigurationManagerImpl#updateLocalCurrentConfiguration, which feeds the
+      // merged result back into the gossiper so this node's own gossip state (and therefore
+      // addUpdateListener's backfill) reflects what was actually merged, not just what was
+      // received on the wire.
+      gossiper.updateCurrentClusterConfiguration(currentClusterConfiguration);
     }
 
     public MemberId id() {
       return atomixCluster.getMembershipService().getLocalMember().id();
+    }
+
+    void addUpdateListener(final ClusterConfigurationUpdateListener listener) {
+      gossiper.addUpdateListener(listener);
     }
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -155,7 +155,7 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       // when - then -- partition join is rejected on zone-aware clusters
       assertThatCode(() -> actuator.joinPartition(0, 1, 1))
           .isInstanceOf(FeignException.BadRequest.class)
-          .hasMessageContaining("is not active");
+          .hasMessageContaining("is not an active member");
     }
   }
 
@@ -306,6 +306,7 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       // when - force-remove zoneA: force-evict its brokers and drop it from the distribution config
       final var forceRemoveResponse = actuator.forceRemoveZone(ZONE_A, false);
       Awaitility.await()
+          .ignoreException(FeignException.class)
           .untilAsserted(
               () ->
                   ClusterActuatorAssert.assertThat(actuator)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantRejoinIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantRejoinIT.java
@@ -14,6 +14,9 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.PartitionBrokerRole;
+import io.camunda.client.api.response.PartitionInfo;
+import io.camunda.client.api.response.Topology;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
 import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
@@ -97,16 +100,27 @@ final class PhysicalTenantRejoinIT {
     }
   }
 
+  // uses the per-physical-tenant topology endpoint (client.newTopologyRequest()) rather than
+  // inspecting the broker bean directly, exercising the same public contract clients rely on
   private void awaitLeaderForEveryPartition(final String group) {
-    Awaitility.await("every partition of physical tenant '" + group + "' has a leader")
-        .atMost(Duration.ofSeconds(60))
-        .pollInSameThread()
-        .untilAsserted(
-            () ->
+    try (final var client = TENANTS.newClientBuilder(cluster.availableGateway(), group).build()) {
+      Awaitility.await("every partition of physical tenant '" + group + "' has a leader")
+          .atMost(Duration.ofSeconds(60))
+          .pollInSameThread()
+          .untilAsserted(
+              () -> {
+                final var topology = client.newTopologyRequest().send().join();
                 IntStream.rangeClosed(1, PARTITIONS_COUNT)
                     .forEach(
-                        partition ->
-                            assertThat(hasLeaderAmongSurvivors(group, partition, null)).isTrue()));
+                        partition -> assertThat(hasLeaderInTopology(topology, partition)).isTrue());
+              });
+    }
+  }
+
+  private static boolean hasLeaderInTopology(final Topology topology, final int partitionId) {
+    return topology.getBrokers().stream()
+        .flatMap(broker -> broker.getPartitions().stream())
+        .anyMatch(partition -> partition.getPartitionId() == partitionId && partition.isLeader());
   }
 
   private void awaitLeaderForEveryPartitionAmongSurvivors(
@@ -137,46 +151,54 @@ final class PhysicalTenantRejoinIT {
   }
 
   // asserts that, for every partition the restarted broker should host in the given group, it now
-  // reports an active raft role (FOLLOWER or LEADER) rather than INACTIVE
+  // reports an active role (FOLLOWER or LEADER) rather than INACTIVE. Uses the per-physical-tenant
+  // topology endpoint (client.newTopologyRequest()) rather than inspecting the broker bean
+  // directly, exercising the same public contract clients rely on.
   private void awaitBrokerRejoinsEveryPartition(final MemberId restarted, final String group) {
-    Awaitility.await(
-            "broker "
-                + restarted
-                + " rejoins every partition of physical tenant '"
-                + group
-                + "' in an active role")
-        .atMost(Duration.ofSeconds(90))
-        .pollInSameThread()
-        .untilAsserted(
-            () -> {
-              final var broker = cluster.brokers().get(restarted);
-              assertThat(broker.isStarted()).isTrue();
-              final var partitionManager =
-                  broker.bean(Broker.class).getBrokerContext().getPartitionManagers().get(group);
-              assertThat(partitionManager)
-                  .describedAs(
-                      "physical tenant '%s' partition manager on restarted broker %s",
-                      group, restarted)
-                  .isNotNull();
-              final var hostedPartitions =
-                  partitionManager.getRaftPartitions().stream()
-                      .map(raftPartition -> raftPartition.id().number())
-                      .collect(Collectors.toSet());
-              assertThat(hostedPartitions)
-                  .describedAs(
-                      "partitions hosted by restarted broker %s in physical tenant '%s'",
-                      restarted, group)
-                  .containsExactlyInAnyOrderElementsOf(expectedPartitions());
-              final Set<Role> roles =
-                  partitionManager.getRaftPartitions().stream()
-                      .map(RaftPartition::getRole)
-                      .collect(Collectors.toSet());
-              assertThat(roles)
-                  .describedAs(
-                      "raft roles reported by restarted broker %s in physical tenant '%s'",
-                      restarted, group)
-                  .doesNotContain((Role) null, Role.INACTIVE);
-            });
+    try (final var client = TENANTS.newClientBuilder(cluster.availableGateway(), group).build()) {
+      Awaitility.await(
+              "broker "
+                  + restarted
+                  + " rejoins every partition of physical tenant '"
+                  + group
+                  + "' in an active role")
+          .atMost(Duration.ofSeconds(90))
+          .pollInSameThread()
+          .untilAsserted(
+              () -> {
+                assertThat(cluster.brokers().get(restarted).isStarted()).isTrue();
+                final var topology = client.newTopologyRequest().send().join();
+                final var brokerInfo =
+                    topology.getBrokers().stream()
+                        .filter(broker -> broker.getMemberId().equals(restarted.id()))
+                        .findFirst()
+                        .orElse(null);
+                assertThat(brokerInfo)
+                    .describedAs(
+                        "physical tenant '%s' topology entry for restarted broker %s",
+                        group, restarted)
+                    .isNotNull();
+                final var hostedPartitions =
+                    brokerInfo.getPartitions().stream()
+                        .map(PartitionInfo::getPartitionId)
+                        .collect(Collectors.toSet());
+                assertThat(hostedPartitions)
+                    .describedAs(
+                        "partitions hosted by restarted broker %s in physical tenant '%s'",
+                        restarted, group)
+                    .containsExactlyInAnyOrderElementsOf(expectedPartitions());
+                final Set<PartitionBrokerRole> roles =
+                    brokerInfo.getPartitions().stream()
+                        .map(PartitionInfo::getRole)
+                        .collect(Collectors.toSet());
+                assertThat(roles)
+                    .describedAs(
+                        "roles reported by the topology for restarted broker %s in physical tenant"
+                            + " '%s'",
+                        restarted, group)
+                    .doesNotContain((PartitionBrokerRole) null, PartitionBrokerRole.INACTIVE);
+              });
+    }
   }
 
   // replicationFactor == brokersCount, so every broker hosts every partition of every group


### PR DESCRIPTION
## Description

This PR permanently enables the new model for dynamic cluster config that support per-group configuration. The PR also includes some bug fixes that were surfaced via IT tests when the feature flag is on. In addition some tests were adapted to use the new model and added some additional tests for missing coverage.

Removing the featureflag and cleaning up the legacy code and tests is out of scope for this PR. This will be handled in a follow up.

## Related issues

related to #56018 
