### PR TITLE
test: fix recurring ZeebeUserTaskImportIT flake caused by exporter index prefix collision

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -158,7 +158,7 @@ jobs:
         with:
           name: integration-test-elasticsearch-${{ matrix.includedGroups }}-junit
           path: |
-            **/failsafe-reports/**/*.xml
+            **/failsafe-reports/**
 
       - name: Docker log dump
         uses: ./.github/actions/docker-logs
@@ -249,7 +249,7 @@ jobs:
         with:
           name: integration-test-opensearch-${{ matrix.includedGroups }}-junit
           path: |
-            **/failsafe-reports/**/*.xml
+            **/failsafe-reports/**
 
       - name: Docker log dump
         uses: ./.github/actions/docker-logs

--- a/optimize/backend/src/it/java/io/camunda/optimize/AbstractCCSMIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/AbstractCCSMIT.java
@@ -291,6 +291,9 @@ public abstract class AbstractCCSMIT extends AbstractIT {
     // are inconsequential since no further tests will read these indices.
     databaseIntegrationTestExtension.deleteAllZeebeIndicesForPrefix(
         zeebeExtension.getZeebeRecordPrefix());
+    // The secondary storage uses its own prefix, so it is not covered by the call above.
+    databaseIntegrationTestExtension.deleteAllZeebeIndicesForPrefix(
+        zeebeExtension.getSecondaryStoragePrefix());
   }
 
   @Override

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeUserTaskImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeUserTaskImportIT.java
@@ -91,11 +91,11 @@ public class ZeebeUserTaskImportIT extends AbstractCCSMIT {
     final ProcessInstanceEvent instance =
         deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
     waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    // remove all zeebe records except userTask ones to test userTask import only
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
     List<ZeebeUserTaskRecordDto> userTaskEvents = getZeebeExportedUserTaskEvents();
     zeebeExtension.completeZeebeUserTask(getExpectedUserTaskInstanceIdFromRecords(userTaskEvents));
     waitUntilUserTaskRecordWithIntentExported(COMPLETED);
+    // remove all zeebe records except userTask ones to test userTask import only
+    removeAllZeebeExportRecordsExceptUserTaskRecords();
 
     // when
     importAllZeebeEntitiesFromScratch();
@@ -153,6 +153,8 @@ public class ZeebeUserTaskImportIT extends AbstractCCSMIT {
     List<ZeebeUserTaskRecordDto> userTaskEvents = getZeebeExportedUserTaskEvents();
     zeebeExtension.completeZeebeUserTask(getExpectedUserTaskInstanceIdFromRecords(userTaskEvents));
     waitUntilUserTaskRecordWithIntentExported(COMPLETED);
+    // remove all zeebe records except userTask ones to test userTask import only
+    removeAllZeebeExportRecordsExceptUserTaskRecords();
 
     // when
     importAllZeebeEntitiesFromLastIndex();
@@ -497,6 +499,8 @@ public class ZeebeUserTaskImportIT extends AbstractCCSMIT {
     zeebeExtension.assignUserTask(
         getExpectedUserTaskInstanceIdFromRecords(exportedEvents), ASSIGNEE_ID);
     waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
+    // remove all zeebe records except userTask ones to test userTask import only
+    removeAllZeebeExportRecordsExceptUserTaskRecords();
 
     // when
     importAllZeebeEntitiesFromLastIndex();
@@ -635,6 +639,8 @@ public class ZeebeUserTaskImportIT extends AbstractCCSMIT {
       zeebeExtension.unassignUserTask(getExpectedUserTaskInstanceIdFromRecords(exportedEvents));
       waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
     }
+    // remove all zeebe records except userTask ones to test userTask import only
+    removeAllZeebeExportRecordsExceptUserTaskRecords();
 
     // when
     importAllZeebeEntitiesFromLastIndex();

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
@@ -55,6 +55,16 @@ public class ZeebeExtension implements BeforeAllCallback, AfterAllCallback {
 
   private String zeebeRecordPrefix;
 
+  /**
+   * Index prefix for the broker's secondary storage (CamundaExporter, Operate, Tasklist).
+   *
+   * <p>Deliberately not a prefix-match of {@link #zeebeRecordPrefix}. Tests clean up Zeebe records
+   * with wildcards over {@code <zeebeRecordPrefix>*}; when both shared one prefix those wildcards
+   * dropped CamundaExporter's own state indices, and the exporter then failed every bulk flush,
+   * stalling the whole exporter pipeline and starving the records Optimize reads. See #58881.
+   */
+  private String secondaryStoragePrefix;
+
   /** Keys of all process instances started during the current test. */
   private final Set<Long> startedInstanceKeys = ConcurrentHashMap.newKeySet();
 
@@ -65,6 +75,7 @@ public class ZeebeExtension implements BeforeAllCallback, AfterAllCallback {
   @Override
   public void beforeAll(final ExtensionContext extensionContext) {
     zeebeRecordPrefix = ZeebeConstants.ZEEBE_RECORD_TEST_PREFIX + "-" + IdGenerator.getNextId();
+    secondaryStoragePrefix = "camunda-secondary-" + IdGenerator.getNextId();
     final var dbType = IntegrationTestConfigurationUtil.getDatabaseType();
     Testcontainers.exposeHostPorts(9200);
     buildAndStartBroker(dbType);
@@ -108,7 +119,7 @@ public class ZeebeExtension implements BeforeAllCallback, AfterAllCallback {
                 cfg.getData()
                     .getSecondaryStorage()
                     .getOpensearch()
-                    .setIndexPrefix(zeebeRecordPrefix);
+                    .setIndexPrefix(secondaryStoragePrefix);
               } else {
                 cfg.getData()
                     .getSecondaryStorage()
@@ -117,7 +128,7 @@ public class ZeebeExtension implements BeforeAllCallback, AfterAllCallback {
                 cfg.getData()
                     .getSecondaryStorage()
                     .getElasticsearch()
-                    .setIndexPrefix(zeebeRecordPrefix);
+                    .setIndexPrefix(secondaryStoragePrefix);
               }
             })
         .withExporter(
@@ -373,6 +384,10 @@ public class ZeebeExtension implements BeforeAllCallback, AfterAllCallback {
 
   public void resolveIncident(final Long incidentKey) {
     camundaClient.newResolveIncidentCommand(incidentKey).send().join();
+  }
+
+  public String getSecondaryStoragePrefix() {
+    return secondaryStoragePrefix;
   }
 
   public String getZeebeRecordPrefix() {


### PR DESCRIPTION
## Problem

`io.camunda.optimize.service.importing.ZeebeUserTaskImportIT` is a recurring flake in the `Optimize / Integration / Elasticsearch ITs (ccsm-test)` CI job. The class stalls and the job hits the 30-minute cap.

## Root cause

`ZeebeExtension` gave the Zeebe record exporter and the broker's secondary storage (CamundaExporter, Operate, Tasklist) the same index prefix. The CCSM test cleanups use a `<zeebeRecordPrefix>*` wildcard and drop everything they match, so they destroyed CamundaExporter's own state indices (`camunda-wait-state`, `camunda-history-deletion`, `camunda-audit-log-cleanup`, `tasklist-task`, `operate-batch-operation`).

CamundaExporter then failed every bulk flush with `no such index`. All exporters on a partition share one `ExporterDirector`, so the failing exporter stopped the director advancing and starved the record stream that Optimize reads. Tests that wait for their own records timed out.

## Evidence

A **green** run of the class (16/16, 43.45 s) still logged 1060 exporter flush failures, in three bursts that match the per-test cleanups. Every missing index was secondary-storage state; none was one of Optimize's six Zeebe record indices. The breakage was constant and latent — green runs were only lucky.

## Changes

1. Secondary storage moves to its own `camunda-secondary-<id>` prefix. `@AfterAll` now also drops those indices, because the per-prefix cleanup no longer covers them.
2. Four tests in `ZeebeUserTaskImportIT` now clean non-user-task records immediately before each import. An unblocked exporter exposed a latent race in them, because process-instance records written after the cleanup now actually arrive.
3. The Optimize IT jobs upload the full `failsafe-reports` directory. A cancelled job never finalizes the JUnit XML, so the per-fork output files are the only record of why a class stalled.

The unsound teardown wait in `AbstractCCSMIT` had two chained 60s Awaitility waits, 120s worst case, which could never succeed after a test dropped the Zeebe indices was replaced with a single wait plus diagnostics. That part is already on `main`.

## Verification

Against a clean Elasticsearch 8.19.16:

- flush failures 1060 -> 0
- `no such index` errors 0
- broker output 1.46 MB -> 225 KB
- `Exporter opened` on both partitions
- the class is 16/16 in 38 s
- the full `ccsm-test` suite is 222 tests, 0 failures. It previously failed
  `importCompletedUnclaimedZeebeUserTaskData_viaWriter` under load.

## Known remaining (cosmetic)

7 `no such index [camunda-secondary-<id>-camunda-wait-state/history-deletion]` warnings at class teardown, because `@AfterAll` drops the secondary indices while the broker is still alive. They come after all assertions pass.

Relates to #58881

🤖 Generated with [Claude Code](https://claude.com/claude-code)
