### PR TITLE
RecoveryServices mode change authZ

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -51,6 +51,7 @@ import io.camunda.service.MessageServices;
 import io.camunda.service.MessageSubscriptionServices;
 import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.RecoveryServices;
 import io.camunda.service.ResourceServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.RuntimeBackupServices;
@@ -72,6 +73,7 @@ import io.camunda.zeebe.backup.common.CheckpointIdGenerator;
 import io.camunda.zeebe.backup.schedule.Schedule;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.gateway.admin.ExportingRequestBroadcaster;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
@@ -133,6 +135,7 @@ public class CamundaServicesConfiguration {
       final AuthorizationCheckerProvider authorizationCheckerProvider,
       final GatewayRestConfiguration gatewayRestConfiguration,
       final BrokerTopologyManager brokerTopologyManager,
+      final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender,
       final MeterRegistry meterRegistry,
       final Environment environment,
       final ManagementServices managementServices,
@@ -431,6 +434,17 @@ public class CamundaServicesConfiguration {
                           converter))
                   .processDefinitionServices(tenantId, processDefinition)
                   .processInstanceServices(tenantId, processInstance)
+                  .recoveryServices(
+                      tenantId,
+                      new RecoveryServices(
+                          tenantId,
+                          brokerClient,
+                          securityContextProvider,
+                          clusterConfigurationRequestSender,
+                          authorizationChecker,
+                          tenantSecurity.getAuthorizations(),
+                          executor,
+                          converter))
                   .resourceServices(
                       tenantId,
                       new ResourceServices(

--- a/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
@@ -37,6 +37,7 @@ import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -380,6 +381,7 @@ class CamundaServicesConfigurationTest {
         authorizationCheckerProvider,
         new GatewayRestConfiguration(),
         mock(BrokerTopologyManager.class),
+        mock(ClusterConfigurationManagementRequestSender.class),
         new SimpleMeterRegistry(),
         new MockEnvironment(),
         new ManagementServices(new CamundaLicense(null)),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RecoveryAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RecoveryAuthorizationIT.java
@@ -68,6 +68,10 @@ class RecoveryAuthorizationIT {
 
   private static final String CHANGE_MODE_PATH = "v2/mode?mode=RECOVERING&dryRun=true";
 
+  private static final String FORBIDDEN_DETAIL =
+      "Unauthorized to perform any of the operations: "
+          + "'RESTORE' on 'BACKUP' or 'UPDATE' on 'SYSTEM'";
+
   @Test
   void shouldRejectUnauthenticatedRequest(
       @Authenticated(NO_PERMISSION_USER) final CamundaClient client) throws Exception {
@@ -86,6 +90,7 @@ class RecoveryAuthorizationIT {
 
     // then it is forbidden
     assertThat(response.statusCode()).isEqualTo(403);
+    assertThat(response.body()).contains(FORBIDDEN_DETAIL);
   }
 
   @Test
@@ -97,6 +102,7 @@ class RecoveryAuthorizationIT {
     // then it is forbidden: a grant on the BACKUP resource type only reaches the mode change when
     // it is the RESTORE permission
     assertThat(response.statusCode()).isEqualTo(403);
+    assertThat(response.body()).contains(FORBIDDEN_DETAIL);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RecoveryAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RecoveryAuthorizationIT.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.client.api.search.enums.PermissionType.READ;
+import static io.camunda.client.api.search.enums.PermissionType.RESTORE;
+import static io.camunda.client.api.search.enums.PermissionType.UPDATE;
+import static io.camunda.client.api.search.enums.ResourceType.BACKUP;
+import static io.camunda.client.api.search.enums.ResourceType.SYSTEM;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+class RecoveryAuthorizationIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+
+  private static final String PASSWORD = "password";
+
+  private static final String NO_PERMISSION_USER = "noPermissionUser";
+  private static final String SYSTEM_UPDATE_USER = "systemUpdateUser";
+  private static final String BACKUP_RESTORE_USER = "backupRestoreUser";
+  private static final String BACKUP_READ_USER = "backupReadUser";
+
+  @UserDefinition
+  private static final TestUser NO_PERMISSION_USER_DEF =
+      new TestUser(NO_PERMISSION_USER, PASSWORD, List.of());
+
+  @UserDefinition
+  private static final TestUser SYSTEM_UPDATE_USER_DEF =
+      new TestUser(
+          SYSTEM_UPDATE_USER, PASSWORD, List.of(new Permissions(SYSTEM, UPDATE, List.of("*"))));
+
+  @UserDefinition
+  private static final TestUser BACKUP_RESTORE_USER_DEF =
+      new TestUser(
+          BACKUP_RESTORE_USER, PASSWORD, List.of(new Permissions(BACKUP, RESTORE, List.of("*"))));
+
+  @UserDefinition
+  private static final TestUser BACKUP_READ_USER_DEF =
+      new TestUser(
+          BACKUP_READ_USER, PASSWORD, List.of(new Permissions(BACKUP, READ, List.of("*"))));
+
+  private static final String CHANGE_MODE_PATH = "v2/mode?mode=RECOVERING&dryRun=true";
+
+  @Test
+  void shouldRejectUnauthenticatedRequest(
+      @Authenticated(NO_PERMISSION_USER) final CamundaClient client) throws Exception {
+    // when the endpoint is called without credentials
+    final var response = changeMode(client, null);
+
+    // then it is rejected before any authorization decision is made
+    assertThat(response.statusCode()).isEqualTo(401);
+  }
+
+  @Test
+  void shouldDenyModeChangeWhenUserHasNoGrants(
+      @Authenticated(NO_PERMISSION_USER) final CamundaClient client) throws Exception {
+    // when an authenticated user without any grant changes the cluster mode
+    final var response = changeMode(client, NO_PERMISSION_USER);
+
+    // then it is forbidden
+    assertThat(response.statusCode()).isEqualTo(403);
+  }
+
+  @Test
+  void shouldDenyModeChangeWithUnrelatedBackupGrant(
+      @Authenticated(BACKUP_READ_USER) final CamundaClient client) throws Exception {
+    // when a user granted only BACKUP:READ changes the cluster mode
+    final var response = changeMode(client, BACKUP_READ_USER);
+
+    // then it is forbidden: a grant on the BACKUP resource type only reaches the mode change when
+    // it is the RESTORE permission
+    assertThat(response.statusCode()).isEqualTo(403);
+  }
+
+  @Test
+  void shouldAllowModeChangeWithSystemUpdateGrant(
+      @Authenticated(SYSTEM_UPDATE_USER) final CamundaClient client) throws Exception {
+    // when a user granted SYSTEM:UPDATE validates a transition into recovery mode
+    final var response = changeMode(client, SYSTEM_UPDATE_USER);
+
+    // then the plan is returned; dryRun leaves the cluster in its current mode
+    assertThat(response.statusCode()).isEqualTo(200);
+  }
+
+  @Test
+  void shouldAllowModeChangeWithBackupRestoreGrant(
+      @Authenticated(BACKUP_RESTORE_USER) final CamundaClient client) throws Exception {
+    // when a user granted only BACKUP:RESTORE validates a transition into recovery mode
+    final var response = changeMode(client, BACKUP_RESTORE_USER);
+
+    // then it is allowed without a second grant: the mode change is a mandatory step of the restore
+    // procedure
+    assertThat(response.statusCode()).isEqualTo(200);
+  }
+
+  /**
+   * Issues a raw HTTP call to the mode change endpoint, authenticated as {@code username} when it
+   * is non-null. The endpoint has no fluent Java client method yet.
+   */
+  private static HttpResponse<String> changeMode(final CamundaClient client, final String username)
+      throws Exception {
+    final var builder = HttpRequest.newBuilder(createUri(client, CHANGE_MODE_PATH));
+    if (username != null) {
+      builder.header("Authorization", basicAuthentication(username));
+    }
+    builder.method("PATCH", BodyPublishers.noBody());
+    try (final var httpClient = HttpClient.newHttpClient()) {
+      return httpClient.send(builder.build(), BodyHandlers.ofString());
+    }
+  }
+
+  private static String basicAuthentication(final String username) {
+    return "Basic "
+        + Base64.getEncoder()
+            .encodeToString((username + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static URI createUri(final CamundaClient client, final String path) {
+    final var base = client.getConfiguration().getRestAddress().toString();
+    final var separator = base.endsWith("/") ? "" : "/";
+    return URI.create(base + separator + path);
+  }
+}

--- a/service/src/main/java/io/camunda/service/RecoveryServices.java
+++ b/service/src/main/java/io/camunda/service/RecoveryServices.java
@@ -33,7 +33,7 @@ import org.jspecify.annotations.NullMarked;
 public final class RecoveryServices extends PhysicalTenantScopedApiServices<RecoveryServices> {
 
   private static final List<RequiredAuthorization<Object>> MODE_CHANGE_AUTHORIZATIONS =
-      List.of(SYSTEM_UPDATE_AUTHORIZATION, BACKUP_RESTORE_AUTHORIZATION);
+      List.of(BACKUP_RESTORE_AUTHORIZATION, SYSTEM_UPDATE_AUTHORIZATION);
 
   private final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender;
   private final AuthorizationChecker authorizationChecker;
@@ -61,9 +61,13 @@ public final class RecoveryServices extends PhysicalTenantScopedApiServices<Reco
 
   public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> changeMode(
       final Mode mode, final boolean dryRun, final CamundaAuthentication authentication) {
-    if (MODE_CHANGE_AUTHORIZATIONS.stream().noneMatch(a -> hasPermission(a, authentication))) {
+    final var missingAuthorizations =
+        MODE_CHANGE_AUTHORIZATIONS.stream()
+            .takeWhile(authorization -> !hasPermission(authorization, authentication))
+            .toList();
+    if (missingAuthorizations.size() == MODE_CHANGE_AUTHORIZATIONS.size()) {
       return CompletableFuture.failedFuture(
-          ErrorMapper.createForbiddenException(MODE_CHANGE_AUTHORIZATIONS.getFirst()));
+          ErrorMapper.createForbiddenException(missingAuthorizations));
     }
 
     return clusterConfigurationRequestSender.modeChange(

--- a/service/src/main/java/io/camunda/service/RecoveryServices.java
+++ b/service/src/main/java/io/camunda/service/RecoveryServices.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static io.camunda.service.authorization.Authorizations.BACKUP_RESTORE_AUTHORIZATION;
+import static io.camunda.service.authorization.Authorizations.SYSTEM_UPDATE_AUTHORIZATION;
+
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.api.model.authz.AuthorizationScope;
+import io.camunda.security.api.model.config.AuthorizationsConfiguration;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.security.core.auth.RequiredAuthorization;
+import io.camunda.security.core.authz.AuthorizationChecker;
+import io.camunda.service.exception.ErrorMapper;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
+import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public final class RecoveryServices extends PhysicalTenantScopedApiServices<RecoveryServices> {
+
+  private static final List<RequiredAuthorization<Object>> MODE_CHANGE_AUTHORIZATIONS =
+      List.of(SYSTEM_UPDATE_AUTHORIZATION, BACKUP_RESTORE_AUTHORIZATION);
+
+  private final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender;
+  private final AuthorizationChecker authorizationChecker;
+  private final AuthorizationsConfiguration authorizationsConfig;
+
+  public RecoveryServices(
+      final String physicalTenantId,
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender,
+      final AuthorizationChecker authorizationChecker,
+      final AuthorizationsConfiguration authorizationsConfig,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        physicalTenantId,
+        brokerClient,
+        securityContextProvider,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+    this.clusterConfigurationRequestSender = clusterConfigurationRequestSender;
+    this.authorizationChecker = authorizationChecker;
+    this.authorizationsConfig = authorizationsConfig;
+  }
+
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> changeMode(
+      final Mode mode, final boolean dryRun, final CamundaAuthentication authentication) {
+    if (MODE_CHANGE_AUTHORIZATIONS.stream().noneMatch(a -> hasPermission(a, authentication))) {
+      return CompletableFuture.failedFuture(
+          ErrorMapper.createForbiddenException(MODE_CHANGE_AUTHORIZATIONS.getFirst()));
+    }
+
+    return clusterConfigurationRequestSender.modeChange(
+        new ModeChangeRequest(getPhysicalTenantId(), mode, dryRun));
+  }
+
+  private boolean hasPermission(
+      final RequiredAuthorization<?> requiredAuthorization,
+      final CamundaAuthentication authentication) {
+    if (!authorizationsConfig.isEnabled()) {
+      return true;
+    }
+
+    return authorizationChecker
+        .collectPermissionTypes(
+            AuthorizationScope.WILDCARD_CHAR, requiredAuthorization.resourceType(), authentication)
+        .contains(requiredAuthorization.permissionType());
+  }
+}

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -11,13 +11,16 @@ import static io.camunda.security.api.model.authz.AuthorizationResourceType.BACK
 import static io.camunda.security.api.model.authz.AuthorizationResourceType.COMPONENT;
 import static io.camunda.security.api.model.authz.AuthorizationResourceType.EXPORTER;
 import static io.camunda.security.api.model.authz.AuthorizationResourceType.SECRET;
+import static io.camunda.security.api.model.authz.AuthorizationResourceType.SYSTEM;
 import static io.camunda.security.api.model.authz.PermissionType.ACCESS;
 import static io.camunda.security.api.model.authz.PermissionType.CREATE;
 import static io.camunda.security.api.model.authz.PermissionType.DELETE;
 import static io.camunda.security.api.model.authz.PermissionType.PAUSE;
 import static io.camunda.security.api.model.authz.PermissionType.READ;
 import static io.camunda.security.api.model.authz.PermissionType.READ_TASK_LISTENER;
+import static io.camunda.security.api.model.authz.PermissionType.RESTORE;
 import static io.camunda.security.api.model.authz.PermissionType.REVEAL;
+import static io.camunda.security.api.model.authz.PermissionType.UPDATE;
 
 import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AgentInstanceHistoryEntity;
@@ -66,6 +69,9 @@ public abstract class Authorizations {
 
   public static final RequiredAuthorization<Object> BACKUP_DELETE_AUTHORIZATION =
       RequiredAuthorization.of(a -> a.resourceType(BACKUP).permissionType(DELETE));
+
+  public static final RequiredAuthorization<Object> BACKUP_RESTORE_AUTHORIZATION =
+      RequiredAuthorization.of(a -> a.resourceType(BACKUP).permissionType(RESTORE));
 
   public static final RequiredAuthorization<BatchOperationEntity>
       BATCH_OPERATION_READ_AUTHORIZATION = RequiredAuthorization.of(a -> a.batchOperation().read());
@@ -134,6 +140,9 @@ public abstract class Authorizations {
 
   public static final RequiredAuthorization<Object> SECRET_READ_AUTHORIZATION =
       RequiredAuthorization.of(a -> a.resourceType(SECRET).permissionType(READ));
+
+  public static final RequiredAuthorization<Object> SYSTEM_UPDATE_AUTHORIZATION =
+      RequiredAuthorization.of(a -> a.resourceType(SYSTEM).permissionType(UPDATE));
 
   public static final RequiredAuthorization<TenantEntity> TENANT_READER_AUTHORIZATION =
       RequiredAuthorization.of(a -> a.tenant().read());

--- a/service/src/main/java/io/camunda/service/exception/ErrorMapper.java
+++ b/service/src/main/java/io/camunda/service/exception/ErrorMapper.java
@@ -36,9 +36,11 @@ import io.camunda.zeebe.gateway.cmd.InvalidVariableRequestException;
 import io.camunda.zeebe.msgpack.MsgpackException;
 import io.netty.channel.ConnectTimeoutException;
 import java.net.ConnectException;
+import java.util.List;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,6 +109,24 @@ public class ErrorMapper {
         "Unauthorized to perform operation '%s' on resource '%s'"
             .formatted(authorization.permissionType(), authorization.resourceType()),
         FORBIDDEN);
+  }
+
+  public static ServiceException createForbiddenException(
+      final List<? extends RequiredAuthorization<?>> authorizations) {
+    if (authorizations.size() == 1) {
+      return createForbiddenException(authorizations.getFirst());
+    }
+
+    final var operations =
+        authorizations.stream()
+            .map(
+                authorization ->
+                    "'%s' on '%s'"
+                        .formatted(authorization.permissionType(), authorization.resourceType()))
+            .distinct()
+            .collect(Collectors.joining(" or "));
+    return new ServiceException(
+        "Unauthorized to perform any of the operations: %s".formatted(operations), FORBIDDEN);
   }
 
   private static ServiceError mapErrorToServiceError(final Throwable error) {

--- a/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
@@ -35,6 +35,7 @@ import io.camunda.service.MessageServices;
 import io.camunda.service.MessageSubscriptionServices;
 import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.RecoveryServices;
 import io.camunda.service.ResourceServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.RuntimeBackupServices;
@@ -83,6 +84,7 @@ public record DefaultServiceRegistry(
     Map<String, MessageSubscriptionServices> messageSubscriptionByTenant,
     Map<String, ProcessDefinitionServices> processDefinitionByTenant,
     Map<String, ProcessInstanceServices> processInstanceByTenant,
+    Map<String, RecoveryServices> recoveryByTenant,
     Map<String, ResourceServices> resourceByTenant,
     Map<String, RoleServices> roleByTenant,
     Map<String, SecretServices> secretByTenant,
@@ -243,6 +245,11 @@ public record DefaultServiceRegistry(
   }
 
   @Override
+  public RecoveryServices recoveryServices(final String physicalTenantId) {
+    return byTenant(recoveryByTenant, physicalTenantId);
+  }
+
+  @Override
   public ResourceServices resourceServices(final String physicalTenantId) {
     return byTenant(resourceByTenant, physicalTenantId);
   }
@@ -368,6 +375,7 @@ public record DefaultServiceRegistry(
     private final Map<String, ProcessDefinitionServices> processDefinitionByTenant =
         new HashMap<>();
     private final Map<String, ProcessInstanceServices> processInstanceByTenant = new HashMap<>();
+    private final Map<String, RecoveryServices> recoveryByTenant = new HashMap<>();
     private final Map<String, ResourceServices> resourceByTenant = new HashMap<>();
     private final Map<String, RoleServices> roleByTenant = new HashMap<>();
     private final Map<String, SecretServices> secretByTenant = new HashMap<>();
@@ -529,6 +537,11 @@ public record DefaultServiceRegistry(
       return this;
     }
 
+    public Builder recoveryServices(final String tenantId, final RecoveryServices service) {
+      recoveryByTenant.put(tenantId, service);
+      return this;
+    }
+
     public Builder resourceServices(final String tenantId, final ResourceServices service) {
       resourceByTenant.put(tenantId, service);
       return this;
@@ -618,6 +631,7 @@ public record DefaultServiceRegistry(
           Map.copyOf(messageSubscriptionByTenant),
           Map.copyOf(processDefinitionByTenant),
           Map.copyOf(processInstanceByTenant),
+          Map.copyOf(recoveryByTenant),
           Map.copyOf(resourceByTenant),
           Map.copyOf(roleByTenant),
           Map.copyOf(secretByTenant),

--- a/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
@@ -35,6 +35,7 @@ import io.camunda.service.MessageServices;
 import io.camunda.service.MessageSubscriptionServices;
 import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.RecoveryServices;
 import io.camunda.service.ResourceServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.RuntimeBackupServices;
@@ -111,6 +112,8 @@ public interface ServiceRegistry {
   ProcessDefinitionServices processDefinitionServices(String physicalTenantId);
 
   ProcessInstanceServices processInstanceServices(String physicalTenantId);
+
+  RecoveryServices recoveryServices(String physicalTenantId);
 
   ResourceServices resourceServices(String physicalTenantId);
 

--- a/service/src/test/java/io/camunda/service/RecoveryServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RecoveryServicesTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.api.model.authz.AuthorizationResourceType;
+import io.camunda.security.api.model.authz.PermissionType;
+import io.camunda.security.api.model.config.AuthorizationsConfiguration;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.security.core.authz.AuthorizationChecker;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
+import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
+import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.util.Either;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class RecoveryServicesTest {
+
+  private static final String PHYSICAL_TENANT_ID = "testtenant";
+
+  private RecoveryServices services;
+  private final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender =
+      mock(ClusterConfigurationManagementRequestSender.class);
+  private final AuthorizationChecker authorizationChecker = mock(AuthorizationChecker.class);
+  private final AuthorizationsConfiguration authorizationsConfig =
+      new AuthorizationsConfiguration();
+  private final CamundaAuthentication authentication = mock(CamundaAuthentication.class);
+
+  @BeforeEach
+  public void before() {
+    authorizationsConfig.setEnabled(false);
+    services =
+        new RecoveryServices(
+            PHYSICAL_TENANT_ID,
+            mock(BrokerClient.class),
+            mock(SecurityContextProvider.class),
+            clusterConfigurationRequestSender,
+            authorizationChecker,
+            authorizationsConfig,
+            mock(ApiServicesExecutorProvider.class),
+            mock(BrokerRequestAuthorizationConverter.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(Mode.class)
+  public void shouldStampPhysicalTenantIdIntoModeChangeRequest(final Mode mode) {
+    // given
+    stubModeChangeSuccess();
+
+    // when
+    final var future = services.changeMode(mode, true, authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    verify(clusterConfigurationRequestSender)
+        .modeChange(new ModeChangeRequest(PHYSICAL_TENANT_ID, mode, true));
+  }
+
+  @Test
+  public void shouldChangeModeWhenAuthorizationsDisabled() {
+    // given
+    stubModeChangeSuccess();
+
+    // when
+    final var future = services.changeMode(Mode.RECOVERING, false, authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    verify(clusterConfigurationRequestSender).modeChange(any());
+  }
+
+  @Test
+  public void shouldChangeModeWhenUserHasSystemUpdatePermission() {
+    // given
+    grant(AuthorizationResourceType.SYSTEM, PermissionType.UPDATE);
+    stubModeChangeSuccess();
+
+    // when
+    final var future = services.changeMode(Mode.RECOVERING, false, authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    verify(clusterConfigurationRequestSender).modeChange(any());
+  }
+
+  @Test
+  public void shouldChangeModeWhenUserHasBackupRestorePermission() {
+    // given - entering and leaving recovery mode is a mandatory step of the restore procedure, so
+    // BACKUP:RESTORE alone must authorize it without a second grant
+    grant(AuthorizationResourceType.BACKUP, PermissionType.RESTORE);
+    stubModeChangeSuccess();
+
+    // when
+    final var future = services.changeMode(Mode.RECOVERING, false, authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    verify(clusterConfigurationRequestSender).modeChange(any());
+  }
+
+  @Test
+  public void shouldFailWithForbiddenWhenUserHasNoAuthorizations() {
+    // given
+    authorizationsConfig.setEnabled(true);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Collections.emptySet());
+
+    // when
+    final var future = services.changeMode(Mode.RECOVERING, false, authentication);
+
+    // then
+    assertForbidden(future);
+    verify(clusterConfigurationRequestSender, never()).modeChange(any());
+  }
+
+  @Test
+  public void shouldFailWithForbiddenWhenUserHasAnUnrelatedPermission() {
+    // given
+    grant(AuthorizationResourceType.BACKUP, PermissionType.READ);
+
+    // when
+    final var future = services.changeMode(Mode.RECOVERING, false, authentication);
+
+    // then
+    assertForbidden(future);
+    verify(clusterConfigurationRequestSender, never()).modeChange(any());
+  }
+
+  @Test
+  public void shouldFailWithForbiddenWhenUpdateIsGrantedOnAnotherResourceType() {
+    // given - the caller holds UPDATE, but not on the SYSTEM resource type
+    authorizationsConfig.setEnabled(true);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Set.of(PermissionType.UPDATE));
+    when(authorizationChecker.collectPermissionTypes(
+            any(), eq(AuthorizationResourceType.SYSTEM), any()))
+        .thenReturn(Collections.emptySet());
+    when(authorizationChecker.collectPermissionTypes(
+            any(), eq(AuthorizationResourceType.BACKUP), any()))
+        .thenReturn(Collections.emptySet());
+
+    // when
+    final var future = services.changeMode(Mode.RECOVERING, false, authentication);
+
+    // then
+    assertForbidden(future);
+    verify(clusterConfigurationRequestSender, never()).modeChange(any());
+  }
+
+  @Test
+  public void shouldReportSystemUpdateWhenDenied() {
+    // given - the denial names the permission that exists for this operation rather than every
+    // accepted alternative
+    authorizationsConfig.setEnabled(true);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Collections.emptySet());
+
+    // when
+    final var future = services.changeMode(Mode.RECOVERING, false, authentication);
+
+    // then
+    assertThat(future)
+        .failsWithin(ofSeconds(1))
+        .withThrowableOfType(ExecutionException.class)
+        .havingCause()
+        .withMessageContaining("UPDATE")
+        .withMessageContaining("SYSTEM");
+  }
+
+  @Test
+  public void shouldPassCoordinatorRejectionThroughUnchanged() {
+    // given - the caller maps ErrorResponse to a status itself, so a rejection must not be
+    // translated or swallowed here
+    final var rejection =
+        new ErrorResponse(ErrorCode.CONCURRENT_MODIFICATION, "a change is ongoing");
+    when(clusterConfigurationRequestSender.modeChange(any()))
+        .thenReturn(CompletableFuture.completedFuture(Either.left(rejection)));
+
+    // when
+    final var future = services.changeMode(Mode.RECOVERING, false, authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    assertThat(future.join().getLeft()).isEqualTo(rejection);
+  }
+
+  private void grant(
+      final AuthorizationResourceType resourceType, final PermissionType permissionType) {
+    authorizationsConfig.setEnabled(true);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Collections.emptySet());
+    when(authorizationChecker.collectPermissionTypes(any(), eq(resourceType), any()))
+        .thenReturn(Set.of(permissionType));
+  }
+
+  private void stubModeChangeSuccess() {
+    when(clusterConfigurationRequestSender.modeChange(any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.right(
+                    new ClusterConfigurationChangeResponse(0L, Map.of(), Map.of(), List.of()))));
+  }
+
+  private static void assertForbidden(final CompletableFuture<?> future) {
+    assertThat(future)
+        .failsWithin(ofSeconds(1))
+        .withThrowableOfType(ExecutionException.class)
+        .havingCause()
+        .asInstanceOf(type(ServiceException.class))
+        .extracting(ServiceException::getStatus)
+        .isEqualTo(Status.FORBIDDEN);
+  }
+}

--- a/service/src/test/java/io/camunda/service/RecoveryServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RecoveryServicesTest.java
@@ -48,6 +48,9 @@ import org.junit.jupiter.params.provider.EnumSource;
 public class RecoveryServicesTest {
 
   private static final String PHYSICAL_TENANT_ID = "testtenant";
+  private static final String FORBIDDEN_MESSAGE =
+      "Unauthorized to perform any of the operations: "
+          + "'RESTORE' on 'BACKUP' or 'UPDATE' on 'SYSTEM'";
 
   private RecoveryServices services;
   private final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender =
@@ -179,26 +182,6 @@ public class RecoveryServicesTest {
   }
 
   @Test
-  public void shouldReportSystemUpdateWhenDenied() {
-    // given - the denial names the permission that exists for this operation rather than every
-    // accepted alternative
-    authorizationsConfig.setEnabled(true);
-    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
-        .thenReturn(Collections.emptySet());
-
-    // when
-    final var future = services.changeMode(Mode.RECOVERING, false, authentication);
-
-    // then
-    assertThat(future)
-        .failsWithin(ofSeconds(1))
-        .withThrowableOfType(ExecutionException.class)
-        .havingCause()
-        .withMessageContaining("UPDATE")
-        .withMessageContaining("SYSTEM");
-  }
-
-  @Test
   public void shouldPassCoordinatorRejectionThroughUnchanged() {
     // given - the caller maps ErrorResponse to a status itself, so a rejection must not be
     // translated or swallowed here
@@ -238,7 +221,10 @@ public class RecoveryServicesTest {
         .withThrowableOfType(ExecutionException.class)
         .havingCause()
         .asInstanceOf(type(ServiceException.class))
-        .extracting(ServiceException::getStatus)
-        .isEqualTo(Status.FORBIDDEN);
+        .satisfies(
+            exception -> {
+              assertThat(exception.getStatus()).isEqualTo(Status.FORBIDDEN);
+              assertThat(exception.getMessage()).isEqualTo(FORBIDDEN_MESSAGE);
+            });
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -109,7 +109,10 @@ paths:
       tags:
         - Recovery
       operationId: changeClusterMode
-      x-required-permissions: []
+      x-required-permissions:
+        - anyOf:
+            - { resourceType: SYSTEM, permissionType: UPDATE }
+            - { resourceType: BACKUP, permissionType: RESTORE }
       security:
         - bearerAuth: []
         - basicAuth: []
@@ -135,6 +138,8 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "401":
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
@@ -12,11 +12,12 @@ import io.camunda.gateway.protocol.model.ClusterModeChangeResponse;
 import io.camunda.gateway.protocol.model.RestoreBrokerStatus;
 import io.camunda.gateway.protocol.model.RestorePartitionStatus;
 import io.camunda.gateway.protocol.model.RestoreStatusResponse;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.spring.utils.DatabaseTypeUtils;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
@@ -57,12 +58,18 @@ public final class RecoveryController {
       "camunda.data.primary-storage.backup.continuous";
 
   private final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender;
+  private final ServiceRegistry serviceRegistry;
+  private final CamundaAuthenticationProvider authenticationProvider;
   private final Environment environment;
 
   public RecoveryController(
       final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender,
+      final ServiceRegistry serviceRegistry,
+      final CamundaAuthenticationProvider authenticationProvider,
       final Environment environment) {
     this.clusterConfigurationRequestSender = clusterConfigurationRequestSender;
+    this.serviceRegistry = serviceRegistry;
+    this.authenticationProvider = authenticationProvider;
     this.environment = environment;
   }
 
@@ -74,10 +81,12 @@ public final class RecoveryController {
       @RequestParam final Mode mode,
       @RequestParam(name = "dryRun", defaultValue = "false") final boolean dryRun) {
     LOG.debug("Requested cluster mode change to {} for physical tenant {}", mode, physicalTenantId);
+    final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
         () ->
-            clusterConfigurationRequestSender
-                .modeChange(new ModeChangeRequest(physicalTenantId, mode, dryRun))
+            serviceRegistry
+                .recoveryServices(physicalTenantId)
+                .changeMode(mode, dryRun, authentication)
                 .thenApply(RecoveryController::unwrapOrThrow),
         RecoveryController::toClusterModeChangeResponse,
         HttpStatus.OK);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
+import static io.camunda.service.authorization.Authorizations.BACKUP_RESTORE_AUTHORIZATION;
+import static io.camunda.service.authorization.Authorizations.SYSTEM_UPDATE_AUTHORIZATION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
@@ -16,7 +18,7 @@ import io.camunda.gateway.protocol.model.RestorePartitionStatus;
 import io.camunda.gateway.protocol.model.RestoreStatusResponse;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.RecoveryServices;
-import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
@@ -143,12 +145,27 @@ public class RecoveryControllerTest extends RestControllerTest {
     Mockito.when(recoveryServices.changeMode(Mockito.any(), Mockito.anyBoolean(), Mockito.any()))
         .thenReturn(
             CompletableFuture.failedFuture(
-                new ServiceException(
-                    "Unauthorized to perform operation 'UPDATE' on resource 'SYSTEM'",
-                    ServiceException.Status.FORBIDDEN)));
+                ErrorMapper.createForbiddenException(
+                    List.of(BACKUP_RESTORE_AUTHORIZATION, SYSTEM_UPDATE_AUTHORIZATION))));
 
     // when / then
-    webClient.patch().uri("/v2/mode?mode=RECOVERING").exchange().expectStatus().isForbidden();
+    webClient
+        .patch()
+        .uri("/v2/mode?mode=RECOVERING")
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "status": 403,
+              "title": "FORBIDDEN",
+              "detail": "Unauthorized to perform any of the operations: 'RESTORE' on 'BACKUP' or 'UPDATE' on 'SYSTEM'",
+              "instance": "/v2/mode"
+            }""",
+            JsonCompareMode.STRICT);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -14,8 +14,11 @@ import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.gateway.protocol.model.RestoreBrokerStatus;
 import io.camunda.gateway.protocol.model.RestorePartitionStatus;
 import io.camunda.gateway.protocol.model.RestoreStatusResponse;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.service.RecoveryServices;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
@@ -38,6 +41,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -54,6 +58,16 @@ import org.springframework.test.json.JsonCompareMode;
 public class RecoveryControllerTest extends RestControllerTest {
 
   @MockitoBean ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender;
+  @MockitoBean ServiceRegistry serviceRegistry;
+  @MockitoBean RecoveryServices recoveryServices;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
+
+  @BeforeEach
+  void setUpRecoveryServices() {
+    Mockito.when(serviceRegistry.recoveryServices(Mockito.any())).thenReturn(recoveryServices);
+    Mockito.when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+  }
 
   private void stubValidationSuccess() {
     Mockito.when(clusterConfigurationRequestSender.restore(Mockito.any()))
@@ -74,8 +88,8 @@ public class RecoveryControllerTest extends RestControllerTest {
             Map.of(),
             List.of(new ModeChangeOperation(MemberId.from("0"), Mode.RECOVERING)));
     Mockito.when(
-            clusterConfigurationRequestSender.modeChange(
-                new ModeChangeRequest("default", Mode.RECOVERING, false)))
+            recoveryServices.changeMode(
+                Mockito.eq(Mode.RECOVERING), Mockito.eq(false), Mockito.any()))
         .thenReturn(CompletableFuture.completedFuture(Either.right(changeResponse)));
 
     final var expectedResponse =
@@ -107,8 +121,8 @@ public class RecoveryControllerTest extends RestControllerTest {
   void shouldMapErrorResponseWhenModeChangeRejected(final String baseUrl) {
     // given
     Mockito.when(
-            clusterConfigurationRequestSender.modeChange(
-                new ModeChangeRequest("default", Mode.RECOVERING, false)))
+            recoveryServices.changeMode(
+                Mockito.eq(Mode.RECOVERING), Mockito.eq(false), Mockito.any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 Either.left(
@@ -121,6 +135,20 @@ public class RecoveryControllerTest extends RestControllerTest {
         .exchange()
         .expectStatus()
         .is4xxClientError();
+  }
+
+  @Test
+  void shouldRejectModeChangeWhenCallerIsNotAuthorized() {
+    // given
+    Mockito.when(recoveryServices.changeMode(Mockito.any(), Mockito.anyBoolean(), Mockito.any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException(
+                    "Unauthorized to perform operation 'UPDATE' on resource 'SYSTEM'",
+                    ServiceException.Status.FORBIDDEN)));
+
+    // when / then
+    webClient.patch().uri("/v2/mode?mode=RECOVERING").exchange().expectStatus().isForbidden();
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Introduce the `RecoveryServices` handling the authorization requirements for the endpoints present under the `RecoveryController`.

Wrap the mode change operation with the required authorizations of `System#UPDATE` or `Backup#RESTORE`.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #59132

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>