### PR TITLE
fix: exclude profile-gated optimize modules from general unit tests

### DIFF
--- a/.ci/scripts/ci/find-pom-artifactids.py
+++ b/.ci/scripts/ci/find-pom-artifactids.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python3
+
+import os
+import xml.etree.ElementTree as ET
+
+def find_pom_files(start_dir):
+    pom_files = []
+    for root, dirs, files in os.walk(start_dir):
+        if 'pom.xml' in files:
+            pom_files.append(os.path.join(root, 'pom.xml'))
+    return pom_files
+
+def get_artifact_id(pom_path):
+    # Maven POM files use the "http://maven.apache.org/POM/4.0.0" namespace
+    ns = {'m': 'http://maven.apache.org/POM/4.0.0'}
+
+    return ET.parse(pom_path).getroot().find('m:artifactId', ns).text
+
+if __name__ == "__main__":
+    for pom_file in find_pom_files('.'):
+        print(get_artifact_id(pom_file))

--- a/.ci/scripts/ci/setup-general-ut.sh
+++ b/.ci/scripts/ci/setup-general-ut.sh
@@ -1,5 +1,4 @@
-#!/bin/bash -eux
-
+#!/bin/bash
 #
 # Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
 # one or more contributor license agreements. See the NOTICE file distributed
@@ -8,12 +7,15 @@
 # except in compliance with the Camunda License 1.0.
 #
 
+set -euxo pipefail
+
 #### Outputs a list of optimize, operate, tasklist, and zeebe modules that should be skipped in the general unit tests
 #### The skipped modules are run elsewhere. This script ensures that any new modules that are added will be run by general unit test
 
 ### Get list of all modules in monorepo
-# shellcheck disable=SC2016,SC2005,SC2006,SC2046
-rawModuleList=$(echo $(./mvnw -B -q -Dquickly exec:exec -Dexec.executable=echo -Dexec.args='###MODULE_GAV### ${project.artifactId}' 2>/dev/null | grep '###MODULE_GAV### ' | cut -f2 -d' '))
+# shellcheck disable=SC2005,SC2046
+rawModuleList=$(echo $(python3 .ci/scripts/ci/find-pom-artifactids.py))
+echo "Raw module list: $rawModuleList"
 
 # Convert the module list string into an array
 IFS=' ' read -ra items <<< "$rawModuleList"


### PR DESCRIPTION
## Problem

`General / Unit - Back End` failed on `stable/8.8` (INC-6840). It failed while building `optimize/qa/schema-integrity-tests`, which unpacks the current Optimize snapshot (`camunda-optimize:tar.gz:production`) from Nexus in its default build:

```
Could not find artifact io.camunda.optimize:camunda-optimize:tar.gz:production:8.8.34-SNAPSHOT (absent) in camunda-nexus
```

Right after `release-8.8.33` was merged back (bumping the branch to `8.8.34-SNAPSHOT`), that snapshot was not yet published to Nexus, so resolution failed and the job went red. This is the same failure class as INC-5968: a build step resolving a freshly-bumped snapshot from Nexus instead of building it locally.

## Root cause

The General UT job is meant to skip optimize modules (they have dedicated jobs), but the skip list was generated by enumerating reactor modules with `./mvnw -Dquickly exec:exec`. The root `pom.xml` only includes the `optimize` module when `quickly != true`, so under `-Dquickly` the optimize modules were never enumerated, never added to the skip list, and therefore built in general UTs after all — pulling the current Optimize snapshot from Nexus.

## Fix

`main` and `stable/8.9` already avoid this by enumerating modules from the `pom.xml` files on disk (`find-pom-artifactids.py`), which discovers profile-gated modules regardless of active profiles. This PR ports that script and the `setup-general-ut.sh` enumeration **verbatim from `main`**, so `stable/8.8` converges to the same behaviour with no branch-specific drift.

## Validation

- Both files are byte-identical to `main`.
- `bash -n` passes.
- Running `setup-general-ut.sh` with the branch's real `DO_NOT_SKIP` / `EXTRA_SKIP` args now emits `'-:optimize-schema-integrity-tests'` (and its optimize siblings) into `GENERAL_UT_MODULES` → excluded from General UT.
- The module's only intended runner (`optimize-ci-data-upgrade-nightly.yml`) already builds the Optimize distro locally (`install -PrunAssembly`) before `verify`, so it does not rely on Nexus for the current snapshot.

Closes INC-6840. Same class as INC-5968.