### PR TITLE
deps: bump management identity to 8.10.0-alpha4.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -74,7 +74,7 @@
     <version.httpclient5>5.6.2</version.httpclient5>
     <version.httpcore5>5.4.3</version.httpcore5>
     <version.httpcomponents>4.4.16</version.httpcomponents>
-    <version.identity>8.10.0-alpha4</version.identity>
+    <version.identity>8.10.0-alpha4.1</version.identity>
     <version.instancio>5.6.0</version.instancio>
     <version.jackson>2.22.1</version.jackson>
     <version.jackson3>3.2.1</version.jackson3>


### PR DESCRIPTION
## Summary
- Bumps `version.identity` from `8.10.0-alpha4` to `8.10.0-alpha4.1` in `parent/pom.xml`, targeting the `release-8.10.0-alpha4` release branch.
- Prep work for the upcoming Management Identity (`camunda/identity`) `8.10.0-alpha4.1` patch release, which is still being built.

## Test plan
- [x] `./mvnw license:format spotless:apply -T1C -pl parent` (no changes needed)
- [ ] CI: expected red until `8.10.0-alpha4.1` is published; re-run once the artifact is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)