### PR TITLE
deps: bump identity to 8.10.0-alpha4

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -74,7 +74,7 @@
     <version.httpclient5>5.6.2</version.httpclient5>
     <version.httpcore5>5.4.3</version.httpcore5>
     <version.httpcomponents>4.4.16</version.httpcomponents>
-    <version.identity>8.10.0-alpha3</version.identity>
+    <version.identity>8.10.0-alpha4</version.identity>
     <version.instancio>5.6.0</version.instancio>
     <version.jackson>2.22.1</version.jackson>
     <version.jackson3>3.2.1</version.jackson3>


### PR DESCRIPTION
## Summary
- Bumps `version.identity` from `8.10.0-alpha3` to `8.10.0-alpha4` in `parent/pom.xml`.
- `8.10.0-alpha3` predates camunda/identity#4833 (merged after alpha3 was cut), which adds a Failsafe retry around `RealmUploadInitializationService.disableSystemClients()`/`generateClientSecret()` for the transient `HTTP 403 Forbidden` Identity can hit while bootstrapping a fresh Keycloak realm (Keycloak reports the realm ready before its authorization layer has fully propagated). `8.10.0-alpha4` includes that fix.
- Verified `parent`, `dist`, and `zeebe/qa/integration-tests` all resolve/compile cleanly against the new version.

## Important caveat
Local reproduction of `zeebe/qa/integration-tests`' `GatewayAuthenticationNoneIT` (which boots the real `camunda/identity` image) shows this bump does **not** fully close the flake: under enough Keycloak latency, the in-process retry can still exhaust its ~3s budget, and once that happens, Identity's `createRealm()` realm-exists guard means a container restart can no longer self-heal the way it used to (`.withStartupAttempts(3)`, added in #57833) — it now fails a different, non-recoverable way instead. That deeper idempotency gap is filed separately as #59216 and needs a fix in `camunda/identity`, not here. This PR is still worth taking since it's a strict improvement (narrows the race and matches the current upstream fix), just not a complete fix on its own.

## Test plan
- [x] `./mvnw install -pl parent -am -Dquickly -T1C`
- [x] `./mvnw install -pl dist -am -Dquickly -T1C`
- [x] `./mvnw install -pl zeebe/qa/integration-tests -am -Dquickly -T1C`
- [x] `./mvnw license:format spotless:apply -T1C -pl parent` (no changes needed)
- [ ] CI: watch `GatewayAuthenticationNoneIT` — may still be flaky per the caveat above until #59216 is resolved upstream

Relates to #59216

🤖 Generated with [Claude Code](https://claude.com/claude-code)