### PR TITLE
docs: ADR for tenant-access provider ownership and uniform seam

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,4 +39,9 @@ ADR for that domain is written.
   path, remapping `camunda.client.*` to `camunda.clients.default.*`, with a
   `defaultCamundaClient` `@Primary` bean plus a `camundaClient` alias for
   backward compatibility (camunda/camunda#57344).
+- `security/002-tenant-access-provider-ownership-and-seam.md` — CSL `core` owns
+  the concrete tenant-access provider and the `TenantOwnedEntity` contract; a
+  uniform `TenantAccessProvider` seam across the read (search) and write
+  (engine) paths, behavior-preserving, with the engine's anonymous/mt-off policy
+  in a thin engine-side decorator (camunda-security-library#582).
 

--- a/docs/adr/security/002-tenant-access-provider-ownership-and-seam.md
+++ b/docs/adr/security/002-tenant-access-provider-ownership-and-seam.md
@@ -1,0 +1,94 @@
+# Tenant-access provider: CSL ownership and a uniform provider seam
+
+**DRI**: Identity / Core Features team
+
+**Status**: Proposed (8.10)
+
+**Purpose**: Establish CSL `core` as the owner of the concrete tenant-access provider and the
+`TenantOwnedEntity` contract, and adopt a single `TenantAccessProvider` seam across both the read
+(search) and write (engine) paths — without changing tenant-authorization behavior on either.
+
+**Audience**: Engineers and AI coding agents working on the Camunda Security Library, the Zeebe
+engine write-path authorization, and the search/query authorization stack.
+
+Relates to: camunda-security-library#582 (Inc 5), camunda-security-library#584,
+camunda/camunda#59107.
+
+## Context
+
+The `TenantAccessProvider` interface and the `TenantAccess` verdict type already live in CSL `core`,
+but the only concrete implementation — `DefaultTenantAccessProvider` — lives in the monorepo, on the
+read path (`search/search-client-query-transformer/.../auth/`). Its resource-aware
+`hasTenantAccess(T)` extracts a tenant from a document via the `TenantOwnedEntity` marker
+(`search/search-domain/.../entities/`), implemented by 21 search read-model entities.
+
+Two forces meet here:
+
+1. **camunda-security-library#582 AC1** asks for a concrete claims-based provider in CSL `core`. An
+   interim stub (`ClaimsBasedTenantAccessProvider`, PR camunda-security-library#584) satisfies it
+   only partially:
+   `hasTenantAccess(T)` throws, because the tenant-from-resource extraction needs `TenantOwnedEntity`,
+   which is not on the CSL classpath.
+2. The Inc 5 goal is for the **engine write-path** to consume `TenantAccessProvider` and retire its
+   bespoke `AuthorizedTenants*` stack, rather than copy the default provider into the engine.
+
+The engine's tenant policy is genuinely richer than plain claims-reading
+(`AuthorizedTenantsResolver`): `anonymous → wildcard`, `multi-tenancy off → default tenant`,
+`no username & no client-id → denied`, else `claims-resolved tenants`. Every input except
+`EngineSecurityConfig.isMultiTenancyChecksEnabled()` is derivable from a `CamundaAuthentication`,
+which the engine can obtain at the call site (`claimsConverter.resolve(...)`).
+
+On the read path, anonymous authentication is routed to a dedicated
+`AnonymousResourceAccessController` that short-circuits to `ResourceAccessChecks.disabled()`; the
+controller that calls `hasTenantAccess` excludes anonymous. So `DefaultTenantAccessProvider` is never
+invoked with an anonymous authentication and correctly ignores the `anonymousUser` flag.
+
+## Decision
+
+**1. Tenant-ownership is a security contract, not a search read-model detail.** Relocate
+`TenantOwnedEntity` and the `DefaultTenantAccessProvider` logic into CSL `core` as the canonical
+claims-based provider. This is why CSL — not `search` — is the right owner: the marker names a
+security property of an entity (which tenant owns it), and the provider is the authorization
+component that reads it. `search-domain` already depends on CSL `core`, so no dependency cycle is
+introduced. The `ClaimsBasedTenantAccessProvider` stub is superseded and removed.
+
+The relocation is behavior-preserving. The monorepo cutover is **atomic** (delete the search
+`TenantOwnedEntity` + `DefaultTenantAccessProvider`, repoint all 21 entities and the read-path
+wiring in one commit) and guarded by a test asserting every tenant-scoped entity is `instanceof` the
+core `TenantOwnedEntity`. This guard is required because `hasTenantAccess(T)` **fails open** —
+returns `allowed` for any resource that is not `instanceof TenantOwnedEntity` — so a missed repoint
+would be a silent authorization bypass, not a compile error.
+
+**2. A uniform tenant-access provider seam across read and write paths.** The engine consumes the
+shared `TenantAccessProvider` through a thin engine-side decorator over the core claims provider:
+`anonymousUser → wildcard`, `mt-off → default tenant`, else delegate. This replaces
+`AuthorizedTenantsResolver`.
+
+The claim of this decision is precisely the **seam**, not elimination of engine code. The
+anonymous / mt-off policy is irreducibly engine-specific (it depends on engine config and on
+signals the read path handles by controller selection) and remains in a named engine class. The
+shared provider stays **anonymous-agnostic**, matching the read path, so no read-path behavior
+changes. Honoring `anonymousUser` inside the shared provider was rejected: it would be dead code on
+the read path and an unnecessary behavior-surface change.
+
+## Alternatives considered
+
+- **Share only the interface + `TenantAccess` type; each side keeps its own impl** — the current
+  shape of engine PR camunda/camunda#59107. Lowest risk, but no shared seam: the engine stays on a
+  bespoke resolver.
+- **Push all policy into `CamundaAuthentication` construction so one dumb provider serves both
+  paths.** Cleanest theoretical end state, but changes how both paths build authentication and must
+  model mt-off/wildcard on the authentication — highest risk for modest gain. The pre-existing
+  `anonymousUser` field is a convenience, not a reason to adopt this.
+
+## Consequences
+
+- CSL `core` gains a security-owned entity contract (`TenantOwnedEntity`) and the canonical provider;
+  its public API now carries both.
+- The two moves are independently shippable. Relocation (decision 1) delivers
+  camunda-security-library#582 AC1 and can land without the engine adoption (decision 2). Neither
+  rides on camunda-security-library#584, which stays predicates-only so its alpha continues to
+  unblock the engine work.
+- Engine adoption (decision 2) reworks the resolver introduced in camunda/camunda#59107; it is a
+  deliberate, separate follow-up, not a prerequisite for the relocation.
+


### PR DESCRIPTION
## What

Adds ADR `security/002` recording the decision (Option D) to make CSL `core` the owner of the
concrete `TenantAccessProvider` and the `TenantOwnedEntity` contract, and to share one provider seam
across the read (search) and write (engine) paths. **Docs-only — no code changes.**

## Why

Inc 5 needs a concrete claims-based provider in CSL `core`, and the engine write-path should consume
it rather than copy the search default. Both goals hinge on where `TenantOwnedEntity` and the
concrete provider live, so the decision needed recording before any implementation.

## Notes

- Behavior-preserving: the shared provider stays anonymous-agnostic (the read path routes anonymous
  via a dedicated controller); the engine's anonymous/mt-off policy stays in a thin engine-side
  decorator.
- Separates the two moves (relocation vs. engine adoption) by value/risk, and records the fail-open
  guard the monorepo cutover must carry.
- The working design spec lives under the (gitignored) `docs/superpowers/specs/`; the ADR is the
  committed artifact.

Related to camunda-security-library#582, camunda-security-library#584,
camunda-security-library#587, and camunda/camunda#59107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
