### PR TITLE
feat: accept bearer tokens on the internal Optimize API under CSL

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityPathAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityPathAdapter.java
@@ -18,9 +18,12 @@ import java.util.Set;
  * href="https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md">ADR-0038</a>.
  *
  * <ul>
- *   <li>{@link #apiPaths()} = the bearer-only public API surface. Only these are claimed by the CSL
- *       OIDC API chain (bearer JWT). Everything else under {@code /api} is served by the catch-all
- *       webapp chain and authenticated from the session.
+ *   <li>{@link #apiPaths()} = the API surface claimed by the CSL OIDC API chain, which accepts
+ *       either a bearer JWT or the webapp session (the chain installs the session filter and uses
+ *       {@code SessionCreationPolicy.NEVER}, so an existing session is restored but never created).
+ *       {@code /api/authentication/**} is deliberately absent: on CCSM the OIDC callback lives at
+ *       {@code /api/authentication/callback}, and the API chain disables {@code oauth2Login}, so
+ *       claiming it here would stop the callback ever reaching the webapp chain and break login.
  *   <li>{@link #unprotectedApiPaths()} = the public subset of {@link #apiPaths()} (the subset
  *       contract is kept). Empty for Optimize: the public API and ingestion endpoints are all
  *       protected.
@@ -34,9 +37,37 @@ import java.util.Set;
  */
 public final class OptimizeSecurityPathAdapter implements SecurityPathPort {
 
+  /**
+   * Enumerated rather than {@code /api/**} so {@code /api/authentication/**} stays on the webapp
+   * chain; see the class javadoc. The public endpoints under {@code /api} are not listed either,
+   * because {@link #unprotectedPaths()} claims them on the order-0 chain.
+   */
   @Override
   public Set<String> apiPaths() {
-    return Set.of("/api/public/**", "/api/ingestion/variable");
+    return Set.of(
+        // Bearer-only surface, unchanged.
+        "/api/public/**",
+        "/api/ingestion/variable",
+        // Internal API, reachable with a bearer token as well as the session.
+        "/api/alert/**",
+        "/api/analysis/**",
+        "/api/assignee/**",
+        "/api/candidateGroup/**",
+        "/api/collection/**",
+        "/api/dashboard/**",
+        "/api/decision-variables/**",
+        "/api/definition/**",
+        "/api/entities/**",
+        "/api/export/**",
+        "/api/flow-node/**",
+        "/api/identity/**",
+        "/api/import/**",
+        "/api/process/**",
+        "/api/report/**",
+        "/api/settings/**",
+        "/api/share/**",
+        "/api/token/**",
+        "/api/variables/**");
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/security/SessionService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/security/SessionService.java
@@ -97,8 +97,8 @@ public class SessionService implements ConfigurationReloadable {
    * Resolves the authenticated user ID from the current request, regardless of whether the request
    * was authenticated via an Identity session cookie or a bearer JWT token.
    *
-   * <p>A CSL login session is resolved on its own: when CSL is active and the request carries one,
-   * the user is whatever CSL authenticated (see {@link #cslAuthenticatedUsername(
+   * <p>A CSL-authenticated request is resolved on its own: when CSL is active and the request
+   * carries one, the user is whatever CSL authenticated (see {@link #cslAuthenticatedUsername(
    * CamundaAuthenticationProvider)}) or nothing at all. It never falls back to the branches below,
    * because the cookie branch reads its subject from an unverified token: under CSL no filter
    * validates the Optimize auth cookie, so a stale or injected one could otherwise attribute the
@@ -119,12 +119,12 @@ public class SessionService implements ConfigurationReloadable {
    */
   public String getRequestUserOrFailNotAuthorized(final HttpServletRequest request) {
     final CamundaAuthenticationProvider cslProvider = cslAuthenticationProvider();
-    if (cslProvider != null && isCslLoginSession()) {
+    if (cslProvider != null && isCslAuthenticatedRequest()) {
       return cslAuthenticatedUsername(cslProvider)
           .orElseThrow(
               () ->
                   new NotAuthorizedException(
-                      "Could not extract request user from the CSL login session!"));
+                      "Could not extract request user from the CSL authentication!"));
     }
     return subjectFromSecurityContext()
         .or(
@@ -141,10 +141,16 @@ public class SessionService implements ConfigurationReloadable {
         : camundaAuthenticationProviderProvider.getIfAvailable();
   }
 
-  /** True when the current request was authenticated by CSL's {@code oauth2Login} chain. */
-  private static boolean isCslLoginSession() {
-    return SecurityContextHolder.getContext().getAuthentication()
-        instanceof OAuth2AuthenticationToken;
+  /**
+   * True when CSL authenticated the current request: an {@link OAuth2AuthenticationToken} from the
+   * {@code oauth2Login} webapp chain, or a {@link JwtAuthenticationToken} from the bearer API
+   * chain. CSL supplies a converter for both, so its authenticated username is authoritative for
+   * either and the legacy branches below are not consulted.
+   */
+  private static boolean isCslAuthenticatedRequest() {
+    final var authentication = SecurityContextHolder.getContext().getAuthentication();
+    return authentication instanceof OAuth2AuthenticationToken
+        || authentication instanceof JwtAuthenticationToken;
   }
 
   /**

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityPathAdapterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityPathAdapterTest.java
@@ -27,6 +27,34 @@ class OptimizeSecurityPathAdapterTest {
   }
 
   @Test
+  void shouldNotClaimTheAuthenticationPathsForTheApiChain() {
+    // The CCSM OIDC callback is /api/authentication/callback and the API chain disables
+    // oauth2Login, so claiming it here would stop the callback reaching the webapp chain and break
+    // login. Guards against anyone widening this to /api/**.
+    assertThat(pathAdapter.apiPaths())
+        .noneSatisfy(path -> assertThat(path).startsWith("/api/authentication"))
+        .doesNotContain("/api/**");
+  }
+
+  @Test
+  void shouldClaimTheInternalApiSoBearerTokensWorkAlongsideTheSession() {
+    assertThat(pathAdapter.apiPaths())
+        .contains("/api/public/**", "/api/ingestion/variable")
+        .contains("/api/dashboard/**", "/api/report/**", "/api/collection/**", "/api/entities/**");
+  }
+
+  @Test
+  void shouldLeaveThePublicEndpointsToTheUnprotectedChain() {
+    // These are matched by the order-0 unprotected chain, so listing them as API paths as well
+    // would be misleading and would change which chain reports on them.
+    assertThat(pathAdapter.apiPaths())
+        .doesNotContain(
+            "/api/readyz", "/api/ui-configuration", "/api/localization", "/api/external/**");
+    assertThat(pathAdapter.unprotectedPaths())
+        .contains("/api/readyz", "/api/ui-configuration", "/api/localization", "/api/external/**");
+  }
+
+  @Test
   void shouldUnprotectActuatorAtDefaultBasePath() {
     OptimizeResourceConstants.ACTUATOR_ENDPOINT = "/actuator";
     assertThat(pathAdapter.unprotectedPaths()).contains("/actuator/**");

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/security/SessionServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/security/SessionServiceTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.auth0.jwt.JWT;
@@ -171,20 +170,32 @@ class SessionServiceTest {
   }
 
   @Test
-  void shouldNotConsultCslForABearerAuthenticatedRequest() {
-    // given — CSL present, but the context holds a bearer JWT rather than an oauth2 session, so the
-    // bearer subject must win and CSL must not be asked
-    when(apiConfiguration.isJwtAuthForApiEnabled()).thenReturn(true);
+  void shouldResolveABearerAuthenticatedRequestThroughCsl() {
+    // given — CSL present and the context holds a bearer JWT from the CSL API chain. CSL has a
+    // converter for that token type, and its username follows the configured username-claim, so it
+    // is authoritative over the raw sub and over the legacy jwtAuthForApiEnabled flag.
     sessionService = sessionServiceWith(camundaAuthenticationProviderOf(CSL_USERNAME));
     SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(buildJwt()));
 
-    // when — the bearer subject resolves first, so the cookie path is never reached
+    // when
     final String user =
         sessionService.getRequestUserOrFailNotAuthorized(mock(HttpServletRequest.class));
 
     // then
+    assertThat(user).isEqualTo(CSL_USERNAME);
+  }
+
+  @Test
+  void shouldStillUseTheBearerSubjectWhenCslIsAbsent() {
+    // given — legacy setup: no CamundaAuthenticationProvider bean, so the pre-CSL behaviour of
+    // taking the subject from the bearer token must be preserved
+    when(apiConfiguration.isJwtAuthForApiEnabled()).thenReturn(true);
+    SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(buildJwt()));
+
+    final String user =
+        sessionService.getRequestUserOrFailNotAuthorized(mock(HttpServletRequest.class));
+
     assertThat(user).isEqualTo(USER_SUBJECT);
-    verifyNoInteractions(camundaAuthenticationProvider);
   }
 
   private ObjectProvider<CamundaAuthenticationProvider> camundaAuthenticationProviderOf(


### PR DESCRIPTION
## Description

Hub needs to call Optimize's internal API on behalf of the signed-in user with a bearer token (camunda/camunda-hub#27006). Today only `/api/public/**` and `/api/ingestion/variable` are claimed by the CSL OIDC API chain, so everything else falls to the webapp chain, which has no resource server and rejects bearer tokens.

Two changes are needed, because the chain and the application layer both blocked it:

1. **`OptimizeSecurityPathAdapter.apiPaths()`** now claims the internal API paths, so the API chain authenticates them. That chain accepts either a bearer JWT or the webapp session, since it installs the session filter and uses `SessionCreationPolicy.NEVER`, so browser traffic is unaffected. CSRF still applies to session requests, because `CsrfProtectionRequestMatcher` requires a token exactly when a session is present.
2. **`SessionService`** now treats a `JwtAuthenticationToken` as CSL-authenticated. Without this the first change is not enough: every internal endpoint resolves its user through `SessionService`, whose CSL branch only matched an `oauth2Login` session, so a bearer request fell through to `subjectFromSecurityContext`, which is gated on the legacy `jwtAuthForApiEnabled` flag (default `false`) and returned a 401 anyway.

The legacy stack never allowed bearer tokens here, so this is a new capability rather than a restored one.

## Notes for reviewers

`apiPaths()` is enumerated instead of `/api/**` on purpose. The API chain does `.oauth2Login(AbstractHttpConfigurer::disable)` and sorts before the webapp chain (`ORDER_API=1` < `ORDER_WEBAPP=2`), while the CCSM OIDC callback is `/api/authentication/callback`. Claiming that path would stop the callback reaching the webapp chain's redirection endpoint and break CCSM login. `shouldNotClaimTheAuthenticationPathsForTheApiChain` guards both the prefix and a literal `/api/**`.

The public endpoints under `/api` are left out too: `/api/readyz`, `/api/ui-configuration`, `/api/localization` and `/api/external/**` are matched by the order-0 unprotected chain.

Resolving bearer requests through CSL rather than through `subjectFromSecurityContext` also gives the right identity: CSL's username follows the configured `username-claim`, which is what Optimize stores entity ownership under, where the legacy path used the raw `sub`. Without CSL the legacy bearer path is untouched, covered by `shouldStillUseTheBearerSubjectWhenCslIsAbsent`.

An unauthenticated browser navigation to an internal API path now returns a bearer-style 401 rather than the webapp entry point's response. XHR already returned 401 either way, so the SPA is unaffected.

## Docs

The calling application's token must carry an audience Optimize accepts, that is one of `camunda.security.authentication.oidc.audiences`. On Self-Managed that set is bridged from `CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE` and `CAMUNDA_OPTIMIZE_API_AUDIENCE`. This needs a note in camunda-docs under the Optimize Self-Managed authentication section, stating that the internal API accepts a bearer token whose `aud` is in that set, alongside the existing session-based access. Happy to draft the wording once the endpoint list Hub needs is final.

## Related issues

Requested by camunda/camunda-hub#27006
Parent epic #58403
Decision: [ADR-0038](https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md)
Related: camunda/camunda-security-library#578, which tracks requiring the SaaS org and cluster claims per token type

🤖 Generated with [Claude Code](https://claude.com/claude-code)
