### PR TITLE
feat: remove nullable `loopIteration` check in Operate

### DIFF
--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.12.1",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.83",
+        "@camunda/camunda-api-zod-schemas": "0.0.86",
         "@camunda/camunda-composite-components": "0.25.2",
         "@carbon/elements": "11.93.0",
         "@carbon/react": "1.112.0",
@@ -498,9 +498,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.83",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.83.tgz",
-      "integrity": "sha512-/8NoB3TVvgfeS6rrmCziaNLRKXzwtuS1WidaYEQUu5R3iRKFuaGLDLhHIfGMUJAOPKGUnHb9dx/F4ACqoENEUw==",
+      "version": "0.0.86",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.86.tgz",
+      "integrity": "sha512-ucjf0OZP/xWjyqd1COeNRXqAC0lkp/caRaxgDTpO8iA1nhNsGIxFWnWxulhV82ZEDmU5DZlJbDP5GuIWPwwfGw==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.12.1",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.83",
+    "@camunda/camunda-api-zod-schemas": "0.0.86",
     "@camunda/camunda-composite-components": "0.25.2",
     "@carbon/elements": "11.93.0",
     "@carbon/react": "1.112.0",

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -32,23 +32,16 @@ import {isActiveAgentInstanceStatus} from 'modules/queries/agentInstances/agentI
 
 function mapIntoLoopIterationChunks(
   pages: InfiniteData<QueryAgentInstanceHistoryResponseBody>,
-): [number, AgentInstanceHistoryItem[]][] {
+): Map<number, AgentInstanceHistoryItem[]> {
   const history = flattenPaginatedPages(pages).items;
   const loopIterationMap = new Map<number, AgentInstanceHistoryItem[]>();
 
   for (const item of history) {
-    const iteration = item.loopIteration;
-    if (iteration === null) {
-      // The connector never set's null and actively guards against it.
-      // Properly grouping those messages is non trivial. To avoid accidental
-      // complexity, this theoretical case is dropped.
-      continue;
-    }
-    const bucket = loopIterationMap.get(iteration) ?? [];
+    const bucket = loopIterationMap.get(item.loopIteration) ?? [];
     bucket.push(item);
-    loopIterationMap.set(iteration, bucket);
+    loopIterationMap.set(item.loopIteration, bucket);
   }
-  return Array.from(loopIterationMap);
+  return loopIterationMap;
 }
 
 type ConversationHistoryProps = {
@@ -125,14 +118,14 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
         onToggleScope={() => setIsScoped((prev) => !prev)}
       />
       <Messages data-dimmed={isPlaceholderData}>
-        {data.length === 0 ? (
+        {data.size === 0 ? (
           <StatusHint>
             {canBeScoped && isScoped
               ? 'No scoped conversation with the agent instance found.'
               : 'No conversation with this agent instance found.'}
           </StatusHint>
         ) : (
-          data.map(([iteration, items]) => {
+          Array.from(data, ([iteration, items]) => {
             const loopIterationNode = (
               <LoopIterationMarker>
                 {iteration}.&nbsp;loop&nbsp;iteration

--- a/operate/client/src/modules/utils/incidents.ts
+++ b/operate/client/src/modules/utils/incidents.ts
@@ -29,6 +29,7 @@ const ERROR_TYPE_NAMES: Record<IncidentErrorType, string> = {
   FORM_NOT_FOUND: 'Form not found.',
   RESOURCE_NOT_FOUND: 'Resource not found.',
   AD_HOC_SUB_PROCESS_NO_RETRIES: 'Ad hoc sub process error (no retries left).',
+  SECRET_RESOLUTION_ERROR: 'Secret resolution error.',
 };
 
 const availableErrorTypes = Object.keys(


### PR DESCRIPTION
## Description

Since https://github.com/camunda/camunda/pull/58952 the `loopIteration` field is no longer nullable. This PR bumps the previously updated API Zod schema version in Operate and removes the previously required null check from `mapIntoLoopIterationChunks`. Furthermore, `mapIntoLoopIterationChunks` now returns the map directly instead of converting it into an array just to map it into a new array.

## Related issues

closes #57399 
