### PR TITLE
test: await element statistics in shouldGetStatisticsForIncidents

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceStatisticsTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceStatisticsTest.java
@@ -142,16 +142,24 @@ public class ProcessInstanceStatisticsTest {
     final var processInstanceKey = createInstance(processDefinitionKey).getProcessInstanceKey();
     waitForProcessInstances(1, f -> f.processDefinitionKey(processDefinitionKey).hasIncident(true));
 
-    // when
-    final var actual =
-        camundaClient.newProcessInstanceElementStatisticsRequest(processInstanceKey).send().join();
-
-    // then
-    assertThat(actual).hasSize(2);
-    assertThat(actual)
-        .containsExactlyInAnyOrder(
-            new ProcessElementStatisticsImpl("ScriptTask", 0L, 0L, 1L, 0L),
-            new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 1L));
+    // The process instance record may report hasIncident=true before the flow node instance
+    // record is updated, so we poll the element statistics endpoint.
+    Awaitility.await("should return element statistics with incident on script task")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                // when
+                assertThat(
+                        camundaClient
+                            .newProcessInstanceElementStatisticsRequest(processInstanceKey)
+                            .send()
+                            .join())
+                    // then
+                    .hasSize(2)
+                    .containsExactlyInAnyOrder(
+                        new ProcessElementStatisticsImpl("ScriptTask", 0L, 0L, 1L, 0L),
+                        new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 1L)));
   }
 
   @Test


### PR DESCRIPTION
## Description

ProcessInstanceStatisticsTest.shouldGetStatisticsForIncidents asserted the element statistics immediately after waiting for the process instance to report hasIncident=true. The process instance record is updated before the flow node instance record carries the incident, so the ScriptTask was frequently still reported as active=1, incidents=0 instead of active=0, incidents=1, failing both the Elasticsearch and OpenSearch QA acceptance test jobs.

Wrap the assertion in an Awaitility poll, consistent with the other tests in this class which already handle the same race.

## Related issues

related to this [incident](https://camunda.slack.com/archives/C0BMX5TNFLY)
