### PR TITLE
fix: resolve type in SecondaryStorageInterceptor using Unified Configuration

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -244,6 +244,24 @@
       <groupId>io.camunda</groupId>
       <artifactId>camunda-security-library-api</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-service</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SecondaryStorageInterceptorOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SecondaryStorageInterceptorOverride.java
@@ -30,7 +30,7 @@ public class SecondaryStorageInterceptorOverride {
       final LegacySecondaryStorageInterceptor legacySecondaryStorageInterceptor,
       final SecondaryStorageReadiness readiness) {
     final SecondaryStorageInterceptor override = new SecondaryStorageInterceptor(readiness);
-    BeanUtils.copyProperties(override, legacySecondaryStorageInterceptor);
+    BeanUtils.copyProperties(legacySecondaryStorageInterceptor, override);
     override.setDatabaseType(uc.getCamunda().getData().getSecondaryStorage().getType().name());
     return override;
   }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SecondaryStorageInterceptorOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SecondaryStorageInterceptorOverride.java
@@ -16,8 +16,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
+@Profile("!restore")
 @DependsOn("unifiedConfigurationHelper")
 public class SecondaryStorageInterceptorOverride {
 

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SecondaryStorageInterceptorOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SecondaryStorageInterceptorOverride.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beanoverrides;
+
+import io.camunda.cluster.SecondaryStorageReadiness;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beans.LegacySecondaryStorageInterceptor;
+import io.camunda.zeebe.gateway.rest.interceptor.SecondaryStorageInterceptor;
+import org.springframework.beans.BeanUtils;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+@DependsOn("unifiedConfigurationHelper")
+public class SecondaryStorageInterceptorOverride {
+
+  @Bean
+  @Primary
+  public SecondaryStorageInterceptor secondaryStorageInterceptor(
+      final UnifiedConfiguration uc,
+      final LegacySecondaryStorageInterceptor legacySecondaryStorageInterceptor,
+      final SecondaryStorageReadiness readiness) {
+    final SecondaryStorageInterceptor override = new SecondaryStorageInterceptor(readiness);
+    BeanUtils.copyProperties(override, legacySecondaryStorageInterceptor);
+    override.setDatabaseType(uc.getCamunda().getData().getSecondaryStorage().getType().name());
+    return override;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beans/LegacySecondaryStorageInterceptor.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/LegacySecondaryStorageInterceptor.java
@@ -9,9 +9,11 @@ package io.camunda.configuration.beans;
 
 import io.camunda.cluster.SecondaryStorageReadiness;
 import io.camunda.zeebe.gateway.rest.interceptor.SecondaryStorageInterceptor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
+@Profile("!restore")
 public class LegacySecondaryStorageInterceptor extends SecondaryStorageInterceptor {
 
   public LegacySecondaryStorageInterceptor(final SecondaryStorageReadiness readiness) {

--- a/configuration/src/main/java/io/camunda/configuration/beans/LegacySecondaryStorageInterceptor.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/LegacySecondaryStorageInterceptor.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beans;
+
+import io.camunda.cluster.SecondaryStorageReadiness;
+import io.camunda.zeebe.gateway.rest.interceptor.SecondaryStorageInterceptor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LegacySecondaryStorageInterceptor extends SecondaryStorageInterceptor {
+
+  public LegacySecondaryStorageInterceptor(final SecondaryStorageReadiness readiness) {
+    super(readiness);
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/beanoverrides/SecondaryStorageInterceptorOverrideTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/beanoverrides/SecondaryStorageInterceptorOverrideTest.java
@@ -133,6 +133,27 @@ class SecondaryStorageInterceptorOverrideTest {
   }
 
   @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.database.type=rdbms",
+        "camunda.data.secondary-storage.type=rdbms",
+      })
+  class WithMatchingLegacyAndUnifiedRdbmsType {
+    @Autowired private SecondaryStorageInterceptor secondaryStorageInterceptor;
+
+    @Test
+    void shouldAllowRequestsRequiringSecondaryStorageWhenBothPropertiesAgree() {
+      final boolean result =
+          secondaryStorageInterceptor.preHandle(
+              requestDispatch(),
+              mock(HttpServletResponse.class),
+              requiresSecondaryStorageHandler());
+
+      assertThat(result).isTrue();
+    }
+  }
+
+  @Nested
   @TestPropertySource(properties = "camunda.data.secondary-storage.type=none")
   class WithNoneType {
     @Autowired private SecondaryStorageInterceptor secondaryStorageInterceptor;

--- a/configuration/src/test/java/io/camunda/configuration/beanoverrides/SecondaryStorageInterceptorOverrideTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/beanoverrides/SecondaryStorageInterceptorOverrideTest.java
@@ -45,14 +45,6 @@ import org.springframework.web.method.HandlerMethod;
 })
 class SecondaryStorageInterceptorOverrideTest {
 
-  @Configuration
-  static class SecondaryStorageReadinessTestConfig {
-    @Bean
-    SecondaryStorageReadiness secondaryStorageReadiness() {
-      return SecondaryStorageReadiness.ALWAYS_READY;
-    }
-  }
-
   @AfterEach
   void tearDown() {
     RequestContextHolder.resetRequestAttributes();
@@ -72,6 +64,14 @@ class SecondaryStorageInterceptorOverrideTest {
     final var handlerMethod = mock(HandlerMethod.class);
     when(handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)).thenReturn(true);
     return handlerMethod;
+  }
+
+  @Configuration
+  static class SecondaryStorageReadinessTestConfig {
+    @Bean
+    SecondaryStorageReadiness secondaryStorageReadiness() {
+      return SecondaryStorageReadiness.ALWAYS_READY;
+    }
   }
 
   @Nested

--- a/configuration/src/test/java/io/camunda/configuration/beanoverrides/SecondaryStorageInterceptorOverrideTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/beanoverrides/SecondaryStorageInterceptorOverrideTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beanoverrides;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.cluster.SecondaryStorageReadiness;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beans.LegacySecondaryStorageInterceptor;
+import io.camunda.service.exception.SecondaryStorageUnavailableException;
+import io.camunda.spring.utils.PhysicalTenantContext;
+import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
+import io.camunda.zeebe.gateway.rest.interceptor.SecondaryStorageInterceptor;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.method.HandlerMethod;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  UnifiedConfigurationHelper.class,
+  LegacySecondaryStorageInterceptor.class,
+  SecondaryStorageInterceptorOverride.class,
+  SecondaryStorageInterceptorOverrideTest.SecondaryStorageReadinessTestConfig.class,
+})
+class SecondaryStorageInterceptorOverrideTest {
+
+  @Configuration
+  static class SecondaryStorageReadinessTestConfig {
+    @Bean
+    SecondaryStorageReadiness secondaryStorageReadiness() {
+      return SecondaryStorageReadiness.ALWAYS_READY;
+    }
+  }
+
+  @AfterEach
+  void tearDown() {
+    RequestContextHolder.resetRequestAttributes();
+  }
+
+  private static HttpServletRequest requestDispatch() {
+    final var request = mock(HttpServletRequest.class);
+    when(request.getDispatcherType()).thenReturn(DispatcherType.REQUEST);
+    when(request.getAttribute(PhysicalTenantContext.REQUEST_ATTRIBUTE_PHYSICAL_TENANT_ID))
+        .thenReturn(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    return request;
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private static HandlerMethod requiresSecondaryStorageHandler() {
+    final var handlerMethod = mock(HandlerMethod.class);
+    when(handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)).thenReturn(true);
+    return handlerMethod;
+  }
+
+  @Nested
+  class WithDefaultConfiguration {
+    @Autowired private SecondaryStorageInterceptor secondaryStorageInterceptor;
+    @Autowired private LegacySecondaryStorageInterceptor legacySecondaryStorageInterceptor;
+
+    @Test
+    void shouldExposeOverrideAsThePrimaryBean() {
+      assertThat(secondaryStorageInterceptor)
+          .isNotSameAs(legacySecondaryStorageInterceptor)
+          .isNotInstanceOf(LegacySecondaryStorageInterceptor.class);
+    }
+
+    @Test
+    void shouldDefaultToElasticsearchDatabaseType() {
+      final boolean result =
+          secondaryStorageInterceptor.preHandle(
+              requestDispatch(),
+              mock(HttpServletResponse.class),
+              requiresSecondaryStorageHandler());
+
+      assertThat(result).isTrue();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = "camunda.data.secondary-storage.type=opensearch")
+  class WithOpensearchType {
+    @Autowired private SecondaryStorageInterceptor secondaryStorageInterceptor;
+
+    @Test
+    void shouldAllowRequestsRequiringSecondaryStorage() {
+      final boolean result =
+          secondaryStorageInterceptor.preHandle(
+              requestDispatch(),
+              mock(HttpServletResponse.class),
+              requiresSecondaryStorageHandler());
+
+      assertThat(result).isTrue();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = "camunda.data.secondary-storage.type=rdbms")
+  class WithRdbmsType {
+    @Autowired private SecondaryStorageInterceptor secondaryStorageInterceptor;
+
+    @Test
+    void shouldAllowRequestsRequiringSecondaryStorage() {
+      final boolean result =
+          secondaryStorageInterceptor.preHandle(
+              requestDispatch(),
+              mock(HttpServletResponse.class),
+              requiresSecondaryStorageHandler());
+
+      assertThat(result).isTrue();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = "camunda.data.secondary-storage.type=none")
+  class WithNoneType {
+    @Autowired private SecondaryStorageInterceptor secondaryStorageInterceptor;
+
+    @Test
+    void shouldRejectRequestsRequiringSecondaryStorage() {
+      assertThatThrownBy(
+              () ->
+                  secondaryStorageInterceptor.preHandle(
+                      requestDispatch(),
+                      mock(HttpServletResponse.class),
+                      requiresSecondaryStorageHandler()))
+          .isInstanceOf(SecondaryStorageUnavailableException.class);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=none",
+        "camunda.database.type=none",
+      })
+  class WithMatchingLegacyAndUnifiedNoneType {
+    @Autowired private SecondaryStorageInterceptor secondaryStorageInterceptor;
+
+    @Test
+    void shouldResolveDatabaseTypeFromLegacyProperty() {
+      assertThatThrownBy(
+              () ->
+                  secondaryStorageInterceptor.preHandle(
+                      requestDispatch(),
+                      mock(HttpServletResponse.class),
+                      requiresSecondaryStorageHandler()))
+          .isInstanceOf(SecondaryStorageUnavailableException.class);
+    }
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/RdbmsTestConfiguration.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/RdbmsTestConfiguration.java
@@ -12,6 +12,7 @@ import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import io.camunda.application.commons.configuration.UnifiedConfigurationModule;
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.application.commons.rdbms.RdbmsDataSources;
+import io.camunda.cluster.SecondaryStorageReadiness;
 import io.micrometer.core.instrument.MeterRegistry;
 import javax.sql.DataSource;
 import org.mockito.Mockito;
@@ -43,5 +44,10 @@ public class RdbmsTestConfiguration {
   @Bean
   public MeterRegistry meterRegistry() {
     return Mockito.mock(MeterRegistry.class, Mockito.RETURNS_DEEP_STUBS);
+  }
+
+  @Bean
+  public SecondaryStorageReadiness secondaryStorageReadiness() {
+    return SecondaryStorageReadiness.ALWAYS_READY;
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsTestConfiguration.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsTestConfiguration.java
@@ -12,6 +12,7 @@ import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import io.camunda.application.commons.configuration.UnifiedConfigurationModule;
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.application.commons.rdbms.RdbmsDataSources;
+import io.camunda.cluster.SecondaryStorageReadiness;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import javax.sql.DataSource;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -32,5 +33,10 @@ public class RdbmsTestConfiguration {
   @Bean(destroyMethod = "") // DataSource will be closed when closing RdbmsDataSources
   public DataSource dataSource(final RdbmsDataSources dataSources) {
     return dataSources.dataSourceFor(DEFAULT_PHYSICAL_TENANT_ID);
+  }
+
+  @Bean
+  public SecondaryStorageReadiness secondaryStorageReadiness() {
+    return SecondaryStorageReadiness.ALWAYS_READY;
   }
 }

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -240,5 +240,10 @@
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-cluster</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
@@ -15,6 +15,7 @@ import io.camunda.application.commons.search.NativeSearchClientsConfiguration;
 import io.camunda.application.commons.search.PhysicalTenantSearchClientReadersConfiguration;
 import io.camunda.application.commons.search.PhysicalTenantSearchEngineConfigurations;
 import io.camunda.application.commons.search.SearchClientReaderConfiguration;
+import io.camunda.cluster.SecondaryStorageReadiness;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator.NoopHealthActuator;
@@ -37,6 +38,13 @@ public class TestStandaloneBackupManager
         PhysicalTenantSearchClientReadersConfiguration.class,
         PhysicalTenantSearchEngineConfigurations.class,
         SearchClientReaderConfiguration.class);
+    // UnifiedConfigurationModule scans in LegacySecondaryStorageInterceptor, which requires a
+    // SecondaryStorageReadiness bean; this standalone application doesn't wire the production
+    // provider (SecondaryStorageReadinessConfiguration), so supply a stand-in here.
+    withBean(
+        "secondaryStorageReadiness",
+        SecondaryStorageReadiness.ALWAYS_READY,
+        SecondaryStorageReadiness.class);
   }
 
   @Override

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneSchemaManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneSchemaManager.java
@@ -10,6 +10,7 @@ package io.camunda.qa.util.cluster;
 import io.atomix.cluster.MemberId;
 import io.camunda.application.StandaloneSchemaManager;
 import io.camunda.application.commons.configuration.UnifiedConfigurationModule;
+import io.camunda.cluster.SecondaryStorageReadiness;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator.NoopHealthActuator;
@@ -22,6 +23,13 @@ public class TestStandaloneSchemaManager
 
   public TestStandaloneSchemaManager() {
     super(UnifiedConfigurationModule.class, StandaloneSchemaManager.class);
+    // UnifiedConfigurationModule scans in LegacySecondaryStorageInterceptor, which requires a
+    // SecondaryStorageReadiness bean; this standalone application doesn't wire the production
+    // provider (SecondaryStorageReadinessConfiguration), so supply a stand-in here.
+    withBean(
+        "secondaryStorageReadiness",
+        SecondaryStorageReadiness.ALWAYS_READY,
+        SecondaryStorageReadiness.class);
   }
 
   @Override

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptor.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptor.java
@@ -68,6 +68,10 @@ public class SecondaryStorageInterceptor implements HandlerInterceptor {
     return true;
   }
 
+  public String getDatabaseType() {
+    return databaseType;
+  }
+
   public void setDatabaseType(final String databaseType) {
     this.databaseType = databaseType;
     secondaryStorageDisabled = CAMUNDA_DATABASE_TYPE_NONE.equalsIgnoreCase(databaseType);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptor.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptor.java
@@ -32,6 +32,9 @@ import org.springframework.web.servlet.HandlerInterceptor;
  *       configured but the request's physical tenant's secondary storage is currently degraded (see
  *       {@link SecondaryStorageReadiness}).
  * </ul>
+ *
+ * NOTE: This is not a @Component. The actual bean is created with the Unified Configuration system
+ * in `SecondaryStorageInterceptorOverride.java`.
  */
 public class SecondaryStorageInterceptor implements HandlerInterceptor {
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptor.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptor.java
@@ -17,9 +17,7 @@ import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
-import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -35,7 +33,6 @@ import org.springframework.web.servlet.HandlerInterceptor;
  *       {@link SecondaryStorageReadiness}).
  * </ul>
  */
-@Component
 public class SecondaryStorageInterceptor implements HandlerInterceptor {
 
   /**
@@ -44,13 +41,15 @@ public class SecondaryStorageInterceptor implements HandlerInterceptor {
    */
   private static final String RETRY_AFTER_SECONDS = "5";
 
-  private final boolean secondaryStorageDisabled;
+  private static final String DEFAULT_DATABASE_TYPE = "elasticsearch";
+
   private final SecondaryStorageReadiness secondaryStorageReadiness;
 
-  public SecondaryStorageInterceptor(
-      @Value("${camunda.database.type:elasticsearch}") final String databaseType,
-      final SecondaryStorageReadiness secondaryStorageReadiness) {
-    secondaryStorageDisabled = CAMUNDA_DATABASE_TYPE_NONE.equalsIgnoreCase(databaseType);
+  private String databaseType;
+  private boolean secondaryStorageDisabled;
+
+  public SecondaryStorageInterceptor(final SecondaryStorageReadiness secondaryStorageReadiness) {
+    setDatabaseType(DEFAULT_DATABASE_TYPE);
     this.secondaryStorageReadiness = secondaryStorageReadiness;
   }
 
@@ -64,6 +63,11 @@ public class SecondaryStorageInterceptor implements HandlerInterceptor {
     }
 
     return true;
+  }
+
+  public void setDatabaseType(final String databaseType) {
+    this.databaseType = databaseType;
+    secondaryStorageDisabled = CAMUNDA_DATABASE_TYPE_NONE.equalsIgnoreCase(databaseType);
   }
 
   private static boolean requiresSecondaryStorage(final HandlerMethod handlerMethod) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptorProblemDetailTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptorProblemDetailTest.java
@@ -40,7 +40,7 @@ class SecondaryStorageInterceptorProblemDetailTest {
     // given
     final var readiness = mock(SecondaryStorageReadiness.class);
     when(readiness.isReady(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)).thenReturn(false);
-    final var interceptor = new SecondaryStorageInterceptor("elasticsearch", readiness);
+    final var interceptor = new SecondaryStorageInterceptor(readiness);
     final MockMvc mockMvc =
         MockMvcBuilders.standaloneSetup(new TestController())
             .addInterceptors(interceptor)

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptorTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptorTest.java
@@ -112,8 +112,7 @@ class SecondaryStorageInterceptorTest {
     when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
     bindPhysicalTenant(PHYSICAL_TENANT_ID);
 
-    final var interceptor =
-        new SecondaryStorageInterceptor(ELASTICSEARCH_DB_TYPE, degraded(PHYSICAL_TENANT_ID));
+    final var interceptor = new SecondaryStorageInterceptor(degraded(PHYSICAL_TENANT_ID));
     assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
         .isInstanceOf(SecondaryStorageDegradedException.class);
   }
@@ -124,8 +123,7 @@ class SecondaryStorageInterceptorTest {
     when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
     bindPhysicalTenant(PHYSICAL_TENANT_ID);
 
-    final var interceptor =
-        new SecondaryStorageInterceptor(ELASTICSEARCH_DB_TYPE, degraded(PHYSICAL_TENANT_ID));
+    final var interceptor = new SecondaryStorageInterceptor(degraded(PHYSICAL_TENANT_ID));
     assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
         .isInstanceOf(SecondaryStorageDegradedException.class);
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptorTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptorTest.java
@@ -55,8 +55,7 @@ class SecondaryStorageInterceptorTest {
     when(handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)).thenReturn(false);
     when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
 
-    final var interceptor =
-        new SecondaryStorageInterceptor("elasticsearch", SecondaryStorageReadiness.ALWAYS_READY);
+    final var interceptor = new SecondaryStorageInterceptor(SecondaryStorageReadiness.ALWAYS_READY);
     final boolean result = interceptor.preHandle(request, response, handlerMethod);
     assertThat(result).isTrue();
   }
@@ -67,7 +66,7 @@ class SecondaryStorageInterceptorTest {
     when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
     final var readiness = mock(SecondaryStorageReadiness.class);
 
-    final var interceptor = new SecondaryStorageInterceptor("elasticsearch", readiness);
+    final var interceptor = new SecondaryStorageInterceptor(readiness);
     interceptor.preHandle(request, response, handlerMethod);
 
     verifyNoInteractions(readiness);
@@ -79,8 +78,7 @@ class SecondaryStorageInterceptorTest {
     when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
     bindPhysicalTenant(PHYSICAL_TENANT_ID);
 
-    final var interceptor =
-        new SecondaryStorageInterceptor("elasticsearch", SecondaryStorageReadiness.ALWAYS_READY);
+    final var interceptor = new SecondaryStorageInterceptor(SecondaryStorageReadiness.ALWAYS_READY);
     final boolean result = interceptor.preHandle(request, response, handlerMethod);
     assertThat(result).isTrue();
   }
@@ -90,9 +88,8 @@ class SecondaryStorageInterceptorTest {
     when(handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)).thenReturn(true);
     when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
 
-    final var interceptor =
-        new SecondaryStorageInterceptor(
-            CAMUNDA_DATABASE_TYPE_NONE, SecondaryStorageReadiness.ALWAYS_READY);
+    final var interceptor = new SecondaryStorageInterceptor(SecondaryStorageReadiness.ALWAYS_READY);
+    interceptor.setDatabaseType(CAMUNDA_DATABASE_TYPE_NONE);
     assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
         .isInstanceOf(SecondaryStorageUnavailableException.class);
   }
@@ -103,8 +100,8 @@ class SecondaryStorageInterceptorTest {
     when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
     bindPhysicalTenant(PHYSICAL_TENANT_ID);
 
-    final var interceptor =
-        new SecondaryStorageInterceptor(CAMUNDA_DATABASE_TYPE_NONE, degraded(PHYSICAL_TENANT_ID));
+    final var interceptor = new SecondaryStorageInterceptor(degraded(PHYSICAL_TENANT_ID));
+    interceptor.setDatabaseType(CAMUNDA_DATABASE_TYPE_NONE);
     assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
         .isInstanceOf(SecondaryStorageUnavailableException.class);
   }
@@ -116,7 +113,7 @@ class SecondaryStorageInterceptorTest {
     bindPhysicalTenant(PHYSICAL_TENANT_ID);
 
     final var interceptor =
-        new SecondaryStorageInterceptor("elasticsearch", degraded(PHYSICAL_TENANT_ID));
+        new SecondaryStorageInterceptor(ELASTICSEARCH_DB_TYPE, degraded(PHYSICAL_TENANT_ID));
     assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
         .isInstanceOf(SecondaryStorageDegradedException.class);
   }
@@ -128,7 +125,7 @@ class SecondaryStorageInterceptorTest {
     bindPhysicalTenant(PHYSICAL_TENANT_ID);
 
     final var interceptor =
-        new SecondaryStorageInterceptor("elasticsearch", degraded(PHYSICAL_TENANT_ID));
+        new SecondaryStorageInterceptor(ELASTICSEARCH_DB_TYPE, degraded(PHYSICAL_TENANT_ID));
     assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
         .isInstanceOf(SecondaryStorageDegradedException.class);
 
@@ -140,9 +137,8 @@ class SecondaryStorageInterceptorTest {
     when(handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)).thenReturn(true);
     when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
 
-    final var interceptor =
-        new SecondaryStorageInterceptor(
-            CAMUNDA_DATABASE_TYPE_NONE, SecondaryStorageReadiness.ALWAYS_READY);
+    final var interceptor = new SecondaryStorageInterceptor(SecondaryStorageReadiness.ALWAYS_READY);
+    interceptor.setDatabaseType(CAMUNDA_DATABASE_TYPE_NONE);
     assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
         .isInstanceOf(SecondaryStorageUnavailableException.class);
 
@@ -155,8 +151,7 @@ class SecondaryStorageInterceptorTest {
     when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
     when(request.getDispatcherType()).thenReturn(DispatcherType.ASYNC);
 
-    final var interceptor =
-        new SecondaryStorageInterceptor("elasticsearch", degraded(PHYSICAL_TENANT_ID));
+    final var interceptor = new SecondaryStorageInterceptor(degraded(PHYSICAL_TENANT_ID));
     final boolean result = interceptor.preHandle(request, response, handlerMethod);
     assertThat(result).isTrue();
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Full context:
* https://github.com/camunda/camunda/issues/58953
* https://github.com/camunda/camunda/issues/58953#issuecomment-5177672885

SecondaryStorageInterceptor previously read camunda.database.type via constructor-injected @Value, coupling it directly to the legacy property instead of the unified configuration's resolved value. This made the interceptor bypass the precedence rules unified configuration applies across legacy and new property sources.

This PR makes the database type mutable via a setter and construct the interceptor with a default, then follow the established legacy-properties-override pattern: LegacySecondaryStorageInterceptor keeps the interceptor available as a plain component for existing wiring, while SecondaryStorageInterceptorOverride provides the @Primary bean, copying its state from the legacy bean and applying the database type from UnifiedConfiguration.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/issues/58953