### PR TITLE
ci: retry Renovate config validation against transient npm failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2386,8 +2386,16 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - run: |
-          npx --yes --package "renovate@latest" -c "renovate-config-validator"
+      # Retry to absorb transient npm-registry resolution failures when npx resolves
+      # renovate@latest and its transitive deps on a fresh run (see INC-6869).
+      - name: Validate Renovate config
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 3
+          retry_on: error
+          retry_wait_seconds: 15
+          timeout_minutes: 5
+          command: npx --yes --package "renovate@latest" -c "renovate-config-validator"
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2394,7 +2394,9 @@ jobs:
           max_attempts: 3
           retry_on: error
           retry_wait_seconds: 15
-          timeout_minutes: 5
+          # 2 min/attempt keeps all 3 attempts (~6.5 min worst case) within the
+          # 10-min job timeout; validation normally completes in well under a minute.
+          timeout_minutes: 2
           command: npx --yes --package "renovate@latest" -c "renovate-config-validator"
       - name: Observe build status
         if: always()

--- a/.github/workflows/renovate-weekly.yml
+++ b/.github/workflows/renovate-weekly.yml
@@ -20,7 +20,8 @@ env:
 jobs:
   config-migration-needed:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # 8 min accommodates the 3-attempt retry below (~6.5 min worst case).
+    timeout-minutes: 8
     permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -35,7 +36,9 @@ jobs:
           max_attempts: 3
           retry_on: error
           retry_wait_seconds: 15
-          timeout_minutes: 5
+          # 2 min/attempt keeps all 3 attempts (~6.5 min worst case) within the
+          # job timeout; validation normally completes in well under a minute.
+          timeout_minutes: 2
           command: npx --yes --package "renovate@latest" -c "renovate-config-validator --strict"
       - name: Observe build status
         if: always()

--- a/.github/workflows/renovate-weekly.yml
+++ b/.github/workflows/renovate-weekly.yml
@@ -27,8 +27,16 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - run: |
-          npx --yes --package "renovate@latest" -c "renovate-config-validator --strict"
+      # Retry to absorb transient npm-registry resolution failures when npx resolves
+      # renovate@latest and its transitive deps on a fresh run (see INC-6869).
+      - name: Validate Renovate config
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 3
+          retry_on: error
+          retry_wait_seconds: 15
+          timeout_minutes: 5
+          command: npx --yes --package "renovate@latest" -c "renovate-config-validator --strict"
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Description

The `renovatelint` (`ci.yml`) and `config-migration-needed` (`renovate-weekly.yml`) jobs both resolve `renovate@latest` fresh on every run via `npx --yes --package "renovate@latest"`. On 2026-07-31 this failed with:

```
npm error ETARGET: No matching version found for @aws-sdk/credential-provider-process@^3.972.65
```

— a transitive Renovate dependency that was briefly unresolvable on the npm registry. The next run recovered with no code change, confirming an upstream registry/publish-race, **not** a config problem (INC-6869).

## Change

Wrap the `npx` step in `nick-fields/retry` (already the repo's pattern for transient-dependency flakiness, e.g. docker/harbor/minimus logins) so a momentary registry hiccup is retried instead of failing the job. Retry fits here because these are shell `run:` steps — unlike the `uses:` steps in INC-6820 where retry was not an option.

## Why not pin the Renovate version?

Renovate does **not** self-update this pin: no custom regex manager in `.github/renovate.json` targets `renovate@` in workflow `run:` steps, and the built-in `github-actions` manager only parses `uses:` lines. Pinning would add manual upkeep (or a new custom manager) for a one-off transient failure. Keeping `@latest` also validates config against the current Renovate schema — which is the point of these jobs.

## Validation

- `actionlint` — clean on the edited lines (only pre-existing `gcp-*` self-hosted runner-label and `if: false` warnings elsewhere).
- `conftest` (`--rego-version v0`, `.github` policy) — 0 failures on both files.
- act tier: **3** (external-only) — the change wraps an npm-registry-dependent `run:` step in a retry action with no new conditional logic; `act` cannot reproduce the upstream registry race and gives no useful signal.

Refs INC-6869