### PR TITLE
feat: report cluster status aggregated over all physical tenants

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -279,11 +279,11 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * aggregated over all physical tenants.
    *
    * <pre>
-   * boolean isHealthy = camundaClient
+   * StatusResponse.Status status = camundaClient
    *  .newStatusRequest()
    *  .send()
    *  .join()
-   *  .isHealthy();
+   *  .getStatus();
    * </pre>
    *
    * @return the request where you must call {@code send()}

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -286,6 +286,11 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *  .getStatus();
    * </pre>
    *
+   * <p>Being cluster-wide, the status is served outside the per-physical-tenant path. The request
+   * therefore fails against a REST address that is a proxy for a tenant-prefixed URL, unless that
+   * proxy also forwards the cluster-scoped paths — see {@link
+   * CamundaClientBuilder#prefixPhysicalTenantPath(boolean)}.
+   *
    * @return the request where you must call {@code send()}
    */
   StatusRequestStep1 newStatusRequest();

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -275,8 +275,8 @@ public interface CamundaClient extends AutoCloseable, JobClient {
   TopologyRequestStep1 newTopologyRequest();
 
   /**
-   * Request the current cluster status. Can be used to check if the cluster is healthy (has at
-   * least one partition with a healthy leader).
+   * Request the current cluster status. Can be used to check whether the cluster can process work,
+   * aggregated over all physical tenants.
    *
    * <pre>
    * boolean isHealthy = camundaClient

--- a/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
@@ -92,6 +92,10 @@ public interface CamundaClientBuilder {
    * custom path layout already routes to the physical tenant. Has no effect on the gRPC {@code
    * Camunda-Physical-Tenant} header, which is always sent when a physical tenant id is set.
    *
+   * <p>Cluster-scoped endpoints such as the {@link CamundaClient#newStatusRequest() cluster status}
+   * report on the whole cluster and are served outside the per-tenant path, so a proxy fronting a
+   * physical tenant must pass them through unprefixed.
+   *
    * @param prefixPhysicalTenantPath whether to auto-prefix the REST base path per physical tenant
    */
   CamundaClientBuilder prefixPhysicalTenantPath(boolean prefixPhysicalTenantPath);

--- a/clients/java/src/main/java/io/camunda/client/api/response/StatusResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/StatusResponse.java
@@ -16,13 +16,14 @@
 package io.camunda.client.api.response;
 
 /**
- * Response for cluster status request. The status endpoint returns 204 (No Content) when healthy
- * and 503 (Service Unavailable) when unhealthy. The response body is always empty.
+ * Response for cluster status request. The status endpoint returns 200 (OK) while the cluster can
+ * process work and 503 (Service Unavailable) when it cannot; both carry the aggregated cluster
+ * status in the response body.
  */
 public interface StatusResponse {
   /**
-   * @return {@link Status#UP} if the cluster is healthy (has at least one partition with a healthy
-   *     leader), {@link Status#DOWN} otherwise
+   * @return {@link Status#UP} if the cluster can process work (all or some physical tenants are
+   *     healthy), {@link Status#DOWN} otherwise
    */
   Status getStatus();
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/StatusRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/StatusRequestImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.response.StatusResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.StatusResponseImpl;
+import io.camunda.client.protocol.rest.ClusterStatusResponse;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -49,12 +50,14 @@ public final class StatusRequestImpl implements StatusRequestStep1 {
   public CamundaFuture<StatusResponse> send() {
     final HttpCamundaFuture<StatusResponse> result = new HttpCamundaFuture<>();
 
-    final Predicate<Integer> successPredicate = status -> status == 204 || status == 503;
-    httpClient.get(
+    // DOWN is reported as 503, every other aggregated status as 200 — both carry a body
+    final Predicate<Integer> successPredicate = status -> status == 200 || status == 503;
+    httpClient.getClusterApi(
         "/status",
         httpRequestConfig
             .setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
             .build(),
+        ClusterStatusResponse.class,
         successPredicate,
         StatusResponseImpl::new,
         result);

--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClient.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClient.java
@@ -58,6 +58,7 @@ public final class HttpClient implements AutoCloseable {
   private final ModalCloseable connectionManager;
   private final ObjectMapper jsonMapper;
   private final URI address;
+  private final URI clusterApiAddress;
   private final RequestConfig defaultRequestConfig;
   private final int maxMessageSize;
   private final TimeValue shutdownTimeout;
@@ -68,6 +69,7 @@ public final class HttpClient implements AutoCloseable {
       final ModalCloseable connectionManager,
       final ObjectMapper jsonMapper,
       final URI address,
+      final URI clusterApiAddress,
       final RequestConfig defaultRequestConfig,
       final int maxMessageSize,
       final TimeValue shutdownTimeout,
@@ -76,6 +78,7 @@ public final class HttpClient implements AutoCloseable {
     this.connectionManager = connectionManager;
     this.jsonMapper = jsonMapper;
     this.address = address;
+    this.clusterApiAddress = clusterApiAddress;
     this.defaultRequestConfig = defaultRequestConfig;
     this.maxMessageSize = maxMessageSize;
     this.shutdownTimeout = shutdownTimeout;
@@ -158,6 +161,32 @@ public final class HttpClient implements AutoCloseable {
         null,
         requestConfig,
         MAX_RETRY_ATTEMPTS,
+        successPredicate,
+        transformer,
+        result,
+        null);
+  }
+
+  /**
+   * Sends a GET to the cluster-scoped API ({@code /cluster/v2}), which reports on the cluster as a
+   * whole and is therefore not resolved against the physical-tenant-scoped base path.
+   */
+  public <HttpT, RespT> void getClusterApi(
+      final String path,
+      final RequestConfig requestConfig,
+      final Class<HttpT> responseType,
+      final Predicate<Integer> successPredicate,
+      final JsonResponseAndStatusCodeTransformer<HttpT, RespT> transformer,
+      final HttpCamundaFuture<RespT> result) {
+    sendRequest(
+        Method.GET,
+        clusterApiAddress,
+        path,
+        Collections.emptyMap(),
+        null,
+        requestConfig,
+        MAX_RETRY_ATTEMPTS,
+        responseType,
         successPredicate,
         transformer,
         result,
@@ -391,6 +420,34 @@ public final class HttpClient implements AutoCloseable {
       final JsonResponseAndStatusCodeTransformer<HttpT, RespT> transformer,
       final HttpCamundaFuture<RespT> result,
       final ApiCallback<HttpT, RespT> callback) {
+    sendRequest(
+        httpMethod,
+        address,
+        path,
+        queryParams,
+        body,
+        requestConfig,
+        maxRetries,
+        responseType,
+        successPredicate,
+        transformer,
+        result,
+        callback);
+  }
+
+  private <HttpT, RespT> void sendRequest(
+      final Method httpMethod,
+      final URI baseAddress,
+      final String path,
+      final Map<String, String> queryParams,
+      final Object body, // Can be a String (for JSON) or HttpEntity (for Multipart)
+      final RequestConfig requestConfig,
+      final int maxRetries,
+      final Class<HttpT> responseType,
+      final Predicate<Integer> successPredicate,
+      final JsonResponseAndStatusCodeTransformer<HttpT, RespT> transformer,
+      final HttpCamundaFuture<RespT> result,
+      final ApiCallback<HttpT, RespT> callback) {
     final AtomicReference<ApiCallback<HttpT, RespT>> apiCallback = new AtomicReference<>(callback);
     // Create retry action to re-execute the same request
     final Runnable retryAction =
@@ -400,6 +457,7 @@ public final class HttpClient implements AutoCloseable {
           }
           sendRequest(
               httpMethod,
+              baseAddress,
               path,
               queryParams,
               body,
@@ -413,7 +471,7 @@ public final class HttpClient implements AutoCloseable {
         };
 
     final SimpleHttpRequest request =
-        buildRequest(httpMethod, queryParams, body, result, buildRequestURI(path));
+        buildRequest(httpMethod, queryParams, body, result, buildRequestURI(baseAddress, path));
     if (request == null) {
       return;
     }
@@ -518,10 +576,10 @@ public final class HttpClient implements AutoCloseable {
     return true;
   }
 
-  private URI buildRequestURI(final String path) {
+  private URI buildRequestURI(final URI baseAddress, final String path) {
     final URI target;
     try {
-      target = new URIBuilder(address).appendPath(path).build();
+      target = new URIBuilder(baseAddress).appendPath(path).build();
     } catch (final URISyntaxException e) {
       throw new RuntimeException(e);
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
@@ -72,6 +72,9 @@ public class HttpClientFactory {
   /** The versioned base REST API context path the client uses for requests */
   public static final String REST_API_PATH = "/v2";
 
+  /** The versioned base context path of the cluster-scoped REST API */
+  public static final String CLUSTER_API_PATH = "/cluster/v2";
+
   private static final ObjectMapper JSON_MAPPER =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
@@ -93,12 +96,14 @@ public class HttpClientFactory {
             .setDefaultRequestConfig(defaultRequestConfig)
             .build();
     final URI gatewayAddress = buildGatewayAddress();
+    final URI clusterApiAddress = buildClusterApiAddress();
 
     return new HttpClient(
         client,
         connectionManager,
         JSON_MAPPER,
         gatewayAddress,
+        clusterApiAddress,
         defaultRequestConfig,
         config.getMaxMessageSize(),
         TimeValue.ofSeconds(15),
@@ -132,16 +137,8 @@ public class HttpClientFactory {
   }
 
   private URI buildGatewayAddress() {
-    String basePath = config.getRestAddress().toString();
-
-    // we need to strip the last / otherwise we'll have an empty path segment which Spring
-    // interprets as a different route
-    if (basePath.endsWith("/")) {
-      basePath = basePath.substring(0, basePath.length() - 1);
-    }
-
     try {
-      final URIBuilder builder = new URIBuilder(basePath);
+      final URIBuilder builder = new URIBuilder(baseAddress());
       final String physicalTenantId = config.getPhysicalTenantId();
       if (config.prefixPhysicalTenantPath()
           && physicalTenantId != null
@@ -154,6 +151,26 @@ public class HttpClientFactory {
     } catch (final URISyntaxException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * The cluster-scoped API is never physical-tenant scoped: it reports on the cluster as a whole,
+   * so it is served next to, not below, the per-tenant {@link #REST_API_PATH} base.
+   */
+  private URI buildClusterApiAddress() {
+    try {
+      return new URIBuilder(baseAddress()).appendPath(CLUSTER_API_PATH).build();
+    } catch (final URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private String baseAddress() {
+    final String basePath = config.getRestAddress().toString();
+
+    // we need to strip the last / otherwise we'll have an empty path segment which Spring
+    // interprets as a different route
+    return basePath.endsWith("/") ? basePath.substring(0, basePath.length() - 1) : basePath;
   }
 
   private HttpAsyncClientBuilder defaultClientBuilder(

--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
@@ -38,6 +38,7 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
@@ -74,6 +75,17 @@ public class HttpClientFactory {
 
   /** The versioned base context path of the cluster-scoped REST API */
   public static final String CLUSTER_API_PATH = "/cluster/v2";
+
+  private static final String PHYSICAL_TENANT_PATH_SEGMENT = "/physical-tenants/";
+
+  /**
+   * Matches a physical tenant segment closing the REST address, e.g. {@code
+   * https://host/physical-tenants/riskproduction}. The id itself is restricted to the characters
+   * the gateway accepts, so an unrelated path ending in a {@code physical-tenants} directory is not
+   * mistaken for one.
+   */
+  private static final Pattern TRAILING_PHYSICAL_TENANT_PATH =
+      Pattern.compile(Pattern.quote(PHYSICAL_TENANT_PATH_SEGMENT) + "[a-zA-Z0-9]+$");
 
   private static final ObjectMapper JSON_MAPPER =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -143,7 +155,7 @@ public class HttpClientFactory {
       if (config.prefixPhysicalTenantPath()
           && physicalTenantId != null
           && !physicalTenantId.trim().isEmpty()) {
-        builder.appendPath("/physical-tenants/" + physicalTenantId.trim());
+        builder.appendPath(PHYSICAL_TENANT_PATH_SEGMENT + physicalTenantId.trim());
       }
       builder.appendPath(REST_API_PATH);
 
@@ -156,13 +168,23 @@ public class HttpClientFactory {
   /**
    * The cluster-scoped API is never physical-tenant scoped: it reports on the cluster as a whole,
    * so it is served next to, not below, the per-tenant {@link #REST_API_PATH} base.
+   *
+   * <p>The gateway registers the tenant-prefixed route only for the per-tenant roots, and
+   * deliberately excludes the cluster-scoped controllers from it. A REST address that already
+   * carries the prefix — the verbatim form used with {@link
+   * io.camunda.client.CamundaClientBuilder#prefixPhysicalTenantPath(boolean)} — would therefore
+   * yield an unroutable cluster path, so the segment is dropped again here.
    */
   private URI buildClusterApiAddress() {
     try {
-      return new URIBuilder(baseAddress()).appendPath(CLUSTER_API_PATH).build();
+      return new URIBuilder(clusterBaseAddress()).appendPath(CLUSTER_API_PATH).build();
     } catch (final URISyntaxException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private String clusterBaseAddress() {
+    return TRAILING_PHYSICAL_TENANT_PATH.matcher(baseAddress()).replaceFirst("");
   }
 
   private String baseAddress() {

--- a/clients/java/src/main/java/io/camunda/client/impl/response/StatusResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/StatusResponseImpl.java
@@ -16,13 +16,34 @@
 package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.StatusResponse;
+import io.camunda.client.protocol.rest.ClusterStatusResponse;
 
 public final class StatusResponseImpl implements StatusResponse {
 
   private final Status status;
 
-  public StatusResponseImpl(final Void ignored, final Integer statusCode) {
-    status = statusCode == 204 ? Status.UP : Status.DOWN;
+  /**
+   * A cluster that is {@code DEGRADED} still processes work, so it maps to {@link Status#UP} just
+   * like {@code HEALTHY}. The status code is the fallback when the body is missing or reports an
+   * aggregated status this client version does not know.
+   */
+  public StatusResponseImpl(final ClusterStatusResponse response, final Integer statusCode) {
+    if (response == null || response.getStatus() == null) {
+      status = statusCode != null && statusCode == 200 ? Status.UP : Status.DOWN;
+      return;
+    }
+
+    switch (response.getStatus()) {
+      case HEALTHY:
+      case DEGRADED:
+        status = Status.UP;
+        break;
+      case DOWN:
+        status = Status.DOWN;
+        break;
+      default:
+        status = statusCode != null && statusCode == 200 ? Status.UP : Status.DOWN;
+    }
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/PhysicalTenantRestPathTest.java
+++ b/clients/java/src/test/java/io/camunda/client/PhysicalTenantRestPathTest.java
@@ -82,6 +82,30 @@ final class PhysicalTenantRestPathTest {
   }
 
   @Test
+  void shouldDropPhysicalTenantFromPreprefixedRestAddressForClusterStatus(
+      final WireMockRuntimeInfo mockInfo) {
+    // given a REST address that already routes to a physical tenant, so auto-prefixing is off
+    try (final CamundaClient client =
+        CamundaClient.newClientBuilder()
+            .preferRestOverGrpc(true)
+            .restAddress(URI.create(mockInfo.getHttpBaseUrl() + "/physical-tenants/riskproduction"))
+            .physicalTenantId("riskproduction")
+            .prefixPhysicalTenantPath(false)
+            .build()) {
+      // when
+      try {
+        client.newStatusRequest().send().join();
+      } catch (final Exception ignored) {
+        // only the outgoing request URL is under test; the (unstubbed) response is irrelevant
+      }
+    }
+
+    // then the gateway serves the cluster status outside the per-tenant path, so keeping the
+    // prefix would produce an unroutable URL
+    verify(getRequestedFor(urlEqualTo("/cluster/v2/status")));
+  }
+
+  @Test
   void shouldUseVerbatimRestBasePathWhenAppendDisabled(final WireMockRuntimeInfo mockInfo) {
     // given
     try (final CamundaClient client = client(mockInfo, false)) {

--- a/clients/java/src/test/java/io/camunda/client/PhysicalTenantRestPathTest.java
+++ b/clients/java/src/test/java/io/camunda/client/PhysicalTenantRestPathTest.java
@@ -66,6 +66,22 @@ final class PhysicalTenantRestPathTest {
   }
 
   @Test
+  void shouldNotPrefixClusterStatusPathWithPhysicalTenant(final WireMockRuntimeInfo mockInfo) {
+    // given
+    try (final CamundaClient client = client(mockInfo, true)) {
+      // when
+      try {
+        client.newStatusRequest().send().join();
+      } catch (final Exception ignored) {
+        // only the outgoing request URL is under test; the (unstubbed) response is irrelevant
+      }
+    }
+
+    // then the cluster status reports on the whole cluster, so it is never tenant scoped
+    verify(getRequestedFor(urlEqualTo("/cluster/v2/status")));
+  }
+
+  @Test
   void shouldUseVerbatimRestBasePathWhenAppendDisabled(final WireMockRuntimeInfo mockInfo) {
     // given
     try (final CamundaClient client = client(mockInfo, false)) {

--- a/clients/java/src/test/java/io/camunda/client/StatusRequestRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/StatusRequestRestTest.java
@@ -15,6 +15,9 @@
  */
 package io.camunda.client;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -30,8 +33,20 @@ import org.junit.jupiter.api.Test;
 public final class StatusRequestRestTest extends ClientRestTest {
 
   @Test
+  void shouldRequestStatusFromClusterScopedEndpoint() {
+    // given
+    gatewayService.onStatusRequestHealthy();
+
+    // when
+    client.newStatusRequest().send().join();
+
+    // then — the cluster status is not physical-tenant scoped, so it is not served below /v2
+    verify(getRequestedFor(urlEqualTo("/cluster/v2/status")));
+  }
+
+  @Test
   void shouldRequestStatusWhenHealthy() throws ExecutionException, InterruptedException {
-    // given - cluster is healthy (returns 204 No Content)
+    // given - the whole cluster is healthy (200 with HEALTHY)
     gatewayService.onStatusRequestHealthy();
 
     // when
@@ -44,8 +59,22 @@ public final class StatusRequestRestTest extends ClientRestTest {
   }
 
   @Test
+  void shouldRequestStatusWhenDegraded() throws ExecutionException, InterruptedException {
+    // given - part of the cluster is degraded but it still processes work (200 with DEGRADED)
+    gatewayService.onStatusRequestDegraded();
+
+    // when
+    final Future<StatusResponse> response = client.newStatusRequest().send();
+
+    // then - a degraded cluster still serves traffic, so it must not be reported as down
+    assertThat(response).succeedsWithin(Duration.ofSeconds(5));
+    final StatusResponse status = response.get();
+    assertThat(status.getStatus()).isEqualTo(Status.UP);
+  }
+
+  @Test
   void shouldRequestStatusWhenUnhealthy() throws ExecutionException, InterruptedException {
-    // given - cluster is unhealthy (returns 503 Service Unavailable)
+    // given - no physical tenant can process work (503 with DOWN)
     gatewayService.onStatusRequestUnhealthy();
 
     // when

--- a/clients/java/src/test/java/io/camunda/client/impl/http/HttpClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/http/HttpClientTest.java
@@ -48,6 +48,7 @@ class HttpClientTest {
             mockConnectionManager,
             new ObjectMapper(),
             URI.create("http://localhost:12345/v2"),
+            URI.create("http://localhost:12345/cluster/v2"),
             RequestConfig.custom().build(),
             1024 * 1024,
             TimeValue.ofMilliseconds(100),

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.util;
 
+import static io.camunda.client.impl.http.HttpClientFactory.CLUSTER_API_PATH;
 import static io.camunda.client.impl.http.HttpClientFactory.REST_API_PATH;
 
 public class RestGatewayPaths {
@@ -113,7 +114,7 @@ public class RestGatewayPaths {
   private static final String URL_TENANT = REST_API_PATH + "/tenants/%s";
   private static final String URL_TENANTS = REST_API_PATH + "/tenants";
   private static final String URL_TOPOLOGY = REST_API_PATH + "/topology";
-  private static final String URL_STATUS = REST_API_PATH + "/status";
+  private static final String URL_STATUS = CLUSTER_API_PATH + "/status";
   private static final String URL_USAGE_METRICS = REST_API_PATH + "/system/usage-metrics";
   private static final String URL_USER = REST_API_PATH + "/users/%s";
   private static final String URL_USERS = REST_API_PATH + "/users";

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -595,8 +595,8 @@ public class RestGatewayService {
   }
 
   /**
-   * Register a status response with a custom HTTP status code and no body, as returned by error
-   * responses.
+   * Register a bodyless status response with a custom HTTP status code, to exercise how the client
+   * maps a status code it does not expect from this endpoint.
    *
    * @param statusCode the HTTP status code to return for status requests
    */

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -33,6 +33,7 @@ import io.camunda.client.protocol.rest.AuthorizationResult;
 import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
 import io.camunda.client.protocol.rest.BatchOperationResponse;
 import io.camunda.client.protocol.rest.BatchOperationSearchQueryResult;
+import io.camunda.client.protocol.rest.ClusterStatusResponse;
 import io.camunda.client.protocol.rest.ClusterVariableResult;
 import io.camunda.client.protocol.rest.DecisionDefinitionResult;
 import io.camunda.client.protocol.rest.DecisionInstanceResult;
@@ -582,15 +583,20 @@ public class RestGatewayService {
   }
 
   public void onStatusRequestHealthy() {
-    onStatusRequest(204);
+    onStatusRequest(200, ClusterStatusResponse.StatusEnum.HEALTHY);
+  }
+
+  public void onStatusRequestDegraded() {
+    onStatusRequest(200, ClusterStatusResponse.StatusEnum.DEGRADED);
   }
 
   public void onStatusRequestUnhealthy() {
-    onStatusRequest(503);
+    onStatusRequest(503, ClusterStatusResponse.StatusEnum.DOWN);
   }
 
   /**
-   * Register a status response with a custom HTTP status code.
+   * Register a status response with a custom HTTP status code and no body, as returned by error
+   * responses.
    *
    * @param statusCode the HTTP status code to return for status requests
    */
@@ -600,6 +606,19 @@ public class RestGatewayService {
         .register(
             WireMock.get(RestGatewayPaths.getStatusUrl())
                 .willReturn(WireMock.aResponse().withStatus(statusCode)));
+  }
+
+  private void onStatusRequest(
+      final int statusCode, final ClusterStatusResponse.StatusEnum status) {
+    mockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(RestGatewayPaths.getStatusUrl())
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(statusCode)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"status\":\"" + status.getValue() + "\"}")));
   }
 
   public void onResourceGetRequest(final long resourceKey, final ResourceResult response) {


### PR DESCRIPTION
## Description

The Java client asked `/v2/status` for the cluster's health. With physical tenants that path is now scoped to the single tenant the client is pinned to, so a client would report the cluster as up while other tenants were down — or, when pinned to a tenant that is down, report an outage that only affects itself. Callers using the status request as a cluster-wide readiness signal would act on the wrong picture.

Route the request to `GET /cluster/v2/status`, which reports the status aggregated over every physical tenant. That endpoint lives next to, not below, the per-tenant base, so the client now builds a second cluster-scoped base URI and never prefixes it with `/physical-tenants/<id>`; threading the base through `sendRequest` was preferred over string-concatenating the path onto the existing base, which would have produced a wrong URL as soon as the tenant prefix is in play.

The endpoint also changes the wire contract (ADR 001, D4): it answers 200 or 503 with a body carrying the aggregated status, not a bodyless 204. `DEGRADED` maps to UP because such a cluster still processes work, and the status code stays as a fallback so an older client meeting an unknown aggregated status still resolves sensibly.

Single-tenant clusters are unaffected: HEALTHY still maps to UP and DOWN to DOWN.

## Related issues

Closes #57376
