### PR TITLE
ci: upload full failsafe-reports for Optimize IT jobs

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -158,7 +158,7 @@ jobs:
         with:
           name: integration-test-elasticsearch-${{ matrix.includedGroups }}-junit
           path: |
-            **/failsafe-reports/**/*.xml
+            **/failsafe-reports/**
 
       - name: Docker log dump
         uses: ./.github/actions/docker-logs
@@ -249,7 +249,7 @@ jobs:
         with:
           name: integration-test-opensearch-${{ matrix.includedGroups }}-junit
           path: |
-            **/failsafe-reports/**/*.xml
+            **/failsafe-reports/**
 
       - name: Docker log dump
         uses: ./.github/actions/docker-logs


### PR DESCRIPTION
## Description

The Optimize Elasticsearch/OpenSearch IT jobs only uploaded `**/failsafe-reports/**/*.xml`. When a job is cancelled on the 30m timeout, the JUnit XML is never finalized for the hung class, so the artifact carried no usable signal for the run that actually failed.

The per-fork `*-output.txt` files hold the interleaved broker/exporter logs and stdout that reveal why a class stalls (e.g. an exporter looping on "no such index"). Widen the glob to the whole `failsafe-reports` directory so those files are uploaded alongside the XML and cancelled runs stay diagnosable from the artifact alone.

## Related issues

closes #
