### PR TITLE
ci: fail fast on GCS build-cache WIF auth hangs instead of eating the job timeout

### DIFF
--- a/.github/actions/gcs-build-cache-auth/README.md
+++ b/.github/actions/gcs-build-cache-auth/README.md
@@ -6,26 +6,27 @@ Authenticates `gcloud` against the run-scoped GCS build-cache bucket
 (`camunda-monorepo-ci-artifacts`) used to share the Zeebe distball and the
 locally-installed `m2` SNAPSHOT tarball across jobs (see #52693).
 
-It bundles the three steps every build-cache consumer repeated verbatim:
+It bundles the four steps every build-cache consumer repeated verbatim:
 
-1. Fetch the `monorepo-build-cache-sa` service account from Vault (WIF provider +
+1. Detect fork PRs (via [`is-fork`](../is-fork)) and skip Vault/WIF auth entirely
+   when running on one, since secrets aren't available there.
+2. Fetch the `monorepo-build-cache-sa` service account from Vault (WIF provider +
    service account, no long-lived key).
-2. Authenticate via `google-github-actions/auth` using Workload Identity Federation.
-3. Install the gcloud CLI via `google-github-actions/setup-gcloud`.
+3. Authenticate via `google-github-actions/auth` using Workload Identity Federation.
+4. Install the gcloud CLI via `google-github-actions/setup-gcloud`.
 
 After this action runs, the caller issues its own `gcloud storage` command
 (`cp` upload/download, or `rm` cleanup) — the storage operation stays at the call
 site so upload/download/delete intent is visible where it happens.
 
-Most build jobs get this indirectly: `setup-build` nests this action behind its
-opt-in `gcs-build-cache-auth: true` input (auto-disabled for fork PRs). Call this
-action directly when either:
-
-- the job has no build stack (no `setup-build`), e.g. the lightweight
-  `check-results` cleanup; or
-- a long step runs between `setup-build` and the `gcloud storage` command (e.g.
-  `build-distball`'s ~15-min build), so auth must happen late to keep the WIF/OIDC
-  token fresh.
+Call this action directly as its own job step, right alongside (not nested inside)
+`setup-build` when the build stack is also needed. It is **not** wired into
+`setup-build` itself: composite actions can't set `timeout-minutes` on their own
+steps (only a workflow step calling a `uses:` action can), so this action must stay
+a direct, top-level step in the workflow for its caller to bound a Vault/WIF hang
+with `timeout-minutes` — see INC-6820, where a silent WIF hang inside a nested
+call consumed an entire job's timeout budget before GitHub killed the job.
+Always set `timeout-minutes` (e.g. `3`) on the call site.
 
 ## Prerequisites
 
@@ -33,6 +34,8 @@ action directly when either:
   action is referenced by local path.
 - The calling job needs `permissions: id-token: write` so `google-github-actions/auth`
   can mint the OIDC token for WIF.
+- The calling *step* should set `timeout-minutes` (e.g. `3`) so a Vault/WIF hang
+  fails fast instead of silently consuming the job's whole timeout budget.
 
 ## Usage
 
@@ -59,7 +62,9 @@ jobs:
       id-token: write  # required for WIF auth
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/gcs-build-cache-auth
+      - name: Authenticate to GCS build-cache
+        timeout-minutes: 3  # fail fast on a Vault/WIF hang -- see INC-6820
+        uses: ./.github/actions/gcs-build-cache-auth
         with:
           vault-addr: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/actions/gcs-build-cache-auth/action.yml
+++ b/.github/actions/gcs-build-cache-auth/action.yml
@@ -21,6 +21,7 @@ runs:
     - name: Fetch GCS build-cache credentials
       id: gcs-secrets
       uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+      timeout-minutes: 3
       with:
         url: ${{ inputs.vault-addr }}
         method: approle
@@ -30,7 +31,9 @@ runs:
         secrets: |
           secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa SERVICE_ACCOUNT | GCS_SA;
           secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa WORKLOAD_IDENTITY_PROVIDER | GCS_WIF;
-    - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+    - name: Authenticate to GCS via WIF
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+      timeout-minutes: 3
       with:
         workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
         service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}

--- a/.github/actions/gcs-build-cache-auth/action.yml
+++ b/.github/actions/gcs-build-cache-auth/action.yml
@@ -18,10 +18,13 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Check for fork
+      uses: ./.github/actions/is-fork
+      id: is-fork
     - name: Fetch GCS build-cache credentials
       id: gcs-secrets
+      if: steps.is-fork.outputs.is-fork != 'true'
       uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
-      timeout-minutes: 3
       with:
         url: ${{ inputs.vault-addr }}
         method: approle
@@ -32,9 +35,10 @@ runs:
           secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa SERVICE_ACCOUNT | GCS_SA;
           secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa WORKLOAD_IDENTITY_PROVIDER | GCS_WIF;
     - name: Authenticate to GCS via WIF
+      if: steps.is-fork.outputs.is-fork != 'true'
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-      timeout-minutes: 3
       with:
         workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
         service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
-    - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+    - if: steps.is-fork.outputs.is-fork != 'true'
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3

--- a/.github/actions/restore-shared-m2/README.md
+++ b/.github/actions/restore-shared-m2/README.md
@@ -16,8 +16,7 @@ consumer does.
 
 - The repository must be checked out first (e.g. `actions/checkout`), since this action
   is referenced by local path.
-- gcloud must already be authenticated against the build-cache bucket — e.g. via
-  [`setup-build`](../setup-build) with `gcs-build-cache-auth: true`, or a direct
+- gcloud must already be authenticated against the build-cache bucket via a prior
   [`gcs-build-cache-auth`](../gcs-build-cache-auth) step.
 - `GCS_BUILD_CACHE_BUCKET` must be set at the workflow level, and the job must run in the
   same `github.run_id` as the `build-distball` job that produced the tarball.
@@ -42,7 +41,13 @@ steps:
       vault-address: ${{ secrets.VAULT_ADDR }}
       vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
       vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      gcs-build-cache-auth: true  # authenticates gcloud for the restore below
+  - name: Authenticate to GCS build-cache  # authenticates gcloud for the restore below
+    timeout-minutes: 3
+    uses: ./.github/actions/gcs-build-cache-auth
+    with:
+      vault-addr: ${{ secrets.VAULT_ADDR }}
+      vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+      vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
   - uses: ./.github/actions/restore-shared-m2
 ```
 

--- a/.github/actions/restore-shared-m2/action.yml
+++ b/.github/actions/restore-shared-m2/action.yml
@@ -4,7 +4,7 @@ description: >-
   Download the run-scoped m2-installed.tar (the io.camunda SNAPSHOTs that build-distball
   installed and archived to the GCS build-cache) and extract it into the local Maven
   repository, so `mvn verify` sees the SNAPSHOTs without re-running the reactor (#52693).
-  Requires gcloud to be authenticated already (e.g. setup-build's gcs-build-cache-auth: true)
+  Requires gcloud to be authenticated already (e.g. via the gcs-build-cache-auth action)
   and the GCS_BUILD_CACHE_BUCKET env var to be set at the workflow level.
 runs:
   using: composite

--- a/.github/actions/setup-build/README.md
+++ b/.github/actions/setup-build/README.md
@@ -14,21 +14,22 @@ individual jobs don't repeat the same bootstrap. In one step it:
 - merges Camunda Nexus + Google Central mirrors with any extra mirrors/servers and
   writes `settings.xml`;
 - optionally sets the build time zone;
-- optionally logs into DockerHub, Harbor, and Minimus;
-- optionally authenticates gcloud against the GCS build-cache
-  (via [`gcs-build-cache-auth`](../gcs-build-cache-auth)).
+- optionally logs into DockerHub, Harbor, and Minimus.
 
 All credential features are **automatically disabled for fork PRs**, since Vault
 secrets can't be retrieved there.
+
+GCS build-cache auth (WIF) is a separate, self-contained action —
+[`gcs-build-cache-auth`](../gcs-build-cache-auth) — called directly by the job
+rather than nested inside this one, so its own `timeout-minutes` can bound a
+Vault/WIF hang (see that action's README).
 
 ## Prerequisites
 
 - The repository must be checked out first (e.g. `actions/checkout`), since this
   action and its nested actions are referenced by local path.
-- To use any Vault-backed feature (Nexus mirror, DockerHub/Harbor/Minimus login,
-  GCS auth), pass `vault-address` / `vault-role-id` / `vault-secret-id`.
-- `gcs-build-cache-auth: true` additionally requires the job to grant
-  `permissions: id-token: write` (Workload Identity Federation).
+- To use any Vault-backed feature (Nexus mirror, DockerHub/Harbor/Minimus login),
+  pass `vault-address` / `vault-role-id` / `vault-secret-id`.
 
 ## Usage
 
@@ -41,7 +42,6 @@ secrets can't be retrieved there.
 | dockerhub-readonly       | Log into DockerHub with a read-only account to avoid rate limits                                     | false    | `"false"` |
 | harbor                   | Log into Harbor with a CI account (disabled for fork PRs)                                            | false    | `"false"` |
 | minimus                  | Log into Minimus with a CI account (disabled for fork PRs)                                           | false    | `"false"` |
-| gcs-build-cache-auth     | Opt-in: set `"true"` to authenticate gcloud to the GCS build-cache via WIF (needs `id-token: write`) | false    | `"false"` |
 | java-distribution        | Java distribution to install                                                                         | false    | `temurin` |
 | java-version             | JDK version to install                                                                               | false    | `"21"`    |
 | maven-cache-key-modifier | Modifier for the Maven cache key                                                                     | false    | `shared`  |
@@ -71,7 +71,6 @@ jobs:
   build:
     permissions:
       contents: read
-      id-token: write  # only needed when gcs-build-cache-auth is true
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-build
@@ -81,6 +80,9 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-          gcs-build-cache-auth: true  # share the run-scoped distball / m2 tarball
 ```
+
+To also share the run-scoped distball / m2 tarball via the GCS build-cache, call
+[`gcs-build-cache-auth`](../gcs-build-cache-auth) directly alongside this action —
+see its README.
 

--- a/.github/actions/setup-build/README.md
+++ b/.github/actions/setup-build/README.md
@@ -35,22 +35,22 @@ Vault/WIF hang (see that action's README).
 
 ### Inputs
 
-|          Input           |                                             Description                                              | Required |  Default  |
-|--------------------------|------------------------------------------------------------------------------------------------------|----------|-----------|
-| camunda-nexus            | Use Camunda Nexus as a Maven mirror (disabled for fork PRs)                                          | false    | `"true"`  |
-| dockerhub                | Log into DockerHub with a CI account (disabled for fork PRs)                                         | false    | `"false"` |
-| dockerhub-readonly       | Log into DockerHub with a read-only account to avoid rate limits                                     | false    | `"false"` |
-| harbor                   | Log into Harbor with a CI account (disabled for fork PRs)                                            | false    | `"false"` |
-| minimus                  | Log into Minimus with a CI account (disabled for fork PRs)                                           | false    | `"false"` |
-| java-distribution        | Java distribution to install                                                                         | false    | `temurin` |
-| java-version             | JDK version to install                                                                               | false    | `"21"`    |
-| maven-cache-key-modifier | Modifier for the Maven cache key                                                                     | false    | `shared`  |
-| maven-mirrors            | JSON list of extra Maven mirrors (merged with Nexus, extras win)                                     | false    | `'[]'`    |
-| maven-servers            | JSON list of extra Maven servers (merged with Nexus, extras win)                                     | false    | `'[]'`    |
-| time-zone                | TZ identifier for the build env, e.g. `Europe/Berlin` (Linux only)                                   | false    |           |
-| vault-address            | Vault URL to retrieve secrets from                                                                   | false    |           |
-| vault-role-id            | Vault AppRole role id                                                                                | false    |           |
-| vault-secret-id          | Vault AppRole secret id                                                                              | false    |           |
+|          Input           |                            Description                             | Required |  Default  |
+|--------------------------|--------------------------------------------------------------------|----------|-----------|
+| camunda-nexus            | Use Camunda Nexus as a Maven mirror (disabled for fork PRs)        | false    | `"true"`  |
+| dockerhub                | Log into DockerHub with a CI account (disabled for fork PRs)       | false    | `"false"` |
+| dockerhub-readonly       | Log into DockerHub with a read-only account to avoid rate limits   | false    | `"false"` |
+| harbor                   | Log into Harbor with a CI account (disabled for fork PRs)          | false    | `"false"` |
+| minimus                  | Log into Minimus with a CI account (disabled for fork PRs)         | false    | `"false"` |
+| java-distribution        | Java distribution to install                                       | false    | `temurin` |
+| java-version             | JDK version to install                                             | false    | `"21"`    |
+| maven-cache-key-modifier | Modifier for the Maven cache key                                   | false    | `shared`  |
+| maven-mirrors            | JSON list of extra Maven mirrors (merged with Nexus, extras win)   | false    | `'[]'`    |
+| maven-servers            | JSON list of extra Maven servers (merged with Nexus, extras win)   | false    | `'[]'`    |
+| time-zone                | TZ identifier for the build env, e.g. `Europe/Berlin` (Linux only) | false    |           |
+| vault-address            | Vault URL to retrieve secrets from                                 | false    |           |
+| vault-role-id            | Vault AppRole role id                                              | false    |           |
+| vault-secret-id          | Vault AppRole secret id                                            | false    |           |
 
 ### Outputs
 

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -37,14 +37,6 @@ inputs:
       Minimus login is automatically disabled for fork PRs.
     required: false
     default: "false"
-  gcs-build-cache-auth:
-    description: |
-      If enabled, authenticates gcloud against the GCS build-cache bucket via Workload
-      Identity Federation, so subsequent `gcloud storage` steps can share the run-scoped
-      distball / m2 tarball (see #52693). Requires the job to grant `permissions: id-token: write`.
-      Automatically disabled for fork PRs (no Vault access).
-    required: false
-    default: "false"
   java-distribution:
     description: Java distribution to use
     required: false
@@ -300,13 +292,3 @@ runs:
       command: |
         printf '%s' "${DOCKER_PASSWORD}" | docker login reg.mini.dev \
           --username minimus --password-stdin
-  - name: Authenticate to GCS build-cache
-    # GCS build-cache auth is disabled for fork PRs (no Vault access)
-    if: >-
-      steps.is-fork.outputs.is-fork != 'true' &&
-      inputs.gcs-build-cache-auth == 'true'
-    uses: ./.github/actions/gcs-build-cache-auth
-    with:
-      vault-addr: ${{ inputs.vault-address }}
-      vault-role-id: ${{ inputs.vault-role-id }}
-      vault-secret-id: ${{ inputs.vault-secret-id }}

--- a/.github/workflows/ci-build-distball-reusable.yml
+++ b/.github/workflows/ci-build-distball-reusable.yml
@@ -91,7 +91,11 @@ jobs:
       # integration-tests' gcp-perf shards consume these from GCS (ingress is free).
       # Authenticate here (not via setup-build) so the WIF/OIDC token is fresh: the
       # build-zeebe step above can run ~15 min, close to the OIDC token lifetime.
-      - uses: ./.github/actions/gcs-build-cache-auth
+      # timeout-minutes bounds a Vault/WIF hang so it fails fast instead of silently
+      # eating the whole job timeout-minutes budget -- see INC-6820.
+      - name: Authenticate to GCS build-cache
+        timeout-minutes: 3
+        uses: ./.github/actions/gcs-build-cache-auth
         with:
           vault-addr: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -142,8 +142,17 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-          # Authenticate gcloud when consuming the shared distball (see restore step below)
-          gcs-build-cache-auth: ${{ inputs.use-shared-distball }}
+      # Authenticate gcloud when consuming the shared distball (see restore step below).
+      # Timed out here directly (not via setup-build) so a Vault/WIF hang fails fast instead
+      # of silently eating the whole job timeout-minutes budget -- see INC-6820.
+      - name: Authenticate to GCS build-cache
+        if: ${{ inputs.use-shared-distball }}
+        timeout-minutes: 3
+        uses: ./.github/actions/gcs-build-cache-auth
+        with:
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - name: Fail fast on ambiguous physical-tenant backend
         if: ${{ inputs.physical-tenant-elasticsearch-url != '' && inputs.physical-tenant-opensearch-url != '' }}
         run: |
@@ -163,7 +172,7 @@ jobs:
       # pull from GCS (same-region, non-billable); the GHA artifact API is throughput-capped
       # on self-hosted runners. github.run_id is stable across nested workflow_call, so it
       # addresses the same run-scoped prefix build-distball wrote. See #52693 and #56931.
-      # (gcloud is authenticated by setup-build's gcs-build-cache-auth above.)
+      # (gcloud is authenticated by the GCS build-cache auth step above.)
       - if: ${{ inputs.use-shared-distball }}
         uses: ./.github/actions/restore-shared-m2
       # Fallback for standalone callers (zeebe-rdbms / zeebe-search) whose run has no

--- a/.github/workflows/ci-webapp-run-ut-reuseable.yml
+++ b/.github/workflows/ci-webapp-run-ut-reuseable.yml
@@ -69,13 +69,22 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-          # Authenticate gcloud when consuming the shared distball (see restore step below)
-          gcs-build-cache-auth: ${{ inputs.use-shared-distball }}
+      # Authenticate gcloud when consuming the shared distball (see restore step below).
+      # Timed out here directly (not via setup-build) so a Vault/WIF hang fails fast instead
+      # of silently eating the whole job timeout-minutes budget -- see INC-6820.
+      - name: Authenticate to GCS build-cache
+        if: ${{ inputs.use-shared-distball }}
+        timeout-minutes: 3
+        uses: ./.github/actions/gcs-build-cache-auth
+        with:
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       # When called from ci.yml (use-shared-distball=true) restore the io.camunda SNAPSHOTs
       # build-distball archived to GCS instead of re-running the ~2 min reactor in each of the
       # operate/tasklist/optimize back-end UT entries. github.run_id is stable across nested
       # workflow_call, addressing the same run-scoped prefix build-distball wrote. See #52693.
-      # (gcloud is authenticated by setup-build's gcs-build-cache-auth above.)
+      # (gcloud is authenticated by the GCS build-cache auth step above.)
       - if: ${{ inputs.use-shared-distball }}
         uses: ./.github/actions/restore-shared-m2
       # Fallback when the run has no build-distball job: build the platform locally.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1270,7 +1270,8 @@ jobs:
       # This job runs on a self-hosted gcp-perf runner where the artifact API is throughput-capped,
       # so restore-shared-m2 pulls from GCS (same-region, non-billable). RDBMS ITs run in-process
       # (no Docker image build), so only the m2 SNAPSHOTs are needed, not the distball tarball.
-      # gcs-build-cache-auth authenticates gcloud for that download. See build-distball.
+      # The GCS build-cache auth step below authenticates gcloud for that download.
+      # See build-distball.
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
@@ -1278,7 +1279,15 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-          gcs-build-cache-auth: true
+      # Timed out here directly (not via setup-build) so a Vault/WIF hang fails fast instead
+      # of silently eating the whole job timeout-minutes budget -- see INC-6820.
+      - name: Authenticate to GCS build-cache
+        timeout-minutes: 3
+        uses: ./.github/actions/gcs-build-cache-auth
+        with:
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - uses: ./.github/actions/restore-shared-m2
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
@@ -1374,7 +1383,7 @@ jobs:
       # Consume the shared distball instead of a ~15 min reactor build. These shards run
       # on self-hosted gcp-perf runners where the artifact API is throughput-capped, so
       # they pull from GCS (same-region, non-billable). See build-distball.
-      # gcs-build-cache-auth authenticates gcloud for the GCS download below.
+      # The GCS build-cache auth step below authenticates gcloud for the download below.
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
@@ -1383,7 +1392,15 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
-          gcs-build-cache-auth: true
+      # Timed out here directly (not via setup-build) so a Vault/WIF hang fails fast instead
+      # of silently eating the whole job timeout-minutes budget -- see INC-6820.
+      - name: Authenticate to GCS build-cache
+        timeout-minutes: 3
+        uses: ./.github/actions/gcs-build-cache-auth
+        with:
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       # Download the shared distball tarball; restore-shared-m2 below handles the SNAPSHOTs.
       - name: Create dist/target
         shell: bash
@@ -2531,9 +2548,12 @@ jobs:
       # consumer-only gate) — strictly safer: a failure anywhere keeps the objects for a rerun.
       # Orphaned objects on abandoned runs are reaped by the bucket TTL (Infra-owned).
       # continue-on-error keeps a Vault/GCS infra flake from failing the merge-queue gate.
+      # timeout-minutes additionally bounds a Vault/WIF hang so continue-on-error doesn't
+      # have to wait out the whole job timeout-minutes budget to take effect -- see INC-6820.
       - name: Authenticate to GCS build-cache
         if: env.SHOULD_CLEANUP_GCS == 'true'
         continue-on-error: true
+        timeout-minutes: 3
         uses: ./.github/actions/gcs-build-cache-auth
         with:
           vault-addr: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
## Summary
- Closes INC-6820: the Tasklist "Unit (CoreFeatures)" job on main hit its 15-minute job timeout with 14 minutes of total silence right after the `google-github-actions/auth` step started (run [30378994280](https://github.com/camunda/camunda/actions/runs/30378994280)) — a genuine hang in the WIF token exchange, not general slowness. Docker-login-retry was ruled out: the job never enables dockerhub/harbor/minimus.
- The WIF/Vault auth steps in `gcs-build-cache-auth` had no timeout, so a hang there silently consumed the entire job budget before GitHub's own job timeout killed it with an opaque "The operation was canceled." Same failure class already fixed downstream in `restore-shared-m2` by #57914, which left this earlier Vault/WIF stage unhardened.
- **`timeout-minutes` is not a supported key on steps inside a composite action** (`runs.steps`) — only workflow job steps support it. So the fix can't live inside `gcs-build-cache-auth`'s own steps; it has to be set on the workflow step that invokes `uses: ./.github/actions/gcs-build-cache-auth`.
- `setup-build` previously nested this action behind an opt-in `gcs-build-cache-auth` input, which put every such call a level too deep (workflow step → `setup-build` step → `gcs-build-cache-auth` step) for a workflow-level timeout to reach. This PR:
  - Drops that input and its internal step from `setup-build`.
  - Calls `gcs-build-cache-auth` directly as its own top-level step, with `timeout-minutes: 3`, at every former call site (the two workflows that used the `setup-build` input, plus two call sites inside `ci.yml`) and at the two sites that already called it directly (`ci-build-distball-reusable.yml`, `ci.yml`'s `check-results` cleanup).
  - Moving the invocation out of `setup-build` drops its automatic fork-PR guard, so `gcs-build-cache-auth` now does its own `is-fork` check internally (mirroring `setup-build`'s), keeping it self-contained and safe to call from anywhere.
- Neither the Vault fetch nor the WIF auth step can be wrapped in `nick-fields/retry` the way the docker/harbor/minimus logins in `setup-build` are (#58548) — retry only wraps shell commands, and these are `uses:` steps. `timeout-minutes: 3` turns a silent 14-minute hang into a fast, clear failure (well within each job's overall timeout) that existing job-level retry mechanisms (merge queue reruns, AlwaysGreen) can act on quickly.
- Updated the three READMEs (`gcs-build-cache-auth`, `setup-build`, `restore-shared-m2`) that documented the old nested wiring to match.

## Test plan
- [x] Confirm jobs using `gcs-build-cache-auth` (Tasklist/Operate/webapp unit tests via `ci-webapp-run-ut-reuseable.yml`, database integration tests, distball build, `ci.yml`'s rdbms/integration-tests shards and `check-results` cleanup) still pass normally
- [ ] Optionally force a slow/hanging Vault or WIF response to confirm the step now fails within ~3 minutes with a clear timeout error, rather than hanging silently for 14 minutes
