### PR TITLE
fix: remove virtual thread broker startup

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/ZoneHelpers.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/ZoneHelpers.java
@@ -40,11 +40,7 @@ public class ZoneHelpers {
         .start();
   }
 
-  /**
-   * Starts a broker with id in a zone without adding it to the topology. The {@link
-   * TestStandaloneBroker#start} is run in a virtual thread as it returns only after it is able to
-   * join the topology
-   */
+  /** Starts a broker with id in a zone without adding it to the topology. */
   public static TestStandaloneBroker startBrokerInZone(
       final TestCluster cluster,
       final String zone,
@@ -69,7 +65,7 @@ public class ZoneHelpers {
                   cfg.getData().getSecondaryStorage().setAutoconfigureCamundaExporter(false);
                 });
 
-    Thread.ofVirtual().name("start-" + zone + "-" + nodeId).start(broker::start);
+    broker.start();
 
     return broker;
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Do not start the broker in a virtual thread. This probably causes flakiness in the CI pipeline and does not properly handle the broker's lifecycle.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
