### PR TITLE
In-flight restore status

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreStatus.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreStatus.java
@@ -19,11 +19,13 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -90,48 +92,50 @@ public record RestoreStatus(ClusterChangePlan plan, List<BrokerRestoreStatus> br
   }
 
   private static List<BrokerRestoreStatus> mapBrokers(final ClusterChangePlan plan) {
-    final var partitions = new TreeMap<PartitionKey, PartitionAccumulator>();
+    // Sorted by broker, then by partition, so the report has a stable order.
+    final SortedMap<String, SortedMap<Integer, PartitionAccumulator>> brokerPartitionMap =
+        new TreeMap<>();
+
     plan.completedOperations()
         .forEach(
-            completed -> accumulate(partitions, completed.operation(), completed.completedAt()));
-    plan.pendingOperations().forEach(pending -> accumulate(partitions, pending, null));
+            completed ->
+                accumulate(brokerPartitionMap, completed.operation(), completed.completedAt()));
+    plan.pendingOperations().forEach(pending -> accumulate(brokerPartitionMap, pending));
 
-    return partitions.entrySet().stream()
-        .collect(
-            Collectors.groupingBy(
-                entry -> entry.getKey().brokerId(),
-                TreeMap::new,
-                Collectors.mapping(
-                    entry -> entry.getValue().toStatus(entry.getKey().partitionId()),
-                    Collectors.toList())))
-        .entrySet()
-        .stream()
-        .map(entry -> toBrokerStatus(entry.getKey(), entry.getValue()))
-        .toList();
+    final var brokers = new ArrayList<BrokerRestoreStatus>();
+    brokerPartitionMap.forEach(
+        (brokerId, partitions) -> brokers.add(toBrokerStatus(brokerId, partitions)));
+    return List.copyOf(brokers);
   }
 
   private static BrokerRestoreStatus toBrokerStatus(
-      final String brokerId, final List<PartitionRestoreStatus> partitions) {
+      final String brokerId, final SortedMap<Integer, PartitionAccumulator> partitions) {
+    final var statuses = new ArrayList<PartitionRestoreStatus>();
+    partitions.forEach(
+        (partitionId, accumulator) -> statuses.add(accumulator.toStatus(partitionId)));
     final var restored =
-        partitions.stream().filter(p -> p.state() == PartitionRestoreState.RESTORED).count();
-    return new BrokerRestoreStatus(brokerId, (int) restored, partitions.size(), partitions);
+        statuses.stream().filter(p -> p.state() == PartitionRestoreState.RESTORED).count();
+
+    return new BrokerRestoreStatus(
+        brokerId, (int) restored, statuses.size(), List.copyOf(statuses));
   }
 
   private static void accumulate(
-      final TreeMap<PartitionKey, PartitionAccumulator> partitions,
+      final Map<String, SortedMap<Integer, PartitionAccumulator>> brokerPartitionMap,
       final ClusterConfigurationChangeOperation operation,
       final @Nullable Instant completedAt) {
     switch (operation) {
       case final PartitionPreRestoreOperation preRestore -> {
-        final var key = new PartitionKey(preRestore.memberId().id(), preRestore.partitionId());
         if (completedAt != null) {
-          partitions.computeIfAbsent(key, ignored -> new PartitionAccumulator()).preRestored = true;
+          final var accumulator =
+              accumulatorOf(
+                  brokerPartitionMap, preRestore.memberId().id(), preRestore.partitionId());
+          accumulator.preRestored = true;
         }
       }
       case final PartitionRestoreOperation restore -> {
-        final var key = new PartitionKey(restore.memberId().id(), restore.partitionId());
         final var accumulator =
-            partitions.computeIfAbsent(key, ignored -> new PartitionAccumulator());
+            accumulatorOf(brokerPartitionMap, restore.memberId().id(), restore.partitionId());
         accumulator.backupIds = restore.backupIds();
         if (completedAt != null) {
           accumulator.restoredAt = completedAt;
@@ -141,6 +145,21 @@ public record RestoreStatus(ClusterChangePlan plan, List<BrokerRestoreStatus> br
         // Non-partition restore operations (mode change, incarnation number) are not reported.
       }
     }
+  }
+
+  private static void accumulate(
+      final Map<String, SortedMap<Integer, PartitionAccumulator>> brokerPartitionMap,
+      final ClusterConfigurationChangeOperation operation) {
+    accumulate(brokerPartitionMap, operation, null);
+  }
+
+  private static PartitionAccumulator accumulatorOf(
+      final Map<String, SortedMap<Integer, PartitionAccumulator>> brokerPartitionMap,
+      final String brokerId,
+      final int partitionId) {
+    return brokerPartitionMap
+        .computeIfAbsent(brokerId, ignored -> new TreeMap<>())
+        .computeIfAbsent(partitionId, ignored -> new PartitionAccumulator());
   }
 
   /** The restore status of a single broker. */
@@ -156,15 +175,6 @@ public record RestoreStatus(ClusterChangePlan plan, List<BrokerRestoreStatus> br
       PartitionRestoreState state,
       List<Long> backupIds,
       @Nullable Instant completedAt) {}
-
-  private record PartitionKey(String brokerId, int partitionId)
-      implements Comparable<PartitionKey> {
-    @Override
-    public int compareTo(final PartitionKey other) {
-      final var brokerCompare = brokerId.compareTo(other.brokerId);
-      return brokerCompare != 0 ? brokerCompare : Integer.compare(partitionId, other.partitionId);
-    }
-  }
 
   /** Mutable accumulator for a single partition's restore state while mapping a change plan. */
   private static final class PartitionAccumulator {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreStatus.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreStatus.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A pending change plan is considered a restore if its pending operations contain a {@link
+ * PartitionRestoreOperation} or {@link PartitionPreRestoreOperation} (partitions are still being
+ * restored), or a trailing epilogue operation - a mode transition to {@link Mode#PROCESSING} or the
+ * final {@link UpdateIncarnationNumberOperation} - whose completed operations already include a
+ * {@link PartitionRestoreOperation} or {@link PartitionPreRestoreOperation}. There is at most one
+ * restore in flight at any time.
+ */
+@NullMarked
+public record RestoreStatus(ClusterChangePlan plan, List<BrokerRestoreStatus> brokers) {
+
+  /** Derives {@code brokers} from the plan once, rather than recomputing it on every access. */
+  public RestoreStatus(final ClusterChangePlan plan) {
+    this(plan, mapBrokers(plan));
+  }
+
+  public static Optional<RestoreStatus> of(final ClusterConfiguration configuration) {
+    return configuration
+        .pendingChanges()
+        .filter(RestoreStatus::isRestoreInProgress)
+        .map(RestoreStatus::new);
+  }
+
+  public Status status() {
+    return plan.status();
+  }
+
+  public long changeId() {
+    return plan.id();
+  }
+
+  public @Nullable Instant startedAt() {
+    return plan.startedAt();
+  }
+
+  private static boolean isRestoreInProgress(final ClusterChangePlan plan) {
+    final var pending = plan.pendingOperations();
+    if (pending.stream().anyMatch(RestoreStatus::isRestoreOperation)) {
+      return true;
+    }
+    return pending.stream().anyMatch(RestoreStatus::isPostRestoreOperation)
+        && plan.completedOperations().stream()
+            .map(CompletedOperation::operation)
+            .anyMatch(RestoreStatus::isRestoreOperation);
+  }
+
+  private static boolean isRestoreOperation(final ClusterConfigurationChangeOperation operation) {
+    return operation instanceof PartitionRestoreOperation
+        || operation instanceof PartitionPreRestoreOperation;
+  }
+
+  private static boolean isPostRestoreOperation(
+      final ClusterConfigurationChangeOperation operation) {
+    return switch (operation) {
+      case final ModeChangeOperation modeChange -> modeChange.mode() == Mode.PROCESSING;
+      case final AwaitModeChangeOperation awaitModeChange ->
+          awaitModeChange.mode() == Mode.PROCESSING;
+      case final UpdateIncarnationNumberOperation ignored -> true;
+      default -> false;
+    };
+  }
+
+  private static List<BrokerRestoreStatus> mapBrokers(final ClusterChangePlan plan) {
+    final var partitions = new TreeMap<PartitionKey, PartitionAccumulator>();
+    plan.completedOperations()
+        .forEach(
+            completed -> accumulate(partitions, completed.operation(), completed.completedAt()));
+    plan.pendingOperations().forEach(pending -> accumulate(partitions, pending, null));
+
+    return partitions.entrySet().stream()
+        .collect(
+            Collectors.groupingBy(
+                entry -> entry.getKey().brokerId(),
+                TreeMap::new,
+                Collectors.mapping(
+                    entry -> entry.getValue().toStatus(entry.getKey().partitionId()),
+                    Collectors.toList())))
+        .entrySet()
+        .stream()
+        .map(entry -> toBrokerStatus(entry.getKey(), entry.getValue()))
+        .toList();
+  }
+
+  private static BrokerRestoreStatus toBrokerStatus(
+      final String brokerId, final List<PartitionRestoreStatus> partitions) {
+    final var restored =
+        partitions.stream().filter(p -> p.state() == PartitionRestoreState.RESTORED).count();
+    return new BrokerRestoreStatus(brokerId, (int) restored, partitions.size(), partitions);
+  }
+
+  private static void accumulate(
+      final TreeMap<PartitionKey, PartitionAccumulator> partitions,
+      final ClusterConfigurationChangeOperation operation,
+      final @Nullable Instant completedAt) {
+    switch (operation) {
+      case final PartitionPreRestoreOperation preRestore -> {
+        final var key = new PartitionKey(preRestore.memberId().id(), preRestore.partitionId());
+        if (completedAt != null) {
+          partitions.computeIfAbsent(key, ignored -> new PartitionAccumulator()).preRestored = true;
+        }
+      }
+      case final PartitionRestoreOperation restore -> {
+        final var key = new PartitionKey(restore.memberId().id(), restore.partitionId());
+        final var accumulator =
+            partitions.computeIfAbsent(key, ignored -> new PartitionAccumulator());
+        accumulator.backupIds = restore.backupIds();
+        if (completedAt != null) {
+          accumulator.restoredAt = completedAt;
+        }
+      }
+      default -> {
+        // Non-partition restore operations (mode change, incarnation number) are not reported.
+      }
+    }
+  }
+
+  /** The restore status of a single broker. */
+  public record BrokerRestoreStatus(
+      String brokerId,
+      int partitionsRestored,
+      int partitionsToRestore,
+      List<PartitionRestoreStatus> partitions) {}
+
+  /** The restore status of a single partition on a broker. */
+  public record PartitionRestoreStatus(
+      int partitionId,
+      PartitionRestoreState state,
+      List<Long> backupIds,
+      @Nullable Instant completedAt) {}
+
+  private record PartitionKey(String brokerId, int partitionId)
+      implements Comparable<PartitionKey> {
+    @Override
+    public int compareTo(final PartitionKey other) {
+      final var brokerCompare = brokerId.compareTo(other.brokerId);
+      return brokerCompare != 0 ? brokerCompare : Integer.compare(partitionId, other.partitionId);
+    }
+  }
+
+  /** Mutable accumulator for a single partition's restore state while mapping a change plan. */
+  private static final class PartitionAccumulator {
+    private @Nullable SortedSet<Long> backupIds;
+    private boolean preRestored;
+    private @Nullable Instant restoredAt;
+
+    private PartitionRestoreStatus toStatus(final int partitionId) {
+      final PartitionRestoreState state;
+      if (restoredAt != null) {
+        state = PartitionRestoreState.RESTORED;
+      } else if (preRestored) {
+        state = PartitionRestoreState.RESTORING;
+      } else {
+        state = PartitionRestoreState.PENDING;
+      }
+      return new PartitionRestoreStatus(
+          partitionId, state, backupIds == null ? List.of() : List.copyOf(backupIds), restoredAt);
+    }
+  }
+
+  /** The restore state of a single partition on a broker. */
+  public enum PartitionRestoreState {
+    /** The partition has not started restoring yet. */
+    PENDING,
+    /** The partition's local data has been dropped and it is being restored. */
+    RESTORING,
+    /** The partition has been restored. */
+    RESTORED
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreStatusTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreStatusTest.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.RestoreStatus.PartitionRestoreState;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CompletedChange;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeSet;
+import org.junit.jupiter.api.Test;
+
+final class RestoreStatusTest {
+
+  // A restore always uses this sentinel id, but detection must not rely on it; some tests use a
+  // different id to prove that.
+  private static final long RESTORE_CHANGE_ID = -2L;
+  private static final MemberId BROKER_1 = MemberId.from("1");
+  private static final Instant STARTED_AT = Instant.parse("2024-01-01T10:00:00Z");
+
+  @Test
+  void shouldReturnEmptyWhenNoChange() {
+    // given
+    final var configuration = ClusterConfiguration.init();
+
+    // when / then
+    assertThat(RestoreStatus.of(configuration)).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyWhenOnlyLastChangeIsPresent() {
+    // given
+    // even if the last completed change happens to carry the restore sentinel id, there is no
+    // pending change plan, so no restore can be in progress.
+    final var lastChange =
+        new CompletedChange(
+            RESTORE_CHANGE_ID, Status.COMPLETED, STARTED_AT, STARTED_AT.plusSeconds(60));
+    final var configuration = configurationWith(Optional.of(lastChange), Optional.empty());
+
+    // when / then
+    assertThat(RestoreStatus.of(configuration)).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyForUnrelatedPendingChange() {
+    // given
+    // an ordinary partition join, not part of a restore, must not be misdetected.
+    final var plan =
+        new ClusterChangePlan(
+            42L,
+            1,
+            Status.IN_PROGRESS,
+            STARTED_AT,
+            List.of(),
+            List.<ClusterConfigurationChangeOperation>of(
+                new PartitionJoinOperation(BROKER_1, 1, 1)));
+    final var configuration = configurationWith(Optional.empty(), Optional.of(plan));
+
+    // when / then
+    assertThat(RestoreStatus.of(configuration)).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyForPendingModeTransitionWithoutRestoreOps() {
+    // given
+    // a plain mode transition to PROCESSING that never involved a restore operation.
+    final var plan =
+        new ClusterChangePlan(
+            42L,
+            1,
+            Status.IN_PROGRESS,
+            STARTED_AT,
+            List.of(),
+            List.<ClusterConfigurationChangeOperation>of(
+                new ModeChangeOperation(BROKER_1, Mode.PROCESSING)));
+    final var configuration = configurationWith(Optional.empty(), Optional.of(plan));
+
+    // when / then
+    assertThat(RestoreStatus.of(configuration)).isEmpty();
+  }
+
+  @Test
+  void shouldMapInProgressRestoreWithPerPartitionDetail() {
+    // given
+    // broker 1: partition 1 fully restored, partition 2 pre-restored but restore still pending
+    final var pre1 = new PartitionPreRestoreOperation(BROKER_1, 1);
+    final var restore1 = new PartitionRestoreOperation(BROKER_1, 1, backups(10L, 11L));
+    final var pre2 = new PartitionPreRestoreOperation(BROKER_1, 2);
+    final var restore2 = new PartitionRestoreOperation(BROKER_1, 2, backups(20L));
+    final var modeChange = new ModeChangeOperation(BROKER_1, Mode.PROCESSING);
+
+    final var plan =
+        new ClusterChangePlan(
+            RESTORE_CHANGE_ID,
+            5,
+            Status.IN_PROGRESS,
+            STARTED_AT,
+            List.of(
+                new CompletedOperation(pre1, STARTED_AT.plusSeconds(1)),
+                new CompletedOperation(restore1, STARTED_AT.plusSeconds(2)),
+                new CompletedOperation(pre2, STARTED_AT.plusSeconds(3))),
+            List.<ClusterConfigurationChangeOperation>of(restore2, modeChange));
+    final var configuration = configurationWith(Optional.empty(), Optional.of(plan));
+
+    // when
+    final var status = RestoreStatus.of(configuration).orElseThrow();
+
+    // then
+    assertThat(status.status()).isEqualTo(Status.IN_PROGRESS);
+    assertThat(status.changeId()).isEqualTo(RESTORE_CHANGE_ID);
+    assertThat(status.startedAt()).isEqualTo(STARTED_AT);
+    assertThat(status.brokers()).hasSize(1);
+
+    final var broker = status.brokers().getFirst();
+    assertThat(broker.brokerId()).isEqualTo("1");
+    assertThat(broker.partitionsRestored()).isEqualTo(1);
+    assertThat(broker.partitionsToRestore()).isEqualTo(2);
+    assertThat(broker.partitions()).hasSize(2);
+
+    final var partition1 = broker.partitions().get(0);
+    assertThat(partition1.partitionId()).isEqualTo(1);
+    assertThat(partition1.state()).isEqualTo(PartitionRestoreState.RESTORED);
+    assertThat(partition1.backupIds()).containsExactly(10L, 11L);
+    assertThat(partition1.completedAt()).isEqualTo(STARTED_AT.plusSeconds(2));
+
+    final var partition2 = broker.partitions().get(1);
+    assertThat(partition2.partitionId()).isEqualTo(2);
+    assertThat(partition2.state()).isEqualTo(PartitionRestoreState.RESTORING);
+    assertThat(partition2.backupIds()).containsExactly(20L);
+    assertThat(partition2.completedAt()).isNull();
+  }
+
+  @Test
+  void shouldMarkPartitionPendingWhenPreRestoreNotDone() {
+    // given
+    final var pre1 = new PartitionPreRestoreOperation(BROKER_1, 1);
+    final var restore1 = new PartitionRestoreOperation(BROKER_1, 1, backups(10L));
+    final var plan =
+        new ClusterChangePlan(
+            RESTORE_CHANGE_ID,
+            1,
+            Status.IN_PROGRESS,
+            STARTED_AT,
+            List.of(),
+            List.<ClusterConfigurationChangeOperation>of(pre1, restore1));
+    final var configuration = configurationWith(Optional.empty(), Optional.of(plan));
+
+    // when
+    final var status = RestoreStatus.of(configuration).orElseThrow();
+
+    // then
+    final var partition = status.brokers().getFirst().partitions().getFirst();
+    assertThat(partition.state()).isEqualTo(PartitionRestoreState.PENDING);
+    assertThat(partition.completedAt()).isNull();
+    assertThat(status.brokers().getFirst().partitionsRestored()).isZero();
+  }
+
+  @Test
+  void shouldDetectInProgressRestoreWhileFinishingModeTransition() {
+    // given
+    // all restore operations completed; only the trailing mode-transition-to-PROCESSING remains
+    // pending. This must still be reported as an in-progress restore.
+    final var pre1 = new PartitionPreRestoreOperation(BROKER_1, 1);
+    final var restore1 = new PartitionRestoreOperation(BROKER_1, 1, backups(10L));
+    final var plan =
+        new ClusterChangePlan(
+            RESTORE_CHANGE_ID,
+            3,
+            Status.IN_PROGRESS,
+            STARTED_AT,
+            List.of(
+                new CompletedOperation(pre1, STARTED_AT.plusSeconds(1)),
+                new CompletedOperation(restore1, STARTED_AT.plusSeconds(2))),
+            List.<ClusterConfigurationChangeOperation>of(
+                new ModeChangeOperation(BROKER_1, Mode.PROCESSING),
+                new AwaitModeChangeOperation(BROKER_1, Mode.PROCESSING)));
+    final var configuration = configurationWith(Optional.empty(), Optional.of(plan));
+
+    // when
+    final var status = RestoreStatus.of(configuration).orElseThrow();
+
+    // then
+    assertThat(status.brokers()).hasSize(1);
+    final var partition = status.brokers().getFirst().partitions().getFirst();
+    assertThat(partition.state()).isEqualTo(PartitionRestoreState.RESTORED);
+  }
+
+  @Test
+  void shouldDetectInProgressRestoreWhileFinishingIncarnationNumberUpdate() {
+    // given
+    // all restore and mode-transition operations completed; only the trailing
+    // UpdateIncarnationNumberOperation remains pending. This must still be reported as an
+    // in-progress restore.
+    final var pre1 = new PartitionPreRestoreOperation(BROKER_1, 1);
+    final var restore1 = new PartitionRestoreOperation(BROKER_1, 1, backups(10L));
+    final var modeChange = new ModeChangeOperation(BROKER_1, Mode.PROCESSING);
+    final var awaitModeChange = new AwaitModeChangeOperation(BROKER_1, Mode.PROCESSING);
+    final var plan =
+        new ClusterChangePlan(
+            RESTORE_CHANGE_ID,
+            5,
+            Status.IN_PROGRESS,
+            STARTED_AT,
+            List.of(
+                new CompletedOperation(pre1, STARTED_AT.plusSeconds(1)),
+                new CompletedOperation(restore1, STARTED_AT.plusSeconds(2)),
+                new CompletedOperation(modeChange, STARTED_AT.plusSeconds(3)),
+                new CompletedOperation(awaitModeChange, STARTED_AT.plusSeconds(4))),
+            List.<ClusterConfigurationChangeOperation>of(
+                new UpdateIncarnationNumberOperation(BROKER_1)));
+    final var configuration = configurationWith(Optional.empty(), Optional.of(plan));
+
+    // when
+    final var status = RestoreStatus.of(configuration).orElseThrow();
+
+    // then
+    assertThat(status.brokers()).hasSize(1);
+    final var partition = status.brokers().getFirst().partitions().getFirst();
+    assertThat(partition.state()).isEqualTo(PartitionRestoreState.RESTORED);
+  }
+
+  private static TreeSet<Long> backups(final Long... ids) {
+    return new TreeSet<>(List.of(ids));
+  }
+
+  private static ClusterConfiguration configurationWith(
+      final Optional<CompletedChange> lastChange,
+      final Optional<ClusterChangePlan> pendingChanges) {
+    return new ClusterConfiguration(
+        2,
+        Map.of(),
+        lastChange,
+        pendingChanges,
+        Optional.empty(),
+        Optional.empty(),
+        0,
+        Optional.empty());
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -177,6 +177,35 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+    get:
+      x-eventually-consistent: false
+      tags:
+        - Recovery
+      operationId: getRestoreStatus
+      x-required-permissions: []
+      security:
+        - bearerAuth: []
+        - basicAuth: []
+      summary: Get the status of the restore that is currently in progress
+      description: >-
+        Returns the status of the restore that is currently in progress, reported per broker and
+        per partition. There is at most one restore in flight at any time. Once the restore has
+        finished this endpoint returns 404; the per-partition detail is not retained after
+        completion.
+      responses:
+        "200":
+          description: The status of the restore that is currently in progress.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RestoreStatusResponse'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "404":
+          description: No restore is currently in progress.
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.10"
 
 ## Schema definitions
 
@@ -448,3 +477,102 @@ components:
             type: integer
             format: int64
           example: [100, 101]
+
+    RestoreStatusResponse:
+      description: The status of the restore that is currently in progress.
+      type: object
+      required:
+        - status
+        - changeId
+        - brokers
+      properties:
+        status:
+          description: The overall status of the restore.
+          type: string
+          enum:
+            - IN_PROGRESS
+            - COMPLETED
+            - FAILED
+            - CANCELLED
+          example: IN_PROGRESS
+        changeId:
+          description: The ID of the cluster change that performs the restore.
+          type: string
+          example: "-2"
+        startedAt:
+          description: The time the restore started, as an ISO 8601 timestamp.
+          type: string
+          format: date-time
+          nullable: true
+          example: "2024-01-01T10:00:00Z"
+        brokers:
+          description: The per-broker restore status.
+          type: array
+          items:
+            $ref: '#/components/schemas/RestoreBrokerStatus'
+
+    RestoreBrokerStatus:
+      description: The restore status of a single broker.
+      type: object
+      required:
+        - brokerId
+        - partitionsRestored
+        - partitionsToRestore
+        - partitions
+      properties:
+        brokerId:
+          description: The ID of the broker, including its zone if it belongs to one.
+          type: string
+          example: "1"
+        partitionsRestored:
+          description: The number of the broker's partitions that have been restored so far.
+          type: integer
+          format: int32
+          example: 1
+        partitionsToRestore:
+          description: The total number of the broker's partitions to restore.
+          type: integer
+          format: int32
+          example: 3
+        partitions:
+          description: The per-partition restore status for this broker.
+          type: array
+          items:
+            $ref: '#/components/schemas/RestorePartitionStatus'
+
+    RestorePartitionStatus:
+      description: The restore status of a single partition on a broker.
+      type: object
+      required:
+        - partitionId
+        - state
+        - backupIds
+      properties:
+        partitionId:
+          description: The ID of the partition.
+          type: integer
+          format: int32
+          example: 1
+        state:
+          description: The restore state of the partition.
+          type: string
+          enum:
+            - PENDING
+            - RESTORING
+            - RESTORED
+          example: RESTORING
+        backupIds:
+          description: The IDs of the backups this partition is restored from.
+          type: array
+          items:
+            type: integer
+            format: int64
+          example: [100, 101]
+        completedAt:
+          description: >-
+            The time the partition was restored, as an ISO 8601 timestamp; null unless the partition
+            state is `restored`.
+          type: string
+          format: date-time
+          nullable: true
+          example: "2024-01-01T10:02:00Z"

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -484,6 +484,7 @@ components:
       required:
         - status
         - changeId
+        - startedAt
         - brokers
       properties:
         status:
@@ -547,6 +548,7 @@ components:
         - partitionId
         - state
         - backupIds
+        - completedAt
       properties:
         partitionId:
           description: The ID of the partition.
@@ -571,7 +573,7 @@ components:
         completedAt:
           description: >-
             The time the partition was restored, as an ISO 8601 timestamp; null unless the partition
-            state is `restored`.
+            state is `RESTORED`.
           type: string
           format: date-time
           nullable: true

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
@@ -9,6 +9,9 @@ package io.camunda.zeebe.gateway.rest.controller;
 
 import io.camunda.gateway.protocol.model.ClusterModeChangeOperation;
 import io.camunda.gateway.protocol.model.ClusterModeChangeResponse;
+import io.camunda.gateway.protocol.model.RestoreBrokerStatus;
+import io.camunda.gateway.protocol.model.RestorePartitionStatus;
+import io.camunda.gateway.protocol.model.RestoreStatusResponse;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.spring.utils.DatabaseTypeUtils;
@@ -17,15 +20,22 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
+import io.camunda.zeebe.dynamic.config.api.RestoreStatus;
+import io.camunda.zeebe.dynamic.config.api.RestoreStatus.BrokerRestoreStatus;
+import io.camunda.zeebe.dynamic.config.api.RestoreStatus.PartitionRestoreStatus;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.util.Either;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
@@ -86,6 +96,19 @@ public final class RecoveryController {
                 .thenApply(RecoveryController::unwrapOrThrow),
         RecoveryController::toClusterModeChangeResponse,
         HttpStatus.ACCEPTED);
+  }
+
+  @CamundaGetMapping(path = "/restore")
+  public CompletableFuture<ResponseEntity<Object>> getRestoreStatus(
+      @PhysicalTenantId final String physicalTenantId) {
+    LOG.debug("Requested restore status for physical tenant {}", physicalTenantId);
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            clusterConfigurationRequestSender
+                .getTopology()
+                .thenApply(RecoveryController::unwrapTopologyOrThrow),
+        RecoveryController::toRestoreStatusResponse,
+        HttpStatus.OK);
   }
 
   private RestoreRequest toRestoreRequest(
@@ -154,5 +177,74 @@ public final class RecoveryController {
         .operation(operation.getClass().getSimpleName())
         .mode(mode)
         .build();
+  }
+
+  private static ClusterConfiguration unwrapTopologyOrThrow(
+      final Either<ErrorResponse, ClusterConfiguration> result) {
+    if (result.isRight()) {
+      return result.get();
+    }
+    final var error = result.getLeft();
+    throw new ServiceException(error.message(), mapErrorStatus(error.code()));
+  }
+
+  private static RestoreStatusResponse toRestoreStatusResponse(
+      final ClusterConfiguration configuration) {
+    return RestoreStatus.of(configuration)
+        .map(RecoveryController::mapRestoreStatus)
+        .orElseThrow(
+            () -> new ServiceException("No restore is currently in progress", Status.NOT_FOUND));
+  }
+
+  private static RestoreStatusResponse mapRestoreStatus(final RestoreStatus restore) {
+    return RestoreStatusResponse.Builder.create()
+        .status(mapStatusEnum(restore.status()))
+        .changeId(Long.toString(restore.changeId()))
+        .brokers(restore.brokers().stream().map(RecoveryController::mapRestoreBroker).toList())
+        .startedAt(toIso(restore.startedAt()))
+        .build();
+  }
+
+  private static RestoreBrokerStatus mapRestoreBroker(final BrokerRestoreStatus broker) {
+    return RestoreBrokerStatus.Builder.create()
+        .brokerId(broker.brokerId())
+        .partitionsRestored(broker.partitionsRestored())
+        .partitionsToRestore(broker.partitionsToRestore())
+        .partitions(
+            broker.partitions().stream().map(RecoveryController::mapRestorePartition).toList())
+        .build();
+  }
+
+  private static RestorePartitionStatus mapRestorePartition(
+      final PartitionRestoreStatus partition) {
+    return RestorePartitionStatus.Builder.create()
+        .partitionId(partition.partitionId())
+        .state(mapPartitionState(partition.state()))
+        .backupIds(partition.backupIds())
+        .completedAt(toIso(partition.completedAt()))
+        .build();
+  }
+
+  private static RestoreStatusResponse.StatusEnum mapStatusEnum(
+      final ClusterChangePlan.Status status) {
+    return switch (status) {
+      case IN_PROGRESS -> RestoreStatusResponse.StatusEnum.IN_PROGRESS;
+      case COMPLETED -> RestoreStatusResponse.StatusEnum.COMPLETED;
+      case FAILED -> RestoreStatusResponse.StatusEnum.FAILED;
+      case CANCELLED -> RestoreStatusResponse.StatusEnum.CANCELLED;
+    };
+  }
+
+  private static RestorePartitionStatus.StateEnum mapPartitionState(
+      final RestoreStatus.PartitionRestoreState state) {
+    return switch (state) {
+      case PENDING -> RestorePartitionStatus.StateEnum.PENDING;
+      case RESTORING -> RestorePartitionStatus.StateEnum.RESTORING;
+      case RESTORED -> RestorePartitionStatus.StateEnum.RESTORED;
+    };
+  }
+
+  private static String toIso(final Instant instant) {
+    return instant == null ? null : instant.toString();
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.util.Either;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
@@ -244,7 +245,7 @@ public final class RecoveryController {
     };
   }
 
-  private static String toIso(final Instant instant) {
+  private static @Nullable String toIso(final @Nullable Instant instant) {
     return instant == null ? null : instant.toString();
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
@@ -107,8 +107,9 @@ public final class RecoveryController {
         () ->
             clusterConfigurationRequestSender
                 .getTopology()
-                .thenApply(RecoveryController::unwrapTopologyOrThrow),
-        RecoveryController::toRestoreStatusResponse,
+                .thenApply(RecoveryController::unwrapOrThrow)
+                .thenApply(RecoveryController::restoreStatus),
+        RecoveryController::mapRestoreStatus,
         HttpStatus.OK);
   }
 
@@ -135,8 +136,7 @@ public final class RecoveryController {
         dryRun);
   }
 
-  private static ClusterConfigurationChangeResponse unwrapOrThrow(
-      final Either<ErrorResponse, ClusterConfigurationChangeResponse> result) {
+  private static <T> T unwrapOrThrow(final Either<ErrorResponse, T> result) {
     if (result.isRight()) {
       return result.get();
     }
@@ -180,19 +180,8 @@ public final class RecoveryController {
         .build();
   }
 
-  private static ClusterConfiguration unwrapTopologyOrThrow(
-      final Either<ErrorResponse, ClusterConfiguration> result) {
-    if (result.isRight()) {
-      return result.get();
-    }
-    final var error = result.getLeft();
-    throw new ServiceException(error.message(), mapErrorStatus(error.code()));
-  }
-
-  private static RestoreStatusResponse toRestoreStatusResponse(
-      final ClusterConfiguration configuration) {
+  private static RestoreStatus restoreStatus(final ClusterConfiguration configuration) {
     return RestoreStatus.of(configuration)
-        .map(RecoveryController::mapRestoreStatus)
         .orElseThrow(
             () -> new ServiceException("No restore is currently in progress", Status.NOT_FOUND));
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
@@ -200,8 +200,8 @@ public final class RecoveryController {
     return RestoreStatusResponse.Builder.create()
         .status(mapStatusEnum(restore.status()))
         .changeId(Long.toString(restore.changeId()))
-        .brokers(restore.brokers().stream().map(RecoveryController::mapRestoreBroker).toList())
         .startedAt(toIso(restore.startedAt()))
+        .brokers(restore.brokers().stream().map(RecoveryController::mapRestoreBroker).toList())
         .build();
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -15,12 +15,23 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CompletedChange;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.util.Either;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -164,9 +175,118 @@ public class RecoveryControllerTest extends RestControllerTest {
         .isEqualTo(HttpStatus.CONFLICT);
   }
 
+  @Test
+  void shouldReturnNotFoundWhenNoRestore() {
+    // given
+    Mockito.when(clusterConfigurationRequestSender.getTopology())
+        .thenReturn(CompletableFuture.completedFuture(Either.right(ClusterConfiguration.init())));
+
+    // when / then
+    webClient.get().uri("/v2/restore").exchange().expectStatus().isNotFound();
+  }
+
+  @Test
+  void shouldReturnInProgressRestoreStatus() {
+    // given
+    final var broker = MemberId.from("1");
+    final var startedAt = Instant.parse("2024-01-01T10:00:00Z");
+    final var plan =
+        new ClusterChangePlan(
+            -2L,
+            3,
+            Status.IN_PROGRESS,
+            startedAt,
+            List.of(
+                new CompletedOperation(
+                    new PartitionPreRestoreOperation(broker, 1), startedAt.plusSeconds(1)),
+                new CompletedOperation(
+                    new PartitionRestoreOperation(broker, 1, new TreeSet<>(List.of(10L, 11L))),
+                    startedAt.plusSeconds(2))),
+            List.<ClusterConfigurationChangeOperation>of(
+                new ModeChangeOperation(broker, Mode.PROCESSING)));
+    stubTopology(Optional.empty(), Optional.of(plan));
+
+    // when / then
+    webClient
+        .get()
+        .uri("/v2/restore")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.status")
+        .isEqualTo("IN_PROGRESS")
+        .jsonPath("$.changeId")
+        .isEqualTo("-2")
+        .jsonPath("$.startedAt")
+        .isEqualTo("2024-01-01T10:00:00Z")
+        .jsonPath("$.brokers[0].brokerId")
+        .isEqualTo("1")
+        .jsonPath("$.brokers[0].partitionsRestored")
+        .isEqualTo(1)
+        .jsonPath("$.brokers[0].partitionsToRestore")
+        .isEqualTo(1)
+        .jsonPath("$.brokers[0].partitions[0].partitionId")
+        .isEqualTo(1)
+        .jsonPath("$.brokers[0].partitions[0].state")
+        .isEqualTo("RESTORED")
+        .jsonPath("$.brokers[0].partitions[0].backupIds[0]")
+        .isEqualTo(10)
+        .jsonPath("$.brokers[0].partitions[0].completedAt")
+        .isEqualTo("2024-01-01T10:00:02Z");
+  }
+
+  @Test
+  void shouldReturnNotFoundOnceRestoreHasCompleted() {
+    // given
+    final var startedAt = Instant.parse("2024-01-01T10:00:00Z");
+    final var lastChange =
+        new CompletedChange(-2L, Status.COMPLETED, startedAt, startedAt.plusSeconds(300));
+    stubTopology(Optional.of(lastChange), Optional.empty());
+
+    // when / then
+    webClient.get().uri("/v2/restore").exchange().expectStatus().isNotFound();
+  }
+
+  @Test
+  void shouldReturnNotFoundForUnrelatedPendingModeTransition() {
+    // given
+    final var broker = MemberId.from("1");
+    final var plan =
+        new ClusterChangePlan(
+            42L,
+            1,
+            Status.IN_PROGRESS,
+            Instant.parse("2024-01-01T10:00:00Z"),
+            List.of(),
+            List.<ClusterConfigurationChangeOperation>of(
+                new ModeChangeOperation(broker, Mode.PROCESSING)));
+    stubTopology(Optional.empty(), Optional.of(plan));
+
+    // when / then
+    webClient.get().uri("/v2/restore").exchange().expectStatus().isNotFound();
+  }
+
+  private void stubTopology(
+      final Optional<CompletedChange> lastChange,
+      final Optional<ClusterChangePlan> pendingChanges) {
+    final var configuration =
+        new ClusterConfiguration(
+            2,
+            Map.of(),
+            lastChange,
+            pendingChanges,
+            Optional.empty(),
+            Optional.empty(),
+            0,
+            Optional.empty());
+    Mockito.when(clusterConfigurationRequestSender.getTopology())
+        .thenReturn(CompletableFuture.completedFuture(Either.right(configuration)));
+  }
+
   @Nested
   @TestPropertySource(properties = {"camunda.data.secondary-storage.type=elasticsearch"})
-  class Elasticsearch extends DocumentSecondaryStorage {
+  class Elasticsearch extends SecondaryStorage {
 
     @Override
     String expectedDatabaseType() {
@@ -176,7 +296,7 @@ public class RecoveryControllerTest extends RestControllerTest {
 
   @Nested
   @TestPropertySource(properties = {"camunda.data.secondary-storage.type=opensearch"})
-  class OpenSearch extends DocumentSecondaryStorage {
+  class OpenSearch extends SecondaryStorage {
 
     @Override
     String expectedDatabaseType() {
@@ -186,7 +306,7 @@ public class RecoveryControllerTest extends RestControllerTest {
 
   @Nested
   @TestPropertySource(properties = {"camunda.data.secondary-storage.type=rdbms"})
-  class Rdbms extends RdbmsSecondaryStorage {
+  class Rdbms extends SecondaryStorage {
 
     @Override
     String expectedDatabaseType() {
@@ -196,7 +316,7 @@ public class RecoveryControllerTest extends RestControllerTest {
 
   @Nested
   @TestPropertySource(properties = {"camunda.data.secondary-storage.type=none"})
-  class None extends RdbmsSecondaryStorage {
+  class None extends SecondaryStorage {
 
     @Override
     String expectedDatabaseType() {
@@ -232,7 +352,7 @@ public class RecoveryControllerTest extends RestControllerTest {
     }
   }
 
-  abstract class RdbmsSecondaryStorage {
+  abstract class SecondaryStorage {
 
     abstract String expectedDatabaseType();
 
@@ -351,68 +471,6 @@ public class RecoveryControllerTest extends RestControllerTest {
                   "2024-01-01T12:00:00Z",
                   expectedDatabaseType(),
                   true,
-                  false));
-    }
-  }
-
-  abstract class DocumentSecondaryStorage {
-
-    abstract String expectedDatabaseType();
-
-    @ParameterizedTest
-    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
-    void shouldForwardBackupIds(final String baseUrl) {
-      // given
-      stubValidationSuccess();
-
-      // when / then
-      webClient
-          .post()
-          .uri(baseUrl)
-          .contentType(MediaType.APPLICATION_JSON)
-          .bodyValue("{\"backupIds\": [100, 101]}")
-          .exchange()
-          .expectStatus()
-          .isAccepted()
-          .expectBody()
-          .json("{\"changeId\": \"0\", \"plannedChanges\": []}", JsonCompareMode.STRICT);
-
-      Mockito.verify(clusterConfigurationRequestSender)
-          .restore(
-              new RestoreRequest(
-                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-                  List.of(100L, 101L),
-                  null,
-                  null,
-                  expectedDatabaseType(),
-                  false,
-                  false));
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
-    void shouldForwardNoParameters(final String baseUrl) {
-      // given
-      stubValidationSuccess();
-
-      // when / then
-      webClient
-          .post()
-          .uri(baseUrl)
-          .contentType(MediaType.APPLICATION_JSON)
-          .exchange()
-          .expectStatus()
-          .isAccepted();
-
-      Mockito.verify(clusterConfigurationRequestSender)
-          .restore(
-              new RestoreRequest(
-                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-                  List.of(),
-                  null,
-                  null,
-                  expectedDatabaseType(),
-                  false,
                   false));
     }
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -7,8 +7,13 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.gateway.protocol.model.RestoreBrokerStatus;
+import io.camunda.gateway.protocol.model.RestorePartitionStatus;
+import io.camunda.gateway.protocol.model.RestoreStatusResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
@@ -206,34 +211,42 @@ public class RecoveryControllerTest extends RestControllerTest {
                 new ModeChangeOperation(broker, Mode.PROCESSING)));
     stubTopology(Optional.empty(), Optional.of(plan));
 
-    // when / then
-    webClient
-        .get()
-        .uri("/v2/restore")
-        .exchange()
-        .expectStatus()
-        .isOk()
-        .expectBody()
-        .jsonPath("$.status")
-        .isEqualTo("IN_PROGRESS")
-        .jsonPath("$.changeId")
-        .isEqualTo("-2")
-        .jsonPath("$.startedAt")
-        .isEqualTo("2024-01-01T10:00:00Z")
-        .jsonPath("$.brokers[0].brokerId")
-        .isEqualTo("1")
-        .jsonPath("$.brokers[0].partitionsRestored")
-        .isEqualTo(1)
-        .jsonPath("$.brokers[0].partitionsToRestore")
-        .isEqualTo(1)
-        .jsonPath("$.brokers[0].partitions[0].partitionId")
-        .isEqualTo(1)
-        .jsonPath("$.brokers[0].partitions[0].state")
-        .isEqualTo("RESTORED")
-        .jsonPath("$.brokers[0].partitions[0].backupIds[0]")
-        .isEqualTo(10)
-        .jsonPath("$.brokers[0].partitions[0].completedAt")
-        .isEqualTo("2024-01-01T10:00:02Z");
+    // when
+    final var response =
+        webClient
+            .get()
+            .uri("/v2/restore")
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(RestoreStatusResponse.class)
+            .returnResult()
+            .getResponseBody();
+
+    // then
+    final var expected =
+        RestoreStatusResponse.Builder.create()
+            .status(RestoreStatusResponse.StatusEnum.IN_PROGRESS)
+            .changeId("-2")
+            .startedAt("2024-01-01T10:00:00Z")
+            .brokers(
+                List.of(
+                    RestoreBrokerStatus.Builder.create()
+                        .brokerId("1")
+                        .partitionsRestored(1)
+                        .partitionsToRestore(1)
+                        .partitions(
+                            List.of(
+                                RestorePartitionStatus.Builder.create()
+                                    .partitionId(1)
+                                    .state(RestorePartitionStatus.StateEnum.RESTORED)
+                                    .backupIds(List.of(10L, 11L))
+                                    .completedAt("2024-01-01T10:00:02Z")
+                                    .build()))
+                        .build()))
+            .build();
+
+    assertThat(response).isEqualTo(expected);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -187,7 +187,7 @@ public class RecoveryControllerTest extends RestControllerTest {
         .thenReturn(CompletableFuture.completedFuture(Either.right(ClusterConfiguration.init())));
 
     // when / then
-    webClient.get().uri("/v2/restore").exchange().expectStatus().isNotFound();
+    expectNoRestoreInProgress();
   }
 
   @Test
@@ -258,7 +258,7 @@ public class RecoveryControllerTest extends RestControllerTest {
     stubTopology(Optional.of(lastChange), Optional.empty());
 
     // when / then
-    webClient.get().uri("/v2/restore").exchange().expectStatus().isNotFound();
+    expectNoRestoreInProgress();
   }
 
   @Test
@@ -277,7 +277,64 @@ public class RecoveryControllerTest extends RestControllerTest {
     stubTopology(Optional.empty(), Optional.of(plan));
 
     // when / then
-    webClient.get().uri("/v2/restore").exchange().expectStatus().isNotFound();
+    expectNoRestoreInProgress();
+  }
+
+  @Test
+  void shouldMapErrorResponseWhenTopologyQueryRejected() {
+    // given
+    Mockito.when(clusterConfigurationRequestSender.getTopology())
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.left(
+                    new ErrorResponse(ErrorCode.INTERNAL_ERROR, "topology is unavailable"))));
+
+    // when / then
+    expectRestoreStatusProblem(
+        HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL", "topology is unavailable");
+  }
+
+  @Test
+  void shouldMapFailedTopologyRequest() {
+    // given
+    Mockito.when(clusterConfigurationRequestSender.getTopology())
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("no coordinator")));
+
+    // when / then
+    expectRestoreStatusProblem(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        RuntimeException.class.getName(),
+        "Unexpected error occurred during the request processing: no coordinator");
+  }
+
+  private void expectNoRestoreInProgress() {
+    expectRestoreStatusProblem(
+        HttpStatus.NOT_FOUND, "NOT_FOUND", "No restore is currently in progress");
+  }
+
+  /** Asserts that {@code GET /v2/restore} answers with the given RFC 9457 problem detail. */
+  private void expectRestoreStatusProblem(
+      final HttpStatus status, final String title, final String detail) {
+    webClient
+        .get()
+        .uri("/v2/restore")
+        .exchange()
+        .expectStatus()
+        .isEqualTo(status)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "status": %d,
+              "title": "%s",
+              "detail": "%s",
+              "instance": "/v2/restore"
+            }"""
+                .formatted(status.value(), title, detail),
+            JsonCompareMode.STRICT);
   }
 
   private void stubTopology(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreRetryOnCorruptionIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreRetryOnCorruptionIT.java
@@ -27,14 +27,8 @@ import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -85,7 +79,8 @@ final class InProcessRestoreRetryOnCorruptionIT {
       takeBackup();
 
       // and - partition 2's backup snapshot is corrupted on disk, partition 1's is left intact
-      final var originalSnapshotFiles = corruptPartitionSnapshot(2);
+      final var originalSnapshotFiles =
+          InProcessRestoreTestUtil.corruptPartitionSnapshot(backupDir, BACKUP_ID, 0, 2);
 
       // when - the broker is put into RECOVERING mode and a restore is triggered
       final var clusterActuator = ClusterActuator.of(broker);
@@ -118,7 +113,7 @@ final class InProcessRestoreRetryOnCorruptionIT {
 
       // when - the corruption is fixed by restoring the original snapshot bytes, without ever
       // re-triggering restore over REST again
-      restoreOriginalSnapshotFiles(originalSnapshotFiles);
+      InProcessRestoreTestUtil.restoreOriginalSnapshotFiles(originalSnapshotFiles);
 
       // then - the SAME change, already pending since the first REST call, completes on its own
       Awaitility.await("restore change plan completes once the retry succeeds")
@@ -165,48 +160,6 @@ final class InProcessRestoreRetryOnCorruptionIT {
                   .extracting(BackupInfo::getBackupId, BackupInfo::getState)
                   .containsExactly(BACKUP_ID, StateCode.COMPLETED);
             });
-  }
-
-  /**
-   * Truncates every {@code .sst} file in the given partition's completed backup snapshot on disk,
-   * overwriting it with garbage bytes so a later restore's RocksDB sanity check fails with a
-   * checksum/corruption error. Returns the original file contents so they can be restored later.
-   */
-  private Map<Path, byte[]> corruptPartitionSnapshot(final int partitionId) throws IOException {
-    final var snapshotDir =
-        backupDir
-            .resolve("contents")
-            .resolve(String.valueOf(partitionId))
-            .resolve(String.valueOf(BACKUP_ID))
-            .resolve("0") // broker/node id, default for a single unconfigured broker
-            .resolve("snapshot");
-
-    final List<Path> sstFiles;
-    try (final var files = Files.list(snapshotDir)) {
-      sstFiles = files.filter(p -> p.toString().endsWith(".sst")).sorted().toList();
-    }
-    assertThat(sstFiles)
-        .describedAs(
-            "partition %d's backup snapshot directory %s must contain .sst files to corrupt",
-            partitionId, snapshotDir)
-        .isNotEmpty();
-
-    final var originalContents = new HashMap<Path, byte[]>();
-    for (final var sstFile : sstFiles) {
-      originalContents.put(sstFile, Files.readAllBytes(sstFile));
-      Files.write(
-          sstFile,
-          "<--corrupted-by-InProcessRestoreRetryOnCorruptionIT-->".getBytes(),
-          StandardOpenOption.TRUNCATE_EXISTING);
-    }
-    return originalContents;
-  }
-
-  private void restoreOriginalSnapshotFiles(final Map<Path, byte[]> originalContents)
-      throws IOException {
-    for (final var entry : originalContents.entrySet()) {
-      Files.write(entry.getKey(), entry.getValue(), StandardOpenOption.TRUNCATE_EXISTING);
-    }
   }
 
   /**

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreStatusIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreStatusIT.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.protocol.rest.RestorePartitionStatus;
+import io.camunda.client.protocol.rest.RestorePartitionStatus.StateEnum;
+import io.camunda.client.protocol.rest.RestoreStatusResponse;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.PrimaryStorageBackup.BackupStoreType;
+import io.camunda.management.backups.BackupInfo;
+import io.camunda.management.backups.StateCode;
+import io.camunda.management.backups.TakeBackupRuntimeResponse;
+import io.camunda.zeebe.qa.util.actuator.BackupActuator;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Verifies that {@code GET v2/restore} reports a single broker's copy of a partition progressing
+ * through {@code RESTORING} to {@code RESTORED}.
+ *
+ * <p>The cluster change plan that drives a restore executes strictly sequentially, one operation at
+ * a time across the whole cluster; every partition's {@code PartitionPreRestoreOperation} runs
+ * before any {@code PartitionRestoreOperation} starts. This test targets broker {@value
+ * #TARGET_BROKER_ID}'s copy of partition {@value #TARGET_PARTITION_ID} - the last operation in that
+ * sequence for a {@value #BROKERS_COUNT}-broker, replication-factor-{@value #BROKERS_COUNT} cluster
+ * - and corrupts only that broker's on-disk backup snapshot for that partition, using the same
+ * technique as {@link InProcessRestoreRetryOnCorruptionIT}. This makes {@code RESTORING} and {@code
+ * RESTORED} fully deterministic: the corrupted step fails and retries with a real backoff until the
+ * corruption is fixed, so the intermediate state is held open for a known window rather than raced
+ * against.
+ *
+ * <p>{@code PENDING} is not asserted here: with only one {@code PartitionPreRestoreOperation}
+ * preceding the target in this small cluster's operation queue, the target flips to {@code
+ * RESTORING} before it can be reliably observed. The full {@code PENDING -> RESTORING -> RESTORED}
+ * sequence is covered deterministically at the unit level in {@code RestoreStatusTest}.
+ */
+@ZeebeIntegration
+final class InProcessRestoreStatusIT {
+
+  private static final int BROKERS_COUNT = 2;
+  private static final int PARTITIONS_COUNT = 2;
+  private static final long BACKUP_ID = 42;
+  private static final String JOB_TYPE = "restore-status-job";
+  private static final String PROCESS_ID = "restore-status-process";
+  private static final int TARGET_BROKER_ID = 1;
+  private static final int TARGET_PARTITION_ID = 2;
+
+  @TempDir private Path backupDir;
+
+  @Test
+  void shouldReportPartitionRestoreStatusThroughRestoringAndRestored() throws IOException {
+    try (final var cluster =
+            TestCluster.builder()
+                .withBrokersCount(BROKERS_COUNT)
+                .withPartitionsCount(PARTITIONS_COUNT)
+                .withReplicationFactor(BROKERS_COUNT)
+                .withEmbeddedGateway(true)
+                .withBrokerConfig(broker -> configureBackupStore(broker.unifiedConfig()))
+                .build()
+                .start()
+                .awaitCompleteTopology();
+        final var client = cluster.newClientBuilder().build()) {
+
+      // given
+      InProcessRestoreTestUtil.deployAndCreateInstancesOnEveryPartition(
+          client, PROCESS_ID, JOB_TYPE, PARTITIONS_COUNT);
+      takeSnapshotOnAllBrokers(cluster);
+      takeBackup(BackupActuator.of(cluster.availableGateway()));
+      final var originalSnapshotFiles =
+          InProcessRestoreTestUtil.corruptPartitionSnapshot(
+              backupDir, BACKUP_ID, TARGET_BROKER_ID, TARGET_PARTITION_ID);
+
+      final var clusterActuator = ClusterActuator.of(cluster.availableGateway());
+      final var toRecovering = InProcessRestoreTestUtil.changeMode(client, "RECOVERING", false);
+      Awaitility.await("cluster transitions to RECOVERING")
+          .timeout(Duration.ofSeconds(60))
+          .untilAsserted(
+              () ->
+                  ClusterActuatorAssert.assertThat(clusterActuator)
+                      .hasCompletedChanges(toRecovering)
+                      .doesNotHavePendingChanges());
+
+      // when
+      final var changeId = InProcessRestoreTestUtil.triggerRestore(client, BACKUP_ID);
+
+      // then
+      Awaitility.await("target partition's restore step is the one stuck retrying")
+          .timeout(Duration.ofSeconds(30))
+          .untilAsserted(() -> assertTargetPartitionState(client, StateEnum.RESTORING));
+
+      Awaitility.await("the corrupted restore keeps reporting restoring across multiple retries")
+          .during(Duration.ofSeconds(25))
+          .atMost(Duration.ofSeconds(35))
+          .until(
+              () -> {
+                assertTargetPartitionState(client, StateEnum.RESTORING);
+                return true;
+              });
+
+      InProcessRestoreTestUtil.restoreOriginalSnapshotFiles(originalSnapshotFiles);
+
+      Awaitility.await("target partition is reported restored once the retry succeeds")
+          .timeout(Duration.ofSeconds(30))
+          .untilAsserted(() -> assertTargetPartitionState(client, StateEnum.RESTORED));
+
+      Awaitility.await("restore change plan completes")
+          .timeout(Duration.ofMinutes(2))
+          .untilAsserted(
+              () ->
+                  ClusterActuatorAssert.assertThat(clusterActuator)
+                      .hasCompletedChanges(changeId)
+                      .doesNotHavePendingChanges());
+    }
+  }
+
+  private void assertTargetPartitionState(final CamundaClient client, final StateEnum expected) {
+    final var status = InProcessRestoreTestUtil.getRestoreStatus(client);
+    assertThat(findTargetPartitionStatus(status).getState()).isEqualTo(expected);
+  }
+
+  private RestorePartitionStatus findTargetPartitionStatus(final RestoreStatusResponse status) {
+    return status.getBrokers().stream()
+        .filter(broker -> broker.getBrokerId().equals(String.valueOf(TARGET_BROKER_ID)))
+        .flatMap(broker -> broker.getPartitions().stream())
+        .filter(partition -> partition.getPartitionId() == TARGET_PARTITION_ID)
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new AssertionError(
+                    "no restore status reported for broker %d partition %d"
+                        .formatted(TARGET_BROKER_ID, TARGET_PARTITION_ID)));
+  }
+
+  private void takeSnapshotOnAllBrokers(final TestCluster cluster) {
+    cluster
+        .brokers()
+        .values()
+        .forEach(
+            broker -> {
+              final var partitions = PartitionsActuator.of(broker);
+              partitions.takeSnapshot();
+              Awaitility.await("snapshot is taken on broker " + broker.nodeId())
+                  .atMost(Duration.ofSeconds(60))
+                  .untilAsserted(
+                      () ->
+                          assertThat(partitions.query().values())
+                              .allSatisfy(status -> assertThat(status.snapshotId()).isNotNull()));
+            });
+  }
+
+  private void takeBackup(final BackupActuator actuator) {
+    assertThat(actuator.take(BACKUP_ID)).isInstanceOf(TakeBackupRuntimeResponse.class);
+    Awaitility.await("until a backup exists with the given ID")
+        .atMost(Duration.ofSeconds(60))
+        .ignoreExceptions() // 404 NOT_FOUND throws exception
+        .untilAsserted(
+            () -> {
+              final var status = actuator.status(BACKUP_ID);
+              assertThat(status)
+                  .extracting(BackupInfo::getBackupId, BackupInfo::getState)
+                  .containsExactly(BACKUP_ID, StateCode.COMPLETED);
+            });
+  }
+
+  /** Backup store can only be configured via UnifiedConfiguration */
+  private void configureBackupStore(final Camunda cfg) {
+    final var backup = cfg.getData().getPrimaryStorage().getBackup();
+    backup.setStore(BackupStoreType.FILESYSTEM);
+
+    final var config = backup.getFilesystem();
+    config.setBasePath(backupDir.toAbsolutePath().toString());
+    backup.setFilesystem(config);
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreTestUtil.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreTestUtil.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.protocol.rest.ClusterModeChangeResponse;
+import io.camunda.client.protocol.rest.RestoreStatusResponse;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.Protocol;
@@ -21,8 +22,12 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -33,10 +38,10 @@ import org.awaitility.Awaitility;
 
 /**
  * Shared helpers for the in-process restore tests ({@link InProcessRestoreAcceptance}, {@link
- * InProcessRestoreRetryOnCorruptionIT} and {@link InProcessRdbmsRangeRestoreIT}), which all trigger
- * a restore over the cluster's REST endpoint while a broker is in {@code RECOVERING} mode. Also
- * exposes {@link #changeMode} for triggering a cluster mode change over {@code v2/mode}, reused by
- * {@code ModeChangeAcceptanceIT} outside this package.
+ * InProcessRestoreRetryOnCorruptionIT}, {@link InProcessRdbmsRangeRestoreIT} and {@link
+ * InProcessRestoreStatusIT}), which all trigger a restore over the cluster's REST endpoint while a
+ * broker is in {@code RECOVERING} mode. Also exposes {@link #changeMode} for triggering a cluster
+ * mode change over {@code v2/mode}, reused by {@code ModeChangeAcceptanceIT} outside this package.
  */
 public final class InProcessRestoreTestUtil {
 
@@ -87,6 +92,25 @@ public final class InProcessRestoreTestUtil {
           OBJECT_MAPPER.readValue(response.body(), ClusterModeChangeResponse.class).getChangeId());
     } catch (final IOException e) {
       throw new UncheckedIOException("Failed to parse restore REST response", e);
+    }
+  }
+
+  /** GETs the current restore status from {@code v2/restore} and returns the parsed response. */
+  static RestoreStatusResponse getRestoreStatus(final CamundaClient client) {
+    try (final var httpClient = HttpClient.newHttpClient()) {
+      final var uri =
+          URI.create("%sv2/restore".formatted(client.getConfiguration().getRestAddress()));
+      final var request = HttpRequest.newBuilder(uri).GET().build();
+      final var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      assertThat(response.statusCode())
+          .describedAs("restore status REST response: %s".formatted(response.body()))
+          .isEqualTo(200);
+      return OBJECT_MAPPER.readValue(response.body(), RestoreStatusResponse.class);
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to fetch restore status via REST endpoint", e);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while fetching restore status via REST endpoint", e);
     }
   }
 
@@ -211,5 +235,51 @@ public final class InProcessRestoreTestUtil {
                   .containsExactlyInAnyOrderElementsOf(
                       IntStream.rangeClosed(1, partitionsCount).boxed().toList());
             });
+  }
+
+  /**
+   * Truncates every {@code .sst} file in the given node's completed backup snapshot for the given
+   * partition on disk, overwriting it with garbage bytes so a later restore's RocksDB sanity check
+   * fails with a checksum/corruption error. Returns the original file contents so they can be
+   * restored later with {@link #restoreOriginalSnapshotFiles}.
+   */
+  static Map<Path, byte[]> corruptPartitionSnapshot(
+      final Path backupDir, final long backupId, final int nodeId, final int partitionId)
+      throws IOException {
+    final var snapshotDir =
+        backupDir
+            .resolve("contents")
+            .resolve(String.valueOf(partitionId))
+            .resolve(String.valueOf(backupId))
+            .resolve(String.valueOf(nodeId))
+            .resolve("snapshot");
+
+    final List<Path> sstFiles;
+    try (final var files = Files.list(snapshotDir)) {
+      sstFiles = files.filter(p -> p.toString().endsWith(".sst")).sorted().toList();
+    }
+    assertThat(sstFiles)
+        .describedAs(
+            "node %d's backup snapshot for partition %d at %s must contain .sst files to corrupt",
+            nodeId, partitionId, snapshotDir)
+        .isNotEmpty();
+
+    final var originalContents = new HashMap<Path, byte[]>();
+    for (final var sstFile : sstFiles) {
+      originalContents.put(sstFile, Files.readAllBytes(sstFile));
+      Files.write(
+          sstFile,
+          "<--corrupted-by-InProcessRestoreTestUtil-->".getBytes(),
+          StandardOpenOption.TRUNCATE_EXISTING);
+    }
+    return originalContents;
+  }
+
+  /** Restores the file contents captured by {@link #corruptPartitionSnapshot}. */
+  static void restoreOriginalSnapshotFiles(final Map<Path, byte[]> originalContents)
+      throws IOException {
+    for (final var entry : originalContents.entrySet()) {
+      Files.write(entry.getKey(), entry.getValue(), StandardOpenOption.TRUNCATE_EXISTING);
+    }
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Introduce `GET v2/:tenantId/restore` to track the restore progress of an in-flight restore operation. The status is aggregated from the topology's pending/completed operations of a given ClusterChangePlan.

Since change plans do not have a _memory_ the status is only reported when a restore operation is in-flight. When no restore is active the endpoint returns a `404`.

_Currently, there is no per-tenant topology. This will be adapted in a future PR._

The status is reported as:

```json
"status": "IN_PROGRESS",
  "changeId": "9",
  "startedAt": "2026-07-27T14:43:24.682322271Z",
  "brokers": [
    {
      "brokerId": "0",
      "partitionsRestored": 1,
      "partitionsToRestore": 2,
      "partitions": [
        {
          "partitionId": 1,
          "state": "RESTORED",
          "backupIds": [
            1785163323056
          ],
          "completedAt": "2026-07-27T14:44:45.538848977Z"
        },
        {
          "partitionId": 2,
          "state": "RESTORING",
          "backupIds": [
            1785163323056
          ],
          "completedAt": null
        }
      ]
    }
  ]
}
```

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #58755
