### PR TITLE
feat: promote desired leader during leadership transfers

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Raft.java
+++ b/configuration/src/main/java/io/camunda/configuration/Raft.java
@@ -422,6 +422,12 @@ public class Raft {
      */
     private Duration replicationTimeout = Duration.ofSeconds(10);
 
+    /**
+     * The maximum number of TimeoutNow requests the current leader sends (including the initial
+     * request) before reporting {@code TIMEOUT_NOW_EXHAUSTED}.
+     */
+    private int maxTransferAttempts = 3;
+
     public DataSize getReplicationLagThreshold() {
       return replicationLagThreshold;
     }
@@ -444,6 +450,18 @@ public class Raft {
         throw new IllegalArgumentException("replicationTimeout must be positive");
       }
       this.replicationTimeout = replicationTimeout;
+    }
+
+    public int getMaxTransferAttempts() {
+      return maxTransferAttempts;
+    }
+
+    public void setMaxTransferAttempts(final int maxTransferAttempts) {
+      if (maxTransferAttempts <= 0) {
+        throw new IllegalArgumentException(
+            "maxTransferAttempts must be positive but was %s".formatted(maxTransferAttempts));
+      }
+      this.maxTransferAttempts = maxTransferAttempts;
     }
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -628,6 +628,10 @@ public class BrokerBasedPropertiesOverride {
         .getRaft()
         .setRebalanceReplicationTimeout(raft.getRebalance().getReplicationTimeout());
     override
+        .getCluster()
+        .getRaft()
+        .setRebalanceMaxTransferAttempts(raft.getRebalance().getMaxTransferAttempts());
+    override
         .getExperimental()
         .getRaft()
         .setPreallocateSegmentFiles(raft.isPreallocateSegmentFiles());

--- a/configuration/src/test/java/io/camunda/configuration/ClusterRaftTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterRaftTest.java
@@ -49,7 +49,8 @@ public class ClusterRaftTest {
         "camunda.cluster.raft.prefer-snapshot-replication-threshold=110",
         "camunda.cluster.raft.preallocate-segment-files=false",
         "camunda.cluster.raft.rebalance.replication-lag-threshold=16MB",
-        "camunda.cluster.raft.rebalance.replication-timeout=30s"
+        "camunda.cluster.raft.rebalance.replication-timeout=30s",
+        "camunda.cluster.raft.rebalance.max-transfer-attempts=5"
       })
   class WithOnlyUnifiedConfigSet {
     final BrokerBasedProperties brokerCfg;
@@ -108,7 +109,8 @@ public class ClusterRaftTest {
     void shouldSetRebalance() {
       assertThat(brokerCfg.getCluster().getRaft())
           .returns(DataSize.ofMegabytes(16), RaftCfg::getRebalanceReplicationLagThreshold)
-          .returns(Duration.ofSeconds(30), RaftCfg::getRebalanceReplicationTimeout);
+          .returns(Duration.ofSeconds(30), RaftCfg::getRebalanceReplicationTimeout)
+          .returns(5, RaftCfg::getRebalanceMaxTransferAttempts);
     }
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/RaftRebalanceValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/RaftRebalanceValidationTest.java
@@ -60,6 +60,18 @@ final class RaftRebalanceValidationTest {
   }
 
   @Test
+  void shouldRejectNonPositiveMaxTransferAttempts() {
+    // given
+    final var rebalance = new Rebalance();
+
+    // when / then
+    assertThatThrownBy(() -> rebalance.setMaxTransferAttempts(0))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> rebalance.setMaxTransferAttempts(-3))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
   void shouldAcceptValidValues() {
     // given
     final var rebalance = new Rebalance();
@@ -69,6 +81,7 @@ final class RaftRebalanceValidationTest {
             () -> {
               rebalance.setReplicationLagThreshold(DataSize.ofMegabytes(16));
               rebalance.setReplicationTimeout(Duration.ofSeconds(30));
+              rebalance.setMaxTransferAttempts(5);
             })
         .doesNotThrowAnyException();
   }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
@@ -61,6 +61,7 @@ cluster.raft.min-step-down-failure-count
 cluster.raft.preallocate-segment-files
 cluster.raft.prefer-snapshot-replication-threshold
 cluster.raft.priority-election-enabled
+cluster.raft.rebalance.max-transfer-attempts
 cluster.raft.rebalance.replication-lag-threshold
 cluster.raft.rebalance.replication-timeout
 cluster.raft.request-timeout

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -1353,6 +1353,10 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     return partitionConfig.getRebalanceReplicationTimeout();
   }
 
+  public int getRebalanceMaxTransferAttempts() {
+    return partitionConfig.getRebalanceMaxTransferAttempts();
+  }
+
   public Duration getMaxQuorumResponseTimeout() {
     return partitionConfig.getMaxQuorumResponseTimeout();
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -35,6 +35,7 @@ public class RaftPartitionConfig {
   private static final Duration DEFAULT_CONFIGURATION_CHANGE_TIMEOUT = Duration.ofSeconds(10);
   private static final long DEFAULT_REBALANCE_REPLICATION_LAG_THRESHOLD = 8L * 1024 * 1024;
   private static final Duration DEFAULT_REBALANCE_REPLICATION_TIMEOUT = Duration.ofSeconds(10);
+  private static final int DEFAULT_REBALANCE_MAX_TRANSFER_ATTEMPTS = 3;
 
   private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
   private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
@@ -48,6 +49,7 @@ public class RaftPartitionConfig {
   private int preferSnapshotReplicationThreshold = DEFAULT_SNAPSHOT_REPLICATION_THRESHOLD;
   private long rebalanceReplicationLagThreshold = DEFAULT_REBALANCE_REPLICATION_LAG_THRESHOLD;
   private Duration rebalanceReplicationTimeout = DEFAULT_REBALANCE_REPLICATION_TIMEOUT;
+  private int rebalanceMaxTransferAttempts = DEFAULT_REBALANCE_MAX_TRANSFER_ATTEMPTS;
   private RaftStorageConfig storageConfig;
   private EntryValidator entryValidator;
   private Duration configurationChangeTimeout = DEFAULT_CONFIGURATION_CHANGE_TIMEOUT;
@@ -227,6 +229,19 @@ public class RaftPartitionConfig {
     this.rebalanceReplicationTimeout = rebalanceReplicationTimeout;
   }
 
+  /**
+   * The maximum number of TimeoutNow requests the current leader sends (including the initial
+   * request) before reporting {@code TIMEOUT_NOW_EXHAUSTED} during a leadership transfer. Maps to
+   * {@code camunda.cluster.raft.rebalance.maxTransferAttempts}.
+   */
+  public int getRebalanceMaxTransferAttempts() {
+    return rebalanceMaxTransferAttempts;
+  }
+
+  public void setRebalanceMaxTransferAttempts(final int rebalanceMaxTransferAttempts) {
+    this.rebalanceMaxTransferAttempts = rebalanceMaxTransferAttempts;
+  }
+
   public RaftStorageConfig getStorageConfig() {
     return storageConfig;
   }
@@ -278,6 +293,12 @@ public class RaftPartitionConfig {
         + maxQuorumResponseTimeout
         + ", preferSnapshotReplicationThreshold="
         + preferSnapshotReplicationThreshold
+        + ", rebalanceReplicationLagThreshold="
+        + rebalanceReplicationLagThreshold
+        + ", rebalanceReplicationTimeout="
+        + rebalanceReplicationTimeout
+        + ", rebalanceMaxTransferAttempts="
+        + rebalanceMaxTransferAttempts
         + ", receiveOnLegacySubject="
         + receiveOnLegacySubject
         + '}';

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/CatchUpWait.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/CatchUpWait.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Waits until the desired leader's {@code matchIndex} reaches the frozen log head, polling on the
- * Raft thread each heartbeat interval. The wait is bounded by the pause watchdog.
+ * Raft thread each heartbeat interval until it catches up or {@code deadlineMs} passes.
  *
  * <p>Owns its poll timer and completes the future returned by {@link #start()} exactly once, either
  * with an empty {@link Optional} once the desired leader is fully caught up, or with a terminal
@@ -44,6 +44,7 @@ final class CatchUpWait {
   private final BooleanSupplier leaderRunning;
   private final MemberId desiredLeader;
   private final long targetIndex;
+  private final long deadlineMs;
   private final CompletableFuture<Optional<LeadershipTransferResult>> result =
       new CompletableFuture<>();
   private @Nullable Scheduled pollTimer;
@@ -52,11 +53,13 @@ final class CatchUpWait {
       final RaftContext raft,
       final BooleanSupplier leaderRunning,
       final MemberId desiredLeader,
-      final long targetIndex) {
+      final long targetIndex,
+      final long deadlineMs) {
     this.raft = raft;
     this.leaderRunning = leaderRunning;
     this.desiredLeader = desiredLeader;
     this.targetIndex = targetIndex;
+    this.deadlineMs = deadlineMs;
   }
 
   CompletableFuture<Optional<LeadershipTransferResult>> start() {
@@ -84,11 +87,6 @@ final class CatchUpWait {
     failWith(LeadershipTransferResult.PAUSE_FAILED);
   }
 
-  /** The leader's freeze watchdog fired, so the desired leader is out of time to catch up. */
-  void onPauseDeadlineExpired() {
-    failWith(LeadershipTransferResult.REPLICATION_TIMED_OUT);
-  }
-
   private void poll() {
     if (result.isDone()) {
       return;
@@ -99,6 +97,12 @@ final class CatchUpWait {
       failWith(LeadershipTransferResult.NOT_MEMBER);
     } else if (isCaughtUp()) {
       succeed();
+    } else if (System.currentTimeMillis() >= deadlineMs) {
+      LOG.warn(
+          "Desired leader {} did not reach index {} in time; reporting REPLICATION_TIMED_OUT",
+          desiredLeader,
+          targetIndex);
+      failWith(LeadershipTransferResult.REPLICATION_TIMED_OUT);
     }
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/CatchUpWait.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/CatchUpWait.java
@@ -31,13 +31,11 @@ import org.slf4j.LoggerFactory;
  * Waits until the desired leader's {@code matchIndex} reaches the frozen log head, polling on the
  * Raft thread each heartbeat interval until it catches up or {@code deadlineMs} passes.
  *
- * <p>Owns its poll timer and completes the future returned by {@link #start()} exactly once, either
- * with an empty {@link Optional} once the desired leader is fully caught up, or with a terminal
- * reason if there was a failure/timeout. Role and pause events are only delivered while the wait is
- * the transfer's active step.
+ * <p>The future returned by {@link #start()} completes with an empty {@link Optional} once the
+ * desired leader is fully caught up, or with a terminal reason if there was a failure/timeout.
  */
 @NullMarked
-final class CatchUpWait {
+final class CatchUpWait implements TransferPhase {
   private static final Logger LOG = LoggerFactory.getLogger(CatchUpWait.class);
 
   private final RaftContext raft;
@@ -73,8 +71,8 @@ final class CatchUpWait {
     return result;
   }
 
-  /** The leader role is stopping, e.g. because this node stepped down. */
-  void onLeaderStopped() {
+  @Override
+  public void onLeaderStopped() {
     if (result.isDone()) {
       return;
     }
@@ -83,7 +81,8 @@ final class CatchUpWait {
   }
 
   /** The freeze ended, so the desired leader can no longer catch up to a frozen log head. */
-  void onPauseCleared() {
+  @Override
+  public void onPauseCleared() {
     failWith(LeadershipTransferResult.PAUSE_FAILED);
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/CatchUpWait.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/CatchUpWait.java
@@ -32,7 +32,8 @@ import org.slf4j.LoggerFactory;
  * Raft thread each heartbeat interval until it catches up or {@code deadlineMs} passes.
  *
  * <p>The future returned by {@link #start()} completes with an empty {@link Optional} once the
- * desired leader is fully caught up, or with a terminal reason if there was a failure/timeout.
+ * desired leader is fully caught up (proceed to promotion), or with a terminal reason if there was
+ * a failure/timeout.
  */
 @NullMarked
 final class CatchUpWait implements TransferPhase {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -506,7 +506,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     if (!pausedForTransfer || !isRunning()) {
       return;
     }
-    log.warn("Partition still paused after the resume deadline; stepping down to follower");
+    log.error("Partition still paused after the resume deadline; stepping down to follower");
     leadershipTransferRunner.onPauseDeadlineExpired();
     clearTransferPause();
     raft.transition(RaftServer.Role.FOLLOWER);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
@@ -41,6 +41,13 @@ import org.slf4j.LoggerFactory;
 final class LeadershipTransferAttempt {
   private static final Logger LOG = LoggerFactory.getLogger(LeadershipTransferAttempt.class);
 
+  /**
+   * Headroom on top of the steps' own budgets. The watchdog is a backstop against the attempt
+   * getting stuck, not a timeout anyone should hit, so this is sized to be unreachable on a healthy
+   * transfer rather than tight.
+   */
+  private static final Duration PAUSE_BUDGET_SLACK = Duration.ofSeconds(5);
+
   private final RaftContext raft;
   private final LeaderRole leader;
   private final MemberId desiredLeader;
@@ -48,6 +55,7 @@ final class LeadershipTransferAttempt {
   private final long correlationId;
   private final Runnable finishListener;
   private long startMs;
+  private boolean finished;
   private @Nullable CatchUpWait activeCatchUp;
 
   LeadershipTransferAttempt(
@@ -66,7 +74,7 @@ final class LeadershipTransferAttempt {
   void start() {
     raft.checkThread();
     startMs = System.currentTimeMillis();
-    pause(raft.getRebalanceReplicationTimeout())
+    pause(pauseBudget())
         .whenCompleteAsync(
             (targetIndex, error) -> {
               if (error != null) {
@@ -97,15 +105,31 @@ final class LeadershipTransferAttempt {
     }
   }
 
-  /** The leader's freeze watchdog fired: the pause outlived its resume deadline. */
+  /**
+   * The leader's freeze watchdog fired. Every step should be bounded well inside the pause budget,
+   * so this condition indicates unexpected behavior. Report it and leave recovery to the watchdog
+   * itself.
+   */
   void onPauseDeadlineExpired() {
-    if (activeCatchUp != null) {
-      activeCatchUp.onPauseDeadlineExpired();
+    if (finished) {
+      return;
     }
+    LOG.error(
+        "Leadership transfer to {} did not finish within its pause budget of {}; abandoning it and "
+            + "leaving recovery to the step-down",
+        desiredLeader,
+        pauseBudget());
+    abandon(LeadershipTransferResult.PAUSE_FAILED);
   }
 
   private void catchUp(final long targetIndex) {
-    final var catchUpWait = new CatchUpWait(raft, leader::isRunning, desiredLeader, targetIndex);
+    final var catchUpWait =
+        new CatchUpWait(
+            raft,
+            leader::isRunning,
+            desiredLeader,
+            targetIndex,
+            startMs + raft.getRebalanceReplicationTimeout().toMillis());
     activeCatchUp = catchUpWait;
     catchUpWait
         .start()
@@ -123,15 +147,35 @@ final class LeadershipTransferAttempt {
    */
   private void onCaughtUp(final long targetIndex) {
     LOG.info("Desired leader {} caught up to index {}", desiredLeader, targetIndex);
+    if (finished) {
+      return;
+    }
+    finished = true;
     finishListener.run();
     observeDuration(LeadershipTransferResult.TRANSFERRED);
     resume();
   }
 
   private void finish(final LeadershipTransferResult result) {
+    if (finished) {
+      return;
+    }
+    finished = true;
     finishListener.run();
     observeDuration(result);
     resume().whenComplete((ignored, resumeError) -> reportResult(result));
+  }
+
+  private void abandon(final LeadershipTransferResult result) {
+    finished = true;
+    finishListener.run();
+    observeDuration(result);
+    reportResult(result);
+  }
+
+  /** How long the partition may stay frozen before the watchdog treats the transfer as stuck. */
+  private Duration pauseBudget() {
+    return raft.getRebalanceReplicationTimeout().plus(PAUSE_BUDGET_SLACK);
   }
 
   private void observeDuration(final LeadershipTransferResult result) {
@@ -174,8 +218,8 @@ final class LeadershipTransferAttempt {
 
   /**
    * Reopens the partition on every terminal path, whether the transfer failed or the desired leader
-   * caught up. A resume that fails can leave the partition frozen: the pause watchdog is the safety
-   * net and steps the leader down once the resume deadline passes.
+   * caught up. A resume that fails steps the leader down where it is detected, so the partition is
+   * rebuilt rather than left frozen.
    */
   private CompletableFuture<Void> resume() {
     final var control = raft.getLeadershipTransferPauseControl();

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
@@ -30,12 +30,12 @@ import org.slf4j.LoggerFactory;
 
 /**
  * One accepted coordinated leadership transfer, sequenced from freezing the partition to reporting
- * the outcome: pause, wait for the desired leader to catch up, then resume. A fresh attempt is
- * created per accepted transfer, so no state can leak from one transfer into the next.
+ * the result to the coordinator: pause, wait for the desired leader to catch up, promote it, then
+ * resume and report. A fresh attempt is created per accepted transfer, so no state can leak from
+ * one transfer into the next.
  *
  * <p>Each step runs as a {@link TransferPhase}; role and pause events are forwarded to the phase
- * currently in flight. Failures converge on {@link #finish}, which reports them to the coordinator;
- * the transfer is not executed yet, so a desired leader that catches up simply ends the attempt.
+ * currently in flight, and every terminal outcome converges on {@link #finish}.
  */
 @NullMarked
 final class LeadershipTransferAttempt {
@@ -136,24 +136,20 @@ final class LeadershipTransferAttempt {
         .whenComplete(
             (failureReason, ignored) -> {
               activePhase = null;
-              failureReason.ifPresentOrElse(this::finish, () -> onCaughtUp(targetIndex));
+              failureReason.ifPresentOrElse(this::finish, this::promote);
             });
   }
 
-  /**
-   * The desired leader is caught up, which is as far as a transfer gets until the promotion step
-   * exists: the attempt is measured as a success and the partition resumed, but there is no
-   * leadership change to report to the coordinator yet.
-   */
-  private void onCaughtUp(final long targetIndex) {
-    LOG.info("Desired leader {} caught up to index {}", desiredLeader, targetIndex);
-    if (finished) {
-      return;
-    }
-    finished = true;
-    finishListener.run();
-    observeDuration(LeadershipTransferResult.TRANSFERRED);
-    resume();
+  private void promote() {
+    final var promotion = new TimeoutNowPromotion(raft, leader::isRunning, desiredLeader);
+    activePhase = promotion;
+    promotion
+        .start()
+        .whenComplete(
+            (result, ignored) -> {
+              activePhase = null;
+              finish(result);
+            });
   }
 
   private void finish(final LeadershipTransferResult result) {
@@ -175,7 +171,12 @@ final class LeadershipTransferAttempt {
 
   /** How long the partition may stay frozen before the watchdog treats the transfer as stuck. */
   private Duration pauseBudget() {
-    return raft.getRebalanceReplicationTimeout().plus(PAUSE_BUDGET_SLACK);
+    return raft.getRebalanceReplicationTimeout().plus(promotionBudget()).plus(PAUSE_BUDGET_SLACK);
+  }
+
+  /** The wall time {@link TimeoutNowPromotion} can spend spacing out its attempts. */
+  private Duration promotionBudget() {
+    return raft.getHeartbeatInterval().multipliedBy(raft.getRebalanceMaxTransferAttempts());
   }
 
   private void observeDuration(final LeadershipTransferResult result) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
@@ -72,10 +72,9 @@ import org.slf4j.LoggerFactory;
  * </pre>
  *
  * <p>Every outcome above lands in {@link #finish}, which reopens the partition before reporting to
- * the coordinator. That reopening only has work to do on the outcomes where this node is still the
- * leader: once leadership has moved, the role transition has already lifted the freeze. {@link
- * #onPauseDeadlineExpired} skips the reopening altogether, leaving it to the step-down behind the
- * watchdog.
+ * the coordinator (but only while this node is still the leader) - once leadership has moved, the
+ * step-down will already have exited the pause. {@link #onPauseDeadlineExpired} leaves reopening to
+ * the step-down for the same reason.
  */
 @NullMarked
 final class LeadershipTransferAttempt {
@@ -193,12 +192,18 @@ final class LeadershipTransferAttempt {
   }
 
   private void finish(final LeadershipTransferResult result) {
+    raft.checkThread();
     if (finished) {
       return;
     }
     finished = true;
     finishListener.run();
     observeDuration(result);
+    if (!leader.isRunning()) {
+      // the step-down that ended this leader already lifted the freeze
+      reportResult(result);
+      return;
+    }
     resume().whenComplete((ignored, resumeError) -> reportResult(result));
   }
 
@@ -258,9 +263,8 @@ final class LeadershipTransferAttempt {
   }
 
   /**
-   * Reopens the partition on every terminal path, whether the transfer failed or the desired leader
-   * caught up. A resume that fails steps the leader down where it is detected, so the partition is
-   * rebuilt rather than left frozen.
+   * Reopens the partition on the terminal paths this leader survives. A resume that fails steps the
+   * leader down where it is detected, so the partition is rebuilt rather than left frozen.
    */
   private CompletableFuture<Void> resume() {
     final var control = raft.getLeadershipTransferPauseControl();

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
@@ -33,9 +33,9 @@ import org.slf4j.LoggerFactory;
  * the outcome: pause, wait for the desired leader to catch up, then resume. A fresh attempt is
  * created per accepted transfer, so no state can leak from one transfer into the next.
  *
- * <p>Role and pause events are forwarded to the step currently in flight. Failures converge on
- * {@link #finish}, which reports them to the coordinator; the transfer is not executed yet, so a
- * desired leader that catches up simply ends the attempt.
+ * <p>Each step runs as a {@link TransferPhase}; role and pause events are forwarded to the phase
+ * currently in flight. Failures converge on {@link #finish}, which reports them to the coordinator;
+ * the transfer is not executed yet, so a desired leader that catches up simply ends the attempt.
  */
 @NullMarked
 final class LeadershipTransferAttempt {
@@ -56,7 +56,7 @@ final class LeadershipTransferAttempt {
   private final Runnable finishListener;
   private long startMs;
   private boolean finished;
-  private @Nullable CatchUpWait activeCatchUp;
+  private @Nullable TransferPhase activePhase;
 
   LeadershipTransferAttempt(
       final RaftContext raft,
@@ -93,15 +93,15 @@ final class LeadershipTransferAttempt {
   }
 
   void onLeaderStopped() {
-    if (activeCatchUp != null) {
-      activeCatchUp.onLeaderStopped();
+    if (activePhase != null) {
+      activePhase.onLeaderStopped();
     }
   }
 
   /** The freeze ended. */
   void onPauseCleared() {
-    if (activeCatchUp != null) {
-      activeCatchUp.onPauseCleared();
+    if (activePhase != null) {
+      activePhase.onPauseCleared();
     }
   }
 
@@ -130,12 +130,12 @@ final class LeadershipTransferAttempt {
             desiredLeader,
             targetIndex,
             startMs + raft.getRebalanceReplicationTimeout().toMillis());
-    activeCatchUp = catchUpWait;
+    activePhase = catchUpWait;
     catchUpWait
         .start()
         .whenComplete(
             (failureReason, ignored) -> {
-              activeCatchUp = null;
+              activePhase = null;
               failureReason.ifPresentOrElse(this::finish, () -> onCaughtUp(targetIndex));
             });
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferAttempt.java
@@ -36,6 +36,46 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Each step runs as a {@link TransferPhase}; role and pause events are forwarded to the phase
  * currently in flight, and every terminal outcome converges on {@link #finish}.
+ *
+ * <pre>
+ *   start()
+ *     |
+ *     v
+ *   PAUSE --------------------------.
+ *     |                             |
+ *     |                             v
+ *     |                           PAUSE_FAILED
+ *     |                           CONFIGURATION_CHANGE_IN_PROGRESS
+ *     |
+ *     | frozen at the target index
+ *     v
+ *   CATCH UP (CatchUpWait) ---------.
+ *     |                             |
+ *     |                             v
+ *     |                           LEADER_CHANGED         (lost leadership)
+ *     |                           PAUSE_FAILED           (freeze ended early)
+ *     |                           NOT_MEMBER             (left the cluster)
+ *     |                           REPLICATION_TIMED_OUT
+ *     |
+ *     | desired leader reached the frozen log head
+ *     v
+ *   PROMOTE (TimeoutNowPromotion) --.
+ *     |                             |
+ *     |                             v
+ *     |                           NOT_MEMBER             (never a member)
+ *     |                           LEADER_CHANGED         (someone else won)
+ *     |                           TIMEOUT_NOW_EXHAUSTED
+ *     |
+ *     | desired leader observed as leader
+ *     v
+ *   TRANSFERRED
+ * </pre>
+ *
+ * <p>Every outcome above lands in {@link #finish}, which reopens the partition before reporting to
+ * the coordinator. That reopening only has work to do on the outcomes where this node is still the
+ * leader: once leadership has moved, the role transition has already lifted the freeze. {@link
+ * #onPauseDeadlineExpired} skips the reopening altogether, leaving it to the step-down behind the
+ * watchdog.
  */
 @NullMarked
 final class LeadershipTransferAttempt {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/TimeoutNowPromotion.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/TimeoutNowPromotion.java
@@ -134,19 +134,42 @@ final class TimeoutNowPromotion implements TransferPhase {
   private void onLeaderObserved(final RaftMember newLeader) {
     raft.checkThread();
     if (result.isDone()) {
+      LOG.trace(
+          "Observed leader {} after the transfer to {} already settled, ignoring it",
+          newLeader.memberId(),
+          target);
       return;
     }
     final var localMember = raft.getCluster().getLocalMember().memberId();
     if (newLeader.memberId().equals(localMember)) {
       if (steppedDown) {
+        LOG.info(
+            "Regained leadership after stepping down during the transfer to {}, reporting a "
+                + "leader change",
+            target);
         complete(LeadershipTransferResult.LEADER_CHANGED);
+      } else {
+        LOG.debug(
+            "Still leader after {} TimeoutNow attempts to {}, waiting for leadership to move",
+            attempts,
+            target);
       }
       return;
     }
-    complete(
-        newLeader.memberId().equals(target)
-            ? LeadershipTransferResult.TRANSFERRED
-            : LeadershipTransferResult.LEADER_CHANGED);
+    if (newLeader.memberId().equals(target)) {
+      LOG.info(
+          "Leadership moved to the desired leader {} after {} TimeoutNow attempts",
+          target,
+          attempts);
+      complete(LeadershipTransferResult.TRANSFERRED);
+    } else {
+      LOG.info(
+          "Leadership moved to {} instead of the desired leader {} after {} TimeoutNow attempts",
+          newLeader.memberId(),
+          target,
+          attempts);
+      complete(LeadershipTransferResult.LEADER_CHANGED);
+    }
   }
 
   private void complete(final LeadershipTransferResult outcome) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/TimeoutNowPromotion.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/TimeoutNowPromotion.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.roles;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.LeadershipTransferResult;
+import io.atomix.raft.cluster.RaftMember;
+import io.atomix.raft.impl.RaftContext;
+import io.atomix.raft.protocol.TimeoutNowRequest;
+import io.atomix.utils.concurrent.Scheduled;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Promotes the desired leader by sending it TimeoutNow, resending every {@code heartbeatInterval}
+ * until leadership actually moves or {@code maxTransferAttempts} sends are spent. Completes with
+ * {@link LeadershipTransferResult#TRANSFERRED} only once the <em>selected</em> target is observed
+ * to have become leader; if a different node wins instead, or leadership otherwise moves away, we
+ * report {@link LeadershipTransferResult#LEADER_CHANGED}. If the leadership doesn't move before our
+ * attempt budget runs out, we report {@link LeadershipTransferResult#TIMEOUT_NOW_EXHAUSTED}.
+ */
+@NullMarked
+final class TimeoutNowPromotion implements TransferPhase {
+  private static final Logger LOG = LoggerFactory.getLogger(TimeoutNowPromotion.class);
+
+  private final RaftContext raft;
+  private final BooleanSupplier leaderRunning;
+  private final MemberId target;
+  private final CompletableFuture<LeadershipTransferResult> result = new CompletableFuture<>();
+  private @Nullable Scheduled retryTimer;
+  private @Nullable Consumer<RaftMember> leaderListener;
+  private int attempts;
+  private boolean steppedDown;
+
+  TimeoutNowPromotion(
+      final RaftContext raft, final BooleanSupplier leaderRunning, final MemberId target) {
+    this.raft = raft;
+    this.leaderRunning = leaderRunning;
+    this.target = target;
+  }
+
+  CompletableFuture<LeadershipTransferResult> start() {
+    raft.checkThread();
+    if (!raft.getCluster().isMember(target)) {
+      result.complete(LeadershipTransferResult.NOT_MEMBER);
+      return result;
+    }
+
+    leaderListener = this::onLeaderObserved;
+    raft.addLeaderElectionListener(leaderListener);
+
+    LOG.info(
+        "Starting TimeoutNow leadership transfer to {} (up to {} attempts, resending every {})",
+        target,
+        raft.getRebalanceMaxTransferAttempts(),
+        raft.getHeartbeatInterval());
+
+    attemptTimeoutNow();
+    return result;
+  }
+
+  @Override
+  public void onLeaderStopped() {
+    if (result.isDone()) {
+      return;
+    }
+    LOG.debug("Stepping down during TimeoutNow transfer to {}; awaiting the new leader", target);
+    steppedDown = true;
+    if (retryTimer != null) {
+      retryTimer.cancel();
+      retryTimer = null;
+    }
+  }
+
+  private void attemptTimeoutNow() {
+    raft.checkThread();
+    if (result.isDone() || !leaderRunning.getAsBoolean()) {
+      return;
+    }
+    if (attempts >= raft.getRebalanceMaxTransferAttempts()) {
+      LOG.info(
+          "TimeoutNow transfer to {} did not move leadership within {} attempts while still "
+              + "leader; giving up",
+          target,
+          attempts);
+      complete(LeadershipTransferResult.TIMEOUT_NOW_EXHAUSTED);
+      return;
+    }
+    sendTimeoutNow();
+    retryTimer =
+        raft.getThreadContext().schedule(raft.getHeartbeatInterval(), this::attemptTimeoutNow);
+  }
+
+  private void sendTimeoutNow() {
+    raft.checkThread();
+    attempts++;
+    final var request =
+        TimeoutNowRequest.builder()
+            .withTerm(raft.getTerm())
+            .withLeader(raft.getCluster().getLocalMember().memberId())
+            .build();
+    LOG.debug("Sending TimeoutNow to {} (attempt {})", target, attempts);
+    raft.getProtocol()
+        .timeoutNow(target, request)
+        .whenCompleteAsync(
+            (response, error) -> {
+              if (error != null) {
+                LOG.trace("TimeoutNow to {} failed, will retry if budget remains", target, error);
+              } else {
+                LOG.trace("TimeoutNow to {} acknowledged: {}", target, response);
+              }
+            },
+            raft.getThreadContext());
+  }
+
+  private void onLeaderObserved(final RaftMember newLeader) {
+    raft.checkThread();
+    if (result.isDone()) {
+      return;
+    }
+    final var localMember = raft.getCluster().getLocalMember().memberId();
+    if (newLeader.memberId().equals(localMember)) {
+      if (steppedDown) {
+        complete(LeadershipTransferResult.LEADER_CHANGED);
+      }
+      return;
+    }
+    complete(
+        newLeader.memberId().equals(target)
+            ? LeadershipTransferResult.TRANSFERRED
+            : LeadershipTransferResult.LEADER_CHANGED);
+  }
+
+  private void complete(final LeadershipTransferResult outcome) {
+    if (retryTimer != null) {
+      retryTimer.cancel();
+      retryTimer = null;
+    }
+    if (leaderListener != null) {
+      raft.removeLeaderElectionListener(leaderListener);
+      leaderListener = null;
+    }
+    result.complete(outcome);
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/TransferPhase.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/TransferPhase.java
@@ -22,7 +22,7 @@ package io.atomix.raft.roles;
  * <p>Role and pause events are forwarded to the currently active phase only; each phase reacts to
  * the events that affect it and ignores the rest. All events arrive on the Raft thread.
  */
-sealed interface TransferPhase permits CatchUpWait {
+sealed interface TransferPhase permits CatchUpWait, TimeoutNowPromotion {
 
   /** The leader role is stopping, e.g. because this node stepped down. */
   default void onLeaderStopped() {}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/TransferPhase.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/TransferPhase.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.roles;
+
+/**
+ * One step of a coordinated leadership transfer. A phase owns its timers and listeners, completes
+ * the future its start method returned exactly once, and cleans up after itself when it completes.
+ *
+ * <p>Role and pause events are forwarded to the currently active phase only; each phase reacts to
+ * the events that affect it and ignores the rest. All events arrive on the Raft thread.
+ */
+sealed interface TransferPhase permits CatchUpWait {
+
+  /** The leader role is stopping, e.g. because this node stepped down. */
+  default void onLeaderStopped() {}
+
+  /** The transfer freeze ended. */
+  default void onPauseCleared() {}
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/CoordinatedTransferDriver.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/CoordinatedTransferDriver.java
@@ -23,7 +23,9 @@ import io.atomix.raft.protocol.LeadershipTransferResultRequest;
 import io.atomix.raft.protocol.LeadershipTransferResultResponse;
 import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.raft.protocol.TestRaftServerProtocol;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -33,8 +35,12 @@ final class CoordinatedTransferDriver {
   private final RaftRule raftRule;
   private final RaftServer leader;
   private final MemberId coordinatorId;
-  private final CompletableFuture<LeadershipTransferResultRequest> reported =
-      new CompletableFuture<>();
+
+  private final List<CompletableFuture<LeadershipTransferResultRequest>> reported =
+      new ArrayList<>();
+
+  private int received;
+  private int consumed;
   private long nextCorrelationId = 0x5eed_0100L;
 
   CoordinatedTransferDriver(final RaftRule raftRule, final RaftServer leader) {
@@ -48,7 +54,9 @@ final class CoordinatedTransferDriver {
     protocolOf(coordinatorId)
         .registerLeadershipTransferResultHandler(
             request -> {
-              reported.complete(request);
+              synchronized (reported) {
+                slot(received++).complete(request);
+              }
               return CompletableFuture.completedFuture(
                   LeadershipTransferResultResponse.builder().withStatus(Status.OK).build());
             });
@@ -82,9 +90,21 @@ final class CoordinatedTransferDriver {
         .get(5, TimeUnit.SECONDS);
   }
 
-  /** Completes with the terminal result the leader reports to the coordinator. */
+  /**
+   * Completes with the next terminal result the leader reports to the coordinator. Successive calls
+   * hand out successive results in report order.
+   */
   CompletableFuture<LeadershipTransferResultRequest> reportedResult() {
-    return reported;
+    synchronized (reported) {
+      return slot(consumed++);
+    }
+  }
+
+  private CompletableFuture<LeadershipTransferResultRequest> slot(final int index) {
+    while (reported.size() <= index) {
+      reported.add(new CompletableFuture<>());
+    }
+    return reported.get(index);
   }
 
   static MemberId memberId(final RaftServer server) {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCoordinatedLeadershipTransferTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCoordinatedLeadershipTransferTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.cluster.MemberId;
+import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.impl.RaftNamespaces;
 import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
 import io.atomix.raft.protocol.LeadershipTransferInitiateResponse;
@@ -34,12 +35,56 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class RaftCoordinatedLeadershipTransferTest {
 
   @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);
+
+  @Test
+  public void shouldDriveTransferOnInitiateAndNotifyCoordinator() throws Exception {
+    // given
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+    final var targetId = memberId(target);
+    final var coordinatorId = coordinator(leader);
+
+    final CompletableFuture<LeadershipTransferResultRequest> reported = new CompletableFuture<>();
+    protocolOf(coordinatorId)
+        .registerLeadershipTransferResultHandler(
+            request -> {
+              reported.complete(request);
+              return CompletableFuture.completedFuture(
+                  LeadershipTransferResultResponse.builder().withStatus(Status.OK).build());
+            });
+
+    // when
+    final var ack =
+        leader
+            .getContext()
+            .getProtocol()
+            .leadershipTransferInitiate(
+                memberId(leader),
+                initiate(targetId, coordinatorId, configIndex(leader), 0x5eed_000aL))
+            .get(5, TimeUnit.SECONDS);
+
+    // then
+    assertThat(ack.accepted()).as("leader accepts the transfer").isTrue();
+    Awaitility.await("target becomes leader")
+        .atMost(Duration.ofSeconds(15))
+        .until(() -> target.getRole() == Role.LEADER);
+    Awaitility.await("the previous leader gives up leadership")
+        .atMost(Duration.ofSeconds(15))
+        .until(() -> leader.getRole() != Role.LEADER);
+    final var notification = reported.get(10, TimeUnit.SECONDS);
+    assertThat(notification.result()).isEqualTo(LeadershipTransferResult.TRANSFERRED);
+    assertThat(notification.correlationId())
+        .as("the success notification echoes the initiate request's correlation id")
+        .isEqualTo(0x5eed_000aL);
+  }
 
   @Test
   public void shouldAcceptInitiateForCaughtUpFollower() throws Exception {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferCatchUpTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferCatchUpTest.java
@@ -16,6 +16,7 @@
 package io.atomix.raft;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftServer.Role;
@@ -91,7 +92,7 @@ public class RaftLeadershipTransferCatchUpTest {
   }
 
   @Test
-  public void shouldStepDownAndReportTimedOutWhenTheFreezeOutlivesItsDeadline() throws Exception {
+  public void shouldKeepLeadershipWhenTheDesiredLeaderNeverCatchesUp() throws Exception {
     // given
     raftRule.appendEntries(5);
     final var leader = raftRule.getLeader().orElseThrow();
@@ -109,9 +110,27 @@ public class RaftLeadershipTransferCatchUpTest {
         .succeedsWithin(REPLICATION_TIMEOUT.plusSeconds(15))
         .extracting(LeadershipTransferResultRequest::result)
         .isEqualTo(LeadershipTransferResult.REPLICATION_TIMED_OUT);
-    Awaitility.await("the pause watchdog steps the leader down")
-        .atMost(Duration.ofSeconds(15))
-        .until(() -> leader.getRole() != Role.LEADER);
+    assertThat(leader.getRole()).isEqualTo(Role.LEADER);
+  }
+
+  @Test
+  public void shouldResumeWritesWhenTheDesiredLeaderNeverCatchesUp() throws Exception {
+    // given
+    raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var driver = new CoordinatedTransferDriver(raftRule, leader);
+    final var target = driver.followerOutsideCoordinator();
+    raftRule.partition(target);
+    raftRule.appendEntries(5);
+
+    // when
+    final var ack = driver.initiate(target);
+    assertThat(ack.accepted()).isTrue();
+    // the result is only reported once the partition has been resumed
+    assertThat(driver.reportedResult()).succeedsWithin(REPLICATION_TIMEOUT.plusSeconds(15));
+
+    // then
+    assertThatNoException().isThrownBy(raftRule::appendEntry);
   }
 
   private long transferDurationCount(final LeadershipTransferResult result) {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferCatchUpTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferCatchUpTest.java
@@ -49,7 +49,7 @@ public class RaftLeadershipTransferCatchUpTest {
           });
 
   @Test
-  public void shouldRecordTransferDurationWhenTheDesiredLeaderCatchesUp() throws Exception {
+  public void shouldRecordTransferDurationWhenTheTransferSucceeds() throws Exception {
     // given
     raftRule.appendEntries(5);
     final var leader = raftRule.getLeader().orElseThrow();
@@ -61,7 +61,7 @@ public class RaftLeadershipTransferCatchUpTest {
 
     // then
     assertThat(ack.accepted()).isTrue();
-    Awaitility.await("the attempt is measured once the desired leader is caught up")
+    Awaitility.await("the attempt is measured once the transfer succeeds")
         .atMost(Duration.ofSeconds(15))
         .untilAsserted(
             () ->

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferPauseBudgetTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferPauseBudgetTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.RaftServer.Role;
+import io.atomix.raft.partition.RaftPartitionConfig;
+import io.atomix.raft.protocol.LeadershipTransferResultRequest;
+import io.atomix.raft.protocol.TestRaftServerProtocol;
+import io.atomix.raft.protocol.TimeoutNowRequest;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Coverage for the pause budget spanning every step of a coordinated leadership transfer, using an
+ * attempt limit whose promotion budget deliberately outlasts the replication timeout.
+ */
+public class RaftLeadershipTransferPauseBudgetTest {
+
+  private static final Duration HEARTBEAT_INTERVAL = Duration.ofMillis(100);
+  private static final Duration REPLICATION_TIMEOUT = Duration.ofSeconds(2);
+  private static final int MAX_TRANSFER_ATTEMPTS = 40;
+
+  @Rule
+  public RaftRule raftRule =
+      RaftRule.withBootstrappedNodes(
+          3,
+          new RaftRule.Configurator() {
+            @Override
+            public void configure(final MemberId id, final RaftServer.Builder builder) {
+              final var config =
+                  new RaftPartitionConfig()
+                      .setElectionTimeout(Duration.ofSeconds(3))
+                      .setHeartbeatInterval(HEARTBEAT_INTERVAL);
+              config.setRebalanceReplicationTimeout(REPLICATION_TIMEOUT);
+              config.setRebalanceMaxTransferAttempts(MAX_TRANSFER_ATTEMPTS);
+              builder.withPartitionConfig(config);
+            }
+          });
+
+  @Test
+  public void shouldKeepLeadershipWhenPromotionOutlastsTheReplicationTimeout() throws Exception {
+    // given
+    assertThat(HEARTBEAT_INTERVAL.multipliedBy(MAX_TRANSFER_ATTEMPTS))
+        .as("promotion alone lasts longer than the replication timeout")
+        .isGreaterThan(REPLICATION_TIMEOUT);
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var driver = new CoordinatedTransferDriver(raftRule, leader);
+    final var target = driver.followerOutsideCoordinator();
+    dropTimeoutNow(leader);
+
+    // when
+    final var ack = driver.initiate(target);
+
+    // then
+    assertThat(ack.accepted()).isTrue();
+    assertThat(driver.reportedResult())
+        .succeedsWithin(Duration.ofSeconds(30))
+        .extracting(LeadershipTransferResultRequest::result)
+        .isEqualTo(LeadershipTransferResult.TIMEOUT_NOW_EXHAUSTED);
+    assertThat(leader.getRole()).isEqualTo(Role.LEADER);
+  }
+
+  private static void dropTimeoutNow(final RaftServer leader) {
+    ((TestRaftServerProtocol) leader.getContext().getProtocol())
+        .interceptRequest(
+            TimeoutNowRequest.class,
+            request -> {
+              return CompletableFuture.<Void>failedFuture(new RuntimeException("dropped in test"));
+            });
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferPromoteTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferPromoteTest.java
@@ -23,11 +23,13 @@ import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.TestRaftServerProtocol;
 import io.atomix.raft.protocol.TimeoutNowRequest;
 import io.atomix.raft.protocol.VoteRequest;
+import io.atomix.raft.roles.LeaderRole;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Function;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -111,6 +113,68 @@ public class RaftLeadershipTransferPromoteTest {
         .succeedsWithin(Duration.ofSeconds(15))
         .extracting(LeadershipTransferResultRequest::result)
         .isEqualTo(LeadershipTransferResult.TRANSFERRED);
+  }
+
+  @Test
+  public void shouldNotReopenThePartitionOnceLeadershipHasMoved() throws Exception {
+    // given
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var driver = new CoordinatedTransferDriver(raftRule, leader);
+    final var target = driver.followerOutsideCoordinator();
+    final var reopens = new LongAdder();
+    leader.getContext().setLeadershipTransferPauseControl(recordingPauseControl(leader, reopens));
+
+    // when
+    final var ack = driver.initiate(target);
+
+    // then
+    assertThat(ack.accepted()).isTrue();
+    assertThat(driver.reportedResult())
+        .succeedsWithin(Duration.ofSeconds(15))
+        .extracting(LeadershipTransferResultRequest::result)
+        .isEqualTo(LeadershipTransferResult.TRANSFERRED);
+    assertThat(reopens.sum())
+        .as("the step-down onto the new leader already lifted the freeze")
+        .isZero();
+  }
+
+  /** Freezes the Raft side the way the broker's control does, and counts the reopens. */
+  private static LeadershipTransferPauseControl recordingPauseControl(
+      final RaftServer leader, final LongAdder reopens) {
+    return new LeadershipTransferPauseControl() {
+      @Override
+      public CompletableFuture<Long> pauseForTransfer(final Duration resumeTimeout) {
+        return onLeaderRole(
+            leaderRole -> leaderRole.pauseForTransfer(resumeTimeout, System.currentTimeMillis()));
+      }
+
+      @Override
+      public CompletableFuture<Void> resumeFromTransfer() {
+        reopens.increment();
+        return onLeaderRole(
+            leaderRole -> {
+              leaderRole.resumeFromTransfer();
+              return null;
+            });
+      }
+
+      private <T> CompletableFuture<T> onLeaderRole(final Function<LeaderRole, T> action) {
+        final var done = new CompletableFuture<T>();
+        leader
+            .getContext()
+            .getThreadContext()
+            .execute(
+                () -> {
+                  if (leader.getContext().getRaftRole() instanceof final LeaderRole leaderRole) {
+                    done.complete(action.apply(leaderRole));
+                  } else {
+                    done.completeExceptionally(new IllegalStateException("no longer the leader"));
+                  }
+                });
+        return done;
+      }
+    };
   }
 
   private static AtomicBoolean gateTimeoutNow(final RaftServer leader) {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferPromoteTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferPromoteTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.raft.RaftServer.Role;
+import io.atomix.raft.protocol.LeadershipTransferResultRequest;
+import io.atomix.raft.protocol.PollRequest;
+import io.atomix.raft.protocol.TestRaftServerProtocol;
+import io.atomix.raft.protocol.TimeoutNowRequest;
+import io.atomix.raft.protocol.VoteRequest;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.LongAdder;
+import org.junit.Rule;
+import org.junit.Test;
+
+/** Coverage for the promotion step of a coordinated leadership transfer. */
+public class RaftLeadershipTransferPromoteTest {
+
+  @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);
+
+  @Test
+  public void shouldSendExactlyMaxTransferAttemptsThenGiveUp() throws Exception {
+    // given
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var driver = new CoordinatedTransferDriver(raftRule, leader);
+    final var target = driver.followerOutsideCoordinator();
+    final int maxAttempts = leader.getContext().getRebalanceMaxTransferAttempts();
+    final var sends = dropTimeoutNow(leader, new CompletableFuture<>());
+
+    // when
+    final var ack = driver.initiate(target);
+
+    // then
+    assertThat(ack.accepted()).isTrue();
+    assertThat(driver.reportedResult())
+        .succeedsWithin(Duration.ofSeconds(15))
+        .extracting(LeadershipTransferResultRequest::result)
+        .isEqualTo(LeadershipTransferResult.TIMEOUT_NOW_EXHAUSTED);
+    assertThat(sends.sum()).as("sends are count-bounded").isEqualTo(maxAttempts);
+    assertThat(leader.getRole()).isEqualTo(Role.LEADER);
+  }
+
+  @Test
+  public void shouldReportLeaderChangedWhenAnotherNodeWinsDuringPromotion() throws Exception {
+    // given
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var driver = new CoordinatedTransferDriver(raftRule, leader);
+    final var target = driver.followerOutsideCoordinator();
+    final var firstAttemptSent = new CompletableFuture<Void>();
+    dropTimeoutNow(leader, firstAttemptSent);
+    dropVotes(target);
+
+    // when
+    final var ack = driver.initiate(target);
+    firstAttemptSent.get(15, TimeUnit.SECONDS);
+    leader.stepDown().get();
+
+    // then
+    assertThat(ack.accepted()).isTrue();
+    assertThat(driver.reportedResult())
+        .succeedsWithin(Duration.ofSeconds(15))
+        .extracting(LeadershipTransferResultRequest::result)
+        .isEqualTo(LeadershipTransferResult.LEADER_CHANGED);
+  }
+
+  @Test
+  public void shouldTransferAfterAnEarlierTransferFailed() throws Exception {
+    // given
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var driver = new CoordinatedTransferDriver(raftRule, leader);
+    final var target = driver.followerOutsideCoordinator();
+    final var dropping = gateTimeoutNow(leader);
+    final var firstResult = driver.reportedResult();
+    final var secondResult = driver.reportedResult();
+
+    // when
+    assertThat(driver.initiate(target).accepted()).isTrue();
+    assertThat(firstResult)
+        .succeedsWithin(Duration.ofSeconds(15))
+        .extracting(LeadershipTransferResultRequest::result)
+        .isEqualTo(LeadershipTransferResult.TIMEOUT_NOW_EXHAUSTED);
+    dropping.set(false);
+    final var secondAck = driver.initiate(target);
+
+    // then
+    assertThat(secondAck.accepted())
+        .as("a leader that kept leadership is free to run another transfer")
+        .isTrue();
+    assertThat(secondResult)
+        .succeedsWithin(Duration.ofSeconds(15))
+        .extracting(LeadershipTransferResultRequest::result)
+        .isEqualTo(LeadershipTransferResult.TRANSFERRED);
+  }
+
+  private static AtomicBoolean gateTimeoutNow(final RaftServer leader) {
+    final var dropping = new AtomicBoolean(true);
+    ((TestRaftServerProtocol) leader.getContext().getProtocol())
+        .interceptRequest(
+            TimeoutNowRequest.class,
+            request -> {
+              if (dropping.get()) {
+                return CompletableFuture.failedFuture(new RuntimeException("dropped in test"));
+              }
+              return CompletableFuture.completedFuture(null);
+            });
+    return dropping;
+  }
+
+  private static void dropVotes(final RaftServer member) {
+    final var protocol = (TestRaftServerProtocol) member.getContext().getProtocol();
+    protocol.interceptRequest(
+        VoteRequest.class,
+        request -> {
+          return CompletableFuture.<Void>failedFuture(new RuntimeException("dropped in test"));
+        });
+    protocol.interceptRequest(
+        PollRequest.class,
+        request -> {
+          return CompletableFuture.<Void>failedFuture(new RuntimeException("dropped in test"));
+        });
+  }
+
+  private static LongAdder dropTimeoutNow(
+      final RaftServer leader, final CompletableFuture<Void> firstSend) {
+    final var sends = new LongAdder();
+    ((TestRaftServerProtocol) leader.getContext().getProtocol())
+        .interceptRequest(
+            TimeoutNowRequest.class,
+            request -> {
+              sends.increment();
+              firstSend.complete(null);
+              return CompletableFuture.failedFuture(new RuntimeException("dropped in test"));
+            });
+    return sends;
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/CatchUpWaitTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/CatchUpWaitTest.java
@@ -30,6 +30,9 @@ import org.junit.Test;
 
 public class CatchUpWaitTest {
 
+  /** Ample budget, so a wait ends for the reason under test rather than for lack of time. */
+  private static final Duration CATCH_UP_BUDGET = Duration.ofMinutes(1);
+
   @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);
 
   @Test
@@ -40,7 +43,7 @@ public class CatchUpWaitTest {
     final var targetId = memberId(raftRule.getFollower().orElseThrow());
 
     // when
-    final var caughtUp = awaitCaughtUp(leader, targetId, committed + 5);
+    final var caughtUp = awaitCaughtUp(leader, targetId, committed + 5, CATCH_UP_BUDGET);
     raftRule.appendEntries(5);
 
     // then
@@ -55,7 +58,8 @@ public class CatchUpWaitTest {
     final var target = raftRule.getFollower().orElseThrow();
 
     // when
-    final var caughtUp = awaitCaughtUp(leader, memberId(target), committed + 1_000);
+    final var caughtUp =
+        awaitCaughtUp(leader, memberId(target), committed + 1_000, CATCH_UP_BUDGET);
     target.leave().get(30, TimeUnit.SECONDS);
 
     // then
@@ -64,8 +68,28 @@ public class CatchUpWaitTest {
         .isEqualTo(Optional.of(LeadershipTransferResult.NOT_MEMBER));
   }
 
+  @Test
+  public void shouldReportReplicationTimedOutWhenTheBudgetRunsOut() throws Exception {
+    // given
+    final long committed = raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var targetId = memberId(raftRule.getFollower().orElseThrow());
+
+    // when
+    final var caughtUp = awaitCaughtUp(leader, targetId, committed + 1_000, Duration.ofSeconds(1));
+
+    // then
+    assertThat(caughtUp)
+        .succeedsWithin(Duration.ofSeconds(15))
+        .isEqualTo(Optional.of(LeadershipTransferResult.REPLICATION_TIMED_OUT));
+  }
+
   private static CompletableFuture<Optional<LeadershipTransferResult>> awaitCaughtUp(
-      final RaftServer leader, final MemberId desiredLeader, final long targetIndex) {
+      final RaftServer leader,
+      final MemberId desiredLeader,
+      final long targetIndex,
+      final Duration catchUpBudget) {
+    final var deadlineMs = System.currentTimeMillis() + catchUpBudget.toMillis();
     final var caughtUp = new CompletableFuture<Optional<LeadershipTransferResult>>();
     leader
         .getContext()
@@ -76,7 +100,8 @@ public class CatchUpWaitTest {
                         leader.getContext(),
                         leaderRole(leader)::isRunning,
                         desiredLeader,
-                        targetIndex)
+                        targetIndex,
+                        deadlineMs)
                     .start()
                     .whenComplete(
                         (result, error) -> {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -116,6 +116,8 @@ public final class RaftPartitionFactory {
         brokerCfg.getCluster().getRaft().getRebalanceReplicationLagThreshold().toBytes());
     partitionConfig.setRebalanceReplicationTimeout(
         brokerCfg.getCluster().getRaft().getRebalanceReplicationTimeout());
+    partitionConfig.setRebalanceMaxTransferAttempts(
+        brokerCfg.getCluster().getRaft().getRebalanceMaxTransferAttempts());
 
     partitionConfig.setReceiveOnLegacySubject(
         brokerCfg.getExperimental().isReceiveOnLegacySubject());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
@@ -15,6 +15,7 @@ public final class RaftCfg implements ConfigurationEntry {
   public static final DataSize DEFAULT_REBALANCE_REPLICATION_LAG_THRESHOLD =
       DataSize.ofMegabytes(8);
   public static final Duration DEFAULT_REBALANCE_REPLICATION_TIMEOUT = Duration.ofSeconds(10);
+  public static final int DEFAULT_REBALANCE_MAX_TRANSFER_ATTEMPTS = 3;
   private static final FlushConfig DEFAULT_FLUSH_CONFIG = new FlushConfig(true, Duration.ZERO);
 
   private boolean enablePriorityElection = DEFAULT_ENABLE_PRIORITY_ELECTION;
@@ -22,6 +23,7 @@ public final class RaftCfg implements ConfigurationEntry {
   private FlushConfig flush = DEFAULT_FLUSH_CONFIG;
   private DataSize rebalanceReplicationLagThreshold = DEFAULT_REBALANCE_REPLICATION_LAG_THRESHOLD;
   private Duration rebalanceReplicationTimeout = DEFAULT_REBALANCE_REPLICATION_TIMEOUT;
+  private int rebalanceMaxTransferAttempts = DEFAULT_REBALANCE_MAX_TRANSFER_ATTEMPTS;
 
   public boolean isEnablePriorityElection() {
     return enablePriorityElection;
@@ -55,6 +57,14 @@ public final class RaftCfg implements ConfigurationEntry {
     this.rebalanceReplicationTimeout = rebalanceReplicationTimeout;
   }
 
+  public int getRebalanceMaxTransferAttempts() {
+    return rebalanceMaxTransferAttempts;
+  }
+
+  public void setRebalanceMaxTransferAttempts(final int rebalanceMaxTransferAttempts) {
+    this.rebalanceMaxTransferAttempts = rebalanceMaxTransferAttempts;
+  }
+
   @Override
   public String toString() {
     return "RaftCfg{"
@@ -66,6 +76,8 @@ public final class RaftCfg implements ConfigurationEntry {
         + rebalanceReplicationLagThreshold
         + ", rebalanceReplicationTimeout="
         + rebalanceReplicationTimeout
+        + ", rebalanceMaxTransferAttempts="
+        + rebalanceMaxTransferAttempts
         + '}';
   }
 


### PR DESCRIPTION
Promotes the caught-up desired leader with retried `TimeoutNow` requests. Success is detected when that member takes leadership. Retry exhaustion and unplanned leadership changes are reported to the coordinator.

The pause watchdog covers the catch-up and promotion budgets with a fixed 5 seconds of slack. Retry exhaustion should therefore resume normally (like replication timeout).  Only a transfer attempt that exceeds the expected time and slack time triggers step-down.

The existing `zeebe.cluster.rebalance.partition.duration` metric now covers promotion, reporting success only when the desired member becomes leader and recording promotion failures by terminal result.

Adds the `camunda.cluster.raft.rebalance.max-transfer-attempts` configuration option to control the maximum number of `TimeoutNow` attempts.

Closes #56759.