### PR TITLE
fix: reject non-upper-case RDBMS table prefixes at config time

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Rdbms.java
+++ b/configuration/src/main/java/io/camunda/configuration/Rdbms.java
@@ -19,7 +19,10 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
   /** If true, the database schema is automatically created and updated on application startup. */
   private boolean autoDdl = DEFAULT_AUTO_DDL;
 
-  /** The prefix to use for all database artifacts like tables, indexes etc. */
+  /**
+   * The prefix to use for all database artifacts like tables, indexes etc. Must contain only
+   * upper-case letters, digits and underscores, and must not start with a digit.
+   */
   private String prefix;
 
   /** The interval at which the exporters execution queue is flushed. */

--- a/configuration/src/main/java/io/camunda/configuration/Rdbms.java
+++ b/configuration/src/main/java/io/camunda/configuration/Rdbms.java
@@ -20,7 +20,10 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
   /** If true, the database schema is automatically created and updated on application startup. */
   private boolean autoDdl = DEFAULT_AUTO_DDL;
 
-  /** The prefix to use for all database artifacts like tables, indexes etc. */
+  /**
+   * The prefix to use for all database artifacts like tables, indexes etc. Must contain only
+   * upper-case letters, digits and underscores, and must not start with a digit.
+   */
   private String prefix;
 
   /** The interval at which the exporters execution queue is flushed. */

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantRdbmsPrefixValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantRdbmsPrefixValidation.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.UnifiedConfigurationException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.Environment;
+
+/**
+ * Table-prefix policy for RDBMS secondary storage: a configured prefix must be usable as an
+ * unquoted SQL identifier prefix, which on the supported dialects means upper case.
+ *
+ * <p>The prefix is interpolated verbatim into DDL and DML identifiers by the Liquibase changelog
+ * and the MyBatis mappers. A mixed-case prefix splits into two different relations: the structured
+ * {@code <createTable>} quotes the resulting name and stores it case-preserved, while the raw-SQL
+ * and mapper references are unquoted and fold to lower case. The boot-time migration then aborts
+ * part-way with a {@code relation "<prefix>process_instance" does not exist} on a table it just
+ * created. Rejecting the prefix up front turns that into a configuration error.
+ *
+ * <p>Enforcement is <em>key inspection plus a single bind</em> per declared prefix property: the
+ * root {@code camunda.data.secondary-storage.rdbms.prefix} and the per-tenant override under each
+ * discovered {@code camunda.physical-tenants.<id>.}. Checking each declared key on its own is
+ * sufficient — a tenant that declares no prefix inherits the root value, which is validated at its
+ * own key.
+ */
+@NullMarked
+final class PhysicalTenantRdbmsPrefixValidation {
+
+  /** The prefix property, expressed relative to a configuration root. */
+  private static final String PREFIX_PROPERTY = "data.secondary-storage.rdbms.prefix";
+
+  /**
+   * An unquoted SQL identifier prefix: upper-case letters, digits and underscores, not starting
+   * with a digit. Trailing separators such as {@code _} are the conventional form ({@code TA_}).
+   */
+  private static final Pattern VALID_PREFIX = Pattern.compile("[A-Z_][A-Z0-9_]*");
+
+  private PhysicalTenantRdbmsPrefixValidation() {}
+
+  static void validate(final Environment environment, final Set<String> physicalTenantIds) {
+    final Binder binder = Binder.get(environment);
+    final List<String> violations = new ArrayList<>();
+    for (final String propertyName : prefixProperties(physicalTenantIds)) {
+      binder
+          .bind(propertyName, Bindable.of(String.class))
+          .ifBound(
+              prefix -> {
+                if (!prefix.isBlank() && !VALID_PREFIX.matcher(prefix.trim()).matches()) {
+                  violations.add(propertyName + "=" + prefix);
+                }
+              });
+    }
+    if (!violations.isEmpty()) {
+      throw new UnifiedConfigurationException(
+          "The RDBMS table prefix is interpolated verbatim into unquoted SQL identifiers, so it must "
+              + "contain only upper-case letters, digits and underscores, and must not start with a "
+              + "digit. A lower-case or mixed-case prefix creates case-quoted tables that the "
+              + "unquoted queries and migrations cannot address, which aborts the schema migration "
+              + "at boot. Invalid prefixes: "
+              + violations);
+    }
+  }
+
+  private static List<String> prefixProperties(final Set<String> physicalTenantIds) {
+    final List<String> propertyNames = new ArrayList<>();
+    propertyNames.add(Camunda.PREFIX + "." + PREFIX_PROPERTY);
+    physicalTenantIds.forEach(
+        id ->
+            propertyNames.add(
+                PhysicalTenantResolver.PHYSICAL_TENANTS_PREFIX + "." + id + "." + PREFIX_PROPERTY));
+    return propertyNames;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
@@ -90,6 +90,7 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
     PhysicalTenantAssignedProvidersValidation.validate(environment);
     PhysicalTenantDocumentAssignedValidation.validateRootAssignedAbsent(environment);
     PhysicalTenantExporterAssignedValidation.validateRootAssignedAbsent(environment);
+    PhysicalTenantRdbmsPrefixValidation.validate(environment, physicalTenantIds);
     final Map<String, Camunda> resolvedPhysicalTenants = new LinkedHashMap<>();
     final Binder binder = Binder.get(environment);
     for (final String physicalTenantId : physicalTenantIds) {

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
@@ -81,6 +81,7 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
     PhysicalTenantRequiredOverrideValidation.validate(environment);
     PhysicalTenantAssignedProvidersValidation.validate(environment);
     PhysicalTenantDocumentAssignedValidation.validateRootAssignedAbsent(environment);
+    PhysicalTenantRdbmsPrefixValidation.validate(environment, physicalTenantIds);
     final Map<String, Camunda> resolvedPhysicalTenants = new LinkedHashMap<>();
     final Binder binder = Binder.get(environment);
     for (final String physicalTenantId : physicalTenantIds) {

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantRdbmsPrefixValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantRdbmsPrefixValidationTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.camunda.configuration.UnifiedConfigurationException;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.mock.env.MockEnvironment;
+
+class PhysicalTenantRdbmsPrefixValidationTest {
+
+  private static final String ROOT_PREFIX = "camunda.data.secondary-storage.rdbms.prefix";
+
+  private static MockEnvironment environmentWith(final Map<String, Object> properties) {
+    final MockEnvironment environment = new MockEnvironment();
+    environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+    return environment;
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"ta_", "Ta_", "tA_", "ta-", "TA-", "1TA_"})
+  void shouldRejectRootPrefixThatIsNotAnUnquotedUpperCaseIdentifier(final String prefix) {
+    // given
+    final MockEnvironment environment = environmentWith(Map.of(ROOT_PREFIX, prefix));
+
+    // when / then the offending key and value are named
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantRdbmsPrefixValidation.validate(environment, Set.of()))
+        .withMessageContaining("upper-case letters, digits and underscores")
+        .withMessageContaining(ROOT_PREFIX + "=" + prefix);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"TA_", "C8_", "_TA", "TA1_", "TA", "  TA_  "})
+  void shouldAcceptUpperCasePrefix(final String prefix) {
+    // given
+    final MockEnvironment environment = environmentWith(Map.of(ROOT_PREFIX, prefix));
+
+    // when / then
+    assertThatCode(() -> PhysicalTenantRdbmsPrefixValidation.validate(environment, Set.of()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldAcceptBlankPrefix() {
+    // given a declared but empty prefix, meaning no prefix at all
+    final MockEnvironment environment = environmentWith(Map.of(ROOT_PREFIX, ""));
+
+    // when / then
+    assertThatCode(() -> PhysicalTenantRdbmsPrefixValidation.validate(environment, Set.of()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldAcceptUndeclaredPrefix() {
+    // given no prefix property at all
+    final MockEnvironment environment = environmentWith(Map.of("camunda.cluster.size", 3));
+
+    // when / then
+    assertThatCode(
+            () -> PhysicalTenantRdbmsPrefixValidation.validate(environment, Set.of("tenanta")))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectPerPhysicalTenantPrefix() {
+    // given a lower-case override on a tenant while the root prefix is valid
+    final String tenantPrefix =
+        "camunda.physical-tenants.tenanta.data.secondary-storage.rdbms.prefix";
+    final MockEnvironment environment =
+        environmentWith(Map.of(ROOT_PREFIX, "DEFAULT_", tenantPrefix, "ta_"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(
+            () -> PhysicalTenantRdbmsPrefixValidation.validate(environment, Set.of("tenanta")))
+        .withMessageContaining(tenantPrefix + "=ta_");
+  }
+
+  @Test
+  void shouldReportEveryInvalidPrefix() {
+    // given both the root and a tenant misconfigured
+    final MockEnvironment environment =
+        environmentWith(
+            Map.of(
+                ROOT_PREFIX,
+                "default_",
+                "camunda.physical-tenants.tenanta.data.secondary-storage.rdbms.prefix",
+                "ta_"));
+
+    // when / then both are named in one message
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(
+            () -> PhysicalTenantRdbmsPrefixValidation.validate(environment, Set.of("tenanta")))
+        .withMessageContaining(ROOT_PREFIX + "=default_")
+        .withMessageContaining("tenanta.data.secondary-storage.rdbms.prefix=ta_");
+  }
+
+  @Test
+  void shouldNotValidateTenantsThatWereNotDiscovered() {
+    // given an undiscovered tenant id, i.e. one with no keys in the environment
+    final MockEnvironment environment = environmentWith(Map.of(ROOT_PREFIX, "DEFAULT_"));
+
+    // when / then
+    assertThatCode(
+            () -> PhysicalTenantRdbmsPrefixValidation.validate(environment, Set.of("tenantb")))
+        .doesNotThrowAnyException();
+  }
+}

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -893,7 +893,8 @@ camunda: # Type: io.camunda.configuration.Camunda
         
         # Password for the database configured as secondary storage.
         password: "" # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD
-        # The prefix to use for all database artifacts like tables, indexes etc.
+        # The prefix to use for all database artifacts like tables, indexes etc. Must contain only upper-case
+        # letters, digits and underscores, and must not start with a digit.
         prefix: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_PREFIX
         # Process definition cache configuration. Defines the size of the process definition cache.
         process-cache: null # Type: io.camunda.configuration.RdbmsCache, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_PROCESSCACHE

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -893,7 +893,8 @@ camunda: # Type: io.camunda.configuration.Camunda
 
         # Password for the database configured as secondary storage.
         password: "" # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD
-        # The prefix to use for all database artifacts like tables, indexes etc.
+        # The prefix to use for all database artifacts like tables, indexes etc. Must contain only upper-case
+        # letters, digits and underscores, and must not start with a digit.
         prefix: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_PREFIX
         # Process definition cache configuration. Defines the size of the process definition cache.
         process-cache: null # Type: io.camunda.configuration.RdbmsCache, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_PROCESSCACHE

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -38,6 +38,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -508,7 +509,8 @@ public class CamundaMultiDBExtension
               + "-"
               + UUID.randomUUID()
               + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL";
-      configurePtStorage = configureRdbmsStorage(ptUrl, "sa", "", testPrefix, null);
+      configurePtStorage =
+          configureRdbmsStorage(ptUrl, "sa", "", testPrefix.toUpperCase(Locale.ROOT), null);
     } else {
       // Per-PT isolated storage derived from the database type: a dedicated schema/database whose
       // namespace lives in the PT URL (Postgres/MySQL/MariaDB/SQL Server), or — on Oracle — a

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -37,6 +37,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -507,7 +508,8 @@ public class CamundaMultiDBExtension
               + "-"
               + UUID.randomUUID()
               + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL";
-      configurePtStorage = configureRdbmsStorage(ptUrl, "sa", "", testPrefix, null);
+      configurePtStorage =
+          configureRdbmsStorage(ptUrl, "sa", "", testPrefix.toUpperCase(Locale.ROOT), null);
     } else {
       // Per-PT isolated storage derived from the database type: a dedicated schema/database whose
       // namespace lives in the PT URL (Postgres/MySQL/MariaDB/SQL Server), or — on Oracle — a


### PR DESCRIPTION
## Description

A lower-case or mixed-case RDBMS table prefix was accepted by the configuration layer but aborted the boot-time Liquibase migration: the structured `<createTable>` quotes the mixed-case name and stores it case-preserved, while the raw-SQL and MyBatis references are unquoted and fold to lower case, so the two addressed different relations.

`PhysicalTenantRdbmsPrefixValidation` joins the pre-bind validations in `PhysicalTenantResolver.of`, so the root prefix and every per-physical-tenant override now fail fast with a `UnifiedConfigurationException` naming the offending keys. `PhysicalTenantResolver` is an unconditional bean, so this also covers deployments with no physical tenants.

The physical-tenant H2 path in `CamundaMultiDBExtension` passed the lower-case test prefix as a table prefix; it now upper-cases it.

## Related issues

closes #56093