### PR TITLE
feat: add observability gauges and blocked-start counter for cross-partition message-start feature

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/CrossPartitionMessageStateMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/CrossPartitionMessageStateMetrics.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import static io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.CROSS_PARTITION_BUFFERED_MESSAGES;
+import static io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.CROSS_PARTITION_LOCKS;
+
+import io.camunda.zeebe.util.micrometer.StatefulGauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Exports the two cross-partition message-start occupancy gauges backed by the message state on the
+ * correlation-key partition:
+ *
+ * <ul>
+ *   <li>{@code zeebe.message.start.cross.partition.locks}: held correlation-key start locks.
+ *   <li>{@code zeebe.message.start.cross.partition.buffered.messages}: buffered business-id-indexed
+ *       messages awaiting a same-partition start.
+ * </ul>
+ *
+ * <p>Both gauges are live mirrors of column families owned by {@link
+ * io.camunda.zeebe.engine.state.message.DbMessageState}. That state increments and decrements them
+ * in lockstep with the column-family inserts and removals, and authoritatively re-seeds them from
+ * the persisted counts on recovery.
+ */
+public final class CrossPartitionMessageStateMetrics {
+
+  private final StatefulGauge startLocks;
+  private final StatefulGauge bufferedMessages;
+
+  public CrossPartitionMessageStateMetrics(final MeterRegistry meterRegistry) {
+    startLocks =
+        StatefulGauge.builder(CROSS_PARTITION_LOCKS.getName())
+            .description(CROSS_PARTITION_LOCKS.getDescription())
+            .register(meterRegistry);
+    bufferedMessages =
+        StatefulGauge.builder(CROSS_PARTITION_BUFFERED_MESSAGES.getName())
+            .description(CROSS_PARTITION_BUFFERED_MESSAGES.getDescription())
+            .register(meterRegistry);
+  }
+
+  public void incrementStartLocks() {
+    startLocks.increment();
+  }
+
+  public void decrementStartLocks() {
+    startLocks.decrement();
+  }
+
+  public void incrementBufferedMessages() {
+    bufferedMessages.increment();
+  }
+
+  public void decrementBufferedMessages() {
+    bufferedMessages.decrement();
+  }
+
+  /**
+   * Sets the start-locks gauge to an absolute value. Only call this from the stream-processing
+   * actor (for example, on recovery); calling it from elsewhere risks incorrect values due to race
+   * conditions.
+   */
+  public void setStartLocks(final long count) {
+    startLocks.set(count);
+  }
+
+  /**
+   * Sets the buffered-messages gauge to an absolute value. Only call this from the
+   * stream-processing actor (for example, on recovery); calling it from elsewhere risks incorrect
+   * values due to race conditions.
+   */
+  public void setBufferedMessages(final long count) {
+    bufferedMessages.set(count);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetrics.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.metrics;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.BlockReason;
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.MessageCorrelationKeyNames;
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReleaseResult;
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReleaseTrigger;
@@ -38,6 +39,7 @@ public final class MessageCorrelationMetrics {
       new EnumMap<>(ReleaseTrigger.class);
   private final Map<ReleaseResult, Counter> lockReleaseCounters =
       new EnumMap<>(ReleaseResult.class);
+  private final Map<BlockReason, Counter> blockedCounters = new EnumMap<>(BlockReason.class);
 
   private final Counter askCounter;
   private final Counter askRetryCounter;
@@ -132,6 +134,22 @@ public final class MessageCorrelationMetrics {
                 registerTaggedCounter(
                     MessageCorrelationMetricsDoc.LOCK_RELEASES,
                     MessageCorrelationKeyNames.RESULT.asString(),
+                    r.getLabel()))
+        .increment();
+  }
+
+  /**
+   * M14: records a message-start correlation left buffered by an active holder on the message
+   * partition, attributed to the uniqueness gate(s) that blocked it.
+   */
+  public void messageStartBlocked(final BlockReason reason) {
+    blockedCounters
+        .computeIfAbsent(
+            reason,
+            r ->
+                registerTaggedCounter(
+                    MessageCorrelationMetricsDoc.MESSAGE_START_BLOCKED,
+                    MessageCorrelationKeyNames.REASON.asString(),
                     r.getLabel()))
         .increment();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsDoc.java
@@ -395,6 +395,43 @@ public enum MessageCorrelationMetricsDoc implements ExtendedMeterDocumentation {
     public KeyName[] getAdditionalKeyNames() {
       return PartitionKeyNames.values();
     }
+  },
+
+  /**
+   * Counts message-start correlations left buffered because an active holder blocks them on the
+   * message partition: a live publish/correlate finds either the correlation key already taken by
+   * an active instance or the business id already held for the process definition, so no new
+   * instance is started and the message stays buffered until the holder frees it. The {@code
+   * reason} tag attributes each block to the gate that fired — the correlation key takes precedence
+   * — so an operator can tell correlation-key contention apart from business-id uniqueness
+   * back-pressure. A sustained rate with no matching drain (started instances) points at holders
+   * that never release.
+   */
+  MESSAGE_START_BLOCKED {
+    @Override
+    public String getName() {
+      return "zeebe.message.start.blocked.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Number of message-start correlations left buffered by an active holder on the message partition, tagged by the uniqueness gate that blocked.";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {MessageCorrelationKeyNames.REASON};
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
   };
 
   public enum MessageCorrelationKeyNames implements KeyName {
@@ -419,6 +456,14 @@ public enum MessageCorrelationMetricsDoc implements ExtendedMeterDocumentation {
       @Override
       public String asString() {
         return "result";
+      }
+    },
+
+    /** Which uniqueness gate blocked a message-start correlation (correlation key, business id). */
+    REASON {
+      @Override
+      public String asString() {
+        return "reason";
       }
     };
   }
@@ -487,6 +532,22 @@ public enum MessageCorrelationMetricsDoc implements ExtendedMeterDocumentation {
     private final String label;
 
     ReleaseResult(final String label) {
+      this.label = label;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+  }
+
+  /** Which uniqueness gate blocked a message-start correlation ({@code reason} tag). */
+  public enum BlockReason {
+    CORRELATION_KEY("correlation_key"),
+    BUSINESS_ID("business_id");
+
+    private final String label;
+
+    BlockReason(final String label) {
       this.label = label;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsDoc.java
@@ -334,9 +334,39 @@ public enum MessageCorrelationMetricsDoc implements ExtendedMeterDocumentation {
     public KeyName[] getAdditionalKeyNames() {
       return PartitionKeyNames.values();
     }
+  },
+
+  /**
+   * Tracks how many buffered messages on this partition carry a business id and are therefore
+   * indexed for the cross-partition message-start uniqueness handshake. A same-partition start that
+   * is skipped on uniqueness is re-found through this index once the holder frees the business id,
+   * so this is the subset of {@code zeebe.buffered.messages.count} that participates in the
+   * handshake. Watching it against the total buffer shows how much of the buffer the feature is
+   * responsible for, and a level that only grows points at business-id index rows that are never
+   * cleaned up.
+   */
+  CROSS_PARTITION_BUFFERED_MESSAGES {
+    @Override
+    public String getName() {
+      return "zeebe.buffered.messages.business.id.count";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Current number of buffered messages indexed by business id on the message partition for the cross-partition message-start uniqueness handshake.";
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
   };
 
-  /** The tag keys used by the message-correlation meters. */
   public enum MessageCorrelationKeyNames implements KeyName {
     /** The outcome of a cross-partition request or reply. */
     OUTCOME {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsDoc.java
@@ -278,6 +278,34 @@ public enum MessageCorrelationMetricsDoc implements ExtendedMeterDocumentation {
     public KeyName[] getAdditionalKeyNames() {
       return PartitionKeyNames.values();
     }
+  },
+
+  /**
+   * Current number of pending cross-partition message-start asks awaiting a reply on {@code P_K}.
+   * Unlike the ask counters this is a live level, seeded from persisted state on recovery: a value
+   * that stays elevated points at asks that never get a terminal reply (the blocked-start symptom
+   * spike #58900 investigates).
+   */
+  CROSS_PARTITION_ASKS_PENDING {
+    @Override
+    public String getName() {
+      return "zeebe.message.start.cross.partition.asks.pending";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Current number of pending cross-partition message-start asks awaiting a reply on the correlation-key partition (P_K).";
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
   };
 
   /** The tag keys used by the message-correlation meters. */

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsDoc.java
@@ -306,6 +306,34 @@ public enum MessageCorrelationMetricsDoc implements ExtendedMeterDocumentation {
     public KeyName[] getAdditionalKeyNames() {
       return PartitionKeyNames.values();
     }
+  },
+
+  /**
+   * Current number of held cross-partition message-start locks on {@code P_K} — correlation keys
+   * reserved by a started cross-partition instance that has not yet released them. A level that
+   * only grows points at releases that never arrive (lost push and lost reconciliation), which
+   * would block further starts on those keys.
+   */
+  CROSS_PARTITION_LOCKS {
+    @Override
+    public String getName() {
+      return "zeebe.message.start.cross.partition.locks";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Current number of held cross-partition message-start correlation-key locks on the correlation-key partition (P_K).";
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
   };
 
   /** The tag keys used by the message-correlation meters. */

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsDoc.java
@@ -365,6 +365,36 @@ public enum MessageCorrelationMetricsDoc implements ExtendedMeterDocumentation {
     public KeyName[] getAdditionalKeyNames() {
       return PartitionKeyNames.values();
     }
+  },
+
+  /**
+   * Tracks how many cross-partition message-start dedup entries are currently outstanding on {@code
+   * P_B = hash(businessId)}. Each entry records a uniqueness decision so a retried request from
+   * {@code P_K} is answered with the original result instead of starting a duplicate; it is removed
+   * once swept after its deadline. A level that only grows points at dedup rows that never expire —
+   * the sweep not keeping up — which both retains stale uniqueness decisions and grows {@code
+   * P_B}'s state unboundedly.
+   */
+  CROSS_PARTITION_DEDUP_ENTRIES {
+    @Override
+    public String getName() {
+      return "zeebe.message.start.cross.partition.dedup.entries";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Current number of outstanding cross-partition message-start dedup entries on the business-id partition (P_B).";
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
   };
 
   public enum MessageCorrelationKeyNames implements KeyName {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageStartProcessInstanceAskMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageStartProcessInstanceAskMetrics.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import static io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.CROSS_PARTITION_ASKS_PENDING;
+
+import io.camunda.zeebe.util.micrometer.StatefulGauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Exports the {@code zeebe.message.start.cross.partition.asks.pending} gauge: the number of pending
+ * cross-partition message-start asks currently held on the correlation-key partition.
+ *
+ * <p>This gauge is a live mirror of the ask column family owned by {@link
+ * io.camunda.zeebe.engine.state.message.DbMessageStartProcessInstanceAskState}. That state
+ * increments and decrements it in lockstep with the column-family inserts and removals, and
+ * authoritatively re-seeds it from the persisted count on recovery.
+ */
+public final class MessageStartProcessInstanceAskMetrics {
+
+  private final StatefulGauge pendingAsks;
+
+  public MessageStartProcessInstanceAskMetrics(final MeterRegistry meterRegistry) {
+    pendingAsks =
+        StatefulGauge.builder(CROSS_PARTITION_ASKS_PENDING.getName())
+            .description(CROSS_PARTITION_ASKS_PENDING.getDescription())
+            .register(meterRegistry);
+  }
+
+  public void incrementPendingAsks() {
+    pendingAsks.increment();
+  }
+
+  public void decrementPendingAsks() {
+    pendingAsks.decrement();
+  }
+
+  /**
+   * Sets the gauge to an absolute value. Only call this from the stream-processing actor (for
+   * example, on recovery); calling it from elsewhere risks incorrect values due to race conditions.
+   */
+  public void setPendingAsks(final long count) {
+    pendingAsks.set(count);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageStartProcessInstanceDedupMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageStartProcessInstanceDedupMetrics.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import static io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.CROSS_PARTITION_DEDUP_ENTRIES;
+
+import io.camunda.zeebe.util.micrometer.StatefulGauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Exports the {@code zeebe.message.start.cross.partition.dedup.entries} gauge: the number of
+ * outstanding cross-partition message-start dedup entries currently held on the business-id
+ * partition.
+ *
+ * <p>This gauge is a live mirror of the dedup column family owned by {@link
+ * io.camunda.zeebe.engine.state.message.DbMessageStartProcessInstanceDedupState}. That state
+ * increments and decrements it in lockstep with the column-family inserts and removals, and
+ * authoritatively re-seeds it from the persisted count on recovery.
+ */
+public final class MessageStartProcessInstanceDedupMetrics {
+
+  private final StatefulGauge dedupEntries;
+
+  public MessageStartProcessInstanceDedupMetrics(final MeterRegistry meterRegistry) {
+    dedupEntries =
+        StatefulGauge.builder(CROSS_PARTITION_DEDUP_ENTRIES.getName())
+            .description(CROSS_PARTITION_DEDUP_ENTRIES.getDescription())
+            .register(meterRegistry);
+  }
+
+  public void incrementDedupEntries() {
+    dedupEntries.increment();
+  }
+
+  public void decrementDedupEntries() {
+    dedupEntries.decrement();
+  }
+
+  /**
+   * Sets the gauge to an absolute value. Only call this from the stream-processing actor (for
+   * example, on recovery); calling it from elsewhere risks incorrect values due to race conditions.
+   */
+  public void setDedupEntries(final long count) {
+    dedupEntries.set(count);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubs
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessInstanceRequestRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Collection;
 import java.util.function.Predicate;
@@ -156,11 +157,8 @@ public final class MessageCorrelateBehavior {
             return;
           }
 
-          final var correlationKeyHeld = isCorrelationKeyHeld(messageData, subscriptionRecord);
-          // Short-circuit: the correlation key is the blocker whenever it is held, so the
-          // businessId
-          // gate is only probed when the key is free.
-          if (!correlationKeyHeld && !isBusinessIdAlreadyHeld(messageData, subscriptionRecord)) {
+          final var correlation = evaluateStartEventCorrelation(messageData, subscriptionRecord);
+          if (correlation.isRight()) {
             final var processInstanceKey =
                 triggerOrDelegateStartEvent(messageData, subscription.getKey(), subscriptionRecord);
             if (processInstanceKey > 0) {
@@ -179,13 +177,10 @@ public final class MessageCorrelateBehavior {
               delegatedCrossPartition.set(true);
             }
           } else {
-            // A live holder blocks this start, so the message stays buffered. Attribute the block
-            // to
-            // the gate that fired — the correlation key takes precedence. Recorded only on this
-            // real
+            // A live holder blocks this start, so the message stays buffered. The reason carries
+            // the gate that fired (correlation key takes precedence). Recorded only on this real
             // mutation path (never in the collect* dry-run mirrors, which would double-count).
-            metrics.messageStartBlocked(
-                correlationKeyHeld ? BlockReason.CORRELATION_KEY : BlockReason.BUSINESS_ID);
+            metrics.messageStartBlocked(correlation.getLeft());
             if (blockedProcessIds != null) {
               blockedProcessIds.add(subscriptionRecord.getBpmnProcessId());
             }
@@ -212,8 +207,9 @@ public final class MessageCorrelateBehavior {
           }
 
           // Mirror the same uniqueness gates as the real correlation path so authorization is only
-          // checked for subscriptions that would actually correlate.
-          if (shouldCorrelateStartEvent(messageData, subscriptionRecord)) {
+          // checked for subscriptions that would actually correlate. The block reason is irrelevant
+          // here — this dry run writes no state and records no metric.
+          if (evaluateStartEventCorrelation(messageData, subscriptionRecord).isRight()) {
             // Just collect, don't write state yet
             correlatingSubscriptions.add(subscriptionRecord);
           }
@@ -313,16 +309,23 @@ public final class MessageCorrelateBehavior {
   }
 
   /**
-   * Returns {@code true} when this start-event subscription should correlate for the given message:
-   * only one instance per (process definition, correlation key) is created — an empty correlation
-   * key allows multiple instances — and, when the businessId uniqueness feature is enabled and the
-   * message carries a businessId, no active root PI on this partition may already hold that
-   * businessId for this process definition.
+   * Evaluates whether this start-event subscription may correlate for the given message. Returns
+   * {@link Either#right} when it may — only one instance per (process definition, correlation key)
+   * is created (an empty correlation key allows multiple instances) and, when the businessId
+   * uniqueness feature is enabled and the message carries a businessId, no active root PI on this
+   * partition already holds that businessId for this process definition. Otherwise returns {@link
+   * Either#left} with the {@link BlockReason} of the gate that fired: the correlation key takes
+   * precedence, so the businessId gate is only probed when the key is free.
    */
-  private boolean shouldCorrelateStartEvent(
+  private Either<BlockReason, Void> evaluateStartEventCorrelation(
       final MessageData messageData, final MessageStartEventSubscriptionRecord subscriptionRecord) {
-    return !isCorrelationKeyHeld(messageData, subscriptionRecord)
-        && !isBusinessIdAlreadyHeld(messageData, subscriptionRecord);
+    if (isCorrelationKeyHeld(messageData, subscriptionRecord)) {
+      return Either.left(BlockReason.CORRELATION_KEY);
+    }
+    if (isBusinessIdAlreadyHeld(messageData, subscriptionRecord)) {
+      return Either.left(BlockReason.BUSINESS_ID);
+    }
+    return Either.rightVoid();
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.message;
 
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.BlockReason;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -155,7 +156,11 @@ public final class MessageCorrelateBehavior {
             return;
           }
 
-          if (shouldCorrelateStartEvent(messageData, subscriptionRecord)) {
+          final var correlationKeyHeld = isCorrelationKeyHeld(messageData, subscriptionRecord);
+          // Short-circuit: the correlation key is the blocker whenever it is held, so the
+          // businessId
+          // gate is only probed when the key is free.
+          if (!correlationKeyHeld && !isBusinessIdAlreadyHeld(messageData, subscriptionRecord)) {
             final var processInstanceKey =
                 triggerOrDelegateStartEvent(messageData, subscription.getKey(), subscriptionRecord);
             if (processInstanceKey > 0) {
@@ -173,8 +178,17 @@ public final class MessageCorrelateBehavior {
               // through to the NOT_FOUND rejection so the correlate does not hang.
               delegatedCrossPartition.set(true);
             }
-          } else if (blockedProcessIds != null) {
-            blockedProcessIds.add(subscriptionRecord.getBpmnProcessId());
+          } else {
+            // A live holder blocks this start, so the message stays buffered. Attribute the block
+            // to
+            // the gate that fired — the correlation key takes precedence. Recorded only on this
+            // real
+            // mutation path (never in the collect* dry-run mirrors, which would double-count).
+            metrics.messageStartBlocked(
+                correlationKeyHeld ? BlockReason.CORRELATION_KEY : BlockReason.BUSINESS_ID);
+            if (blockedProcessIds != null) {
+              blockedProcessIds.add(subscriptionRecord.getBpmnProcessId());
+            }
           }
         });
     return delegatedCrossPartition.get();
@@ -307,13 +321,22 @@ public final class MessageCorrelateBehavior {
    */
   private boolean shouldCorrelateStartEvent(
       final MessageData messageData, final MessageStartEventSubscriptionRecord subscriptionRecord) {
-    final var correlationKeyFree =
-        messageData.correlationKey().capacity() == 0
-            || !messageState.existActiveProcessInstance(
-                messageData.tenantId(),
-                subscriptionRecord.getBpmnProcessIdBuffer(),
-                messageData.correlationKey());
-    return correlationKeyFree && !isBusinessIdAlreadyHeld(messageData, subscriptionRecord);
+    return !isCorrelationKeyHeld(messageData, subscriptionRecord)
+        && !isBusinessIdAlreadyHeld(messageData, subscriptionRecord);
+  }
+
+  /**
+   * Returns {@code true} when the message carries a non-empty correlation key that an active root
+   * PI already holds for this process definition on this partition — only one instance per (process
+   * definition, correlation key) is created, while an empty correlation key allows multiple.
+   */
+  private boolean isCorrelationKeyHeld(
+      final MessageData messageData, final MessageStartEventSubscriptionRecord subscriptionRecord) {
+    return messageData.correlationKey().capacity() != 0
+        && messageState.existActiveProcessInstance(
+            messageData.tenantId(),
+            subscriptionRecord.getBpmnProcessIdBuffer(),
+            messageData.correlationKey());
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -135,7 +135,7 @@ public class ProcessingDbState implements MutableProcessingState {
   private final MutableMessageState messageState;
   private final DbMessageSubscriptionState messageSubscriptionState;
   private final MutableMessageStartEventSubscriptionState messageStartEventSubscriptionState;
-  private final MutableMessageStartProcessInstanceDedupState messageStartProcessInstanceDedupState;
+  private final DbMessageStartProcessInstanceDedupState messageStartProcessInstanceDedupState;
   private final DbMessageStartProcessInstanceAskState messageStartProcessInstanceAskState;
   private final DbProcessMessageSubscriptionState processMessageSubscriptionState;
   private final DbMessageCorrelationState messageCorrelationState;
@@ -259,6 +259,7 @@ public class ProcessingDbState implements MutableProcessingState {
     bannedInstanceState.onRecovered(context);
     messageState.onRecovered(context);
     messageStartProcessInstanceAskState.onRecovered(context);
+    messageStartProcessInstanceDedupState.onRecovered(context);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskState.java
@@ -12,13 +12,12 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbCompositeKey;
 import io.camunda.zeebe.db.impl.DbLong;
-import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc;
+import io.camunda.zeebe.engine.metrics.MessageStartProcessInstanceAskMetrics;
 import io.camunda.zeebe.engine.state.message.TransientPendingMessageStartProcessInstanceAskState.PendingAskKey;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartProcessInstanceAskState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
-import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -52,7 +51,7 @@ public final class DbMessageStartProcessInstanceAskState
   private final ColumnFamily<DbCompositeKey<DbLong, DbLong>, MessageStartProcessInstanceAsk>
       columnFamily;
   private final TransientPendingMessageStartProcessInstanceAskState transientState;
-  private final StatefulGauge pendingAsks;
+  private final MessageStartProcessInstanceAskMetrics askMetrics;
 
   public DbMessageStartProcessInstanceAskState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
@@ -62,10 +61,7 @@ public final class DbMessageStartProcessInstanceAskState
     columnFamily =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.CROSS_PARTITION_MESSAGE_START_ASK, transactionContext, key, value);
-    pendingAsks =
-        StatefulGauge.builder(MessageCorrelationMetricsDoc.CROSS_PARTITION_ASKS_PENDING.getName())
-            .description(MessageCorrelationMetricsDoc.CROSS_PARTITION_ASKS_PENDING.getDescription())
-            .register(zeebeDb.getMeterRegistry());
+    askMetrics = new MessageStartProcessInstanceAskMetrics(zeebeDb.getMeterRegistry());
   }
 
   @Override
@@ -84,7 +80,7 @@ public final class DbMessageStartProcessInstanceAskState
         });
     // Authoritatively re-seed the gauge from persisted state, discarding any level accumulated by
     // the +1/-1 mutations replayed before this hook runs.
-    pendingAsks.set(columnFamily.count());
+    askMetrics.setPendingAsks(columnFamily.count());
   }
 
   @Override
@@ -126,7 +122,7 @@ public final class DbMessageStartProcessInstanceAskState
     columnFamily.upsert(key, ask);
     transientState.add(new PendingAskKey(ask.getMessageKey(), ask.getProcessDefinitionKey()), 0L);
     if (isNew) {
-      pendingAsks.increment();
+      askMetrics.incrementPendingAsks();
     }
   }
 
@@ -138,7 +134,7 @@ public final class DbMessageStartProcessInstanceAskState
     columnFamily.deleteIfExists(key);
     transientState.remove(new PendingAskKey(messageKey, processDefinitionKey));
     if (existed) {
-      pendingAsks.decrement();
+      askMetrics.decrementPendingAsks();
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskState.java
@@ -12,11 +12,13 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbCompositeKey;
 import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc;
 import io.camunda.zeebe.engine.state.message.TransientPendingMessageStartProcessInstanceAskState.PendingAskKey;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartProcessInstanceAskState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
+import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,6 +52,7 @@ public final class DbMessageStartProcessInstanceAskState
   private final ColumnFamily<DbCompositeKey<DbLong, DbLong>, MessageStartProcessInstanceAsk>
       columnFamily;
   private final TransientPendingMessageStartProcessInstanceAskState transientState;
+  private final StatefulGauge pendingAsks;
 
   public DbMessageStartProcessInstanceAskState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
@@ -59,6 +62,10 @@ public final class DbMessageStartProcessInstanceAskState
     columnFamily =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.CROSS_PARTITION_MESSAGE_START_ASK, transactionContext, key, value);
+    pendingAsks =
+        StatefulGauge.builder(MessageCorrelationMetricsDoc.CROSS_PARTITION_ASKS_PENDING.getName())
+            .description(MessageCorrelationMetricsDoc.CROSS_PARTITION_ASKS_PENDING.getDescription())
+            .register(zeebeDb.getMeterRegistry());
   }
 
   @Override
@@ -75,6 +82,9 @@ public final class DbMessageStartProcessInstanceAskState
           transientState.add(
               new PendingAskKey(k.first().getValue(), k.second().getValue()), lastSentSeed);
         });
+    // Authoritatively re-seed the gauge from persisted state, discarding any level accumulated by
+    // the +1/-1 mutations replayed before this hook runs.
+    pendingAsks.set(columnFamily.count());
   }
 
   @Override
@@ -111,16 +121,25 @@ public final class DbMessageStartProcessInstanceAskState
   public void put(final MessageStartProcessInstanceAsk ask) {
     messageKey.wrapLong(ask.getMessageKey());
     processDefinitionKey.wrapLong(ask.getProcessDefinitionKey());
+    // put upserts, so only a genuine insert changes the pending level.
+    final boolean isNew = !columnFamily.exists(key);
     columnFamily.upsert(key, ask);
     transientState.add(new PendingAskKey(ask.getMessageKey(), ask.getProcessDefinitionKey()), 0L);
+    if (isNew) {
+      pendingAsks.increment();
+    }
   }
 
   @Override
   public void remove(final long messageKey, final long processDefinitionKey) {
     this.messageKey.wrapLong(messageKey);
     this.processDefinitionKey.wrapLong(processDefinitionKey);
+    final boolean existed = columnFamily.exists(key);
     columnFamily.deleteIfExists(key);
     transientState.remove(new PendingAskKey(messageKey, processDefinitionKey));
+    if (existed) {
+      pendingAsks.decrement();
+    }
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceDedupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceDedupState.java
@@ -12,8 +12,12 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbCompositeKey;
 import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartProcessInstanceDedupState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
+import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import org.agrona.collections.MutableBoolean;
 
 /**
@@ -42,7 +46,7 @@ import org.agrona.collections.MutableBoolean;
  * deadline.
  */
 public final class DbMessageStartProcessInstanceDedupState
-    implements MutableMessageStartProcessInstanceDedupState {
+    implements MutableMessageStartProcessInstanceDedupState, StreamProcessorLifecycleAware {
 
   private final DbLong processDefinitionKey = new DbLong();
   private final DbLong messageKey = new DbLong();
@@ -52,6 +56,7 @@ public final class DbMessageStartProcessInstanceDedupState
       new MessageStartProcessInstanceDedupEntry();
   private final ColumnFamily<DbCompositeKey<DbLong, DbLong>, MessageStartProcessInstanceDedupEntry>
       columnFamily;
+  private final StatefulGauge dedupEntries;
 
   public DbMessageStartProcessInstanceDedupState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
@@ -61,6 +66,18 @@ public final class DbMessageStartProcessInstanceDedupState
             transactionContext,
             processDefinitionAndMessageKey,
             entry);
+    dedupEntries =
+        StatefulGauge.builder(MessageCorrelationMetricsDoc.CROSS_PARTITION_DEDUP_ENTRIES.getName())
+            .description(
+                MessageCorrelationMetricsDoc.CROSS_PARTITION_DEDUP_ENTRIES.getDescription())
+            .register(zeebeDb.getMeterRegistry());
+  }
+
+  @Override
+  public void onRecovered(final ReadonlyStreamProcessorContext context) {
+    // Authoritatively re-seed the gauge from persisted state, discarding any level accumulated by
+    // the +1/-1 mutations replayed before this hook runs.
+    dedupEntries.set(columnFamily.count());
   }
 
   @Override
@@ -117,13 +134,22 @@ public final class DbMessageStartProcessInstanceDedupState
     this.processDefinitionKey.wrapLong(processDefinitionKey);
     this.messageKey.wrapLong(messageKey);
     entry.setProcessInstanceKey(processInstanceKey).setDeletionDeadline(deletionDeadline);
+    // put upserts, so only a genuine insert changes the outstanding-entry level.
+    final boolean isNew = !columnFamily.exists(processDefinitionAndMessageKey);
     columnFamily.upsert(processDefinitionAndMessageKey, entry);
+    if (isNew) {
+      dedupEntries.increment();
+    }
   }
 
   @Override
   public void delete(final long processDefinitionKey, final long messageKey) {
     this.processDefinitionKey.wrapLong(processDefinitionKey);
     this.messageKey.wrapLong(messageKey);
+    final boolean existed = columnFamily.exists(processDefinitionAndMessageKey);
     columnFamily.deleteIfExists(processDefinitionAndMessageKey);
+    if (existed) {
+      dedupEntries.decrement();
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceDedupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceDedupState.java
@@ -12,12 +12,11 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbCompositeKey;
 import io.camunda.zeebe.db.impl.DbLong;
-import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc;
+import io.camunda.zeebe.engine.metrics.MessageStartProcessInstanceDedupMetrics;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartProcessInstanceDedupState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
-import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import org.agrona.collections.MutableBoolean;
 
 /**
@@ -56,7 +55,7 @@ public final class DbMessageStartProcessInstanceDedupState
       new MessageStartProcessInstanceDedupEntry();
   private final ColumnFamily<DbCompositeKey<DbLong, DbLong>, MessageStartProcessInstanceDedupEntry>
       columnFamily;
-  private final StatefulGauge dedupEntries;
+  private final MessageStartProcessInstanceDedupMetrics dedupMetrics;
 
   public DbMessageStartProcessInstanceDedupState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
@@ -66,18 +65,14 @@ public final class DbMessageStartProcessInstanceDedupState
             transactionContext,
             processDefinitionAndMessageKey,
             entry);
-    dedupEntries =
-        StatefulGauge.builder(MessageCorrelationMetricsDoc.CROSS_PARTITION_DEDUP_ENTRIES.getName())
-            .description(
-                MessageCorrelationMetricsDoc.CROSS_PARTITION_DEDUP_ENTRIES.getDescription())
-            .register(zeebeDb.getMeterRegistry());
+    dedupMetrics = new MessageStartProcessInstanceDedupMetrics(zeebeDb.getMeterRegistry());
   }
 
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
     // Authoritatively re-seed the gauge from persisted state, discarding any level accumulated by
     // the +1/-1 mutations replayed before this hook runs.
-    dedupEntries.set(columnFamily.count());
+    dedupMetrics.setDedupEntries(columnFamily.count());
   }
 
   @Override
@@ -138,7 +133,7 @@ public final class DbMessageStartProcessInstanceDedupState
     final boolean isNew = !columnFamily.exists(processDefinitionAndMessageKey);
     columnFamily.upsert(processDefinitionAndMessageKey, entry);
     if (isNew) {
-      dedupEntries.increment();
+      dedupMetrics.incrementDedupEntries();
     }
   }
 
@@ -149,7 +144,7 @@ public final class DbMessageStartProcessInstanceDedupState
     final boolean existed = columnFamily.exists(processDefinitionAndMessageKey);
     columnFamily.deleteIfExists(processDefinitionAndMessageKey);
     if (existed) {
-      dedupEntries.decrement();
+      dedupMetrics.decrementDedupEntries();
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
@@ -177,6 +177,7 @@ public final class DbMessageState implements MutableMessageState {
 
   private final BufferedMessagesMetrics bufferedMessagesMetrics;
   private final StatefulGauge crossPartitionStartLocks;
+  private final StatefulGauge crossPartitionBufferedMessages;
 
   private Long localMessageDeadlineCount = 0L;
 
@@ -289,6 +290,12 @@ public final class DbMessageState implements MutableMessageState {
         StatefulGauge.builder(MessageCorrelationMetricsDoc.CROSS_PARTITION_LOCKS.getName())
             .description(MessageCorrelationMetricsDoc.CROSS_PARTITION_LOCKS.getDescription())
             .register(zeebeDb.getMeterRegistry());
+    crossPartitionBufferedMessages =
+        StatefulGauge.builder(
+                MessageCorrelationMetricsDoc.CROSS_PARTITION_BUFFERED_MESSAGES.getName())
+            .description(
+                MessageCorrelationMetricsDoc.CROSS_PARTITION_BUFFERED_MESSAGES.getDescription())
+            .register(zeebeDb.getMeterRegistry());
   }
 
   @Override
@@ -302,6 +309,7 @@ public final class DbMessageState implements MutableMessageState {
     // Authoritatively re-seed the lock gauge from persisted state, discarding any level accumulated
     // by the +1/-1 mutations replayed before this hook runs.
     crossPartitionStartLocks.set(crossPartitionStartLockColumnFamily.count());
+    crossPartitionBufferedMessages.set(messageByBusinessIdColumnFamily.count());
   }
 
   @Override
@@ -335,6 +343,7 @@ public final class DbMessageState implements MutableMessageState {
     if (businessIdBuffer.capacity() > 0) {
       businessId.wrapBuffer(businessIdBuffer);
       messageByBusinessIdColumnFamily.insert(businessIdMessageKey, DbNil.INSTANCE);
+      crossPartitionBufferedMessages.increment();
     }
   }
 
@@ -532,7 +541,14 @@ public final class DbMessageState implements MutableMessageState {
       // deleteIfExists (not deleteExisting): the business-id index was added after buffered
       // messages already carried a business id, so a message published before the index existed
       // (upgraded RocksDB state) has no entry here. Removing it must not throw on the missing key.
+      // Decrement the gauge only when a row was actually present, so the upgraded-state case and
+      // any
+      // repeated removal cannot drive the level negative.
+      final boolean existed = messageByBusinessIdColumnFamily.exists(businessIdMessageKey);
       messageByBusinessIdColumnFamily.deleteIfExists(businessIdMessageKey);
+      if (existed) {
+        crossPartitionBufferedMessages.decrement();
+      }
     }
 
     deadline.wrapLong(storedMessage.getMessage().getDeadline());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
@@ -21,11 +21,13 @@ import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.db.impl.DbTenantAwareKey;
 import io.camunda.zeebe.db.impl.DbTenantAwareKey.PlacementType;
 import io.camunda.zeebe.engine.metrics.BufferedMessagesMetrics;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.MutableBoolean;
 
@@ -174,6 +176,7 @@ public final class DbMessageState implements MutableMessageState {
   private final CrossPartitionMessageStartHolderOrigin crossPartitionStartHolderOrigin;
 
   private final BufferedMessagesMetrics bufferedMessagesMetrics;
+  private final StatefulGauge crossPartitionStartLocks;
 
   private Long localMessageDeadlineCount = 0L;
 
@@ -282,6 +285,10 @@ public final class DbMessageState implements MutableMessageState {
             crossPartitionStartHolderOrigin);
 
     bufferedMessagesMetrics = new BufferedMessagesMetrics(zeebeDb.getMeterRegistry());
+    crossPartitionStartLocks =
+        StatefulGauge.builder(MessageCorrelationMetricsDoc.CROSS_PARTITION_LOCKS.getName())
+            .description(MessageCorrelationMetricsDoc.CROSS_PARTITION_LOCKS.getDescription())
+            .register(zeebeDb.getMeterRegistry());
   }
 
   @Override
@@ -292,6 +299,9 @@ public final class DbMessageState implements MutableMessageState {
     }
 
     bufferedMessagesMetrics.setBufferedMessagesCounter(localMessageDeadlineCount);
+    // Authoritatively re-seed the lock gauge from persisted state, discarding any level accumulated
+    // by the +1/-1 mutations replayed before this hook runs.
+    crossPartitionStartLocks.set(crossPartitionStartLockColumnFamily.count());
   }
 
   @Override
@@ -388,8 +398,12 @@ public final class DbMessageState implements MutableMessageState {
     // upsert because cross-partition STARTED replies can be retried (P_B's success-only dedup
     // re-replies the same processInstanceKey); writing the same holder twice is a no-op overwrite
     // rather than an error.
+    final boolean isNew = !crossPartitionStartLockColumnFamily.exists(bpmnProcessIdCorrelationKey);
     crossPartitionStartLockColumnFamily.upsert(
         bpmnProcessIdCorrelationKey, crossPartitionStartLock);
+    if (isNew) {
+      crossPartitionStartLocks.increment();
+    }
   }
 
   @Override
@@ -423,7 +437,11 @@ public final class DbMessageState implements MutableMessageState {
 
     bpmnProcessIdKey.wrapBuffer(bpmnProcessId);
     this.correlationKey.wrapBuffer(correlationKey);
+    final boolean existed = crossPartitionStartLockColumnFamily.exists(bpmnProcessIdCorrelationKey);
     crossPartitionStartLockColumnFamily.deleteIfExists(bpmnProcessIdCorrelationKey);
+    if (existed) {
+      crossPartitionStartLocks.decrement();
+    }
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
@@ -21,13 +21,12 @@ import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.db.impl.DbTenantAwareKey;
 import io.camunda.zeebe.db.impl.DbTenantAwareKey.PlacementType;
 import io.camunda.zeebe.engine.metrics.BufferedMessagesMetrics;
-import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc;
+import io.camunda.zeebe.engine.metrics.CrossPartitionMessageStateMetrics;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.MutableBoolean;
 
@@ -176,8 +175,7 @@ public final class DbMessageState implements MutableMessageState {
   private final CrossPartitionMessageStartHolderOrigin crossPartitionStartHolderOrigin;
 
   private final BufferedMessagesMetrics bufferedMessagesMetrics;
-  private final StatefulGauge crossPartitionStartLocks;
-  private final StatefulGauge crossPartitionBufferedMessages;
+  private final CrossPartitionMessageStateMetrics crossPartitionMetrics;
 
   private Long localMessageDeadlineCount = 0L;
 
@@ -286,16 +284,7 @@ public final class DbMessageState implements MutableMessageState {
             crossPartitionStartHolderOrigin);
 
     bufferedMessagesMetrics = new BufferedMessagesMetrics(zeebeDb.getMeterRegistry());
-    crossPartitionStartLocks =
-        StatefulGauge.builder(MessageCorrelationMetricsDoc.CROSS_PARTITION_LOCKS.getName())
-            .description(MessageCorrelationMetricsDoc.CROSS_PARTITION_LOCKS.getDescription())
-            .register(zeebeDb.getMeterRegistry());
-    crossPartitionBufferedMessages =
-        StatefulGauge.builder(
-                MessageCorrelationMetricsDoc.CROSS_PARTITION_BUFFERED_MESSAGES.getName())
-            .description(
-                MessageCorrelationMetricsDoc.CROSS_PARTITION_BUFFERED_MESSAGES.getDescription())
-            .register(zeebeDb.getMeterRegistry());
+    crossPartitionMetrics = new CrossPartitionMessageStateMetrics(zeebeDb.getMeterRegistry());
   }
 
   @Override
@@ -306,10 +295,10 @@ public final class DbMessageState implements MutableMessageState {
     }
 
     bufferedMessagesMetrics.setBufferedMessagesCounter(localMessageDeadlineCount);
-    // Authoritatively re-seed the lock gauge from persisted state, discarding any level accumulated
+    // Authoritatively re-seed the gauges from persisted state, discarding any level accumulated
     // by the +1/-1 mutations replayed before this hook runs.
-    crossPartitionStartLocks.set(crossPartitionStartLockColumnFamily.count());
-    crossPartitionBufferedMessages.set(messageByBusinessIdColumnFamily.count());
+    crossPartitionMetrics.setStartLocks(crossPartitionStartLockColumnFamily.count());
+    crossPartitionMetrics.setBufferedMessages(messageByBusinessIdColumnFamily.count());
   }
 
   @Override
@@ -343,7 +332,7 @@ public final class DbMessageState implements MutableMessageState {
     if (businessIdBuffer.capacity() > 0) {
       businessId.wrapBuffer(businessIdBuffer);
       messageByBusinessIdColumnFamily.insert(businessIdMessageKey, DbNil.INSTANCE);
-      crossPartitionBufferedMessages.increment();
+      crossPartitionMetrics.incrementBufferedMessages();
     }
   }
 
@@ -411,7 +400,7 @@ public final class DbMessageState implements MutableMessageState {
     crossPartitionStartLockColumnFamily.upsert(
         bpmnProcessIdCorrelationKey, crossPartitionStartLock);
     if (isNew) {
-      crossPartitionStartLocks.increment();
+      crossPartitionMetrics.incrementStartLocks();
     }
   }
 
@@ -449,7 +438,7 @@ public final class DbMessageState implements MutableMessageState {
     final boolean existed = crossPartitionStartLockColumnFamily.exists(bpmnProcessIdCorrelationKey);
     crossPartitionStartLockColumnFamily.deleteIfExists(bpmnProcessIdCorrelationKey);
     if (existed) {
-      crossPartitionStartLocks.decrement();
+      crossPartitionMetrics.decrementStartLocks();
     }
   }
 
@@ -547,7 +536,7 @@ public final class DbMessageState implements MutableMessageState {
       final boolean existed = messageByBusinessIdColumnFamily.exists(businessIdMessageKey);
       messageByBusinessIdColumnFamily.deleteIfExists(businessIdMessageKey);
       if (existed) {
-        crossPartitionBufferedMessages.decrement();
+        crossPartitionMetrics.decrementBufferedMessages();
       }
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.BlockReason;
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReleaseResult;
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReleaseTrigger;
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReplyOutcome;
@@ -136,6 +137,18 @@ final class MessageCorrelationMetricsTest {
     assertThat(lockReleaseCount("redundant")).isEqualTo(1.0);
   }
 
+  @Test
+  void shouldRecordBlockedStartsTaggedByReason() {
+    // when
+    metrics.messageStartBlocked(BlockReason.CORRELATION_KEY);
+    metrics.messageStartBlocked(BlockReason.BUSINESS_ID);
+    metrics.messageStartBlocked(BlockReason.BUSINESS_ID);
+
+    // then each reason is counted independently under its own tag (M14)
+    assertThat(blockedCount("correlation_key")).isEqualTo(1.0);
+    assertThat(blockedCount("business_id")).isEqualTo(2.0);
+  }
+
   private double counter(final String name) {
     final var counter = registry.find(name).counter();
     return counter != null ? counter.count() : 0.0;
@@ -161,5 +174,9 @@ final class MessageCorrelationMetricsTest {
 
   private double lockReleaseCount(final String result) {
     return taggedCount("zeebe.message.start.cross.partition.lock.releases.total", "result", result);
+  }
+
+  private double blockedCount(final String reason) {
+    return taggedCount("zeebe.message.start.blocked.total", "reason", reason);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartBlockedMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartBlockedMetricsTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Behavioural assertions for the {@code zeebe.message.start.blocked.total} counter (M14): a live
+ * message-start correlate that finds a holder leaves the message buffered instead of starting a new
+ * instance, and the block is attributed by the {@code reason} tag. A single partition is used so
+ * every gate is evaluated locally and the businessId arm never delegates cross-partition.
+ */
+public final class MessageStartBlockedMetricsTest {
+
+  private static final String BLOCKED_METRIC = "zeebe.message.start.blocked.total";
+
+  private static final String PROCESS_ID = "wf-blocked";
+  private static final String MESSAGE_NAME = "start-msg";
+  private static final String JOB_TYPE = "test";
+
+  // The holder started by the first publish; later publishes reuse or vary these to pick a reason.
+  private static final String HELD_CORRELATION_KEY = "ck-held";
+  private static final String HELD_BUSINESS_ID = "biz-held";
+  private static final String FREE_CORRELATION_KEY = "ck-free";
+  private static final String FREE_BUSINESS_ID = "biz-free";
+
+  private static final BpmnModelInstance MESSAGE_START_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent("msgStart")
+          .message(MESSAGE_NAME)
+          .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+          .endEvent()
+          .done();
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
+
+  @Before
+  public void deployAndHoldBothGates() {
+    engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();
+    RecordingExporter.messageStartEventSubscriptionRecords(
+            MessageStartEventSubscriptionIntent.CREATED)
+        .withMessageName(MESSAGE_NAME)
+        .getFirst();
+
+    // Start a holder instance that owns both the correlation key and the business id.
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey(HELD_CORRELATION_KEY)
+        .withBusinessId(HELD_BUSINESS_ID)
+        .publish();
+
+    // Wait until the holder is active (reached the service task) so both uniqueness indexes are
+    // set.
+    RecordingExporter.jobRecords(JobIntent.CREATED).withType(JOB_TYPE).getFirst();
+  }
+
+  @Test
+  public void shouldCountBlockOnHeldCorrelationKeyOnly() {
+    // when a publish reuses the held correlation key but carries a fresh business id
+    publishBlocked(HELD_CORRELATION_KEY, FREE_BUSINESS_ID);
+
+    // then the block is attributed to the correlation key alone (M14)
+    assertThat(blockedCount("correlation_key")).isEqualTo(1.0);
+    assertThat(blockedCount("business_id")).isZero();
+  }
+
+  @Test
+  public void shouldCountBlockOnHeldBusinessIdOnly() {
+    // when a publish carries a fresh correlation key but reuses the held business id
+    publishBlocked(FREE_CORRELATION_KEY, HELD_BUSINESS_ID);
+
+    // then the block is attributed to the business id alone (M14)
+    assertThat(blockedCount("business_id")).isEqualTo(1.0);
+    assertThat(blockedCount("correlation_key")).isZero();
+  }
+
+  @Test
+  public void shouldAttributeBlockToCorrelationKeyWhenBothGatesHeld() {
+    // when a publish reuses both the held correlation key and the held business id
+    publishBlocked(HELD_CORRELATION_KEY, HELD_BUSINESS_ID);
+
+    // then the correlation key takes precedence — the business-id gate is not even probed (M14)
+    assertThat(blockedCount("correlation_key")).isEqualTo(1.0);
+    assertThat(blockedCount("business_id")).isZero();
+  }
+
+  private void publishBlocked(final String correlationKey, final String businessId) {
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey(correlationKey)
+        .withBusinessId(businessId)
+        .withTimeToLive(0L)
+        .publish();
+    // The correlate (and the metric) runs while the PUBLISH command is processed; awaiting the
+    // second PUBLISHED record (holder + this one) guarantees the block has been recorded.
+    RecordingExporter.messageRecords(MessageIntent.PUBLISHED)
+        .withName(MESSAGE_NAME)
+        .limit(2)
+        .asList();
+  }
+
+  private double blockedCount(final String reason) {
+    final var counter =
+        engine.getMeterRegistry().find(BLOCKED_METRIC).tag("reason", reason).counter();
+    return counter != null ? counter.count() : 0.0;
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskStateTest.java
@@ -11,21 +11,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.engine.util.ProcessingStateRule;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessInstanceRequestRecord;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamClock;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class DbMessageStartProcessInstanceAskStateTest {
+@ExtendWith(ProcessingStateExtension.class)
+final class DbMessageStartProcessInstanceAskStateTest {
 
-  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
+  private MutableProcessingState processingState;
 
   @Test
-  public void shouldPutAndGetPendingAsk() {
+  void shouldPutAndGetPendingAsk() {
     // given
-    final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
+    final var state = processingState.getMessageStartProcessInstanceAskState();
     final var record = createRecord(123L, 456L, "test-business-id", "test-process");
     final var ask = new MessageStartProcessInstanceAsk().wrap(record);
 
@@ -40,9 +42,9 @@ public class DbMessageStartProcessInstanceAskStateTest {
   }
 
   @Test
-  public void shouldRemovePendingAsk() {
+  void shouldRemovePendingAsk() {
     // given
-    final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
+    final var state = processingState.getMessageStartProcessInstanceAskState();
     final var record = createRecord(123L, 456L, "test-business-id", "test-process");
     final var ask = new MessageStartProcessInstanceAsk().wrap(record);
     state.put(ask);
@@ -55,10 +57,10 @@ public class DbMessageStartProcessInstanceAskStateTest {
   }
 
   @Test
-  public void shouldRemoveAllPendingAsksForGivenMessageKey() {
+  void shouldRemoveAllPendingAsksForGivenMessageKey() {
     // given two pending asks for the same messageKey targeting different process definitions, and
     // one pending ask for a different messageKey that must survive
-    final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
+    final var state = processingState.getMessageStartProcessInstanceAskState();
     state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(7L, 100L, "b1", "p1")));
     state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(7L, 200L, "b2", "p2")));
     state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(8L, 300L, "b3", "p3")));
@@ -73,9 +75,9 @@ public class DbMessageStartProcessInstanceAskStateTest {
   }
 
   @Test
-  public void shouldVisitAllPendingAsks() {
+  void shouldVisitAllPendingAsks() {
     // given
-    final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
+    final var state = processingState.getMessageStartProcessInstanceAskState();
     state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 10L, "b1", "p1")));
     state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(2L, 20L, "b2", "p2")));
     state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(3L, 30L, "b3", "p3")));
@@ -89,9 +91,9 @@ public class DbMessageStartProcessInstanceAskStateTest {
   }
 
   @Test
-  public void shouldVisitPendingAsksWithLastSentTime() {
+  void shouldVisitPendingAsksWithLastSentTime() {
     // given two pending asks; one already has a last-sent time recorded
-    final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
+    final var state = processingState.getMessageStartProcessInstanceAskState();
     state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 10L, "b1", "p1")));
     state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(2L, 20L, "b2", "p2")));
     state.updateLastSentTime(2L, 20L, 5_000L);
@@ -108,7 +110,7 @@ public class DbMessageStartProcessInstanceAskStateTest {
   }
 
   @Test
-  public void shouldPopulateRecordFromAsk() {
+  void shouldPopulateRecordFromAsk() {
     // given
     final var originalRecord = createRecord(123L, 456L, "test-business-id", "test-process");
     originalRecord.setMessageName("test-message");
@@ -140,7 +142,7 @@ public class DbMessageStartProcessInstanceAskStateTest {
   }
 
   @Test
-  public void shouldDefaultRejectionCountToZeroForFreshAsk() {
+  void shouldDefaultRejectionCountToZeroForFreshAsk() {
     // given a fresh ask sourced from a request record (never rejected)
     final var ask = new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 2L, "b", "p"));
 
@@ -150,9 +152,9 @@ public class DbMessageStartProcessInstanceAskStateTest {
   }
 
   @Test
-  public void shouldPersistRejectionCount() {
+  void shouldPersistRejectionCount() {
     // given
-    final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
+    final var state = processingState.getMessageStartProcessInstanceAskState();
     final var ask =
         new MessageStartProcessInstanceAsk()
             .wrap(createRecord(123L, 456L, "b", "p"))
@@ -167,7 +169,7 @@ public class DbMessageStartProcessInstanceAskStateTest {
   }
 
   @Test
-  public void shouldPreserveRejectionCountOnCopy() {
+  void shouldPreserveRejectionCountOnCopy() {
     // given
     final var ask =
         new MessageStartProcessInstanceAsk()
@@ -182,9 +184,9 @@ public class DbMessageStartProcessInstanceAskStateTest {
   }
 
   @Test
-  public void shouldIncrementRejectionCountOnBackOff() {
+  void shouldIncrementRejectionCountOnBackOff() {
     // given a pending ask with no rejections yet
-    final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
+    final var state = processingState.getMessageStartProcessInstanceAskState();
     state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 2L, "b", "p")));
 
     // when backed off twice
@@ -196,9 +198,9 @@ public class DbMessageStartProcessInstanceAskStateTest {
   }
 
   @Test
-  public void shouldNotResetSendEligibilityOnBackOff() {
+  void shouldNotResetSendEligibilityOnBackOff() {
     // given a pending ask that has already been sent (transient last-sent advanced)
-    final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
+    final var state = processingState.getMessageStartProcessInstanceAskState();
     state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 2L, "b", "p")));
     state.updateLastSentTime(1L, 2L, 10_000L);
 
@@ -214,9 +216,9 @@ public class DbMessageStartProcessInstanceAskStateTest {
   }
 
   @Test
-  public void shouldBeNoOpWhenBackingOffMissingAsk() {
+  void shouldBeNoOpWhenBackingOffMissingAsk() {
     // given no pending ask for the key
-    final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
+    final var state = processingState.getMessageStartProcessInstanceAskState();
 
     // when / then no exception and nothing is created
     state.backOff(7L, 8L);
@@ -224,9 +226,9 @@ public class DbMessageStartProcessInstanceAskStateTest {
   }
 
   @Test
-  public void shouldSeedRecoveryEligibilityByRejectionCount() {
+  void shouldSeedRecoveryEligibilityByRejectionCount() {
     // given a fresh ask (never rejected) and a backed-off ask
-    final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
+    final var state = processingState.getMessageStartProcessInstanceAskState();
     state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 10L, "b1", "p1")));
     state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(2L, 20L, "b2", "p2")));
     state.backOff(2L, 20L);
@@ -250,9 +252,9 @@ public class DbMessageStartProcessInstanceAskStateTest {
   }
 
   @Test
-  public void shouldCapRejectionCount() {
+  void shouldCapRejectionCount() {
     // given a pending ask
-    final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
+    final var state = processingState.getMessageStartProcessInstanceAskState();
     state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 2L, "b", "p")));
 
     // when backed off far more often than the cap (30)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskStateTest.java
@@ -11,8 +11,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessInstanceRequestRecord;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamClock;
@@ -22,6 +25,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(ProcessingStateExtension.class)
 final class DbMessageStartProcessInstanceAskStateTest {
 
+  private static final String PENDING_ASKS_GAUGE =
+      MessageCorrelationMetricsDoc.CROSS_PARTITION_ASKS_PENDING.getName();
+
+  private ZeebeDb<ZbColumnFamilies> zeebeDb;
   private MutableProcessingState processingState;
 
   @Test
@@ -265,6 +272,89 @@ final class DbMessageStartProcessInstanceAskStateTest {
     // then the persisted count saturates at the cap, so it never overflows when the scheduler
     // computes 2^rejectionCount
     assertThat(state.get(1L, 2L).getRejectionCount()).isEqualTo(30L);
+  }
+
+  @Test
+  void shouldTrackPendingAsksGaugeAcrossPutAndRemove() {
+    // given
+    final var state = processingState.getMessageStartProcessInstanceAskState();
+
+    // when two asks are registered
+    state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 10L, "b1", "p1")));
+    state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(2L, 20L, "b2", "p2")));
+
+    // then the pending-asks gauge reflects both
+    assertThat(pendingAsksGauge()).isEqualTo(2.0);
+
+    // when one is removed
+    state.remove(1L, 10L);
+
+    // then the gauge drops to one
+    assertThat(pendingAsksGauge()).isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldNotDoubleCountPendingAsksGaugeWhenPuttingSameAskAgain() {
+    // given a registered ask
+    final var state = processingState.getMessageStartProcessInstanceAskState();
+    state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 10L, "b1", "p1")));
+
+    // when the same (messageKey, processDefinitionKey) is put again (put upserts)
+    state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 10L, "b1", "p1")));
+
+    // then the gauge counts the ask only once
+    assertThat(pendingAsksGauge()).isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldNotDecrementPendingAsksGaugeWhenRemovingMissingAsk() {
+    // given one registered ask
+    final var state = processingState.getMessageStartProcessInstanceAskState();
+    state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 10L, "b1", "p1")));
+
+    // when removing an ask that was never registered
+    state.remove(7L, 70L);
+
+    // then the gauge is unaffected
+    assertThat(pendingAsksGauge()).isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldDecrementPendingAsksGaugeForEachRemovedAskOnRemoveAll() {
+    // given two asks for the same messageKey and one for another
+    final var state = processingState.getMessageStartProcessInstanceAskState();
+    state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(7L, 100L, "b1", "p1")));
+    state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(7L, 200L, "b2", "p2")));
+    state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(8L, 300L, "b3", "p3")));
+    assertThat(pendingAsksGauge()).isEqualTo(3.0);
+
+    // when all asks for messageKey 7 are removed
+    state.removeAllByMessageKey(7L);
+
+    // then the gauge drops by exactly the two removed asks
+    assertThat(pendingAsksGauge()).isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldReseedPendingAsksGaugeFromStateOnRecovery() {
+    // given two persisted asks
+    final var state = processingState.getMessageStartProcessInstanceAskState();
+    state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 10L, "b1", "p1")));
+    state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(2L, 20L, "b2", "p2")));
+
+    // when the partition recovers
+    final var context = mock(ReadonlyStreamProcessorContext.class);
+    final var clock = mock(StreamClock.class);
+    when(context.getClock()).thenReturn(clock);
+    when(clock.millis()).thenReturn(50_000L);
+    ((DbMessageStartProcessInstanceAskState) state).onRecovered(context);
+
+    // then the gauge is authoritatively seeded from the persisted count
+    assertThat(pendingAsksGauge()).isEqualTo(2.0);
+  }
+
+  private double pendingAsksGauge() {
+    return zeebeDb.getMeterRegistry().get(PENDING_ASKS_GAUGE).gauge().value();
   }
 
   private MessageStartProcessInstanceRequestRecord createRecord(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStartProcessInstanceDedupStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStartProcessInstanceDedupStateTest.java
@@ -10,10 +10,13 @@ package io.camunda.zeebe.engine.state.message;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc;
 import io.camunda.zeebe.engine.state.immutable.MessageStartProcessInstanceDedupState.ExpiredEntryVisitor;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartProcessInstanceDedupState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,6 +25,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(ProcessingStateExtension.class)
 final class MessageStartProcessInstanceDedupStateTest {
 
+  private static final String DEDUP_GAUGE =
+      MessageCorrelationMetricsDoc.CROSS_PARTITION_DEDUP_ENTRIES.getName();
+
+  private ZeebeDb<ZbColumnFamilies> zeebeDb;
   private MutableProcessingState processingState;
   private MutableMessageStartProcessInstanceDedupState state;
 
@@ -170,5 +177,62 @@ final class MessageStartProcessInstanceDedupStateTest {
   void shouldTreatDeleteOfUnknownEntryAsNoOp() {
     // when / then — must not throw
     state.delete(10L, 20L);
+  }
+
+  @Test
+  void shouldTrackDedupEntriesGaugeAcrossPutAndDelete() {
+    // when two distinct dedup entries are stored
+    state.put(10L, 20L, 100L, 1_000L);
+    state.put(10L, 21L, 101L, 2_000L);
+
+    // then the gauge reflects both
+    assertThat(dedupEntriesGauge()).isEqualTo(2.0);
+
+    // when one is deleted
+    state.delete(10L, 20L);
+
+    // then the gauge drops to one
+    assertThat(dedupEntriesGauge()).isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldNotDoubleCountDedupEntriesGaugeOnReReply() {
+    // given a stored dedup entry
+    state.put(10L, 20L, 100L, 1_000L);
+
+    // when a fresh STARTED reply overwrites the same key (put upserts)
+    state.put(10L, 20L, 101L, 5_000L);
+
+    // then the gauge counts the entry only once
+    assertThat(dedupEntriesGauge()).isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldNotDecrementDedupEntriesGaugeWhenDeletingAbsentEntry() {
+    // given one stored entry
+    state.put(10L, 20L, 100L, 1_000L);
+
+    // when deleting an entry that was never stored
+    state.delete(10L, 21L);
+
+    // then the gauge is unaffected
+    assertThat(dedupEntriesGauge()).isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldReseedDedupEntriesGaugeFromStateOnRecovery() {
+    // given two persisted dedup entries
+    state.put(10L, 20L, 100L, 1_000L);
+    state.put(10L, 21L, 101L, 2_000L);
+
+    // when the partition recovers
+    ((DbMessageStartProcessInstanceDedupState) state).onRecovered(null);
+
+    // then the gauge is authoritatively seeded from the persisted count
+    assertThat(dedupEntriesGauge()).isEqualTo(2.0);
+  }
+
+  private double dedupEntriesGauge() {
+    return zeebeDb.getMeterRegistry().get(DEDUP_GAUGE).gauge().value();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStateTest.java
@@ -34,6 +34,8 @@ public final class MessageStateTest {
   private static final String DEFAULT_TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   private static final String LOCKS_GAUGE =
       MessageCorrelationMetricsDoc.CROSS_PARTITION_LOCKS.getName();
+  private static final String BUFFERED_BID_GAUGE =
+      MessageCorrelationMetricsDoc.CROSS_PARTITION_BUFFERED_MESSAGES.getName();
 
   private ZeebeDb<ZbColumnFamilies> zeebeDb;
   private MutableMessageState messageState;
@@ -749,6 +751,57 @@ public final class MessageStateTest {
 
   private double locksGauge() {
     return zeebeDb.getMeterRegistry().get(LOCKS_GAUGE).gauge().value();
+  }
+
+  @Test
+  void shouldTrackBufferedBusinessIdMessagesGaugeAcrossPutAndRemove() {
+    // when two buffered messages carrying a business id are stored
+    messageState.put(1L, createMessageWithBusinessId("name", "correlationKey", "bid-1"));
+    messageState.put(2L, createMessageWithBusinessId("name", "correlationKey", "bid-2"));
+
+    // then the business-id buffer gauge reflects both
+    assertThat(bufferedBusinessIdMessagesGauge()).isEqualTo(2.0);
+
+    // when one message is removed
+    messageState.remove(1L);
+
+    // then the gauge drops to one
+    assertThat(bufferedBusinessIdMessagesGauge()).isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldNotCountBufferedMessagesWithoutBusinessId() {
+    // when a buffered message without a business id is stored
+    messageState.put(1L, createMessage("name", "correlationKey"));
+
+    // then the business-id buffer gauge stays at zero
+    assertThat(bufferedBusinessIdMessagesGauge()).isEqualTo(0.0);
+
+    // and removing it does not drive the gauge negative
+    messageState.remove(1L);
+    assertThat(bufferedBusinessIdMessagesGauge()).isEqualTo(0.0);
+  }
+
+  @Test
+  void shouldReseedBufferedBusinessIdMessagesGaugeFromStateOnRecovery() {
+    // given two persisted messages carrying a business id
+    messageState.put(1L, createMessageWithBusinessId("name", "correlationKey", "bid-1"));
+    messageState.put(2L, createMessageWithBusinessId("name", "correlationKey", "bid-2"));
+
+    // when the partition recovers
+    ((DbMessageState) messageState).onRecovered(null);
+
+    // then the gauge is authoritatively seeded from the persisted count
+    assertThat(bufferedBusinessIdMessagesGauge()).isEqualTo(2.0);
+  }
+
+  private double bufferedBusinessIdMessagesGauge() {
+    return zeebeDb.getMeterRegistry().get(BUFFERED_BID_GAUGE).gauge().value();
+  }
+
+  private MessageRecord createMessageWithBusinessId(
+      final String name, final String correlationKey, final String businessId) {
+    return createMessage(name, correlationKey).setBusinessId(businessId);
   }
 
   private MessageRecord createMessage(final String name, final String correlationKey) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStateTest.java
@@ -10,10 +10,13 @@ package io.camunda.zeebe.engine.state.message;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.MsgPackUtil;
@@ -29,7 +32,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public final class MessageStateTest {
 
   private static final String DEFAULT_TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+  private static final String LOCKS_GAUGE =
+      MessageCorrelationMetricsDoc.CROSS_PARTITION_LOCKS.getName();
 
+  private ZeebeDb<ZbColumnFamilies> zeebeDb;
   private MutableMessageState messageState;
   private MutableProcessingState processingState;
 
@@ -679,6 +685,70 @@ public final class MessageStateTest {
     final var origin = messageState.getCrossPartitionStartHolderOrigin(1L);
     assertThat(origin).isNotNull();
     assertThat(origin.getMessageKey()).isEqualTo(42L);
+  }
+
+  @Test
+  void shouldTrackCrossPartitionLocksGaugeAcrossPutAndRemove() {
+    // when two distinct correlation-key locks are held
+    messageState.putCrossPartitionStartLock(
+        wrapString("process-1"), wrapString("key-1"), 42L, DEFAULT_TENANT);
+    messageState.putCrossPartitionStartLock(
+        wrapString("process-1"), wrapString("key-2"), 43L, DEFAULT_TENANT);
+
+    // then the lock gauge reflects both
+    assertThat(locksGauge()).isEqualTo(2.0);
+
+    // when one is released
+    messageState.removeCrossPartitionStartLock(wrapString("process-1"), wrapString("key-1"));
+
+    // then the gauge drops to one
+    assertThat(locksGauge()).isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldNotDoubleCountCrossPartitionLocksGaugeOnReAppliedReply() {
+    // given a held lock
+    messageState.putCrossPartitionStartLock(
+        wrapString("process-1"), wrapString("key-1"), 42L, DEFAULT_TENANT);
+
+    // when a retried STARTED reply writes the same holder again (put upserts)
+    messageState.putCrossPartitionStartLock(
+        wrapString("process-1"), wrapString("key-1"), 42L, DEFAULT_TENANT);
+
+    // then the gauge counts the lock only once
+    assertThat(locksGauge()).isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldNotDecrementCrossPartitionLocksGaugeWhenRemovingAbsentLock() {
+    // given one held lock
+    messageState.putCrossPartitionStartLock(
+        wrapString("process-1"), wrapString("key-1"), 42L, DEFAULT_TENANT);
+
+    // when removing a lock that was never held
+    messageState.removeCrossPartitionStartLock(wrapString("process-1"), wrapString("absent"));
+
+    // then the gauge is unaffected
+    assertThat(locksGauge()).isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldReseedCrossPartitionLocksGaugeFromStateOnRecovery() {
+    // given two persisted locks
+    messageState.putCrossPartitionStartLock(
+        wrapString("process-1"), wrapString("key-1"), 42L, DEFAULT_TENANT);
+    messageState.putCrossPartitionStartLock(
+        wrapString("process-1"), wrapString("key-2"), 43L, DEFAULT_TENANT);
+
+    // when the partition recovers
+    ((DbMessageState) messageState).onRecovered(null);
+
+    // then the gauge is authoritatively seeded from the persisted count
+    assertThat(locksGauge()).isEqualTo(2.0);
+  }
+
+  private double locksGauge() {
+    return zeebeDb.getMeterRegistry().get(LOCKS_GAUGE).gauge().value();
   }
 
   private MessageRecord createMessage(final String name, final String correlationKey) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStateTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
-import io.camunda.zeebe.engine.util.ProcessingStateRule;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.MsgPackUtil;
@@ -21,26 +21,25 @@ import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.mutable.MutableObject;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ProcessingStateExtension.class)
 public final class MessageStateTest {
 
   private static final String DEFAULT_TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
-  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableMessageState messageState;
   private MutableProcessingState processingState;
 
-  @Before
-  public void setUp() {
-    processingState = stateRule.getProcessingState();
+  @BeforeEach
+  void setUp() {
     messageState = processingState.getMessageState();
   }
 
   @Test
-  public void shouldNotExistIfNameDoesntMatch() {
+  void shouldNotExistIfNameDoesntMatch() {
     // given
     final var message = createMessage("name", "correlationKey", "{}", "id");
     messageState.put(1L, message);
@@ -58,7 +57,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldNotExistIfCorrelationKeyDoesntMatch() {
+  void shouldNotExistIfCorrelationKeyDoesntMatch() {
     // given
     final var message = createMessage("name", "correlationKey", "{}", "id");
     messageState.put(1L, message);
@@ -76,7 +75,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldNotExistIfMessageIdDoesntMatch() {
+  void shouldNotExistIfMessageIdDoesntMatch() {
     // given
     final var message = createMessage("name", "correlationKey", "{}", "id");
     messageState.put(1L, message);
@@ -94,7 +93,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldExist() {
+  void shouldExist() {
     // given
     final var message = createMessage("name", "correlationKey", "{}", "id");
     messageState.put(1L, message);
@@ -112,7 +111,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldVisitMessages() {
+  void shouldVisitMessages() {
     // given
     final var message = createMessage("name", "correlationKey");
     messageState.put(1L, message);
@@ -134,7 +133,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldVisitMessagesInOrder() {
+  void shouldVisitMessagesInOrder() {
     // given
     final var message = createMessage("name", "correlationKey");
     messageState.put(1L, message);
@@ -155,7 +154,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldVisitMessagesUntilStop() {
+  void shouldVisitMessagesUntilStop() {
     // given
     final var message = createMessage("name", "correlationKey");
     messageState.put(1L, message);
@@ -179,7 +178,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldNotVisitMessagesIfNameDoesntMatch() {
+  void shouldNotVisitMessagesIfNameDoesntMatch() {
     // given
     final var message = createMessage("name", "correlationKey");
     messageState.put(1L, message);
@@ -197,7 +196,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldNotVisitMessageIfCorrelationKeyDoesntMatch() {
+  void shouldNotVisitMessageIfCorrelationKeyDoesntMatch() {
     // given
     final var message = createMessage("name", "correlationKey");
     messageState.put(1L, message);
@@ -215,7 +214,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldVisitMessagesUntilVisitorReturnsFalse() {
+  void shouldVisitMessagesUntilVisitorReturnsFalse() {
     // given
     final var message = createMessage("name", "correlationKey", "{}", "nr1", 1234);
     final var message2 = createMessage("otherName", "correlationKey", "{}", "nr2", 2000);
@@ -241,7 +240,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldVisitMessagesWhileVisitorReturnsTrue() {
+  void shouldVisitMessagesWhileVisitorReturnsTrue() {
     // given
     final var message = createMessage("name", "correlationKey", "{}", "nr1", 1234);
     final var message2 = createMessage("otherName", "correlationKey", "{}", "nr2", 2000);
@@ -268,7 +267,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldNotVisitMessagesBeforeTime() {
+  void shouldNotVisitMessagesBeforeTime() {
     // given
     final var message = createMessage("name", "correlationKey", "{}", "nr1", 1234);
     final var message2 = createMessage("name", "correlationKey", "{}", "nr2", 4567);
@@ -285,7 +284,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldVisitMessagesBeforeTime() {
+  void shouldVisitMessagesBeforeTime() {
     // given
     final var message = createMessage("name", "correlationKey", "{}", "nr1", 1234);
     final var message2 = createMessage("otherName", "correlationKey", "{}", "nr2", 2000);
@@ -303,7 +302,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldVisitMessagesBeforeTimeInOrder() {
+  void shouldVisitMessagesBeforeTimeInOrder() {
     // given
     final long now = InstantSource.system().millis();
 
@@ -326,7 +325,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldVisitMessagesBeforeTimeStartingAtIndex() {
+  void shouldVisitMessagesBeforeTimeStartingAtIndex() {
     // given four messages
     final var message = createMessage("name", "correlationKey", "{}", "nr1", 1234);
     final var message2 = createMessage("otherName", "correlationKey", "{}", "nr2", 2000);
@@ -359,7 +358,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldRemoveMessage() {
+  void shouldRemoveMessage() {
     // given
     final var message = createMessage("name", "correlationKey", "{}", "id", 1234);
     messageState.put(1L, message);
@@ -402,7 +401,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldRemoveMessageWithoutId() {
+  void shouldRemoveMessageWithoutId() {
     // given
     final var message = createMessage("name", "correlationKey");
 
@@ -430,7 +429,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldNotFailOnRemoveMessageTwice() {
+  void shouldNotFailOnRemoveMessageTwice() {
     // given
     final var message = createMessage("name", "correlationKey", "{}", "id", 1234);
 
@@ -468,7 +467,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldNotRemoveDifferentMessage() {
+  void shouldNotRemoveDifferentMessage() {
     // given
     final var message = createMessage("name", "correlationKey", "{}", "id1", 1234);
     final var message2 = createMessage("name", "correlationKey", "{}", "id2", 4567);
@@ -514,7 +513,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldExistCorrelatedMessage() {
+  void shouldExistCorrelatedMessage() {
     // when
     final var messageKey = 1L;
     final var message = createMessage("name", "correlationKey", "{}", "id1", 1234);
@@ -529,7 +528,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldRemoveMessageCorrelation() {
+  void shouldRemoveMessageCorrelation() {
     // given
     final long messageKey = 6L;
     final var message = createMessage("name", "correlationKey", "{}", "id1", 1234);
@@ -545,7 +544,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldExistActiveProcessInstance() {
+  void shouldExistActiveProcessInstance() {
     // when
     messageState.putActiveProcessInstance(wrapString("wf-1"), wrapString("key-1"));
 
@@ -566,7 +565,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldRemoveActiveProcessInstance() {
+  void shouldRemoveActiveProcessInstance() {
     // given
     messageState.putActiveProcessInstance(wrapString("wf-1"), wrapString("key-1"));
     messageState.putActiveProcessInstance(wrapString("wf-2"), wrapString("key-1"));
@@ -591,7 +590,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldGetProcessInstanceCorrelationKey() {
+  void shouldGetProcessInstanceCorrelationKey() {
     // when
     messageState.putProcessInstanceCorrelationKey(1L, wrapString("key-1"));
 
@@ -602,7 +601,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldRemoveProcessInstanceCorrelationKey() {
+  void shouldRemoveProcessInstanceCorrelationKey() {
     // given
     messageState.putProcessInstanceCorrelationKey(1L, wrapString("key-1"));
     messageState.putProcessInstanceCorrelationKey(2L, wrapString("key-2"));
@@ -616,7 +615,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldGetCrossPartitionStartHolderOrigin() {
+  void shouldGetCrossPartitionStartHolderOrigin() {
     // when
     messageState.putCrossPartitionStartHolderOrigin(
         1L, wrapString("process-1"), wrapString("key-1"), "tenant-1", 42L);
@@ -631,7 +630,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldReturnNullForAbsentCrossPartitionStartHolderOrigin() {
+  void shouldReturnNullForAbsentCrossPartitionStartHolderOrigin() {
     // given
     messageState.putCrossPartitionStartHolderOrigin(
         1L, wrapString("process-1"), wrapString("key-1"), DEFAULT_TENANT, 42L);
@@ -641,7 +640,7 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldRemoveCrossPartitionStartHolderOrigin() {
+  void shouldRemoveCrossPartitionStartHolderOrigin() {
     // given
     messageState.putCrossPartitionStartHolderOrigin(
         1L, wrapString("process-1"), wrapString("key-1"), "tenant-1", 42L);
@@ -660,14 +659,14 @@ public final class MessageStateTest {
   }
 
   @Test
-  public void shouldNotThrowWhenRemovingAbsentCrossPartitionStartHolderOrigin() {
+  void shouldNotThrowWhenRemovingAbsentCrossPartitionStartHolderOrigin() {
     // when - then (no exception)
     messageState.removeCrossPartitionStartHolderOrigin(99L);
     assertThat(messageState.getCrossPartitionStartHolderOrigin(99L)).isNull();
   }
 
   @Test
-  public void shouldOverwriteCrossPartitionStartHolderOrigin() {
+  void shouldOverwriteCrossPartitionStartHolderOrigin() {
     // given
     messageState.putCrossPartitionStartHolderOrigin(
         1L, wrapString("process-1"), wrapString("key-1"), "tenant-1", 42L);


### PR DESCRIPTION
## Description

Adds state-backed occupancy gauges and a blocked-start counter for the cross-partition message-start uniqueness feature, making buffering pressure and backlog visible to operators for the first time.

### New metrics

| ID | Metric name | Type | Where |
|----|-------------|------|-------|
| M4 | `zeebe.message.start.cross.partition.asks.pending` | Gauge | `DbMessageStartProcessInstanceAskState` |
| M5 | `zeebe.message.start.cross.partition.locks` | Gauge | `DbMessageState` |
| M6 | `zeebe.message.start.cross.partition.dedup.entries` | Gauge | `DbMessageStartProcessInstanceDedupState` |
| M14 | `zeebe.message.start.blocked.total` | Counter (`reason` tag: `correlation_key` \| `business_id`) | `MessageCorrelateBehavior` |
| M15 | `zeebe.buffered.messages.business.id.count` | Gauge | `DbMessageState` |

### Implementation details

- **State gauges** are built from `zeebeDb.getMeterRegistry()` inside the respective `Db*State` classes — no threading changes required in `EngineProcessors`.
- **Upsert-safe increments** — `put` on the ask and dedup states checks `columnFamily.exists` before incrementing, so retried writes are not double-counted.
- **Recovery seeding** — all gauges are authoritatively re-seeded from persisted state in `onRecovered`, discarding any +1/−1 accumulated during replay to guarantee accuracy after leader failover.
- `DbMessageStartProcessInstanceDedupState` now implements `StreamProcessorLifecycleAware` and its `onRecovered` is wired into `ProcessingDbState.onRecovered`.
- **M14 blocked-start counter** — `MessageCorrelateBehavior.shouldCorrelateStartEvent` is refactored into `evaluateStartEventCorrelation` returning `Either<BlockReason, Void>`, so the gate that fired (correlation key takes precedence over business id) is attributed precisely. The metric is recorded only on the real mutation path, never in the dry-run `collectMessageStartEventSubscriptions` mirror.

### Tests

- Unit tests for all gauge behaviours: put/remove tracking, upsert-safety, absent-key no-decrement, and recovery reseeding (`DbMessageStartProcessInstanceAskStateTest`, `DbMessageStartProcessInstanceDedupStateTest`, `MessageStateTest`).
- `MessageCorrelationMetricsTest` — unit test for M14 counter attribution by reason.
- `MessageStartBlockedMetricsTest` — new behavioural test using a single-partition `EngineRule` verifying that each uniqueness gate (correlation key, business id, both-held) is attributed correctly in a live correlation scenario.
- Test classes migrated from JUnit 4 (`ProcessingStateRule`) to JUnit 5 (`ProcessingStateExtension`) where touched.

## Related issues

Closes #59139