### PR TITLE
test: stop ILM cache test racing the policy application

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -998,13 +998,15 @@ final class ElasticsearchArchiverRepositoryIT {
     final var repository = createRepository(clientSpy);
 
     // when - first time setting policy for indexName2 it should make the put settings for
-    // indexName2
-    repository.setIndexLifeCycle(indexName2);
+    // indexName2. Wait for the future to complete rather than only for the interaction: the
+    // applied-policy cache is populated when the request completes, so resetting the spy or
+    // issuing the second round any earlier would race with the cache update.
+    repository.setIndexLifeCycle(indexName2).join();
 
     final ArgumentCaptor<PutIndicesSettingsRequest> captor =
         ArgumentCaptor.forClass(PutIndicesSettingsRequest.class);
 
-    Awaitility.await().untilAsserted(() -> verify(indicesClientSpy).putSettings(captor.capture()));
+    verify(indicesClientSpy).putSettings(captor.capture());
 
     final var putIndicesSettingsRequest = captor.getValue();
     assertThat(putIndicesSettingsRequest.index()).containsExactly(indexName2);
@@ -1014,14 +1016,13 @@ final class ElasticsearchArchiverRepositoryIT {
     // setting policy first time for indexName1 but second time for indexName2, it
     // should have cached the fact that indexName2 already has a policy and not be included in
     // the request.
-    repository.setIndexLifeCycle(indexName1);
-    repository.setIndexLifeCycle(indexName2);
+    repository.setIndexLifeCycle(indexName1).join();
+    repository.setIndexLifeCycle(indexName2).join();
 
     // then
     final var captor2 = ArgumentCaptor.forClass(PutIndicesSettingsRequest.class);
 
-    Awaitility.await()
-        .untilAsserted(() -> verify(indicesClientSpy, times(1)).putSettings(captor2.capture()));
+    verify(indicesClientSpy, times(1)).putSettings(captor2.capture());
 
     final var putIndicesSettingsRequest2 = captor2.getValue();
     assertThat(putIndicesSettingsRequest2.index()).containsExactly(indexName1);


### PR DESCRIPTION
## Description

ElasticsearchArchiverRepositoryIT.shouldCacheIndicesWhichHaveRetention PolicyAppliedAndNotReapplyPointlessly failed intermittently in CI with Mockito's "wanted 1 time, but was 2 times" on putSettings.

The test fired setIndexLifeCycle without joining the returned future and waited only for the putSettings *invocation* via Awaitility. The applied-policy cache is populated when that request completes, not when it is issued, so the second round of calls could overtake the cache update and re-apply the policy to the already-covered index -- producing the extra invocation.

Join each future before resetting the spy and before verifying, so the assertions run against a settled cache. With the futures joined the Awaitility polling is redundant, so the verifications are now direct; this also matches the sibling test
shouldReapplyILMPolicyAfterRetentionPeriodExpiration, which already joins.

## Related issues

related to [this incident](https://app.slack.com/client/T0PM0P1SA/C0BM23BNNVC)
