### PR TITLE
fix(operate): complete RESOLVE incident when engine returns NOT_FOUND

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/ResolveIncidentHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/ResolveIncidentHandler.java
@@ -9,14 +9,22 @@ package io.camunda.operate.webapp.zeebe.operation;
 
 import static io.camunda.webapps.schema.entities.operation.OperationType.RESOLVE_INCIDENT;
 
+import io.camunda.client.api.command.ClientStatusException;
+import io.camunda.operate.exceptions.PersistenceException;
+import io.camunda.operate.util.OperationsManager;
 import io.camunda.operate.webapp.reader.IncidentReader;
 import io.camunda.operate.webapp.rest.exception.NotFoundException;
+import io.camunda.service.exception.ServiceException;
 import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.incident.ErrorType;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -25,7 +33,10 @@ import org.springframework.stereotype.Component;
 @ConditionalOnRdbmsDisabled
 public class ResolveIncidentHandler extends AbstractOperationHandler implements OperationHandler {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(ResolveIncidentHandler.class);
+
   @Autowired private IncidentReader incidentReader;
+  @Autowired private OperationsManager operationsManager;
 
   @Override
   public void handleWithException(final OperationEntity operation) throws Exception {
@@ -47,7 +58,20 @@ public class ResolveIncidentHandler extends AbstractOperationHandler implements 
     if (errorType != null && errorType.isResolvedViaRetries()) {
       operationServicesAdapter.updateJobRetries(incident.getJobKey(), 1, operation.getId());
     }
-    operationServicesAdapter.resolveIncident(incident.getKey(), operation.getId());
+    try {
+      operationServicesAdapter.resolveIncident(incident.getKey(), operation.getId());
+    } catch (final Exception ex) {
+      if (isIncidentNotFound(ex)) {
+        // Incident already resolved/removed in the engine — desired end-state achieved.
+        LOGGER.debug(
+            "Incident {} no longer exists while processing operation {}; marking completed.",
+            incident.getKey(),
+            operation.getId());
+        completeOperation(operation);
+        return;
+      }
+      throw ex;
+    }
     // mark operation as sent
     markAsSent(operation);
   }
@@ -55,5 +79,33 @@ public class ResolveIncidentHandler extends AbstractOperationHandler implements 
   @Override
   public Set<OperationType> getTypes() {
     return Set.of(RESOLVE_INCIDENT);
+  }
+
+  private void completeOperation(final OperationEntity operation) throws PersistenceException {
+    operationsManager.completeOperation(operation);
+  }
+
+  /**
+   * Whether the failure means the incident is already gone in the engine (idempotent RESOLVE).
+   * Walks cause chain for service-layer and client/gRPC NOT_FOUND rejections.
+   */
+  static boolean isIncidentNotFound(final Throwable error) {
+    Throwable current = error;
+    while (current != null) {
+      if (current instanceof final ServiceException serviceException
+          && serviceException.getStatus() == ServiceException.Status.NOT_FOUND) {
+        return true;
+      }
+      if (current instanceof final ClientStatusException clientStatusException
+          && clientStatusException.getStatusCode() == Status.Code.NOT_FOUND) {
+        return true;
+      }
+      if (current instanceof final StatusRuntimeException statusRuntimeException
+          && statusRuntimeException.getStatus().getCode() == Status.Code.NOT_FOUND) {
+        return true;
+      }
+      current = current.getCause();
+    }
+    return false;
   }
 }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/zeebe/operation/ResolveIncidentHandlerTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/zeebe/operation/ResolveIncidentHandlerTest.java
@@ -7,8 +7,12 @@
  */
 package io.camunda.operate.webapp.zeebe.operation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -20,14 +24,17 @@ import io.camunda.client.impl.command.ResolveIncidentCommandImpl;
 import io.camunda.operate.Metrics;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.property.OperationExecutorProperties;
+import io.camunda.operate.util.OperationsManager;
 import io.camunda.operate.webapp.elasticsearch.writer.BatchOperationWriter;
 import io.camunda.operate.webapp.reader.IncidentReader;
 import io.camunda.operate.webapp.zeebe.operation.adapter.OperateServicesAdapter;
+import io.camunda.service.exception.ServiceException;
 import io.camunda.webapps.schema.entities.incident.ErrorType;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationState;
 import io.camunda.webapps.schema.entities.operation.OperationType;
+import java.util.concurrent.CompletionException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
@@ -51,6 +58,8 @@ public class ResolveIncidentHandlerTest {
   @Mock Metrics metrics;
 
   @Mock OperateProperties operateProperties;
+
+  @Mock OperationsManager operationsManager;
 
   @InjectMocks private ResolveIncidentHandler resolveIncidentHandler;
 
@@ -97,5 +106,71 @@ public class ResolveIncidentHandlerTest {
     verify(operateServicesAdapter, times(1)).resolveIncident(incidentKey, operationId);
     inOrder.verify(operateServicesAdapter).updateJobRetries(jobKey, 1, operationId);
     inOrder.verify(operateServicesAdapter).resolveIncident(incidentKey, operationId);
+    verify(operationsManager, never()).completeOperation(any());
+  }
+
+  @Test
+  public void shouldCompleteWhenIncidentAlreadyGoneInEngine() throws Exception {
+    final Long incidentKey = 123L;
+    final String workerId = "1";
+    when(incidentReader.getIncidentById(incidentKey))
+        .thenReturn(new IncidentEntity().setKey(incidentKey));
+
+    final OperationEntity operationEntity =
+        new OperationEntity()
+            .setType(OperationType.RESOLVE_INCIDENT)
+            .setIncidentKey(incidentKey)
+            .setId("456")
+            .setState(OperationState.LOCKED)
+            .setLockOwner(workerId);
+
+    doThrow(
+            new CompletionException(
+                new ServiceException(
+                    "Expected to resolve incident with key '123', but no such incident was found",
+                    ServiceException.Status.NOT_FOUND)))
+        .when(operateServicesAdapter)
+        .resolveIncident(incidentKey, "456");
+
+    resolveIncidentHandler.handleWithException(operationEntity);
+
+    verify(operationsManager).completeOperation(operationEntity);
+    verify(batchOperationWriter, never()).updateOperation(any());
+  }
+
+  @Test
+  public void shouldRethrowWhenResolveFailsForOtherReason() {
+    final Long incidentKey = 123L;
+    when(incidentReader.getIncidentById(incidentKey))
+        .thenReturn(new IncidentEntity().setKey(incidentKey));
+
+    final OperationEntity operationEntity =
+        new OperationEntity()
+            .setType(OperationType.RESOLVE_INCIDENT)
+            .setIncidentKey(incidentKey)
+            .setId("456")
+            .setState(OperationState.LOCKED)
+            .setLockOwner("1");
+
+    doThrow(
+            new CompletionException(
+                new ServiceException("broker unavailable", ServiceException.Status.UNAVAILABLE)))
+        .when(operateServicesAdapter)
+        .resolveIncident(incidentKey, "456");
+
+    assertThatThrownBy(() -> resolveIncidentHandler.handleWithException(operationEntity))
+        .isInstanceOf(CompletionException.class);
+  }
+
+  @Test
+  public void isIncidentNotFoundRecognizesWrappedServiceException() {
+    final var wrapped =
+        new CompletionException(
+            new ServiceException("no such incident", ServiceException.Status.NOT_FOUND));
+    assertThat(ResolveIncidentHandler.isIncidentNotFound(wrapped)).isTrue();
+    assertThat(
+            ResolveIncidentHandler.isIncidentNotFound(
+                new ServiceException("bad", ServiceException.Status.INVALID_ARGUMENT)))
+        .isFalse();
   }
 }


### PR DESCRIPTION
## Description

When Operate's operation executor runs a `RESOLVE_INCIDENT` operation, the incident may already have been resolved or removed in Zeebe (race with concurrent resolution, exporter lag, etc.). Zeebe rejects the command with `NOT_FOUND`, and the handler previously treated that as a hard failure:

```
Unable to process operation ... Command 'RESOLVE' rejected with code 'NOT_FOUND' ... Will NOT be retried.
```

This change treats engine `NOT_FOUND` on resolve as an idempotent success: the desired end-state (incident gone) is already achieved, so the operation is completed instead of failed. Other rejections continue to fail as before.

Detection covers:
- `ServiceException` with `Status.NOT_FOUND` (services-based adapter / current default path)
- `ClientStatusException` / gRPC `StatusRuntimeException` with `NOT_FOUND` (compatibility client path)

## Checklist

- [x] Bug fix scoped to Operate operation handler on `stable/8.9` (handler removed on `main` after architecture streamlining)
- [ ] Enable backports when necessary — **targets `stable/8.9` directly** (`affects/8.9`); not applicable to `main` (code path gone)

## Related issues

Fixes #59205

## Testing

```
./mvnw -pl operate/webapp test -Dtest=ResolveIncidentHandlerTest
```

Result: `Tests run: 4, Failures: 0, Errors: 0, Skipped: 0`

Added coverage for:
- complete when resolve returns wrapped `ServiceException.NOT_FOUND`
- rethrow for other statuses (e.g. `UNAVAILABLE`)
- existing retries-before-resolve ordering still holds