### PR TITLE
test: wait for migrated business-rule-task incident via API

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -754,6 +754,7 @@ test.describe.serial('Process Instance Migration', () => {
         processInstanceKey,
         'BusinessRuleTask2',
         1,
+        300000,
       );
       await page.reload();
       await operateDiagramPage.resetDiagramZoomButton.click();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -15,6 +15,7 @@ import {sleep} from 'utils/sleep';
 import {waitForAssertion} from 'utils/waitForAssertion';
 import {getNewOperationIds} from 'utils/getNewOperationIds';
 import {waitForProcessVersion} from 'utils/processDefinitions.helper';
+import {waitForFlowNodeIncidents} from 'utils/incidentsHelper';
 
 const PROCESS_INSTANCE_COUNT = 10;
 const AUTO_MIGRATION_INSTANCE_COUNT = 6;
@@ -695,12 +696,14 @@ test.describe.serial('Process Instance Migration', () => {
 
   test('Migrated tasks', async ({
     page,
+    request,
     operateFiltersPanelPage,
     operateProcessesPage,
     operateDiagramPage,
   }) => {
     const targetBpmnProcessId = testProcesses.processV3.bpmnProcessId;
     const targetVersion = testProcesses.processV3.version.toString();
+    let processInstanceKey: string;
 
     await test.step('Navigate to first migrated process instance', async () => {
       await operateFiltersPanelPage.selectProcess(targetBpmnProcessId);
@@ -717,6 +720,8 @@ test.describe.serial('Process Instance Migration', () => {
       });
 
       await operateProcessesPage.clickProcessInstanceLink();
+      await expect(page).toHaveURL(/\/operate\/processes\/\d+/);
+      processInstanceKey = /\/operate\/processes\/(\d+)/.exec(page.url())![1];
       await operateDiagramPage.resetDiagramZoomButton.click();
     });
 
@@ -734,13 +739,25 @@ test.describe.serial('Process Instance Migration', () => {
     });
 
     await test.step('Verify Business rule task incident migration', async () => {
-      // This step is not sharing data with anything else and already retries
-      // with reload — it failed in CI anyway after 3, then 5 attempts (run
-      // 30438261914). Unlike the other fixes in this file, this isn't a
-      // data-uniqueness issue; it's backend contention from concurrently-running
-      // specs outlasting the retry budget. Bumping retries / adding a settle
-      // sleep is a stopgap, not a fix for that — the durable fix is reducing
-      // Operate import/backend contention under the concurrent E2E load.
+      // BusinessRuleTask2 calls decisionId "invalid2", which is deployed
+      // nowhere, so its incident is deterministic — but Operate indexes the
+      // migrated flow node before the incident lands on it, and under
+      // concurrent E2E load that gap outlasted a blind reload budget (runs
+      // 30438261914, 30503781330: the node showed active with no incident
+      // after 8 reloads over ~5 min). Reloading only re-reads the same
+      // not-yet-written data, so wait on the condition itself via the REST
+      // endpoint the UI reads, then assert the popover. If the incident never
+      // arrives this poll fails and names the backend, instead of surfacing as
+      // a missing popover heading.
+      await waitForFlowNodeIncidents(
+        request,
+        processInstanceKey,
+        'BusinessRuleTask2',
+        1,
+      );
+      await page.reload();
+      await operateDiagramPage.resetDiagramZoomButton.click();
+
       await waitForAssertion({
         assertion: async () => {
           await operateDiagramPage.clickFlowNode('BusinessRuleTask2');


### PR DESCRIPTION
## Why

8.7 nightly E2E is intermittently red on `operate/processInstanceMigration.spec.ts` › **Migrated tasks**, step *Verify Business rule task incident migration*:

```
expect(getByTestId('popover').getByRole('heading', {name: 'Incident'})).toBeVisible() — element(s) not found
```

Latest occurrence: nightly run [30503781330](https://github.com/camunda/camunda/actions/runs/30503781330) (also 30438261914). The nightly fix agent triaged it in run [30515408122](https://github.com/camunda/camunda/actions/runs/30515408122) but concluded no safe fix was available, so nothing shipped.

The failure is a synchronisation race, not a product regression:

- `BusinessRuleTask2` in `orderProcessMigration_v_3.bpmn` calls `decisionId="invalid2"`, which is deployed nowhere, and the node is fed by a parallel gateway — so the incident is **mandatory and deterministic**, not conditional.
- At failure the node rendered active / "running (5 minutes)" with no incident, `Called Decision Instance: —`, while the same instance carried incidents on *other* nodes and the preceding migration test passed. So migration and Operate import were both working — the incident had simply not been written to this flow node yet.
- The step only polled the **UI**, reload-and-retry, 8× with a 5 s settle (~284 s). Reloading re-reads the same not-yet-written data rather than waiting for it, so a slow write outlasts any reload budget. Run history is intermittent (red 07-23, 07-24, 07-29, 07-30; green in between), which is the signature of a race, not a regression.

## What changed

Wait on the condition itself before touching the UI, using `waitForFlowNodeIncidents` — the helper already used for exactly this purpose in `processInstanceIncidents.spec.ts` — which polls the same Operate REST endpoint the UI reads until the incident is indexed on `BusinessRuleTask2`. The process instance key is taken from the URL after navigating into the instance.

Deliberately **not** changed: the assertion, and the retry budget (still `maxRetries: 8`). Nothing is masked or weakened — a genuinely missing incident still fails the test. It now fails at the poll, which points at the backend, instead of surfacing as a missing popover heading.

The stale comment claiming the only durable fix is reducing backend contention is replaced: the test can and now does wait on the real condition.

## Verification

- `npx tsc` clean, `npx eslint` 0 errors (3 pre-existing warnings on untouched lines), `npx prettier --check` clean.
- Not executed locally — this suite needs a live orchestration cluster, and the nightly cluster for this run is gone. Needs a green on-demand E2E run against this branch before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)