### PR TITLE
test: increase archiver rollover batch size

### DIFF
--- a/load-tests/setup/main/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-defaults.yaml
@@ -230,7 +230,7 @@ orchestration:
         zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
 
         # Camunda Exporter configuration
-        zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+        zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
         zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
 
         # Configure a rate limit for all writes, so that we can visualize flow control metrics.

--- a/load-tests/setup/stable-88/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-88/values/camunda-platform-values-defaults.yaml
@@ -224,7 +224,7 @@ orchestration:
       zeebe.broker.data.disk.freeSpace.replication: "2GB"
 
       # Camunda Exporter configuration
-      zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+      zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
       zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
 
       # We moved the archiver configuration under retention at some point, but still need to support the previous

--- a/load-tests/setup/stable-89/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-defaults.yaml
@@ -229,7 +229,7 @@ orchestration:
         zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
 
         # Camunda Exporter configuration
-        zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+        zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
         zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
 
         # Configure a rate limit for all writes, so that we can visualize flow control metrics.

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -278,7 +278,7 @@ data:
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
     
     # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
     zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
@@ -289,7 +289,7 @@ data:
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
     
     # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
     zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/configmap.yaml
@@ -289,7 +289,7 @@ data:
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
     
     # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
     zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -291,7 +291,7 @@ data:
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
     
     # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
     zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/configmap.yaml
@@ -305,7 +305,7 @@ data:
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
     
     # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
     zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/configmap.yaml
@@ -305,7 +305,7 @@ data:
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
     
     # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
     zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/configmap-unified.yaml
@@ -266,7 +266,7 @@ data:
     zeebe.broker.data.disk.freeSpace.replication: "2GB"
     
     # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
     zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # We moved the archiver configuration under retention at some point, but still need to support the previous

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/orchestration/configmap-unified.yaml
@@ -277,7 +277,7 @@ data:
     zeebe.broker.data.disk.freeSpace.replication: "2GB"
     
     # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
     zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # We moved the archiver configuration under retention at some point, but still need to support the previous

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/orchestration/configmap-unified.yaml
@@ -277,7 +277,7 @@ data:
     zeebe.broker.data.disk.freeSpace.replication: "2GB"
     
     # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
     zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # We moved the archiver configuration under retention at some point, but still need to support the previous

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/configmap-unified.yaml
@@ -281,7 +281,7 @@ data:
     zeebe.broker.data.disk.freeSpace.replication: "2GB"
     
     # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
     zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # We moved the archiver configuration under retention at some point, but still need to support the previous

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/orchestration/configmap-unified.yaml
@@ -292,7 +292,7 @@ data:
     zeebe.broker.data.disk.freeSpace.replication: "2GB"
     
     # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
     zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # We moved the archiver configuration under retention at some point, but still need to support the previous

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/orchestration/configmap-unified.yaml
@@ -292,7 +292,7 @@ data:
     zeebe.broker.data.disk.freeSpace.replication: "2GB"
     
     # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
     zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # We moved the archiver configuration under retention at some point, but still need to support the previous

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -278,7 +278,7 @@ data:
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
     
     # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
     zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
@@ -289,7 +289,7 @@ data:
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
     
     # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
     zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/configmap.yaml
@@ -289,7 +289,7 @@ data:
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
     
     # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
     zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -291,7 +291,7 @@ data:
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
     
     # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
     zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/configmap.yaml
@@ -305,7 +305,7 @@ data:
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
     
     # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
     zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/configmap.yaml
@@ -305,7 +305,7 @@ data:
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
     
     # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
     zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.


### PR DESCRIPTION
so it can hopefully keep up during benchmarks.

this larger value should be ok, now that we're using the reindex by id logic.

## Related issues

refs #43121
