### PR TITLE
feat: add Micrometer metrics for the business-ID message-start cross-partition handshake and lock-release path

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetrics.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.MessageCorrelationKeyNames;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReleaseResult;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReleaseTrigger;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReplyOutcome;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.RequestOutcome;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Instruments the Business-ID message-start correlation feature: the cross-partition uniqueness
+ * handshake, the pending-ask retry/back-off, and the correlation-key lock-release path. Meters are
+ * documented in {@link MessageCorrelationMetricsDoc}.
+ *
+ * <p>All recording happens on live leader-only paths (command processors, behaviors and
+ * schedulers), never in event appliers, so replay does not double-count. Counters tagged by a
+ * closed enum are registered lazily per tag value using the {@link EnumMap} idiom.
+ */
+public final class MessageCorrelationMetrics {
+
+  private final MeterRegistry registry;
+
+  private final Map<RequestOutcome, Counter> requestCounters = new EnumMap<>(RequestOutcome.class);
+  private final Map<ReplyOutcome, Counter> replyCounters = new EnumMap<>(ReplyOutcome.class);
+  private final Map<ReleaseTrigger, Counter> lockReleaseSentCounters =
+      new EnumMap<>(ReleaseTrigger.class);
+  private final Map<ReleaseResult, Counter> lockReleaseCounters =
+      new EnumMap<>(ReleaseResult.class);
+
+  private final Counter askCounter;
+  private final Counter askRetryCounter;
+  private final Counter lockReleaseQueryCounter;
+  private final Counter dedupSweptCounter;
+  private final DistributionSummary lockReleaseQueryBatchSize;
+
+  public MessageCorrelationMetrics(final MeterRegistry registry) {
+    this.registry = Objects.requireNonNull(registry, "must specify a registry");
+
+    askCounter = registerCounter(MessageCorrelationMetricsDoc.CROSS_PARTITION_ASKS);
+    askRetryCounter = registerCounter(MessageCorrelationMetricsDoc.CROSS_PARTITION_ASK_RETRIES);
+    lockReleaseQueryCounter = registerCounter(MessageCorrelationMetricsDoc.LOCK_RELEASE_QUERIES);
+    dedupSweptCounter = registerCounter(MessageCorrelationMetricsDoc.DEDUP_SWEPT);
+
+    final var batchSizeDoc = MessageCorrelationMetricsDoc.LOCK_RELEASE_QUERY_BATCH_SIZE;
+    lockReleaseQueryBatchSize =
+        DistributionSummary.builder(batchSizeDoc.getName())
+            .description(batchSizeDoc.getDescription())
+            .serviceLevelObjectives(batchSizeDoc.getDistributionSLOs())
+            .register(registry);
+  }
+
+  /** M1: records the outcome of the cross-partition REQUEST decision ladder on {@code P_B}. */
+  public void crossPartitionRequest(final RequestOutcome outcome) {
+    requestCounters
+        .computeIfAbsent(
+            outcome,
+            o ->
+                registerOutcomeCounter(
+                    MessageCorrelationMetricsDoc.CROSS_PARTITION_REQUESTS, o.getLabel()))
+        .increment();
+  }
+
+  /** M2: records a cross-partition reply outcome processed on {@code P_K}. */
+  public void crossPartitionReply(final ReplyOutcome outcome) {
+    replyCounters
+        .computeIfAbsent(
+            outcome,
+            o ->
+                registerOutcomeCounter(
+                    MessageCorrelationMetricsDoc.CROSS_PARTITION_REPLIES, o.getLabel()))
+        .increment();
+  }
+
+  /** M3: records a newly-registered cross-partition ask dispatched from {@code P_K}. */
+  public void crossPartitionAskSent() {
+    askCounter.increment();
+  }
+
+  /** M8: records a cross-partition ask retry sent by the pending-ask scheduler on {@code P_K}. */
+  public void crossPartitionAskRetried() {
+    askRetryCounter.increment();
+  }
+
+  /**
+   * M9: records a correlation-key lock-release reconciliation query dispatched from {@code P_K}.
+   */
+  public void lockReleaseQuerySent() {
+    lockReleaseQueryCounter.increment();
+  }
+
+  /** M10: records the holder count of a correlation-key lock-release reconciliation query. */
+  public void lockReleaseQueryBatchSize(final int holders) {
+    lockReleaseQueryBatchSize.record(holders);
+  }
+
+  /** M11: records swept expired cross-partition dedup entries on {@code P_B}. */
+  public void dedupSwept(final int count) {
+    dedupSweptCounter.increment(count);
+  }
+
+  /** M12: records a correlation-key lock-release command sent to {@code P_K}. */
+  public void lockReleaseSent(final ReleaseTrigger trigger) {
+    lockReleaseSentCounters
+        .computeIfAbsent(
+            trigger,
+            t ->
+                registerTaggedCounter(
+                    MessageCorrelationMetricsDoc.LOCK_RELEASES_SENT,
+                    MessageCorrelationKeyNames.TRIGGER.asString(),
+                    t.getLabel()))
+        .increment();
+  }
+
+  /** M13: records a correlation-key lock-release outcome processed on {@code P_K}. */
+  public void lockReleased(final ReleaseResult result) {
+    lockReleaseCounters
+        .computeIfAbsent(
+            result,
+            r ->
+                registerTaggedCounter(
+                    MessageCorrelationMetricsDoc.LOCK_RELEASES,
+                    MessageCorrelationKeyNames.RESULT.asString(),
+                    r.getLabel()))
+        .increment();
+  }
+
+  private Counter registerCounter(final MessageCorrelationMetricsDoc doc) {
+    return Counter.builder(doc.getName()).description(doc.getDescription()).register(registry);
+  }
+
+  private Counter registerOutcomeCounter(
+      final MessageCorrelationMetricsDoc doc, final String outcome) {
+    return registerTaggedCounter(doc, MessageCorrelationKeyNames.OUTCOME.asString(), outcome);
+  }
+
+  private Counter registerTaggedCounter(
+      final MessageCorrelationMetricsDoc doc, final String tagKey, final String tagValue) {
+    return Counter.builder(doc.getName())
+        .description(doc.getDescription())
+        .tag(tagKey, tagValue)
+        .register(registry);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsDoc.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+
+/**
+ * Documents the meters that instrument the Business-ID message-start correlation feature: the
+ * cross-partition uniqueness handshake, the pending-ask retry/back-off, and the correlation-key
+ * lock-release path.
+ *
+ * <p>The {@code partition} tag is added automatically by the per-partition meter registry, so the
+ * engine code never sets it; every meter here documents it via {@link #getAdditionalKeyNames()}.
+ * All other tags are closed enums (see the nested value enums) — no user-supplied value (business
+ * id, correlation key, message name, tenant) is ever used as a tag.
+ */
+public enum MessageCorrelationMetricsDoc implements ExtendedMeterDocumentation {
+
+  /**
+   * Counts the outcomes of the cross-partition message-start REQUEST decision ladder on {@code P_B
+   * = hash(businessId)} — the "cross-partition uniqueness results" of the handshake.
+   */
+  CROSS_PARTITION_REQUESTS {
+    @Override
+    public String getName() {
+      return "zeebe.message.start.cross.partition.requests.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Counts the outcomes of the cross-partition message-start REQUEST decision ladder on the business-id partition (P_B).";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {MessageCorrelationKeyNames.OUTCOME};
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /**
+   * Counts the cross-partition reply outcomes processed on {@code P_K = hash(correlationKey)}. A
+   * gap between {@link #CROSS_PARTITION_REQUESTS} and this meter indicates inter-partition reply
+   * loss (which the retry then papers over).
+   */
+  CROSS_PARTITION_REPLIES {
+    @Override
+    public String getName() {
+      return "zeebe.message.start.cross.partition.replies.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Counts the cross-partition message-start reply outcomes processed on the correlation-key partition (P_K).";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {MessageCorrelationKeyNames.OUTCOME};
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /** Counts newly-registered cross-partition message-start asks dispatched from {@code P_K}. */
+  CROSS_PARTITION_ASKS {
+    @Override
+    public String getName() {
+      return "zeebe.message.start.cross.partition.asks.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Counts the newly-registered cross-partition message-start asks dispatched from the correlation-key partition (P_K).";
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /**
+   * Counts cross-partition message-start ask retries sent by the pending-ask scheduler on {@code
+   * P_K}; every scheduler send is by definition a retry (the initial send is counted by {@link
+   * #CROSS_PARTITION_ASKS}).
+   */
+  CROSS_PARTITION_ASK_RETRIES {
+    @Override
+    public String getName() {
+      return "zeebe.message.start.cross.partition.asks.retries.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Counts the cross-partition message-start ask retries sent by the pending-ask scheduler on the correlation-key partition (P_K).";
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /** Counts correlation-key lock-release reconciliation queries dispatched from {@code P_K}. */
+  LOCK_RELEASE_QUERIES {
+    @Override
+    public String getName() {
+      return "zeebe.message.start.cross.partition.lock.release.queries.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Counts the correlation-key lock-release reconciliation queries dispatched from the correlation-key partition (P_K).";
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /**
+   * Distribution of the number of holders per correlation-key lock-release reconciliation query. A
+   * p-max pinned at the batch limit reveals reconciliation saturation.
+   */
+  LOCK_RELEASE_QUERY_BATCH_SIZE {
+    private static final double[] BUCKETS = {1, 8, 16, 32, 64, 128};
+
+    @Override
+    public String getName() {
+      return "zeebe.message.start.cross.partition.lock.release.query.batch.size";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.DISTRIBUTION_SUMMARY;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Distribution of the number of holders per correlation-key lock-release reconciliation query dispatched from P_K.";
+    }
+
+    @Override
+    public double[] getDistributionSLOs() {
+      return BUCKETS;
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /** Counts expired cross-partition message-start dedup entries swept on {@code P_B}. */
+  DEDUP_SWEPT {
+    @Override
+    public String getName() {
+      return "zeebe.message.start.cross.partition.dedup.swept.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Counts the expired cross-partition message-start dedup entries swept on the business-id partition (P_B).";
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /**
+   * Counts correlation-key lock-release commands sent to {@code P_K}, tagged by whether they
+   * originate from the push fast-path ({@code P_B} holder completion) or the reconciliation poll. A
+   * rising {@code reconciliation} rate means pushes are being lost (ADR 0001, Consequences).
+   */
+  LOCK_RELEASES_SENT {
+    @Override
+    public String getName() {
+      return "zeebe.message.start.cross.partition.lock.releases.sent.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Counts the correlation-key lock-release commands sent to P_K, tagged by push fast-path vs reconciliation poll.";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {MessageCorrelationKeyNames.TRIGGER};
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /**
+   * Counts correlation-key lock-release outcomes processed on {@code P_K}: an actual release, or a
+   * redundant reply (the lock was already released or re-acquired — a push-vs-poll race or stale
+   * reply).
+   */
+  LOCK_RELEASES {
+    @Override
+    public String getName() {
+      return "zeebe.message.start.cross.partition.lock.releases.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Counts the correlation-key lock-release outcomes processed on P_K, tagged released vs redundant.";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {MessageCorrelationKeyNames.RESULT};
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  };
+
+  /** The tag keys used by the message-correlation meters. */
+  public enum MessageCorrelationKeyNames implements KeyName {
+    /** The outcome of a cross-partition request or reply. */
+    OUTCOME {
+      @Override
+      public String asString() {
+        return "outcome";
+      }
+    },
+
+    /** What triggered a correlation-key lock release (push vs reconciliation). */
+    TRIGGER {
+      @Override
+      public String asString() {
+        return "trigger";
+      }
+    },
+
+    /** The result of processing a correlation-key lock-release reply (released vs redundant). */
+    RESULT {
+      @Override
+      public String asString() {
+        return "result";
+      }
+    };
+  }
+
+  /**
+   * Outcomes of the cross-partition REQUEST decision ladder on {@code P_B} ({@code outcome} tag).
+   */
+  public enum RequestOutcome {
+    STARTED("started"),
+    DEDUP_HIT("dedup_hit"),
+    REJECTED_UNIQUENESS("rejected_uniqueness"),
+    REJECTED_NO_SUBSCRIPTION("rejected_no_subscription"),
+    REJECTED_NOT_ACTIVATABLE("rejected_not_activatable"),
+    REJECTED_EXPIRED("rejected_expired");
+
+    private final String label;
+
+    RequestOutcome(final String label) {
+      this.label = label;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+  }
+
+  /** Outcomes of the cross-partition reply processors on {@code P_K} ({@code outcome} tag). */
+  public enum ReplyOutcome {
+    STARTED("started"),
+    REJECTED_UNIQUENESS("rejected_uniqueness"),
+    REJECTED_NO_SUBSCRIPTION("rejected_no_subscription"),
+    REJECTED_EXPIRED("rejected_expired");
+
+    private final String label;
+
+    ReplyOutcome(final String label) {
+      this.label = label;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+  }
+
+  /** What triggered a correlation-key lock release ({@code trigger} tag). */
+  public enum ReleaseTrigger {
+    PUSH("push"),
+    RECONCILIATION("reconciliation");
+
+    private final String label;
+
+    ReleaseTrigger(final String label) {
+      this.label = label;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+  }
+
+  /** The result of processing a correlation-key lock-release reply ({@code result} tag). */
+  public enum ReleaseResult {
+    RELEASED("released"),
+    REDUNDANT("redundant");
+
+    private final String label;
+
+    ReleaseResult(final String label) {
+      this.label = label;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
 import io.camunda.zeebe.engine.metrics.DistributionMetrics;
 import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessDefinitionMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.metrics.TenantMetrics;
@@ -166,6 +167,8 @@ public final class EngineProcessors {
         new ProcessDefinitionMetrics(
             typedRecordProcessorContext.getMeterRegistry(), processingState.getProcessState());
     final var tenantMetrics = new TenantMetrics(typedRecordProcessorContext.getMeterRegistry());
+    final var messageCorrelationMetrics =
+        new MessageCorrelationMetrics(typedRecordProcessorContext.getMeterRegistry());
 
     subscriptionCommandSender.setWriters(writers);
 
@@ -262,6 +265,7 @@ public final class EngineProcessors {
             expressionLanguageMetrics,
             config,
             incidentMetrics,
+            messageCorrelationMetrics,
             featureFlags.evaluateBoundaryEventCorrelationKeyInActivityScope(),
             cslCheck);
 
@@ -311,7 +315,8 @@ public final class EngineProcessors {
         routingInfo,
         authzService,
         claimsConverter,
-        securityConfig);
+        securityConfig,
+        messageCorrelationMetrics);
 
     final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor =
         addProcessProcessors(
@@ -607,6 +612,7 @@ public final class EngineProcessors {
       final ExpressionLanguageMetrics expressionLanguageMetrics,
       final EngineConfiguration config,
       final IncidentMetrics incidentMetrics,
+      final MessageCorrelationMetrics messageCorrelationMetrics,
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
       final CslAuthorizationCheck cslCheck) {
     return new BpmnBehaviorsImpl(
@@ -623,6 +629,7 @@ public final class EngineProcessors {
         expressionLanguageMetrics,
         config,
         incidentMetrics,
+        messageCorrelationMetrics,
         evaluateBoundaryEventCorrelationKeyInActivityScope,
         cslCheck);
   }
@@ -757,7 +764,8 @@ public final class EngineProcessors {
       final RoutingInfo routingInfo,
       final AuthorizationCheckPort authzService,
       final LazyTokenClaimsConverter claimsConverter,
-      final EngineSecurityConfig securityConfig) {
+      final EngineSecurityConfig securityConfig,
+      final MessageCorrelationMetrics messageCorrelationMetrics) {
     MessageEventProcessors.addMessageProcessors(
         partitionId,
         bpmnBehaviors,
@@ -773,7 +781,8 @@ public final class EngineProcessors {
         routingInfo,
         authzService,
         claimsConverter,
-        securityConfig);
+        securityConfig,
+        messageCorrelationMetrics);
   }
 
   private static void addDecisionProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.el.ExpressionLanguageMetrics;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.ProcessInstanceStateTransitionGuard;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
@@ -84,6 +85,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final ExpressionLanguageMetrics expressionMetrics,
       final EngineConfiguration config,
       final IncidentMetrics incidentMetrics,
+      final MessageCorrelationMetrics messageCorrelationMetrics,
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
       final CslAuthorizationCheck cslCheck) {
 
@@ -219,7 +221,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             subscriptionCommandSender,
             routingInfo,
             clock,
-            config.isBusinessIdUniquenessEnabled());
+            config.isBusinessIdUniquenessEnabled(),
+            messageCorrelationMetrics);
 
     jobActivationBehavior =
         new BpmnJobActivationBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
@@ -49,6 +50,7 @@ public final class BpmnBufferedMessageStartEventBehavior {
   private final InstantSource clock;
   private final StateWriter stateWriter;
   private final SubscriptionCommandSender commandSender;
+  private final MessageCorrelationMetrics metrics;
 
   public BpmnBufferedMessageStartEventBehavior(
       final ProcessingState processingState,
@@ -59,7 +61,8 @@ public final class BpmnBufferedMessageStartEventBehavior {
       final SubscriptionCommandSender commandSender,
       final RoutingInfo routingInfo,
       final InstantSource clock,
-      final boolean businessIdUniquenessEnabled) {
+      final boolean businessIdUniquenessEnabled,
+      final MessageCorrelationMetrics metrics) {
     messageState = processingState.getMessageState();
     processState = processingState.getProcessState();
     messageStartEventSubscriptionState = processingState.getMessageStartEventSubscriptionState();
@@ -70,6 +73,7 @@ public final class BpmnBufferedMessageStartEventBehavior {
     this.clock = clock;
     stateWriter = writers.state();
     this.commandSender = commandSender;
+    this.metrics = metrics;
 
     final var eventHandle =
         new EventHandle(
@@ -95,7 +99,8 @@ public final class BpmnBufferedMessageStartEventBehavior {
             bannedInstanceState,
             businessIdUniquenessEnabled,
             routingInfo,
-            processingState.getPartitionId());
+            processingState.getPartitionId(),
+            metrics);
   }
 
   public Optional<DirectBuffer> findCorrelationKey(final BpmnElementContext context) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReleaseTrigger;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
@@ -150,6 +151,7 @@ public final class BpmnBufferedMessageStartEventBehavior {
     stateWriter.appendFollowUpEvent(
         processInstanceKey, MessageStartCorrelationKeyLockReleaseIntent.PUSHED, record);
     commandSender.sendCorrelationKeyLockRelease(requestKey, holder);
+    metrics.lockReleaseSent(ReleaseTrigger.PUSH);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseScheduler.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.message;
 
 import com.google.common.collect.Lists;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.protocol.Protocol;
@@ -62,18 +63,21 @@ public final class CrossPartitionMessageStartLockReleaseScheduler
   private final MessageState messageState;
   private final Supplier<Duration> pollInterval;
   private final IntSupplier batchLimit;
+  private final MessageCorrelationMetrics metrics;
 
   public CrossPartitionMessageStartLockReleaseScheduler(
       final int partitionId,
       final SubscriptionCommandSender commandSender,
       final MessageState messageState,
       final Supplier<Duration> pollInterval,
-      final IntSupplier batchLimit) {
+      final IntSupplier batchLimit,
+      final MessageCorrelationMetrics metrics) {
     this.partitionId = partitionId;
     this.commandSender = commandSender;
     this.messageState = messageState;
     this.pollInterval = pollInterval;
     this.batchLimit = batchLimit;
+    this.metrics = metrics;
   }
 
   @Override
@@ -148,6 +152,8 @@ public final class CrossPartitionMessageStartLockReleaseScheduler
         targetPartition,
         chunk.size());
     commandSender.sendDirectCorrelationKeyLockReleaseQuery(targetPartition, query);
+    metrics.lockReleaseQuerySent();
+    metrics.lockReleaseQueryBatchSize(chunk.size());
   }
 
   private record Lock(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -88,6 +89,7 @@ public final class MessageCorrelateBehavior {
   private final SubscriptionCommandSender commandSender;
   private final RoutingInfo routingInfo;
   private final int partitionId;
+  private final MessageCorrelationMetrics metrics;
 
   private final MessageStartProcessInstanceRequestRecord askRecord =
       new MessageStartProcessInstanceRequestRecord();
@@ -103,7 +105,8 @@ public final class MessageCorrelateBehavior {
       final BannedInstanceState bannedInstanceState,
       final boolean businessIdUniquenessEnabled,
       final RoutingInfo routingInfo,
-      final int partitionId) {
+      final int partitionId,
+      final MessageCorrelationMetrics metrics) {
     this.startEventSubscriptionState = startEventSubscriptionState;
     this.messageSubscriptionState = messageSubscriptionState;
     this.messageState = messageState;
@@ -115,6 +118,7 @@ public final class MessageCorrelateBehavior {
     this.businessIdUniquenessEnabled = businessIdUniquenessEnabled;
     this.routingInfo = routingInfo;
     this.partitionId = partitionId;
+    this.metrics = metrics;
   }
 
   public void correlateToMessageStartEvents(
@@ -421,6 +425,8 @@ public final class MessageCorrelateBehavior {
 
     stateWriter.appendFollowUpEvent(
         messageData.messageKey(), MessageStartProcessInstanceRequestIntent.REQUESTED, askRecord);
+
+    metrics.crossPartitionAskSent();
 
     commandSender.sendStartProcessInstanceRequest(
         routingInfo.partitionForCorrelationKey(messageData.businessId()),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.message;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import io.camunda.security.core.auth.RequiredAuthorization;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
@@ -79,7 +80,8 @@ public final class MessageCorrelationCorrelateProcessor
       final BannedInstanceState bannedInstanceState,
       final boolean businessIdUniquenessEnabled,
       final RoutingInfo routingInfo,
-      final int partitionId) {
+      final int partitionId,
+      final MessageCorrelationMetrics metrics) {
     stateWriter = writers.state();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
@@ -105,7 +107,8 @@ public final class MessageCorrelationCorrelateProcessor
             bannedInstanceState,
             businessIdUniquenessEnabled,
             routingInfo,
-            partitionId);
+            partitionId,
+            metrics);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -11,6 +11,7 @@ import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
@@ -54,7 +55,8 @@ public final class MessageEventProcessors {
       final RoutingInfo routingInfo,
       final AuthorizationCheckPort authCheckPort,
       final LazyTokenClaimsConverter claimsConverter,
-      final EngineSecurityConfig securityConfig) {
+      final EngineSecurityConfig securityConfig,
+      final MessageCorrelationMetrics metrics) {
 
     final MutableMessageState messageState = processingState.getMessageState();
     final MutableMessageCorrelationState messageCorrelationState =
@@ -93,7 +95,8 @@ public final class MessageEventProcessors {
                 elementInstanceState,
                 bannedInstanceState,
                 businessIdUniquenessEnabled,
-                bpmnBehaviors.variableBehavior()))
+                bpmnBehaviors.variableBehavior(),
+                metrics))
         .onCommand(
             ValueType.MESSAGE_BATCH,
             MessageBatchIntent.EXPIRE,
@@ -165,7 +168,8 @@ public final class MessageEventProcessors {
                 bannedInstanceState,
                 businessIdUniquenessEnabled,
                 routingInfo,
-                partitionId))
+                partitionId,
+                metrics))
         .onCommand(
             ValueType.MESSAGE_START_PROCESS_INSTANCE_REQUEST,
             MessageStartProcessInstanceRequestIntent.REQUEST,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -186,7 +186,8 @@ public final class MessageEventProcessors {
                 keyGenerator,
                 clock,
                 businessIdUniquenessEnabled,
-                writers))
+                writers,
+                metrics))
         .onCommand(
             ValueType.MESSAGE_START_PROCESS_INSTANCE_REQUEST,
             MessageStartProcessInstanceRequestIntent.SWEEP_EXPIRED_DEDUPS,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -202,21 +202,33 @@ public final class MessageEventProcessors {
             ValueType.MESSAGE_START_PROCESS_INSTANCE_REQUEST,
             MessageStartProcessInstanceRequestIntent.START,
             new MessageStartProcessInstanceRequestStartProcessor(
-                writers.state(), writers.response(), messageState, messageCorrelationState))
+                writers.state(),
+                writers.response(),
+                messageState,
+                messageCorrelationState,
+                metrics))
         .onCommand(
             ValueType.MESSAGE_START_PROCESS_INSTANCE_REQUEST,
             MessageStartProcessInstanceRequestIntent.REJECT_UNIQUENESS,
             new MessageStartProcessInstanceRequestRejectUniquenessProcessor(
-                writers.state(), writers.response(), messageCorrelationState, messageState))
+                writers.state(),
+                writers.response(),
+                messageCorrelationState,
+                messageState,
+                metrics))
         .onCommand(
             ValueType.MESSAGE_START_PROCESS_INSTANCE_REQUEST,
             MessageStartProcessInstanceRequestIntent.REJECT_NO_SUBSCRIPTION,
             new MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor(
-                writers.state(), writers.response(), messageCorrelationState, messageState))
+                writers.state(),
+                writers.response(),
+                messageCorrelationState,
+                messageState,
+                metrics))
         .onCommand(
             ValueType.MESSAGE_START_PROCESS_INSTANCE_REQUEST,
             MessageStartProcessInstanceRequestIntent.REJECT_EXPIRED,
-            new MessageStartProcessInstanceRequestRejectExpiredProcessor(writers.state()))
+            new MessageStartProcessInstanceRequestRejectExpiredProcessor(writers.state(), metrics))
         // Holder-liveness release query handler on P_B - answers whether a cross-partition
         // message-start holder instance is still active, so P_K can release its correlation-key
         // lock. The queries are dispatched by CrossPartitionMessageStartLockReleaseScheduler below.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -274,6 +274,7 @@ public final class MessageEventProcessors {
                 subscriptionCommandSender,
                 scheduledTaskStateFactory.get().getMessageState(),
                 config::getMessageStartLockReleasePollInterval,
-                config::getMessageStartLockReleasePollBatchLimit));
+                config::getMessageStartLockReleasePollBatchLimit,
+                metrics));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -241,7 +241,8 @@ public final class MessageEventProcessors {
                 bannedInstanceState,
                 messageState,
                 subscriptionCommandSender,
-                writers))
+                writers,
+                metrics))
         // Holder-completion release handler on P_K - on a RELEASE reply from P_B, releases the
         // correlation-key lock and picks up the next buffered message for that key.
         .onCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -249,7 +249,7 @@ public final class MessageEventProcessors {
             ValueType.MESSAGE_START_CORRELATION_KEY_LOCK_RELEASE,
             MessageStartCorrelationKeyLockReleaseIntent.RELEASE,
             new MessageStartCorrelationKeyLockReleaseReleaseProcessor(
-                messageState, bpmnBehaviors.bufferedMessageStartEventBehavior(), writers))
+                messageState, bpmnBehaviors.bufferedMessageStartEventBehavior(), writers, metrics))
         .withListener(
             new MessageTimeToLiveCheckScheduler(
                 config.getMessagesTtlCheckerInterval(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -266,7 +266,8 @@ public final class MessageEventProcessors {
                 subscriptionCommandSender,
                 scheduledTaskStateFactory.get().getMessageStartProcessInstanceAskState(),
                 routingInfo,
-                config::getMessageStartAskRetryInterval))
+                config::getMessageStartAskRetryInterval,
+                metrics))
         .withListener(
             new CrossPartitionMessageStartLockReleaseScheduler(
                 partitionId,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -196,7 +196,8 @@ public final class MessageEventProcessors {
                 writers.command(),
                 processingState.getMessageStartProcessInstanceDedupState(),
                 config.getMessageStartDedupExpirationSweepBatchLimit(),
-                clock))
+                clock,
+                metrics))
         // Reply command processors on P_K - these handle the cross-partition replies from P_B
         .onCommand(
             ValueType.MESSAGE_START_PROCESS_INSTANCE_REQUEST,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.message;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import io.camunda.security.core.auth.RequiredAuthorization;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
@@ -77,7 +78,8 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
       final ElementInstanceState elementInstanceState,
       final BannedInstanceState bannedInstanceState,
       final boolean businessIdUniquenessEnabled,
-      final VariableBehavior variableBehavior) {
+      final VariableBehavior variableBehavior,
+      final MessageCorrelationMetrics metrics) {
     this.partitionId = partitionId;
     this.messageState = messageState;
     this.keyGenerator = keyGenerator;
@@ -107,7 +109,8 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
             bannedInstanceState,
             businessIdUniquenessEnabled,
             routingInfo,
-            partitionId);
+            partitionId,
+            metrics);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseQueryProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseQueryProcessor.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReleaseTrigger;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -56,18 +58,21 @@ public final class MessageStartCorrelationKeyLockReleaseQueryProcessor
   private final MessageState messageState;
   private final SubscriptionCommandSender commandSender;
   private final StateWriter stateWriter;
+  private final MessageCorrelationMetrics metrics;
 
   public MessageStartCorrelationKeyLockReleaseQueryProcessor(
       final ElementInstanceState elementInstanceState,
       final BannedInstanceState bannedInstanceState,
       final MessageState messageState,
       final SubscriptionCommandSender commandSender,
-      final Writers writers) {
+      final Writers writers,
+      final MessageCorrelationMetrics metrics) {
     this.elementInstanceState = elementInstanceState;
     this.bannedInstanceState = bannedInstanceState;
     this.messageState = messageState;
     this.commandSender = commandSender;
     stateWriter = writers.state();
+    this.metrics = metrics;
   }
 
   @Override
@@ -82,6 +87,7 @@ public final class MessageStartCorrelationKeyLockReleaseQueryProcessor
         continue;
       }
       commandSender.sendCorrelationKeyLockRelease(query.getRequestKey(), holder);
+      metrics.lockReleaseSent(ReleaseTrigger.RECONCILIATION);
       cleanUpOriginIfLeftover(holder);
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseReleaseProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseReleaseProcessor.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReleaseResult;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBufferedMessageStartEventBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -57,15 +59,18 @@ public final class MessageStartCorrelationKeyLockReleaseReleaseProcessor
   private final BpmnBufferedMessageStartEventBehavior bufferedMessageStartEventBehavior;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
+  private final MessageCorrelationMetrics metrics;
 
   public MessageStartCorrelationKeyLockReleaseReleaseProcessor(
       final MessageState messageState,
       final BpmnBufferedMessageStartEventBehavior bufferedMessageStartEventBehavior,
-      final Writers writers) {
+      final Writers writers,
+      final MessageCorrelationMetrics metrics) {
     this.messageState = messageState;
     this.bufferedMessageStartEventBehavior = bufferedMessageStartEventBehavior;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
+    this.metrics = metrics;
   }
 
   @Override
@@ -95,6 +100,7 @@ public final class MessageStartCorrelationKeyLockReleaseReleaseProcessor
       // successor's lock.
       rejectionWriter.appendRejection(
           record, RejectionType.INVALID_STATE, REDUNDANT_RELEASE_REJECTION_REASON);
+      metrics.lockReleased(ReleaseResult.REDUNDANT);
       return;
     }
 
@@ -106,6 +112,7 @@ public final class MessageStartCorrelationKeyLockReleaseReleaseProcessor
     // the lock removal above, so the pick-up sees the lock free and can trigger / re-route the next
     // buffered message through the normal correlation logic.
     for (final var holder : releasable.getHolders()) {
+      metrics.lockReleased(ReleaseResult.RELEASED);
       bufferedMessageStartEventBehavior.correlateNextBufferedMessage(
           BufferUtil.wrapString(holder.getBpmnProcessId()),
           BufferUtil.wrapString(holder.getCorrelationKey()),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectExpiredProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectExpiredProcessor.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReplyOutcome;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -33,9 +35,12 @@ public final class MessageStartProcessInstanceRequestRejectExpiredProcessor
     implements TypedRecordProcessor<MessageStartProcessInstanceRequestRecord> {
 
   private final StateWriter stateWriter;
+  private final MessageCorrelationMetrics metrics;
 
-  public MessageStartProcessInstanceRequestRejectExpiredProcessor(final StateWriter stateWriter) {
+  public MessageStartProcessInstanceRequestRejectExpiredProcessor(
+      final StateWriter stateWriter, final MessageCorrelationMetrics metrics) {
     this.stateWriter = stateWriter;
+    this.metrics = metrics;
   }
 
   @Override
@@ -44,5 +49,6 @@ public final class MessageStartProcessInstanceRequestRejectExpiredProcessor
         record.getKey(),
         MessageStartProcessInstanceRequestIntent.EXPIRED_REJECTED,
         record.getValue());
+    metrics.crossPartitionReply(ReplyOutcome.REJECTED_EXPIRED);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReplyOutcome;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -45,14 +47,17 @@ public final class MessageStartProcessInstanceRequestRejectNoSubscriptionProcess
       "Expected to find subscription for message with name '%s' and correlation key '%s', but none was found.";
 
   private final StateWriter stateWriter;
+  private final MessageCorrelationMetrics metrics;
   private final DeferredMessageStartCorrelationResponse deferredCorrelationResponse;
 
   public MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor(
       final StateWriter stateWriter,
       final TypedResponseWriter responseWriter,
       final MessageCorrelationState messageCorrelationState,
-      final MessageState messageState) {
+      final MessageState messageState,
+      final MessageCorrelationMetrics metrics) {
     this.stateWriter = stateWriter;
+    this.metrics = metrics;
     deferredCorrelationResponse =
         new DeferredMessageStartCorrelationResponse(
             stateWriter, responseWriter, messageCorrelationState, messageState);
@@ -63,6 +68,7 @@ public final class MessageStartProcessInstanceRequestRejectNoSubscriptionProcess
     final var reply = record.getValue();
     stateWriter.appendFollowUpEvent(
         record.getKey(), MessageStartProcessInstanceRequestIntent.NO_SUBSCRIPTION_REJECTED, reply);
+    metrics.crossPartitionReply(ReplyOutcome.REJECTED_NO_SUBSCRIPTION);
 
     deferredCorrelationResponse.writeNotCorrelatedResponse(
         reply,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectUniquenessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectUniquenessProcessor.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReplyOutcome;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -48,14 +50,17 @@ public final class MessageStartProcessInstanceRequestRejectUniquenessProcessor
           + " instance per business ID is allowed for message start events.";
 
   private final StateWriter stateWriter;
+  private final MessageCorrelationMetrics metrics;
   private final DeferredMessageStartCorrelationResponse deferredCorrelationResponse;
 
   public MessageStartProcessInstanceRequestRejectUniquenessProcessor(
       final StateWriter stateWriter,
       final TypedResponseWriter responseWriter,
       final MessageCorrelationState messageCorrelationState,
-      final MessageState messageState) {
+      final MessageState messageState,
+      final MessageCorrelationMetrics metrics) {
     this.stateWriter = stateWriter;
+    this.metrics = metrics;
     deferredCorrelationResponse =
         new DeferredMessageStartCorrelationResponse(
             stateWriter, responseWriter, messageCorrelationState, messageState);
@@ -66,6 +71,7 @@ public final class MessageStartProcessInstanceRequestRejectUniquenessProcessor
     final var reply = record.getValue();
     stateWriter.appendFollowUpEvent(
         record.getKey(), MessageStartProcessInstanceRequestIntent.UNIQUENESS_REJECTED, reply);
+    metrics.crossPartitionReply(ReplyOutcome.REJECTED_UNIQUENESS);
 
     deferredCorrelationResponse.writeNotCorrelatedResponse(
         reply,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRequestProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRequestProcessor.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.RequestOutcome;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
@@ -99,6 +101,7 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
   private final KeyGenerator keyGenerator;
   private final InstantSource clock;
   private final boolean businessIdUniquenessEnabled;
+  private final MessageCorrelationMetrics metrics;
   private final MessageStartProcessInstanceRequestRecord startedEventBuffer =
       new MessageStartProcessInstanceRequestRecord();
 
@@ -115,7 +118,8 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
       final KeyGenerator keyGenerator,
       final InstantSource clock,
       final boolean businessIdUniquenessEnabled,
-      final Writers writers) {
+      final Writers writers,
+      final MessageCorrelationMetrics metrics) {
     this.startEventSubscriptionState = startEventSubscriptionState;
     this.elementInstanceState = elementInstanceState;
     this.bannedInstanceState = bannedInstanceState;
@@ -125,6 +129,7 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
     this.keyGenerator = keyGenerator;
     this.clock = clock;
     this.businessIdUniquenessEnabled = businessIdUniquenessEnabled;
+    this.metrics = metrics;
     eventHandle =
         new EventHandle(
             keyGenerator,
@@ -148,22 +153,26 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
       // and start a duplicate. Reply like every other outcome; the EXPIRED_REJECTED applier on P_K
       // backs the pending ask off (removal stays owned by P_K's message-expiry path).
       commandSender.sendStartProcessInstanceExpiredRejected(request);
+      metrics.crossPartitionRequest(RequestOutcome.REJECTED_EXPIRED);
       return;
     }
 
     final var cachedPiKey = lookupValidDedupHit(request);
     if (cachedPiKey != null) {
       commandSender.sendStartProcessInstanceStarted(request, cachedPiKey);
+      metrics.crossPartitionRequest(RequestOutcome.DEDUP_HIT);
       return;
     }
 
     if (!localSubscriptionExists(request)) {
       commandSender.sendStartProcessInstanceNoSubscriptionRejected(request);
+      metrics.crossPartitionRequest(RequestOutcome.REJECTED_NO_SUBSCRIPTION);
       return;
     }
 
     if (businessIdUniquenessEnabled && isBusinessIdAlreadyHeld(request)) {
       commandSender.sendStartProcessInstanceUniquenessRejected(request);
+      metrics.crossPartitionRequest(RequestOutcome.REJECTED_UNIQUENESS);
       return;
     }
 
@@ -185,6 +194,7 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
     if (!activated) {
       // Activation failed because the definition is draining/deleted on this partition.
       commandSender.sendStartProcessInstanceNoSubscriptionRejected(request);
+      metrics.crossPartitionRequest(RequestOutcome.REJECTED_NOT_ACTIVATABLE);
       return;
     }
 
@@ -198,6 +208,7 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
         record.getKey(), MessageStartProcessInstanceRequestIntent.STARTED, startedEventBuffer);
 
     commandSender.sendStartProcessInstanceStarted(request, processInstanceKey);
+    metrics.crossPartitionRequest(RequestOutcome.STARTED);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestStartProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestStartProcessor.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReplyOutcome;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -73,6 +75,7 @@ public final class MessageStartProcessInstanceRequestStartProcessor
 
   private final StateWriter stateWriter;
   private final MessageState messageState;
+  private final MessageCorrelationMetrics metrics;
   private final DeferredMessageStartCorrelationResponse deferredCorrelationResponse;
   private final MessageStartEventSubscriptionRecord correlatedSubscriptionRecord =
       new MessageStartEventSubscriptionRecord();
@@ -82,9 +85,11 @@ public final class MessageStartProcessInstanceRequestStartProcessor
       final StateWriter stateWriter,
       final TypedResponseWriter responseWriter,
       final MessageState messageState,
-      final MessageCorrelationState messageCorrelationState) {
+      final MessageCorrelationState messageCorrelationState,
+      final MessageCorrelationMetrics metrics) {
     this.stateWriter = stateWriter;
     this.messageState = messageState;
+    this.metrics = metrics;
     deferredCorrelationResponse =
         new DeferredMessageStartCorrelationResponse(
             stateWriter, responseWriter, messageCorrelationState, messageState);
@@ -93,6 +98,8 @@ public final class MessageStartProcessInstanceRequestStartProcessor
   @Override
   public void processRecord(final TypedRecord<MessageStartProcessInstanceRequestRecord> record) {
     final var reply = record.getValue();
+
+    metrics.crossPartitionReply(ReplyOutcome.STARTED);
 
     // Look up the buffered message once: both the CORRELATED applier and the EXPIRED applier need
     // it (CORRELATED writes a foreign-key reference into MESSAGE_KEY; EXPIRED removes the buffered

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -40,23 +41,27 @@ public final class MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor
   private final MessageStartProcessInstanceDedupState dedupState;
   private final int batchLimit;
   private final InstantSource clock;
+  private final MessageCorrelationMetrics metrics;
 
   public MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor(
       final StateWriter stateWriter,
       final TypedCommandWriter commandWriter,
       final MessageStartProcessInstanceDedupState dedupState,
       final int batchLimit,
-      final InstantSource clock) {
+      final InstantSource clock,
+      final MessageCorrelationMetrics metrics) {
     this.stateWriter = stateWriter;
     this.commandWriter = commandWriter;
     this.dedupState = dedupState;
     this.batchLimit = batchLimit;
     this.clock = clock;
+    this.metrics = metrics;
   }
 
   @Override
   public void processRecord(final TypedRecord<MessageStartProcessInstanceRequestRecord> record) {
     final var visited = new MutableLong(0);
+    final var deleted = new MutableLong(0);
     final var entry = new MessageStartProcessInstanceRequestRecord();
     final boolean hasMore =
         dedupState.visitExpiredEntries(
@@ -75,8 +80,13 @@ public final class MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor
                   record.getKey(),
                   MessageStartProcessInstanceRequestIntent.EXPIRED_DEDUP_DELETED,
                   entry);
+              deleted.increment();
               return true;
             });
+
+    if (deleted.get() > 0) {
+      metrics.dedupSwept((int) deleted.get());
+    }
 
     if (hasMore) {
       // Past-deadline dedup entries remain beyond what fit in this batch. Schedule the next cycle

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageStartAskCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageStartAskCheckScheduler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.state.immutable.MessageStartProcessInstanceAskState;
 import io.camunda.zeebe.engine.state.message.MessageStartProcessInstanceAsk;
@@ -59,6 +60,7 @@ public final class PendingMessageStartAskCheckScheduler
   private final MessageStartProcessInstanceAskState state;
   private final RoutingInfo routingInfo;
   private final Supplier<Duration> retryInterval;
+  private final MessageCorrelationMetrics metrics;
 
   private InstantSource clock;
 
@@ -75,11 +77,13 @@ public final class PendingMessageStartAskCheckScheduler
       final SubscriptionCommandSender commandSender,
       final MessageStartProcessInstanceAskState state,
       final RoutingInfo routingInfo,
-      final Supplier<Duration> retryInterval) {
+      final Supplier<Duration> retryInterval,
+      final MessageCorrelationMetrics metrics) {
     this.commandSender = commandSender;
     this.state = state;
     this.routingInfo = routingInfo;
     this.retryInterval = retryInterval;
+    this.metrics = metrics;
   }
 
   @Override
@@ -139,6 +143,7 @@ public final class PendingMessageStartAskCheckScheduler
 
     // Update the sent time to prevent it from being re-sent too soon
     state.updateLastSentTime(ask.getMessageKey(), ask.getProcessDefinitionKey(), now);
+    metrics.crossPartitionAskRetried();
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReleaseResult;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReleaseTrigger;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReplyOutcome;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.RequestOutcome;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Recorder-level unit tests: verifies that every recording method registers the documented meter
+ * under the expected name and tags and increments/records it. The per-partition wiring and the
+ * behavioural call sites are covered by the processor, scheduler and multi-partition tests added in
+ * the following commits.
+ */
+final class MessageCorrelationMetricsTest {
+
+  private SimpleMeterRegistry registry;
+  private MessageCorrelationMetrics metrics;
+
+  @BeforeEach
+  void setUp() {
+    registry = new SimpleMeterRegistry();
+    metrics = new MessageCorrelationMetrics(registry);
+  }
+
+  @Test
+  void shouldRecordRequestOutcomesTaggedByOutcome() {
+    // when
+    metrics.crossPartitionRequest(RequestOutcome.STARTED);
+    metrics.crossPartitionRequest(RequestOutcome.STARTED);
+    metrics.crossPartitionRequest(RequestOutcome.REJECTED_UNIQUENESS);
+
+    // then each outcome is counted independently under its own tag (M1)
+    assertThat(requestCount("started")).isEqualTo(2.0);
+    assertThat(requestCount("rejected_uniqueness")).isEqualTo(1.0);
+    assertThat(requestCount("dedup_hit")).isZero();
+  }
+
+  @Test
+  void shouldRecordReplyOutcomesTaggedByOutcome() {
+    // when
+    metrics.crossPartitionReply(ReplyOutcome.STARTED);
+    metrics.crossPartitionReply(ReplyOutcome.REJECTED_NO_SUBSCRIPTION);
+
+    // then (M2)
+    assertThat(replyCount("started")).isEqualTo(1.0);
+    assertThat(replyCount("rejected_no_subscription")).isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldCountAsksSent() {
+    // when
+    metrics.crossPartitionAskSent();
+    metrics.crossPartitionAskSent();
+
+    // then (M3)
+    assertThat(counter("zeebe.message.start.cross.partition.asks.total")).isEqualTo(2.0);
+  }
+
+  @Test
+  void shouldCountAskRetries() {
+    // when
+    metrics.crossPartitionAskRetried();
+
+    // then (M8)
+    assertThat(counter("zeebe.message.start.cross.partition.asks.retries.total")).isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldCountLockReleaseQueries() {
+    // when
+    metrics.lockReleaseQuerySent();
+    metrics.lockReleaseQuerySent();
+    metrics.lockReleaseQuerySent();
+
+    // then (M9)
+    assertThat(counter("zeebe.message.start.cross.partition.lock.release.queries.total"))
+        .isEqualTo(3.0);
+  }
+
+  @Test
+  void shouldRecordLockReleaseQueryBatchSizeDistribution() {
+    // when
+    metrics.lockReleaseQueryBatchSize(4);
+    metrics.lockReleaseQueryBatchSize(2);
+
+    // then (M10)
+    final var summary =
+        registry.get("zeebe.message.start.cross.partition.lock.release.query.batch.size").summary();
+    assertThat(summary.count()).isEqualTo(2L);
+    assertThat(summary.totalAmount()).isEqualTo(6.0);
+    assertThat(summary.max()).isEqualTo(4.0);
+  }
+
+  @Test
+  void shouldCountSweptDedupEntriesByBatchAmount() {
+    // when
+    metrics.dedupSwept(5);
+    metrics.dedupSwept(3);
+
+    // then the swept counter accumulates the swept amounts, not the number of calls (M11)
+    assertThat(counter("zeebe.message.start.cross.partition.dedup.swept.total")).isEqualTo(8.0);
+  }
+
+  @Test
+  void shouldRecordLockReleasesSentTaggedByTrigger() {
+    // when
+    metrics.lockReleaseSent(ReleaseTrigger.PUSH);
+    metrics.lockReleaseSent(ReleaseTrigger.RECONCILIATION);
+    metrics.lockReleaseSent(ReleaseTrigger.RECONCILIATION);
+
+    // then (M12)
+    assertThat(lockReleaseSentCount("push")).isEqualTo(1.0);
+    assertThat(lockReleaseSentCount("reconciliation")).isEqualTo(2.0);
+  }
+
+  @Test
+  void shouldRecordLockReleasesAppliedTaggedByResult() {
+    // when
+    metrics.lockReleased(ReleaseResult.RELEASED);
+    metrics.lockReleased(ReleaseResult.REDUNDANT);
+
+    // then (M13)
+    assertThat(lockReleaseCount("released")).isEqualTo(1.0);
+    assertThat(lockReleaseCount("redundant")).isEqualTo(1.0);
+  }
+
+  private double counter(final String name) {
+    final var counter = registry.find(name).counter();
+    return counter != null ? counter.count() : 0.0;
+  }
+
+  private double taggedCount(final String name, final String key, final String value) {
+    final var counter = registry.find(name).tag(key, value).counter();
+    return counter != null ? counter.count() : 0.0;
+  }
+
+  private double requestCount(final String outcome) {
+    return taggedCount("zeebe.message.start.cross.partition.requests.total", "outcome", outcome);
+  }
+
+  private double replyCount(final String outcome) {
+    return taggedCount("zeebe.message.start.cross.partition.replies.total", "outcome", outcome);
+  }
+
+  private double lockReleaseSentCount(final String trigger) {
+    return taggedCount(
+        "zeebe.message.start.cross.partition.lock.releases.sent.total", "trigger", trigger);
+  }
+
+  private double lockReleaseCount(final String result) {
+    return taggedCount("zeebe.message.start.cross.partition.lock.releases.total", "result", result);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleasePushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleasePushTest.java
@@ -201,6 +201,17 @@ public final class CrossPartitionMessageStartLockReleasePushTest {
     assertThat(release.getPartitionId())
         .as("the RELEASE is routed to the lock partition P_K")
         .isEqualTo(partitionFor(CORRELATION_KEY));
+
+    // and the push-triggered release is counted on the holder partition P_B (M12)
+    assertThat(
+            engine
+                .getMeterRegistry(partitionFor(BUSINESS_ID))
+                .get("zeebe.message.start.cross.partition.lock.releases.sent.total")
+                .tag("trigger", "push")
+                .counter()
+                .count())
+        .as("M12: the holder completion pushes a release, counted on P_B with trigger=push")
+        .isEqualTo(1.0);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CrossPartitionMessageStartLockReleaseSchedulerTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.immutable.MessageState.CrossPartitionStartLockVisitor;
@@ -24,6 +25,7 @@ import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartCorrelationKeyLockReleaseRecord;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -50,6 +52,7 @@ public final class CrossPartitionMessageStartLockReleaseSchedulerTest {
   private ReadonlyStreamProcessorContext mockContext;
   private int batchLimit;
   private final List<Lock> locks = new ArrayList<>();
+  private SimpleMeterRegistry meterRegistry;
 
   private CrossPartitionMessageStartLockReleaseScheduler scheduler;
 
@@ -79,13 +82,15 @@ public final class CrossPartitionMessageStartLockReleaseSchedulerTest {
         .when(mockMessageState)
         .visitCrossPartitionStartLocks(any());
 
+    meterRegistry = new SimpleMeterRegistry();
     scheduler =
         new CrossPartitionMessageStartLockReleaseScheduler(
             LOCAL_PARTITION,
             mockCommandSender,
             mockMessageState,
             () -> POLL_INTERVAL,
-            () -> batchLimit);
+            () -> batchLimit,
+            new MessageCorrelationMetrics(meterRegistry));
     scheduler.onRecovered(mockContext);
   }
 
@@ -221,6 +226,32 @@ public final class CrossPartitionMessageStartLockReleaseSchedulerTest {
 
     // then no query is dispatched to ourselves
     verify(mockCommandSender, never()).sendDirectCorrelationKeyLockReleaseQuery(anyInt(), any());
+  }
+
+  @Test
+  void shouldRecordQueryAndBatchSizeMetricsPerDispatchedQuery() {
+    // given two holders on partition 2 and one on partition 3
+    addLock("wf", "ck-a", holderKeyOnPartition(2, 1));
+    addLock("wf", "ck-b", holderKeyOnPartition(2, 2));
+    addLock("wf", "ck-c", holderKeyOnPartition(3, 1));
+
+    // when
+    scheduler.run();
+
+    // then one query is counted per dispatched query (M9), and the batch-size distribution (M10)
+    // records the holder count of each query
+    assertThat(
+            meterRegistry
+                .get("zeebe.message.start.cross.partition.lock.release.queries.total")
+                .counter()
+                .count())
+        .isEqualTo(2.0);
+    final var batchSize =
+        meterRegistry
+            .get("zeebe.message.start.cross.partition.lock.release.query.batch.size")
+            .summary();
+    assertThat(batchSize.count()).isEqualTo(2L);
+    assertThat(batchSize.totalAmount()).isEqualTo(3.0);
   }
 
   private void addLock(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseQueryProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseQueryProcessorTest.java
@@ -84,6 +84,17 @@ public final class MessageStartCorrelationKeyLockReleaseQueryProcessorTest {
     assertThat(release.getRecordType()).isEqualTo(RecordType.COMMAND);
     assertQueryPreserved(release.getValue(), ABSENT_HOLDER_KEY);
 
+    // and the reconciliation-triggered release is counted on this partition (M12)
+    assertThat(
+            engine
+                .getMeterRegistry(1)
+                .get("zeebe.message.start.cross.partition.lock.releases.sent.total")
+                .tag("trigger", "reconciliation")
+                .counter()
+                .count())
+        .as("M12: the pull-based query dispatches a reconciliation-triggered release")
+        .isEqualTo(1.0);
+
     // and no PUSHED cleanup is appended: this gone holder has no leftover holder-origin entry, so
     // the origin cleanup only fires for holders that actually left one behind (e.g. banned ones)
     assertThat(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseReleaseProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseReleaseProcessorTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBufferedMessageStartEventBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -30,6 +31,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageStartCorrelationKeyLockRel
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -52,6 +54,7 @@ public final class MessageStartCorrelationKeyLockReleaseReleaseProcessorTest {
   private BpmnBufferedMessageStartEventBehavior bufferedBehavior;
   private StateWriter stateWriter;
   private TypedRejectionWriter rejectionWriter;
+  private SimpleMeterRegistry meterRegistry;
   private MessageStartCorrelationKeyLockReleaseReleaseProcessor processor;
 
   @BeforeEach
@@ -63,9 +66,18 @@ public final class MessageStartCorrelationKeyLockReleaseReleaseProcessorTest {
     final var writers = mock(Writers.class);
     when(writers.state()).thenReturn(stateWriter);
     when(writers.rejection()).thenReturn(rejectionWriter);
+    meterRegistry = new SimpleMeterRegistry();
     processor =
         new MessageStartCorrelationKeyLockReleaseReleaseProcessor(
-            messageState, bufferedBehavior, writers);
+            messageState, bufferedBehavior, writers, new MessageCorrelationMetrics(meterRegistry));
+  }
+
+  private double releaseCount(final String result) {
+    return meterRegistry
+        .get("zeebe.message.start.cross.partition.lock.releases.total")
+        .tag("result", result)
+        .counter()
+        .count();
   }
 
   @Test
@@ -100,6 +112,9 @@ public final class MessageStartCorrelationKeyLockReleaseReleaseProcessorTest {
 
     // and the reply is not rejected
     verify(rejectionWriter, never()).appendRejection(any(), any(), anyString());
+
+    // and the release is counted as a released outcome (M13)
+    assertThat(releaseCount("released")).isEqualTo(1.0);
   }
 
   @Test
@@ -117,6 +132,9 @@ public final class MessageStartCorrelationKeyLockReleaseReleaseProcessorTest {
         .appendRejection(eq(record), eq(RejectionType.INVALID_STATE), anyString());
     verify(stateWriter, never()).appendFollowUpEvent(anyLong(), any(), any());
     verifyNoInteractions(bufferedBehavior);
+
+    // and the release is counted as a redundant outcome (M13)
+    assertThat(releaseCount("redundant")).isEqualTo(1.0);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionMetricsTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
+import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Multi-partition metric assertions for the cross-partition message-start handshake counters. This
+ * class drives the same scenarios as {@link MessageStartProcessInstanceCrossPartitionHandshakeTest}
+ * and only asserts that the meters are recorded on the expected partition registries.
+ */
+public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
+
+  private static final int PARTITION_COUNT = 3;
+
+  // Same stable routing constants as the handshake test: hash("ck-1") and hash("biz-1") land on
+  // different partitions so the cross-partition arm is exercised (re-asserted at @Before).
+  private static final String CORRELATION_KEY = "ck-1";
+  private static final String BUSINESS_ID = "biz-1";
+
+  private static final String PROCESS_ID = "wf-cross";
+  private static final String MESSAGE_NAME = "start-msg";
+  private static final String START_EVENT_ID = "msgStart";
+
+  private static final String ASKS_METRIC = "zeebe.message.start.cross.partition.asks.total";
+
+  private static final BpmnModelInstance MESSAGE_START_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent(START_EVENT_ID)
+          .message(MESSAGE_NAME)
+          .serviceTask("task", t -> t.zeebeJobType("test"))
+          .endEvent()
+          .done();
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.multiplePartition(PARTITION_COUNT)
+          .withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
+
+  @Before
+  public void assertCrossPartitionRouting() {
+    assertThat(partitionFor(CORRELATION_KEY))
+        .as(
+            "CORRELATION_KEY (%s) and BUSINESS_ID (%s) must hash to different partitions so the"
+                + " cross-partition arm is actually exercised",
+            CORRELATION_KEY, BUSINESS_ID)
+        .isNotEqualTo(partitionFor(BUSINESS_ID));
+  }
+
+  @Test
+  public void shouldRecordAskMetricForCleanCrossPartitionStart() {
+    // given
+    deployAndAwaitStartEventSubscriptionsOnAllPartitions(MESSAGE_START_PROCESS);
+
+    // when a message-start publish lands on P_K but its businessId hashes to P_B
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey(CORRELATION_KEY)
+        .withBusinessId(BUSINESS_ID)
+        .publish();
+
+    // and the handshake completes: the PI is started on P_B
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+        .withElementType(BpmnElementType.PROCESS)
+        .withBpmnProcessId(PROCESS_ID)
+        .getFirst();
+
+    // then the ask is counted on P_K (M3)
+    final int pK = partitionFor(CORRELATION_KEY);
+    assertThat(counter(pK, ASKS_METRIC))
+        .as("M3: the cross-partition ask is dispatched from P_K")
+        .isEqualTo(1.0);
+  }
+
+  private double counter(final int partition, final String name) {
+    final var counter = engine.getMeterRegistry(partition).find(name).counter();
+    return counter != null ? counter.count() : 0.0;
+  }
+
+  private void deployAndAwaitStartEventSubscriptionsOnAllPartitions(
+      final BpmnModelInstance process) {
+    engine.deployment().withXmlResource(process).deploy();
+    RecordingExporter.messageStartEventSubscriptionRecords(
+            MessageStartEventSubscriptionIntent.CREATED)
+        .withMessageName(MESSAGE_NAME)
+        .limit(PARTITION_COUNT)
+        .asList();
+  }
+
+  private static int partitionFor(final String key) {
+    return SubscriptionUtil.getSubscriptionPartitionId(BufferUtil.wrapString(key), PARTITION_COUNT);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionMetricsTest.java
@@ -13,7 +13,9 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -23,9 +25,10 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * Multi-partition metric assertions for the cross-partition message-start handshake counters. This
- * class drives the same scenarios as {@link MessageStartProcessInstanceCrossPartitionHandshakeTest}
- * and only asserts that the meters are recorded on the expected partition registries.
+ * Multi-partition metric assertions for the cross-partition message-start handshake counters M1
+ * (REQUEST outcomes on {@code P_B}) and M3 (asks dispatched from {@code P_K}). This class drives
+ * the same scenarios as {@link MessageStartProcessInstanceCrossPartitionHandshakeTest} and only
+ * asserts that the meters are recorded on the expected partition registries.
  */
 public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
 
@@ -40,6 +43,8 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
   private static final String MESSAGE_NAME = "start-msg";
   private static final String START_EVENT_ID = "msgStart";
 
+  private static final String REQUESTS_METRIC =
+      "zeebe.message.start.cross.partition.requests.total";
   private static final String ASKS_METRIC = "zeebe.message.start.cross.partition.asks.total";
 
   private static final BpmnModelInstance MESSAGE_START_PROCESS =
@@ -48,6 +53,17 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
           .message(MESSAGE_NAME)
           .serviceTask("task", t -> t.zeebeJobType("test"))
           .endEvent()
+          .done();
+
+  private static final BpmnModelInstance DUAL_START_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent("noneStart")
+          .serviceTask("task", t -> t.zeebeJobType("test"))
+          .endEvent()
+          .moveToProcess(PROCESS_ID)
+          .startEvent(START_EVENT_ID)
+          .message(MESSAGE_NAME)
+          .connectTo("task")
           .done();
 
   @Rule
@@ -66,7 +82,7 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
   }
 
   @Test
-  public void shouldRecordAskMetricForCleanCrossPartitionStart() {
+  public void shouldRecordAskAndRequestMetricsForCleanCrossPartitionStart() {
     // given
     deployAndAwaitStartEventSubscriptionsOnAllPartitions(MESSAGE_START_PROCESS);
 
@@ -83,16 +99,68 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
         .withElementType(BpmnElementType.PROCESS)
         .withBpmnProcessId(PROCESS_ID)
         .getFirst();
+    RecordingExporter.messageStartProcessInstanceRequestRecords(
+            MessageStartProcessInstanceRequestIntent.STARTED)
+        .getFirst();
 
-    // then the ask is counted on P_K (M3)
+    // then the ask is counted on P_K (M3) and the REQUEST is counted as started on P_B (M1)
     final int pK = partitionFor(CORRELATION_KEY);
-    assertThat(counter(pK, ASKS_METRIC))
+    final int pB = partitionFor(BUSINESS_ID);
+    assertThat(counter(pK, ASKS_METRIC, null, null))
         .as("M3: the cross-partition ask is dispatched from P_K")
+        .isEqualTo(1.0);
+    assertThat(counter(pB, REQUESTS_METRIC, "outcome", "started"))
+        .as("M1: the REQUEST is decided as a clean start on P_B")
         .isEqualTo(1.0);
   }
 
-  private double counter(final int partition, final String name) {
-    final var counter = engine.getMeterRegistry(partition).find(name).counter();
+  @Test
+  public void shouldRecordUniquenessRejectionRequestMetric() {
+    // given a holder PI already owns the businessId on P_B
+    deployAndAwaitStartEventSubscriptionsOnAllPartitions(DUAL_START_PROCESS);
+    final long holderKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .onPartition(partitionFor(BUSINESS_ID))
+            .withBusinessId(BUSINESS_ID)
+            .create();
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .filter(r -> r.getValue().getProcessInstanceKey() == holderKey)
+        .getFirst();
+
+    // when a message-start publish asks P_B for the same businessId
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey(CORRELATION_KEY)
+        .withBusinessId(BUSINESS_ID)
+        .withTimeToLive(0L)
+        .publish();
+
+    // and P_B replies UNIQUENESS_REJECTED
+    RecordingExporter.messageStartProcessInstanceRequestRecords(
+            MessageStartProcessInstanceRequestIntent.UNIQUENESS_REJECTED)
+        .getFirst();
+
+    // then the uniqueness rejection is counted on the REQUEST side (M1) and an ask was sent (M3)
+    final int pK = partitionFor(CORRELATION_KEY);
+    final int pB = partitionFor(BUSINESS_ID);
+    assertThat(counter(pB, REQUESTS_METRIC, "outcome", "rejected_uniqueness"))
+        .as("M1: the REQUEST is rejected for businessId uniqueness on P_B")
+        .isGreaterThanOrEqualTo(1.0);
+    assertThat(counter(pK, ASKS_METRIC, null, null))
+        .as("M3: at least one ask was dispatched from P_K")
+        .isGreaterThanOrEqualTo(1.0);
+  }
+
+  private double counter(
+      final int partition, final String name, final String tagKey, final String tagValue) {
+    var search = engine.getMeterRegistry(partition).find(name);
+    if (tagKey != null) {
+      search = search.tag(tagKey, tagValue);
+    }
+    final var counter = search.counter();
     return counter != null ? counter.count() : 0.0;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionMetricsTest.java
@@ -26,9 +26,10 @@ import org.junit.Test;
 
 /**
  * Multi-partition metric assertions for the cross-partition message-start handshake counters M1
- * (REQUEST outcomes on {@code P_B}) and M3 (asks dispatched from {@code P_K}). This class drives
- * the same scenarios as {@link MessageStartProcessInstanceCrossPartitionHandshakeTest} and only
- * asserts that the meters are recorded on the expected partition registries.
+ * (REQUEST outcomes on {@code P_B}), M2 (reply outcomes on {@code P_K}) and M3 (asks dispatched
+ * from {@code P_K}). This class drives the same scenarios as {@link
+ * MessageStartProcessInstanceCrossPartitionHandshakeTest} and only asserts that the meters are
+ * recorded on the expected partition registries.
  */
 public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
 
@@ -45,6 +46,7 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
 
   private static final String REQUESTS_METRIC =
       "zeebe.message.start.cross.partition.requests.total";
+  private static final String REPLIES_METRIC = "zeebe.message.start.cross.partition.replies.total";
   private static final String ASKS_METRIC = "zeebe.message.start.cross.partition.asks.total";
 
   private static final BpmnModelInstance MESSAGE_START_PROCESS =
@@ -82,7 +84,7 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
   }
 
   @Test
-  public void shouldRecordAskAndRequestMetricsForCleanCrossPartitionStart() {
+  public void shouldRecordAskRequestAndReplyMetricsForCleanCrossPartitionStart() {
     // given
     deployAndAwaitStartEventSubscriptionsOnAllPartitions(MESSAGE_START_PROCESS);
 
@@ -94,7 +96,7 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
         .withBusinessId(BUSINESS_ID)
         .publish();
 
-    // and the handshake completes: the PI is started on P_B
+    // and the handshake completes: the PI is started on P_B and P_K processes the STARTED reply
     RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
         .withElementType(BpmnElementType.PROCESS)
         .withBpmnProcessId(PROCESS_ID)
@@ -103,7 +105,8 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
             MessageStartProcessInstanceRequestIntent.STARTED)
         .getFirst();
 
-    // then the ask is counted on P_K (M3) and the REQUEST is counted as started on P_B (M1)
+    // then the ask is counted on P_K (M3), the REQUEST is counted as started on P_B (M1), and the
+    // STARTED reply is counted on P_K (M2)
     final int pK = partitionFor(CORRELATION_KEY);
     final int pB = partitionFor(BUSINESS_ID);
     assertThat(counter(pK, ASKS_METRIC, null, null))
@@ -112,10 +115,13 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
     assertThat(counter(pB, REQUESTS_METRIC, "outcome", "started"))
         .as("M1: the REQUEST is decided as a clean start on P_B")
         .isEqualTo(1.0);
+    assertThat(counter(pK, REPLIES_METRIC, "outcome", "started"))
+        .as("M2: the STARTED reply is processed on P_K")
+        .isEqualTo(1.0);
   }
 
   @Test
-  public void shouldRecordUniquenessRejectionRequestMetric() {
+  public void shouldRecordUniquenessRejectionRequestAndReplyMetrics() {
     // given a holder PI already owns the businessId on P_B
     deployAndAwaitStartEventSubscriptionsOnAllPartitions(DUAL_START_PROCESS);
     final long holderKey =
@@ -143,11 +149,14 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
             MessageStartProcessInstanceRequestIntent.UNIQUENESS_REJECTED)
         .getFirst();
 
-    // then the uniqueness rejection is counted on the REQUEST side (M1) and an ask was sent (M3)
+    // then the uniqueness rejection is counted on both the REQUEST (M1) and reply (M2) sides
     final int pK = partitionFor(CORRELATION_KEY);
     final int pB = partitionFor(BUSINESS_ID);
     assertThat(counter(pB, REQUESTS_METRIC, "outcome", "rejected_uniqueness"))
         .as("M1: the REQUEST is rejected for businessId uniqueness on P_B")
+        .isGreaterThanOrEqualTo(1.0);
+    assertThat(counter(pK, REPLIES_METRIC, "outcome", "rejected_uniqueness"))
+        .as("M2: the uniqueness-rejection reply is processed on P_K")
         .isGreaterThanOrEqualTo(1.0);
     assertThat(counter(pK, ASKS_METRIC, null, null))
         .as("M3: at least one ask was dispatched from P_K")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceReplyProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceReplyProcessorTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.state.immutable.MessageCorrelationState;
@@ -35,6 +36,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -59,6 +61,8 @@ public final class MessageStartProcessInstanceReplyProcessorTest {
   private MessageState mockMessageState;
   private TypedResponseWriter mockResponseWriter;
   private MessageCorrelationState mockMessageCorrelationState;
+  private SimpleMeterRegistry meterRegistry;
+  private MessageCorrelationMetrics metrics;
 
   @BeforeEach
   void setUp() {
@@ -66,22 +70,44 @@ public final class MessageStartProcessInstanceReplyProcessorTest {
     mockMessageState = mock(MessageState.class);
     mockResponseWriter = mock(TypedResponseWriter.class);
     mockMessageCorrelationState = mock(MessageCorrelationState.class);
+    meterRegistry = new SimpleMeterRegistry();
+    metrics = new MessageCorrelationMetrics(meterRegistry);
+  }
+
+  private double replyCount(final String outcome) {
+    return meterRegistry
+        .get("zeebe.message.start.cross.partition.replies.total")
+        .tag("outcome", outcome)
+        .counter()
+        .count();
   }
 
   private MessageStartProcessInstanceRequestStartProcessor startProcessor() {
     return new MessageStartProcessInstanceRequestStartProcessor(
-        mockStateWriter, mockResponseWriter, mockMessageState, mockMessageCorrelationState);
+        mockStateWriter,
+        mockResponseWriter,
+        mockMessageState,
+        mockMessageCorrelationState,
+        metrics);
   }
 
   private MessageStartProcessInstanceRequestRejectUniquenessProcessor uniquenessProcessor() {
     return new MessageStartProcessInstanceRequestRejectUniquenessProcessor(
-        mockStateWriter, mockResponseWriter, mockMessageCorrelationState, mockMessageState);
+        mockStateWriter,
+        mockResponseWriter,
+        mockMessageCorrelationState,
+        mockMessageState,
+        metrics);
   }
 
   private MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor
       noSubscriptionProcessor() {
     return new MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor(
-        mockStateWriter, mockResponseWriter, mockMessageCorrelationState, mockMessageState);
+        mockStateWriter,
+        mockResponseWriter,
+        mockMessageCorrelationState,
+        mockMessageState,
+        metrics);
   }
 
   @SuppressWarnings("unchecked")
@@ -155,6 +181,9 @@ public final class MessageStartProcessInstanceReplyProcessorTest {
 
       verify(mockStateWriter)
           .appendFollowUpEvent(eq(MESSAGE_KEY), eq(MessageIntent.EXPIRED), any());
+
+      // and the STARTED reply outcome is counted (M2)
+      assertThat(replyCount("started")).isEqualTo(1.0);
     }
 
     @Test
@@ -271,6 +300,9 @@ public final class MessageStartProcessInstanceReplyProcessorTest {
               eq(record.getKey()),
               eq(MessageStartProcessInstanceRequestIntent.UNIQUENESS_REJECTED),
               any());
+
+      // and the uniqueness-rejection reply outcome is counted (M2)
+      assertThat(replyCount("rejected_uniqueness")).isEqualTo(1.0);
     }
 
     @Test
@@ -350,6 +382,9 @@ public final class MessageStartProcessInstanceReplyProcessorTest {
               eq(record.getKey()),
               eq(MessageStartProcessInstanceRequestIntent.NO_SUBSCRIPTION_REJECTED),
               any());
+
+      // and the no-subscription-rejection reply outcome is counted (M2)
+      assertThat(replyCount("rejected_no_subscription")).isEqualTo(1.0);
     }
 
     @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestSweepExpiredDedupsProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestSweepExpiredDedupsProcessorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.state.immutable.MessageStartProcessInstanceDedupState;
+import io.camunda.zeebe.engine.state.immutable.MessageStartProcessInstanceDedupState.ExpiredEntryVisitor;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessInstanceRequestRecord;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.InstantSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the swept-dedup metric (M11) recorded by the expired-dedup sweeper on {@code P_B}.
+ * The processor deletes past-deadline dedup rows in bounded batches; the metric lets an operator
+ * see how many entries each sweep cycle reclaims.
+ */
+public final class MessageStartProcessInstanceRequestSweepExpiredDedupsProcessorTest {
+
+  private static final long RECORD_KEY = 42L;
+  private static final int BATCH_LIMIT = 64;
+  private static final String SWEPT_METRIC =
+      "zeebe.message.start.cross.partition.dedup.swept.total";
+
+  private StateWriter mockStateWriter;
+  private TypedCommandWriter mockCommandWriter;
+  private MessageStartProcessInstanceDedupState mockDedupState;
+  private TypedRecord<MessageStartProcessInstanceRequestRecord> mockRecord;
+  private SimpleMeterRegistry meterRegistry;
+  private MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor processor;
+
+  @BeforeEach
+  void setUp() {
+    mockStateWriter = mock(StateWriter.class);
+    mockCommandWriter = mock(TypedCommandWriter.class);
+    mockDedupState = mock(MessageStartProcessInstanceDedupState.class);
+    mockRecord = mock(TypedRecord.class);
+    when(mockRecord.getKey()).thenReturn(RECORD_KEY);
+
+    meterRegistry = new SimpleMeterRegistry();
+    processor =
+        new MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor(
+            mockStateWriter,
+            mockCommandWriter,
+            mockDedupState,
+            BATCH_LIMIT,
+            InstantSource.system(),
+            new MessageCorrelationMetrics(meterRegistry));
+  }
+
+  @Test
+  void shouldRecordSweptCountForDeletedEntries() {
+    // given three past-deadline dedup rows to visit
+    visitEntries(3);
+
+    // when
+    processor.processRecord(mockRecord);
+
+    // then the swept counter (M11) is incremented once per deleted entry
+    assertThat(meterRegistry.get(SWEPT_METRIC).counter().count()).isEqualTo(3.0);
+  }
+
+  @Test
+  void shouldNotRecordWhenNothingSwept() {
+    // given no past-deadline dedup rows
+    visitEntries(0);
+
+    // when
+    processor.processRecord(mockRecord);
+
+    // then the swept counter (M11) stays at zero
+    assertThat(meterRegistry.get(SWEPT_METRIC).counter().count()).isEqualTo(0.0);
+  }
+
+  private void visitEntries(final int count) {
+    when(mockDedupState.visitExpiredEntries(anyLong(), org.mockito.ArgumentMatchers.any()))
+        .thenAnswer(
+            invocation -> {
+              final ExpiredEntryVisitor visitor = invocation.getArgument(1);
+              for (int i = 0; i < count; i++) {
+                visitor.visit(100L + i, 200L + i);
+              }
+              return false;
+            });
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -25,6 +25,7 @@ import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.DistributionMetrics;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
@@ -50,6 +51,7 @@ import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.FeatureFlags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.time.InstantSource;
 import java.util.Optional;
@@ -119,7 +121,8 @@ public final class MessageStreamProcessorTest {
               routingInfo,
               mock(AuthorizationCheckPort.class),
               mock(LazyTokenClaimsConverter.class),
-              mock(EngineSecurityConfig.class));
+              mock(EngineSecurityConfig.class),
+              new MessageCorrelationMetrics(new SimpleMeterRegistry()));
           return typedRecordProcessors;
         });
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/PendingMessageStartAskCheckSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/PendingMessageStartAskCheckSchedulerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.state.immutable.MessageStartProcessInstanceAskState;
 import io.camunda.zeebe.engine.state.immutable.MessageStartProcessInstanceAskState.PendingAskVisitor;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +49,8 @@ public final class PendingMessageStartAskCheckSchedulerTest {
   private ProcessingScheduleService mockScheduleService;
   private ReadonlyStreamProcessorContext mockContext;
   private StreamClock mockClock;
+  private SimpleMeterRegistry meterRegistry;
+  private MessageCorrelationMetrics metrics;
   private PendingMessageStartAskCheckScheduler scheduler;
 
   @BeforeEach
@@ -57,6 +61,8 @@ public final class PendingMessageStartAskCheckSchedulerTest {
     mockScheduleService = mock(ProcessingScheduleService.class);
     mockContext = mock(ReadonlyStreamProcessorContext.class);
     mockClock = mock(StreamClock.class);
+    meterRegistry = new SimpleMeterRegistry();
+    metrics = new MessageCorrelationMetrics(meterRegistry);
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     when(mockContext.getClock()).thenReturn(mockClock);
@@ -64,7 +70,14 @@ public final class PendingMessageStartAskCheckSchedulerTest {
 
     scheduler =
         new PendingMessageStartAskCheckScheduler(
-            mockCommandSender, mockState, mockRoutingInfo, () -> RETRY_INTERVAL);
+            mockCommandSender, mockState, mockRoutingInfo, () -> RETRY_INTERVAL, metrics);
+  }
+
+  private double retryCount() {
+    return meterRegistry
+        .get("zeebe.message.start.cross.partition.asks.retries.total")
+        .counter()
+        .count();
   }
 
   /**
@@ -184,6 +197,34 @@ public final class PendingMessageStartAskCheckSchedulerTest {
 
       // then
       verify(mockState).updateLastSentTime(1L, 100L, NOW);
+    }
+
+    @Test
+    void shouldRecordRetryMetricPerSentAsk() {
+      // given two due asks
+      scheduler.onRecovered(mockContext);
+      stubPendingAsks(
+          NOW - BASE_MILLIS, createAsk(1L, 100L, "business-a"), createAsk(2L, 200L, "business-b"));
+      when(mockRoutingInfo.partitionForCorrelationKey(any())).thenReturn(2);
+
+      // when
+      scheduler.run();
+
+      // then every scheduler send is counted as a retry (M8)
+      assertThat(retryCount()).isEqualTo(2.0);
+    }
+
+    @Test
+    void shouldNotRecordRetryMetricWhenNoAskIsDue() {
+      // given a fresh ask that is not yet due
+      scheduler.onRecovered(mockContext);
+      stubPendingAsks(NOW, createAsk(1L, 100L, "my-business-id"));
+
+      // when
+      scheduler.run();
+
+      // then no retry is counted
+      assertThat(retryCount()).isEqualTo(0.0);
     }
 
     @Test
@@ -369,7 +410,8 @@ public final class PendingMessageStartAskCheckSchedulerTest {
               mockCommandSender,
               mockState,
               mockRoutingInfo,
-              () -> Duration.ofMillis(Long.MAX_VALUE / 3));
+              () -> Duration.ofMillis(Long.MAX_VALUE / 3),
+              metrics);
       hugeBaseScheduler.onRecovered(mockContext);
       // a rejected ask (count 6) last sent long ago, evaluated at a normal clock value
       stubPendingAsks(0L, createAsk(1L, 100L, "b", 6L));


### PR DESCRIPTION
## Description

Introduces `MessageCorrelationMetricsDoc` and `MessageCorrelationMetrics` to instrument the Business-ID message-start correlation feature end-to-end. This makes the cross-partition uniqueness handshake, ask/retry volume, and lock-release health fully observable.

### What's added

**New classes:**
- `MessageCorrelationMetricsDoc` — `ExtendedMeterDocumentation` enum documenting all meters and their closed-enum tag values (`outcome`, `trigger`, `result`). The `partition` tag is supplied automatically by the per-partition registry.
- `MessageCorrelationMetrics` — recording class with `EnumMap`-backed, lazily-registered counters and a `DistributionSummary`.

**Meters implemented:**

| ID | Metric name | Type | Tags | Recorded on |
|----|-------------|------|------|-------------|
| M1 | `zeebe.message.start.cross.partition.requests.total` | Counter | `outcome` (started, dedup_hit, rejected_uniqueness, rejected_no_subscription, rejected_not_activatable, rejected_expired) | `P_B` — REQUEST decision ladder |
| M2 | `zeebe.message.start.cross.partition.replies.total` | Counter | `outcome` (started, rejected_uniqueness, rejected_no_subscription, rejected_expired) | `P_K` — reply processors |
| M3 | `zeebe.message.start.cross.partition.asks.total` | Counter | — | `P_K` — per newly-registered ask |
| M8 | `zeebe.message.start.cross.partition.asks.retries.total` | Counter | — | `P_K` — per scheduler retry send |
| M9 | `zeebe.message.start.cross.partition.lock.release.queries.total` | Counter | — | `P_K` — per reconciliation query dispatched |
| M10 | `zeebe.message.start.cross.partition.lock.release.query.batch.size` | Distribution | — (SLOs: 1, 8, 16, 32, 64, 128) | `P_K` — holder count per query |
| M11 | `zeebe.message.start.cross.partition.dedup.swept.total` | Counter | — | `P_B` — expired dedup entries swept per batch |
| M12 | `zeebe.message.start.cross.partition.lock.releases.sent.total` | Counter | `trigger` (push, reconciliation) | `P_B` — lock-release commands sent |
| M13 | `zeebe.message.start.cross.partition.lock.releases.total` | Counter | `result` (released, redundant) | `P_K` — lock-release outcomes applied |

**Wiring:**
- `MessageCorrelationMetrics` is constructed in `EngineProcessors` and threaded through `createBehaviors` / `BpmnBehaviorsImpl` and both `addMessageProcessors` overloads.
- All recording happens only on live leader paths (command processors, behaviors, schedulers) — never inside event appliers — so replay is always replay-safe.

### Why this matters

The Business-ID handshake and lock-release path was previously uninstrumented. The **M1/M2** and **M12/M13** counter pairs expose inter-partition reply and push loss that the retry mechanism otherwise silently papers over, enabling operators to detect and diagnose cross-partition correlation issues.

### Testing

- `MessageCorrelationMetricsTest` — unit tests for every recording method against a `SimpleMeterRegistry`.
- `MessageStartProcessInstanceCrossPartitionMetricsTest` — multi-partition integration tests asserting M1, M2, and M3 on the correct partition registries for happy-path and uniqueness-rejection scenarios.
- Updated existing processor/scheduler tests (`PendingMessageStartAskCheckSchedulerTest`, `CrossPartitionMessageStartLockReleaseSchedulerTest`, `MessageStartCorrelationKeyLockReleaseReleaseProcessorTest`, `MessageStartProcessInstanceReplyProcessorTest`, etc.) to assert the relevant counters.

## Related issues

closes #59138