### PR TITLE
test: fix flakey rescheduling closed task test

### DIFF
--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/tasks/ReschedulingTaskTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/tasks/ReschedulingTaskTest.java
@@ -214,17 +214,28 @@ final class ReschedulingTaskTest {
   void shouldNotRescheduleIfClosed() {
     // given
     final var runningCounter = new AtomicInteger();
-    when(archiverJob.execute())
-        .thenReturn(CompletableFuture.completedFuture(runningCounter.incrementAndGet()));
 
     final var task = new ReschedulingTask(archiverJob, 1, 100, 100, EXECUTOR, LOGGER);
 
+    final CompletableFuture<Integer> future = new CompletableFuture<>();
+
+    when(archiverJob.execute())
+        .thenReturn(
+            future.thenApply(
+                unused -> {
+                  // ensure task is closed before the future actually completes
+                  // so the task will be closed before we attempt to reschedule it
+                  task.close();
+                  return runningCounter.incrementAndGet();
+                }));
+
     // when
     task.run();
-    task.close();
+    future.complete(1);
 
     // then
-    Awaitility.await("Until it's been rescheduled").until(() -> task.executionCount() == 1);
+    Awaitility.await("Until task has been run").until(() -> task.executionCount() >= 1);
+    assertThat(task.executionCount()).isEqualTo(1L);
     assertThat(runningCounter.get()).isEqualTo(1);
   }
 }


### PR DESCRIPTION
this removes a race condition from the test that meant the task was not always closed before attempting to reschedule it.
