### PR TITLE
fix: run processing side effects after results are committed

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -195,6 +195,10 @@ public class RaftPartitionServer implements HealthMonitorable {
     return server.getContext().getLog().openCommittedReader();
   }
 
+  public RaftLogReader openUncommittedReader() {
+    return server.getContext().getLog().openUncommittedReader();
+  }
+
   public void addRoleChangeListener(final RaftRoleChangeListener listener) {
     server.addRoleChangeListener(listener);
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -196,6 +196,10 @@ public class RaftPartitionServer implements HealthMonitorable {
     return server.getContext().getLog().openCommittedReader();
   }
 
+  public RaftLogReader openUncommittedReader() {
+    return server.getContext().getLog().openUncommittedReader();
+  }
+
   public void addRoleChangeListener(final RaftRoleChangeListener listener) {
     server.addRoleChangeListener(listener);
   }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointClearStateProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointClearStateProcessor.java
@@ -70,11 +70,7 @@ public final class CheckpointClearStateProcessor {
     // Schedule post-commit task to sync metadata (will write empty metadata to backup store)
     final var checkpoints = checkpointMetadataState.getAllCheckpoints();
     final var ranges = backupRangeState.getAllRanges();
-    resultBuilder.appendPostCommitTask(
-        () -> {
-          backupManager.syncMetadata(checkpoints, ranges);
-          return true;
-        });
+    resultBuilder.appendPostCommitTask(() -> backupManager.syncMetadata(checkpoints, ranges));
 
     return resultBuilder.build();
   }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointConfirmBackupProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointConfirmBackupProcessor.java
@@ -62,11 +62,7 @@ public class CheckpointConfirmBackupProcessor {
 
       final var checkpoints = checkpointMetadataState.getAllCheckpoints();
       final var ranges = backupRangeState.getAllRanges();
-      resultBuilder.appendPostCommitTask(
-          () -> {
-            backupManager.syncMetadata(checkpoints, ranges);
-            return true;
-          });
+      resultBuilder.appendPostCommitTask(() -> backupManager.syncMetadata(checkpoints, ranges));
     } else {
       LOG.debug(
           "Ignoring backup for checkpoint {} as it is older than the latest backup {}",

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointDeleteBackupProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointDeleteBackupProcessor.java
@@ -74,16 +74,8 @@ public final class CheckpointDeleteBackupProcessor {
             .intent(CheckpointIntent.DELETED_BACKUP));
     final var checkpoints = checkpointMetadataState.getAllCheckpoints();
     final var ranges = backupRangeState.getAllRanges();
-    resultBuilder.appendPostCommitTask(
-        () -> {
-          backupManager.syncMetadata(checkpoints, ranges);
-          return true;
-        });
-    resultBuilder.appendPostCommitTask(
-        () -> {
-          backupManager.deleteBackup(checkpointId);
-          return true;
-        });
+    resultBuilder.appendPostCommitTask(() -> backupManager.syncMetadata(checkpoints, ranges));
+    resultBuilder.appendPostCommitTask(() -> backupManager.deleteBackup(checkpointId));
 
     return resultBuilder.build();
   }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.stream.api.PostCommitTask;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamClock;
@@ -1001,10 +1002,9 @@ final class CheckpointRecordsProcessorTest {
     assertThat(result.postCommitTasks()).hasSize(1);
 
     // when — the post-commit task is executed
-    final var success = result.executePostCommitTasks();
+    result.postCommitTasks().forEach(PostCommitTask::flush);
 
     // then — task succeeds (fire-and-forget) and sync metadata is called
-    assertThat(success).isTrue();
     verify(backupManager).syncMetadata(any(), any());
   }
 
@@ -1103,10 +1103,9 @@ final class CheckpointRecordsProcessorTest {
     assertThat(result.postCommitTasks()).hasSize(1);
 
     // when — the post-commit task is executed
-    final var success = result.executePostCommitTasks();
+    result.postCommitTasks().forEach(PostCommitTask::flush);
 
     // then — task succeeds and sync metadata is called
-    assertThat(success).isTrue();
     verify(backupManager).syncMetadata(any(), any());
   }
 

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -1001,10 +1001,9 @@ final class CheckpointRecordsProcessorTest {
     assertThat(result.postCommitTasks()).hasSize(1);
 
     // when — the post-commit task is executed
-    final var success = result.executePostCommitTasks();
+    result.executePostCommitTasks();
 
     // then — task succeeds (fire-and-forget) and sync metadata is called
-    assertThat(success).isTrue();
     verify(backupManager).syncMetadata(any(), any());
   }
 
@@ -1103,10 +1102,9 @@ final class CheckpointRecordsProcessorTest {
     assertThat(result.postCommitTasks()).hasSize(1);
 
     // when — the post-commit task is executed
-    final var success = result.executePostCommitTasks();
+    result.executePostCommitTasks();
 
     // then — task succeeds and sync metadata is called
-    assertThat(success).isTrue();
     verify(backupManager).syncMetadata(any(), any());
   }
 

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
@@ -40,12 +40,8 @@ record MockProcessingResult(
   }
 
   @Override
-  public boolean executePostCommitTasks() {
-    var result = true;
-    for (final var task : postCommitTasks) {
-      result = result && task.flush();
-    }
-    return result;
+  public List<PostCommitTask> getPostCommitTasks() {
+    return postCommitTasks;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorage.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorage.java
@@ -24,18 +24,25 @@ import java.util.concurrent.CopyOnWriteArraySet;
 public class AtomixLogStorage implements LogStorage, RaftApplicationEntryCommittedPositionListener {
 
   private final AtomixReaderFactory readerFactory;
+  private final AtomixReaderFactory uncommittedReaderFactory;
   private final ZeebeLogAppender logAppender;
   private final Set<CommitListener> commitListeners = new CopyOnWriteArraySet<>();
+  private final Set<AppendedListener> appendedListeners = new CopyOnWriteArraySet<>();
 
   public AtomixLogStorage(
-      final AtomixReaderFactory readerFactory, final ZeebeLogAppender logAppender) {
+      final AtomixReaderFactory readerFactory,
+      final AtomixReaderFactory uncommittedReaderFactory,
+      final ZeebeLogAppender logAppender) {
     this.readerFactory = readerFactory;
+    this.uncommittedReaderFactory = uncommittedReaderFactory;
     this.logAppender = logAppender;
   }
 
   public static AtomixLogStorage ofPartition(
-      final AtomixReaderFactory readerFactory, final ZeebeLogAppender appender) {
-    return new AtomixLogStorage(readerFactory, appender);
+      final AtomixReaderFactory readerFactory,
+      final AtomixReaderFactory uncommittedReaderFactory,
+      final ZeebeLogAppender appender) {
+    return new AtomixLogStorage(readerFactory, uncommittedReaderFactory, appender);
   }
 
   @Override
@@ -44,12 +51,30 @@ public class AtomixLogStorage implements LogStorage, RaftApplicationEntryCommitt
   }
 
   @Override
+  public AtomixLogStorageReader newUncommittedReader() {
+    return new AtomixLogStorageReader(uncommittedReaderFactory.create());
+  }
+
+  @Override
   public void append(
       final long lowestPosition,
       final long highestPosition,
       final BufferWriter bufferWriter,
       final AppendListener listener) {
-    final var adapter = new AtomixAppendListenerAdapter(listener);
+    final var adapter =
+        new AtomixAppendListenerAdapter(
+            new AppendListener() {
+              @Override
+              public void onWrite(final long index, final long highestPosition) {
+                listener.onWrite(index, highestPosition);
+                appendedListeners.forEach(l -> l.onAppend(highestPosition));
+              }
+
+              @Override
+              public void onCommit(final long index, final long highestPosition) {
+                listener.onCommit(index, highestPosition);
+              }
+            });
     logAppender.appendEntry(lowestPosition, highestPosition, bufferWriter, adapter);
   }
 
@@ -61,6 +86,16 @@ public class AtomixLogStorage implements LogStorage, RaftApplicationEntryCommitt
   @Override
   public void removeCommitListener(final CommitListener listener) {
     commitListeners.remove(listener);
+  }
+
+  @Override
+  public void addAppendedListener(final AppendedListener listener) {
+    appendedListeners.add(listener);
+  }
+
+  @Override
+  public void removeAppendedListener(final AppendedListener listener) {
+    appendedListeners.remove(listener);
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorage.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorage.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.logstreams;
 
-import io.atomix.raft.RaftCommitListener;
+import io.atomix.raft.RaftApplicationEntryCommittedPositionListener;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.camunda.zeebe.util.buffer.BufferWriter;
@@ -21,7 +21,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
  * should be changed when the log storage implementation is taken out of this module, at which point
  * it can be made final.
  */
-public class AtomixLogStorage implements LogStorage, RaftCommitListener {
+public class AtomixLogStorage implements LogStorage, RaftApplicationEntryCommittedPositionListener {
 
   private final AtomixReaderFactory readerFactory;
   private final ZeebeLogAppender logAppender;
@@ -64,7 +64,7 @@ public class AtomixLogStorage implements LogStorage, RaftCommitListener {
   }
 
   @Override
-  public void onCommit(final long index) {
-    commitListeners.forEach(CommitListener::onCommit);
+  public void onCommit(final long highestPosition) {
+    commitListeners.forEach(listener -> listener.onCommit(highestPosition));
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorage.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorage.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.logstreams;
 
+import io.atomix.raft.RaftApplicationEntryCommittedPositionListener;
 import io.atomix.raft.RaftCommitListener;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
@@ -26,6 +27,16 @@ public class AtomixLogStorage implements LogStorage, RaftCommitListener {
   private final AtomixReaderFactory readerFactory;
   private final ZeebeLogAppender logAppender;
   private final Set<CommitListener> commitListeners = new CopyOnWriteArraySet<>();
+  private final Set<CommittedPositionListener> committedPositionListeners =
+      new CopyOnWriteArraySet<>();
+
+  /**
+   * Raft notifies committed indexes and committed application entry positions through two separate
+   * listeners with the same method signature, so this cannot be a second interface implemented by
+   * this class.
+   */
+  private final RaftApplicationEntryCommittedPositionListener committedPositionNotifier =
+      this::onCommittedPosition;
 
   public AtomixLogStorage(
       final AtomixReaderFactory readerFactory, final ZeebeLogAppender logAppender) {
@@ -64,7 +75,33 @@ public class AtomixLogStorage implements LogStorage, RaftCommitListener {
   }
 
   @Override
+  public void addCommittedPositionListener(final CommittedPositionListener listener) {
+    committedPositionListeners.add(listener);
+  }
+
+  @Override
+  public void removeCommittedPositionListener(final CommittedPositionListener listener) {
+    committedPositionListeners.remove(listener);
+  }
+
+  /**
+   * Notified by Raft on every role, whenever the commit index advances. This is the only commit
+   * signal a follower receives, because it never appends entries itself.
+   */
+  @Override
   public void onCommit(final long index) {
     commitListeners.forEach(CommitListener::onCommit);
+  }
+
+  /**
+   * The listener to register for committed application entry positions. Raft only notifies it on
+   * the leader, and only for entries the leader appended itself.
+   */
+  public RaftApplicationEntryCommittedPositionListener committedPositionNotifier() {
+    return committedPositionNotifier;
+  }
+
+  private void onCommittedPosition(final long highestPosition) {
+    committedPositionListeners.forEach(listener -> listener.onCommittedPosition(highestPosition));
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorage.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorage.java
@@ -25,10 +25,12 @@ import java.util.concurrent.CopyOnWriteArraySet;
 public class AtomixLogStorage implements LogStorage, RaftCommitListener {
 
   private final AtomixReaderFactory readerFactory;
+  private final AtomixReaderFactory uncommittedReaderFactory;
   private final ZeebeLogAppender logAppender;
   private final Set<CommitListener> commitListeners = new CopyOnWriteArraySet<>();
   private final Set<CommittedPositionListener> committedPositionListeners =
       new CopyOnWriteArraySet<>();
+  private final Set<AppendedListener> appendedListeners = new CopyOnWriteArraySet<>();
 
   /**
    * Raft notifies committed indexes and committed application entry positions through two separate
@@ -39,14 +41,19 @@ public class AtomixLogStorage implements LogStorage, RaftCommitListener {
       this::onCommittedPosition;
 
   public AtomixLogStorage(
-      final AtomixReaderFactory readerFactory, final ZeebeLogAppender logAppender) {
+      final AtomixReaderFactory readerFactory,
+      final AtomixReaderFactory uncommittedReaderFactory,
+      final ZeebeLogAppender logAppender) {
     this.readerFactory = readerFactory;
+    this.uncommittedReaderFactory = uncommittedReaderFactory;
     this.logAppender = logAppender;
   }
 
   public static AtomixLogStorage ofPartition(
-      final AtomixReaderFactory readerFactory, final ZeebeLogAppender appender) {
-    return new AtomixLogStorage(readerFactory, appender);
+      final AtomixReaderFactory readerFactory,
+      final AtomixReaderFactory uncommittedReaderFactory,
+      final ZeebeLogAppender appender) {
+    return new AtomixLogStorage(readerFactory, uncommittedReaderFactory, appender);
   }
 
   @Override
@@ -55,12 +62,30 @@ public class AtomixLogStorage implements LogStorage, RaftCommitListener {
   }
 
   @Override
+  public AtomixLogStorageReader newUncommittedReader() {
+    return new AtomixLogStorageReader(uncommittedReaderFactory.create());
+  }
+
+  @Override
   public void append(
       final long lowestPosition,
       final long highestPosition,
       final BufferWriter bufferWriter,
       final AppendListener listener) {
-    final var adapter = new AtomixAppendListenerAdapter(listener);
+    final var adapter =
+        new AtomixAppendListenerAdapter(
+            new AppendListener() {
+              @Override
+              public void onWrite(final long index, final long highestPosition) {
+                listener.onWrite(index, highestPosition);
+                appendedListeners.forEach(l -> l.onAppend(highestPosition));
+              }
+
+              @Override
+              public void onCommit(final long index, final long highestPosition) {
+                listener.onCommit(index, highestPosition);
+              }
+            });
     logAppender.appendEntry(lowestPosition, highestPosition, bufferWriter, adapter);
   }
 
@@ -82,6 +107,16 @@ public class AtomixLogStorage implements LogStorage, RaftCommitListener {
   @Override
   public void removeCommittedPositionListener(final CommittedPositionListener listener) {
     committedPositionListeners.remove(listener);
+  }
+
+  @Override
+  public void addAppendedListener(final AppendedListener listener) {
+    appendedListeners.add(listener);
+  }
+
+  @Override
+  public void removeAppendedListener(final AppendedListener listener) {
+    appendedListeners.remove(listener);
   }
 
   /**

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -46,7 +46,7 @@ public final class AsyncSnapshotDirector extends Actor
 
   private static final Logger LOG = Loggers.SNAPSHOT_LOGGER;
   private static final String LOG_MSG_WAIT_UNTIL_COMMITTED =
-      "Finished taking temporary snapshot, need to wait until last written event position {} is committed, current commit position is {}. After that snapshot will be committed.";
+      "Finished taking temporary snapshot, need to wait until position {} is committed, which is the highest of the last processed and last written event position, current commit position is {}. After that snapshot will be committed.";
   private static final String ERROR_MSG_ON_RESOLVE_PROCESSED_POS =
       "Unexpected error in resolving last processed position.";
   private static final String ERROR_MSG_ON_RESOLVE_WRITTEN_POS =
@@ -241,7 +241,8 @@ public final class AsyncSnapshotDirector extends Actor
       final InProgressSnapshot inProgressSnapshot, final boolean forceSnapshot) {
     return takeTransientSnapshot(inProgressSnapshot, forceSnapshot)
         .andThen(() -> getPositionsAfterSnapshot(inProgressSnapshot), actor)
-        .andThen(() -> waitUntilLastWrittenPositionIsCommitted(inProgressSnapshot), actor)
+        .andThen(
+            () -> waitUntilLastProcessedAndWrittenPositionIsCommitted(inProgressSnapshot), actor)
         .andThen(this::flushJournal, actor)
         .andThen(() -> persistSnapshot(inProgressSnapshot), actor);
   }
@@ -304,25 +305,46 @@ public final class AsyncSnapshotDirector extends Actor
             (position, error) -> {
               if (error != null) {
                 LOG.error(ERROR_MSG_ON_RESOLVE_WRITTEN_POS, error);
-                return CompletableActorFuture.completedExceptionally(error);
-              } else {
-                inProgressSnapshot.lastWrittenPosition = position;
-                return CompletableActorFuture.completed(null);
+                return CompletableActorFuture.<Void>completedExceptionally(error);
               }
+              inProgressSnapshot.lastWrittenPosition = position;
+              return getLastProcessedPositionAfterSnapshot(inProgressSnapshot);
             },
             actor);
   }
 
-  private ActorFuture<Void> waitUntilLastWrittenPositionIsCommitted(
+  /**
+   * Reads the processed position again, after the transient snapshot was taken, because that is the
+   * position the snapshot's contents actually reflect. The one read before the snapshot only bounds
+   * the snapshot from below, so waiting for it to commit would not cover a record the processor
+   * processed while the snapshot was being taken.
+   */
+  private ActorFuture<Void> getLastProcessedPositionAfterSnapshot(
       final InProgressSnapshot inProgressSnapshot) {
+    return streamProcessor
+        .getLastProcessedPositionAsync()
+        .andThen(
+            (position, error) -> {
+              if (error != null) {
+                LOG.error(ERROR_MSG_ON_RESOLVE_PROCESSED_POS, error);
+                return CompletableActorFuture.<Void>completedExceptionally(error);
+              }
+              inProgressSnapshot.lastProcessedPosition = position;
+              return CompletableActorFuture.completed(null);
+            },
+            actor);
+  }
+
+  private ActorFuture<Void> waitUntilLastProcessedAndWrittenPositionIsCommitted(
+      final InProgressSnapshot inProgressSnapshot) {
+    final var requiredCommitPosition = inProgressSnapshot.requiredCommitPosition();
     if (streamProcessorMode == StreamProcessorMode.REPLAY
-        || commitPosition >= inProgressSnapshot.lastWrittenPosition) {
+        || commitPosition >= requiredCommitPosition) {
       return CompletableActorFuture.completed(null);
     } else {
-      LOG.info(
-          LOG_MSG_WAIT_UNTIL_COMMITTED, inProgressSnapshot.lastWrittenPosition, commitPosition);
+      LOG.info(LOG_MSG_WAIT_UNTIL_COMMITTED, requiredCommitPosition, commitPosition);
       return commitAwaiters.computeIfAbsent(
-          inProgressSnapshot.lastWrittenPosition, k -> new CompletableActorFuture<>());
+          requiredCommitPosition, k -> new CompletableActorFuture<>());
     }
   }
 
@@ -404,8 +426,23 @@ public final class AsyncSnapshotDirector extends Actor
 
   private static final class InProgressSnapshot {
     private long lastWrittenPosition;
+    private long lastProcessedPosition;
     private TransientSnapshot pendingSnapshot;
     private long lowerBoundSnapshotPosition;
     private long maxExportedPosition;
+
+    /**
+     * The position that has to be committed before this snapshot may be persisted: the highest of
+     * what the processor has written and what it has processed.
+     *
+     * <p>The written position alone is not enough. The processor reads uncommitted records, so it
+     * can have processed a record above the commit index, and a result without follow-up records
+     * leaves the written position behind that record. Persisting then would record a processed
+     * position that a later truncation can remove from the log, and recovery would resume past
+     * records that never committed.
+     */
+    private long requiredCommitPosition() {
+      return Math.max(lastProcessedPosition, lastWrittenPosition);
+    }
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
@@ -34,7 +34,9 @@ public final class LogStoragePartitionTransitionStep implements PartitionTransit
     if (logStorage != null
         && (shouldInstallOnTransition(targetRole, context.getCurrentRole())
             || targetRole == Role.INACTIVE)) {
-      context.getRaftPartition().getServer().removeCommitListener(logStorage);
+      final var server = context.getRaftPartition().getServer();
+      server.removeCommitListener(logStorage);
+      server.removeCommittedEntryListener(logStorage.committedPositionNotifier());
       context.setLogStorage(null);
     }
     return CompletableActorFuture.completed(null);
@@ -52,7 +54,9 @@ public final class LogStoragePartitionTransitionStep implements PartitionTransit
       if (logStorageOrException.isRight()) {
         final var logStorage = logStorageOrException.get();
         context.setLogStorage(logStorage);
-        context.getRaftPartition().getServer().addCommitListener(logStorage);
+        final var server = context.getRaftPartition().getServer();
+        server.addCommitListener(logStorage);
+        server.addCommittedEntryListener(logStorage.committedPositionNotifier());
         openFuture.complete(null);
       } else {
         openFuture.completeExceptionally(logStorageOrException.getLeft());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
@@ -34,7 +34,8 @@ public final class LogStoragePartitionTransitionStep implements PartitionTransit
     if (logStorage != null
         && (shouldInstallOnTransition(targetRole, context.getCurrentRole())
             || targetRole == Role.INACTIVE)) {
-      context.getRaftPartition().getServer().removeCommitListener(logStorage);
+      final var server = context.getRaftPartition().getServer();
+      server.removeCommittedEntryListener(logStorage);
       context.setLogStorage(null);
     }
     return CompletableActorFuture.completed(null);
@@ -52,7 +53,8 @@ public final class LogStoragePartitionTransitionStep implements PartitionTransit
       if (logStorageOrException.isRight()) {
         final var logStorage = logStorageOrException.get();
         context.setLogStorage(logStorage);
-        context.getRaftPartition().getServer().addCommitListener(logStorage);
+        final var server = context.getRaftPartition().getServer();
+        server.addCommittedEntryListener(logStorage);
         openFuture.complete(null);
       } else {
         openFuture.completeExceptionally(logStorageOrException.getLeft());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
@@ -96,6 +96,7 @@ public final class LogStoragePartitionTransitionStep implements PartitionTransit
     return right(
         new AtomixLogStorage(
             server::openReader,
+            server::openUncommittedReader,
             // Prevent followers from writing new events
             new LogAppenderForReadOnlyStorage()));
   }
@@ -127,7 +128,9 @@ public final class LogStoragePartitionTransitionStep implements PartitionTransit
           new NotLeaderException(
               String.format(WRONG_TERM_ERROR_MSG, targetTerm, raftTerm, context.getPartitionId())));
     } else {
-      final var logStorage = AtomixLogStorage.ofPartition(server::openReader, logAppender);
+      final var logStorage =
+          AtomixLogStorage.ofPartition(
+              server::openReader, server::openUncommittedReader, logAppender);
       return right(logStorage);
     }
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
@@ -94,6 +94,7 @@ public final class LogStoragePartitionTransitionStep implements PartitionTransit
     return right(
         new AtomixLogStorage(
             server::openReader,
+            server::openUncommittedReader,
             // Prevent followers from writing new events
             new LogAppenderForReadOnlyStorage()));
   }
@@ -125,7 +126,9 @@ public final class LogStoragePartitionTransitionStep implements PartitionTransit
           new NotLeaderException(
               String.format(WRONG_TERM_ERROR_MSG, targetTerm, raftTerm, context.getPartitionId())));
     } else {
-      final var logStorage = AtomixLogStorage.ofPartition(server::openReader, logAppender);
+      final var logStorage =
+          AtomixLogStorage.ofPartition(
+              server::openReader, server::openUncommittedReader, logAppender);
       return right(logStorage);
     }
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -176,8 +176,8 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
             context.getBrokerCfg().getProcessing().getScheduledTaskCheckInterval())
         .processingFilter(processingFilter)
         .listener(
-            processedCommand ->
-                context.getLogStream().getFlowControl().onProcessed(processedCommand.getPosition()))
+            processedPosition ->
+                context.getLogStream().getFlowControl().onProcessed(processedPosition))
         .addLifecycleListener(
             new StreamProcessorLifecycleAware() {
               @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReaderTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReaderTest.java
@@ -45,7 +45,8 @@ final class AtomixLogStorageReaderTest {
             .withMetaStore(mock(JournalMetaStore.class))
             .build();
     final Appender appender = new Appender();
-    logStorage = new AtomixLogStorage(log::openUncommittedReader, appender);
+    logStorage =
+        new AtomixLogStorage(log::openUncommittedReader, log::openUncommittedReader, appender);
     reader = logStorage.newReader();
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.logstreams;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.atomix.raft.zeebe.ZeebeLogAppender;
+import io.camunda.zeebe.logstreams.storage.LogStorage.CommitListener;
+import io.camunda.zeebe.logstreams.storage.LogStorage.CommittedPositionListener;
+import org.junit.jupiter.api.Test;
+
+final class AtomixLogStorageTest {
+
+  private final AtomixLogStorage logStorage =
+      new AtomixLogStorage(mock(AtomixReaderFactory.class), mock(ZeebeLogAppender.class));
+
+  @Test
+  void shouldNotifyCommitListenersOnCommittedIndex() {
+    // given
+    final var listener = mock(CommitListener.class);
+    logStorage.addCommitListener(listener);
+
+    // when -- raft notifies a new commit index, which is all a follower ever observes
+    logStorage.onCommit(7);
+
+    // then
+    verify(listener).onCommit();
+  }
+
+  @Test
+  void shouldNotifyCommittedPositionListenersWithPosition() {
+    // given
+    final var listener = mock(CommittedPositionListener.class);
+    logStorage.addCommittedPositionListener(listener);
+
+    // when
+    logStorage.committedPositionNotifier().onCommit(42);
+
+    // then
+    verify(listener).onCommittedPosition(42);
+  }
+
+  @Test
+  void shouldNotNotifyCommittedPositionListenersOnCommittedIndex() {
+    // given -- a committed index carries no application record position
+    final var listener = mock(CommittedPositionListener.class);
+    logStorage.addCommittedPositionListener(listener);
+
+    // when
+    logStorage.onCommit(7);
+
+    // then
+    verifyNoInteractions(listener);
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageTest.java
@@ -20,7 +20,10 @@ final class AtomixLogStorageTest {
   void shouldNotifyCommitListenersWithPosition() {
     // given
     final var logStorage =
-        new AtomixLogStorage(mock(AtomixReaderFactory.class), mock(ZeebeLogAppender.class));
+        new AtomixLogStorage(
+            mock(AtomixReaderFactory.class),
+            mock(AtomixReaderFactory.class),
+            mock(ZeebeLogAppender.class));
     final var listener = mock(CommitListener.class);
     logStorage.addCommitListener(listener);
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageTest.java
@@ -19,7 +19,10 @@ import org.junit.jupiter.api.Test;
 final class AtomixLogStorageTest {
 
   private final AtomixLogStorage logStorage =
-      new AtomixLogStorage(mock(AtomixReaderFactory.class), mock(ZeebeLogAppender.class));
+      new AtomixLogStorage(
+          mock(AtomixReaderFactory.class),
+          mock(AtomixReaderFactory.class),
+          mock(ZeebeLogAppender.class));
 
   @Test
   void shouldNotifyCommitListenersOnCommittedIndex() {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.logstreams;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.atomix.raft.zeebe.ZeebeLogAppender;
+import io.camunda.zeebe.logstreams.storage.LogStorage.CommitListener;
+import org.junit.jupiter.api.Test;
+
+final class AtomixLogStorageTest {
+
+  @Test
+  void shouldNotifyCommitListenersWithPosition() {
+    // given
+    final var logStorage =
+        new AtomixLogStorage(mock(AtomixReaderFactory.class), mock(ZeebeLogAppender.class));
+    final var listener = mock(CommitListener.class);
+    logStorage.addCommitListener(listener);
+
+    // when
+    logStorage.onCommit(42);
+
+    // then
+    verify(listener).onCommit(42);
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -148,6 +149,36 @@ public final class AsyncSnapshottingTest {
 
     // when
     setCommitPosition(100L);
+
+    // then
+    assertThat(snapshot.join()).isNotNull();
+    assertThat(persistedSnapshotStore.getLatestSnapshot()).hasValue(snapshot.join());
+  }
+
+  @Test
+  public void shouldNotPersistSnapshotUntilLastProcessedPositionIsCommitted() {
+    // given a processor that processed a record above the commit index whose result wrote nothing,
+    // leaving the written position behind the processed one
+    when(mockStreamProcessor.getLastProcessedPositionAsync())
+        .thenReturn(CompletableActorFuture.completed(50L));
+    when(mockStreamProcessor.getLastWrittenPositionAsync())
+        .thenReturn(CompletableActorFuture.completed(10L));
+    createSnapshotDirector(StreamProcessorMode.PROCESSING);
+    final var snapshot = asyncSnapshotDirector.forceSnapshot();
+    verify(mockStreamProcessor, timeout(10000)).getLastWrittenPositionAsync();
+
+    // when only the written position is committed
+    setCommitPosition(10L);
+
+    // then the snapshot is held back, because the state it captured includes position 50
+    Awaitility.await("the snapshot is not persisted")
+        .during(Duration.ofMillis(500))
+        .atMost(Duration.ofSeconds(5))
+        .until(() -> !snapshot.isDone());
+    assertThat(persistedSnapshotStore.getLatestSnapshot()).isEmpty();
+
+    // when the processed position is committed too
+    setCommitPosition(50L);
 
     // then
     assertThat(snapshot.join()).isNotNull();

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -54,6 +54,8 @@ There are three sources of commands.
 - Command processors can request next steps by appending commands, e.g. flow to the next element in the process after completing a task.
 - Scheduled tasks that run periodically inside the engine can append commands, e.g. to remove a message from the buffer after its TTL has expired.
 
+Commands are processed as soon as they are appended to the log, without waiting for them to be committed. This overlaps processing with replication and reduces the latency of command responses. The stream processor rebuilds its state from committed records on recovery, so processing records that are later truncated is harmless: the state is discarded and rebuilt from the committed log.
+
 ### Relation to other components
 
 The workflow engine is built on top of the `protocol` and `stream-platform` modules.

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -398,7 +398,7 @@ guide on golden files, common scenarios, and porting pitfalls.
 
 ### Side-effects are not guaranteed to be executed
 
-- Side-effects are executed before the next command is picked up, but if execution fails or if failover occurs the side-effect may not be executed.
+- Side-effects are executed asynchronously after their processing results are committed, but if execution fails or if failover occurs the side-effect may not be executed.
 - **Don't** do things that must happen in a side-effect.
 - **Do** use side-effects for things like updating caches or sending responses.
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -101,7 +101,7 @@ public class BpmnJobActivationBehavior {
     this.clock = clock;
     this.cslCheck = cslCheck;
     this.tenantCheck = tenantCheck;
-    this.jobAuthorizationLogger = JobAuthorizationLogger.createDefault();
+    jobAuthorizationLogger = JobAuthorizationLogger.createDefault();
     secretLookup = new JobSecretLookup(secretStoreRegistry);
     this.incidentBehavior = incidentBehavior;
   }
@@ -172,7 +172,6 @@ public class BpmnJobActivationBehavior {
         sideEffectWriter.appendSideEffect(
             () -> {
               jobMetrics.countJobEvent(JobAction.SKIPPED_LEASED, jobKind, jobType);
-              return true;
             });
       }
       // the job stays activatable; a long poll checks its secret references when it collects it
@@ -226,7 +225,6 @@ public class BpmnJobActivationBehavior {
         () -> {
           jobStream.push(activatedJob);
           jobMetrics.countJobEvent(JobAction.PUSHED, jobKind, jobType);
-          return true;
         });
     return true;
   }
@@ -337,7 +335,6 @@ public class BpmnJobActivationBehavior {
         () -> {
           jobStreamer.notifyWorkAvailable(jobType);
           jobMetrics.countJobEvent(JobAction.WORKERS_NOTIFIED, jobKind, jobType);
-          return true;
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -110,7 +110,6 @@ public class BpmnJobActivationBehavior {
           () -> {
             jobStream.push(activatedJob);
             jobMetrics.countJobEvent(JobAction.PUSHED, jobKind, jobType);
-            return true;
           });
     } else {
       notifyJobAvailable(jobType, jobKind);
@@ -126,7 +125,6 @@ public class BpmnJobActivationBehavior {
         () -> {
           jobStreamer.notifyWorkAvailable(jobType);
           jobMetrics.countJobEvent(JobAction.WORKERS_NOTIFIED, jobKind, jobType);
-          return true;
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockPinProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockPinProcessor.java
@@ -110,11 +110,7 @@ public final class ClockPinProcessor implements DistributedTypedRecordProcessor<
 
   private void applyClockModification(final long key, final ClockRecord clockRecord) {
     final var pinnedAt = Instant.ofEpochMilli(clockRecord.getTime());
-    final SideEffectProducer sideEffect =
-        () -> {
-          clock.pinAt(pinnedAt);
-          return true;
-        };
+    final SideEffectProducer sideEffect = () -> clock.pinAt(pinnedAt);
     sideEffectWriter.appendSideEffect(sideEffect);
     stateWriter.appendFollowUpEvent(key, ClockIntent.PINNED, clockRecord);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockResetProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockResetProcessor.java
@@ -96,11 +96,7 @@ public final class ClockResetProcessor implements DistributedTypedRecordProcesso
   }
 
   private void applyClockModification(final long key, final ClockRecord clockRecord) {
-    final SideEffectProducer sideEffect =
-        () -> {
-          clock.reset();
-          return true;
-        };
+    final SideEffectProducer sideEffect = () -> clock.reset();
     sideEffectWriter.appendSideEffect(sideEffect);
     stateWriter.appendFollowUpEvent(key, ClockIntent.RESETTED, clockRecord);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -442,7 +442,6 @@ public final class CatchEventBehavior {
           transientProcessMessageSubscriptionState.update(
               new PendingSubscription(elementInstanceKey, subscriptionMessageName, tenantId),
               lastSentTime);
-          return true;
         });
   }
 
@@ -496,7 +495,6 @@ public final class CatchEventBehavior {
           /* timerChecker implements onRecovered to recover from restart, so no need to schedule
           this in TimerCreatedApplier.*/
           timerChecker.scheduleTimer(dueDate);
-          return true;
         });
 
     stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), TimerIntent.CREATED, timerRecord);
@@ -691,7 +689,6 @@ public final class CatchEventBehavior {
           transientProcessMessageSubscriptionState.update(
               new PendingSubscription(elementInstanceKey, messageNameString, tenantId),
               lastSentTime);
-          return true;
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -311,7 +311,6 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
           () -> {
             interPartitionCommandSender.sendCommand(
                 partition, valueType, intent, distributionKey, commandValue, authInfo);
-            return true;
           });
     }
   }
@@ -340,7 +339,6 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
               CommandDistributionIntent.ACKNOWLEDGE,
               distributionKey,
               acknowledgeRecord);
-          return true;
         });
 
     getMetrics().sentAcknowledgeDistribution(receiverPartitionId);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -104,7 +104,6 @@ public class AuthorizationCreateProcessor
               sideEffectWriter.appendSideEffect(
                   () -> {
                     authorizationScopeStateAdapter.invalidateAll();
-                    return true;
                   });
             },
             rejection ->
@@ -133,7 +132,6 @@ public class AuthorizationCreateProcessor
     sideEffectWriter.appendSideEffect(
         () -> {
           authorizationScopeStateAdapter.invalidateAll();
-          return true;
         });
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
@@ -112,7 +112,6 @@ public class AuthorizationDeleteProcessor
               sideEffectWriter.appendSideEffect(
                   () -> {
                     authorizationScopeStateAdapter.invalidateAll();
-                    return true;
                   });
             },
             rejection ->
@@ -155,7 +154,6 @@ public class AuthorizationDeleteProcessor
     sideEffectWriter.appendSideEffect(
         () -> {
           authorizationScopeStateAdapter.invalidateAll();
-          return true;
         });
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
@@ -111,7 +111,6 @@ public class AuthorizationUpdateProcessor
               sideEffectWriter.appendSideEffect(
                   () -> {
                     authorizationScopeStateAdapter.invalidateAll();
-                    return true;
                   });
             },
             rejection ->
@@ -141,7 +140,6 @@ public class AuthorizationUpdateProcessor
     sideEffectWriter.appendSideEffect(
         () -> {
           authorizationScopeStateAdapter.invalidateAll();
-          return true;
         });
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
@@ -157,7 +157,6 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
     sideEffectWriter.appendSideEffect(
         () -> {
           membershipStateAdapter.invalidateAll();
-          return true;
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
@@ -149,7 +149,6 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
     sideEffectWriter.appendSideEffect(
         () -> {
           membershipStateAdapter.invalidateAll();
-          return true;
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -158,7 +158,6 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
     sideEffectWriter.appendSideEffect(
         () -> {
           membershipStateAdapter.invalidateAll();
-          return true;
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
@@ -152,7 +152,6 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
     sideEffectWriter.appendSideEffect(
         () -> {
           membershipStateAdapter.invalidateAll();
-          return true;
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -142,7 +142,6 @@ public final class JobFailProcessor
       sideEffectWriter.appendSideEffect(
           () -> {
             jobBackoffChecker.scheduleBackOff(retryBackOff + receivedTime);
-            return true;
           });
     }
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.FAILED, failedJob);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -137,7 +137,6 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
       sideEffectWriter.appendSideEffect(
           () -> {
             jobBackoffChecker.scheduleBackOff(retryBackOff + receivedTime);
-            return true;
           });
     }
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.FAILED, failedJob);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -149,7 +149,6 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
         () -> {
           transientProcessMessageSubscriptionState.remove(
               new PendingSubscription(elementInstanceKey, messageName, tenantId));
-          return true;
         });
 
     final var catchEvent = getCatchEvent(elementInstance.getValue(), record.getElementIdBuffer());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -146,7 +146,6 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
         () -> {
           transientProcessMessageSubscriptionState.remove(
               new PendingSubscription(elementInstanceKey, messageName, tenantId));
-          return true;
         });
 
     final var catchEvent = getCatchEvent(elementInstance.getValue(), record.getElementIdBuffer());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCreateProcessor.java
@@ -74,7 +74,6 @@ public final class ProcessMessageSubscriptionCreateProcessor
           () -> {
             transientProcessMessageSubscriptionState.remove(
                 new PendingSubscription(elementInstanceKey, messageName, tenantId));
-            return true;
           });
     } else {
       rejectCommand(command, subscription);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionDeleteProcessor.java
@@ -72,7 +72,6 @@ public final class ProcessMessageSubscriptionDeleteProcessor
         () -> {
           transientProcessMessageSubscriptionState.remove(
               new PendingSubscription(elementInstanceKey, messageName, tenantId));
-          return true;
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -623,7 +623,6 @@ public class SubscriptionCommandSender {
               () -> {
                 interPartitionCommandSender.sendCommand(
                     receiverPartitionId, valueType, intent, record);
-                return true;
               });
     }
     return true;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessor.java
@@ -101,7 +101,6 @@ public final class ProcessInstanceCompleteResumingProcessor
     sideEffectWriter.appendSideEffect(
         () -> {
           timerChecker.scheduleTimer(-1);
-          return true;
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -149,7 +149,6 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
     sideEffectWriter.appendSideEffect(
         () -> {
           membershipStateAdapter.invalidateAll();
-          return true;
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
@@ -166,7 +166,6 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
         () -> {
           authorizationScopeStateAdapter.invalidateAll();
           membershipStateAdapter.invalidateAll();
-          return true;
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
@@ -127,7 +127,6 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
     sideEffectWriter.appendSideEffect(
         () -> {
           membershipStateAdapter.invalidateAll();
-          return true;
         });
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ReplayStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ReplayStateTest.java
@@ -52,7 +52,7 @@ public final class ReplayStateTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
-          .withOnProcessedCallback(record -> lastProcessedPosition = record.getPosition())
+          .withOnProcessedCallback(position -> lastProcessedPosition = position)
           .withOnSkippedCallback(record -> lastProcessedPosition = record.getPosition());
 
   @Parameters(name = "{0}")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -80,7 +80,6 @@ import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
 import io.camunda.zeebe.stream.api.StreamClock;
-import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.impl.ClusterContextImpl;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
@@ -105,6 +104,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.LongConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.agrona.DirectBuffer;
@@ -129,7 +129,7 @@ public final class EngineRule extends ExternalResource {
       ResetRecordingExporterMode.AFTER_IDENTITY_SETUP;
   private boolean initializeRoutingState = true;
 
-  private Consumer<TypedRecord> onProcessedCallback = record -> {};
+  private LongConsumer onProcessedCallback = position -> {};
   private Consumer<LoggedEvent> onSkippedCallback = record -> {};
 
   private long lastProcessedPosition = -1L;
@@ -261,7 +261,7 @@ public final class EngineRule extends ExternalResource {
     return this;
   }
 
-  public EngineRule withOnProcessedCallback(final Consumer<TypedRecord> onProcessedCallback) {
+  public EngineRule withOnProcessedCallback(final LongConsumer onProcessedCallback) {
     this.onProcessedCallback = this.onProcessedCallback.andThen(onProcessedCallback);
     return this;
   }
@@ -391,14 +391,15 @@ public final class EngineRule extends ExternalResource {
               Optional.of(
                   new StreamProcessorListener() {
                     @Override
-                    public void onProcessed(final TypedRecord<?> processedCommand) {
-                      lastProcessedPosition = processedCommand.getPosition();
-                      onProcessedCallback.accept(processedCommand);
+                    public void onProcessed(final long processedPosition) {
+                      lastProcessedPosition = Math.max(lastProcessedPosition, processedPosition);
+                      onProcessedCallback.accept(processedPosition);
                     }
 
                     @Override
                     public void onSkipped(final LoggedEvent skippedRecord) {
-                      lastProcessedPosition = skippedRecord.getPosition();
+                      lastProcessedPosition =
+                          Math.max(lastProcessedPosition, skippedRecord.getPosition());
                       onSkippedCallback.accept(skippedRecord);
                     }
                   }),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorListenerRelay.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorListenerRelay.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.util;
 
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
-import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.impl.StreamProcessorListener;
 import java.util.Collections;
 import java.util.List;
@@ -22,8 +21,8 @@ final class StreamProcessorListenerRelay implements StreamProcessorListener {
   }
 
   @Override
-  public void onProcessed(final TypedRecord<?> processedCommand) {
-    delegates.forEach(l -> l.onProcessed(processedCommand));
+  public void onProcessed(final long processedPosition) {
+    delegates.forEach(l -> l.onProcessed(processedPosition));
   }
 
   @Override

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
+import io.camunda.zeebe.logstreams.storage.LogStorage.AppendedListener;
 import io.camunda.zeebe.logstreams.storage.LogStorage.CommitListener;
 import io.camunda.zeebe.logstreams.storage.LogStorage.CommittedPositionListener;
 import io.camunda.zeebe.logstreams.storage.LogStorageReader;
@@ -24,10 +25,11 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.time.InstantSource;
 import java.util.Collection;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Supplier;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
-public final class LogStreamImpl implements LogStream, CommitListener {
+public final class LogStreamImpl implements LogStream, CommitListener, AppendedListener {
 
   private static final Logger LOG = Loggers.LOGSTREAMS_LOGGER;
 
@@ -70,6 +72,7 @@ public final class LogStreamImpl implements LogStream, CommitListener {
             new SequencerMetrics(meterRegistry),
             flowControl);
     logStorage.addCommitListener(this);
+    logStorage.addAppendedListener(this);
   }
 
   @Override
@@ -78,6 +81,7 @@ public final class LogStreamImpl implements LogStream, CommitListener {
     LOG.debug("Closing {} with {} readers", logName, readers.size());
     readers.forEach(LogStreamReader::close);
     logStorage.removeCommitListener(this);
+    logStorage.removeAppendedListener(this);
   }
 
   @Override
@@ -93,7 +97,13 @@ public final class LogStreamImpl implements LogStream, CommitListener {
   @Override
   public LogStreamReader newLogStreamReader() {
     ensureOpen();
-    return createLogStreamReader();
+    return createLogStreamReader(logStorage::newReader);
+  }
+
+  @Override
+  public LogStreamReader newUncommittedLogStreamReader() {
+    ensureOpen();
+    return createLogStreamReader(logStorage::newUncommittedReader);
   }
 
   @Override
@@ -142,6 +152,15 @@ public final class LogStreamImpl implements LogStream, CommitListener {
 
   @Override
   public void onCommit() {
+    notifyRecordAvailable();
+  }
+
+  @Override
+  public void onAppend(final long highestPosition) {
+    notifyRecordAvailable();
+  }
+
+  private void notifyRecordAvailable() {
     if (closed) {
       // This can be called by the raft thread after we've already closed the log stream.
       // We can just ignore it in that case. Using `ensureOpen` would throw an exception that would
@@ -157,8 +176,8 @@ public final class LogStreamImpl implements LogStream, CommitListener {
     }
   }
 
-  private LogStreamReader createLogStreamReader() {
-    final var newReader = new LogStreamReaderImpl(logStorage.newReader());
+  private LogStreamReader createLogStreamReader(final Supplier<LogStorageReader> readerSupplier) {
+    final var newReader = new LogStreamReaderImpl(readerSupplier.get());
     readers.add(newReader);
     return newReader;
   }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -128,7 +128,18 @@ public final class LogStreamImpl implements LogStream, CommitListener {
   }
 
   @Override
-  public void onCommit() {
+  public void registerCommitListener(final CommitListener listener) {
+    ensureOpen();
+    logStorage.addCommitListener(listener);
+  }
+
+  @Override
+  public void removeCommitListener(final CommitListener listener) {
+    logStorage.removeCommitListener(listener);
+  }
+
+  @Override
+  public void onCommit(final long highestPosition) {
     if (closed) {
       // This can be called by the raft thread after we've already closed the log stream.
       // We can just ignore it in that case. Using `ensureOpen` would throw an exception that would

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -34,7 +34,8 @@ public final class LogStreamImpl implements LogStream, CommitListener, AppendedL
   private static final Logger LOG = Loggers.LOGSTREAMS_LOGGER;
 
   private final Collection<LogStreamReader> readers = new CopyOnWriteArrayList<>();
-  private final Collection<LogRecordAwaiter> recordAwaiters = new CopyOnWriteArrayList<>();
+  private final Collection<LogRecordAwaiter> committedRecordAwaiters = new CopyOnWriteArrayList<>();
+  private final Collection<LogRecordAwaiter> appendedRecordAwaiters = new CopyOnWriteArrayList<>();
 
   private @Nullable final String logName;
   private final int partitionId;
@@ -130,13 +131,25 @@ public final class LogStreamImpl implements LogStream, CommitListener, AppendedL
   @Override
   public void registerRecordAvailableListener(final LogRecordAwaiter recordAwaiter) {
     ensureOpen();
-    recordAwaiters.add(recordAwaiter);
+    committedRecordAwaiters.add(recordAwaiter);
   }
 
   @Override
   public void removeRecordAvailableListener(final LogRecordAwaiter recordAwaiter) {
     ensureOpen();
-    recordAwaiters.remove(recordAwaiter);
+    committedRecordAwaiters.remove(recordAwaiter);
+  }
+
+  @Override
+  public void registerAppendedRecordAvailableListener(final LogRecordAwaiter recordAwaiter) {
+    ensureOpen();
+    appendedRecordAwaiters.add(recordAwaiter);
+  }
+
+  @Override
+  public void removeAppendedRecordAvailableListener(final LogRecordAwaiter recordAwaiter) {
+    ensureOpen();
+    appendedRecordAwaiters.remove(recordAwaiter);
   }
 
   @Override
@@ -152,22 +165,22 @@ public final class LogStreamImpl implements LogStream, CommitListener, AppendedL
 
   @Override
   public void onCommit() {
-    notifyRecordAvailable();
+    notifyRecordAvailable(committedRecordAwaiters);
   }
 
   @Override
   public void onAppend(final long highestPosition) {
-    notifyRecordAvailable();
+    notifyRecordAvailable(appendedRecordAwaiters);
   }
 
-  private void notifyRecordAvailable() {
+  private void notifyRecordAvailable(final Collection<LogRecordAwaiter> awaiters) {
     if (closed) {
       // This can be called by the raft thread after we've already closed the log stream.
       // We can just ignore it in that case. Using `ensureOpen` would throw an exception that would
       // break the raft thread.
       return;
     }
-    recordAwaiters.forEach(LogRecordAwaiter::onRecordAvailable);
+    awaiters.forEach(LogRecordAwaiter::onRecordAvailable);
   }
 
   private void ensureOpen() {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -18,6 +18,8 @@ import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.camunda.zeebe.logstreams.storage.LogStorage.CommitListener;
+import io.camunda.zeebe.logstreams.storage.LogStorage.CommittedPositionListener;
+import io.camunda.zeebe.logstreams.storage.LogStorageReader;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.InstantSource;
 import java.util.Collection;
@@ -125,6 +127,17 @@ public final class LogStreamImpl implements LogStream, CommitListener {
   public void removeRecordAvailableListener(final LogRecordAwaiter recordAwaiter) {
     ensureOpen();
     recordAwaiters.remove(recordAwaiter);
+  }
+
+  @Override
+  public void registerCommittedPositionListener(final CommittedPositionListener listener) {
+    ensureOpen();
+    logStorage.addCommittedPositionListener(listener);
+  }
+
+  @Override
+  public void removeCommittedPositionListener(final CommittedPositionListener listener) {
+    logStorage.removeCommittedPositionListener(listener);
   }
 
   @Override

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -17,15 +17,18 @@ import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
+import io.camunda.zeebe.logstreams.storage.LogStorage.AppendedListener;
 import io.camunda.zeebe.logstreams.storage.LogStorage.CommitListener;
+import io.camunda.zeebe.logstreams.storage.LogStorageReader;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.InstantSource;
 import java.util.Collection;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Supplier;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
-public final class LogStreamImpl implements LogStream, CommitListener {
+public final class LogStreamImpl implements LogStream, CommitListener, AppendedListener {
 
   private static final Logger LOG = Loggers.LOGSTREAMS_LOGGER;
 
@@ -68,6 +71,7 @@ public final class LogStreamImpl implements LogStream, CommitListener {
             new SequencerMetrics(meterRegistry),
             flowControl);
     logStorage.addCommitListener(this);
+    logStorage.addAppendedListener(this);
   }
 
   @Override
@@ -76,6 +80,7 @@ public final class LogStreamImpl implements LogStream, CommitListener {
     LOG.debug("Closing {} with {} readers", logName, readers.size());
     readers.forEach(LogStreamReader::close);
     logStorage.removeCommitListener(this);
+    logStorage.removeAppendedListener(this);
   }
 
   @Override
@@ -91,7 +96,13 @@ public final class LogStreamImpl implements LogStream, CommitListener {
   @Override
   public LogStreamReader newLogStreamReader() {
     ensureOpen();
-    return createLogStreamReader();
+    return createLogStreamReader(logStorage::newReader);
+  }
+
+  @Override
+  public LogStreamReader newUncommittedLogStreamReader() {
+    ensureOpen();
+    return createLogStreamReader(logStorage::newUncommittedReader);
   }
 
   @Override
@@ -149,14 +160,22 @@ public final class LogStreamImpl implements LogStream, CommitListener {
     recordAwaiters.forEach(LogRecordAwaiter::onRecordAvailable);
   }
 
+  @Override
+  public void onAppend(final long highestPosition) {
+    if (closed) {
+      return;
+    }
+    recordAwaiters.forEach(LogRecordAwaiter::onRecordAvailable);
+  }
+
   private void ensureOpen() {
     if (closed) {
       throw new IllegalStateException("%s is closed".formatted(logName));
     }
   }
 
-  private LogStreamReader createLogStreamReader() {
-    final var newReader = new LogStreamReaderImpl(logStorage.newReader());
+  private LogStreamReader createLogStreamReader(final Supplier<LogStorageReader> readerSupplier) {
+    final var newReader = new LogStreamReaderImpl(readerSupplier.get());
     readers.add(newReader);
     return newReader;
   }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.logstreams.log;
 
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl;
 import io.camunda.zeebe.logstreams.impl.log.LogStreamBuilderImpl;
+import io.camunda.zeebe.logstreams.storage.LogStorage.CommittedPositionListener;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -81,4 +82,14 @@ public interface LogStream extends AutoCloseable {
    * @param recordAwaiter the listener to remove
    */
   void removeRecordAvailableListener(LogRecordAwaiter recordAwaiter);
+
+  /**
+   * Registers a listener that is notified with the highest committed position of the records that
+   * this node appended itself. See {@link CommittedPositionListener} for the cases in which it is
+   * not notified.
+   */
+  void registerCommittedPositionListener(CommittedPositionListener listener);
+
+  /** Removes a committed position listener. */
+  void removeCommittedPositionListener(CommittedPositionListener listener);
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
@@ -77,8 +77,9 @@ public interface LogStream extends AutoCloseable {
   void resumeWrites();
 
   /**
-   * Registers a listener that will be notified when new records are available to read from the
-   * logstream.
+   * Registers a listener that will be notified when new <em>committed</em> records are available to
+   * read from the logstream. This is what a consumer reading through {@link #newLogStreamReader()}
+   * wants: an append tells it nothing, because the record it appended is not yet visible to it.
    *
    * @param recordAwaiter the listener to be notified
    */
@@ -90,6 +91,23 @@ public interface LogStream extends AutoCloseable {
    * @param recordAwaiter the listener to remove
    */
   void removeRecordAvailableListener(LogRecordAwaiter recordAwaiter);
+
+  /**
+   * Registers a listener that will be notified as soon as new records are <em>appended</em>, before
+   * they are committed. This is what a consumer reading through {@link
+   * #newUncommittedLogStreamReader()} wants: it can read the record straight away, and the later
+   * commit reveals nothing new to it.
+   *
+   * @param recordAwaiter the listener to be notified
+   */
+  void registerAppendedRecordAvailableListener(LogRecordAwaiter recordAwaiter);
+
+  /**
+   * Removes the listener.
+   *
+   * @param recordAwaiter the listener to remove
+   */
+  void removeAppendedRecordAvailableListener(LogRecordAwaiter recordAwaiter);
 
   /**
    * Registers a listener that is notified with the highest committed position of the records that

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.logstreams.log;
 
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl;
 import io.camunda.zeebe.logstreams.impl.log.LogStreamBuilderImpl;
+import io.camunda.zeebe.logstreams.storage.LogStorage.CommitListener;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -81,4 +82,12 @@ public interface LogStream extends AutoCloseable {
    * @param recordAwaiter the listener to remove
    */
   void removeRecordAvailableListener(LogRecordAwaiter recordAwaiter);
+
+  /**
+   * Registers a listener that is notified with the highest committed application record position.
+   */
+  void registerCommitListener(CommitListener listener);
+
+  /** Removes an application record commit listener. */
+  void removeCommitListener(CommitListener listener);
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
@@ -49,6 +49,14 @@ public interface LogStream extends AutoCloseable {
   LogStreamReader newLogStreamReader();
 
   /**
+   * Returns a new log stream reader that also reads records that have not been committed yet. This
+   * is only safe for consumers that can tolerate records being truncated again.
+   *
+   * @return a new log stream reader
+   */
+  LogStreamReader newUncommittedLogStreamReader();
+
+  /**
    * @return a future, when successfully completed it returns a newly created log stream record
    *     writer
    */

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
@@ -33,6 +33,15 @@ public interface LogStorage {
   LogStorageReader newReader();
 
   /**
+   * Creates a new reader that also reads records that have been appended to the storage but are not
+   * yet committed. This is only safe for consumers that can tolerate records being truncated again,
+   * e.g. the stream processor which rebuilds its state from committed records on recovery.
+   *
+   * @return a new stateful storage reader
+   */
+  LogStorageReader newUncommittedReader();
+
+  /**
    * Writes a block containing one or multiple log entries in the storage and returns the address at
    * which the block has been written.
    *
@@ -93,6 +102,21 @@ public interface LogStorage {
   void removeCommitListener(CommitListener listener);
 
   /**
+   * Register an append listener
+   *
+   * @param listener the listener which will be notified when new records are appended to the
+   *     storage, before they are committed.
+   */
+  void addAppendedListener(AppendedListener listener);
+
+  /**
+   * Remove an append listener
+   *
+   * @param listener the listener to remove
+   */
+  void removeAppendedListener(AppendedListener listener);
+
+  /**
    * An append listener can be added to an append call to be notified of different events that can
    * occur during the append operation.
    */
@@ -130,5 +154,22 @@ public interface LogStorage {
      * @param highestPosition the highest committed record position
      */
     void onCommit(long highestPosition);
+  }
+
+  /**
+   * Consumers of LogStorage can use this listener to get notified when new records are appended to
+   * the storage, before they are committed. The difference between this and {@link AppendListener}
+   * is that {@link AppendListener} can only be used by the writer of a record. {@link
+   * AppendedListener} can be used by any consumers of LogStorage, and get notified of new records
+   * appended even if it did not write the record itself.
+   */
+  interface AppendedListener {
+
+    /**
+     * Called when records are appended to the storage.
+     *
+     * @param highestPosition the highest appended record position
+     */
+    void onAppend(long highestPosition);
   }
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
@@ -33,6 +33,15 @@ public interface LogStorage {
   LogStorageReader newReader();
 
   /**
+   * Creates a new reader that also reads records that have been appended to the storage but are not
+   * yet committed. This is only safe for consumers that can tolerate records being truncated again,
+   * e.g. the stream processor which rebuilds its state from committed records on recovery.
+   *
+   * @return a new stateful storage reader
+   */
+  LogStorageReader newUncommittedReader();
+
+  /**
    * Writes a block containing one or multiple log entries in the storage and returns the address at
    * which the block has been written.
    *
@@ -107,6 +116,21 @@ public interface LogStorage {
   void removeCommittedPositionListener(CommittedPositionListener listener);
 
   /**
+   * Register an append listener
+   *
+   * @param listener the listener which will be notified when new records are appended to the
+   *     storage, before they are committed.
+   */
+  void addAppendedListener(AppendedListener listener);
+
+  /**
+   * Remove an append listener
+   *
+   * @param listener the listener to remove
+   */
+  void removeAppendedListener(AppendedListener listener);
+
+  /**
    * An append listener can be added to an append call to be notified of different events that can
    * occur during the append operation.
    */
@@ -158,5 +182,22 @@ public interface LogStorage {
      * @param highestPosition the highest committed record position
      */
     void onCommittedPosition(long highestPosition);
+  }
+
+  /**
+   * Consumers of LogStorage can use this listener to get notified when new records are appended to
+   * the storage, before they are committed. The difference between this and {@link AppendListener}
+   * is that {@link AppendListener} can only be used by the writer of a record. {@link
+   * AppendedListener} can be used by any consumers of LogStorage, and get notified of new records
+   * appended even if it did not write the record itself.
+   */
+  interface AppendedListener {
+
+    /**
+     * Called when records are appended to the storage.
+     *
+     * @param highestPosition the highest appended record position
+     */
+    void onAppend(long highestPosition);
   }
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
@@ -124,7 +124,11 @@ public interface LogStorage {
    */
   interface CommitListener {
 
-    /** Called when a new record is committed in the storage */
-    void onCommit();
+    /**
+     * Called when records are committed in the storage.
+     *
+     * @param highestPosition the highest committed record position
+     */
+    void onCommit(long highestPosition);
   }
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
@@ -93,6 +93,20 @@ public interface LogStorage {
   void removeCommitListener(CommitListener listener);
 
   /**
+   * Register a committed position listener
+   *
+   * @param listener the listener which will be notified with the highest committed record position.
+   */
+  void addCommittedPositionListener(CommittedPositionListener listener);
+
+  /**
+   * Remove a committed position listener
+   *
+   * @param listener the listener to remove
+   */
+  void removeCommittedPositionListener(CommittedPositionListener listener);
+
+  /**
    * An append listener can be added to an append call to be notified of different events that can
    * occur during the append operation.
    */
@@ -126,5 +140,23 @@ public interface LogStorage {
 
     /** Called when a new record is committed in the storage */
     void onCommit();
+  }
+
+  /**
+   * Consumers of LogStorage can use this listener to get notified of the position up to which
+   * records are committed. Unlike {@link CommitListener}, which is notified whenever the storage
+   * commits anything, this listener is only notified for records that the local node appended
+   * itself. In particular, a follower is never notified, and a leader is not notified for records
+   * appended by a previous leader. Consumers that must observe every commit, regardless of who
+   * wrote the record, have to use {@link CommitListener} instead.
+   */
+  interface CommittedPositionListener {
+
+    /**
+     * Called when records appended by this node are committed in the storage.
+     *
+     * @param highestPosition the highest committed record position
+     */
+    void onCommittedPosition(long highestPosition);
   }
 }

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
@@ -525,6 +525,11 @@ final class SequencerTest {
     }
 
     @Override
+    public LogStorageReader newUncommittedReader() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void append(
         final long lowestPosition,
         final long highestPosition,
@@ -554,6 +559,16 @@ final class SequencerTest {
 
     @Override
     public void removeCommittedPositionListener(final CommittedPositionListener listener) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addAppendedListener(final AppendedListener listener) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeAppendedListener(final AppendedListener listener) {
       throw new UnsupportedOperationException();
     }
   }

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
@@ -546,5 +546,15 @@ final class SequencerTest {
     public void removeCommitListener(final CommitListener listener) {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void addCommittedPositionListener(final CommittedPositionListener listener) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeCommittedPositionListener(final CommittedPositionListener listener) {
+      throw new UnsupportedOperationException();
+    }
   }
 }

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
@@ -525,6 +525,11 @@ final class SequencerTest {
     }
 
     @Override
+    public LogStorageReader newUncommittedReader() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void append(
         final long lowestPosition,
         final long highestPosition,
@@ -544,6 +549,16 @@ final class SequencerTest {
 
     @Override
     public void removeCommitListener(final CommitListener listener) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addAppendedListener(final AppendedListener listener) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeAppendedListener(final AppendedListener listener) {
       throw new UnsupportedOperationException();
     }
   }

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamTest.java
@@ -97,6 +97,30 @@ public final class LogStreamTest {
   }
 
   @Test
+  public void shouldNotifyAppendedListenerBeforeTheRecordIsCommitted() throws InterruptedException {
+    // given a listener for each visibility, and a storage that does not commit on its own
+    final var logStorage = logStreamRule.getLogStorage();
+    logStorage.deferCommits();
+    final CountDownLatch appendedListener = new CountDownLatch(1);
+    final CountDownLatch committedListener = new CountDownLatch(1);
+    logStream.registerAppendedRecordAvailableListener(appendedListener::countDown);
+    logStream.registerRecordAvailableListener(committedListener::countDown);
+
+    // when the record is appended but not committed
+    logStreamRule.getLogStreamWriter().tryWrite(WriteContext.internal(), TestEntry.ofDefaults());
+
+    // then only the listener that reads uncommitted records is woken
+    assertThat(appendedListener.await(2, TimeUnit.SECONDS)).isTrue();
+    assertThat(committedListener.getCount()).isOne();
+
+    // when the record commits
+    logStorage.commitPendingEntries();
+
+    // then
+    assertThat(committedListener.await(2, TimeUnit.SECONDS)).isTrue();
+  }
+
+  @Test
   public void shouldNotifyMultipleListenersWhenNewRecordsAreAvailable()
       throws InterruptedException {
     // given

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.camunda.zeebe.logstreams.storage.LogStorageReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.nio.ByteBuffer;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -22,6 +21,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.LongConsumer;
 import org.agrona.DirectBuffer;
@@ -35,9 +35,12 @@ public class ListLogStorage implements LogStorage {
   private final ConcurrentNavigableMap<Long, Integer> positionIndexMapping;
   private final ConcurrentSkipListMap<Integer, Entry> entries;
   private @Nullable LongConsumer positionListener;
-  private final Set<CommitListener> commitListeners = new HashSet<>();
-  private final Set<CommittedPositionListener> committedPositionListeners = new HashSet<>();
-  private final Set<AppendedListener> appendedListeners = new HashSet<>();
+  // Appends and commits notify listeners from the appending thread while tests add and remove
+  // listeners from their own thread, so these sets must tolerate concurrent iteration and mutation.
+  private final Set<CommitListener> commitListeners = new CopyOnWriteArraySet<>();
+  private final Set<CommittedPositionListener> committedPositionListeners =
+      new CopyOnWriteArraySet<>();
+  private final Set<AppendedListener> appendedListeners = new CopyOnWriteArraySet<>();
   private final Queue<Runnable> pendingCommits = new ConcurrentLinkedQueue<>();
   private final List<ListLogStorageReader> listLogStorageReaders;
   private final AtomicInteger currentIndex = new AtomicInteger(0);

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
@@ -16,7 +16,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -34,8 +36,10 @@ public class ListLogStorage implements LogStorage {
   private final ConcurrentSkipListMap<Integer, Entry> entries;
   private @Nullable LongConsumer positionListener;
   private final Set<CommitListener> commitListeners = new HashSet<>();
+  private final Queue<Runnable> pendingCommits = new ConcurrentLinkedQueue<>();
   private final List<ListLogStorageReader> listLogStorageReaders;
   private final AtomicInteger currentIndex = new AtomicInteger(0);
+  private volatile boolean deferCommits;
 
   public ListLogStorage() {
     entries = new ConcurrentSkipListMap<Integer, Entry>();
@@ -80,8 +84,16 @@ public class ListLogStorage implements LogStorage {
     if (positionListener != null) {
       positionListener.accept(highestPosition);
     }
-    listener.onCommit(index, highestPosition);
-    commitListeners.forEach(CommitListener::onCommit);
+    final Runnable commit =
+        () -> {
+          listener.onCommit(index, highestPosition);
+          commitListeners.forEach(commitListener -> commitListener.onCommit(highestPosition));
+        };
+    if (deferCommits) {
+      pendingCommits.add(commit);
+    } else {
+      commit.run();
+    }
   }
 
   @Override
@@ -92,6 +104,21 @@ public class ListLogStorage implements LogStorage {
   @Override
   public void removeCommitListener(final CommitListener listener) {
     commitListeners.remove(listener);
+  }
+
+  public void deferCommits() {
+    deferCommits = true;
+  }
+
+  public int pendingCommitCount() {
+    return pendingCommits.size();
+  }
+
+  public void commitPendingEntries() {
+    Runnable pendingCommit;
+    while ((pendingCommit = pendingCommits.poll()) != null) {
+      pendingCommit.run();
+    }
   }
 
   public void reset() {

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
@@ -36,9 +36,11 @@ public class ListLogStorage implements LogStorage {
   private final ConcurrentSkipListMap<Integer, Entry> entries;
   private @Nullable LongConsumer positionListener;
   private final Set<CommitListener> commitListeners = new HashSet<>();
+  private final Set<AppendedListener> appendedListeners = new HashSet<>();
   private final Queue<Runnable> pendingCommits = new ConcurrentLinkedQueue<>();
   private final List<ListLogStorageReader> listLogStorageReaders;
   private final AtomicInteger currentIndex = new AtomicInteger(0);
+  private final AtomicInteger committedIndex = new AtomicInteger(-1);
   private volatile boolean deferCommits;
 
   public ListLogStorage() {
@@ -53,7 +55,14 @@ public class ListLogStorage implements LogStorage {
 
   @Override
   public LogStorageReader newReader() {
-    final ListLogStorageReader listLogStorageReader = new ListLogStorageReader();
+    final ListLogStorageReader listLogStorageReader = new ListLogStorageReader(true);
+    listLogStorageReaders.add(listLogStorageReader);
+    return listLogStorageReader;
+  }
+
+  @Override
+  public LogStorageReader newUncommittedReader() {
+    final ListLogStorageReader listLogStorageReader = new ListLogStorageReader(false);
     listLogStorageReaders.add(listLogStorageReader);
     return listLogStorageReader;
   }
@@ -80,12 +89,14 @@ public class ListLogStorage implements LogStorage {
     entries.put(index, entry);
     positionIndexMapping.put(lowestPosition, index);
     listener.onWrite(index, highestPosition);
+    appendedListeners.forEach(appendedListener -> appendedListener.onAppend(highestPosition));
 
     if (positionListener != null) {
       positionListener.accept(highestPosition);
     }
     final Runnable commit =
         () -> {
+          committedIndex.set(index);
           listener.onCommit(index, highestPosition);
           commitListeners.forEach(commitListener -> commitListener.onCommit(highestPosition));
         };
@@ -104,6 +115,16 @@ public class ListLogStorage implements LogStorage {
   @Override
   public void removeCommitListener(final CommitListener listener) {
     commitListeners.remove(listener);
+  }
+
+  @Override
+  public void addAppendedListener(final AppendedListener listener) {
+    appendedListeners.add(listener);
+  }
+
+  @Override
+  public void removeAppendedListener(final AppendedListener listener) {
+    appendedListeners.remove(listener);
   }
 
   public void deferCommits() {
@@ -134,13 +155,17 @@ public class ListLogStorage implements LogStorage {
 
   private final class ListLogStorageReader implements LogStorageReader {
     final AtomicInteger currentIndex = new AtomicInteger(0);
+    private final boolean committedOnly;
+
+    private ListLogStorageReader(final boolean committedOnly) {
+      this.committedOnly = committedOnly;
+    }
 
     @Override
     public void seek(final long position) {
       currentIndex.set(
           Optional.ofNullable(positionIndexMapping.lowerEntry(position))
               .map(Map.Entry::getValue)
-              //              .map(index -> index - 1)
               .orElse(0));
     }
 
@@ -152,7 +177,10 @@ public class ListLogStorage implements LogStorage {
     @Override
     public boolean hasNext() {
       final var index = currentIndex.get();
-      return index >= 0 && !entries.tailMap(index).isEmpty(); // && currentIndex < entries.size();
+      if (committedOnly && index > committedIndex.get()) {
+        return false;
+      }
+      return index >= 0 && !entries.tailMap(index).isEmpty();
     }
 
     @Override

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
@@ -16,7 +16,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -34,8 +36,11 @@ public class ListLogStorage implements LogStorage {
   private final ConcurrentSkipListMap<Integer, Entry> entries;
   private @Nullable LongConsumer positionListener;
   private final Set<CommitListener> commitListeners = new HashSet<>();
+  private final Set<CommittedPositionListener> committedPositionListeners = new HashSet<>();
+  private final Queue<Runnable> pendingCommits = new ConcurrentLinkedQueue<>();
   private final List<ListLogStorageReader> listLogStorageReaders;
   private final AtomicInteger currentIndex = new AtomicInteger(0);
+  private volatile boolean deferCommits;
 
   public ListLogStorage() {
     entries = new ConcurrentSkipListMap<Integer, Entry>();
@@ -80,8 +85,18 @@ public class ListLogStorage implements LogStorage {
     if (positionListener != null) {
       positionListener.accept(highestPosition);
     }
-    listener.onCommit(index, highestPosition);
-    commitListeners.forEach(CommitListener::onCommit);
+    final Runnable commit =
+        () -> {
+          listener.onCommit(index, highestPosition);
+          commitListeners.forEach(CommitListener::onCommit);
+          committedPositionListeners.forEach(
+              positionListener -> positionListener.onCommittedPosition(highestPosition));
+        };
+    if (deferCommits) {
+      pendingCommits.add(commit);
+    } else {
+      commit.run();
+    }
   }
 
   @Override
@@ -92,6 +107,31 @@ public class ListLogStorage implements LogStorage {
   @Override
   public void removeCommitListener(final CommitListener listener) {
     commitListeners.remove(listener);
+  }
+
+  @Override
+  public void addCommittedPositionListener(final CommittedPositionListener listener) {
+    committedPositionListeners.add(listener);
+  }
+
+  @Override
+  public void removeCommittedPositionListener(final CommittedPositionListener listener) {
+    committedPositionListeners.remove(listener);
+  }
+
+  public void deferCommits() {
+    deferCommits = true;
+  }
+
+  public int pendingCommitCount() {
+    return pendingCommits.size();
+  }
+
+  public void commitPendingEntries() {
+    Runnable pendingCommit;
+    while ((pendingCommit = pendingCommits.poll()) != null) {
+      pendingCommit.run();
+    }
   }
 
   public void reset() {

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
@@ -37,9 +37,11 @@ public class ListLogStorage implements LogStorage {
   private @Nullable LongConsumer positionListener;
   private final Set<CommitListener> commitListeners = new HashSet<>();
   private final Set<CommittedPositionListener> committedPositionListeners = new HashSet<>();
+  private final Set<AppendedListener> appendedListeners = new HashSet<>();
   private final Queue<Runnable> pendingCommits = new ConcurrentLinkedQueue<>();
   private final List<ListLogStorageReader> listLogStorageReaders;
   private final AtomicInteger currentIndex = new AtomicInteger(0);
+  private final AtomicInteger committedIndex = new AtomicInteger(-1);
   private volatile boolean deferCommits;
 
   public ListLogStorage() {
@@ -54,7 +56,14 @@ public class ListLogStorage implements LogStorage {
 
   @Override
   public LogStorageReader newReader() {
-    final ListLogStorageReader listLogStorageReader = new ListLogStorageReader();
+    final ListLogStorageReader listLogStorageReader = new ListLogStorageReader(true);
+    listLogStorageReaders.add(listLogStorageReader);
+    return listLogStorageReader;
+  }
+
+  @Override
+  public LogStorageReader newUncommittedReader() {
+    final ListLogStorageReader listLogStorageReader = new ListLogStorageReader(false);
     listLogStorageReaders.add(listLogStorageReader);
     return listLogStorageReader;
   }
@@ -81,12 +90,14 @@ public class ListLogStorage implements LogStorage {
     entries.put(index, entry);
     positionIndexMapping.put(lowestPosition, index);
     listener.onWrite(index, highestPosition);
+    appendedListeners.forEach(appendedListener -> appendedListener.onAppend(highestPosition));
 
     if (positionListener != null) {
       positionListener.accept(highestPosition);
     }
     final Runnable commit =
         () -> {
+          committedIndex.set(index);
           listener.onCommit(index, highestPosition);
           commitListeners.forEach(CommitListener::onCommit);
           committedPositionListeners.forEach(
@@ -119,6 +130,16 @@ public class ListLogStorage implements LogStorage {
     committedPositionListeners.remove(listener);
   }
 
+  @Override
+  public void addAppendedListener(final AppendedListener listener) {
+    appendedListeners.add(listener);
+  }
+
+  @Override
+  public void removeAppendedListener(final AppendedListener listener) {
+    appendedListeners.remove(listener);
+  }
+
   public void deferCommits() {
     deferCommits = true;
   }
@@ -147,13 +168,17 @@ public class ListLogStorage implements LogStorage {
 
   private final class ListLogStorageReader implements LogStorageReader {
     final AtomicInteger currentIndex = new AtomicInteger(0);
+    private final boolean committedOnly;
+
+    private ListLogStorageReader(final boolean committedOnly) {
+      this.committedOnly = committedOnly;
+    }
 
     @Override
     public void seek(final long position) {
       currentIndex.set(
           Optional.ofNullable(positionIndexMapping.lowerEntry(position))
               .map(Map.Entry::getValue)
-              //              .map(index -> index - 1)
               .orElse(0));
     }
 
@@ -165,7 +190,10 @@ public class ListLogStorage implements LogStorage {
     @Override
     public boolean hasNext() {
       final var index = currentIndex.get();
-      return index >= 0 && !entries.tailMap(index).isEmpty(); // && currentIndex < entries.size();
+      if (committedOnly && index > committedIndex.get()) {
+        return false;
+      }
+      return index >= 0 && !entries.tailMap(index).isEmpty();
     }
 
     @Override

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamRule.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamRule.java
@@ -119,6 +119,11 @@ public final class LogStreamRule extends ExternalResource {
     return logStream;
   }
 
+  /** Exposed so that a test can control when appended entries commit. */
+  public ListLogStorage getLogStorage() {
+    return listLogStorage;
+  }
+
   public ControlledClock getClock() {
     return clock;
   }

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/TestLogStream.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/TestLogStream.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
 import io.camunda.zeebe.logstreams.log.WriteContext;
+import io.camunda.zeebe.logstreams.storage.LogStorage.CommittedPositionListener;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import java.util.List;
@@ -126,6 +127,16 @@ public class TestLogStream implements LogStream {
   @Override
   public void removeRecordAvailableListener(final LogRecordAwaiter recordAwaiter) {
     logStream.removeRecordAvailableListener(recordAwaiter);
+  }
+
+  @Override
+  public void registerCommittedPositionListener(final CommittedPositionListener listener) {
+    logStream.registerCommittedPositionListener(listener);
+  }
+
+  @Override
+  public void removeCommittedPositionListener(final CommittedPositionListener listener) {
+    logStream.removeCommittedPositionListener(listener);
   }
 
   private Either<WriteFailure, Long> syncTryWrite(

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/TestLogStream.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/TestLogStream.java
@@ -100,6 +100,11 @@ public class TestLogStream implements LogStream {
   }
 
   @Override
+  public LogStreamReader newUncommittedLogStreamReader() {
+    return logStream.newUncommittedLogStreamReader();
+  }
+
+  @Override
   public LogStreamWriter newLogStreamWriter() {
     return logStream.newLogStreamWriter();
   }

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/TestLogStream.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/TestLogStream.java
@@ -135,6 +135,16 @@ public class TestLogStream implements LogStream {
   }
 
   @Override
+  public void registerAppendedRecordAvailableListener(final LogRecordAwaiter recordAwaiter) {
+    logStream.registerAppendedRecordAvailableListener(recordAwaiter);
+  }
+
+  @Override
+  public void removeAppendedRecordAvailableListener(final LogRecordAwaiter recordAwaiter) {
+    logStream.removeAppendedRecordAvailableListener(recordAwaiter);
+  }
+
+  @Override
   public void registerCommittedPositionListener(final CommittedPositionListener listener) {
     logStream.registerCommittedPositionListener(listener);
   }

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/TestLogStream.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/TestLogStream.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
 import io.camunda.zeebe.logstreams.log.WriteContext;
+import io.camunda.zeebe.logstreams.storage.LogStorage.CommitListener;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import java.util.List;
@@ -126,6 +127,16 @@ public class TestLogStream implements LogStream {
   @Override
   public void removeRecordAvailableListener(final LogRecordAwaiter recordAwaiter) {
     logStream.removeRecordAvailableListener(recordAwaiter);
+  }
+
+  @Override
+  public void registerCommitListener(final CommitListener listener) {
+    logStream.registerCommitListener(listener);
+  }
+
+  @Override
+  public void removeCommitListener(final CommitListener listener) {
+    logStream.removeCommitListener(listener);
   }
 
   private Either<WriteFailure, Long> syncTryWrite(

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/EmptyProcessingResult.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/EmptyProcessingResult.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.stream.api;
 
 import io.camunda.zeebe.stream.api.records.ImmutableRecordBatch;
 import io.camunda.zeebe.stream.impl.records.RecordBatch;
+import java.util.List;
 import java.util.Optional;
 
 public final class EmptyProcessingResult implements ProcessingResult {
@@ -31,8 +32,8 @@ public final class EmptyProcessingResult implements ProcessingResult {
   }
 
   @Override
-  public boolean executePostCommitTasks() {
-    return true;
+  public List<PostCommitTask> getPostCommitTasks() {
+    return List.of();
   }
 
   @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResult.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResult.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.stream.api;
 
 import io.camunda.zeebe.stream.api.records.ImmutableRecordBatch;
 import io.camunda.zeebe.stream.impl.records.RecordBatchEntry;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -33,9 +34,26 @@ public interface ProcessingResult {
   Optional<ProcessingResponse> getProcessingResponse();
 
   /**
+   * Returns the post-commit tasks that belong to this processing result.
+   *
+   * @return the post-commit tasks to execute once the result is committed
+   */
+  List<PostCommitTask> getPostCommitTasks();
+
+  /**
    * @return <code>false</code> to indicate that the side effect could not be applied successfully
    */
-  boolean executePostCommitTasks();
+  default boolean executePostCommitTasks() {
+    boolean aggregatedResult = true;
+    for (final PostCommitTask task : getPostCommitTasks()) {
+      try {
+        aggregatedResult = aggregatedResult && task.flush();
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return aggregatedResult;
+  }
 
   /**
    * Indicates whether the processing result is empty.

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResult.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResult.java
@@ -40,19 +40,11 @@ public interface ProcessingResult {
    */
   List<PostCommitTask> getPostCommitTasks();
 
-  /**
-   * @return <code>false</code> to indicate that the side effect could not be applied successfully
-   */
-  default boolean executePostCommitTasks() {
-    boolean aggregatedResult = true;
+  /** Executes the post-commit tasks of this processing result. */
+  default void executePostCommitTasks() {
     for (final PostCommitTask task : getPostCommitTasks()) {
-      try {
-        aggregatedResult = aggregatedResult && task.flush();
-      } catch (final Exception e) {
-        throw new RuntimeException(e);
-      }
+      task.flush();
     }
-    return aggregatedResult;
   }
 
   /**

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResult.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResult.java
@@ -41,21 +41,6 @@ public interface ProcessingResult {
   List<PostCommitTask> getPostCommitTasks();
 
   /**
-   * @return <code>false</code> to indicate that the side effect could not be applied successfully
-   */
-  default boolean executePostCommitTasks() {
-    boolean aggregatedResult = true;
-    for (final PostCommitTask task : getPostCommitTasks()) {
-      try {
-        aggregatedResult = aggregatedResult && task.flush();
-      } catch (final Exception e) {
-        throw new RuntimeException(e);
-      }
-    }
-    return aggregatedResult;
-  }
-
-  /**
    * Indicates whether the processing result is empty.
    *
    * @return true if all the following applies:

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/SideEffectProducer.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/SideEffectProducer.java
@@ -14,10 +14,6 @@ package io.camunda.zeebe.stream.api;
 @FunctionalInterface
 public interface SideEffectProducer {
 
-  /**
-   * Applies the side effect.
-   *
-   * @return <code>false</code> to indicate that the side effect could not be applied successfully
-   */
-  boolean flush();
+  /** Applies the side effect. */
+  void flush();
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedResult.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedResult.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.stream.api.ProcessingResult;
 import io.camunda.zeebe.stream.api.records.ImmutableRecordBatch;
 import io.camunda.zeebe.stream.api.scheduling.TaskResult;
 import io.camunda.zeebe.stream.impl.BufferedProcessingResultBuilder.ProcessingResponseImpl;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.jspecify.annotations.Nullable;
@@ -34,7 +33,7 @@ final class BufferedResult implements ProcessingResult, TaskResult {
       final @Nullable ProcessingResponseImpl processingResponse,
       final List<PostCommitTask> postCommitTasks,
       final boolean processInASeparateBatch) {
-    this.postCommitTasks = new ArrayList<>(postCommitTasks);
+    this.postCommitTasks = List.copyOf(postCommitTasks);
     this.processingResponse = processingResponse;
     this.immutableRecordBatch = immutableRecordBatch;
     this.processInASeparateBatch = processInASeparateBatch;
@@ -51,18 +50,8 @@ final class BufferedResult implements ProcessingResult, TaskResult {
   }
 
   @Override
-  public boolean executePostCommitTasks() {
-    boolean aggregatedResult = true;
-
-    for (final PostCommitTask task : postCommitTasks) {
-      try {
-        aggregatedResult = aggregatedResult && task.flush();
-      } catch (final Exception e) {
-        throw new RuntimeException(e);
-      }
-    }
-
-    return aggregatedResult;
+  public List<PostCommitTask> getPostCommitTasks() {
+    return postCommitTasks;
   }
 
   @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -29,7 +29,6 @@ import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.retry.AbortableDelayedRetryStrategy;
-import io.camunda.zeebe.scheduler.retry.AbortableRetryStrategy;
 import io.camunda.zeebe.scheduler.retry.RecoverableRetryStrategy;
 import io.camunda.zeebe.scheduler.retry.RetryStrategy;
 import io.camunda.zeebe.stream.api.EmptyProcessingResult;
@@ -49,7 +48,6 @@ import io.camunda.zeebe.stream.impl.records.TypedRecordImpl;
 import io.camunda.zeebe.stream.impl.records.UnwrittenRecord;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.ExponentialBackoffRetryDelay;
-import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.exception.RecoverableException;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 import java.time.Duration;
@@ -99,7 +97,7 @@ import org.slf4j.Logger;
  *
  * </pre>
  */
-public final class ProcessingStateMachine {
+public final class ProcessingStateMachine implements CloseableSilently {
 
   /**
    * Warn message when the batch processing exceeded the maximum message size. If this message is
@@ -113,8 +111,6 @@ public final class ProcessingStateMachine {
       "Expected to write one or more follow-up records for record '{} {}' without errors, but exception was thrown.";
   private static final String ERROR_MESSAGE_ROLLBACK_ABORTED =
       "Expected to roll back the current transaction for record '{} {}' successfully, but exception was thrown.";
-  private static final String ERROR_MESSAGE_EXECUTE_SIDE_EFFECT_ABORTED =
-      "Expected to execute side effects for record '{} {}' successfully, but exception was thrown.";
   private static final String ERROR_MESSAGE_PROCESSING_FAILED_RETRY_PROCESSING =
       "Expected to process record '{} {}' successfully on stream processor, but caught recoverable exception. Retry processing.";
   private static final String ERROR_MESSAGE_PROCESSING_FAILED_UNRECOVERABLE =
@@ -146,7 +142,6 @@ public final class ProcessingStateMachine {
   private final LogStreamReader logStreamReader;
   private final TransactionContext transactionContext;
   private final RetryStrategy writeRetryStrategy;
-  private final RetryStrategy sideEffectsRetryStrategy;
   private final RetryStrategy updateStateRetryStrategy;
   private final BooleanSupplier shouldProcessNext;
   private final BooleanSupplier abortCondition;
@@ -175,6 +170,7 @@ public final class ProcessingStateMachine {
   private final int maxCommandsInBatch;
   private int processedCommandsCount;
   private final ProcessingMetrics processingMetrics;
+  private final SideEffectRunner sideEffectRunner;
   private final ScheduledCommandCache scheduledCommandCache;
   private volatile ErrorHandlingPhase errorHandlingPhase = ErrorHandlingPhase.NO_ERROR;
   private final ControllableStreamClock clock;
@@ -207,7 +203,6 @@ public final class ProcessingStateMachine {
                 WRITE_RETRY_BACKOFF_MAX_DELAY,
                 WRITE_RETRY_BACKOFF_MIN_DELAY,
                 WRITE_RETRY_BACKOFF_FACTOR));
-    sideEffectsRetryStrategy = new AbortableRetryStrategy(actor);
     updateStateRetryStrategy =
         new RecoverableRetryStrategy(actor, context.getMaxRecoverableRetries());
     this.shouldProcessNext = shouldProcessNext;
@@ -217,6 +212,10 @@ public final class ProcessingStateMachine {
 
     streamProcessorListener = context.getStreamProcessorListener();
     processingMetrics = new ProcessingMetrics(context.getMeterRegistry());
+    sideEffectRunner =
+        new SideEffectRunner(
+            context.getPartitionId(), actor, processingMetrics, context.getCommandResponseWriter());
+    context.getLogStream().registerCommittedPositionListener(sideEffectRunner);
     final EventFilter commandFilter =
         event -> {
           recordTypeDecoder.wrap(event.getMetadata(), event.getMetadataOffset());
@@ -740,68 +739,30 @@ public final class ProcessingStateMachine {
           } else {
             scheduledCommandCache.remove(
                 metadata.getIntent(), requireNonNull(currentRecord).getKey());
-            executeSideEffects();
+            registerSideEffects();
+            markProcessingCompleted();
+            actor.submit(this::tryToReadNextRecord);
           }
         });
   }
 
-  private void executeSideEffects() {
-    final ActorFuture<Boolean> retryFuture =
-        sideEffectsRetryStrategy.runWithRetry(
-            () -> {
-              // TODO refactor this into two parallel tasks, which are then combined, and on the
-              // completion of which the process continues
-              for (final var processingResponse : requireNonNull(pendingResponses)) {
-                final var responseWriter = context.getCommandResponseWriter();
-
-                final var responseValue = processingResponse.responseValue();
-                final var recordMetadata = responseValue.recordMetadata();
-                responseWriter
-                    .intent(recordMetadata.getIntent())
-                    .key(responseValue.key())
-                    .recordType(recordMetadata.getRecordType())
-                    .rejectionReason(BufferUtil.wrapString(recordMetadata.getRejectionReason()))
-                    .rejectionType(recordMetadata.getRejectionType())
-                    .partitionId(context.getPartitionId())
-                    .valueType(recordMetadata.getValueType())
-                    .valueWriter(responseValue.recordValue())
-                    .tryWriteResponse(
-                        processingResponse.requestStreamId(), processingResponse.requestId());
-              }
-              return executePostCommitTasks();
-            },
-            abortCondition);
-
-    actor.runOnCompletion(
-        retryFuture,
-        (bool, throwable) -> {
-          if (throwable != null) {
-            LOG.error(
-                ERROR_MESSAGE_EXECUTE_SIDE_EFFECT_ABORTED, currentRecord, metadata, throwable);
-          }
-
-          notifyProcessedListener(typedCommand);
-
-          // observe the processing duration
-          requireNonNull(processingTimer).close();
-
-          // continue with next record
-          markProcessingCompleted();
-          actor.submit(this::tryToReadNextRecord);
-        });
+  private void registerSideEffects() {
+    final var processedPosition = requireNonNull(currentRecord).getPosition();
+    final var sideEffectPosition =
+        requireNonNull(pendingWrites).isEmpty() ? processedPosition : writtenPosition;
+    sideEffectRunner.addSideEffects(
+        sideEffectPosition,
+        requireNonNull(pendingResponses),
+        requireNonNull(currentProcessingResult).getPostCommitTasks(),
+        () -> notifyProcessedListener(processedPosition));
+    requireNonNull(processingTimer).close();
   }
 
-  private boolean executePostCommitTasks() {
-    try (final var timer = processingMetrics.startBatchProcessingPostCommitTasksTimer()) {
-      return requireNonNull(currentProcessingResult).executePostCommitTasks();
-    }
-  }
-
-  private void notifyProcessedListener(final TypedRecord processedRecord) {
+  private void notifyProcessedListener(final long processedPosition) {
     try {
-      streamProcessorListener.onProcessed(processedRecord);
+      streamProcessorListener.onProcessed(processedPosition);
     } catch (final Exception e) {
-      LOG.error(NOTIFY_PROCESSED_LISTENER_ERROR_MESSAGE, processedRecord, e);
+      LOG.error(NOTIFY_PROCESSED_LISTENER_ERROR_MESSAGE, processedPosition, e);
     }
   }
 
@@ -840,7 +801,13 @@ public final class ProcessingStateMachine {
       lastWrittenPosition = lastProcessingPositions.getLastWrittenPosition();
     }
 
+    sideEffectRunner.onCommittedPosition(lastProcessingPositions.getLastWrittenPosition());
     actor.submit(this::tryToReadNextRecord);
+  }
+
+  @Override
+  public void close() {
+    context.getLogStream().removeCommittedPositionListener(sideEffectRunner);
   }
 
   private void updateErrorHandlingPhase(final ErrorHandlingPhase errorHandlingPhase) {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -180,7 +180,7 @@ public final class ProcessingStateMachine implements CloseableSilently {
     this.scheduledCommandCache = scheduledCommandCache;
     actor = context.getActor();
     recordValues = context.getRecordValues();
-    logStreamReader = context.getLogStreamReader();
+    logStreamReader = context.getProcessingLogStreamReader();
     logStreamWriter = context.getLogStreamWriter();
     transactionContext = context.getTransactionContext();
     abortCondition = context.getAbortCondition();

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -204,11 +204,7 @@ public final class ProcessingStateMachine implements CloseableSilently {
     processingMetrics = new ProcessingMetrics(context.getMeterRegistry());
     sideEffectRunner =
         new SideEffectRunner(
-            context.getPartitionId(),
-            actor,
-            processingMetrics,
-            context.getCommandResponseWriter(),
-            abortCondition);
+            context.getPartitionId(), actor, processingMetrics, context.getCommandResponseWriter());
     context.getLogStream().registerCommitListener(sideEffectRunner);
     final EventFilter commandFilter =
         event -> {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -186,7 +186,7 @@ public final class ProcessingStateMachine implements CloseableSilently {
     this.scheduledCommandCache = scheduledCommandCache;
     actor = context.getActor();
     recordValues = context.getRecordValues();
-    logStreamReader = context.getLogStreamReader();
+    logStreamReader = context.getProcessingLogStreamReader();
     logStreamWriter = context.getLogStreamWriter();
     transactionContext = context.getTransactionContext();
     abortCondition = context.getAbortCondition();

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -29,7 +29,6 @@ import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.retry.AbortableDelayedRetryStrategy;
-import io.camunda.zeebe.scheduler.retry.AbortableRetryStrategy;
 import io.camunda.zeebe.scheduler.retry.RecoverableRetryStrategy;
 import io.camunda.zeebe.scheduler.retry.RetryStrategy;
 import io.camunda.zeebe.stream.api.EmptyProcessingResult;
@@ -49,7 +48,6 @@ import io.camunda.zeebe.stream.impl.records.TypedRecordImpl;
 import io.camunda.zeebe.stream.impl.records.UnwrittenRecord;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.ExponentialBackoffRetryDelay;
-import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.exception.RecoverableException;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 import java.time.Duration;
@@ -99,7 +97,7 @@ import org.slf4j.Logger;
  *
  * </pre>
  */
-public final class ProcessingStateMachine {
+public final class ProcessingStateMachine implements CloseableSilently {
 
   /**
    * Warn message when the batch processing exceeded the maximum message size. If this message is
@@ -113,8 +111,6 @@ public final class ProcessingStateMachine {
       "Expected to write one or more follow-up records for record '{} {}' without errors, but exception was thrown.";
   private static final String ERROR_MESSAGE_ROLLBACK_ABORTED =
       "Expected to roll back the current transaction for record '{} {}' successfully, but exception was thrown.";
-  private static final String ERROR_MESSAGE_EXECUTE_SIDE_EFFECT_ABORTED =
-      "Expected to execute side effects for record '{} {}' successfully, but exception was thrown.";
   private static final String ERROR_MESSAGE_PROCESSING_FAILED_RETRY_PROCESSING =
       "Expected to process record '{} {}' successfully on stream processor, but caught recoverable exception. Retry processing.";
   private static final String ERROR_MESSAGE_PROCESSING_FAILED_UNRECOVERABLE =
@@ -140,7 +136,6 @@ public final class ProcessingStateMachine {
   private final LogStreamReader logStreamReader;
   private final TransactionContext transactionContext;
   private final RetryStrategy writeRetryStrategy;
-  private final RetryStrategy sideEffectsRetryStrategy;
   private final RetryStrategy updateStateRetryStrategy;
   private final BooleanSupplier shouldProcessNext;
   private final BooleanSupplier abortCondition;
@@ -169,6 +164,7 @@ public final class ProcessingStateMachine {
   private final int maxCommandsInBatch;
   private int processedCommandsCount;
   private final ProcessingMetrics processingMetrics;
+  private final SideEffectRunner sideEffectRunner;
   private final ScheduledCommandCache scheduledCommandCache;
   private volatile ErrorHandlingPhase errorHandlingPhase = ErrorHandlingPhase.NO_ERROR;
   private final ControllableStreamClock clock;
@@ -197,7 +193,6 @@ public final class ProcessingStateMachine {
     writeRetryStrategy =
         new AbortableDelayedRetryStrategy(
             actor, new ExponentialBackoffRetryDelay(Duration.ofMillis(50), Duration.ofMillis(1)));
-    sideEffectsRetryStrategy = new AbortableRetryStrategy(actor);
     updateStateRetryStrategy =
         new RecoverableRetryStrategy(actor, context.getMaxRecoverableRetries());
     this.shouldProcessNext = shouldProcessNext;
@@ -207,6 +202,14 @@ public final class ProcessingStateMachine {
 
     streamProcessorListener = context.getStreamProcessorListener();
     processingMetrics = new ProcessingMetrics(context.getMeterRegistry());
+    sideEffectRunner =
+        new SideEffectRunner(
+            context.getPartitionId(),
+            actor,
+            processingMetrics,
+            context.getCommandResponseWriter(),
+            abortCondition);
+    context.getLogStream().registerCommitListener(sideEffectRunner);
     final EventFilter commandFilter =
         event -> {
           recordTypeDecoder.wrap(event.getMetadata(), event.getMetadataOffset());
@@ -730,68 +733,35 @@ public final class ProcessingStateMachine {
           } else {
             scheduledCommandCache.remove(
                 metadata.getIntent(), requireNonNull(currentRecord).getKey());
-            executeSideEffects();
+            registerSideEffects();
+            markProcessingCompleted();
+            actor.submit(this::tryToReadNextRecord);
           }
         });
   }
 
-  private void executeSideEffects() {
-    final ActorFuture<Boolean> retryFuture =
-        sideEffectsRetryStrategy.runWithRetry(
-            () -> {
-              // TODO refactor this into two parallel tasks, which are then combined, and on the
-              // completion of which the process continues
-              for (final var processingResponse : requireNonNull(pendingResponses)) {
-                final var responseWriter = context.getCommandResponseWriter();
-
-                final var responseValue = processingResponse.responseValue();
-                final var recordMetadata = responseValue.recordMetadata();
-                responseWriter
-                    .intent(recordMetadata.getIntent())
-                    .key(responseValue.key())
-                    .recordType(recordMetadata.getRecordType())
-                    .rejectionReason(BufferUtil.wrapString(recordMetadata.getRejectionReason()))
-                    .rejectionType(recordMetadata.getRejectionType())
-                    .partitionId(context.getPartitionId())
-                    .valueType(recordMetadata.getValueType())
-                    .valueWriter(responseValue.recordValue())
-                    .tryWriteResponse(
-                        processingResponse.requestStreamId(), processingResponse.requestId());
-              }
-              return executePostCommitTasks();
-            },
-            abortCondition);
-
-    actor.runOnCompletion(
-        retryFuture,
-        (bool, throwable) -> {
-          if (throwable != null) {
-            LOG.error(
-                ERROR_MESSAGE_EXECUTE_SIDE_EFFECT_ABORTED, currentRecord, metadata, throwable);
-          }
-
-          notifyProcessedListener(typedCommand);
-
-          // observe the processing duration
-          requireNonNull(processingTimer).close();
-
-          // continue with next record
-          markProcessingCompleted();
-          actor.submit(this::tryToReadNextRecord);
-        });
+  private void registerSideEffects() {
+    final var sideEffectPosition =
+        requireNonNull(pendingWrites).isEmpty()
+            ? requireNonNull(currentRecord).getPosition()
+            : writtenPosition;
+    final var processingResult = requireNonNull(currentProcessingResult);
+    final var postCommitTasks = processingResult.getPostCommitTasks();
+    final var processedPosition = requireNonNull(currentRecord).getPosition();
+    final var processingTimer = requireNonNull(this.processingTimer);
+    sideEffectRunner.addSideEffects(
+        sideEffectPosition,
+        requireNonNull(pendingResponses),
+        postCommitTasks,
+        () -> notifyProcessedListener(processedPosition));
+    processingTimer.close();
   }
 
-  private boolean executePostCommitTasks() {
-    try (final var timer = processingMetrics.startBatchProcessingPostCommitTasksTimer()) {
-      return requireNonNull(currentProcessingResult).executePostCommitTasks();
-    }
-  }
-
-  private void notifyProcessedListener(final TypedRecord processedRecord) {
+  private void notifyProcessedListener(final long processedPosition) {
     try {
-      streamProcessorListener.onProcessed(processedRecord);
+      streamProcessorListener.onProcessed(processedPosition);
     } catch (final Exception e) {
-      LOG.error(NOTIFY_PROCESSED_LISTENER_ERROR_MESSAGE, processedRecord, e);
+      LOG.error(NOTIFY_PROCESSED_LISTENER_ERROR_MESSAGE, processedPosition, e);
     }
   }
 
@@ -830,7 +800,13 @@ public final class ProcessingStateMachine {
       lastWrittenPosition = lastProcessingPositions.getLastWrittenPosition();
     }
 
+    sideEffectRunner.onCommit(lastProcessingPositions.getLastWrittenPosition());
     actor.submit(this::tryToReadNextRecord);
+  }
+
+  @Override
+  public void close() {
+    context.getLogStream().removeCommitListener(sideEffectRunner);
   }
 
   private void updateErrorHandlingPhase(final ErrorHandlingPhase errorHandlingPhase) {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
@@ -79,6 +79,7 @@ final class SideEffectRunner implements CommittedPositionListener {
             responses,
             new AggregatePostCommitTask(position, postCommitTasks),
             completionCallback));
+    processingMetrics.setPendingSideEffects(sideEffects.size());
     executeNextSideEffects();
   }
 
@@ -104,6 +105,7 @@ final class SideEffectRunner implements CommittedPositionListener {
 
   private void completeSideEffects(final SideEffects completedSideEffects) {
     sideEffects.remove();
+    processingMetrics.setPendingSideEffects(sideEffects.size());
     executingSideEffects = false;
     completedSideEffects.completionCallback().run();
     executeNextSideEffects();

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
@@ -75,7 +75,10 @@ final class SideEffectRunner implements CommitListener {
       final Runnable completionCallback) {
     sideEffects.add(
         new SideEffects(
-            position, responses, new AggregatePostCommitTask(postCommitTasks), completionCallback));
+            position,
+            responses,
+            new AggregatePostCommitTask(position, postCommitTasks),
+            completionCallback));
     executeNextSideEffects();
   }
 
@@ -92,31 +95,18 @@ final class SideEffectRunner implements CommitListener {
   }
 
   private void executeSideEffects(final SideEffects sideEffects) {
-    try {
-      sendResponses(sideEffects.responses());
-      try (final var timer = processingMetrics.startBatchProcessingPostCommitTasksTimer()) {
-        // The flush result is intentionally ignored: side effects are executed exactly once and
-        // cannot be retried, as a retry could duplicate effects that already partially succeeded.
-        sideEffects.postCommitTask().flush();
-      }
-    } catch (final Exception exception) {
-      LOG.error(
-          "Expected to execute side effects for processing result at position '{}' successfully, but exception was thrown.",
-          sideEffects.position(),
-          exception);
-    } finally {
-      completeSideEffects(sideEffects);
+    sendResponses(sideEffects.responses());
+    try (final var timer = processingMetrics.startBatchProcessingPostCommitTasksTimer()) {
+      sideEffects.postCommitTask().flush();
     }
+    completeSideEffects(sideEffects);
   }
 
   private void completeSideEffects(final SideEffects completedSideEffects) {
     sideEffects.remove();
     executingSideEffects = false;
-    try {
-      completedSideEffects.completionCallback().run();
-    } finally {
-      executeNextSideEffects();
-    }
+    completedSideEffects.completionCallback().run();
+    executeNextSideEffects();
   }
 
   private void sendResponses(final Collection<ProcessingResponse> responses) {
@@ -149,17 +139,27 @@ final class SideEffectRunner implements CommitListener {
    *     allows early garbage collection of the written records. The task list is an immutable
    *     snapshot taken by the processing result when it is built.
    */
-  private static class AggregatePostCommitTask implements PostCommitTask {
+  private static final class AggregatePostCommitTask implements PostCommitTask {
+    private final long position;
     private final List<PostCommitTask> postCommitTasks;
 
-    private AggregatePostCommitTask(final List<PostCommitTask> postCommitTasks) {
+    private AggregatePostCommitTask(
+        final long position, final List<PostCommitTask> postCommitTasks) {
+      this.position = position;
       this.postCommitTasks = postCommitTasks;
     }
 
     @Override
     public void flush() {
       for (final PostCommitTask task : postCommitTasks) {
-        task.flush();
+        try {
+          task.flush();
+        } catch (final Exception e) {
+          LOG.error(
+              "Expected to execute side effects for processing result at position '{}' successfully, but exception was thrown.",
+              position,
+              e);
+        }
       }
     }
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import io.camunda.zeebe.logstreams.storage.LogStorage.CommittedPositionListener;
+import io.camunda.zeebe.scheduler.ActorControl;
+import io.camunda.zeebe.stream.api.CommandResponseWriter;
+import io.camunda.zeebe.stream.api.PostCommitTask;
+import io.camunda.zeebe.stream.api.ProcessingResponse;
+import io.camunda.zeebe.stream.impl.metrics.ProcessingMetrics;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.List;
+import java.util.Queue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs a processing result's side effects as soon as the processing result's entries are committed
+ * by Raft.
+ *
+ * <p>Must run on the Processing State Machine's actor because side effects are not necessarily
+ * thread-safe.
+ */
+final class SideEffectRunner implements CommittedPositionListener {
+  private static final Logger LOG = LoggerFactory.getLogger(SideEffectRunner.class);
+
+  private final int partitionId;
+  private final ActorControl actor;
+  private final ProcessingMetrics processingMetrics;
+  private final CommandResponseWriter responseWriter;
+  private final Queue<SideEffects> sideEffects;
+  private long highestCommittedPosition = StreamProcessor.UNSET_POSITION;
+  private boolean executingSideEffects;
+
+  SideEffectRunner(
+      final int partitionId,
+      final ActorControl actor,
+      final ProcessingMetrics processingMetrics,
+      final CommandResponseWriter responseWriter) {
+    this.actor = actor;
+    this.processingMetrics = processingMetrics;
+    this.responseWriter = responseWriter;
+    this.partitionId = partitionId;
+    sideEffects = new ArrayDeque<>();
+  }
+
+  /**
+   * Executes side effects that have been registered for positions that have been committed. May be
+   * called concurrently.
+   */
+  @Override
+  public void onCommittedPosition(final long highestPosition) {
+    actor.run(
+        () -> {
+          highestCommittedPosition = Math.max(highestCommittedPosition, highestPosition);
+          executeNextSideEffects();
+        });
+  }
+
+  /**
+   * Registers new side effects to run when it's {@link SideEffects#position} is committed. Must be
+   * called sequentially and ordered by {@link SideEffects#position}.
+   */
+  void addSideEffects(
+      final long position,
+      final Collection<ProcessingResponse> responses,
+      final List<PostCommitTask> postCommitTasks,
+      final Runnable completionCallback) {
+    sideEffects.add(
+        new SideEffects(
+            position,
+            responses,
+            new AggregatePostCommitTask(position, postCommitTasks),
+            completionCallback));
+    executeNextSideEffects();
+  }
+
+  private void executeNextSideEffects() {
+    final var nextSideEffects = sideEffects.peek();
+    if (executingSideEffects
+        || nextSideEffects == null
+        || nextSideEffects.position() > highestCommittedPosition) {
+      return;
+    }
+
+    executingSideEffects = true;
+    actor.submit(() -> executeSideEffects(nextSideEffects));
+  }
+
+  private void executeSideEffects(final SideEffects sideEffects) {
+    sendResponses(sideEffects.responses());
+    try (final var timer = processingMetrics.startBatchProcessingPostCommitTasksTimer()) {
+      sideEffects.postCommitTask().flush();
+    }
+    completeSideEffects(sideEffects);
+  }
+
+  private void completeSideEffects(final SideEffects completedSideEffects) {
+    sideEffects.remove();
+    executingSideEffects = false;
+    completedSideEffects.completionCallback().run();
+    executeNextSideEffects();
+  }
+
+  private void sendResponses(final Collection<ProcessingResponse> responses) {
+    for (final var processingResponse : responses) {
+      final var responseValue = processingResponse.responseValue();
+      final var recordMetadata = responseValue.recordMetadata();
+      responseWriter
+          .intent(recordMetadata.getIntent())
+          .key(responseValue.key())
+          .recordType(recordMetadata.getRecordType())
+          .rejectionReason(BufferUtil.wrapString(recordMetadata.getRejectionReason()))
+          .rejectionType(recordMetadata.getRejectionType())
+          .partitionId(partitionId)
+          .valueType(recordMetadata.getValueType())
+          .valueWriter(responseValue.recordValue())
+          .tryWriteResponse(processingResponse.requestStreamId(), processingResponse.requestId());
+    }
+  }
+
+  record SideEffects(
+      long position,
+      Collection<ProcessingResponse> responses,
+      PostCommitTask postCommitTask,
+      Runnable completionCallback) {}
+
+  /**
+   * A holder for many {@link PostCommitTask} that runs all provided tasks together.
+   *
+   * @implNote Static to ensure that the aggregate does not capture the processing result. This
+   *     allows early garbage collection of the written records. The task list is an immutable
+   *     snapshot taken by the processing result when it is built.
+   */
+  private static final class AggregatePostCommitTask implements PostCommitTask {
+    private final long position;
+    private final List<PostCommitTask> postCommitTasks;
+
+    private AggregatePostCommitTask(
+        final long position, final List<PostCommitTask> postCommitTasks) {
+      this.position = position;
+      this.postCommitTasks = postCommitTasks;
+    }
+
+    @Override
+    public boolean flush() {
+      for (final PostCommitTask task : postCommitTasks) {
+        try {
+          task.flush();
+        } catch (final Exception e) {
+          LOG.error(
+              "Expected to execute side effects for processing result at position '{}' successfully, but exception was thrown.",
+              position,
+              e);
+        }
+      }
+      return true;
+    }
+  }
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import io.camunda.zeebe.logstreams.storage.LogStorage.CommitListener;
+import io.camunda.zeebe.scheduler.ActorControl;
+import io.camunda.zeebe.stream.api.CommandResponseWriter;
+import io.camunda.zeebe.stream.api.PostCommitTask;
+import io.camunda.zeebe.stream.api.ProcessingResponse;
+import io.camunda.zeebe.stream.impl.metrics.ProcessingMetrics;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.List;
+import java.util.Queue;
+import java.util.function.BooleanSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs a processing result's side effects as soon as the processing result's entries are committed
+ * by Raft.
+ *
+ * <p>Must run on the Processing State Machine's actor because side effects are not necessarily
+ * thread-safe.
+ */
+final class SideEffectRunner implements CommitListener {
+  private static final long RETRY_DELAY_MILLIS = 1;
+  private static final Logger LOG = Loggers.PROCESSOR_LOGGER;
+  private static final String ERROR_MESSAGE_EXECUTE_SIDE_EFFECT_ABORTED =
+      "Expected to execute side effects for processing result at position '{}' successfully, but exception was thrown.";
+
+  private final int partitionId;
+  private final ActorControl actor;
+  private final ProcessingMetrics processingMetrics;
+  private final CommandResponseWriter responseWriter;
+  private final Queue<SideEffects> sideEffects;
+  private final BooleanSupplier abortCondition;
+  private long highestCommittedPosition = StreamProcessor.UNSET_POSITION;
+  private boolean executingSideEffects;
+
+  SideEffectRunner(
+      final int partitionId,
+      final ActorControl actor,
+      final ProcessingMetrics processingMetrics,
+      final CommandResponseWriter responseWriter,
+      final BooleanSupplier abortCondition) {
+    this.actor = actor;
+    this.processingMetrics = processingMetrics;
+    this.responseWriter = responseWriter;
+    this.abortCondition = abortCondition;
+    this.partitionId = partitionId;
+    sideEffects = new ArrayDeque<>();
+  }
+
+  /**
+   * Executes side effects that have been registered for positions that have been committed. May be
+   * called concurrently.
+   */
+  @Override
+  public void onCommit(final long highestPosition) {
+    actor.run(
+        () -> {
+          highestCommittedPosition = Math.max(highestCommittedPosition, highestPosition);
+          executeNextSideEffects();
+        });
+  }
+
+  /**
+   * Registers new side effects to run when it's {@link SideEffects#position} is committed. Must be
+   * called sequentially and ordered by {@link SideEffects#position}.
+   */
+  void addSideEffects(
+      final long position,
+      final Collection<ProcessingResponse> responses,
+      final List<PostCommitTask> postCommitTasks,
+      final Runnable completionCallback) {
+    sideEffects.add(
+        new SideEffects(
+            position, responses, new AggregatePostCommitTask(postCommitTasks), completionCallback));
+    executeNextSideEffects();
+  }
+
+  private void executeNextSideEffects() {
+    final var nextSideEffects = sideEffects.peek();
+    if (executingSideEffects
+        || nextSideEffects == null
+        || nextSideEffects.position() > highestCommittedPosition) {
+      return;
+    }
+
+    executingSideEffects = true;
+    actor.submit(() -> executeSideEffectsWithRetry(nextSideEffects));
+  }
+
+  private void executeSideEffectsWithRetry(final SideEffects sideEffects) {
+    try {
+      if (executeSideEffects(sideEffects) || abortCondition.getAsBoolean()) {
+        completeSideEffects(sideEffects);
+      } else {
+        actor.schedule(RETRY_DELAY_MILLIS, () -> executeSideEffectsWithRetry(sideEffects));
+      }
+    } catch (final Exception exception) {
+      LOG.error(ERROR_MESSAGE_EXECUTE_SIDE_EFFECT_ABORTED, sideEffects.position(), exception);
+      completeSideEffects(sideEffects);
+    }
+  }
+
+  private void completeSideEffects(final SideEffects completedSideEffects) {
+    sideEffects.remove();
+    executingSideEffects = false;
+    try {
+      completedSideEffects.completionCallback().run();
+    } finally {
+      executeNextSideEffects();
+    }
+  }
+
+  private boolean executeSideEffects(final SideEffects sideEffects) {
+    sendResponses(sideEffects.responses());
+    try (final var timer = processingMetrics.startBatchProcessingPostCommitTasksTimer()) {
+      return sideEffects.postCommitTask().flush();
+    }
+  }
+
+  private void sendResponses(final Collection<ProcessingResponse> responses) {
+    for (final var processingResponse : responses) {
+      final var responseValue = processingResponse.responseValue();
+      final var recordMetadata = responseValue.recordMetadata();
+      responseWriter
+          .intent(recordMetadata.getIntent())
+          .key(responseValue.key())
+          .recordType(recordMetadata.getRecordType())
+          .rejectionReason(BufferUtil.wrapString(recordMetadata.getRejectionReason()))
+          .rejectionType(recordMetadata.getRejectionType())
+          .partitionId(partitionId)
+          .valueType(recordMetadata.getValueType())
+          .valueWriter(responseValue.recordValue())
+          .tryWriteResponse(processingResponse.requestStreamId(), processingResponse.requestId());
+    }
+  }
+
+  record SideEffects(
+      long position,
+      Collection<ProcessingResponse> responses,
+      PostCommitTask postCommitTask,
+      Runnable completionCallback) {}
+
+  /**
+   * A holder for many {@link PostCommitTask} that runs all provided tasks together.
+   *
+   * @implNote Static to ensure that the aggregate does not capture the processing result. This
+   *     allows early garbage collection of the written records. The task list is an immutable
+   *     snapshot taken by the processing result when it is built.
+   */
+  private static class AggregatePostCommitTask implements PostCommitTask {
+    private final List<PostCommitTask> postCommitTasks;
+
+    private AggregatePostCommitTask(final List<PostCommitTask> postCommitTasks) {
+      this.postCommitTasks = postCommitTasks;
+    }
+
+    @Override
+    public boolean flush() {
+      boolean aggregatedResult = true;
+      for (final PostCommitTask task : postCommitTasks) {
+        try {
+          aggregatedResult = aggregatedResult && task.flush();
+        } catch (final Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+      return aggregatedResult;
+    }
+  }
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
@@ -96,9 +96,19 @@ final class SideEffectRunner implements CommittedPositionListener {
   }
 
   private void executeSideEffects(final SideEffects sideEffects) {
-    sendResponses(sideEffects.responses());
-    try (final var timer = processingMetrics.startBatchProcessingPostCommitTasksTimer()) {
-      sideEffects.postCommitTask().flush();
+    try {
+      sendResponses(sideEffects.responses());
+      try (final var timer = processingMetrics.startBatchProcessingPostCommitTasksTimer()) {
+        sideEffects.postCommitTask().flush();
+      }
+    } catch (final Exception e) {
+      // Side effects are best-effort: an exception escaping here would be an uncaught failure in an
+      // actor job, which fails the whole stream processor. It would also leave the queue stuck on
+      // this entry forever, so no later side effect would ever run either.
+      LOG.error(
+          "Expected to execute side effects for processing result at position '{}' successfully, but exception was thrown.",
+          sideEffects.position(),
+          e);
     }
     completeSideEffects(sideEffects);
   }
@@ -113,18 +123,28 @@ final class SideEffectRunner implements CommittedPositionListener {
 
   private void sendResponses(final Collection<ProcessingResponse> responses) {
     for (final var processingResponse : responses) {
-      final var responseValue = processingResponse.responseValue();
-      final var recordMetadata = responseValue.recordMetadata();
-      responseWriter
-          .intent(recordMetadata.getIntent())
-          .key(responseValue.key())
-          .recordType(recordMetadata.getRecordType())
-          .rejectionReason(BufferUtil.wrapString(recordMetadata.getRejectionReason()))
-          .rejectionType(recordMetadata.getRejectionType())
-          .partitionId(partitionId)
-          .valueType(recordMetadata.getValueType())
-          .valueWriter(responseValue.recordValue())
-          .tryWriteResponse(processingResponse.requestStreamId(), processingResponse.requestId());
+      // Isolated per response, like the post-commit tasks: one client that cannot be answered must
+      // not cost the others their response.
+      try {
+        final var responseValue = processingResponse.responseValue();
+        final var recordMetadata = responseValue.recordMetadata();
+        responseWriter
+            .intent(recordMetadata.getIntent())
+            .key(responseValue.key())
+            .recordType(recordMetadata.getRecordType())
+            .rejectionReason(BufferUtil.wrapString(recordMetadata.getRejectionReason()))
+            .rejectionType(recordMetadata.getRejectionType())
+            .partitionId(partitionId)
+            .valueType(recordMetadata.getValueType())
+            .valueWriter(responseValue.recordValue())
+            .tryWriteResponse(processingResponse.requestStreamId(), processingResponse.requestId());
+      } catch (final Exception e) {
+        LOG.error(
+            "Expected to send response for request '{}' on stream '{}', but exception was thrown.",
+            processingResponse.requestId(),
+            processingResponse.requestStreamId(),
+            e);
+      }
     }
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
@@ -67,6 +67,10 @@ final class SideEffectRunner implements CommittedPositionListener {
   /**
    * Registers new side effects to run when it's {@link SideEffects#position} is committed. Must be
    * called sequentially and ordered by {@link SideEffects#position}.
+   *
+   * <p>Unlike {@link #onCommittedPosition(long)} this must be called on {@link #actor}'s thread.
+   * The only caller is the processing state machine, which already runs there, so it touches the
+   * queue directly instead of paying for another actor job per processed record.
    */
   void addSideEffects(
       final long position,

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
@@ -81,7 +81,7 @@ final class SideEffectRunner implements CommittedPositionListener {
         new SideEffects(
             position,
             responses,
-            new AggregatePostCommitTask(position, postCommitTasks),
+            new AggregatePostCommitTask(partitionId, position, postCommitTasks),
             completionCallback));
     processingMetrics.setPendingSideEffects(sideEffects.size());
     executeNextSideEffects();
@@ -110,8 +110,10 @@ final class SideEffectRunner implements CommittedPositionListener {
       // actor job, which fails the whole stream processor. It would also leave the queue stuck on
       // this entry forever, so no later side effect would ever run either.
       LOG.error(
-          "Expected to execute side effects for processing result at position '{}' successfully, but exception was thrown.",
+          "Expected to execute the side effects of the processing result at position '{}' on partition '{}' successfully, but exception was thrown. The result carried {} response(s) and its post-commit tasks.",
           sideEffects.position(),
+          partitionId,
+          sideEffects.responses().size(),
           e);
     }
     completeSideEffects(sideEffects);
@@ -127,11 +129,11 @@ final class SideEffectRunner implements CommittedPositionListener {
 
   private void sendResponses(final Collection<ProcessingResponse> responses) {
     for (final var processingResponse : responses) {
+      final var responseValue = processingResponse.responseValue();
+      final var recordMetadata = responseValue.recordMetadata();
       // Isolated per response, like the post-commit tasks: one client that cannot be answered must
       // not cost the others their response.
       try {
-        final var responseValue = processingResponse.responseValue();
-        final var recordMetadata = responseValue.recordMetadata();
         responseWriter
             .intent(recordMetadata.getIntent())
             .key(responseValue.key())
@@ -144,7 +146,10 @@ final class SideEffectRunner implements CommittedPositionListener {
             .tryWriteResponse(processingResponse.requestStreamId(), processingResponse.requestId());
       } catch (final Exception e) {
         LOG.error(
-            "Expected to send response for request '{}' on stream '{}', but exception was thrown.",
+            "Expected to send response '{}' for key '{}' on partition '{}' to request '{}' of stream '{}', but exception was thrown.",
+            recordMetadata,
+            responseValue.key(),
+            partitionId,
             processingResponse.requestId(),
             processingResponse.requestStreamId(),
             e);
@@ -166,24 +171,33 @@ final class SideEffectRunner implements CommittedPositionListener {
    *     snapshot taken by the processing result when it is built.
    */
   private static final class AggregatePostCommitTask implements PostCommitTask {
+    private final int partitionId;
     private final long position;
     private final List<PostCommitTask> postCommitTasks;
 
     private AggregatePostCommitTask(
-        final long position, final List<PostCommitTask> postCommitTasks) {
+        final int partitionId, final long position, final List<PostCommitTask> postCommitTasks) {
+      this.partitionId = partitionId;
       this.position = position;
       this.postCommitTasks = postCommitTasks;
     }
 
     @Override
     public void flush() {
-      for (final PostCommitTask task : postCommitTasks) {
+      for (int i = 0; i < postCommitTasks.size(); i++) {
         try {
-          task.flush();
+          postCommitTasks.get(i).flush();
         } catch (final Exception e) {
+          // The task is a lambda closed over by its processor, so its class name is the only handle
+          // on which side effect failed. Its index identifies it among the tasks of the same
+          // result.
           LOG.error(
-              "Expected to execute side effects for processing result at position '{}' successfully, but exception was thrown.",
+              "Expected to execute post-commit task {} of {} ('{}') for the processing result at position '{}' on partition '{}' successfully, but exception was thrown.",
+              i + 1,
+              postCommitTasks.size(),
+              postCommitTasks.get(i).getClass().getName(),
               position,
+              partitionId,
               e);
         }
       }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
@@ -18,7 +18,6 @@ import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.List;
 import java.util.Queue;
-import java.util.function.BooleanSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,17 +29,13 @@ import org.slf4j.LoggerFactory;
  * thread-safe.
  */
 final class SideEffectRunner implements CommitListener {
-  private static final long RETRY_DELAY_MILLIS = 1;
-  private static final Logger LOG = Loggers.PROCESSOR_LOGGER;
-  private static final String ERROR_MESSAGE_EXECUTE_SIDE_EFFECT_ABORTED =
-      "Expected to execute side effects for processing result at position '{}' successfully, but exception was thrown.";
+  private static final Logger LOG = LoggerFactory.getLogger(SideEffectRunner.class);
 
   private final int partitionId;
   private final ActorControl actor;
   private final ProcessingMetrics processingMetrics;
   private final CommandResponseWriter responseWriter;
   private final Queue<SideEffects> sideEffects;
-  private final BooleanSupplier abortCondition;
   private long highestCommittedPosition = StreamProcessor.UNSET_POSITION;
   private boolean executingSideEffects;
 
@@ -48,12 +43,10 @@ final class SideEffectRunner implements CommitListener {
       final int partitionId,
       final ActorControl actor,
       final ProcessingMetrics processingMetrics,
-      final CommandResponseWriter responseWriter,
-      final BooleanSupplier abortCondition) {
+      final CommandResponseWriter responseWriter) {
     this.actor = actor;
     this.processingMetrics = processingMetrics;
     this.responseWriter = responseWriter;
-    this.abortCondition = abortCondition;
     this.partitionId = partitionId;
     sideEffects = new ArrayDeque<>();
   }
@@ -95,18 +88,23 @@ final class SideEffectRunner implements CommitListener {
     }
 
     executingSideEffects = true;
-    actor.submit(() -> executeSideEffectsWithRetry(nextSideEffects));
+    actor.submit(() -> executeSideEffects(nextSideEffects));
   }
 
-  private void executeSideEffectsWithRetry(final SideEffects sideEffects) {
+  private void executeSideEffects(final SideEffects sideEffects) {
     try {
-      if (executeSideEffects(sideEffects) || abortCondition.getAsBoolean()) {
-        completeSideEffects(sideEffects);
-      } else {
-        actor.schedule(RETRY_DELAY_MILLIS, () -> executeSideEffectsWithRetry(sideEffects));
+      sendResponses(sideEffects.responses());
+      try (final var timer = processingMetrics.startBatchProcessingPostCommitTasksTimer()) {
+        // The flush result is intentionally ignored: side effects are executed exactly once and
+        // cannot be retried, as a retry could duplicate effects that already partially succeeded.
+        sideEffects.postCommitTask().flush();
       }
     } catch (final Exception exception) {
-      LOG.error(ERROR_MESSAGE_EXECUTE_SIDE_EFFECT_ABORTED, sideEffects.position(), exception);
+      LOG.error(
+          "Expected to execute side effects for processing result at position '{}' successfully, but exception was thrown.",
+          sideEffects.position(),
+          exception);
+    } finally {
       completeSideEffects(sideEffects);
     }
   }
@@ -118,13 +116,6 @@ final class SideEffectRunner implements CommitListener {
       completedSideEffects.completionCallback().run();
     } finally {
       executeNextSideEffects();
-    }
-  }
-
-  private boolean executeSideEffects(final SideEffects sideEffects) {
-    sendResponses(sideEffects.responses());
-    try (final var timer = processingMetrics.startBatchProcessingPostCommitTasksTimer()) {
-      return sideEffects.postCommitTask().flush();
     }
   }
 
@@ -166,16 +157,10 @@ final class SideEffectRunner implements CommitListener {
     }
 
     @Override
-    public boolean flush() {
-      boolean aggregatedResult = true;
+    public void flush() {
       for (final PostCommitTask task : postCommitTasks) {
-        try {
-          aggregatedResult = aggregatedResult && task.flush();
-        } catch (final Exception e) {
-          throw new RuntimeException(e);
-        }
+        task.flush();
       }
-      return aggregatedResult;
     }
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
@@ -150,7 +150,7 @@ final class SideEffectRunner implements CommittedPositionListener {
     }
 
     @Override
-    public boolean flush() {
+    public void flush() {
       for (final PostCommitTask task : postCommitTasks) {
         try {
           task.flush();
@@ -161,7 +161,6 @@ final class SideEffectRunner implements CommittedPositionListener {
               e);
         }
       }
-      return true;
     }
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -296,7 +296,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private void tearDown() {
     closeReplayReader();
     CloseHelper.close(processingLogStreamReader);
-    logStream.removeRecordAvailableListener(this);
+    logStream.removeAppendedRecordAvailableListener(this);
     CloseHelper.close(processingStateMachine);
     CloseHelper.close(replayStateMachine);
     scheduledCommandCache.clear();
@@ -315,7 +315,9 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
             recordProcessors,
             scheduledCommandCache);
 
-    logStream.registerRecordAvailableListener(this);
+    // Processing reads uncommitted records, so it must be woken as soon as records are appended;
+    // the later commit of those same records would tell it nothing new.
+    logStream.registerAppendedRecordAvailableListener(this);
 
     // start reading
     lifecycleAwareListeners.forEach(l -> l.onRecovered(streamProcessorContext));

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -274,6 +274,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private void tearDown() {
     streamProcessorContext.getLogStreamReader().close();
     logStream.removeRecordAvailableListener(this);
+    CloseHelper.close(processingStateMachine);
     CloseHelper.close(replayStateMachine);
     scheduledCommandCache.clear();
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -104,6 +104,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   // processing
   private final StreamProcessorContext streamProcessorContext;
   private @Nullable LogStreamReader logStreamReader;
+  private @Nullable LogStreamReader processingLogStreamReader;
   private @Nullable ProcessingStateMachine processingStateMachine;
   private @Nullable ReplayStateMachine replayStateMachine;
 
@@ -145,8 +146,14 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     final var reader = logStream.newLogStreamReader();
     logStreamReader = reader;
     streamProcessorContext.logStreamReader(reader);
-    final var processingReader = logStream.newUncommittedLogStreamReader();
-    streamProcessorContext.processingLogStreamReader(processingReader);
+    if (!isInReplayOnlyMode()) {
+      // Only the processing state machine reads uncommitted records, and it is never created in
+      // replay-only mode. Since an open reader defers deletion of the segment it sits on, opening
+      // one here would hold on to a segment that nothing ever reads.
+      final var processingReader = logStream.newUncommittedLogStreamReader();
+      processingLogStreamReader = processingReader;
+      streamProcessorContext.processingLogStreamReader(processingReader);
+    }
   }
 
   @Override
@@ -288,7 +295,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   private void tearDown() {
     closeReplayReader();
-    streamProcessorContext.getProcessingLogStreamReader().close();
+    CloseHelper.close(processingLogStreamReader);
     logStream.removeRecordAvailableListener(this);
     CloseHelper.close(processingStateMachine);
     CloseHelper.close(replayStateMachine);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -273,8 +273,21 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     return isOpened() && shouldProcess;
   }
 
+  /**
+   * Closes the reader that replay reads committed records from, at most once. In REPLAY mode replay
+   * never finishes, so this only runs on shutdown; in PROCESSING mode it runs as soon as replay is
+   * done.
+   */
+  private void closeReplayReader() {
+    final var reader = logStreamReader;
+    if (reader != null) {
+      logStreamReader = null;
+      reader.close();
+    }
+  }
+
   private void tearDown() {
-    streamProcessorContext.getLogStreamReader().close();
+    closeReplayReader();
     streamProcessorContext.getProcessingLogStreamReader().close();
     logStream.removeRecordAvailableListener(this);
     CloseHelper.close(processingStateMachine);
@@ -363,6 +376,13 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   }
 
   private void onRecovered(final LastProcessingPositions lastProcessingPositions) {
+    // Replay is the only consumer of the committed reader, and it is done: it is reached only in
+    // PROCESSING mode, where the replay state machine never registers as a record-available
+    // listener and so is never woken again. Leaving the reader open would pin the oldest log
+    // position that any reader still needs, keeping segments (and, in the test log storage, every
+    // appended entry) alive for the lifetime of the partition.
+    closeReplayReader();
+
     final var writer = logStream.newLogStreamWriter();
     streamProcessorContext.logStreamWriter(writer);
     streamProcessorContext.streamProcessorPhase(Phase.PROCESSING);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -145,6 +145,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     final var reader = logStream.newLogStreamReader();
     logStreamReader = reader;
     streamProcessorContext.logStreamReader(reader);
+    final var processingReader = logStream.newUncommittedLogStreamReader();
+    streamProcessorContext.processingLogStreamReader(processingReader);
   }
 
   @Override
@@ -273,6 +275,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   private void tearDown() {
     streamProcessorContext.getLogStreamReader().close();
+    streamProcessorContext.getProcessingLogStreamReader().close();
     logStream.removeRecordAvailableListener(this);
     CloseHelper.close(processingStateMachine);
     CloseHelper.close(replayStateMachine);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -40,6 +40,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private @Nullable LogStream logStream;
   private @Nullable PartitionId partitionId;
   private @Nullable LogStreamReader logStreamReader;
+  private @Nullable LogStreamReader processingLogStreamReader;
   private @Nullable RecordValues recordValues;
   private @Nullable TransactionContext transactionContext;
 
@@ -133,6 +134,17 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
     return this;
   }
 
+  /**
+   * Sets the reader that is used for processing records. In contrast to {@link
+   * #logStreamReader(LogStreamReader)}, this reader may also read records that have not been
+   * committed yet.
+   */
+  public StreamProcessorContext processingLogStreamReader(
+      final LogStreamReader processingLogStreamReader) {
+    this.processingLogStreamReader = processingLogStreamReader;
+    return this;
+  }
+
   public StreamProcessorContext eventCache(final RecordValues recordValues) {
     this.recordValues = recordValues;
     return this;
@@ -181,6 +193,11 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
 
   public LogStreamReader getLogStreamReader() {
     return requireNonNull(logStreamReader);
+  }
+
+  /** Returns the reader used for processing records, which may also read uncommitted records. */
+  public LogStreamReader getProcessingLogStreamReader() {
+    return requireNonNull(processingLogStreamReader);
   }
 
   public RecordValues getRecordValues() {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -191,6 +191,14 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
     return requireNonNull(actor);
   }
 
+  /**
+   * Returns the reader that replay reads committed records from.
+   *
+   * <p>Only valid while replay is running. In {@link StreamProcessorMode#PROCESSING} the stream
+   * processor closes this reader once replay completes, so that it stops pinning log positions that
+   * nothing needs any more. Consumers that outlive replay must use {@link
+   * #getProcessingLogStreamReader()}.
+   */
   public LogStreamReader getLogStreamReader() {
     return requireNonNull(logStreamReader);
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -203,7 +203,12 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
     return requireNonNull(logStreamReader);
   }
 
-  /** Returns the reader used for processing records, which may also read uncommitted records. */
+  /**
+   * Returns the reader used for processing records, which may also read uncommitted records.
+   *
+   * <p>Only set in {@link StreamProcessorMode#PROCESSING}, because replay never reads uncommitted
+   * records.
+   */
   public LogStreamReader getProcessingLogStreamReader() {
     return requireNonNull(processingLogStreamReader);
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorListener.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorListener.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.stream.impl;
 
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
-import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 /**
  * A listener for the {@link StreamProcessor}. Allows retrieving insides of the processing and
@@ -21,9 +20,9 @@ public interface StreamProcessorListener {
   /**
    * Is called when a command is processed.
    *
-   * @param processedCommand the command that is processed
+   * @param processedPosition the position of the command that was processed
    */
-  void onProcessed(TypedRecord<?> processedCommand);
+  void onProcessed(long processedPosition);
 
   /**
    * Is called when a record is skipped and not processed.

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/ProcessingMetrics.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/ProcessingMetrics.java
@@ -33,6 +33,7 @@ public class ProcessingMetrics {
   private static final String ACTION_PROCESSED = "processed";
 
   private final AtomicLong lastProcessedPosition = new AtomicLong();
+  private final AtomicLong pendingSideEffects = new AtomicLong();
   private final Table<ValueType, Intent, Timer> processingDuration = Table.simple();
   private final Map<String, Counter> streamProcessorEvents = new HashMap<>();
 
@@ -48,6 +49,7 @@ public class ProcessingMetrics {
     this.registry = registry;
 
     registerLastProcessedPosition();
+    registerPendingSideEffects();
     batchProcessingDuration = registerTimer(StreamMetricsDoc.BATCH_PROCESSING_DURATION);
     batchProcessingPostCommitTasks =
         registerTimer(StreamMetricsDoc.BATCH_PROCESSING_POST_COMMIT_TASKS);
@@ -124,6 +126,10 @@ public class ProcessingMetrics {
     lastProcessedPosition.set(position);
   }
 
+  public void setPendingSideEffects(final int count) {
+    pendingSideEffects.set(count);
+  }
+
   private DistributionSummary registerBatchProcessingCommands() {
     final DistributionSummary batchProcessingCommands;
     final var commandsDoc = StreamMetricsDoc.BATCH_PROCESSING_COMMANDS;
@@ -155,6 +161,13 @@ public class ProcessingMetrics {
   private void registerLastProcessedPosition() {
     final var meterDoc = StreamMetricsDoc.LAST_PROCESSED_POSITION;
     Gauge.builder(meterDoc.getName(), lastProcessedPosition, AtomicLong::longValue)
+        .description(meterDoc.getDescription())
+        .register(registry);
+  }
+
+  private void registerPendingSideEffects() {
+    final var meterDoc = StreamMetricsDoc.PENDING_SIDE_EFFECTS;
+    Gauge.builder(meterDoc.getName(), pendingSideEffects, AtomicLong::longValue)
         .description(meterDoc.getDescription())
         .register(registry);
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamMetricsDoc.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamMetricsDoc.java
@@ -108,6 +108,27 @@ public enum StreamMetricsDoc implements ExtendedMeterDocumentation {
     }
   },
 
+  /**
+   * Number of processing results whose side effects are queued, waiting for the results to be
+   * committed
+   */
+  PENDING_SIDE_EFFECTS {
+    @Override
+    public String getDescription() {
+      return "Number of processing results whose side effects are queued, waiting for the results to be committed";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.stream.processor.side.effects.pending";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+  },
+
   /** Number of times batch processing failed due to reaching batch limit and was retried */
   BATCH_PROCESSING_RETRIES {
     @Override

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
@@ -79,6 +79,7 @@ public final class StreamPlatform {
   private final StreamProcessorListener mockStreamProcessorListener;
   private TestCommandCache scheduledCommandCache;
   private final InstantSource clock;
+  private MeterRegistry processorMeterRegistry;
 
   public StreamPlatform(
       final Path dataDirectory,
@@ -127,6 +128,11 @@ public final class StreamPlatform {
 
   public CommandResponseWriter getMockCommandResponseWriter() {
     return mockCommandResponseWriter;
+  }
+
+  /** The registry of the stream processor built last, holding its processing metrics. */
+  public MeterRegistry getProcessorMeterRegistry() {
+    return processorMeterRegistry;
   }
 
   public void resetLogContext() {
@@ -290,9 +296,10 @@ public final class StreamPlatform {
       zeebeDb = zeebeDbFactory.createDb(storage.toFile());
     }
 
+    processorMeterRegistry = new SimpleMeterRegistry();
     final var builder =
         StreamProcessor.builder()
-            .meterRegistry(new SimpleMeterRegistry())
+            .meterRegistry(processorMeterRegistry)
             .clock(StreamClock.controllable(clock))
             .logStream(stream)
             .zeebeDb(zeebeDb)

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -750,6 +750,47 @@ public final class StreamProcessorTest {
   }
 
   @Test
+  public void shouldProcessRecordsBeforeTheyAreCommitted() {
+    // given
+    final var logStorage = new ListLogStorage();
+    streamPlatform.setLogContext(streamPlatform.createLogContext(logStorage, 1));
+    logStorage.deferCommits();
+
+    final var postCommitTask = mock(PostCommitTask.class);
+    final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
+    resultBuilder
+        .appendRecord(
+            2,
+            Records.processInstance(2),
+            new RecordMetadata()
+                .recordType(RecordType.EVENT)
+                .intent(ELEMENT_ACTIVATING)
+                .rejectionType(RejectionType.NULL_VAL)
+                .rejectionReason(""))
+        .appendPostCommitTask(postCommitTask);
+    final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(defaultMockedRecordProcessor.process(any(), any())).thenReturn(resultBuilder.build());
+    streamPlatform.startStreamProcessor();
+
+    // when - write a command whose results are not committed yet
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then - the command is processed even though its results are not committed yet
+    verify(defaultMockedRecordProcessor, TIMEOUT).process(any(), any());
+    assertThat(logStorage.pendingCommitCount()).isGreaterThanOrEqualTo(1);
+    verify(postCommitTask, never()).flush();
+    verify(streamPlatform.getMockStreamProcessorListener(), never()).onProcessed(anyLong());
+
+    // when - the command and its results are committed
+    logStorage.commitPendingEntries();
+
+    // then - the side effects run
+    verify(postCommitTask, TIMEOUT).flush();
+    verify(streamPlatform.getMockStreamProcessorListener(), TIMEOUT).onProcessed(anyLong());
+  }
+
+  @Test
   public void shouldLogAndContinueWhenPostCommitTaskThrows() {
     // given
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
@@ -1637,6 +1678,12 @@ public final class StreamProcessorTest {
                     (LogStreamReader) invocation.callRealMethod(), recordUnmapped))
         .when(spyStream)
         .newLogStreamReader();
+    doAnswer(
+            invocation ->
+                new UnmapOnCrossReader(
+                    (LogStreamReader) invocation.callRealMethod(), recordUnmapped))
+        .when(spyStream)
+        .newUncommittedLogStreamReader();
 
     final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
     streamPlatform.buildStreamProcessor(spyStream, true);

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -750,7 +750,7 @@ public final class StreamProcessorTest {
   }
 
   @Test
-  public void shouldNotRepeatPostCommitOnException() throws Exception {
+  public void shouldLogAndContinueWhenPostCommitTaskThrows() {
     // given
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
     final var mockPostCommitTask = mock(PostCommitTask.class);
@@ -772,6 +772,8 @@ public final class StreamProcessorTest {
     // then
     verify(defaultMockedRecordProcessor, TIMEOUT.times(2)).process(any(), any());
     verify(mockPostCommitTask, TIMEOUT.times(1)).flush();
+    verify(streamPlatform.getMockStreamProcessorListener(), TIMEOUT.times(2))
+        .onProcessed(anyLong());
   }
 
   @Test
@@ -788,9 +790,7 @@ public final class StreamProcessorTest {
         };
     // in order to not mark the processing as skipped we need to return a result
     testProcessor.processingResult =
-        new BufferedProcessingResultBuilder((c, s) -> true)
-            .appendPostCommitTask(() -> {})
-            .build();
+        new BufferedProcessingResultBuilder((c, s) -> true).appendPostCommitTask(() -> {}).build();
     doCallRealMethod()
         .doReturn(EmptyProcessingResult.INSTANCE)
         .when(testProcessor)

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -865,6 +865,47 @@ public final class StreamProcessorTest {
   }
 
   @Test
+  public void shouldLogAndContinueWhenSendingResponseThrows() {
+    // given
+    final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    final var mockPostCommitTask = mock(PostCommitTask.class);
+    doThrow(new RuntimeException("expected"))
+        .when(streamPlatform.getMockCommandResponseWriter())
+        .tryWriteResponse(anyInt(), anyLong());
+
+    final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
+    resultBuilder
+        .withResponse(
+            RecordType.EVENT,
+            3,
+            ELEMENT_ACTIVATING,
+            Records.processInstance(1),
+            ValueType.PROCESS_INSTANCE,
+            RejectionType.NULL_VAL,
+            "",
+            1,
+            12)
+        .appendPostCommitTask(mockPostCommitTask);
+    when(defaultMockedRecordProcessor.process(any(), any()))
+        .thenReturn(resultBuilder.build())
+        .thenReturn(EmptyProcessingResult.INSTANCE);
+
+    streamPlatform.startStreamProcessor();
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then a failed response neither skips the remaining side effects of the same result nor stops
+    // the stream processor
+    verify(mockPostCommitTask, TIMEOUT.times(1)).flush();
+    verify(defaultMockedRecordProcessor, TIMEOUT.times(2)).process(any(), any());
+    verify(streamPlatform.getMockStreamProcessorListener(), TIMEOUT.times(2))
+        .onProcessed(anyLong());
+  }
+
+  @Test
   public void shouldUpdateStateOnSuccessfulProcessing() {
     // given
     final var testProcessor = spy(new TestProcessor());

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -49,6 +49,7 @@ import io.camunda.zeebe.stream.api.RecordProcessor;
 import io.camunda.zeebe.stream.api.RecordProcessorContext;
 import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.impl.metrics.StreamMetricsDoc;
 import io.camunda.zeebe.stream.impl.records.RecordBatchEntry;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
 import io.camunda.zeebe.stream.util.RecordToWrite;
@@ -747,6 +748,52 @@ public final class StreamProcessorTest {
     sideEffectOrder.verify(processorListener).onProcessed(1);
     sideEffectOrder.verify(postCommitTask).flush();
     sideEffectOrder.verify(processorListener).onProcessed(2);
+  }
+
+  @Test
+  public void shouldReportPendingSideEffects() {
+    // given
+    final var logStorage = new ListLogStorage();
+    streamPlatform.setLogContext(streamPlatform.createLogContext(logStorage, 1));
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(2)));
+    logStorage.deferCommits();
+
+    final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
+    resultBuilder
+        .appendRecord(
+            3,
+            Records.processInstance(3),
+            new RecordMetadata()
+                .recordType(RecordType.EVENT)
+                .intent(ELEMENT_ACTIVATING)
+                .rejectionType(RejectionType.NULL_VAL)
+                .rejectionReason(""))
+        .appendPostCommitTask(mock(PostCommitTask.class));
+    final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(defaultMockedRecordProcessor.process(any(), any())).thenReturn(resultBuilder.build());
+    streamPlatform.startStreamProcessor();
+
+    // when - both commands are processed but their results are not committed
+    // then - their side effects are reported as pending
+    await("side effects of both processed commands are pending")
+        .untilAsserted(() -> assertThat(pendingSideEffects()).isEqualTo(2));
+
+    // when - the results are committed
+    logStorage.commitPendingEntries();
+
+    // then - no side effects are left pending
+    await("no side effects are pending anymore")
+        .untilAsserted(() -> assertThat(pendingSideEffects()).isZero());
+  }
+
+  private double pendingSideEffects() {
+    return streamPlatform
+        .getProcessorMeterRegistry()
+        .get(StreamMetricsDoc.PENDING_SIDE_EFFECTS.getName())
+        .gauge()
+        .value();
   }
 
   @Test

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -750,6 +750,47 @@ public final class StreamProcessorTest {
   }
 
   @Test
+  public void shouldProcessRecordsBeforeTheyAreCommitted() {
+    // given
+    final var logStorage = new ListLogStorage();
+    streamPlatform.setLogContext(streamPlatform.createLogContext(logStorage, 1));
+    logStorage.deferCommits();
+
+    final var postCommitTask = mock(PostCommitTask.class);
+    final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
+    resultBuilder
+        .appendRecord(
+            2,
+            Records.processInstance(2),
+            new RecordMetadata()
+                .recordType(RecordType.EVENT)
+                .intent(ELEMENT_ACTIVATING)
+                .rejectionType(RejectionType.NULL_VAL)
+                .rejectionReason(""))
+        .appendPostCommitTask(postCommitTask);
+    final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(defaultMockedRecordProcessor.process(any(), any())).thenReturn(resultBuilder.build());
+    streamPlatform.startStreamProcessor();
+
+    // when - write a command whose results are not committed yet
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then - the command is processed even though its results are not committed yet
+    verify(defaultMockedRecordProcessor, TIMEOUT).process(any(), any());
+    assertThat(logStorage.pendingCommitCount()).isGreaterThanOrEqualTo(1);
+    verify(postCommitTask, never()).flush();
+    verify(streamPlatform.getMockStreamProcessorListener(), never()).onProcessed(anyLong());
+
+    // when - the command and its results are committed
+    logStorage.commitPendingEntries();
+
+    // then - the side effects run
+    verify(postCommitTask, TIMEOUT).flush();
+    verify(streamPlatform.getMockStreamProcessorListener(), TIMEOUT).onProcessed(anyLong());
+  }
+
+  @Test
   public void shouldLogAndContinueWhenPostCommitTaskThrows() {
     // given
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
@@ -790,9 +831,7 @@ public final class StreamProcessorTest {
         };
     // in order to not mark the processing as skipped we need to return a result
     testProcessor.processingResult =
-        new BufferedProcessingResultBuilder((c, s) -> true)
-            .appendPostCommitTask(() -> {})
-            .build();
+        new BufferedProcessingResultBuilder((c, s) -> true).appendPostCommitTask(() -> {}).build();
     doCallRealMethod()
         .doReturn(EmptyProcessingResult.INSTANCE)
         .when(testProcessor)
@@ -1639,6 +1678,12 @@ public final class StreamProcessorTest {
                     (LogStreamReader) invocation.callRealMethod(), recordUnmapped))
         .when(spyStream)
         .newLogStreamReader();
+    doAnswer(
+            invocation ->
+                new UnmapOnCrossReader(
+                    (LogStreamReader) invocation.callRealMethod(), recordUnmapped))
+        .when(spyStream)
+        .newUncommittedLogStreamReader();
 
     final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
     streamPlatform.buildStreamProcessor(spyStream, true);

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.db.ZeebeDbTransaction;
 import io.camunda.zeebe.logstreams.impl.log.LoggedEventImpl;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
+import io.camunda.zeebe.logstreams.util.ListLogStorage;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -687,6 +688,70 @@ public final class StreamProcessorTest {
   }
 
   @Test
+  public void shouldExecuteSideEffectsOnlyAfterProcessingResultsAreCommitted() {
+    // given
+    final var logStorage = new ListLogStorage();
+    streamPlatform.setLogContext(streamPlatform.createLogContext(logStorage, 1));
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(2)));
+    logStorage.deferCommits();
+
+    final var postCommitTask = mock(PostCommitTask.class);
+    when(postCommitTask.flush()).thenReturn(true);
+    final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
+    resultBuilder
+        .appendRecord(
+            3,
+            Records.processInstance(3),
+            new RecordMetadata()
+                .recordType(RecordType.EVENT)
+                .intent(ELEMENT_ACTIVATING)
+                .rejectionType(RejectionType.NULL_VAL)
+                .rejectionReason(""))
+        .withResponse(
+            RecordType.EVENT,
+            3,
+            ELEMENT_ACTIVATING,
+            Records.processInstance(3),
+            ValueType.PROCESS_INSTANCE,
+            RejectionType.NULL_VAL,
+            "",
+            1,
+            12)
+        .appendPostCommitTask(postCommitTask);
+    final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(defaultMockedRecordProcessor.process(any(), any())).thenReturn(resultBuilder.build());
+    streamPlatform.startStreamProcessor();
+
+    await("both commands are processed before their results are committed")
+        .untilAsserted(
+            () -> {
+              verify(defaultMockedRecordProcessor, Mockito.times(2)).process(any(), any());
+              assertThat(logStorage.pendingCommitCount()).isEqualTo(2);
+            });
+
+    final var responseWriter = streamPlatform.getMockCommandResponseWriter();
+    final var processorListener = streamPlatform.getMockStreamProcessorListener();
+    verify(postCommitTask, never()).flush();
+    verify(responseWriter, never()).tryWriteResponse(anyInt(), anyLong());
+    verify(processorListener, never()).onProcessed(anyLong());
+
+    // when
+    logStorage.commitPendingEntries();
+
+    // then
+    verify(postCommitTask, TIMEOUT.times(2)).flush();
+    verify(responseWriter, TIMEOUT.times(2)).tryWriteResponse(12, 1);
+    verify(processorListener, TIMEOUT.times(2)).onProcessed(anyLong());
+    final var sideEffectOrder = inOrder(postCommitTask, processorListener);
+    sideEffectOrder.verify(postCommitTask).flush();
+    sideEffectOrder.verify(processorListener).onProcessed(1);
+    sideEffectOrder.verify(postCommitTask).flush();
+    sideEffectOrder.verify(processorListener).onProcessed(2);
+  }
+
+  @Test
   public void shouldRepeatExecutePostCommitTask() {
     // given
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
@@ -694,16 +759,28 @@ public final class StreamProcessorTest {
     when(mockPostCommitTask.flush()).thenReturn(false);
 
     final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
-    resultBuilder.appendPostCommitTask(mockPostCommitTask);
+    resultBuilder
+        .appendRecord(
+            1,
+            Records.processInstance(1),
+            new RecordMetadata()
+                .recordType(RecordType.EVENT)
+                .intent(ELEMENT_ACTIVATING)
+                .rejectionType(RejectionType.NULL_VAL)
+                .rejectionReason(""))
+        .appendPostCommitTask(mockPostCommitTask);
     when(defaultMockedRecordProcessor.process(any(), any())).thenReturn(resultBuilder.build());
 
     streamPlatform.startStreamProcessor();
 
     // when
     streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
         RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
 
     // then
+    verify(defaultMockedRecordProcessor, TIMEOUT.times(2)).process(any(), any());
+    verify(streamPlatform.getMockStreamProcessorListener(), TIMEOUT.times(2)).onSkipped(any());
     verify(mockPostCommitTask, TIMEOUT.atLeast(5)).flush();
   }
 
@@ -1232,7 +1309,7 @@ public final class StreamProcessorTest {
     // then
 
     verify(defaultMockedRecordProcessor, TIMEOUT.times(2)).process(any(), any());
-    verify(mockStreamProcessorListener, TIMEOUT.times(2)).onProcessed(any());
+    verify(mockStreamProcessorListener, TIMEOUT.times(2)).onProcessed(anyLong());
   }
 
   @Test

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -673,7 +673,6 @@ public final class StreamProcessorTest {
     // given
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
     final var mockPostCommitTask = mock(PostCommitTask.class);
-    when(mockPostCommitTask.flush()).thenReturn(true);
     final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
     resultBuilder.appendPostCommitTask(mockPostCommitTask);
     when(defaultMockedRecordProcessor.process(any(), any())).thenReturn(resultBuilder.build());
@@ -698,7 +697,6 @@ public final class StreamProcessorTest {
     logStorage.deferCommits();
 
     final var postCommitTask = mock(PostCommitTask.class);
-    when(postCommitTask.flush()).thenReturn(true);
     final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
     resultBuilder
         .appendRecord(
@@ -752,44 +750,11 @@ public final class StreamProcessorTest {
   }
 
   @Test
-  public void shouldRepeatExecutePostCommitTask() {
-    // given
-    final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
-    final var mockPostCommitTask = mock(PostCommitTask.class);
-    when(mockPostCommitTask.flush()).thenReturn(false);
-
-    final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
-    resultBuilder
-        .appendRecord(
-            1,
-            Records.processInstance(1),
-            new RecordMetadata()
-                .recordType(RecordType.EVENT)
-                .intent(ELEMENT_ACTIVATING)
-                .rejectionType(RejectionType.NULL_VAL)
-                .rejectionReason(""))
-        .appendPostCommitTask(mockPostCommitTask);
-    when(defaultMockedRecordProcessor.process(any(), any())).thenReturn(resultBuilder.build());
-
-    streamPlatform.startStreamProcessor();
-
-    // when
-    streamPlatform.writeBatch(
-        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
-        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
-
-    // then
-    verify(defaultMockedRecordProcessor, TIMEOUT.times(2)).process(any(), any());
-    verify(streamPlatform.getMockStreamProcessorListener(), TIMEOUT.times(2)).onSkipped(any());
-    verify(mockPostCommitTask, TIMEOUT.atLeast(5)).flush();
-  }
-
-  @Test
   public void shouldNotRepeatPostCommitOnException() throws Exception {
     // given
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
     final var mockPostCommitTask = mock(PostCommitTask.class);
-    when(mockPostCommitTask.flush()).thenThrow(new RuntimeException("expected"));
+    doThrow(new RuntimeException("expected")).when(mockPostCommitTask).flush();
 
     final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
     resultBuilder.appendPostCommitTask(mockPostCommitTask);
@@ -824,7 +789,7 @@ public final class StreamProcessorTest {
     // in order to not mark the processing as skipped we need to return a result
     testProcessor.processingResult =
         new BufferedProcessingResultBuilder((c, s) -> true)
-            .appendPostCommitTask(() -> true)
+            .appendPostCommitTask(() -> {})
             .build();
     doCallRealMethod()
         .doReturn(EmptyProcessingResult.INSTANCE)
@@ -1297,7 +1262,7 @@ public final class StreamProcessorTest {
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
 
     final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
-    resultBuilder.appendPostCommitTask(() -> true);
+    resultBuilder.appendPostCommitTask(() -> {});
     when(defaultMockedRecordProcessor.process(any(), any())).thenReturn(resultBuilder.build());
     streamPlatform.startStreamProcessor();
 
@@ -1337,7 +1302,7 @@ public final class StreamProcessorTest {
     final var mockStreamProcessorListener = streamPlatform.getMockStreamProcessorListener();
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
     final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
-    resultBuilder.appendPostCommitTask(() -> true);
+    resultBuilder.appendPostCommitTask(() -> {});
     when(defaultMockedRecordProcessor.process(any(), any())).thenReturn(resultBuilder.build());
     streamPlatform.startStreamProcessor();
 

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.db.ZeebeDbTransaction;
 import io.camunda.zeebe.logstreams.impl.log.LoggedEventImpl;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
+import io.camunda.zeebe.logstreams.util.ListLogStorage;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -687,28 +688,71 @@ public final class StreamProcessorTest {
   }
 
   @Test
-  public void shouldRepeatExecutePostCommitTask() {
+  public void shouldExecuteSideEffectsOnlyAfterProcessingResultsAreCommitted() {
     // given
-    final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
-    final var mockPostCommitTask = mock(PostCommitTask.class);
-    when(mockPostCommitTask.flush()).thenReturn(false);
+    final var logStorage = new ListLogStorage();
+    streamPlatform.setLogContext(streamPlatform.createLogContext(logStorage, 1));
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(2)));
+    logStorage.deferCommits();
 
+    final var postCommitTask = mock(PostCommitTask.class);
+    when(postCommitTask.flush()).thenReturn(true);
     final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
-    resultBuilder.appendPostCommitTask(mockPostCommitTask);
+    resultBuilder
+        .appendRecord(
+            3,
+            Records.processInstance(3),
+            new RecordMetadata()
+                .recordType(RecordType.EVENT)
+                .intent(ELEMENT_ACTIVATING)
+                .rejectionType(RejectionType.NULL_VAL)
+                .rejectionReason(""))
+        .withResponse(
+            RecordType.EVENT,
+            3,
+            ELEMENT_ACTIVATING,
+            Records.processInstance(3),
+            ValueType.PROCESS_INSTANCE,
+            RejectionType.NULL_VAL,
+            "",
+            1,
+            12)
+        .appendPostCommitTask(postCommitTask);
+    final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
     when(defaultMockedRecordProcessor.process(any(), any())).thenReturn(resultBuilder.build());
-
     streamPlatform.startStreamProcessor();
 
+    await("both commands are processed before their results are committed")
+        .untilAsserted(
+            () -> {
+              verify(defaultMockedRecordProcessor, Mockito.times(2)).process(any(), any());
+              assertThat(logStorage.pendingCommitCount()).isEqualTo(2);
+            });
+
+    final var responseWriter = streamPlatform.getMockCommandResponseWriter();
+    final var processorListener = streamPlatform.getMockStreamProcessorListener();
+    verify(postCommitTask, never()).flush();
+    verify(responseWriter, never()).tryWriteResponse(anyInt(), anyLong());
+    verify(processorListener, never()).onProcessed(anyLong());
+
     // when
-    streamPlatform.writeBatch(
-        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+    logStorage.commitPendingEntries();
 
     // then
-    verify(mockPostCommitTask, TIMEOUT.atLeast(5)).flush();
+    verify(postCommitTask, TIMEOUT.times(2)).flush();
+    verify(responseWriter, TIMEOUT.times(2)).tryWriteResponse(12, 1);
+    verify(processorListener, TIMEOUT.times(2)).onProcessed(anyLong());
+    final var sideEffectOrder = inOrder(postCommitTask, processorListener);
+    sideEffectOrder.verify(postCommitTask).flush();
+    sideEffectOrder.verify(processorListener).onProcessed(1);
+    sideEffectOrder.verify(postCommitTask).flush();
+    sideEffectOrder.verify(processorListener).onProcessed(2);
   }
 
   @Test
-  public void shouldNotRepeatPostCommitOnException() throws Exception {
+  public void shouldLogAndContinueWhenPostCommitTaskThrows() {
     // given
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
     final var mockPostCommitTask = mock(PostCommitTask.class);
@@ -730,6 +774,8 @@ public final class StreamProcessorTest {
     // then
     verify(defaultMockedRecordProcessor, TIMEOUT.times(2)).process(any(), any());
     verify(mockPostCommitTask, TIMEOUT.times(1)).flush();
+    verify(streamPlatform.getMockStreamProcessorListener(), TIMEOUT.times(2))
+        .onProcessed(anyLong());
   }
 
   @Test
@@ -1232,7 +1278,7 @@ public final class StreamProcessorTest {
     // then
 
     verify(defaultMockedRecordProcessor, TIMEOUT.times(2)).process(any(), any());
-    verify(mockStreamProcessorListener, TIMEOUT.times(2)).onProcessed(any());
+    verify(mockStreamProcessorListener, TIMEOUT.times(2)).onProcessed(anyLong());
   }
 
   @Test

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -673,7 +673,6 @@ public final class StreamProcessorTest {
     // given
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
     final var mockPostCommitTask = mock(PostCommitTask.class);
-    when(mockPostCommitTask.flush()).thenReturn(true);
     final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
     resultBuilder.appendPostCommitTask(mockPostCommitTask);
     when(defaultMockedRecordProcessor.process(any(), any())).thenReturn(resultBuilder.build());
@@ -698,7 +697,6 @@ public final class StreamProcessorTest {
     logStorage.deferCommits();
 
     final var postCommitTask = mock(PostCommitTask.class);
-    when(postCommitTask.flush()).thenReturn(true);
     final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
     resultBuilder
         .appendRecord(
@@ -756,7 +754,7 @@ public final class StreamProcessorTest {
     // given
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
     final var mockPostCommitTask = mock(PostCommitTask.class);
-    when(mockPostCommitTask.flush()).thenThrow(new RuntimeException("expected"));
+    doThrow(new RuntimeException("expected")).when(mockPostCommitTask).flush();
 
     final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
     resultBuilder.appendPostCommitTask(mockPostCommitTask);
@@ -793,7 +791,7 @@ public final class StreamProcessorTest {
     // in order to not mark the processing as skipped we need to return a result
     testProcessor.processingResult =
         new BufferedProcessingResultBuilder((c, s) -> true)
-            .appendPostCommitTask(() -> true)
+            .appendPostCommitTask(() -> {})
             .build();
     doCallRealMethod()
         .doReturn(EmptyProcessingResult.INSTANCE)
@@ -1266,7 +1264,7 @@ public final class StreamProcessorTest {
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
 
     final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
-    resultBuilder.appendPostCommitTask(() -> true);
+    resultBuilder.appendPostCommitTask(() -> {});
     when(defaultMockedRecordProcessor.process(any(), any())).thenReturn(resultBuilder.build());
     streamPlatform.startStreamProcessor();
 
@@ -1306,7 +1304,7 @@ public final class StreamProcessorTest {
     final var mockStreamProcessorListener = streamPlatform.getMockStreamProcessorListener();
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
     final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
-    resultBuilder.appendPostCommitTask(() -> true);
+    resultBuilder.appendPostCommitTask(() -> {});
     when(defaultMockedRecordProcessor.process(any(), any())).thenReturn(resultBuilder.build());
     streamPlatform.startStreamProcessor();
 


### PR DESCRIPTION
This PR makes two related changes to the stream processor's relationship with the Raft commit index.

### Side effects run after results are committed

A processing result's side effects (command responses, post-commit tasks, and the `onProcessed` flow-control signal) previously ran synchronously right after the state update, before the result's records were committed by Raft. A client could be told success for an effect that never durably happens: if the leader changed before those records reached quorum, they were truncated and the new leader could process the command again — possibly differently, since reprocessing commands is not guaranteed to be deterministic across versions.

Side effects now run asynchronously once the result's records are committed. A `SideEffectRunner` registered as a commit listener executes queued side effects in position order as commits arrive. On recovery it is seeded with the last written position, so failover does not drop or duplicate side effects for committed records.

While auditing whether side effects can actually fail (to justify a retry mechanism), we found that no production side effect can: every implementation is best-effort and never reports failure. The retry loop was dead code, and retrying is unsafe for non-idempotent effects, so side effects now run exactly once and `SideEffectProducer.flush()` returns `void` to prevent new side effects from relying on a retry that no longer exists. Failures of individual post-commit tasks are logged by the aggregate and do not abort the remaining tasks.

### Processing reads uncommitted records

Waiting for the command's commit before processing it, and then for the results' commit before responding, put two sequential quorum round trips on the response path. The stream processor now reads records as soon as they are appended and processes them while they replicate: the response still waits for the results to commit, but the command's own commit is hidden under the processing time, restoring the previous response latency.

The processing reader reads uncommitted records, while replay, exporters, and the snapshot director keep reading committed records only. Replay stays safe because the state is rebuilt from committed records on recovery, so processing records that are later truncated is harmless: the state is discarded and rebuilt from the committed log. The processor is woken when records are appended, not only when they are committed.

Closes #59177
