### PR TITLE
test: backend integration tests for Business Value Dashboard

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/BusinessValueInstanceFixtures.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/BusinessValueInstanceFixtures.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize;
+
+import static io.camunda.optimize.service.util.importing.ZeebeConstants.FLOW_NODE_TYPE_BUSINESS_RULE_TASK;
+import static io.camunda.optimize.service.util.importing.ZeebeConstants.FLOW_NODE_TYPE_MANUAL_TASK;
+import static io.camunda.optimize.service.util.importing.ZeebeConstants.FLOW_NODE_TYPE_SCRIPT_TASK;
+import static io.camunda.optimize.service.util.importing.ZeebeConstants.FLOW_NODE_TYPE_SEND_TASK;
+import static io.camunda.optimize.service.util.importing.ZeebeConstants.FLOW_NODE_TYPE_SERVICE_TASK;
+import static io.camunda.optimize.service.util.importing.ZeebeConstants.FLOW_NODE_TYPE_USER_TASK;
+
+import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
+import io.camunda.optimize.dto.optimize.query.process.FlowNodeInstanceDto;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Test-data builders for the Business Value Dashboard integration tests. Kept in the {@code
+ * io.camunda.optimize} package so the static factories can reach the {@code protected static
+ * AbstractBrokerlessZeebeCCSMIT#completedInstance} base builder without inheriting from it,
+ * mirroring {@link AgenticInstanceFixtures}.
+ */
+public final class BusinessValueInstanceFixtures {
+
+  private static final String STRUCTURAL_GATEWAY = "exclusiveGateway";
+  private static final String STRUCTURAL_START_EVENT = "startEvent";
+  private static final String STRUCTURAL_END_EVENT = "endEvent";
+
+  private BusinessValueInstanceFixtures() {}
+
+  /**
+   * Builds a completed instance with the given execution duration (ms). Used by the cycle-time
+   * tiles that assert on {@code DURATION}-view averages/percentiles.
+   */
+  public static ProcessInstanceDto.ProcessInstanceDtoBuilder bvdInstanceWithDuration(
+      final String processDefinitionKey, final long durationMs) {
+    return AbstractBrokerlessZeebeCCSMIT.completedInstance(processDefinitionKey)
+        .duration(durationMs);
+  }
+
+  /**
+   * Builds a completed instance carrying the given flow-node instances. Each flow-node inherits the
+   * instance's process-definition key/version/tenant so the nested aggregation joins correctly with
+   * the parent process instance.
+   */
+  public static ProcessInstanceDto bvdInstanceWithFlowNodes(
+      final String processDefinitionKey, final String... flowNodeTypes) {
+    final ProcessInstanceDto instance =
+        AbstractBrokerlessZeebeCCSMIT.completedInstance(processDefinitionKey).build();
+    final List<FlowNodeInstanceDto> nodes =
+        Arrays.stream(flowNodeTypes).map(type -> flowNode(instance, type)).toList();
+    instance.setFlowNodeInstances(nodes);
+    return instance;
+  }
+
+  public static String serviceTaskNode() {
+    return FLOW_NODE_TYPE_SERVICE_TASK;
+  }
+
+  public static String businessRuleTaskNode() {
+    return FLOW_NODE_TYPE_BUSINESS_RULE_TASK;
+  }
+
+  public static String scriptTaskNode() {
+    return FLOW_NODE_TYPE_SCRIPT_TASK;
+  }
+
+  public static String sendTaskNode() {
+    return FLOW_NODE_TYPE_SEND_TASK;
+  }
+
+  public static String userTaskNode() {
+    return FLOW_NODE_TYPE_USER_TASK;
+  }
+
+  public static String manualTaskNode() {
+    return FLOW_NODE_TYPE_MANUAL_TASK;
+  }
+
+  public static String gatewayNode() {
+    return STRUCTURAL_GATEWAY;
+  }
+
+  public static String startEventNode() {
+    return STRUCTURAL_START_EVENT;
+  }
+
+  public static String endEventNode() {
+    return STRUCTURAL_END_EVENT;
+  }
+
+  private static FlowNodeInstanceDto flowNode(
+      final ProcessInstanceDto parent, final String flowNodeType) {
+    final FlowNodeInstanceDto node = new FlowNodeInstanceDto();
+    node.setFlowNodeInstanceId(UUID.randomUUID().toString());
+    node.setFlowNodeId(flowNodeType + "-" + UUID.randomUUID());
+    node.setFlowNodeType(flowNodeType);
+    node.setProcessInstanceId(parent.getProcessInstanceId());
+    node.setDefinitionKey(parent.getProcessDefinitionKey());
+    node.setDefinitionVersion(parent.getProcessDefinitionVersion());
+    node.setTenantId(parent.getTenantId());
+    return node;
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/BusinessValueAgenticPresenceTileIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/BusinessValueAgenticPresenceTileIT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.dashboard;
+
+import static io.camunda.optimize.AgenticInstanceFixtures.agenticInstanceWithTokens;
+import static io.camunda.optimize.BusinessValueInstanceFixtures.bvdInstanceWithDuration;
+import static io.camunda.optimize.service.dashboard.AgenticReportFilters.noExtraFilters;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.AGENT_PRESENCE_BY_PROCESS_REPORT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.query.report.single.result.hyper.MapResultEntryDto;
+import io.camunda.optimize.service.report.ReportEvaluationService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Evaluates the agentic-presence tile, which combines {@code AGENT_INSTANCE TOTAL_TOKENS SUM} view
+ * with the {@code hasAgentInstances()} filter — so non-agentic instances must be excluded even when
+ * they belong to the same process definition key.
+ */
+class BusinessValueAgenticPresenceTileIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private AgenticReportEvaluator reports;
+
+  @BeforeEach
+  void setUp() {
+    embeddedOptimizeExtension.getBean(BusinessValueDashboardService.class).reconcile();
+    reports =
+        new AgenticReportEvaluator(
+            embeddedOptimizeExtension.getBean(ReportEvaluationService.class));
+  }
+
+  @Test
+  void shouldExcludeNonAgenticInstancesFromAgenticPresenceTile() {
+    // given two agentic processes with different token totals, and one plain non-agentic process
+    final String agentA = "agentic-a";
+    final String agentB = "agentic-b";
+    final String plain = "non-agentic";
+    persistProcessInstances(
+        List.of(
+            agenticInstanceWithTokens(agentA, 100L, 50L).build(),
+            agenticInstanceWithTokens(agentB, 200L, 100L).build(),
+            bvdInstanceWithDuration(plain, 1_000L).build()));
+
+    // when evaluating the agent-presence-by-process tile
+    final List<MapResultEntryDto> result =
+        reports.evaluateMapData(AGENT_PRESENCE_BY_PROCESS_REPORT_ID, noExtraFilters());
+
+    // then only the two agentic processes appear — the tile's hasAgentInstances filter drops the
+    // plain process even though it is a completed instance
+    assertThat(result)
+        .extracting(MapResultEntryDto::getKey)
+        .containsExactlyInAnyOrder(agentA, agentB);
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/BusinessValueAutomationRateTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/BusinessValueAutomationRateTilesIT.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.dashboard;
+
+import static io.camunda.optimize.BusinessValueInstanceFixtures.businessRuleTaskNode;
+import static io.camunda.optimize.BusinessValueInstanceFixtures.bvdInstanceWithFlowNodes;
+import static io.camunda.optimize.BusinessValueInstanceFixtures.endEventNode;
+import static io.camunda.optimize.BusinessValueInstanceFixtures.gatewayNode;
+import static io.camunda.optimize.BusinessValueInstanceFixtures.manualTaskNode;
+import static io.camunda.optimize.BusinessValueInstanceFixtures.scriptTaskNode;
+import static io.camunda.optimize.BusinessValueInstanceFixtures.sendTaskNode;
+import static io.camunda.optimize.BusinessValueInstanceFixtures.serviceTaskNode;
+import static io.camunda.optimize.BusinessValueInstanceFixtures.startEventNode;
+import static io.camunda.optimize.BusinessValueInstanceFixtures.userTaskNode;
+import static io.camunda.optimize.service.dashboard.AgenticReportFilters.noExtraFilters;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.AUTOMATION_RATE_AGGREGATE_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.AUTOMATION_RATE_BY_PROCESS_REPORT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.query.report.single.result.hyper.MapResultEntryDto;
+import io.camunda.optimize.service.report.ReportEvaluationService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the automation-rate view interpreter end-to-end through the seeded BVD tiles. The
+ * interpreter counts flow-node instances of automated task types (serviceTask, businessRuleTask,
+ * scriptTask, sendTask) and human task types (userTask, manualTask); structural elements (events,
+ * gateways, containers) are excluded from both sides of the ratio. These tests seed distinct
+ * flow-node distributions and assert on the ratio the tile actually returns — the aggregation
+ * internals are covered separately by {@code ProcessViewAutomationRateInterpreterES|OSTest}.
+ */
+class BusinessValueAutomationRateTilesIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private AgenticReportEvaluator reports;
+
+  @BeforeEach
+  void setUp() {
+    embeddedOptimizeExtension.getBean(BusinessValueDashboardService.class).reconcile();
+    reports =
+        new AgenticReportEvaluator(
+            embeddedOptimizeExtension.getBean(ReportEvaluationService.class));
+  }
+
+  @Test
+  void shouldReturnHundredPercentWhenAllTasksAreAutomated() {
+    // given an instance whose task-typed flow-nodes cover every automated task type
+    final String procKey = "auto-full";
+    persistProcessInstances(
+        List.of(
+            bvdInstanceWithFlowNodes(
+                procKey,
+                serviceTaskNode(),
+                businessRuleTaskNode(),
+                scriptTaskNode(),
+                sendTaskNode())));
+
+    // then aggregate automation rate is 100 %
+    assertThat(reports.evaluateNumber(AUTOMATION_RATE_AGGREGATE_REPORT_ID, noExtraFilters()))
+        .isEqualTo(100.0);
+  }
+
+  @Test
+  void shouldReturnZeroPercentWhenAllTasksAreHuman() {
+    // given an instance whose task-typed flow-nodes are only user/manual tasks
+    final String procKey = "auto-none";
+    persistProcessInstances(
+        List.of(bvdInstanceWithFlowNodes(procKey, userTaskNode(), manualTaskNode())));
+
+    // then aggregate automation rate is 0 % — distinct from null (which means "no task nodes")
+    assertThat(reports.evaluateNumber(AUTOMATION_RATE_AGGREGATE_REPORT_ID, noExtraFilters()))
+        .isEqualTo(0.0);
+  }
+
+  @Test
+  void shouldReturnMixedRatioAcrossAutomatedAndHumanTasks() {
+    // given four task flow-nodes: three automated, one human
+    final String procKey = "auto-mixed";
+    persistProcessInstances(
+        List.of(
+            bvdInstanceWithFlowNodes(
+                procKey, serviceTaskNode(), serviceTaskNode(), serviceTaskNode(), userTaskNode())));
+
+    // then aggregate automation rate is 75 % — 3 automated / (3 + 1) * 100
+    assertThat(reports.evaluateNumber(AUTOMATION_RATE_AGGREGATE_REPORT_ID, noExtraFilters()))
+        .isEqualTo(75.0);
+  }
+
+  @Test
+  void shouldIgnoreStructuralNodesWhenComputingRatio() {
+    // given instances that include gateways and events alongside a single automated task
+    final String procKey = "auto-structural";
+    persistProcessInstances(
+        List.of(
+            bvdInstanceWithFlowNodes(
+                procKey, startEventNode(), gatewayNode(), serviceTaskNode(), endEventNode())));
+
+    // then only the automated task is counted — the ratio ignores structural nodes entirely
+    assertThat(reports.evaluateNumber(AUTOMATION_RATE_AGGREGATE_REPORT_ID, noExtraFilters()))
+        .isEqualTo(100.0);
+  }
+
+  @Test
+  void shouldReturnNullWhenNoTaskFlowNodesArePresent() {
+    // given an instance whose flow-nodes are all structural (no service/user/manual/...)
+    final String procKey = "auto-structural-only";
+    persistProcessInstances(
+        List.of(
+            bvdInstanceWithFlowNodes(procKey, startEventNode(), gatewayNode(), endEventNode())));
+
+    // then aggregate automation rate is null — the frontend renders "—" instead of a misleading 0 %
+    assertThat(reports.evaluateNumber(AUTOMATION_RATE_AGGREGATE_REPORT_ID, noExtraFilters()))
+        .isNull();
+  }
+
+  @Test
+  void shouldReturnNullWhenNoInstancesExist() {
+    // given no completed instances at all — the reconcile ran but nothing was seeded
+
+    // then aggregate automation rate is null
+    assertThat(reports.evaluateNumber(AUTOMATION_RATE_AGGREGATE_REPORT_ID, noExtraFilters()))
+        .isNull();
+  }
+
+  @Test
+  void shouldRankProcessesByAutomationRateDescForPerProcessTile() {
+    // given three processes with clearly separated automation rates
+    final String allAutomated = "rank-100";
+    final String half = "rank-50";
+    final String mostlyHuman = "rank-25";
+    persistProcessInstances(
+        List.of(
+            bvdInstanceWithFlowNodes(allAutomated, serviceTaskNode(), serviceTaskNode()),
+            bvdInstanceWithFlowNodes(half, serviceTaskNode(), userTaskNode()),
+            bvdInstanceWithFlowNodes(
+                mostlyHuman, serviceTaskNode(), userTaskNode(), userTaskNode(), userTaskNode())));
+
+    // when evaluating the per-process automation rate tile
+    final List<MapResultEntryDto> result =
+        reports.evaluateMapData(AUTOMATION_RATE_BY_PROCESS_REPORT_ID, noExtraFilters());
+
+    // then all three processes appear with the expected rates, sorted DESC
+    assertThat(result)
+        .extracting(MapResultEntryDto::getKey, MapResultEntryDto::getValue)
+        .containsExactly(tuple(allAutomated, 100.0), tuple(half, 50.0), tuple(mostlyHuman, 25.0));
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/BusinessValueCycleTimeTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/BusinessValueCycleTimeTilesIT.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.dashboard;
+
+import static io.camunda.optimize.BusinessValueInstanceFixtures.bvdInstanceWithDuration;
+import static io.camunda.optimize.service.dashboard.AgenticReportFilters.noExtraFilters;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.DURATION_AVG_TOTAL_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.DURATION_BY_DATE_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.DURATION_BY_PROCESS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.DURATION_PERCENTILES_REPORT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.query.report.single.result.hyper.MapResultEntryDto;
+import io.camunda.optimize.service.report.ReportEvaluationService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Evaluates the L0-cycleTime / L1-overview duration tiles. Covers average/percentile aggregation
+ * over synthetic completed instances so a regression in {@code PROCESS_INSTANCE DURATION} view math
+ * fails a targeted assertion.
+ */
+class BusinessValueCycleTimeTilesIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private AgenticReportEvaluator reports;
+
+  @BeforeEach
+  void setUp() {
+    embeddedOptimizeExtension.getBean(BusinessValueDashboardService.class).reconcile();
+    reports =
+        new AgenticReportEvaluator(
+            embeddedOptimizeExtension.getBean(ReportEvaluationService.class));
+  }
+
+  @Test
+  void shouldReturnArithmeticMeanForDurationAvgTotal() {
+    // given three completed instances with distinct durations
+    final String procKey = "cyc-avg-total";
+    persistProcessInstances(
+        List.of(
+            bvdInstanceWithDuration(procKey, 1_000L).build(),
+            bvdInstanceWithDuration(procKey, 3_000L).build(),
+            bvdInstanceWithDuration(procKey, 5_000L).build()));
+
+    // when evaluating the aggregate cycle-time tile
+    // then the AVERAGE aggregation returns the arithmetic mean
+    assertThat(reports.evaluateNumber(DURATION_AVG_TOTAL_REPORT_ID, noExtraFilters()))
+        .isEqualTo(3_000.0);
+  }
+
+  @Test
+  void shouldReturnPerProcessAverageDurationsSortedDesc() {
+    // given three processes with clearly separated averages
+    final String slow = "cyc-proc-slow";
+    final String mid = "cyc-proc-mid";
+    final String fast = "cyc-proc-fast";
+    persistProcessInstances(
+        List.of(
+            bvdInstanceWithDuration(slow, 10_000L).build(),
+            bvdInstanceWithDuration(slow, 10_000L).build(),
+            bvdInstanceWithDuration(mid, 5_000L).build(),
+            bvdInstanceWithDuration(mid, 5_000L).build(),
+            bvdInstanceWithDuration(fast, 1_000L).build()));
+
+    // when evaluating the per-process duration tile
+    final List<MapResultEntryDto> result =
+        reports.evaluateMapData(DURATION_BY_PROCESS_REPORT_ID, noExtraFilters());
+
+    // then all three processes appear with the expected averages, sorted DESC by duration
+    assertThat(result)
+        .extracting(MapResultEntryDto::getKey, MapResultEntryDto::getValue)
+        .containsExactly(tuple(slow, 10_000.0), tuple(mid, 5_000.0), tuple(fast, 1_000.0));
+  }
+
+  @Test
+  void shouldEvaluatePercentilesTileEndToEnd() {
+    // given 10 evenly-spaced durations so the AVG measure is deterministic (5_500 = mean of
+    // 1..10 * 1_000). The tile is a NUMBER visualization with three multi-aggregation measures
+    // (AVG, P50, P95); AgenticReportEvaluator#evaluateNumber returns the first measure (AVG).
+    // Asserting on that value proves the percentile-configured tile evaluates end-to-end;
+    // the P50/P95 measure shapes are covered by the unit tests on the aggregation classes.
+    final String procKey = "cyc-percentiles";
+    persistProcessInstances(
+        java.util.stream.LongStream.rangeClosed(1, 10)
+            .mapToObj(i -> bvdInstanceWithDuration(procKey, i * 1_000L).build())
+            .toList());
+
+    // then the AVG measure returns the arithmetic mean of the seeded durations
+    assertThat(reports.evaluateNumber(DURATION_PERCENTILES_REPORT_ID, noExtraFilters()))
+        .isEqualTo(5_500.0);
+  }
+
+  @Test
+  void shouldReturnAverageDurationPerDateBucketForDurationByDateTile() {
+    // given two completed instances that ended on separate days with distinct durations
+    final String procKey = "cyc-by-date";
+    final java.time.OffsetDateTime now = java.time.OffsetDateTime.now();
+    persistProcessInstances(
+        List.of(
+            bvdInstanceWithDuration(procKey, 2_000L)
+                .startDate(now.minusDays(1).minusHours(1))
+                .endDate(now.minusDays(1))
+                .build(),
+            bvdInstanceWithDuration(procKey, 6_000L)
+                .startDate(now.minusDays(2).minusHours(1))
+                .endDate(now.minusDays(2))
+                .build()));
+
+    // when evaluating the cycle-time history tile
+    final List<MapResultEntryDto> result =
+        reports.evaluateMapData(DURATION_BY_DATE_REPORT_ID, noExtraFilters());
+
+    // then the non-null buckets carry the two seeded per-day averages — asserting on the values
+    // themselves (rather than bucket labels) so the test survives AUTOMATIC unit choices
+    assertThat(
+            result.stream()
+                .map(MapResultEntryDto::getValue)
+                .filter(java.util.Objects::nonNull)
+                .toList())
+        .containsExactlyInAnyOrder(2_000.0, 6_000.0);
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/BusinessValueCycleTimeTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/BusinessValueCycleTimeTilesIT.java
@@ -100,31 +100,37 @@ class BusinessValueCycleTimeTilesIT extends AbstractBrokerlessZeebeCCSMIT {
 
   @Test
   void shouldReturnAverageDurationPerDateBucketForDurationByDateTile() {
-    // given two completed instances that ended on separate days with distinct durations
+    // given two completed instances that ended on different days but share the same duration —
+    // giving them the same duration means the bucket AVG equals that duration regardless of how
+    // many buckets AggregateByDateUnit.AUTOMATIC picks: if AUTOMATIC splits them into per-day
+    // buckets we get two buckets each averaging 4_000; if it collapses them into one wider
+    // bucket the single average is still 4_000. Distinct durations would have made the assertion
+    // brittle against AUTOMATIC unit changes.
     final String procKey = "cyc-by-date";
+    final long duration = 4_000L;
     final java.time.OffsetDateTime now = java.time.OffsetDateTime.now();
     persistProcessInstances(
         List.of(
-            bvdInstanceWithDuration(procKey, 2_000L)
+            bvdInstanceWithDuration(procKey, duration)
                 .startDate(now.minusDays(1).minusHours(1))
                 .endDate(now.minusDays(1))
                 .build(),
-            bvdInstanceWithDuration(procKey, 6_000L)
+            bvdInstanceWithDuration(procKey, duration)
                 .startDate(now.minusDays(2).minusHours(1))
                 .endDate(now.minusDays(2))
                 .build()));
 
     // when evaluating the cycle-time history tile
-    final List<MapResultEntryDto> result =
-        reports.evaluateMapData(DURATION_BY_DATE_REPORT_ID, noExtraFilters());
+    final List<MapResultEntryDto> nonNullValues =
+        reports.evaluateMapData(DURATION_BY_DATE_REPORT_ID, noExtraFilters()).stream()
+            .filter(entry -> entry.getValue() != null)
+            .toList();
 
-    // then the non-null buckets carry the two seeded per-day averages — asserting on the values
-    // themselves (rather than bucket labels) so the test survives AUTOMATIC unit choices
-    assertThat(
-            result.stream()
-                .map(MapResultEntryDto::getValue)
-                .filter(java.util.Objects::nonNull)
-                .toList())
-        .containsExactlyInAnyOrder(2_000.0, 6_000.0);
+    // then at least one bucket carries data and every non-null bucket returns the shared
+    // per-instance duration — no assumption about how many buckets AUTOMATIC produced
+    assertThat(nonNullValues).isNotEmpty();
+    assertThat(nonNullValues)
+        .extracting(MapResultEntryDto::getValue)
+        .allMatch(value -> value == (double) duration);
   }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/BusinessValueDashboardReconcileIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/BusinessValueDashboardReconcileIT.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.dashboard;
+
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.AGENT_PRESENCE_BY_PROCESS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.AUTOMATION_RATE_AGGREGATE_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.AUTOMATION_RATE_BY_PROCESS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.BUSINESS_VALUE_DASHBOARD_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.COUNT_BY_DATE_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.COUNT_BY_PROCESS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.DURATION_AVG_TOTAL_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.DURATION_BY_DATE_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.DURATION_BY_PROCESS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.DURATION_PERCENTILES_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.WORK_HANDLED_TOTAL_REPORT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.query.dashboard.DashboardDefinitionRestDto;
+import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.reader.DashboardReader;
+import io.camunda.optimize.service.db.reader.ReportReader;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link BusinessValueDashboardService#reconcile()} seeds the dashboard and all ten
+ * backing reports, and that running it a second time does not duplicate reports, mutate the
+ * deterministic ids, or drop the {@code businessValueReport = true} marker that the guard, picker,
+ * and evaluation pipelines rely on. Runs against whichever backend the IT suite is configured with
+ * (Elasticsearch or OpenSearch).
+ *
+ * <p>The {@code @BeforeEach} reconcile is required because {@link
+ * AbstractBrokerlessZeebeCCSMIT#cleanupOptimizeData()} wipes all Optimize data after every test —
+ * so the {@link org.springframework.boot.context.event.ApplicationReadyEvent}-driven seed from
+ * container startup is only visible to the first test in the class, and relying on that would make
+ * the outcome depend on JUnit's test ordering.
+ */
+class BusinessValueDashboardReconcileIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private static final List<String> BVD_REPORT_IDS =
+      List.of(
+          WORK_HANDLED_TOTAL_REPORT_ID,
+          DURATION_AVG_TOTAL_REPORT_ID,
+          COUNT_BY_PROCESS_REPORT_ID,
+          COUNT_BY_DATE_REPORT_ID,
+          DURATION_BY_PROCESS_REPORT_ID,
+          DURATION_PERCENTILES_REPORT_ID,
+          DURATION_BY_DATE_REPORT_ID,
+          AGENT_PRESENCE_BY_PROCESS_REPORT_ID,
+          AUTOMATION_RATE_AGGREGATE_REPORT_ID,
+          AUTOMATION_RATE_BY_PROCESS_REPORT_ID);
+
+  private BusinessValueDashboardService service;
+  private ReportReader reportReader;
+  private DashboardReader dashboardReader;
+
+  @BeforeEach
+  void setUp() {
+    service = embeddedOptimizeExtension.getBean(BusinessValueDashboardService.class);
+    reportReader = embeddedOptimizeExtension.getBean(ReportReader.class);
+    dashboardReader = embeddedOptimizeExtension.getBean(DashboardReader.class);
+    // reseed after the previous test's cleanup wiped the dashboard + reports
+    service.reconcile();
+  }
+
+  @Test
+  void shouldSeedAllTilesAndDashboardOnReconcile() {
+    // given reconcile() has just run in setUp
+
+    // then the dashboard exists with the deterministic id, is flagged as system-generated, and
+    // carries tiles pointing at all 10 canonical BVD report ids
+    final DashboardDefinitionRestDto dashboard =
+        dashboardReader.getDashboard(BUSINESS_VALUE_DASHBOARD_ID).orElseThrow();
+    assertThat(dashboard.isBusinessValueDashboard()).isTrue();
+    assertThat(dashboard.getTiles())
+        .extracting(tile -> tile.getId())
+        .containsExactlyInAnyOrderElementsOf(BVD_REPORT_IDS);
+
+    // and every seeded report is present and flagged as system-generated
+    for (final String reportId : BVD_REPORT_IDS) {
+      final ReportDefinitionDto report = reportReader.getReport(reportId).orElseThrow();
+      assertThat(report.getData()).isInstanceOf(ProcessReportDataDto.class);
+      assertThat(((ProcessReportDataDto) report.getData()).isBusinessValueReport()).isTrue();
+    }
+  }
+
+  @Test
+  void shouldBeIdempotentAcrossRestarts() {
+    // given the first reconcile already ran in setUp (simulating one container startup)
+
+    // when reconcile runs a second time (simulating a restart)
+    service.reconcile();
+
+    // then exactly the 10 canonical BVD reports still resolve — deterministic UUID upsert
+    // rules out same-id duplicates by construction, so the fanout query returns at most 10
+    // matches, and asserting the returned set equals BVD_REPORT_IDS proves none were dropped.
+    final List<ReportDefinitionDto> reports =
+        reportReader.getAllReportsForIdsOmitXml(BVD_REPORT_IDS);
+    final Set<String> reportIds =
+        reports.stream().map(ReportDefinitionDto::getId).collect(Collectors.toSet());
+    assertThat(reportIds).containsExactlyInAnyOrderElementsOf(BVD_REPORT_IDS);
+
+    // and every one of them still carries businessValueReport = true after the second reconcile —
+    // guards against a regression that upserts the report with the flag cleared, which the guard
+    // and picker pipelines would then silently stop protecting.
+    assertThat(reports)
+        .allSatisfy(
+            report ->
+                assertThat(report.getData())
+                    .asInstanceOf(
+                        org.assertj.core.api.InstanceOfAssertFactories.type(
+                            ProcessReportDataDto.class))
+                    .extracting(ProcessReportDataDto::isBusinessValueReport)
+                    .isEqualTo(true));
+
+    // and the dashboard still resolves to the deterministic id and its tiles still reference the
+    // same 10 canonical BVD report ids — asserting on the tile ids (not just the count) is what
+    // guards the deterministic-UUID contract: if reconcile ever regenerated ids and rewired the
+    // dashboard, a count-only assertion would still pass while the guarantee was broken.
+    final DashboardDefinitionRestDto dashboard =
+        dashboardReader.getDashboard(BUSINESS_VALUE_DASHBOARD_ID).orElseThrow();
+    assertThat(dashboard.isBusinessValueDashboard()).isTrue();
+    assertThat(dashboard.getTiles())
+        .extracting(tile -> tile.getId())
+        .containsExactlyInAnyOrderElementsOf(BVD_REPORT_IDS);
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/BusinessValueVolumeTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/BusinessValueVolumeTilesIT.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.dashboard;
+
+import static io.camunda.optimize.BusinessValueInstanceFixtures.bvdInstanceWithDuration;
+import static io.camunda.optimize.service.dashboard.AgenticReportFilters.noExtraFilters;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.COUNT_BY_DATE_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.COUNT_BY_PROCESS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.WORK_HANDLED_TOTAL_REPORT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.ProcessInstanceConstants;
+import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
+import io.camunda.optimize.dto.optimize.query.report.single.result.hyper.MapResultEntryDto;
+import io.camunda.optimize.service.report.ReportEvaluationService;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Evaluates the L0-activity / L1-overview volume tiles against a synthetic tenant so a regression
+ * in the {@code PROCESS_INSTANCE FREQUENCY} view or the {@code completedInstancesOnly} filter fails
+ * a targeted check rather than surfacing as a dashboard rendering bug. Runs against whichever
+ * backend the IT suite is configured with.
+ */
+class BusinessValueVolumeTilesIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private AgenticReportEvaluator reports;
+
+  @BeforeEach
+  void setUp() {
+    embeddedOptimizeExtension.getBean(BusinessValueDashboardService.class).reconcile();
+    reports =
+        new AgenticReportEvaluator(
+            embeddedOptimizeExtension.getBean(ReportEvaluationService.class));
+  }
+
+  @Test
+  void shouldCountOnlyCompletedInstancesForWorkHandledTotal() {
+    // given three completed instances and one running instance for the same process — the running
+    // instance must be filtered out because the tile carries completedInstancesOnly()
+    final String procKey = "vol-work-handled";
+    final ProcessInstanceDto running =
+        bvdInstanceWithDuration(procKey, 3_600_000L)
+            .state(ProcessInstanceConstants.ACTIVE_STATE)
+            .endDate(null)
+            .duration(null)
+            .build();
+    persistProcessInstances(
+        List.of(
+            bvdInstanceWithDuration(procKey, 3_600_000L).build(),
+            bvdInstanceWithDuration(procKey, 3_600_000L).build(),
+            bvdInstanceWithDuration(procKey, 3_600_000L).build(),
+            running));
+
+    // when evaluating the aggregate work-handled tile
+    // then only the three completed instances are counted
+    assertThat(reports.evaluateNumber(WORK_HANDLED_TOTAL_REPORT_ID, noExtraFilters()))
+        .isEqualTo(3.0);
+  }
+
+  @Test
+  void shouldReturnPerProcessCountsSortedDescForCountByProcess() {
+    // given four processes with distinct completed-instance counts
+    final String hot = "vol-proc-hot";
+    final String warm = "vol-proc-warm";
+    final String cool = "vol-proc-cool";
+    final String cold = "vol-proc-cold";
+    final List<ProcessInstanceDto> instances = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      instances.add(bvdInstanceWithDuration(hot, 100L).build());
+    }
+    for (int i = 0; i < 3; i++) {
+      instances.add(bvdInstanceWithDuration(warm, 100L).build());
+    }
+    for (int i = 0; i < 2; i++) {
+      instances.add(bvdInstanceWithDuration(cool, 100L).build());
+    }
+    instances.add(bvdInstanceWithDuration(cold, 100L).build());
+    persistProcessInstances(instances);
+
+    // when evaluating the per-process count tile
+    final List<MapResultEntryDto> result =
+        reports.evaluateMapData(COUNT_BY_PROCESS_REPORT_ID, noExtraFilters());
+
+    // then all four processes appear with the expected counts, sorted DESC by value — Hub reads
+    // the top-N config off the tile and slices client-side, so the backend must return the full
+    // ordered result
+    assertThat(result)
+        .extracting(MapResultEntryDto::getKey, MapResultEntryDto::getValue)
+        .containsExactly(tuple(hot, 5.0), tuple(warm, 3.0), tuple(cool, 2.0), tuple(cold, 1.0));
+  }
+
+  @Test
+  void shouldBucketCompletedInstancesByEndDateForCountByDateTile() {
+    // given three instances that ended on three different days
+    final String procKey = "vol-count-date";
+    final OffsetDateTime now = OffsetDateTime.now();
+    persistProcessInstances(
+        List.of(
+            bvdInstanceWithDuration(procKey, 100L)
+                .startDate(now.minusDays(1).minusHours(1))
+                .endDate(now.minusDays(1))
+                .build(),
+            bvdInstanceWithDuration(procKey, 100L)
+                .startDate(now.minusDays(2).minusHours(1))
+                .endDate(now.minusDays(2))
+                .build(),
+            bvdInstanceWithDuration(procKey, 100L)
+                .startDate(now.minusDays(3).minusHours(1))
+                .endDate(now.minusDays(3))
+                .build()));
+
+    // when evaluating the momentum tile with AUTOMATIC bucketing
+    final List<MapResultEntryDto> result =
+        reports.evaluateMapData(COUNT_BY_DATE_REPORT_ID, noExtraFilters());
+
+    // then the non-null buckets sum to the three completed instances — asserting on the total
+    // rather than the bucket layout so the test is stable across AUTOMATIC unit choices
+    final double bucketed =
+        result.stream()
+            .map(MapResultEntryDto::getValue)
+            .filter(java.util.Objects::nonNull)
+            .mapToDouble(Double::doubleValue)
+            .sum();
+    assertThat(bucketed).isEqualTo(3.0);
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/report/BusinessValueReportEditGuardIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/report/BusinessValueReportEditGuardIT.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.report;
+
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.WORK_HANDLED_TOTAL_REPORT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.service.dashboard.BusinessValueDashboardService;
+import io.camunda.optimize.service.db.reader.ReportReader;
+import io.camunda.optimize.service.exceptions.OptimizeValidationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Business Value Dashboard reports are system-generated ({@code data.businessValueReport = true})
+ * and must not be mutated by users — otherwise the next reconcile would recreate the report they
+ * just deleted, or overwrite an edit that was never persisted. This verifies the {@link
+ * ReportService} guard recognises the {@code businessValueReport} flag alongside {@code
+ * agenticControlReport}, mirroring {@code AgenticControlReportEditGuardIT}.
+ */
+class BusinessValueReportEditGuardIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private ReportService reportService;
+  private ReportReader reportReader;
+
+  @BeforeEach
+  void setUp() {
+    // seeds the business value dashboard and its system-generated reports
+    embeddedOptimizeExtension.getBean(BusinessValueDashboardService.class).reconcile();
+    reportService = embeddedOptimizeExtension.getBean(ReportService.class);
+    reportReader = embeddedOptimizeExtension.getBean(ReportReader.class);
+  }
+
+  @Test
+  void shouldRejectDeletingBusinessValueReport() {
+    // given a business value report was seeded by the reconcile above
+    assertThat(reportReader.getReport(WORK_HANDLED_TOTAL_REPORT_ID)).isPresent();
+
+    // when deleting it manually, then the system-generated guard rejects it
+    assertThatThrownBy(() -> reportService.deleteReport(WORK_HANDLED_TOTAL_REPORT_ID))
+        .isInstanceOf(OptimizeValidationException.class)
+        .hasMessageContaining("System-generated reports cannot be deleted");
+
+    // and the report is left untouched
+    assertThat(reportReader.getReport(WORK_HANDLED_TOTAL_REPORT_ID)).isPresent();
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/report/BusinessValueReportPickerExclusionIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/report/BusinessValueReportPickerExclusionIT.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.report;
+
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.AGENT_PRESENCE_BY_PROCESS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.AUTOMATION_RATE_AGGREGATE_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.AUTOMATION_RATE_BY_PROCESS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.COUNT_BY_DATE_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.COUNT_BY_PROCESS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.DURATION_AVG_TOTAL_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.DURATION_BY_DATE_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.DURATION_BY_PROCESS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.DURATION_PERCENTILES_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.WORK_HANDLED_TOTAL_REPORT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.dashboard.BusinessValueDashboardService;
+import io.camunda.optimize.service.db.reader.ReportReader;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression coverage for the dashboard "Add a Report" picker, which is backed by {@link
+ * ReportReader#getAllPrivateReportsOmitXml()}. Business Value Dashboard reports are
+ * system-generated implementation details flagged with {@code data.businessValueReport = true};
+ * they must not be selectable when users build their own dashboards. Mirrors {@code
+ * AgenticControlReportPickerExclusionIT} for the BVD flag.
+ */
+class BusinessValueReportPickerExclusionIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private static final List<String> BVD_REPORT_IDS =
+      List.of(
+          WORK_HANDLED_TOTAL_REPORT_ID,
+          DURATION_AVG_TOTAL_REPORT_ID,
+          COUNT_BY_PROCESS_REPORT_ID,
+          COUNT_BY_DATE_REPORT_ID,
+          DURATION_BY_PROCESS_REPORT_ID,
+          DURATION_PERCENTILES_REPORT_ID,
+          DURATION_BY_DATE_REPORT_ID,
+          AGENT_PRESENCE_BY_PROCESS_REPORT_ID,
+          AUTOMATION_RATE_AGGREGATE_REPORT_ID,
+          AUTOMATION_RATE_BY_PROCESS_REPORT_ID);
+
+  private ReportReader reportReader;
+
+  @BeforeEach
+  void setUp() {
+    // seeds the business value dashboard and its system-generated reports
+    embeddedOptimizeExtension.getBean(BusinessValueDashboardService.class).reconcile();
+    reportReader = embeddedOptimizeExtension.getBean(ReportReader.class);
+  }
+
+  @Test
+  void shouldNotReturnBusinessValueReportsInPrivateReportPicker() {
+    // given the BVD reports were actually persisted by the reconcile above
+    assertThat(reportReader.getReport(WORK_HANDLED_TOTAL_REPORT_ID)).isPresent();
+
+    // when fetching the private reports backing the "Add a Report" picker
+    final List<ReportDefinitionDto> reports = reportReader.getAllPrivateReportsOmitXml();
+
+    // then none of the BVD reports leak into the picker, and no report data still carries the
+    // businessValueReport marker — protects against a future picker path that forgets to filter
+    assertThat(reports)
+        .extracting(ReportDefinitionDto::getId)
+        .doesNotContainAnyElementsOf(BVD_REPORT_IDS);
+    assertThat(reports)
+        .noneMatch(
+            report ->
+                report.getData() instanceof final ProcessReportDataDto data
+                    && data.isBusinessValueReport());
+  }
+}


### PR DESCRIPTION
Closes camunda/camunda-hub#26937. Part of camunda/camunda-hub#26932 (M1.4). Depends on `26934-automation-rate-view` (M1.3) — until that merges, the diff against `main` includes those commits.

## Summary

Backend integration tests for the Business Value Dashboard, mirroring the Agentic Control Plane IT pattern. No production code changes.

- `BusinessValueDashboardReconcileIT` — seed idempotency: 10 report ids stable across restart, dashboard tiles still reference the same ids, `businessValueReport` flag preserved.
- `BusinessValueVolumeTilesIT` / `CycleTimeTilesIT` / `AgenticPresenceTileIT` — each seeded tile evaluates to expected numbers against synthetic completed instances.
- `BusinessValueAutomationRateTilesIT` — automation-rate ratios across flow-node distributions (100 %, 0 %, 75 %, structural-only → null, empty → null, DESC top-N).
- `BusinessValueReportEditGuardIT` / `PickerExclusionIT` — system-generated flag protects BVD reports from delete and hides them from the report picker.
- `BusinessValueInstanceFixtures` — shared builders in the `io.camunda.optimize` root package.

All ITs extend `AbstractBrokerlessZeebeCCSMIT` and reuse the package-private `AgenticReportEvaluator` + `AgenticReportFilters`.

## Test plan

- [ ] `./mvnw verify -pl optimize/backend -Pccsm-it -DskipTests=false -DskipUTs -Dit.test="BusinessValueDashboardReconcileIT,BusinessValueVolumeTilesIT,BusinessValueCycleTimeTilesIT,BusinessValueAgenticPresenceTileIT,BusinessValueAutomationRateTilesIT,BusinessValueReportEditGuardIT,BusinessValueReportPickerExclusionIT"` — Elasticsearch
- [ ] Same against OpenSearch (CI matrix)