### PR TITLE
fix: surface prefix-migration clone failures and validate target prefix

### DIFF
--- a/dist/src/main/java/io/camunda/application/StandalonePrefixMigration.java
+++ b/dist/src/main/java/io/camunda/application/StandalonePrefixMigration.java
@@ -19,6 +19,7 @@ import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverr
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import java.io.IOException;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.WebApplicationType;
@@ -34,11 +35,13 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
       TasklistIndexPrefixPropertiesOverride.class,
       OperateIndexPrefixPropertiesOverride.class
     })
-public class StandalonePrefixMigration implements CommandLineRunner {
+public class StandalonePrefixMigration implements CommandLineRunner, ExitCodeGenerator {
 
   private final ConnectConfiguration connectConfiguration;
   private final TasklistIndexPrefixPropertiesOverride tasklistProperties;
   private final OperateIndexPrefixPropertiesOverride operateProperties;
+
+  private int exitCode;
 
   public StandalonePrefixMigration(
       final ConnectConfiguration connectConfiguration,
@@ -72,15 +75,20 @@ public class StandalonePrefixMigration implements CommandLineRunner {
             .addCommandLineProperties(true)
             .build(args);
 
-    application.run(args);
-
-    System.exit(0);
+    System.exit(SpringApplication.exit(application.run(args)));
   }
 
   @Override
   public void run(final String... args) throws Exception {
-    PrefixMigrationHelper.runPrefixMigration(
-        operateProperties, tasklistProperties, connectConfiguration);
+    final var success =
+        PrefixMigrationHelper.runPrefixMigration(
+            operateProperties, tasklistProperties, connectConfiguration);
+    exitCode = success ? 0 : 1;
+  }
+
+  @Override
+  public int getExitCode() {
+    return exitCode;
   }
 
   ///  Override {@link io.camunda.tasklist.property.TasklistProperties} bean which is validated

--- a/dist/src/main/java/io/camunda/application/commons/migration/PrefixMigrationHelper.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/PrefixMigrationHelper.java
@@ -52,6 +52,7 @@ import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -115,6 +116,16 @@ public final class PrefixMigrationHelper {
               TasklistVariableIndex.class);
 
   /**
+   * Prefix literals reserved by other components (see
+   * https://docs.camunda.io/docs/self-managed/concepts/secondary-storage/managing-secondary-storage/).
+   * A target prefix exactly matching one of these would collide with a component-name segment in
+   * the resulting index names.
+   */
+  @VisibleForTesting
+  public static final Set<String> RESERVED_INDEX_PREFIX_LITERALS =
+      Set.of("camunda", "tasklist", "operate", "zeebe-record", "optimize");
+
+  /**
    * Conservative limit for the combined length of comma-separated index names in a single DELETE
    * request URL, to avoid exceeding http.max_initial_line_length (default: 4096 bytes). The
    * overhead for the HTTP request line (e.g. "DELETE / HTTP/1.1") is subtracted.
@@ -140,6 +151,10 @@ public final class PrefixMigrationHelper {
             ? tasklistProperties.elasticsearchIndexPrefix()
             : tasklistProperties.opensearchIndexPrefix();
     final var targetPrefix = connectConfiguration.getIndexPrefix();
+
+    if (!isValidTargetPrefix(targetPrefix, operatePrefix, tasklistPrefix)) {
+      return false;
+    }
 
     final var prefixMigrationClient = getPrefixMigrationClient(connectConfiguration);
     final var descriptors = new IndexDescriptors(targetPrefix, isElasticsearch);
@@ -222,6 +237,57 @@ public final class PrefixMigrationHelper {
     }
 
     return true;
+  }
+
+  /**
+   * Validates the target index prefix before any clone operation starts. Logs every violation found
+   * (rather than failing fast) so an operator sees all problems in a single run. See
+   * https://docs.camunda.io/docs/self-managed/concepts/secondary-storage/managing-secondary-storage/.
+   */
+  @VisibleForTesting
+  static boolean isValidTargetPrefix(
+      final String targetPrefix, final String operatePrefix, final String tasklistPrefix) {
+    if (!StringUtils.hasText(targetPrefix)) {
+      // a blank target prefix is a legitimate "no prefix" configuration
+      return true;
+    }
+
+    final var lowerTargetPrefix = targetPrefix.toLowerCase(Locale.ROOT);
+    var valid = true;
+
+    if (StringUtils.hasText(operatePrefix)
+        && startsWithEitherWay(lowerTargetPrefix, operatePrefix.toLowerCase(Locale.ROOT))) {
+      LOG.error(
+          "Target index prefix [{}] must not reuse or be a prefix of the old Operate index"
+              + " prefix [{}]",
+          targetPrefix,
+          operatePrefix);
+      valid = false;
+    }
+
+    if (StringUtils.hasText(tasklistPrefix)
+        && startsWithEitherWay(lowerTargetPrefix, tasklistPrefix.toLowerCase(Locale.ROOT))) {
+      LOG.error(
+          "Target index prefix [{}] must not reuse or be a prefix of the old Tasklist index"
+              + " prefix [{}]",
+          targetPrefix,
+          tasklistPrefix);
+      valid = false;
+    }
+
+    if (RESERVED_INDEX_PREFIX_LITERALS.contains(lowerTargetPrefix)) {
+      LOG.error(
+          "Target index prefix [{}] must not be one of the reserved names {}",
+          targetPrefix,
+          RESERVED_INDEX_PREFIX_LITERALS);
+      valid = false;
+    }
+
+    return valid;
+  }
+
+  private static boolean startsWithEitherWay(final String a, final String b) {
+    return a.startsWith(b) || b.startsWith(a);
   }
 
   public static Supplier<CompletableFuture<List<CloneResult>>> migrate(

--- a/dist/src/main/java/io/camunda/application/commons/migration/PrefixMigrationHelper.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/PrefixMigrationHelper.java
@@ -21,6 +21,7 @@ import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.search.schema.PrefixMigrationClient;
 import io.camunda.search.schema.elasticsearch.ElasticsearchPrefixMigrationClient;
 import io.camunda.search.schema.opensearch.OpensearchPrefixMigrationClient;
+import io.camunda.search.schema.utils.CloneResult;
 import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
 import io.camunda.webapps.schema.descriptors.AbstractTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
@@ -124,7 +125,7 @@ public final class PrefixMigrationHelper {
 
   private PrefixMigrationHelper() {}
 
-  public static void runPrefixMigration(
+  public static boolean runPrefixMigration(
       final OperateIndexPrefixPropertiesOverride operateProperties,
       final TasklistIndexPrefixPropertiesOverride tasklistProperties,
       final ConnectConfiguration connectConfiguration) {
@@ -138,53 +139,92 @@ public final class PrefixMigrationHelper {
         isElasticsearch
             ? tasklistProperties.elasticsearchIndexPrefix()
             : tasklistProperties.opensearchIndexPrefix();
+    final var targetPrefix = connectConfiguration.getIndexPrefix();
 
     final var prefixMigrationClient = getPrefixMigrationClient(connectConfiguration);
-    final var targetPrefix = connectConfiguration.getIndexPrefix();
     final var descriptors = new IndexDescriptors(targetPrefix, isElasticsearch);
     final var executor = Executors.newVirtualThreadPerTaskExecutor();
 
-    final var migrateFutures =
-        PrefixMigrationHelper.migrate(
-            operatePrefix,
-            tasklistPrefix,
-            targetPrefix,
-            isElasticsearch,
-            descriptors,
-            prefixMigrationClient,
-            executor);
+    try {
+      final var migrateFutures =
+          PrefixMigrationHelper.migrate(
+              operatePrefix,
+              tasklistPrefix,
+              targetPrefix,
+              isElasticsearch,
+              descriptors,
+              prefixMigrationClient,
+              executor);
 
-    final var deleteFutures =
-        PrefixMigrationHelper.deleteDeprecatedIndices(
-            operatePrefix, tasklistPrefix, isElasticsearch, prefixMigrationClient, descriptors);
+      final var cloneResults = migrateFutures.get().join();
+      if (!logResultsAndCheckAllSucceeded(cloneResults)) {
+        return false;
+      }
 
-    final var deleteIndexTemplateFutures =
-        PrefixMigrationHelper.deleteIndexTemplates(
-            operatePrefix,
-            tasklistPrefix,
-            isElasticsearch,
-            prefixMigrationClient,
-            descriptors,
-            executor);
+      final var deleteFutures =
+          PrefixMigrationHelper.deleteDeprecatedIndices(
+              operatePrefix, tasklistPrefix, isElasticsearch, prefixMigrationClient, descriptors);
 
-    final var deleteComponentTemplateFutures =
-        PrefixMigrationHelper.deleteComponentTemplates(
-            operatePrefix, tasklistPrefix, prefixMigrationClient);
+      final var deleteIndexTemplateFutures =
+          PrefixMigrationHelper.deleteIndexTemplates(
+              operatePrefix,
+              tasklistPrefix,
+              isElasticsearch,
+              prefixMigrationClient,
+              descriptors,
+              executor);
 
-    CompletableFuture.allOf(migrateFutures.get())
-        .thenRun(() -> LOG.info("Migration of indices completed."))
-        .thenCompose(v -> CompletableFuture.allOf(deleteFutures.get()))
-        .thenRun(() -> LOG.info("Deletion of indices completed."))
-        .thenCompose(v -> CompletableFuture.allOf(deleteIndexTemplateFutures.get()))
-        .thenRun(() -> LOG.info("Deletion of index templates completed."))
-        .thenCompose(v -> CompletableFuture.allOf(deleteComponentTemplateFutures.get()))
-        .thenRun(() -> LOG.info("Deletion of component templates completed."))
-        .join();
+      final var deleteComponentTemplateFutures =
+          PrefixMigrationHelper.deleteComponentTemplates(
+              operatePrefix, tasklistPrefix, prefixMigrationClient);
 
-    executor.close();
+      CompletableFuture.allOf(deleteFutures.get())
+          .thenRun(() -> LOG.info("Deletion of indices completed."))
+          .thenCompose(v -> CompletableFuture.allOf(deleteIndexTemplateFutures.get()))
+          .thenRun(() -> LOG.info("Deletion of index templates completed."))
+          .thenCompose(v -> CompletableFuture.allOf(deleteComponentTemplateFutures.get()))
+          .thenRun(() -> LOG.info("Deletion of component templates completed."))
+          .join();
+
+      return true;
+    } catch (final Exception e) {
+      LOG.error("Prefix migration failed", e);
+      return false;
+    } finally {
+      executor.close();
+    }
   }
 
-  public static Supplier<CompletableFuture[]> migrate(
+  /**
+   * Logs an overall summary and reports whether every clone succeeded. Each failed clone is already
+   * logged with its cause at the point of failure (see {@code handleMigrationFailure} in the
+   * elasticsearch/opensearch {@code PrefixMigrationClient} implementations), so only the summary is
+   * logged here to avoid duplicate log lines. Deprecated-index/template deletion must only proceed
+   * when this returns {@code true} - deleting an old index whose clone failed would destroy the
+   * only remaining copy of that data.
+   */
+  @VisibleForTesting
+  static boolean logResultsAndCheckAllSucceeded(final List<CloneResult> cloneResults) {
+    final var failedResults = cloneResults.stream().filter(result -> !result.successful()).toList();
+
+    LOG.info(
+        "Migrated {}/{} indices, {} failed",
+        cloneResults.size() - failedResults.size(),
+        cloneResults.size(),
+        failedResults.size());
+
+    if (!failedResults.isEmpty()) {
+      LOG.error(
+          "Skipping deletion of deprecated indices, index templates, and component templates"
+              + " because {} index clone(s) failed.",
+          failedResults.size());
+      return false;
+    }
+
+    return true;
+  }
+
+  public static Supplier<CompletableFuture<List<CloneResult>>> migrate(
       final String operatePrefix,
       final String tasklistPrefix,
       final String targetPrefix,
@@ -221,28 +261,36 @@ public final class PrefixMigrationHelper {
                   .map(cloneOperations::add));
     }
 
-    return () ->
-        cloneOperations.stream()
-            .parallel()
-            .map(
-                entry ->
-                    CompletableFuture.supplyAsync(
-                        () -> {
-                          final var innerFutures =
-                              entry.indices().stream()
-                                  .parallel()
-                                  .map(
-                                      idx ->
-                                          prefixMigrationClient.cloneAndDeleteIndex(
-                                              idx.getLeft(),
-                                              entry.srcAlias,
-                                              idx.getRight(),
-                                              entry.destAlias))
-                                  .toArray(CompletableFuture[]::new);
-                          return CompletableFuture.allOf(innerFutures).join();
-                        },
-                        executor))
-            .toArray(CompletableFuture[]::new);
+    return () -> {
+      final var entryFutures =
+          cloneOperations.stream()
+              .parallel()
+              .map(
+                  entry ->
+                      CompletableFuture.supplyAsync(
+                          () -> {
+                            // Materialize every clone future for this alias group before
+                            // blocking, so all clones are in flight concurrently instead of
+                            // being started and joined one at a time.
+                            final var innerFutures =
+                                entry.indices().stream()
+                                    .map(
+                                        idx ->
+                                            prefixMigrationClient.cloneAndDeleteIndex(
+                                                idx.getLeft(),
+                                                entry.srcAlias,
+                                                idx.getRight(),
+                                                entry.destAlias))
+                                    .toList();
+                            return innerFutures.stream().map(CompletableFuture::join).toList();
+                          },
+                          executor))
+              .toList();
+
+      return CompletableFuture.allOf(entryFutures.toArray(CompletableFuture[]::new))
+          .thenApply(
+              ignored -> entryFutures.stream().flatMap(future -> future.join().stream()).toList());
+    };
   }
 
   private static Supplier<CompletableFuture> deleteDeprecatedIndices(

--- a/dist/src/test/java/io/camunda/application/commons/migration/PrefixMigrationHelperTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/migration/PrefixMigrationHelperTest.java
@@ -132,6 +132,105 @@ class PrefixMigrationHelperTest {
   }
 
   @Test
+  void shouldAcceptBlankTargetPrefix() {
+    // when
+    final var valid = PrefixMigrationHelper.isValidTargetPrefix("", "operate-dev", "tasklist-dev");
+
+    // then
+    assertThat(valid).isTrue();
+  }
+
+  @Test
+  void shouldAcceptTargetPrefixUnrelatedToOldPrefixesAndReservedNames() {
+    // when
+    final var valid =
+        PrefixMigrationHelper.isValidTargetPrefix("some-new-prefix", "operate-dev", "tasklist-dev");
+
+    // then
+    assertThat(valid).isTrue();
+  }
+
+  @Test
+  void shouldAcceptTargetPrefixThatMerelyContainsAReservedName() {
+    // when - "my-env-camunda" contains "camunda" but is not equal to it
+    final var valid =
+        PrefixMigrationHelper.isValidTargetPrefix("my-env-camunda", "operate-dev", "tasklist-dev");
+
+    // then
+    assertThat(valid).isTrue();
+  }
+
+  @Test
+  void shouldRejectTargetPrefixExactlyEqualToAReservedName() {
+    // when
+    final var valid =
+        PrefixMigrationHelper.isValidTargetPrefix("camunda", "operate-dev", "tasklist-dev");
+
+    // then
+    assertThat(valid).isFalse();
+  }
+
+  @Test
+  void shouldRejectTargetPrefixEqualToAReservedNameCaseInsensitively() {
+    // when
+    final var valid =
+        PrefixMigrationHelper.isValidTargetPrefix("CAMUNDA", "operate-dev", "tasklist-dev");
+
+    // then
+    assertThat(valid).isFalse();
+  }
+
+  @Test
+  void shouldRejectTargetPrefixThatStartsWithAnOldPrefix() {
+    // when - old operate prefix "operate", target "operate-dev-2" starts with it
+    final var valid =
+        PrefixMigrationHelper.isValidTargetPrefix("operate-dev-2", "operate", "tasklist-dev");
+
+    // then
+    assertThat(valid).isFalse();
+  }
+
+  @Test
+  void shouldRejectTargetPrefixThatIsAPrefixOfAnOldPrefix() {
+    // when - old operate prefix "operate-dev" starts with target "operate"
+    final var valid =
+        PrefixMigrationHelper.isValidTargetPrefix("operate", "operate-dev", "tasklist-dev");
+
+    // then
+    assertThat(valid).isFalse();
+  }
+
+  @Test
+  void shouldAcceptTargetPrefixThatOnlySharesCharactersWithOldPrefixWithoutStartsWithRelation() {
+    // when - "dev" is not a startsWith match in either direction against "operate-dev"
+    final var valid =
+        PrefixMigrationHelper.isValidTargetPrefix("dev", "operate-dev", "tasklist-dev");
+
+    // then
+    assertThat(valid).isTrue();
+  }
+
+  @Test
+  void shouldSkipOldPrefixCheckWhenOldPrefixIsBlank() {
+    // when - operate isn't being migrated (blank prefix), so no collision with "operate"
+    final var valid = PrefixMigrationHelper.isValidTargetPrefix("operate", "", "tasklist-dev");
+
+    // then
+    assertThat(valid).isFalse(); // still rejected - "operate" is a reserved literal
+  }
+
+  @Test
+  void shouldReportAllViolationsWithoutFailingFast() {
+    // given - "camunda" is both a reserved literal and, contrived here, the old operate prefix
+    // when
+    final var valid =
+        PrefixMigrationHelper.isValidTargetPrefix("camunda", "camunda", "tasklist-dev");
+
+    // then
+    assertThat(valid).isFalse();
+  }
+
+  @Test
   void shouldReportAllCloneSucceededWhenNoFailures() {
     // given
     final var results =

--- a/dist/src/test/java/io/camunda/application/commons/migration/PrefixMigrationHelperTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/migration/PrefixMigrationHelperTest.java
@@ -9,8 +9,14 @@ package io.camunda.application.commons.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.search.schema.PrefixMigrationClient;
+import io.camunda.search.schema.utils.CloneResult;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
@@ -123,5 +129,159 @@ class PrefixMigrationHelperTest {
     // then
     assertThat(batches).hasSize(1);
     assertThat(batches.getFirst()).containsExactly(index);
+  }
+
+  @Test
+  void shouldReportAllCloneSucceededWhenNoFailures() {
+    // given
+    final var results =
+        List.of(
+            new CloneResult(true, "source-a", "dest-a", null),
+            new CloneResult(true, "source-b", "dest-b", null));
+
+    // when
+    final var allSucceeded = PrefixMigrationHelper.logResultsAndCheckAllSucceeded(results);
+
+    // then
+    assertThat(allSucceeded).isTrue();
+  }
+
+  @Test
+  void shouldReportCloneFailureWhenAnyResultFailed() {
+    // given
+    final var results =
+        List.of(
+            new CloneResult(true, "source-a", "dest-a", null),
+            new CloneResult(false, "source-b", "dest-b", new RuntimeException("clone failed")));
+
+    // when
+    final var allSucceeded = PrefixMigrationHelper.logResultsAndCheckAllSucceeded(results);
+
+    // then
+    assertThat(allSucceeded).isFalse();
+  }
+
+  @Test
+  void shouldReportFailureWhenAllClonesFailed() {
+    // given
+    final var results =
+        List.of(
+            new CloneResult(false, "source-a", "dest-a", new RuntimeException("boom")),
+            new CloneResult(false, "source-b", "dest-b", new RuntimeException("boom")));
+
+    // when
+    final var allSucceeded = PrefixMigrationHelper.logResultsAndCheckAllSucceeded(results);
+
+    // then
+    assertThat(allSucceeded).isFalse();
+  }
+
+  @Test
+  void shouldReportSuccessForEmptyResults() {
+    // when
+    final var allSucceeded = PrefixMigrationHelper.logResultsAndCheckAllSucceeded(List.of());
+
+    // then
+    assertThat(allSucceeded).isTrue();
+  }
+
+  @Test
+  void shouldFlattenCloneResultsAcrossAllAliasGroups() {
+    // given
+    final var expectedTotal =
+        PrefixMigrationHelper.TASKLIST_INDICES_TO_MIGRATE.size()
+            + PrefixMigrationHelper.OPERATE_INDICES_TO_MIGRATE.size();
+    final var descriptors = new IndexDescriptors("camunda", true);
+    final var client = new FakePrefixMigrationClient(Set.of());
+    final var executor = Executors.newVirtualThreadPerTaskExecutor();
+
+    try {
+      // when
+      final var results =
+          PrefixMigrationHelper.migrate(
+                  "operate-dev", "tasklist-dev", "camunda", true, descriptors, client, executor)
+              .get()
+              .join();
+
+      // then
+      assertThat(results).hasSize(expectedTotal);
+      assertThat(results).allMatch(CloneResult::successful);
+    } finally {
+      executor.close();
+    }
+  }
+
+  @Test
+  void shouldFlattenMixedSuccessAndFailureCloneResultsAcrossAliasGroups() {
+    // given - only the ProcessIndex alias group is made to fail
+    final var expectedTotal =
+        PrefixMigrationHelper.TASKLIST_INDICES_TO_MIGRATE.size()
+            + PrefixMigrationHelper.OPERATE_INDICES_TO_MIGRATE.size();
+    final var descriptors = new IndexDescriptors("camunda", true);
+    final var client = new FakePrefixMigrationClient(Set.of("process"));
+    final var executor = Executors.newVirtualThreadPerTaskExecutor();
+
+    try {
+      // when
+      final var results =
+          PrefixMigrationHelper.migrate(
+                  "operate-dev", "tasklist-dev", "camunda", true, descriptors, client, executor)
+              .get()
+              .join();
+
+      // then
+      assertThat(results).hasSize(expectedTotal);
+      assertThat(results.stream().filter(result -> !result.successful())).hasSize(1);
+    } finally {
+      executor.close();
+    }
+  }
+
+  /**
+   * Fake {@link PrefixMigrationClient} that reports exactly one index per queried alias and
+   * completes {@code cloneAndDeleteIndex} synchronously, failing only for aliases containing one of
+   * the given substrings - used to exercise {@link PrefixMigrationHelper#migrate} without a real
+   * Elasticsearch/OpenSearch client.
+   */
+  private static final class FakePrefixMigrationClient implements PrefixMigrationClient {
+    private final Set<String> failingAliasSubstrings;
+
+    private FakePrefixMigrationClient(final Set<String> failingAliasSubstrings) {
+      this.failingAliasSubstrings = failingAliasSubstrings;
+    }
+
+    @Override
+    public List<String> getIndicesInAlias(final String alias) {
+      return List.of(alias.replace("_alias", "_index"));
+    }
+
+    @Override
+    public CompletableFuture<CloneResult> cloneAndDeleteIndex(
+        final String source,
+        final String sourceAlias,
+        final String destination,
+        final String destinationAlias) {
+      final var shouldFail = failingAliasSubstrings.stream().anyMatch(sourceAlias::contains);
+      return CompletableFuture.completedFuture(
+          shouldFail
+              ? new CloneResult(
+                  false, source, destination, new RuntimeException("simulated failure"))
+              : new CloneResult(true, source, destination, null));
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteIndex(final String... indexName) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteComponentTemplate(final String componentTemplateName) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteIndexTemplate(final String indexTemplateName) {
+      return CompletableFuture.completedFuture(null);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- `StandalonePrefixMigration` (`bin/prefix-migration`) previously always exited 0 and always logged success, even if every index clone failed, because `CloneResult.successful()` was computed but never checked. A failed run looked identical to a successful one, which is a real data-loss risk since operators are told not to restart the 8.7 cluster once this tool has run.
- `PrefixMigrationHelper.runPrefixMigration` now surfaces clone failures: it logs an accurate `Migrated X/Y indices, Z failed` summary, skips deleting deprecated indices/templates entirely if any clone failed, and returns a `boolean` outcome. `StandalonePrefixMigration` now implements `ExitCodeGenerator` and propagates that outcome as the process exit code.
- Added `isValidTargetPrefix`: rejects a target prefix that collides with an old Operate/Tasklist prefix (`startsWith` either direction, case-insensitive) or that exactly matches a reserved component-name literal (`camunda`, `tasklist`, `operate`, `zeebe-record`, `optimize`). A blank target prefix is explicitly still accepted - it's an existing, documented "no prefix" configuration, not an error.

Closes #59056