### PR TITLE
feat: persist Optimize CSL web sessions in Elasticsearch

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/security/OptimizeSessionStoreAdapterIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/security/OptimizeSessionStoreAdapterIT.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.security;
+
+import static io.camunda.optimize.AbstractIT.OPENSEARCH_SINGLE_TEST_FAIL_OK;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.rest.security.csl.OptimizeSessionStoreAdapter;
+import io.camunda.optimize.service.db.repository.PersistentWebSessionRepository;
+import io.camunda.optimize.service.util.IdGenerator;
+import io.camunda.security.api.model.session.PersistentSession;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Round-trips CSL's server-side sessions through the real {@code web-session} index (ADR-0038).
+ * Covers what a mocked repository cannot: that the index the schema manager creates actually
+ * accepts the document, and that the Base64-encoded attribute map survives the trip.
+ *
+ * <p>The adapter is constructed directly rather than taken from the context: its bean only exists
+ * with {@code optimize.security.csl.enabled=true}, which would swap the whole security chain and
+ * break this rig's authentication. The store path exercised here is the same either way.
+ *
+ * <p>Elasticsearch-only until the OpenSearch store lands (#58472), hence the tag that keeps it out
+ * of the OpenSearch pipeline.
+ */
+@Tag(OPENSEARCH_SINGLE_TEST_FAIL_OK)
+public class OptimizeSessionStoreAdapterIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private static final String ATTRIBUTE_NAME = "SPRING_SECURITY_CONTEXT";
+  private static final byte[] ATTRIBUTE_VALUE = "serialized-principal".getBytes(UTF_8);
+  private static final long MAX_INACTIVE_INTERVAL_SECONDS = 1800L;
+
+  private OptimizeSessionStoreAdapter sessionStore;
+
+  @BeforeEach
+  void setUp() {
+    sessionStore =
+        new OptimizeSessionStoreAdapter(
+            embeddedOptimizeExtension.getBean(PersistentWebSessionRepository.class));
+  }
+
+  @Test
+  void shouldStoreAndLoadASession() {
+    // given
+    final PersistentSession session = newSession();
+
+    // when
+    sessionStore.upsert(session);
+
+    // then the session is readable without an index refresh, as it must be for the very next
+    // request
+    final PersistentSession loaded = sessionStore.get(session.id());
+    assertThat(loaded).isNotNull();
+    assertThat(loaded.id()).isEqualTo(session.id());
+    assertThat(loaded.creationTime()).isEqualTo(session.creationTime());
+    assertThat(loaded.lastAccessedTime()).isEqualTo(session.lastAccessedTime());
+    assertThat(loaded.maxInactiveIntervalInSeconds()).isEqualTo(MAX_INACTIVE_INTERVAL_SECONDS);
+    assertThat(loaded.attributes().get(ATTRIBUTE_NAME)).isEqualTo(ATTRIBUTE_VALUE);
+  }
+
+  @Test
+  void shouldReturnNullForAnUnknownSession() {
+    // when
+    final PersistentSession loaded = sessionStore.get(IdGenerator.getNextId());
+
+    // then
+    assertThat(loaded).isNull();
+  }
+
+  @Test
+  void shouldRefreshTheSessionOnEveryAccess() {
+    // given a stored session
+    final PersistentSession session = newSession();
+    sessionStore.upsert(session);
+
+    // when the same session is written again with a later access time, as CSL does per request
+    final long laterAccess = session.lastAccessedTime() + 60_000L;
+    sessionStore.upsert(
+        new PersistentSession(
+            session.id(),
+            session.creationTime(),
+            laterAccess,
+            MAX_INACTIVE_INTERVAL_SECONDS,
+            session.attributes()));
+
+    // then the update replaced the document instead of adding a second one
+    assertThat(sessionStore.get(session.id()).lastAccessedTime()).isEqualTo(laterAccess);
+    assertThat(sessionsInStore()).extracting(PersistentSession::id).containsOnlyOnce(session.id());
+  }
+
+  @Test
+  void shouldDeleteASession() {
+    // given a stored session
+    final PersistentSession session = newSession();
+    sessionStore.upsert(session);
+
+    // when the user logs out
+    sessionStore.delete(session.id());
+
+    // then the session document is gone, so the session cannot be resumed anywhere in the cluster
+    assertThat(sessionStore.get(session.id())).isNull();
+  }
+
+  @Test
+  void shouldIgnoreDeletionOfAnUnknownSession() {
+    // when a session that was already swept is deleted again
+    // then nothing is thrown
+    sessionStore.delete(IdGenerator.getNextId());
+  }
+
+  @Test
+  void shouldListEverySessionForTheExpirySweep() {
+    // given
+    final PersistentSession first = newSession();
+    final PersistentSession second = newSession();
+    sessionStore.upsert(first);
+    sessionStore.upsert(second);
+
+    // when
+    // then CSL's deletion task sees both, which is what lets it evict the expired ones
+    assertThat(sessionsInStore())
+        .extracting(PersistentSession::id)
+        .contains(first.id(), second.id());
+  }
+
+  private List<PersistentSession> sessionsInStore() {
+    // getAll is a search, so the writes have to be visible to it first
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+    return sessionStore.getAll();
+  }
+
+  private static PersistentSession newSession() {
+    final long now = System.currentTimeMillis();
+    return new PersistentSession(
+        IdGenerator.getNextId(),
+        now,
+        now,
+        MAX_INACTIVE_INTERVAL_SECONDS,
+        Map.of(ATTRIBUTE_NAME, ATTRIBUTE_VALUE));
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/WebSessionDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/WebSessionDto.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query;
+
+import java.util.Map;
+
+/**
+ * Persisted representation of a server-side web session in the {@code web-session} index, mirroring
+ * the Camunda Security Library's {@code PersistentSession}. Jackson writes each {@code byte[]}
+ * attribute value as Base64, so {@code attributes} round-trips as a JSON object.
+ *
+ * <p>The no-arg constructor is required for deserialization.
+ */
+public class WebSessionDto {
+
+  private String id;
+  private Long creationTime;
+  private Long lastAccessedTime;
+  private Long maxInactiveIntervalInSeconds;
+  private Map<String, byte[]> attributes;
+
+  public WebSessionDto() {}
+
+  public WebSessionDto(
+      final String id,
+      final Long creationTime,
+      final Long lastAccessedTime,
+      final Long maxInactiveIntervalInSeconds,
+      final Map<String, byte[]> attributes) {
+    this.id = id;
+    this.creationTime = creationTime;
+    this.lastAccessedTime = lastAccessedTime;
+    this.maxInactiveIntervalInSeconds = maxInactiveIntervalInSeconds;
+    this.attributes = attributes;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public Long getCreationTime() {
+    return creationTime;
+  }
+
+  public void setCreationTime(final Long creationTime) {
+    this.creationTime = creationTime;
+  }
+
+  public Long getLastAccessedTime() {
+    return lastAccessedTime;
+  }
+
+  public void setLastAccessedTime(final Long lastAccessedTime) {
+    this.lastAccessedTime = lastAccessedTime;
+  }
+
+  public Long getMaxInactiveIntervalInSeconds() {
+    return maxInactiveIntervalInSeconds;
+  }
+
+  public void setMaxInactiveIntervalInSeconds(final Long maxInactiveIntervalInSeconds) {
+    this.maxInactiveIntervalInSeconds = maxInactiveIntervalInSeconds;
+  }
+
+  public Map<String, byte[]> getAttributes() {
+    return attributes;
+  }
+
+  public void setAttributes(final Map<String, byte[]> attributes) {
+    this.attributes = attributes;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCamundaSecurityConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCamundaSecurityConfig.java
@@ -17,6 +17,7 @@ import io.camunda.security.spring.CamundaSecurityAutoConfiguration;
 import io.camunda.security.spring.converter.OidcTokenAuthenticationConverter;
 import io.camunda.security.spring.converter.OidcUserAuthenticationConverter;
 import io.camunda.security.spring.oidc.OidcAccessTokenDecoderFactory;
+import io.camunda.security.spring.session.WebSessionConfiguration;
 import io.camunda.security.spring.spi.OidcAuthenticationEntryPoint;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
@@ -26,6 +27,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.Ordered;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
@@ -45,6 +47,12 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepo
  * {@link SecurityPathPort#webappPaths()}: the stock webapp chain becomes the catch-all that sorts
  * below the bearer API chain. No custom webapp chain bean is needed.
  *
+ * <p>{@link WebSessionConfiguration} is imported explicitly because the umbrella does not include
+ * it: it carries the session lifecycle beans (repository, mapper, attribute converter, expiry
+ * sweep) that persist through {@link OptimizeSessionStoreAdapter}. It self-activates on {@code
+ * camunda.security.session.persistent.enabled}, so without that property CSL keeps its in-memory
+ * sessions and nothing here changes.
+ *
  * <p>Required application config:
  *
  * <ul>
@@ -57,6 +65,7 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepo
 @Configuration
 @ConditionalOnProperty(name = "optimize.security.csl.enabled", havingValue = "true")
 @ImportAutoConfiguration(CamundaSecurityAutoConfiguration.class)
+@Import(WebSessionConfiguration.class)
 public class OptimizeCamundaSecurityConfig {
 
   private static final Logger LOG = LoggerFactory.getLogger(OptimizeCamundaSecurityConfig.class);

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.optimize.rest.security.csl;
 
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.DatabaseType;
+import io.camunda.security.api.model.config.SessionConfiguration;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -68,6 +71,7 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
 
     final Map<String, Object> derived = new HashMap<>();
     applyAlwaysOnDefaults(derived);
+    applySessionPersistence(env, derived);
     bridgeIdentityOidc(env, derived);
     bridgeAuth0Cloud(env, derived);
     bridgePublicApiJwt(env, derived);
@@ -91,12 +95,29 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     derived.put("camunda.security.authentication.method", "oidc");
     // Optimize's webapp chain is /**, so the CSL deny chain must be suppressed.
     derived.put("camunda.security.authentication.catch-all-unhandled-paths-enabled", "false");
-    // Session persistence is intentionally not set here: it is owned by the dedicated session-store
-    // configuration (task 1.3, #58471), not by this legacy-config bridge.
     // CSL needs a redirect-uri for authorization-code login and derives its listener path from it
     // (ADR-0038). CCSM reuses Optimize's existing /api/authentication/callback (no Identity-client
     // change); bridgeAuth0Cloud overrides it for Auth0. putIfAbsent so an explicit value wins.
     derived.putIfAbsent(OIDC_PREFIX + "redirect-uri", "{baseUrl}/api/authentication/callback");
+  }
+
+  /**
+   * Turns on CSL's server-side sessions, which {@code OptimizeSessionStoreAdapter} persists in the
+   * {@code web-session} index. Only for the Elasticsearch edition: the store has no OpenSearch
+   * implementation yet, and CSL's session repository requires a {@code SessionStorePort} bean once
+   * the property is set, so enabling it on OpenSearch would fail startup. OpenSearch therefore
+   * keeps CSL's in-memory sessions (single-node only) until the OpenSearch store lands.
+   */
+  private void applySessionPersistence(
+      final ConfigurableEnvironment env, final Map<String, Object> derived) {
+    if (ConfigurationService.getDatabaseType(env) == DatabaseType.ELASTICSEARCH) {
+      derived.putIfAbsent(SessionConfiguration.PERSISTENT_ENABLED_PROPERTY, "true");
+    } else {
+      LOG.warn(
+          "Persistent web sessions are not enabled: the CSL session store is currently"
+              + " Elasticsearch-only. Sessions are kept in memory, so they are lost on restart and"
+              + " are not shared across Optimize instances.");
+    }
   }
 
   // OIDC / Identity (CCSM), from the CAMUNDA_OPTIMIZE_IDENTITY_* env vars. Skipped when Auth0 is

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSessionStoreAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSessionStoreAdapter.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.csl;
+
+import io.camunda.optimize.dto.optimize.query.WebSessionDto;
+import io.camunda.optimize.service.db.repository.PersistentWebSessionRepository;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import io.camunda.security.api.model.session.PersistentSession;
+import io.camunda.security.core.port.out.SessionStorePort;
+import java.util.List;
+import java.util.Map;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+/**
+ * Persists the server-side sessions of CSL's stateful OIDC webapp chain in Optimize's own database,
+ * replacing the stateless JWT cookie (<a
+ * href="https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md">ADR-0038</a>).
+ * A shared store rather than in-memory sessions is what keeps Optimize scalable without a sticky
+ * load balancer, and what makes logout able to invalidate a session cluster-wide.
+ *
+ * <p>OC's adapter cannot be reused: it lives in a module Optimize does not depend on and is bound
+ * to that host's search clients.
+ *
+ * <p>Active only under Elasticsearch and when {@code optimize.security.csl.enabled=true}. CSL
+ * routes sessions here only while {@code camunda.security.session.persistent.enabled=true}, which
+ * {@link OptimizeSecurityConfigCompatibilityPostProcessor} sets for the Elasticsearch edition;
+ * OpenSearch keeps CSL's in-memory sessions until the OpenSearch store lands.
+ */
+@Component
+@Conditional(ElasticSearchCondition.class)
+@ConditionalOnProperty(name = "optimize.security.csl.enabled", havingValue = "true")
+public class OptimizeSessionStoreAdapter implements SessionStorePort {
+
+  private final PersistentWebSessionRepository repository;
+
+  public OptimizeSessionStoreAdapter(final PersistentWebSessionRepository repository) {
+    this.repository = repository;
+  }
+
+  @Override
+  public PersistentSession get(final String sessionId) {
+    return repository
+        .get(sessionId)
+        .map(OptimizeSessionStoreAdapter::toPersistentSession)
+        .orElse(null);
+  }
+
+  @Override
+  public void upsert(final PersistentSession session) {
+    repository.upsert(toDto(session));
+  }
+
+  @Override
+  public void delete(final String sessionId) {
+    repository.delete(sessionId);
+  }
+
+  @Override
+  public List<PersistentSession> getAll() {
+    return repository.getAll().stream()
+        .map(OptimizeSessionStoreAdapter::toPersistentSession)
+        .toList();
+  }
+
+  private static PersistentSession toPersistentSession(final WebSessionDto dto) {
+    return new PersistentSession(
+        dto.getId(),
+        dto.getCreationTime(),
+        dto.getLastAccessedTime(),
+        dto.getMaxInactiveIntervalInSeconds(),
+        dto.getAttributes() != null ? dto.getAttributes() : Map.of());
+  }
+
+  private static WebSessionDto toDto(final PersistentSession session) {
+    return new WebSessionDto(
+        session.id(),
+        session.creationTime(),
+        session.lastAccessedTime(),
+        session.maxInactiveIntervalInSeconds(),
+        session.attributes());
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSessionStoreAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSessionStoreAdapter.java
@@ -14,6 +14,8 @@ import io.camunda.security.api.model.session.PersistentSession;
 import io.camunda.security.core.port.out.SessionStorePort;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -32,11 +34,18 @@ import org.springframework.stereotype.Component;
  * routes sessions here only while {@code camunda.security.session.persistent.enabled=true}, which
  * {@link OptimizeSecurityConfigCompatibilityPostProcessor} sets for the Elasticsearch edition;
  * OpenSearch keeps CSL's in-memory sessions until the OpenSearch store lands.
+ *
+ * <p>A failed {@link #upsert(PersistentSession)} is logged and swallowed. Spring Session saves the
+ * session while the response is being committed, so letting a storage failure through would turn an
+ * Elasticsearch blip into failed requests. The reads stay strict: a session that cannot be loaded
+ * must not be mistaken for one that does not exist.
  */
 @Component
 @Conditional(ElasticSearchCondition.class)
 @ConditionalOnProperty(name = "optimize.security.csl.enabled", havingValue = "true")
 public class OptimizeSessionStoreAdapter implements SessionStorePort {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OptimizeSessionStoreAdapter.class);
 
   private final PersistentWebSessionRepository repository;
 
@@ -54,7 +63,13 @@ public class OptimizeSessionStoreAdapter implements SessionStorePort {
 
   @Override
   public void upsert(final PersistentSession session) {
-    repository.upsert(toDto(session));
+    try {
+      repository.upsert(toDto(session));
+    } catch (final RuntimeException e) {
+      // The session stays valid on the instance that handled the request, but it is not shared and
+      // it does not survive a restart, so the user may have to log in again.
+      LOG.warn("Could not save web session {} to Elasticsearch.", session.id(), e);
+    }
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/PersistentWebSessionRepository.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/PersistentWebSessionRepository.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository;
+
+import io.camunda.optimize.dto.optimize.query.WebSessionDto;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Storage of the server-side web sessions held in the {@code web-session} index. Backs {@code
+ * OptimizeSessionStoreAdapter}, which is what the Camunda Security Library persists sessions
+ * through.
+ */
+public interface PersistentWebSessionRepository {
+
+  /** Returns the stored session, or empty when no session with that id exists. */
+  Optional<WebSessionDto> get(String sessionId);
+
+  /** Inserts the session, or replaces it when one with the same id already exists. */
+  void upsert(WebSessionDto session);
+
+  /** Deletes the session; a no-op when no session with that id exists. */
+  void delete(String sessionId);
+
+  /** Returns every stored session, so expired ones can be swept. */
+  List<WebSessionDto> getAll();
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/PersistentWebSessionRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/PersistentWebSessionRepositoryES.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository.es;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.WEB_SESSION_INDEX_NAME;
+
+import co.elastic.clients.elasticsearch._types.Time;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchAllQuery;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.optimize.query.WebSessionDto;
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.db.es.builders.OptimizeDeleteRequestBuilderES;
+import io.camunda.optimize.service.db.es.builders.OptimizeGetRequestBuilderES;
+import io.camunda.optimize.service.db.es.builders.OptimizeIndexRequestBuilderES;
+import io.camunda.optimize.service.db.es.builders.OptimizeSearchRequestBuilderES;
+import io.camunda.optimize.service.db.es.reader.ElasticsearchReaderUtil;
+import io.camunda.optimize.service.db.repository.PersistentWebSessionRepository;
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(ElasticSearchCondition.class)
+public class PersistentWebSessionRepositoryES implements PersistentWebSessionRepository {
+
+  // First page of the sweep scroll; retrieveAllScrollResults pages through the rest.
+  private static final int SCROLL_PAGE_SIZE = 1000;
+
+  private final OptimizeElasticsearchClient esClient;
+  private final ConfigurationService configurationService;
+  private final ObjectMapper objectMapper;
+
+  public PersistentWebSessionRepositoryES(
+      final OptimizeElasticsearchClient esClient,
+      final ConfigurationService configurationService,
+      final ObjectMapper objectMapper) {
+    this.esClient = esClient;
+    this.configurationService = configurationService;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public Optional<WebSessionDto> get(final String sessionId) {
+    try {
+      // A get by id reads through the translog, so a session is visible without a prior refresh.
+      final var response =
+          esClient.get(
+              OptimizeGetRequestBuilderES.of(
+                  g -> g.optimizeIndex(esClient, WEB_SESSION_INDEX_NAME).id(sessionId)),
+              WebSessionDto.class);
+      return response.found() ? Optional.ofNullable(response.source()) : Optional.empty();
+    } catch (final IOException e) {
+      throw new OptimizeRuntimeException("Could not read web session " + sessionId, e);
+    }
+  }
+
+  @Override
+  public void upsert(final WebSessionDto session) {
+    try {
+      esClient.index(
+          OptimizeIndexRequestBuilderES.of(
+              b ->
+                  b.optimizeIndex(esClient, WEB_SESSION_INDEX_NAME)
+                      .id(session.getId())
+                      .document(session)));
+    } catch (final IOException e) {
+      throw new OptimizeRuntimeException("Could not persist web session " + session.getId(), e);
+    }
+  }
+
+  @Override
+  public void delete(final String sessionId) {
+    try {
+      esClient.delete(
+          OptimizeDeleteRequestBuilderES.of(
+              d -> d.optimizeIndex(esClient, WEB_SESSION_INDEX_NAME).id(sessionId)));
+    } catch (final IOException e) {
+      throw new OptimizeRuntimeException("Could not delete web session " + sessionId, e);
+    }
+  }
+
+  @Override
+  public List<WebSessionDto> getAll() {
+    final int scrollTimeout =
+        configurationService.getElasticSearchConfiguration().getScrollTimeoutInSeconds();
+    final var searchRequest =
+        OptimizeSearchRequestBuilderES.of(
+            b ->
+                b.optimizeIndex(esClient, WEB_SESSION_INDEX_NAME)
+                    .size(SCROLL_PAGE_SIZE)
+                    .query(q -> q.matchAll(MatchAllQuery.of(m -> m)))
+                    .scroll(Time.of(t -> t.time(scrollTimeout + "s"))));
+    final SearchResponse<WebSessionDto> response;
+    try {
+      response = esClient.search(searchRequest, WebSessionDto.class);
+    } catch (final IOException e) {
+      throw new OptimizeRuntimeException("Could not read web sessions", e);
+    }
+    return ElasticsearchReaderUtil.retrieveAllScrollResults(
+        response, WebSessionDto.class, objectMapper, esClient, scrollTimeout);
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/CslWebSessionWiringTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/CslWebSessionWiringTest.java
@@ -17,6 +17,7 @@ import io.camunda.security.spring.session.WebSessionConfiguration;
 import io.camunda.security.spring.session.WebSessionRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 /**
@@ -60,5 +61,23 @@ class CslWebSessionWiringTest {
           assertThat(context).hasNotFailed();
           assertThat(context).doesNotHaveBean(WebSessionRepository.class);
         });
+  }
+
+  @Test
+  void shouldFailToStartWhenPersistenceIsEnabledWithoutAStore() {
+    // given the wiring of a database Optimize has no session store for, such as OpenSearch
+    new ApplicationContextRunner()
+        .withPropertyValues(
+            "optimize.security.csl.enabled=true",
+            SessionConfiguration.PERSISTENT_ENABLED_PROPERTY + "=true")
+        .withBean(HttpServletRequest.class, () -> mock(HttpServletRequest.class))
+        .withUserConfiguration(WebSessionConfiguration.class)
+        .run(
+            context ->
+                // then the context cannot be built, which is why the post processor only sets the
+                // property for a database that has a store
+                assertThat(context)
+                    .getFailure()
+                    .hasRootCauseInstanceOf(NoSuchBeanDefinitionException.class));
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/CslWebSessionWiringTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/CslWebSessionWiringTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.csl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.optimize.service.db.repository.PersistentWebSessionRepository;
+import io.camunda.security.api.model.config.SessionConfiguration;
+import io.camunda.security.core.port.out.SessionStorePort;
+import io.camunda.security.spring.session.WebSessionConfiguration;
+import io.camunda.security.spring.session.WebSessionRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Pins the contract between CSL's session lifecycle and Optimize's store: {@link
+ * WebSessionConfiguration} activates on {@code camunda.security.session.persistent.enabled} and
+ * then <em>requires</em> a {@code SessionStorePort}. That coupling is why {@link
+ * OptimizeSecurityConfigCompatibilityPostProcessor} only sets the property for the database
+ * Optimize has a store for.
+ */
+class CslWebSessionWiringTest {
+
+  private final ApplicationContextRunner runner =
+      new ApplicationContextRunner()
+          .withPropertyValues("optimize.security.csl.enabled=true")
+          .withBean(HttpServletRequest.class, () -> mock(HttpServletRequest.class))
+          .withBean(
+              PersistentWebSessionRepository.class,
+              () -> mock(PersistentWebSessionRepository.class))
+          .withUserConfiguration(OptimizeSessionStoreAdapter.class, WebSessionConfiguration.class);
+
+  @Test
+  void shouldPersistSessionsThroughOptimizeStoreWhenPersistenceIsEnabled() {
+    runner
+        .withPropertyValues(SessionConfiguration.PERSISTENT_ENABLED_PROPERTY + "=true")
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed();
+              // CSL's repository is what the session filter uses, and it persists through the
+              // single SessionStorePort bean, so sessions land in Optimize's index, not in memory
+              assertThat(context).hasSingleBean(WebSessionRepository.class);
+              assertThat(context).hasSingleBean(SessionStorePort.class);
+              assertThat(context.getBean(SessionStorePort.class))
+                  .isInstanceOf(OptimizeSessionStoreAdapter.class);
+            });
+  }
+
+  @Test
+  void shouldKeepCslSessionsInMemoryWhenPersistenceIsNotEnabled() {
+    runner.run(
+        context -> {
+          assertThat(context).hasNotFailed();
+          assertThat(context).doesNotHaveBean(WebSessionRepository.class);
+        });
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -7,8 +7,11 @@
  */
 package io.camunda.optimize.rest.security.csl;
 
+import static io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants.CAMUNDA_OPTIMIZE_DATABASE;
+import static io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants.OPENSEARCH_DATABASE_PROPERTY;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.security.api.model.config.SessionConfiguration;
 import io.github.netmikey.logunit.api.LogCapturer;
 import java.util.HashMap;
 import java.util.Map;
@@ -375,5 +378,50 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     processor.postProcessEnvironment(env, null);
 
     assertThat(env.getProperty("contextPath")).isEqualTo("/explicit");
+  }
+
+  @Test
+  void shouldEnablePersistentSessionsOnElasticsearch() {
+    // given the default database, which is Elasticsearch
+    final StandardEnvironment env = environmentWith(cslEnabledConfig());
+
+    // when
+    processor.postProcessEnvironment(env, null);
+
+    // then the CSL session store is active, so sessions survive a restart and are shared
+    assertThat(env.getProperty(SessionConfiguration.PERSISTENT_ENABLED_PROPERTY)).isEqualTo("true");
+  }
+
+  @Test
+  void shouldNotEnablePersistentSessionsOnOpenSearch() {
+    // given
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put(CAMUNDA_OPTIMIZE_DATABASE, OPENSEARCH_DATABASE_PROPERTY);
+    final StandardEnvironment env = environmentWith(legacy);
+
+    // when
+    processor.postProcessEnvironment(env, null);
+
+    // then CSL keeps its in-memory sessions: enabling persistence without an OpenSearch store
+    // would leave CSL's session repository without a SessionStorePort and fail startup
+    assertThat(env.getProperty(SessionConfiguration.PERSISTENT_ENABLED_PROPERTY)).isNull();
+    logs.assertContains(
+        entry -> entry.getMessage().contains("Persistent web sessions are not enabled"),
+        "expected a warning that sessions are kept in memory on OpenSearch");
+  }
+
+  @Test
+  void shouldLetOperatorTurnOffPersistentSessionsOnElasticsearch() {
+    // given an operator who explicitly opted out
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put(SessionConfiguration.PERSISTENT_ENABLED_PROPERTY, "false");
+    final StandardEnvironment env = environmentWith(legacy);
+
+    // when
+    processor.postProcessEnvironment(env, null);
+
+    // then the bridged default does not override them
+    assertThat(env.getProperty(SessionConfiguration.PERSISTENT_ENABLED_PROPERTY))
+        .isEqualTo("false");
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSessionStoreAdapterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSessionStoreAdapterTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.csl;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.query.WebSessionDto;
+import io.camunda.optimize.service.db.repository.PersistentWebSessionRepository;
+import io.camunda.security.api.model.session.PersistentSession;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * CSL owns the session lifecycle and only ever sees a {@link PersistentSession}, so the adapter's
+ * whole job is a faithful translation to and from the stored document. A field dropped or swapped
+ * here surfaces as a session that silently expires early, or one that never expires.
+ */
+@ExtendWith(MockitoExtension.class)
+class OptimizeSessionStoreAdapterTest {
+
+  private static final String SESSION_ID = "session-id";
+  private static final String ATTRIBUTE_NAME = "SPRING_SECURITY_CONTEXT";
+  private static final byte[] ATTRIBUTE_VALUE = "principal".getBytes(UTF_8);
+  private static final long CREATION_TIME = 1000L;
+  private static final long LAST_ACCESSED_TIME = 2000L;
+  private static final long MAX_INACTIVE_INTERVAL_SECONDS = 1800L;
+
+  @Mock private PersistentWebSessionRepository repository;
+
+  private OptimizeSessionStoreAdapter adapter;
+
+  @BeforeEach
+  void setUp() {
+    adapter = new OptimizeSessionStoreAdapter(repository);
+  }
+
+  @Test
+  void shouldReturnNullWhenSessionIsAbsent() {
+    // given
+    when(repository.get(SESSION_ID)).thenReturn(Optional.empty());
+
+    // when
+    final PersistentSession session = adapter.get(SESSION_ID);
+
+    // then the port contract is a null, which tells CSL to start a fresh session
+    assertThat(session).isNull();
+  }
+
+  @Test
+  void shouldReadBackEveryStoredField() {
+    // given
+    when(repository.get(SESSION_ID)).thenReturn(Optional.of(webSessionDto()));
+
+    // when
+    final PersistentSession session = adapter.get(SESSION_ID);
+
+    // then
+    assertThat(session.id()).isEqualTo(SESSION_ID);
+    assertThat(session.creationTime()).isEqualTo(CREATION_TIME);
+    assertThat(session.lastAccessedTime()).isEqualTo(LAST_ACCESSED_TIME);
+    assertThat(session.maxInactiveIntervalInSeconds()).isEqualTo(MAX_INACTIVE_INTERVAL_SECONDS);
+    assertThat(session.attributes()).containsExactly(Map.entry(ATTRIBUTE_NAME, ATTRIBUTE_VALUE));
+  }
+
+  @Test
+  void shouldTreatMissingAttributesAsEmpty() {
+    // given a document written without any attribute
+    final WebSessionDto dto = webSessionDto();
+    dto.setAttributes(null);
+    when(repository.get(SESSION_ID)).thenReturn(Optional.of(dto));
+
+    // when
+    final PersistentSession session = adapter.get(SESSION_ID);
+
+    // then PersistentSession rejects a null attribute map, so the adapter substitutes an empty one
+    assertThat(session.attributes()).isEmpty();
+  }
+
+  @Test
+  void shouldStoreEveryFieldOfASession() {
+    // when
+    adapter.upsert(persistentSession());
+
+    // then
+    final ArgumentCaptor<WebSessionDto> stored = ArgumentCaptor.forClass(WebSessionDto.class);
+    verify(repository).upsert(stored.capture());
+    final WebSessionDto dto = stored.getValue();
+    assertThat(dto.getId()).isEqualTo(SESSION_ID);
+    assertThat(dto.getCreationTime()).isEqualTo(CREATION_TIME);
+    assertThat(dto.getLastAccessedTime()).isEqualTo(LAST_ACCESSED_TIME);
+    assertThat(dto.getMaxInactiveIntervalInSeconds()).isEqualTo(MAX_INACTIVE_INTERVAL_SECONDS);
+    assertThat(dto.getAttributes()).containsExactly(Map.entry(ATTRIBUTE_NAME, ATTRIBUTE_VALUE));
+  }
+
+  @Test
+  void shouldDeleteBySessionId() {
+    // when
+    adapter.delete(SESSION_ID);
+
+    // then
+    verify(repository).delete(SESSION_ID);
+  }
+
+  @Test
+  void shouldMapEverySessionOfTheExpirySweep() {
+    // given
+    final WebSessionDto other = webSessionDto();
+    other.setId("other-session-id");
+    when(repository.getAll()).thenReturn(List.of(webSessionDto(), other));
+
+    // when
+    final List<PersistentSession> sessions = adapter.getAll();
+
+    // then
+    assertThat(sessions)
+        .extracting(PersistentSession::id)
+        .containsExactly(SESSION_ID, "other-session-id");
+  }
+
+  private static WebSessionDto webSessionDto() {
+    return new WebSessionDto(
+        SESSION_ID,
+        CREATION_TIME,
+        LAST_ACCESSED_TIME,
+        MAX_INACTIVE_INTERVAL_SECONDS,
+        Map.of(ATTRIBUTE_NAME, ATTRIBUTE_VALUE));
+  }
+
+  private static PersistentSession persistentSession() {
+    return new PersistentSession(
+        SESSION_ID,
+        CREATION_TIME,
+        LAST_ACCESSED_TIME,
+        MAX_INACTIVE_INTERVAL_SECONDS,
+        Map.of(ATTRIBUTE_NAME, ATTRIBUTE_VALUE));
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSessionStoreAdapterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSessionStoreAdapterTest.java
@@ -9,11 +9,16 @@ package io.camunda.optimize.rest.security.csl;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.optimize.dto.optimize.query.WebSessionDto;
 import io.camunda.optimize.service.db.repository.PersistentWebSessionRepository;
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.security.api.model.session.PersistentSession;
 import java.util.List;
 import java.util.Map;
@@ -105,6 +110,30 @@ class OptimizeSessionStoreAdapterTest {
     assertThat(dto.getLastAccessedTime()).isEqualTo(LAST_ACCESSED_TIME);
     assertThat(dto.getMaxInactiveIntervalInSeconds()).isEqualTo(MAX_INACTIVE_INTERVAL_SECONDS);
     assertThat(dto.getAttributes()).containsExactly(Map.entry(ATTRIBUTE_NAME, ATTRIBUTE_VALUE));
+  }
+
+  @Test
+  void shouldNotFailTheRequestWhenTheSessionCannotBeStored() {
+    // given a database that is temporarily unreachable
+    doThrow(new OptimizeRuntimeException("elasticsearch is down"))
+        .when(repository)
+        .upsert(any(WebSessionDto.class));
+
+    // when
+    // then Spring Session saves while the response is committing, so the blip must not surface
+    assertThatNoException().isThrownBy(() -> adapter.upsert(persistentSession()));
+  }
+
+  @Test
+  void shouldPropagateFailuresWhenTheSessionCannotBeLoaded() {
+    // given
+    when(repository.get(SESSION_ID))
+        .thenThrow(new OptimizeRuntimeException("elasticsearch is down"));
+
+    // when
+    // then an unreadable session must not look like an absent one, which would silently log the
+    // user out and start a fresh session
+    assertThatThrownBy(() -> adapter.get(SESSION_ID)).isInstanceOf(OptimizeRuntimeException.class);
   }
 
   @Test

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseConstants.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseConstants.java
@@ -46,6 +46,7 @@ public final class DatabaseConstants {
   public static final String METADATA_INDEX_NAME = "metadata";
   public static final String UPDATE_LOG_ENTRY_INDEX_NAME = "update-log";
   public static final String TERMINATED_USER_SESSION_INDEX_NAME = "terminated-user-session";
+  public static final String WEB_SESSION_INDEX_NAME = "web-session";
   public static final String TENANT_INDEX_NAME = "tenant";
   public static final String VARIABLE_LABEL_INDEX_NAME = "variable-label";
   public static final String PROCESS_OVERVIEW_INDEX_NAME = "process-overview";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/ElasticSearchSchemaManager.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/ElasticSearchSchemaManager.java
@@ -38,6 +38,7 @@ import io.camunda.optimize.service.db.es.schema.index.SettingsIndexES;
 import io.camunda.optimize.service.db.es.schema.index.TenantIndexES;
 import io.camunda.optimize.service.db.es.schema.index.TerminatedUserSessionIndexES;
 import io.camunda.optimize.service.db.es.schema.index.VariableLabelIndexES;
+import io.camunda.optimize.service.db.es.schema.index.WebSessionIndexES;
 import io.camunda.optimize.service.db.es.schema.index.index.PositionBasedImportIndexES;
 import io.camunda.optimize.service.db.es.schema.index.index.TimestampBasedImportIndexES;
 import io.camunda.optimize.service.db.es.schema.index.report.CombinedReportIndexES;
@@ -388,6 +389,7 @@ public class ElasticSearchSchemaManager
         new SettingsIndexES(),
         new TenantIndexES(),
         new TerminatedUserSessionIndexES(),
+        new WebSessionIndexES(),
         new TimestampBasedImportIndexES(),
         new PositionBasedImportIndexES(),
         new CombinedReportIndexES(),

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/index/WebSessionIndexES.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/index/WebSessionIndexES.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.schema.index;
+
+import co.elastic.clients.elasticsearch.indices.IndexSettings;
+import io.camunda.optimize.service.db.schema.index.WebSessionIndex;
+import java.io.IOException;
+
+public class WebSessionIndexES extends WebSessionIndex<IndexSettings.Builder> {
+
+  @Override
+  public IndexSettings.Builder addStaticSetting(
+      final String key, final int value, final IndexSettings.Builder builder) throws IOException {
+    return builder.numberOfShards(Integer.toString(value));
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/OpenSearchSchemaManager.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/OpenSearchSchemaManager.java
@@ -36,6 +36,7 @@ import io.camunda.optimize.service.db.os.schema.index.SettingsIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.TenantIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.TerminatedUserSessionIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.VariableLabelIndexOS;
+import io.camunda.optimize.service.db.os.schema.index.WebSessionIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.index.PositionBasedImportIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.index.TimestampBasedImportIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.report.CombinedReportIndexOS;
@@ -558,6 +559,7 @@ public class OpenSearchSchemaManager
         new ReportShareIndexOS(),
         new SettingsIndexOS(),
         new TerminatedUserSessionIndexOS(),
+        new WebSessionIndexOS(),
         new TenantIndexOS(),
         new TimestampBasedImportIndexOS(),
         new PositionBasedImportIndexOS(),

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/index/WebSessionIndexOS.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/index/WebSessionIndexOS.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.schema.index;
+
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchUtil;
+import io.camunda.optimize.service.db.schema.index.WebSessionIndex;
+import org.opensearch.client.opensearch.indices.IndexSettings;
+
+public class WebSessionIndexOS extends WebSessionIndex<IndexSettings.Builder> {
+
+  @Override
+  public IndexSettings.Builder addStaticSetting(
+      final String key, final int value, final IndexSettings.Builder contentBuilder) {
+    return OptimizeOpenSearchUtil.addStaticSetting(key, value, contentBuilder);
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/IndexLookupUtil.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/IndexLookupUtil.java
@@ -25,6 +25,7 @@ import io.camunda.optimize.service.db.es.schema.index.SettingsIndexES;
 import io.camunda.optimize.service.db.es.schema.index.TenantIndexES;
 import io.camunda.optimize.service.db.es.schema.index.TerminatedUserSessionIndexES;
 import io.camunda.optimize.service.db.es.schema.index.VariableLabelIndexES;
+import io.camunda.optimize.service.db.es.schema.index.WebSessionIndexES;
 import io.camunda.optimize.service.db.es.schema.index.index.PositionBasedImportIndexES;
 import io.camunda.optimize.service.db.es.schema.index.index.TimestampBasedImportIndexES;
 import io.camunda.optimize.service.db.es.schema.index.report.CombinedReportIndexES;
@@ -48,6 +49,7 @@ import io.camunda.optimize.service.db.os.schema.index.SettingsIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.TenantIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.TerminatedUserSessionIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.VariableLabelIndexOS;
+import io.camunda.optimize.service.db.os.schema.index.WebSessionIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.index.PositionBasedImportIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.index.TimestampBasedImportIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.report.CombinedReportIndexOS;
@@ -123,6 +125,7 @@ public class IndexLookupUtil {
     lookupMap.put(
         TerminatedUserSessionIndexES.class.getSimpleName(),
         index -> new TerminatedUserSessionIndexOS());
+    lookupMap.put(WebSessionIndexES.class.getSimpleName(), index -> new WebSessionIndexOS());
     lookupMap.put(
         TimestampBasedImportIndexES.class.getSimpleName(),
         index -> new TimestampBasedImportIndexOS());
@@ -172,6 +175,7 @@ public class IndexLookupUtil {
     lookupMap.put(
         TerminatedUserSessionIndexOS.class.getSimpleName(),
         index -> new TerminatedUserSessionIndexES());
+    lookupMap.put(WebSessionIndexOS.class.getSimpleName(), index -> new WebSessionIndexES());
     lookupMap.put(
         TimestampBasedImportIndexOS.class.getSimpleName(),
         index -> new TimestampBasedImportIndexES());

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/WebSessionIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/WebSessionIndex.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.schema.index;
+
+import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+import io.camunda.optimize.service.db.DatabaseConstants;
+import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+
+/**
+ * Backs the server-side web sessions of the Camunda Security Library's stateful OIDC webapp chain
+ * (<a
+ * href="https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md">ADR-0038</a>).
+ * The fields mirror CSL's {@code PersistentSession}: the session id, its lifecycle timestamps in
+ * epoch millis, the maximum inactive interval in seconds, and the serialized attribute map.
+ *
+ * <p>Attribute keys are dynamic (Spring Security decides them), so {@code attributes} is a disabled
+ * object: it stays in {@code _source} and is never indexed, which keeps the strict mapping intact.
+ */
+public abstract class WebSessionIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder> {
+
+  public static final int VERSION = 1;
+
+  public static final String ID = "id";
+  public static final String CREATION_TIME = "creationTime";
+  public static final String LAST_ACCESSED_TIME = "lastAccessedTime";
+  public static final String MAX_INACTIVE_INTERVAL_SECONDS = "maxInactiveIntervalInSeconds";
+  public static final String ATTRIBUTES = "attributes";
+
+  @Override
+  public TypeMapping.Builder addProperties(final TypeMapping.Builder builder) {
+    return builder
+        .properties(ID, p -> p.keyword(k -> k))
+        .properties(CREATION_TIME, p -> p.long_(l -> l))
+        .properties(LAST_ACCESSED_TIME, p -> p.long_(l -> l))
+        .properties(MAX_INACTIVE_INTERVAL_SECONDS, p -> p.long_(l -> l))
+        .properties(ATTRIBUTES, p -> p.object(o -> o.enabled(false)));
+  }
+
+  @Override
+  public String getIndexName() {
+    return DatabaseConstants.WEB_SESSION_INDEX_NAME;
+  }
+
+  @Override
+  public int getVersion() {
+    return VERSION;
+  }
+}


### PR DESCRIPTION
## Description

Implements Optimize's `SessionStorePort` over its own Elasticsearch, so CSL mode
gets real server-side sessions instead of in-memory ones (ADR-0038, epic #58403,
task 1.3). Behind the default-off `optimize.security.csl.enabled` flag; no change
when off.

Adds the `web-session` index, a `PersistentWebSessionRepository` seam with an
Elasticsearch implementation, and the adapter mapping CSL's `PersistentSession`
onto it. The config bridge now sets `camunda.security.session.persistent.enabled`,
and `OptimizeCamundaSecurityConfig` imports CSL's `WebSessionConfiguration`, which
the security umbrella does not include.

## Notes for reviewers

- **The enable-property is gated on Elasticsearch.** CSL's session repository
  requires a `SessionStorePort` bean, so setting the property without a store
  fails startup. OpenSearch keeps in-memory sessions until #58472.
- **`WebSessionIndexOS` ships without its store** because `IndexLookupUtilTest`
  asserts every non-dynamic ES mapping converts to a registered OS one. Effect on
  OpenSearch: one extra empty index. This also covers #58472's first AC.
- **No forced refresh on upsert**, unlike the spike: get by id is realtime, and CSL
  writes the session on every request. Matches OC's client.
- The IT is tagged `openSearchSingleTestFailOK` so the OpenSearch job skips it;
  first use of that tag in the repo.
- `WebSessionDto` sits next to `TerminatedUserSessionDto` rather than in the `csl`
  package, since the db layer owns it.

## Acceptance criteria

- [x] Adapter stores, loads, refreshes and deletes sessions in a dedicated ES index.
- [x] The index is created by the ES schema manager on startup.
- [ ] Logout removes the session document: the `delete` path is covered here, but
  the end-to-end claim needs #58474 (PR #58955) on main.
- [x] Integration test covers the store round-trip. Optimize's rig uses an
  externally started Elasticsearch rather than per-test Testcontainers.

## Testing

`OptimizeSessionStoreAdapterIT` round-trips store, load, refresh, delete and the
sweep listing against a real Elasticsearch. Unit tests cover the mapping, the
database gate, and that CSL's repository resolves our store when persistence is on
and is absent when it is off.

Closes #58471