### PR TITLE
test: retrieve more PIs at once during benchmark data availability check

### DIFF
--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
@@ -219,7 +219,7 @@ public class Starter implements CommandLineRunner {
                       .newProcessInstanceSearchRequest()
                       .filter((f) -> f.processInstanceKey(key -> key.in(listOfStartedInstances)))
                       .sort(ProcessInstanceSort::startDate)
-                      .page(p -> p.limit(100))
+                      .page(p -> p.limit(2500))
                       .send();
 
               return send.thenApply(

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
@@ -17,7 +17,6 @@ import io.camunda.client.api.response.Process;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.response.SearchResponse;
-import io.camunda.client.api.search.sort.ProcessInstanceSort;
 import io.camunda.zeebe.config.LoadTesterProperties;
 import io.camunda.zeebe.config.StarterProperties;
 import io.camunda.zeebe.metrics.ConnectionMonitor;
@@ -218,7 +217,7 @@ public class Starter implements CommandLineRunner {
                   client
                       .newProcessInstanceSearchRequest()
                       .filter((f) -> f.processInstanceKey(key -> key.in(listOfStartedInstances)))
-                      .sort(ProcessInstanceSort::startDate)
+                      .sort(s -> s.startDate().asc())
                       .page(p -> p.limit(2500))
                       .send();
 


### PR DESCRIPTION
so we can hopefully avoid building up a backlog of PIs to check for, which will make data availability seem worse than it might actually be.

On it's own this won't solve data availability issues in benchmarks, but it should help avoid us seeing spurious results (e.g. if there are temporary glitches etc).

## Related issues

refs #43121
