### PR TITLE
feat: support metadata on cluster variables in the Spring Boot starter

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/ClusterVariables.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/ClusterVariables.java
@@ -37,8 +37,11 @@ public @interface ClusterVariables {
    * JSON resource files to load cluster variables from. Supports Spring resource pattern resolver
    * mechanisms (e.g., {@code "classpath:cluster-variables.json"}).
    *
-   * <p>Each JSON file should contain a flat JSON object where each key becomes a variable name and
-   * the corresponding value becomes the variable value.
+   * <p>Each JSON file contains either a flat JSON object, where each key becomes a variable name
+   * and the corresponding value becomes the variable value, or a JSON array of entries of the form
+   * <code>{"name": ..., "value": ..., "metadata": {...}, "kind": ...}</code>, which additionally
+   * supports metadata. The same applies to the value returned by a method-level annotation. An
+   * entry must not define a {@code tenantId} — the scope is defined by {@link #tenantId()}.
    *
    * <p>Only effective on class level.
    */

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/ClusterVariablesAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/ClusterVariablesAnnotationProcessor.java
@@ -122,7 +122,7 @@ public class ClusterVariablesAnnotationProcessor extends AbstractCamundaAnnotati
       }
       variables.forEach(
           entry -> {
-            if (tenantIdOf(entry) != null) {
+            if (entry.getTenantId() != null) {
               throw new IllegalArgumentException(
                   "Cluster variable '"
                       + entry.getName()

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/ClusterVariablesAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/ClusterVariablesAnnotationProcessor.java
@@ -24,9 +24,14 @@ import io.camunda.client.annotation.value.ClusterVariablesValue;
 import io.camunda.client.annotation.value.MethodClusterVariablesValue;
 import io.camunda.client.annotation.value.ResourceClusterVariablesValue;
 import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.GloballyScopedClusterVariableCreationCommandStep1;
+import io.camunda.client.api.command.GloballyScopedClusterVariableUpdateCommandStep1;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.command.TenantScopedClusterVariableCreationCommandStep1;
+import io.camunda.client.api.command.TenantScopedClusterVariableUpdateCommandStep1;
 import io.camunda.client.bean.BeanInfo;
 import io.camunda.client.spring.properties.CamundaClientClusterVariablesProperties;
+import io.camunda.client.spring.properties.ClusterVariableEntry;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -98,38 +103,16 @@ public class ClusterVariablesAnnotationProcessor extends AbstractCamundaAnnotati
 
   @Override
   public void start(final CamundaClient client) {
-    // Process global variables from properties
-    final Map<String, Object> globalVariables = properties.getGlobal();
-    if (globalVariables != null && !globalVariables.isEmpty()) {
-      LOGGER.debug(
-          "Upserting {} globally-scoped cluster variable(s) from properties",
-          globalVariables.size());
-      upsertClusterVariables(client, globalVariables, null);
-    }
-
-    // Process tenant-scoped variables from properties
-    final Map<String, Map<String, Object>> tenantVariables = properties.getTenant();
-    if (tenantVariables != null && !tenantVariables.isEmpty()) {
-      for (final Map.Entry<String, Map<String, Object>> entry : tenantVariables.entrySet()) {
-        final String tenantId = entry.getKey();
-        if (tenantId == null || tenantId.isBlank()) {
-          throw new IllegalArgumentException(
-              "Invalid tenant ID in 'camunda.client.cluster-variables.tenant': tenant ID must not be null or blank");
-        }
-        final Map<String, Object> variables = entry.getValue();
-        if (variables != null && !variables.isEmpty()) {
-          LOGGER.debug(
-              "Upserting {} cluster variable(s) from properties for tenant '{}'",
-              variables.size(),
-              tenantId);
-          upsertClusterVariables(client, variables, tenantId);
-        }
-      }
+    // Process variables from properties
+    final List<ClusterVariableEntry> propertyVariables = properties.resolveVariables();
+    if (!propertyVariables.isEmpty()) {
+      LOGGER.debug("Upserting {} cluster variable(s) from properties", propertyVariables.size());
+      upsertClusterVariables(client, propertyVariables);
     }
 
     // Process variables from annotations
     for (final ClusterVariablesValue value : clusterVariablesValues) {
-      final Map<String, Object> variables;
+      final List<ClusterVariableEntry> variables;
       if (value instanceof ResourceClusterVariablesValue resourceValue) {
         variables = loadVariablesFromResources(resourceValue.getResources());
       } else if (value instanceof MethodClusterVariablesValue methodValue) {
@@ -137,7 +120,17 @@ public class ClusterVariablesAnnotationProcessor extends AbstractCamundaAnnotati
       } else {
         continue;
       }
-      upsertClusterVariables(client, variables, value.getTenantId());
+      variables.forEach(
+          entry -> {
+            if (tenantIdOf(entry) != null) {
+              throw new IllegalArgumentException(
+                  "Cluster variable '"
+                      + entry.getName()
+                      + "' must not define a tenantId; use @ClusterVariables(tenantId = ...) instead");
+            }
+            entry.setTenantId(value.getTenantId());
+          });
+      upsertClusterVariables(client, variables);
     }
   }
 
@@ -146,8 +139,9 @@ public class ClusterVariablesAnnotationProcessor extends AbstractCamundaAnnotati
     clusterVariablesValues.clear();
   }
 
-  private Map<String, Object> loadVariablesFromResources(final List<String> resourcePatterns) {
-    final Map<String, Object> variables = new LinkedHashMap<>();
+  private List<ClusterVariableEntry> loadVariablesFromResources(
+      final List<String> resourcePatterns) {
+    final Map<String, ClusterVariableEntry> variables = new LinkedHashMap<>();
     final List<Resource> allResources =
         resourcePatterns.stream()
             .flatMap(pattern -> Arrays.stream(getResources(pattern)))
@@ -160,36 +154,60 @@ public class ClusterVariablesAnnotationProcessor extends AbstractCamundaAnnotati
     for (final Resource resource : allResources) {
       try (final InputStream inputStream = resource.getInputStream()) {
         final String json = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
-        final Map<String, Object> loaded = jsonMapper.fromJsonAsMap(json);
+        final List<ClusterVariableEntry> loaded = parseVariables(json);
         LOGGER.debug(
             "Loaded {} variable(s) from resource '{}'", loaded.size(), resource.getFilename());
-        variables.putAll(loaded);
+        loaded.forEach(entry -> variables.put(entry.getName(), entry));
       } catch (final Exception e) {
         throw new RuntimeException(
             "Error reading cluster variables from resource: " + resource.getFilename(), e);
       }
     }
-    return variables;
+    return new ArrayList<>(variables.values());
   }
 
-  private Map<String, Object> loadVariablesFromSupplier(final Supplier<Object> variableSupplier) {
+  private List<ClusterVariableEntry> loadVariablesFromSupplier(
+      final Supplier<Object> variableSupplier) {
     final Object result = variableSupplier.get();
     if (result == null) {
       throw new IllegalStateException("@ClusterVariables method must not return null");
     }
-    return jsonMapper.fromJsonAsMap(jsonMapper.toJson(result));
+    return parseVariables(jsonMapper.toJson(result));
+  }
+
+  /**
+   * Parses either a JSON array of {@link ClusterVariableEntry} objects or a flat JSON object where
+   * each key becomes a variable name and the corresponding value becomes the variable value.
+   */
+  private List<ClusterVariableEntry> parseVariables(final String json) {
+    if (json != null && json.stripLeading().startsWith("[")) {
+      return new ArrayList<>(
+          Arrays.asList(jsonMapper.fromJson(json, ClusterVariableEntry[].class)));
+    }
+    final List<ClusterVariableEntry> variables = new ArrayList<>();
+    jsonMapper
+        .fromJsonAsMap(json)
+        .forEach(
+            (name, value) -> {
+              final ClusterVariableEntry entry = new ClusterVariableEntry();
+              entry.setName(name);
+              entry.setValue(value);
+              variables.add(entry);
+            });
+    return variables;
   }
 
   private void upsertClusterVariables(
-      final CamundaClient client, final Map<String, Object> variables, final String tenantId) {
-    for (final Map.Entry<String, Object> entry : variables.entrySet()) {
-      final String name = entry.getKey();
-      final Object value = entry.getValue();
+      final CamundaClient client, final List<ClusterVariableEntry> variables) {
+    for (final ClusterVariableEntry variable : variables) {
+      if (variable.getName() == null || variable.getName().isBlank()) {
+        throw new IllegalArgumentException("Cluster variable name must not be null or blank");
+      }
       try {
-        createClusterVariable(client, name, value, tenantId);
+        createClusterVariable(client, variable);
       } catch (final ProblemException e) {
         if (e.code() == 409) {
-          updateClusterVariable(client, name, value, tenantId);
+          updateClusterVariable(client, variable);
         } else {
           throw e;
         }
@@ -198,25 +216,75 @@ public class ClusterVariablesAnnotationProcessor extends AbstractCamundaAnnotati
   }
 
   private void createClusterVariable(
-      final CamundaClient client, final String name, final Object value, final String tenantId) {
+      final CamundaClient client, final ClusterVariableEntry variable) {
+    final String name = variable.getName();
+    final String tenantId = tenantIdOf(variable);
     if (tenantId != null) {
-      client.newTenantScopedClusterVariableCreateRequest(tenantId).create(name, value).execute();
+      TenantScopedClusterVariableCreationCommandStep1 command =
+          client
+              .newTenantScopedClusterVariableCreateRequest(tenantId)
+              .create(name, variable.getValue());
+      if (hasMetadata(variable)) {
+        command = command.metadata(variable.getMetadata());
+      }
+      if (variable.getKind() != null) {
+        command = command.kind(variable.getKind());
+      }
+      command.execute();
       LOGGER.debug("Created tenant-scoped cluster variable '{}' for tenant '{}'", name, tenantId);
     } else {
-      client.newGloballyScopedClusterVariableCreateRequest().create(name, value).execute();
+      GloballyScopedClusterVariableCreationCommandStep1 command =
+          client.newGloballyScopedClusterVariableCreateRequest().create(name, variable.getValue());
+      if (hasMetadata(variable)) {
+        command = command.metadata(variable.getMetadata());
+      }
+      if (variable.getKind() != null) {
+        command = command.kind(variable.getKind());
+      }
+      command.execute();
       LOGGER.debug("Created globally-scoped cluster variable '{}'", name);
     }
   }
 
   private void updateClusterVariable(
-      final CamundaClient client, final String name, final Object value, final String tenantId) {
+      final CamundaClient client, final ClusterVariableEntry variable) {
+    final String name = variable.getName();
+    final String tenantId = tenantIdOf(variable);
+    if (variable.getKind() != null) {
+      LOGGER.warn(
+          "Ignoring kind '{}' for cluster variable '{}': the kind of an existing cluster variable cannot be changed",
+          variable.getKind(),
+          name);
+    }
     if (tenantId != null) {
-      client.newTenantScopedClusterVariableUpdateRequest(tenantId).update(name, value).execute();
+      TenantScopedClusterVariableUpdateCommandStep1 command =
+          client
+              .newTenantScopedClusterVariableUpdateRequest(tenantId)
+              .update(name, variable.getValue());
+      if (hasMetadata(variable)) {
+        command = command.metadata(variable.getMetadata());
+      }
+      command.execute();
       LOGGER.debug("Updated tenant-scoped cluster variable '{}' for tenant '{}'", name, tenantId);
     } else {
-      client.newGloballyScopedClusterVariableUpdateRequest().update(name, value).execute();
+      GloballyScopedClusterVariableUpdateCommandStep1 command =
+          client.newGloballyScopedClusterVariableUpdateRequest().update(name, variable.getValue());
+      if (hasMetadata(variable)) {
+        command = command.metadata(variable.getMetadata());
+      }
+      command.execute();
       LOGGER.debug("Updated globally-scoped cluster variable '{}'", name);
     }
+  }
+
+  /** A blank tenant ID means the variable is globally scoped. */
+  private static String tenantIdOf(final ClusterVariableEntry variable) {
+    final String tenantId = variable.getTenantId();
+    return tenantId == null || tenantId.isBlank() ? null : tenantId;
+  }
+
+  private static boolean hasMetadata(final ClusterVariableEntry variable) {
+    return variable.getMetadata() != null && !variable.getMetadata().isEmpty();
   }
 
   private Resource[] getResources(final String resourcePattern) {

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/ClusterVariablesAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/ClusterVariablesAnnotationProcessor.java
@@ -18,6 +18,7 @@ package io.camunda.client.spring.annotation.processor;
 import static io.camunda.client.annotation.AnnotationUtil.isClusterVariables;
 import static org.springframework.util.ReflectionUtils.doWithMethods;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.annotation.AnnotationUtil;
 import io.camunda.client.annotation.value.ClusterVariablesValue;
@@ -180,9 +181,10 @@ public class ClusterVariablesAnnotationProcessor extends AbstractCamundaAnnotati
    * each key becomes a variable name and the corresponding value becomes the variable value.
    */
   private List<ClusterVariableEntry> parseVariables(final String json) {
-    if (json != null && json.stripLeading().startsWith("[")) {
+    final JsonNode root = jsonMapper.fromJson(json, JsonNode.class);
+    if (root.isArray()) {
       return new ArrayList<>(
-          Arrays.asList(jsonMapper.fromJson(json, ClusterVariableEntry[].class)));
+          Arrays.asList(jsonMapper.transform(root, ClusterVariableEntry[].class)));
     }
     final List<ClusterVariableEntry> variables = new ArrayList<>();
     jsonMapper

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientClusterVariablesProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientClusterVariablesProperties.java
@@ -15,23 +15,44 @@
  */
 package io.camunda.client.spring.properties;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 
 public class CamundaClientClusterVariablesProperties {
 
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(CamundaClientClusterVariablesProperties.class);
+
   /**
    * Indicates if cluster variable processing is enabled. When {@code true}, variables configured
-   * via <code>@ClusterVariables</code> annotations and via the {@code global}/{@code tenant}
-   * properties are applied at startup. When {@code false}, all cluster variable processing is
-   * skipped.
+   * via <code>@ClusterVariables</code> annotations and via the {@code variables} property are
+   * applied at startup. When {@code false}, all cluster variable processing is skipped.
    */
   private boolean enabled = true;
 
-  /** Globally-scoped cluster variables to set at startup as key-value pairs. */
-  private Map<String, Object> global;
+  /**
+   * Cluster variables to set at startup. Each entry carries a name, a value and optionally
+   * metadata, a kind and a tenant ID. Entries without a tenant ID are globally scoped.
+   */
+  private List<ClusterVariableEntry> variables;
 
-  /** Tenant-scoped cluster variables to set at startup, keyed by tenant ID. */
-  private Map<String, Map<String, Object>> tenant;
+  /**
+   * Globally-scoped cluster variables to set at startup as key-value pairs.
+   *
+   * @deprecated use {@link #variables} instead, which also supports metadata.
+   */
+  @Deprecated private Map<String, Object> global;
+
+  /**
+   * Tenant-scoped cluster variables to set at startup, keyed by tenant ID.
+   *
+   * @deprecated use {@link #variables} instead, which also supports metadata.
+   */
+  @Deprecated private Map<String, Map<String, Object>> tenant;
 
   public boolean isEnabled() {
     return enabled;
@@ -41,18 +62,89 @@ public class CamundaClientClusterVariablesProperties {
     this.enabled = enabled;
   }
 
+  public List<ClusterVariableEntry> getVariables() {
+    return variables;
+  }
+
+  public void setVariables(final List<ClusterVariableEntry> variables) {
+    this.variables = variables;
+  }
+
+  /**
+   * Returns the configured cluster variables, converting the deprecated {@code global}/{@code
+   * tenant} maps into entries when the {@code variables} list is not set. When both shapes are
+   * configured, {@code variables} wins and the deprecated maps are ignored.
+   */
+  public List<ClusterVariableEntry> resolveVariables() {
+    final boolean hasGlobal = global != null && !global.isEmpty();
+    final boolean hasTenant = tenant != null && !tenant.isEmpty();
+
+    if (variables != null && !variables.isEmpty()) {
+      if (hasGlobal || hasTenant) {
+        LOGGER.warn(
+            "Ignoring 'camunda.client.cluster-variables.global' and "
+                + "'camunda.client.cluster-variables.tenant' because "
+                + "'camunda.client.cluster-variables.variables' is configured");
+      }
+      return variables;
+    }
+
+    final List<ClusterVariableEntry> resolved = new ArrayList<>();
+    if (hasGlobal) {
+      LOGGER.warn(
+          "The property 'camunda.client.cluster-variables.global' is deprecated, "
+              + "use 'camunda.client.cluster-variables.variables' instead");
+      global.forEach((name, value) -> resolved.add(entry(name, value, null)));
+    }
+    if (hasTenant) {
+      LOGGER.warn(
+          "The property 'camunda.client.cluster-variables.tenant' is deprecated, "
+              + "use 'camunda.client.cluster-variables.variables' instead");
+      tenant.forEach(
+          (tenantId, variables) -> {
+            if (tenantId == null || tenantId.isBlank()) {
+              throw new IllegalArgumentException(
+                  "Invalid tenant ID in 'camunda.client.cluster-variables.tenant': tenant ID must not be null or blank");
+            }
+            if (variables != null) {
+              variables.forEach((name, value) -> resolved.add(entry(name, value, tenantId)));
+            }
+          });
+    }
+    return resolved;
+  }
+
+  private static ClusterVariableEntry entry(
+      final String name, final Object value, final String tenantId) {
+    final ClusterVariableEntry entry = new ClusterVariableEntry();
+    entry.setName(name);
+    entry.setValue(value);
+    entry.setTenantId(tenantId);
+    return entry;
+  }
+
+  @Deprecated
+  @DeprecatedConfigurationProperty(
+      reason = "does not support metadata",
+      replacement = "camunda.client.cluster-variables.variables")
   public Map<String, Object> getGlobal() {
     return global;
   }
 
+  @Deprecated
   public void setGlobal(final Map<String, Object> global) {
     this.global = global;
   }
 
+  @Deprecated
+  @DeprecatedConfigurationProperty(
+      reason = "does not support metadata",
+      replacement = "camunda.client.cluster-variables.variables")
   public Map<String, Map<String, Object>> getTenant() {
     return tenant;
   }
 
+  @Deprecated
   public void setTenant(final Map<String, Map<String, Object>> tenant) {
     this.tenant = tenant;
   }
@@ -62,6 +154,8 @@ public class CamundaClientClusterVariablesProperties {
     return "CamundaClientClusterVariablesProperties{"
         + "enabled="
         + enabled
+        + ", variables="
+        + variables
         + ", global="
         + global
         + ", tenant="

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientClusterVariablesProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientClusterVariablesProperties.java
@@ -30,7 +30,8 @@ public class CamundaClientClusterVariablesProperties {
   /**
    * Indicates if cluster variable processing is enabled. When {@code true}, variables configured
    * via <code>@ClusterVariables</code> annotations and via the {@code variables} property are
-   * applied at startup. When {@code false}, all cluster variable processing is skipped.
+   * applied at startup. The deprecated {@code global} and {@code tenant} properties are also
+   * applied for compatibility. When {@code false}, all cluster variable processing is skipped.
    */
   private boolean enabled = true;
 
@@ -101,13 +102,13 @@ public class CamundaClientClusterVariablesProperties {
           "The property 'camunda.client.cluster-variables.tenant' is deprecated, "
               + "use 'camunda.client.cluster-variables.variables' instead");
       tenant.forEach(
-          (tenantId, variables) -> {
+          (tenantId, tenantVariables) -> {
             if (tenantId == null || tenantId.isBlank()) {
               throw new IllegalArgumentException(
                   "Invalid tenant ID in 'camunda.client.cluster-variables.tenant': tenant ID must not be null or blank");
             }
-            if (variables != null) {
-              variables.forEach((name, value) -> resolved.add(entry(name, value, tenantId)));
+            if (tenantVariables != null) {
+              tenantVariables.forEach((name, value) -> resolved.add(entry(name, value, tenantId)));
             }
           });
     }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/ClusterVariableEntry.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/ClusterVariableEntry.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.properties;
+
+import io.camunda.client.api.search.enums.ClusterVariableKind;
+import java.util.Map;
+
+/**
+ * A single cluster variable to be set at startup, including optional metadata.
+ *
+ * <p>Used both by the {@code camunda.client.cluster-variables.variables} property and by <code>
+ * @ClusterVariables</code> JSON resources and methods, which may provide a list of such entries
+ * instead of a flat name-to-value object.
+ */
+public class ClusterVariableEntry {
+
+  /** The name of the cluster variable. Required. */
+  private String name;
+
+  /** The value of the cluster variable. Required. */
+  private Object value;
+
+  /**
+   * Optional metadata attached to the cluster variable. Values must be strings or numbers, as
+   * enforced by the server.
+   */
+  private Map<String, Object> metadata;
+
+  /**
+   * Optional kind of the cluster variable, defaults to {@code JSON} on the server. Only applied
+   * when the variable is created; the kind of an existing variable cannot be changed.
+   */
+  private ClusterVariableKind kind;
+
+  /**
+   * Optional tenant ID. When absent or blank, the variable is globally scoped. Only supported on
+   * the {@code camunda.client.cluster-variables.variables} property; for <code>@ClusterVariables
+   * </code> the annotation's {@code tenantId} defines the scope.
+   */
+  private String tenantId;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public Object getValue() {
+    return value;
+  }
+
+  public void setValue(final Object value) {
+    this.value = value;
+  }
+
+  public Map<String, Object> getMetadata() {
+    return metadata;
+  }
+
+  public void setMetadata(final Map<String, Object> metadata) {
+    this.metadata = metadata;
+  }
+
+  public ClusterVariableKind getKind() {
+    return kind;
+  }
+
+  public void setKind(final ClusterVariableKind kind) {
+    this.kind = kind;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  @Override
+  public String toString() {
+    return "ClusterVariableEntry{"
+        + "name='"
+        + name
+        + '\''
+        + ", value="
+        + value
+        + ", metadata="
+        + metadata
+        + ", kind="
+        + kind
+        + ", tenantId='"
+        + tenantId
+        + '\''
+        + '}';
+  }
+}

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
@@ -236,11 +236,8 @@ public class AlignmentTest {
               "camunda.client.cluster-variables.enabled",
               new Getter(p -> p.getClusterVariables().isEnabled())),
           entry(
-              "camunda.client.cluster-variables.global",
-              new Getter(p -> p.getClusterVariables().getGlobal())),
-          entry(
-              "camunda.client.cluster-variables.tenant",
-              new Getter(p -> p.getClusterVariables().getTenant())),
+              "camunda.client.cluster-variables.variables",
+              new Getter(p -> p.getClusterVariables().getVariables())),
           entry(
               "camunda.client.physical-tenant-id",
               new Getter(CamundaClientProperties::getPhysicalTenantId)),

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/ClusterVariablesAnnotationProcessorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/ClusterVariablesAnnotationProcessorTest.java
@@ -294,6 +294,26 @@ public class ClusterVariablesAnnotationProcessorTest {
   }
 
   @Test
+  void shouldRejectBlankEntryLevelTenantIdFromResource() throws IOException {
+    // given
+    final Resource resource =
+        mockJsonResource(
+            """
+            [{"name": "var", "value": "v", "tenantId": ""}]""");
+    when(resourcePatternResolver.getResources("classpath:variables.json"))
+        .thenReturn(new Resource[] {resource});
+
+    // when / then
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () -> {
+              processor.configureFor(beanInfo(new WithSingleResource()));
+              processor.start(client);
+            })
+        .withMessageContaining("must not define a tenantId");
+  }
+
+  @Test
   void shouldCreateVariablesFromPojoMethod() {
     // given
     mockGlobalCreateCommand();
@@ -454,8 +474,9 @@ public class ClusterVariablesAnnotationProcessorTest {
     // given
     final Resource resource =
         mockJsonResource(
-            "[{\"name\": \"region\", \"value\": \"eu-1\", \"metadata\": {\"owner\": \"platform\"}}, "
-                + "{\"name\": \"retries\", \"value\": 3}]");
+            """
+                [{"name": "region", "value": "eu-1", "metadata": {"owner": "platform"}}, \
+                {"name": "retries", "value": 3}]""");
     when(resourcePatternResolver.getResources("classpath:variables.json"))
         .thenReturn(new Resource[] {resource});
     mockGlobalCreateCommand();

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/ClusterVariablesAnnotationProcessorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/ClusterVariablesAnnotationProcessorTest.java
@@ -28,12 +28,15 @@ import io.camunda.client.api.command.GloballyScopedClusterVariableUpdateCommandS
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.command.TenantScopedClusterVariableCreationCommandStep1;
 import io.camunda.client.api.command.TenantScopedClusterVariableUpdateCommandStep1;
+import io.camunda.client.api.search.enums.ClusterVariableKind;
 import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.client.spring.annotation.processor.ClusterVariablesAnnotationProcessor;
 import io.camunda.client.spring.properties.CamundaClientClusterVariablesProperties;
+import io.camunda.client.spring.properties.ClusterVariableEntry;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -385,6 +388,171 @@ public class ClusterVariablesAnnotationProcessorTest {
     verify(tenantUpdateStep).update("tenantVar", "newValue");
   }
 
+  @Test
+  void shouldCreateVariablesWithMetadataFromProperties() {
+    // given
+    properties.setVariables(
+        List.of(entry("withMeta", "value", Map.of("owner", "platform"), null, null)));
+    mockGlobalCreateCommand();
+    when(globalCreateStep.metadata(anyMap())).thenReturn(globalCreateStep);
+
+    // when
+    processor.start(client);
+
+    // then
+    verify(globalCreateStep).create("withMeta", "value");
+    verify(globalCreateStep).metadata(Map.of("owner", "platform"));
+  }
+
+  @Test
+  void shouldCreateVariableWithKindFromProperties() {
+    // given
+    properties.setVariables(
+        List.of(entry("secret", "my/secret", null, ClusterVariableKind.SECRET_REFERENCE, null)));
+    mockGlobalCreateCommand();
+    when(globalCreateStep.kind(any())).thenReturn(globalCreateStep);
+
+    // when
+    processor.start(client);
+
+    // then
+    verify(globalCreateStep).kind(ClusterVariableKind.SECRET_REFERENCE);
+    verify(globalCreateStep, never()).metadata(anyMap());
+  }
+
+  @Test
+  void shouldCreateTenantScopedVariableFromVariablesProperty() {
+    // given
+    properties.setVariables(List.of(entry("tenantVar", "tenantValue", null, null, "my-tenant")));
+    mockTenantCreateCommand();
+
+    // when
+    processor.start(client);
+
+    // then
+    verify(client).newTenantScopedClusterVariableCreateRequest("my-tenant");
+    verify(tenantCreateStep).create("tenantVar", "tenantValue");
+  }
+
+  @Test
+  void shouldPreferVariablesOverDeprecatedProperties() {
+    // given
+    properties.setVariables(List.of(entry("fromList", "listValue", null, null, null)));
+    properties.setGlobal(Map.of("fromGlobal", "globalValue"));
+    mockGlobalCreateCommand();
+
+    // when
+    processor.start(client);
+
+    // then
+    verify(globalCreateStep).create("fromList", "listValue");
+    verify(globalCreateStep, never()).create("fromGlobal", "globalValue");
+  }
+
+  @Test
+  void shouldCreateVariablesWithMetadataFromResource() throws IOException {
+    // given
+    final Resource resource =
+        mockJsonResource(
+            "[{\"name\": \"region\", \"value\": \"eu-1\", \"metadata\": {\"owner\": \"platform\"}}, "
+                + "{\"name\": \"retries\", \"value\": 3}]");
+    when(resourcePatternResolver.getResources("classpath:variables.json"))
+        .thenReturn(new Resource[] {resource});
+    mockGlobalCreateCommand();
+    when(globalCreateStep.metadata(anyMap())).thenReturn(globalCreateStep);
+
+    // when
+    processor.configureFor(beanInfo(new WithSingleResource()));
+    processor.start(client);
+
+    // then
+    verify(globalCreateStep).create("region", "eu-1");
+    verify(globalCreateStep).metadata(Map.of("owner", "platform"));
+    verify(globalCreateStep).create("retries", 3);
+  }
+
+  @Test
+  void shouldCreateVariablesWithMetadataFromMethod() {
+    // given
+    mockGlobalCreateCommand();
+    when(globalCreateStep.metadata(anyMap())).thenReturn(globalCreateStep);
+
+    // when
+    processor.configureFor(beanInfo(new WithEntryListMethod()));
+    processor.start(client);
+
+    // then
+    verify(globalCreateStep).create("environment", "production");
+    verify(globalCreateStep).metadata(Map.of("owner", "platform"));
+  }
+
+  @Test
+  void shouldRejectEntryLevelTenantIdFromResource() throws IOException {
+    // given
+    final Resource resource =
+        mockJsonResource("[{\"name\": \"var\", \"value\": \"v\", \"tenantId\": \"other\"}]");
+    when(resourcePatternResolver.getResources("classpath:variables.json"))
+        .thenReturn(new Resource[] {resource});
+
+    // when / then
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () -> {
+              processor.configureFor(beanInfo(new WithSingleResource()));
+              processor.start(client);
+            })
+        .withMessageContaining("must not define a tenantId");
+  }
+
+  @Test
+  void shouldRejectVariableWithoutName() {
+    // given
+    properties.setVariables(List.of(entry(null, "value", null, null, null)));
+
+    // when / then
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> processor.start(client))
+        .withMessageContaining("name must not be null or blank");
+  }
+
+  @Test
+  void shouldUpdateVariableWithMetadataWhenAlreadyExists() {
+    // given
+    properties.setVariables(
+        List.of(
+            entry(
+                "myVar", "newValue", Map.of("owner", "platform"), ClusterVariableKind.JSON, null)));
+    when(client.newGloballyScopedClusterVariableCreateRequest()).thenReturn(globalCreateStep);
+    when(globalCreateStep.create(anyString(), any())).thenReturn(globalCreateStep);
+    when(globalCreateStep.metadata(anyMap())).thenReturn(globalCreateStep);
+    when(globalCreateStep.kind(any())).thenReturn(globalCreateStep);
+    doThrow(new ProblemException(409, "Conflict", null)).when(globalCreateStep).execute();
+    mockGlobalUpdateCommand();
+    when(globalUpdateStep.metadata(anyMap())).thenReturn(globalUpdateStep);
+
+    // when
+    processor.start(client);
+
+    // then
+    verify(globalUpdateStep).update("myVar", "newValue");
+    verify(globalUpdateStep).metadata(Map.of("owner", "platform"));
+  }
+
+  private static ClusterVariableEntry entry(
+      final String name,
+      final Object value,
+      final Map<String, Object> metadata,
+      final ClusterVariableKind kind,
+      final String tenantId) {
+    final ClusterVariableEntry entry = new ClusterVariableEntry();
+    entry.setName(name);
+    entry.setValue(value);
+    entry.setMetadata(metadata);
+    entry.setKind(kind);
+    entry.setTenantId(tenantId);
+    return entry;
+  }
+
   private void mockGlobalCreateCommand() {
     when(client.newGloballyScopedClusterVariableCreateRequest()).thenReturn(globalCreateStep);
     when(globalCreateStep.create(anyString(), any())).thenReturn(globalCreateStep);
@@ -420,6 +588,14 @@ public class ClusterVariablesAnnotationProcessorTest {
     @ClusterVariables
     public Map<String, Object> clusterVariables() {
       return Map.of("environment", "production", "version", "1.0");
+    }
+  }
+
+  // Public to allow reflective method invocation from SpringMethodInfo (different package)
+  public static final class WithEntryListMethod {
+    @ClusterVariables
+    public List<ClusterVariableEntry> clusterVariables() {
+      return List.of(entry("environment", "production", Map.of("owner", "platform"), null, null));
     }
   }
 


### PR DESCRIPTION
## Summary

Cluster variables in the Spring Boot starter now support metadata, kind, and tenant ID through configuration entries and `@ClusterVariables`, while keeping the deprecated `global` and `tenant` properties compatible. Kind is sent only on create, with a warning when the create-then-update fallback cannot preserve it.

Closes #58465

## Testing

Focused tests are included in this branch; no additional local validation was run.