### PR TITLE
Restore operations authz

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RecoveryAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RecoveryAuthorizationIT.java
@@ -33,6 +33,12 @@ import java.util.Base64;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
+/**
+ * {@code POST /restore} and {@code GET /restore} are both gated strictly on {@code BACKUP:RESTORE}
+ * — unlike {@code PATCH /mode}, {@code SYSTEM:UPDATE} does not reach either of them: being allowed
+ * to change the cluster's mode must not imply being allowed to consume a backup or read the status
+ * of an in-flight restore.
+ */
 @MultiDbTest
 class RecoveryAuthorizationIT {
 
@@ -67,6 +73,8 @@ class RecoveryAuthorizationIT {
           BACKUP_READ_USER, PASSWORD, List.of(new Permissions(BACKUP, READ, List.of("*"))));
 
   private static final String CHANGE_MODE_PATH = "v2/mode?mode=RECOVERING&dryRun=true";
+  private static final String RESTORE_PATH = "v2/restore";
+  private static final String RESTORE_BODY = "{\"backupIds\": [1]}";
 
   private static final String FORBIDDEN_DETAIL =
       "Unauthorized to perform any of the operations: "
@@ -126,6 +134,88 @@ class RecoveryAuthorizationIT {
     assertThat(response.statusCode()).isEqualTo(200);
   }
 
+  @Test
+  void shouldRejectUnauthenticatedRestoreRequest(
+      @Authenticated(NO_PERMISSION_USER) final CamundaClient client) throws Exception {
+    // when the endpoint is called without credentials
+    final var response = restore(client, null);
+
+    // then it is rejected before any authorization decision is made
+    assertThat(response.statusCode()).isEqualTo(401);
+  }
+
+  @Test
+  void shouldRejectUnauthenticatedGetRestoreStatusRequest(
+      @Authenticated(NO_PERMISSION_USER) final CamundaClient client) throws Exception {
+    // when the endpoint is called without credentials
+    final var response = getRestoreStatus(client, null);
+
+    // then it is rejected before any authorization decision is made
+    assertThat(response.statusCode()).isEqualTo(401);
+  }
+
+  @Test
+  void shouldDenyRestoreWhenUserHasNoGrants(
+      @Authenticated(NO_PERMISSION_USER) final CamundaClient client) throws Exception {
+    // when an authenticated user without any grant triggers a restore
+    final var response = restore(client, NO_PERMISSION_USER);
+
+    // then it is forbidden
+    assertThat(response.statusCode()).isEqualTo(403);
+  }
+
+  @Test
+  void shouldDenyRestoreWithSystemUpdateGrant(
+      @Authenticated(SYSTEM_UPDATE_USER) final CamundaClient client) throws Exception {
+    // when a user granted only SYSTEM:UPDATE triggers a restore
+    final var response = restore(client, SYSTEM_UPDATE_USER);
+
+    // then it is forbidden: being allowed to change the cluster mode must not imply being allowed
+    // to consume a backup
+    assertThat(response.statusCode()).isEqualTo(403);
+  }
+
+  @Test
+  void shouldAllowRestoreWithBackupRestoreGrant(
+      @Authenticated(BACKUP_RESTORE_USER) final CamundaClient client) throws Exception {
+    // when a user granted BACKUP:RESTORE triggers a restore while the cluster is processing
+    final var response = restore(client, BACKUP_RESTORE_USER);
+
+    // then authorization passes and the request is rejected on cluster state instead: the cluster
+    // must be in recovery mode for the restore to be accepted
+    assertThat(response.statusCode()).isEqualTo(409);
+  }
+
+  @Test
+  void shouldDenyGetRestoreStatusWhenUserHasNoGrants(
+      @Authenticated(NO_PERMISSION_USER) final CamundaClient client) throws Exception {
+    // when an authenticated user without any grant reads the restore status
+    final var response = getRestoreStatus(client, NO_PERMISSION_USER);
+
+    // then it is forbidden
+    assertThat(response.statusCode()).isEqualTo(403);
+  }
+
+  @Test
+  void shouldDenyGetRestoreStatusWithSystemUpdateGrant(
+      @Authenticated(SYSTEM_UPDATE_USER) final CamundaClient client) throws Exception {
+    // when a user granted only SYSTEM:UPDATE reads the restore status
+    final var response = getRestoreStatus(client, SYSTEM_UPDATE_USER);
+
+    // then it is forbidden
+    assertThat(response.statusCode()).isEqualTo(403);
+  }
+
+  @Test
+  void shouldAllowGetRestoreStatusWithBackupRestoreGrant(
+      @Authenticated(BACKUP_RESTORE_USER) final CamundaClient client) throws Exception {
+    // when a user granted BACKUP:RESTORE reads the restore status
+    final var response = getRestoreStatus(client, BACKUP_RESTORE_USER);
+
+    // then authorization passes; no restore is in progress on this cluster
+    assertThat(response.statusCode()).isEqualTo(404);
+  }
+
   /**
    * Issues a raw HTTP call to the mode change endpoint, authenticated as {@code username} when it
    * is non-null. The endpoint has no fluent Java client method yet.
@@ -137,6 +227,39 @@ class RecoveryAuthorizationIT {
       builder.header("Authorization", basicAuthentication(username));
     }
     builder.method("PATCH", BodyPublishers.noBody());
+    try (final var httpClient = HttpClient.newHttpClient()) {
+      return httpClient.send(builder.build(), BodyHandlers.ofString());
+    }
+  }
+
+  /**
+   * Issues a raw HTTP call to {@code POST /restore}, authenticated as {@code username} when it is
+   * non-null. The endpoint has no fluent Java client method yet.
+   */
+  private static HttpResponse<String> restore(final CamundaClient client, final String username)
+      throws Exception {
+    final var builder = HttpRequest.newBuilder(createUri(client, RESTORE_PATH));
+    if (username != null) {
+      builder.header("Authorization", basicAuthentication(username));
+    }
+    builder.header("Content-Type", "application/json");
+    builder.method("POST", BodyPublishers.ofString(RESTORE_BODY));
+    try (final var httpClient = HttpClient.newHttpClient()) {
+      return httpClient.send(builder.build(), BodyHandlers.ofString());
+    }
+  }
+
+  /**
+   * Issues a raw HTTP call to {@code GET /restore}, authenticated as {@code username} when it is
+   * non-null. The endpoint has no fluent Java client method yet.
+   */
+  private static HttpResponse<String> getRestoreStatus(
+      final CamundaClient client, final String username) throws Exception {
+    final var builder = HttpRequest.newBuilder(createUri(client, RESTORE_PATH));
+    if (username != null) {
+      builder.header("Authorization", basicAuthentication(username));
+    }
+    builder.method("GET", BodyPublishers.noBody());
     try (final var httpClient = HttpClient.newHttpClient()) {
       return httpClient.send(builder.build(), BodyHandlers.ofString());
     }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RecoveryAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RecoveryAuthorizationIT.java
@@ -76,9 +76,11 @@ class RecoveryAuthorizationIT {
   private static final String RESTORE_PATH = "v2/restore";
   private static final String RESTORE_BODY = "{\"backupIds\": [1]}";
 
-  private static final String FORBIDDEN_DETAIL =
+  private static final String MODE_CHANGE_FORBIDDEN_DETAIL =
       "Unauthorized to perform any of the operations: "
           + "'RESTORE' on 'BACKUP' or 'UPDATE' on 'SYSTEM'";
+  private static final String RESTORE_FORBIDDEN_DETAIL =
+      "Unauthorized to perform operation 'RESTORE' on resource 'BACKUP'";
 
   @Test
   void shouldRejectUnauthenticatedRequest(
@@ -98,7 +100,7 @@ class RecoveryAuthorizationIT {
 
     // then it is forbidden
     assertThat(response.statusCode()).isEqualTo(403);
-    assertThat(response.body()).contains(FORBIDDEN_DETAIL);
+    assertThat(response.body()).contains(MODE_CHANGE_FORBIDDEN_DETAIL);
   }
 
   @Test
@@ -110,7 +112,7 @@ class RecoveryAuthorizationIT {
     // then it is forbidden: a grant on the BACKUP resource type only reaches the mode change when
     // it is the RESTORE permission
     assertThat(response.statusCode()).isEqualTo(403);
-    assertThat(response.body()).contains(FORBIDDEN_DETAIL);
+    assertThat(response.body()).contains(MODE_CHANGE_FORBIDDEN_DETAIL);
   }
 
   @Test
@@ -162,6 +164,7 @@ class RecoveryAuthorizationIT {
 
     // then it is forbidden
     assertThat(response.statusCode()).isEqualTo(403);
+    assertThat(response.body()).contains(RESTORE_FORBIDDEN_DETAIL);
   }
 
   @Test
@@ -171,8 +174,9 @@ class RecoveryAuthorizationIT {
     final var response = restore(client, SYSTEM_UPDATE_USER);
 
     // then it is forbidden: being allowed to change the cluster mode must not imply being allowed
-    // to consume a backup
+    // to consume a backup, and the error names the permission that is actually required
     assertThat(response.statusCode()).isEqualTo(403);
+    assertThat(response.body()).contains(RESTORE_FORBIDDEN_DETAIL);
   }
 
   @Test
@@ -194,6 +198,7 @@ class RecoveryAuthorizationIT {
 
     // then it is forbidden
     assertThat(response.statusCode()).isEqualTo(403);
+    assertThat(response.body()).contains(RESTORE_FORBIDDEN_DETAIL);
   }
 
   @Test
@@ -204,6 +209,7 @@ class RecoveryAuthorizationIT {
 
     // then it is forbidden
     assertThat(response.statusCode()).isEqualTo(403);
+    assertThat(response.body()).contains(RESTORE_FORBIDDEN_DETAIL);
   }
 
   @Test

--- a/service/src/main/java/io/camunda/service/RecoveryServices.java
+++ b/service/src/main/java/io/camunda/service/RecoveryServices.java
@@ -21,11 +21,12 @@ import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.util.Either;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.jspecify.annotations.NullMarked;
 
@@ -72,6 +73,26 @@ public final class RecoveryServices extends PhysicalTenantScopedApiServices<Reco
 
     return clusterConfigurationRequestSender.modeChange(
         new ModeChangeRequest(getPhysicalTenantId(), mode, dryRun));
+  }
+
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> restore(
+      final RestoreRequest restoreRequest, final CamundaAuthentication authentication) {
+    if (missingPermission(BACKUP_RESTORE_AUTHORIZATION, authentication)) {
+      return CompletableFuture.failedFuture(
+          ErrorMapper.createForbiddenException(BACKUP_RESTORE_AUTHORIZATION));
+    }
+
+    return clusterConfigurationRequestSender.restore(restoreRequest);
+  }
+
+  public CompletableFuture<Either<ErrorResponse, ClusterConfiguration>> restoreStatus(
+      final CamundaAuthentication authentication) {
+    if (missingPermission(BACKUP_RESTORE_AUTHORIZATION, authentication)) {
+      return CompletableFuture.failedFuture(
+          ErrorMapper.createForbiddenException(BACKUP_RESTORE_AUTHORIZATION));
+    }
+
+    return clusterConfigurationRequestSender.getTopology();
   }
 
   private boolean hasPermission(

--- a/service/src/main/java/io/camunda/service/RecoveryServices.java
+++ b/service/src/main/java/io/camunda/service/RecoveryServices.java
@@ -27,7 +27,9 @@ import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.util.Either;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -35,6 +37,8 @@ public final class RecoveryServices extends PhysicalTenantScopedApiServices<Reco
 
   private static final List<RequiredAuthorization<Object>> MODE_CHANGE_AUTHORIZATIONS =
       List.of(BACKUP_RESTORE_AUTHORIZATION, SYSTEM_UPDATE_AUTHORIZATION);
+  private static final List<RequiredAuthorization<Object>> RESTORE_AUTHORIZATIONS =
+      List.of(BACKUP_RESTORE_AUTHORIZATION);
 
   private final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender;
   private final AuthorizationChecker authorizationChecker;
@@ -62,37 +66,42 @@ public final class RecoveryServices extends PhysicalTenantScopedApiServices<Reco
 
   public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> changeMode(
       final Mode mode, final boolean dryRun, final CamundaAuthentication authentication) {
-    final var missingAuthorizations =
-        MODE_CHANGE_AUTHORIZATIONS.stream()
-            .takeWhile(authorization -> !hasPermission(authorization, authentication))
-            .toList();
-    if (missingAuthorizations.size() == MODE_CHANGE_AUTHORIZATIONS.size()) {
-      return CompletableFuture.failedFuture(
-          ErrorMapper.createForbiddenException(missingAuthorizations));
-    }
-
-    return clusterConfigurationRequestSender.modeChange(
-        new ModeChangeRequest(getPhysicalTenantId(), mode, dryRun));
+    return withAnyPermission(
+        MODE_CHANGE_AUTHORIZATIONS,
+        authentication,
+        () ->
+            clusterConfigurationRequestSender.modeChange(
+                new ModeChangeRequest(getPhysicalTenantId(), mode, dryRun)));
   }
 
   public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> restore(
       final RestoreRequest restoreRequest, final CamundaAuthentication authentication) {
-    if (missingPermission(BACKUP_RESTORE_AUTHORIZATION, authentication)) {
-      return CompletableFuture.failedFuture(
-          ErrorMapper.createForbiddenException(BACKUP_RESTORE_AUTHORIZATION));
-    }
-
-    return clusterConfigurationRequestSender.restore(restoreRequest);
+    return withAnyPermission(
+        RESTORE_AUTHORIZATIONS,
+        authentication,
+        () -> clusterConfigurationRequestSender.restore(restoreRequest));
   }
 
   public CompletableFuture<Either<ErrorResponse, ClusterConfiguration>> restoreStatus(
       final CamundaAuthentication authentication) {
-    if (missingPermission(BACKUP_RESTORE_AUTHORIZATION, authentication)) {
+    return withAnyPermission(
+        RESTORE_AUTHORIZATIONS, authentication, clusterConfigurationRequestSender::getTopology);
+  }
+
+  private <T> CompletableFuture<T> withAnyPermission(
+      final List<RequiredAuthorization<Object>> requiredAuthorizations,
+      final CamundaAuthentication authentication,
+      final Supplier<CompletableFuture<T>> operation) {
+    final var missingAuthorizations =
+        requiredAuthorizations.stream()
+            .filter(authorization -> !hasPermission(authorization, authentication))
+            .toList();
+    if (missingAuthorizations.size() == requiredAuthorizations.size()) {
       return CompletableFuture.failedFuture(
-          ErrorMapper.createForbiddenException(BACKUP_RESTORE_AUTHORIZATION));
+          ErrorMapper.createForbiddenException(missingAuthorizations));
     }
 
-    return clusterConfigurationRequestSender.getTopology();
+    return operation.get();
   }
 
   private boolean hasPermission(

--- a/service/src/test/java/io/camunda/service/RecoveryServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RecoveryServicesTest.java
@@ -50,9 +50,11 @@ import org.junit.jupiter.params.provider.EnumSource;
 public class RecoveryServicesTest {
 
   private static final String PHYSICAL_TENANT_ID = "testtenant";
-  private static final String FORBIDDEN_MESSAGE =
+  private static final String MODE_CHANGE_FORBIDDEN_MESSAGE =
       "Unauthorized to perform any of the operations: "
           + "'RESTORE' on 'BACKUP' or 'UPDATE' on 'SYSTEM'";
+  private static final String RESTORE_FORBIDDEN_MESSAGE =
+      "Unauthorized to perform operation 'RESTORE' on resource 'BACKUP'";
 
   private RecoveryServices services;
   private final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender =
@@ -145,7 +147,7 @@ public class RecoveryServicesTest {
     final var future = services.changeMode(Mode.RECOVERING, false, authentication);
 
     // then
-    assertForbidden(future);
+    assertForbidden(future, MODE_CHANGE_FORBIDDEN_MESSAGE);
     verify(clusterConfigurationRequestSender, never()).modeChange(any());
   }
 
@@ -158,7 +160,7 @@ public class RecoveryServicesTest {
     final var future = services.changeMode(Mode.RECOVERING, false, authentication);
 
     // then
-    assertForbidden(future);
+    assertForbidden(future, MODE_CHANGE_FORBIDDEN_MESSAGE);
     verify(clusterConfigurationRequestSender, never()).modeChange(any());
   }
 
@@ -179,7 +181,7 @@ public class RecoveryServicesTest {
     final var future = services.changeMode(Mode.RECOVERING, false, authentication);
 
     // then
-    assertForbidden(future);
+    assertForbidden(future, MODE_CHANGE_FORBIDDEN_MESSAGE);
     verify(clusterConfigurationRequestSender, never()).modeChange(any());
   }
 
@@ -254,7 +256,7 @@ public class RecoveryServicesTest {
     final var future = services.restore(restoreRequest(), authentication);
 
     // then
-    assertForbidden(future);
+    assertForbidden(future, RESTORE_FORBIDDEN_MESSAGE);
     verify(clusterConfigurationRequestSender, never()).restore(any());
   }
 
@@ -268,7 +270,7 @@ public class RecoveryServicesTest {
     final var future = services.restore(restoreRequest(), authentication);
 
     // then
-    assertForbidden(future);
+    assertForbidden(future, RESTORE_FORBIDDEN_MESSAGE);
     verify(clusterConfigurationRequestSender, never()).restore(any());
   }
 
@@ -344,7 +346,7 @@ public class RecoveryServicesTest {
     final var future = services.restoreStatus(authentication);
 
     // then
-    assertForbidden(future);
+    assertForbidden(future, RESTORE_FORBIDDEN_MESSAGE);
     verify(clusterConfigurationRequestSender, never()).getTopology();
   }
 
@@ -358,7 +360,7 @@ public class RecoveryServicesTest {
     final var future = services.restoreStatus(authentication);
 
     // then
-    assertForbidden(future);
+    assertForbidden(future, RESTORE_FORBIDDEN_MESSAGE);
     verify(clusterConfigurationRequestSender, never()).getTopology();
   }
 
@@ -412,7 +414,8 @@ public class RecoveryServicesTest {
                     new ClusterConfigurationChangeResponse(0L, Map.of(), Map.of(), List.of()))));
   }
 
-  private static void assertForbidden(final CompletableFuture<?> future) {
+  private static void assertForbidden(
+      final CompletableFuture<?> future, final String expectedMessage) {
     assertThat(future)
         .failsWithin(ofSeconds(1))
         .withThrowableOfType(ExecutionException.class)
@@ -421,7 +424,7 @@ public class RecoveryServicesTest {
         .satisfies(
             exception -> {
               assertThat(exception.getStatus()).isEqualTo(Status.FORBIDDEN);
-              assertThat(exception.getMessage()).isEqualTo(FORBIDDEN_MESSAGE);
+              assertThat(exception.getMessage()).isEqualTo(expectedMessage);
             });
   }
 }

--- a/service/src/test/java/io/camunda/service/RecoveryServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RecoveryServicesTest.java
@@ -29,9 +29,11 @@ import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.util.Either;
 import java.util.Collections;
@@ -196,6 +198,201 @@ public class RecoveryServicesTest {
     // then
     assertThat(future).succeedsWithin(ofSeconds(1));
     assertThat(future.join().getLeft()).isEqualTo(rejection);
+  }
+
+  @Test
+  public void shouldForwardRestoreRequestUnchanged() {
+    // given
+    final var request =
+        new RestoreRequest(
+            PHYSICAL_TENANT_ID, List.of(100L, 101L), null, null, "elasticsearch", false, false);
+    stubRestoreSuccess();
+
+    // when
+    final var future = services.restore(request, authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    verify(clusterConfigurationRequestSender).restore(request);
+  }
+
+  @Test
+  public void shouldRestoreWhenAuthorizationsDisabled() {
+    // given
+    stubRestoreSuccess();
+
+    // when
+    final var future = services.restore(restoreRequest(), authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    verify(clusterConfigurationRequestSender).restore(any());
+  }
+
+  @Test
+  public void shouldRestoreWhenUserHasBackupRestorePermission() {
+    // given
+    grant(AuthorizationResourceType.BACKUP, PermissionType.RESTORE);
+    stubRestoreSuccess();
+
+    // when
+    final var future = services.restore(restoreRequest(), authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    verify(clusterConfigurationRequestSender).restore(any());
+  }
+
+  @Test
+  public void shouldFailRestoreWithForbiddenWhenUserHasNoAuthorizations() {
+    // given
+    authorizationsConfig.setEnabled(true);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Collections.emptySet());
+
+    // when
+    final var future = services.restore(restoreRequest(), authentication);
+
+    // then
+    assertForbidden(future);
+    verify(clusterConfigurationRequestSender, never()).restore(any());
+  }
+
+  @Test
+  public void shouldFailRestoreWithForbiddenWhenUserOnlyHasSystemUpdatePermission() {
+    // given - unlike the mode change, restoring is not OR-gated: SYSTEM:UPDATE alone must not
+    // authorize consuming a backup
+    grant(AuthorizationResourceType.SYSTEM, PermissionType.UPDATE);
+
+    // when
+    final var future = services.restore(restoreRequest(), authentication);
+
+    // then
+    assertForbidden(future);
+    verify(clusterConfigurationRequestSender, never()).restore(any());
+  }
+
+  @Test
+  public void shouldReportBackupRestoreWhenRestoreIsDenied() {
+    // given
+    authorizationsConfig.setEnabled(true);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Collections.emptySet());
+
+    // when
+    final var future = services.restore(restoreRequest(), authentication);
+
+    // then
+    assertThat(future)
+        .failsWithin(ofSeconds(1))
+        .withThrowableOfType(ExecutionException.class)
+        .havingCause()
+        .withMessageContaining("RESTORE")
+        .withMessageContaining("BACKUP");
+  }
+
+  @Test
+  public void shouldPassRestoreCoordinatorRejectionThroughUnchanged() {
+    // given
+    final var rejection = new ErrorResponse(ErrorCode.INVALID_STATE, "restore already running");
+    when(clusterConfigurationRequestSender.restore(any()))
+        .thenReturn(CompletableFuture.completedFuture(Either.left(rejection)));
+
+    // when
+    final var future = services.restore(restoreRequest(), authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    assertThat(future.join().getLeft()).isEqualTo(rejection);
+  }
+
+  @Test
+  public void shouldGetRestoreStatusWhenAuthorizationsDisabled() {
+    // given
+    stubTopologySuccess();
+
+    // when
+    final var future = services.restoreStatus(authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    verify(clusterConfigurationRequestSender).getTopology();
+  }
+
+  @Test
+  public void shouldGetRestoreStatusWhenUserHasBackupRestorePermission() {
+    // given
+    grant(AuthorizationResourceType.BACKUP, PermissionType.RESTORE);
+    stubTopologySuccess();
+
+    // when
+    final var future = services.restoreStatus(authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    verify(clusterConfigurationRequestSender).getTopology();
+  }
+
+  @Test
+  public void shouldFailGetRestoreStatusWithForbiddenWhenUserHasNoAuthorizations() {
+    // given
+    authorizationsConfig.setEnabled(true);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Collections.emptySet());
+
+    // when
+    final var future = services.restoreStatus(authentication);
+
+    // then
+    assertForbidden(future);
+    verify(clusterConfigurationRequestSender, never()).getTopology();
+  }
+
+  @Test
+  public void shouldFailGetRestoreStatusWithForbiddenWhenUserOnlyHasSystemUpdatePermission() {
+    // given - reading the restore status is gated the same as triggering one: SYSTEM:UPDATE alone
+    // must not suffice
+    grant(AuthorizationResourceType.SYSTEM, PermissionType.UPDATE);
+
+    // when
+    final var future = services.restoreStatus(authentication);
+
+    // then
+    assertForbidden(future);
+    verify(clusterConfigurationRequestSender, never()).getTopology();
+  }
+
+  @Test
+  public void shouldPassGetRestoreStatusCoordinatorRejectionThroughUnchanged() {
+    // given
+    final var rejection = new ErrorResponse(ErrorCode.INTERNAL_ERROR, "topology is unavailable");
+    when(clusterConfigurationRequestSender.getTopology())
+        .thenReturn(CompletableFuture.completedFuture(Either.left(rejection)));
+
+    // when
+    final var future = services.restoreStatus(authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    assertThat(future.join().getLeft()).isEqualTo(rejection);
+  }
+
+  private static RestoreRequest restoreRequest() {
+    return new RestoreRequest(
+        PHYSICAL_TENANT_ID, List.of(100L), null, null, "elasticsearch", false, false);
+  }
+
+  private void stubRestoreSuccess() {
+    when(clusterConfigurationRequestSender.restore(any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.right(
+                    new ClusterConfigurationChangeResponse(0L, Map.of(), Map.of(), List.of()))));
+  }
+
+  private void stubTopologySuccess() {
+    when(clusterConfigurationRequestSender.getTopology())
+        .thenReturn(CompletableFuture.completedFuture(Either.right(ClusterConfiguration.init())));
   }
 
   private void grant(

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -150,7 +150,8 @@ paths:
       tags:
         - Recovery
       operationId: restore
-      x-required-permissions: []
+      x-required-permissions:
+        - { resourceType: BACKUP, permissionType: RESTORE }
       security:
         - bearerAuth: []
         - basicAuth: []
@@ -177,6 +178,8 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "401":
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "409":
           description: The cluster is not in recovery mode, so the restore cannot be accepted.
         "500":
@@ -187,7 +190,8 @@ paths:
       tags:
         - Recovery
       operationId: getRestoreStatus
-      x-required-permissions: []
+      x-required-permissions:
+        - { resourceType: BACKUP, permissionType: RESTORE }
       security:
         - bearerAuth: []
         - basicAuth: []
@@ -206,6 +210,8 @@ paths:
                 $ref: '#/components/schemas/RestoreStatusResponse'
         "401":
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "404":
           description: No restore is currently in progress.
         "500":

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
@@ -19,7 +19,6 @@ import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.spring.utils.DatabaseTypeUtils;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.api.RestoreStatus;
 import io.camunda.zeebe.dynamic.config.api.RestoreStatus.BrokerRestoreStatus;
@@ -57,17 +56,14 @@ public final class RecoveryController {
   private static final String CONTINUOUS_BACKUPS_PROPERTY =
       "camunda.data.primary-storage.backup.continuous";
 
-  private final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender;
   private final ServiceRegistry serviceRegistry;
   private final CamundaAuthenticationProvider authenticationProvider;
   private final Environment environment;
 
   public RecoveryController(
-      final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender,
       final ServiceRegistry serviceRegistry,
       final CamundaAuthenticationProvider authenticationProvider,
       final Environment environment) {
-    this.clusterConfigurationRequestSender = clusterConfigurationRequestSender;
     this.serviceRegistry = serviceRegistry;
     this.authenticationProvider = authenticationProvider;
     this.environment = environment;
@@ -99,10 +95,13 @@ public final class RecoveryController {
           final io.camunda.gateway.protocol.model.RestoreRequest restoreRequest,
       @RequestParam(name = "dryRun", defaultValue = "false") final boolean dryRun) {
     LOG.info("Requested restore for physical tenant {}: {}", physicalTenantId, restoreRequest);
+    final var authentication = authenticationProvider.getCamundaAuthentication();
+    final var request = toRestoreRequest(physicalTenantId, restoreRequest, dryRun);
     return RequestExecutor.executeServiceMethod(
         () ->
-            clusterConfigurationRequestSender
-                .restore(toRestoreRequest(physicalTenantId, restoreRequest, dryRun))
+            serviceRegistry
+                .recoveryServices(physicalTenantId)
+                .restore(request, authentication)
                 .thenApply(RecoveryController::unwrapOrThrow),
         RecoveryController::toClusterModeChangeResponse,
         HttpStatus.ACCEPTED);
@@ -112,10 +111,12 @@ public final class RecoveryController {
   public CompletableFuture<ResponseEntity<Object>> getRestoreStatus(
       @PhysicalTenantId final String physicalTenantId) {
     LOG.debug("Requested restore status for physical tenant {}", physicalTenantId);
+    final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
         () ->
-            clusterConfigurationRequestSender
-                .getTopology()
+            serviceRegistry
+                .recoveryServices(physicalTenantId)
+                .restoreStatus(authentication)
                 .thenApply(RecoveryController::unwrapOrThrow)
                 .thenApply(RecoveryController::restoreStatus),
         RecoveryController::mapRestoreStatus,

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -174,9 +174,7 @@ public class RecoveryControllerTest extends RestControllerTest {
     Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.any()))
         .thenReturn(
             CompletableFuture.failedFuture(
-                new ServiceException(
-                    "Unauthorized to perform operation 'RESTORE' on resource 'BACKUP'",
-                    ServiceException.Status.FORBIDDEN)));
+                ErrorMapper.createForbiddenException(BACKUP_RESTORE_AUTHORIZATION)));
 
     // when / then
     webClient
@@ -186,7 +184,18 @@ public class RecoveryControllerTest extends RestControllerTest {
         .bodyValue("{\"backupIds\": [100]}")
         .exchange()
         .expectStatus()
-        .isForbidden();
+        .isForbidden()
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "status": 403,
+              "title": "FORBIDDEN",
+              "detail": "Unauthorized to perform operation 'RESTORE' on resource 'BACKUP'",
+              "instance": "/v2/restore"
+            }""",
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -252,12 +261,26 @@ public class RecoveryControllerTest extends RestControllerTest {
     Mockito.when(recoveryServices.restoreStatus(Mockito.any()))
         .thenReturn(
             CompletableFuture.failedFuture(
-                new ServiceException(
-                    "Unauthorized to perform operation 'RESTORE' on resource 'BACKUP'",
-                    ServiceException.Status.FORBIDDEN)));
+                ErrorMapper.createForbiddenException(BACKUP_RESTORE_AUTHORIZATION)));
 
     // when / then
-    webClient.get().uri("/v2/restore").exchange().expectStatus().isForbidden();
+    webClient
+        .get()
+        .uri("/v2/restore")
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "status": 403,
+              "title": "FORBIDDEN",
+              "detail": "Unauthorized to perform operation 'RESTORE' on resource 'BACKUP'",
+              "instance": "/v2/restore"
+            }""",
+            JsonCompareMode.STRICT);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.gateway.rest.controller;
 import static io.camunda.service.authorization.Authorizations.BACKUP_RESTORE_AUTHORIZATION;
 import static io.camunda.service.authorization.Authorizations.SYSTEM_UPDATE_AUTHORIZATION;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PhysicalTenantIds;
@@ -22,7 +24,6 @@ import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
@@ -59,7 +60,6 @@ import org.springframework.test.json.JsonCompareMode;
 @WebMvcTest(RecoveryController.class)
 public class RecoveryControllerTest extends RestControllerTest {
 
-  @MockitoBean ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender;
   @MockitoBean ServiceRegistry serviceRegistry;
   @MockitoBean RecoveryServices recoveryServices;
   @MockitoBean CamundaAuthenticationProvider authenticationProvider;
@@ -72,7 +72,7 @@ public class RecoveryControllerTest extends RestControllerTest {
   }
 
   private void stubValidationSuccess() {
-    Mockito.when(clusterConfigurationRequestSender.restore(Mockito.any()))
+    Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 Either.right(
@@ -169,9 +169,30 @@ public class RecoveryControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldRejectRestoreWhenCallerIsNotAuthorized() {
+    // given
+    Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException(
+                    "Unauthorized to perform operation 'RESTORE' on resource 'BACKUP'",
+                    ServiceException.Status.FORBIDDEN)));
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/restore")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupIds\": [100]}")
+        .exchange()
+        .expectStatus()
+        .isForbidden();
+  }
+
+  @Test
   void shouldMapInvalidRequestErrorFromCoordinator() {
     // given
-    Mockito.when(clusterConfigurationRequestSender.restore(Mockito.any()))
+    Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 Either.left(new ErrorResponse(ErrorCode.INVALID_REQUEST, "bad params"))));
@@ -190,7 +211,7 @@ public class RecoveryControllerTest extends RestControllerTest {
   @Test
   void shouldMapInternalErrorFromCoordinator() {
     // given
-    Mockito.when(clusterConfigurationRequestSender.restore(Mockito.any()))
+    Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 Either.left(new ErrorResponse(ErrorCode.INTERNAL_ERROR, "boom"))));
@@ -209,7 +230,7 @@ public class RecoveryControllerTest extends RestControllerTest {
   @Test
   void shouldMapConcurrentModificationFromCoordinator() {
     // given
-    Mockito.when(clusterConfigurationRequestSender.restore(Mockito.any()))
+    Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 Either.left(new ErrorResponse(ErrorCode.CONCURRENT_MODIFICATION, "boom"))));
@@ -226,9 +247,23 @@ public class RecoveryControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldRejectRestoreStatusWhenCallerIsNotAuthorized() {
+    // given
+    Mockito.when(recoveryServices.restoreStatus(Mockito.any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException(
+                    "Unauthorized to perform operation 'RESTORE' on resource 'BACKUP'",
+                    ServiceException.Status.FORBIDDEN)));
+
+    // when / then
+    webClient.get().uri("/v2/restore").exchange().expectStatus().isForbidden();
+  }
+
+  @Test
   void shouldReturnNotFoundWhenNoRestore() {
     // given
-    Mockito.when(clusterConfigurationRequestSender.getTopology())
+    Mockito.when(recoveryServices.restoreStatus(Mockito.any()))
         .thenReturn(CompletableFuture.completedFuture(Either.right(ClusterConfiguration.init())));
 
     // when / then
@@ -328,7 +363,7 @@ public class RecoveryControllerTest extends RestControllerTest {
   @Test
   void shouldMapErrorResponseWhenTopologyQueryRejected() {
     // given
-    Mockito.when(clusterConfigurationRequestSender.getTopology())
+    Mockito.when(recoveryServices.restoreStatus(Mockito.any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 Either.left(
@@ -342,7 +377,7 @@ public class RecoveryControllerTest extends RestControllerTest {
   @Test
   void shouldMapFailedTopologyRequest() {
     // given
-    Mockito.when(clusterConfigurationRequestSender.getTopology())
+    Mockito.when(recoveryServices.restoreStatus(Mockito.any()))
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException("no coordinator")));
 
     // when / then
@@ -395,7 +430,7 @@ public class RecoveryControllerTest extends RestControllerTest {
             Optional.empty(),
             0,
             Optional.empty());
-    Mockito.when(clusterConfigurationRequestSender.getTopology())
+    Mockito.when(recoveryServices.restoreStatus(Mockito.any()))
         .thenReturn(CompletableFuture.completedFuture(Either.right(configuration)));
   }
 
@@ -489,16 +524,18 @@ public class RecoveryControllerTest extends RestControllerTest {
           .expectBody()
           .json("{\"changeId\": \"0\", \"plannedChanges\": []}", JsonCompareMode.STRICT);
 
-      Mockito.verify(clusterConfigurationRequestSender)
+      Mockito.verify(recoveryServices)
           .restore(
-              new RestoreRequest(
-                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-                  List.of(100L, 101L),
-                  null,
-                  null,
-                  expectedDatabaseType(),
-                  false,
-                  false));
+              eq(
+                  new RestoreRequest(
+                      PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                      List.of(100L, 101L),
+                      null,
+                      null,
+                      expectedDatabaseType(),
+                      false,
+                      false)),
+              any());
     }
 
     @ParameterizedTest
@@ -516,16 +553,18 @@ public class RecoveryControllerTest extends RestControllerTest {
           .expectStatus()
           .isAccepted();
 
-      Mockito.verify(clusterConfigurationRequestSender)
+      Mockito.verify(recoveryServices)
           .restore(
-              new RestoreRequest(
-                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-                  List.of(),
-                  null,
-                  null,
-                  expectedDatabaseType(),
-                  false,
-                  false));
+              eq(
+                  new RestoreRequest(
+                      PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                      List.of(),
+                      null,
+                      null,
+                      expectedDatabaseType(),
+                      false,
+                      false)),
+              any());
     }
   }
 
@@ -549,16 +588,18 @@ public class RecoveryControllerTest extends RestControllerTest {
           .expectStatus()
           .isAccepted();
 
-      Mockito.verify(clusterConfigurationRequestSender)
+      Mockito.verify(recoveryServices)
           .restore(
-              new RestoreRequest(
-                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-                  List.of(100L, 101L),
-                  null,
-                  null,
-                  expectedDatabaseType(),
-                  true,
-                  false));
+              eq(
+                  new RestoreRequest(
+                      PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                      List.of(100L, 101L),
+                      null,
+                      null,
+                      expectedDatabaseType(),
+                      true,
+                      false)),
+              any());
     }
 
     @ParameterizedTest
@@ -577,16 +618,18 @@ public class RecoveryControllerTest extends RestControllerTest {
           .expectStatus()
           .isAccepted();
 
-      Mockito.verify(clusterConfigurationRequestSender)
+      Mockito.verify(recoveryServices)
           .restore(
-              new RestoreRequest(
-                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-                  List.of(),
-                  "2024-01-01T10:00:00Z",
-                  "2024-01-01T12:00:00Z",
-                  expectedDatabaseType(),
-                  true,
-                  false));
+              eq(
+                  new RestoreRequest(
+                      PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                      List.of(),
+                      "2024-01-01T10:00:00Z",
+                      "2024-01-01T12:00:00Z",
+                      expectedDatabaseType(),
+                      true,
+                      false)),
+              any());
     }
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Enable authorization checks for executing an in-process restore operation alongise querying its status via the `Backup#RESTORE` permissions.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #59131

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>