### PR TITLE
fix: remove nullable from `AgentInstanceHistoryItem.loopIteration`

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -21,7 +21,7 @@
 		"@bpmn-io/element-template-icon-renderer": "1.0.0",
 		"@bpmn-io/form-js-carbon-styles": "1.24.1",
 		"@bpmn-io/form-js-viewer": "1.24.1",
-		"@camunda/camunda-api-zod-schemas": "0.0.85",
+		"@camunda/camunda-api-zod-schemas": "0.0.86",
 		"@camunda/camunda-composite-components": "0.25.4",
 		"@carbon/grid": "11.58.0",
 		"@carbon/layout": "11.55.0",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -30,7 +30,7 @@
 				"@bpmn-io/element-template-icon-renderer": "1.0.0",
 				"@bpmn-io/form-js-carbon-styles": "1.24.1",
 				"@bpmn-io/form-js-viewer": "1.24.1",
-				"@camunda/camunda-api-zod-schemas": "0.0.85",
+				"@camunda/camunda-api-zod-schemas": "0.0.86",
 				"@camunda/camunda-composite-components": "0.25.4",
 				"@carbon/grid": "11.58.0",
 				"@carbon/layout": "11.55.0",
@@ -11895,7 +11895,7 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.85",
+				"@camunda/camunda-api-zod-schemas": "0.0.86",
 				"typescript": "7.0.2"
 			}
 		},
@@ -11936,7 +11936,7 @@
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.85",
+			"version": "0.0.86",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "26.1.2",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.85",
+		"@camunda/camunda-api-zod-schemas": "0.0.86",
 		"typescript": "7.0.2"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.86
+
+### 🩹 Fixes
+
+- Mark `AgentInstanceHistoryItem.loopIteration` as non-nullable in the response schema ([#57399](https://github.com/camunda/camunda/issues/57399))
+
+### ❤️ Contributors
+
+- [@christoph-fricke](https://github.com/christoph-fricke)
+
 ## v0.0.85
 
 ### 🚀 Enhancements
@@ -1126,4 +1136,3 @@ Accidental empty release
 ### ❤️ Contributors
 
 - Vinicius Goulart
-

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
@@ -176,7 +176,7 @@ const agentInstanceHistoryItemSchema = z.object({
 	elementInstanceKey: z.string(),
 	jobKey: z.string(),
 	jobLease: z.string(),
-	loopIteration: z.number().int().nullable(),
+	loopIteration: z.number().int(),
 	role: agentInstanceHistoryRoleSchema,
 	content: z.array(agentInstanceMessageContentSchema),
 	toolCalls: z.array(agentInstanceToolCallSchema),

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.85",
+	"version": "0.0.86",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

A recent backend adjusted removed nullability from the `AgentInstanceHistoryItem.loopIteration` field (https://github.com/camunda/camunda/pull/58952). This PR aligns the Zod API schema with the OpenAPI spec in regards to that change.


## TODO:

- [x] Release package version

## Related issues

relates #57399
