### PR TITLE
fix: prevent historic index rename corruption when prefix recurs in name

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/migration/PrefixMigrationHelper.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/PrefixMigrationHelper.java
@@ -531,7 +531,8 @@ public final class PrefixMigrationHelper {
                   if (isHistoricIndex(
                       srcIndex, descriptor.getIndexName(), descriptor.getVersion())) {
                     destIndex =
-                        srcIndex.replace(
+                        renameHistoricIndexPrefix(
+                            srcIndex,
                             oldPrefix,
                             descriptor.getIndexPrefix() + "-" + descriptor.getComponentName());
                   } else {
@@ -545,6 +546,25 @@ public final class PrefixMigrationHelper {
       return Optional.of(new AliasCloneTargets(srcAlias, destAlias, targetIndices));
     }
     return Optional.empty();
+  }
+
+  /**
+   * {@code srcIndex} is expected to start with {@code oldPrefix} (it comes from {@link
+   * PrefixMigrationClient#getIndicesInAlias}, whose alias is built from that same prefix), so only
+   * the leading occurrence must be swapped. A plain {@link String#replace} would also rewrite any
+   * later occurrence of {@code oldPrefix} inside the rest of the index name. The prefix is verified
+   * rather than assumed, since an alias can in principle be attached to an index whose name doesn't
+   * follow the expected convention -- silently mangling such a name would be worse than the bug
+   * being fixed here.
+   */
+  @VisibleForTesting
+  static String renameHistoricIndexPrefix(
+      final String srcIndex, final String oldPrefix, final String newPrefixAndComponent) {
+    if (!srcIndex.startsWith(oldPrefix)) {
+      throw new IllegalStateException(
+          "Expected historic index [%s] to start with prefix [%s]".formatted(srcIndex, oldPrefix));
+    }
+    return newPrefixAndComponent + srcIndex.substring(oldPrefix.length());
   }
 
   private static List<String> indicesToDelete(

--- a/dist/src/test/java/io/camunda/application/commons/migration/PrefixMigrationHelperTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/migration/PrefixMigrationHelperTest.java
@@ -8,6 +8,7 @@
 package io.camunda.application.commons.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.search.schema.PrefixMigrationClient;
 import io.camunda.search.schema.utils.CloneResult;
@@ -334,6 +335,69 @@ class PrefixMigrationHelperTest {
     } finally {
       executor.close();
     }
+  }
+
+  @Test
+  void shouldRenameHistoricIndexWhenOldPrefixRecursInBaseIndexName() {
+    // given
+    // old prefix "instance" recurs inside the base index name "flownode-instance"
+    final var srcIndex = "instance-flownode-instance-8.3.0_2024-11-03";
+    final var oldPrefix = "instance";
+    final var newPrefixAndComponent = "new-prefix";
+
+    // when
+    final var destIndex =
+        PrefixMigrationHelper.renameHistoricIndexPrefix(srcIndex, oldPrefix, newPrefixAndComponent);
+
+    // then
+    assertThat(destIndex).isEqualTo("new-prefix-flownode-instance-8.3.0_2024-11-03");
+  }
+
+  @Test
+  void shouldRenameHistoricIndexWhenOldPrefixDoesNotRecur() {
+    // given
+    final var srcIndex = "old-prefix-decision-8.3.0_2024-11-03";
+    final var oldPrefix = "old-prefix";
+    final var newPrefixAndComponent = "new-prefix";
+
+    // when
+    final var destIndex =
+        PrefixMigrationHelper.renameHistoricIndexPrefix(srcIndex, oldPrefix, newPrefixAndComponent);
+
+    // then
+    assertThat(destIndex).isEqualTo("new-prefix-decision-8.3.0_2024-11-03");
+  }
+
+  @Test
+  void shouldRenameHistoricIndexWhenNewPrefixIsEmpty() {
+    // given
+    final var srcIndex = "old-prefix-decision-8.3.0_2024-11-03";
+    final var oldPrefix = "old-prefix";
+    final var newPrefixAndComponent = "";
+
+    // when
+    final var destIndex =
+        PrefixMigrationHelper.renameHistoricIndexPrefix(srcIndex, oldPrefix, newPrefixAndComponent);
+
+    // then
+    assertThat(destIndex).isEqualTo("-decision-8.3.0_2024-11-03");
+  }
+
+  @Test
+  void shouldThrowWhenSrcIndexDoesNotStartWithOldPrefix() {
+    // given
+    final var srcIndex = "unrelated-index-name-8.3.0_2024-11-03";
+    final var oldPrefix = "old-prefix";
+    final var newPrefixAndComponent = "new-prefix";
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                PrefixMigrationHelper.renameHistoricIndexPrefix(
+                    srcIndex, oldPrefix, newPrefixAndComponent))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(srcIndex)
+        .hasMessageContaining(oldPrefix);
   }
 
   /**


### PR DESCRIPTION
## Summary
- The prefix-migration tool renamed historic (archived) indices via `srcIndex.replace(oldPrefix, newPrefix)`, an unanchored replace that rewrites every occurrence of `oldPrefix`, not just the leading segment
- If `oldPrefix` recurs later in the index name (e.g. old prefix `instance` recurring inside base index name `flownode-instance`), the rename corrupted the destination name, and the clone silently targeted a name the schema didn't expect
- Replaced it with a leading-segment-only swap extracted into a small, independently unit-testable function, with the prefix match verified (fails loudly) rather than assumed

Closes #59057 