### PR TITLE
feat: add creationTime to 8.10 job zod schema

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -21,7 +21,7 @@
 		"@bpmn-io/element-template-icon-renderer": "1.0.0",
 		"@bpmn-io/form-js-carbon-styles": "1.24.1",
 		"@bpmn-io/form-js-viewer": "1.24.1",
-		"@camunda/camunda-api-zod-schemas": "0.0.84",
+		"@camunda/camunda-api-zod-schemas": "0.0.85",
 		"@camunda/camunda-composite-components": "0.25.4",
 		"@carbon/grid": "11.58.0",
 		"@carbon/layout": "11.55.0",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -30,7 +30,7 @@
 				"@bpmn-io/element-template-icon-renderer": "1.0.0",
 				"@bpmn-io/form-js-carbon-styles": "1.24.1",
 				"@bpmn-io/form-js-viewer": "1.24.1",
-				"@camunda/camunda-api-zod-schemas": "0.0.84",
+				"@camunda/camunda-api-zod-schemas": "0.0.85",
 				"@camunda/camunda-composite-components": "0.25.4",
 				"@carbon/grid": "11.58.0",
 				"@carbon/layout": "11.55.0",
@@ -11895,7 +11895,7 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.84",
+				"@camunda/camunda-api-zod-schemas": "0.0.85",
 				"typescript": "7.0.2"
 			}
 		},
@@ -11936,7 +11936,7 @@
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.84",
+			"version": "0.0.85",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "26.1.2",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.84",
+		"@camunda/camunda-api-zod-schemas": "0.0.85",
 		"typescript": "7.0.2"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.0.85
+
+### 🚀 Enhancements
+
+- Add `creationTime` as a sortable field to the 8.10 jobs search schema, enabling jobs (including execution/task listeners) to be sorted by their creation time ([#58500](https://github.com/camunda/camunda/issues/58500))
+
 ## v0.0.84
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add `creationTime` as a sortable field to the 8.10 jobs search schema, enabling jobs (including execution/task listeners) to be sorted by their creation time ([#58500](https://github.com/camunda/camunda/issues/58500))
 
+### ❤️ Contributors
+
+- [@aleksander-dytko](https://github.com/aleksander-dytko)
+
 ## v0.0.84
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/job.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/job.ts
@@ -99,6 +99,7 @@ const queryJobsRequestBodySchema = getQueryRequestBodySchema({
 		'customHeaders',
 		'deadline',
 		'endTime',
+		'creationTime',
 		'processDefinitionId',
 		'processDefinitionKey',
 		'processInstanceKey',

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.84",
+	"version": "0.0.85",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

Adds `creationTime` to the `8.10` jobs search `sortFields` in
`@camunda/camunda-api-zod-schemas` and releases it as `v0.0.85`.

The backend side — the `creationTime` enum value on
`JobSearchQuerySortRequest` plus the domain/RDBMS sort wiring — is added in
#58639. This PR is the schema-package half, split out per
[the documented process](https://github.com/camunda/camunda/blob/main/docs/monorepo-docs/frontend/camunda-api-zod-schemas.md#when-the-schema-update-is-part-of-a-new-feature)
and following the precedent of #58610.

- Add `creationTime` to the jobs `sortFields`
- Bump `0.0.84` → `0.0.85` + CHANGELOG entry
- Bump workspace consumers (`orchestration-cluster-webapp`, `c8-mocks`) + lockfile

**TODO after merge:** publish `v0.0.85` from `main` via the manual
`workflow_dispatch` on
[`publish-zod-schemas.yml`](https://github.com/camunda/camunda/actions/workflows/publish-zod-schemas.yml)
(uncheck the dry-run option). The Operate Listeners tab PR then bumps
`operate/client` to `0.0.85` and consumes the new sort field.

## Checklist

- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to #58500
