### PR TITLE
feat: declare suspension behavior for process-instance processors

### DIFF
--- a/qa/archunit-tests/pom.xml
+++ b/qa/archunit-tests/pom.xml
@@ -200,6 +200,7 @@
             <dep>io.camunda:webapps-schema</dep>
             <dep>org.springframework:spring-beans</dep>
             <dep>org.springframework:spring-context</dep>
+            <dep>org.springframework:spring-core</dep>
             <dep>org.springframework:spring-web</dep>
             <dep>org.opensearch.client:opensearch-java</dep>
             <dep>com.fasterxml.jackson.core:jackson-databind</dep>

--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionAwareArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionAwareArchTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.streamprocessor;
+
+import static com.tngtech.archunit.lang.SimpleConditionEvent.violated;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClass.Predicates;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
+import java.util.Set;
+import org.springframework.core.GenericTypeResolver;
+
+/**
+ * Every {@link TypedRecordProcessor} whose command value type implements {@link
+ * ProcessInstanceRelated} is gated by the primary suspension gate in {@code Engine.process}. Such a
+ * processor must either:
+ *
+ * <ul>
+ *   <li>implement {@link SuspensionAware}, which forces it to return an explicit
+ *       PROCESS/REJECT/BUFFER decision (the interface has no default), or
+ *   <li>be listed in {@link #WHITELIST} when it processes commands unrelated to process instance
+ *       state changes and therefore needs no suspension classification.
+ * </ul>
+ *
+ * <p>This ensures every process-instance related command processor either makes a conscious,
+ * documented suspension decision or is explicitly exempted.
+ */
+@AnalyzeClasses(
+    packages = "io.camunda.zeebe.engine.processing",
+    importOptions = ImportOption.DoNotIncludeTests.class)
+public class SuspensionAwareArchTest {
+
+  @ArchTest
+  public static final ArchRule PROCESS_INSTANCE_RELATED_PROCESSORS_IMPLEMENT_SUSPENSION_AWARE =
+      classes()
+          .that(processProcessInstanceRelatedCommands())
+          .should(implementSuspensionAwareOrBeWhitelisted());
+
+  /**
+   * Fully-qualified names of processors that do not need to implement {@link SuspensionAware}
+   * because they process commands unrelated to process instance state changes.
+   */
+  private static final Set<String> WHITELIST =
+      Set.of(
+          "io.camunda.zeebe.engine.processing.message.ProcessMessageSubscriptionCreateProcessor",
+          "io.camunda.zeebe.engine.processing.message.ProcessMessageSubscriptionDeleteProcessor",
+          "io.camunda.zeebe.engine.processing.message.MessageSubscriptionCreateProcessor",
+          "io.camunda.zeebe.engine.processing.message.MessageSubscriptionCorrelateProcessor",
+          "io.camunda.zeebe.engine.processing.message.MessageSubscriptionDeleteProcessor",
+          "io.camunda.zeebe.engine.processing.message.MessageSubscriptionMigrateProcessor",
+          "io.camunda.zeebe.engine.processing.message.MessageSubscriptionRejectProcessor",
+          "io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationCreateProcessor",
+          "io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationCreateWithAwaitingResultProcessor");
+
+  private static DescribedPredicate<JavaClass> processProcessInstanceRelatedCommands() {
+    return new DescribedPredicate<>(
+        "are concrete TypedRecordProcessor implementations for a ProcessInstanceRelated command"
+            + " value") {
+      @Override
+      public boolean test(final JavaClass javaClass) {
+        if (javaClass.isInterface()
+            || javaClass.getModifiers().contains(JavaModifier.ABSTRACT)
+            || !Predicates.implement(TypedRecordProcessor.class).test(javaClass)) {
+          return false;
+        }
+        final Class<?> valueType = resolveCommandValueType(javaClass.reflect());
+        if (valueType == null) {
+          // Fail loudly rather than silently skipping the processor: a guard that under-matches is
+          // worse than no guard.
+          throw new IllegalStateException(
+              "Could not resolve the command value type of TypedRecordProcessor '"
+                  + javaClass.getName()
+                  + "'. The suspension rule would silently skip it; extend resolveCommandValueType"
+                  + " to handle its type hierarchy.");
+        }
+        return ProcessInstanceRelated.class.isAssignableFrom(valueType);
+      }
+    };
+  }
+
+  /**
+   * Resolves the {@code T} of the {@code TypedRecordProcessor<T>} that {@code clazz} implements,
+   * following superclasses and transitively-extended interfaces (e.g. {@code
+   * DistributedTypedRecordProcessor}) and binding type variables. Returns {@code null} only when
+   * the argument genuinely can't be resolved to a concrete class.
+   */
+  private static Class<?> resolveCommandValueType(final Class<?> clazz) {
+    return GenericTypeResolver.resolveTypeArgument(clazz, TypedRecordProcessor.class);
+  }
+
+  private static ArchCondition<JavaClass> implementSuspensionAwareOrBeWhitelisted() {
+    return new ArchCondition<>("implement SuspensionAware or be listed in the WHITELIST") {
+      @Override
+      public void check(final JavaClass item, final ConditionEvents events) {
+        final boolean implementsSuspensionAware =
+            Predicates.implement(SuspensionAware.class).test(item);
+        final boolean isWhitelisted = WHITELIST.contains(item.getFullName());
+        if (!implementsSuspensionAware && !isWhitelisted) {
+          events.add(
+              violated(
+                  item,
+                  String.format(
+                      "Class '%s' processes a ProcessInstanceRelated command but does not implement"
+                          + " SuspensionAware, and is not listed in the WHITELIST of"
+                          + " SuspensionAwareArchTest. Either implement SuspensionAware (returning an"
+                          + " explicit PROCESS/REJECT/BUFFER decision) or add it to the whitelist if"
+                          + " it processes commands unrelated to process instance state changes.",
+                      item.getFullName())));
+        }
+      }
+    };
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -46,6 +46,8 @@ public class Engine implements RecordProcessor {
 
   public static final String ERROR_MESSAGE_BANNED_PI =
       "Expected to process command for process instance with key '%d', but the process instance is banned due to previous errors. The process instance can't be recovered, but it can be cancelled.";
+  public static final String ERROR_MESSAGE_SUSPENDED_PI =
+      "Expected to process command for process instance with key '%d', but the process instance is suspended.";
   private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
   private static final String ERROR_MESSAGE_PROCESSOR_NOT_FOUND =
       "Expected to find processor for record '{}', but caught an exception. Skip this record.";

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.engine.processing.agenthistory;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -20,7 +22,8 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 // COMMIT is always a follow-up command emitted internally by the engine and is never issued
 // through the public API, so there is no user to authorize against.
 @ExcludeAuthorizationCheck
-public final class AgentHistoryCommitProcessor implements TypedRecordProcessor<AgentHistoryRecord> {
+public final class AgentHistoryCommitProcessor
+    implements TypedRecordProcessor<AgentHistoryRecord>, SuspensionAware<AgentHistoryRecord> {
 
   private final StateWriter stateWriter;
   private final AgentHistoryState agentHistoryState;
@@ -55,5 +58,10 @@ public final class AgentHistoryCommitProcessor implements TypedRecordProcessor<A
           });
     }
     // no-op when no items exist — backward-compatible with non-agentic jobs
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<AgentHistoryRecord> record) {
+    return SuspensionBehavior.BUFFER;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -11,6 +11,8 @@ import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -28,7 +30,8 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
-public final class AgentHistoryCreateProcessor implements TypedRecordProcessor<AgentHistoryRecord> {
+public final class AgentHistoryCreateProcessor
+    implements TypedRecordProcessor<AgentHistoryRecord>, SuspensionAware<AgentHistoryRecord> {
 
   private static final String ERROR_MSG_AGENT_INSTANCE_NOT_FOUND =
       "Expected to create agent history entry for agent instance with key '%d', but no such agent instance was found.";
@@ -171,5 +174,10 @@ public final class AgentHistoryCreateProcessor implements TypedRecordProcessor<A
       final String reason) {
     rejectionWriter.appendRejection(command, rejectionType, reason);
     responseWriter.writeRejectedResponseOnCommand(command, rejectionType, reason);
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<AgentHistoryRecord> record) {
+    return SuspensionBehavior.BUFFER;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardProcessor.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.engine.processing.agenthistory;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -21,7 +23,7 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 // destroyed without completing, so there is no user to authorize against.
 @ExcludeAuthorizationCheck
 public final class AgentHistoryDiscardProcessor
-    implements TypedRecordProcessor<AgentHistoryRecord> {
+    implements TypedRecordProcessor<AgentHistoryRecord>, SuspensionAware<AgentHistoryRecord> {
 
   private final StateWriter stateWriter;
   private final AgentHistoryState agentHistoryState;
@@ -50,5 +52,10 @@ public final class AgentHistoryDiscardProcessor
       agentHistoryState.visitByJobLease(jobKey, jobLease, visitor);
     }
     // no-op when no items exist — backward-compatible with non-agentic jobs
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<AgentHistoryRecord> record) {
+    return SuspensionBehavior.BUFFER;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteProcessor.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.engine.processing.agentinstance;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -23,7 +25,7 @@ import java.util.List;
 
 @ExcludeAuthorizationCheck
 public final class AgentInstanceCompleteProcessor
-    implements TypedRecordProcessor<AgentInstanceRecord> {
+    implements TypedRecordProcessor<AgentInstanceRecord>, SuspensionAware<AgentInstanceRecord> {
 
   private static final String ERROR_MSG_NOT_FOUND =
       "Expected to complete agent instance with key '%d', but no such agent instance was found.";
@@ -52,5 +54,10 @@ public final class AgentInstanceCompleteProcessor
     current.setStatus(AgentInstanceStatus.COMPLETED);
     current.setChangedAttributes(List.of(AgentInstanceRecord.ATTR_STATUS));
     stateWriter.appendFollowUpEvent(agentInstanceKey, AgentInstanceIntent.COMPLETED, current);
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<AgentInstanceRecord> record) {
+    return SuspensionBehavior.BUFFER;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -11,6 +11,8 @@ import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -32,7 +34,7 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.List;
 
 public final class AgentInstanceCreateProcessor
-    implements TypedRecordProcessor<AgentInstanceRecord> {
+    implements TypedRecordProcessor<AgentInstanceRecord>, SuspensionAware<AgentInstanceRecord> {
 
   // CAUTION: callers may parse this message to extract the existing agentInstanceKey from the
   // second '%d'. Wording changes that alter the position of the numeric values are a breaking
@@ -188,5 +190,10 @@ public final class AgentInstanceCreateProcessor
       final String reason) {
     rejectionWriter.appendRejection(command, rejectionType, reason);
     responseWriter.writeRejectedResponseOnCommand(command, rejectionType, reason);
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<AgentInstanceRecord> record) {
+    return SuspensionBehavior.BUFFER;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -11,6 +11,8 @@ import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -35,7 +37,7 @@ import java.util.List;
 import java.util.Set;
 
 public final class AgentInstanceUpdateProcessor
-    implements TypedRecordProcessor<AgentInstanceRecord> {
+    implements TypedRecordProcessor<AgentInstanceRecord>, SuspensionAware<AgentInstanceRecord> {
 
   // Iteration order matters: it determines the order of names in the emitted changedAttributes
   // list and must be stable across JVMs and replays. Used both as the allow-list for incoming
@@ -358,5 +360,10 @@ public final class AgentInstanceUpdateProcessor
       final String reason) {
     rejectionWriter.appendRejection(command, rejectionType, reason);
     responseWriter.writeRejectedResponseOnCommand(command, rejectionType, reason);
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<AgentInstanceRecord> record) {
+    return SuspensionBehavior.BUFFER;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlo
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutionListener;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -47,7 +48,8 @@ import java.util.function.Function;
 import org.slf4j.Logger;
 
 @ExcludeAuthorizationCheck
-public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessInstanceRecord> {
+public final class BpmnStreamProcessor
+    implements TypedRecordProcessor<ProcessInstanceRecord>, SuspensionAware<ProcessInstanceRecord> {
 
   private static final Logger LOGGER = Loggers.PROCESS_PROCESSOR_LOGGER;
 
@@ -159,6 +161,16 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
       }
     }
     return ProcessingError.UNEXPECTED_ERROR;
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<ProcessInstanceRecord> record) {
+    // Termination must complete even on a suspended instance. Any other externally issued command
+    // is rejected; internal forward-progress element events are buffered instead.
+    return switch ((ProcessInstanceIntent) record.getIntent()) {
+      case TERMINATE_ELEMENT, CONTINUE_TERMINATING_ELEMENT -> SuspensionBehavior.PROCESS;
+      default -> record.isInternalCommand() ? SuspensionBehavior.BUFFER : SuspensionBehavior.REJECT;
+    };
   }
 
   private void processEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalSubscriptionTriggerProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalSubscriptionTriggerProcessor.java
@@ -11,6 +11,8 @@ import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -27,7 +29,8 @@ import org.agrona.DirectBuffer;
 
 @ExcludeAuthorizationCheck
 public class ConditionalSubscriptionTriggerProcessor
-    implements TypedRecordProcessor<ConditionalSubscriptionRecord> {
+    implements TypedRecordProcessor<ConditionalSubscriptionRecord>,
+        SuspensionAware<ConditionalSubscriptionRecord> {
 
   private static final String NO_CONDITIONAL_SUBSCRIPTION_FOUND_MESSAGE =
       "Expected to trigger condition subscription with key '%d', but no such subscription was found "
@@ -107,5 +110,11 @@ public class ConditionalSubscriptionTriggerProcessor
             catchEventIdBuffer,
             ExecutableCatchEvent.class);
     eventHandle.activateElement(catchEvent, elementInstanceKey, elementInstance.getValue());
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(
+      final TypedRecord<ConditionalSubscriptionRecord> record) {
+    return SuspensionBehavior.BUFFER;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -13,6 +13,8 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavio
 import io.camunda.zeebe.engine.processing.common.BannedInstanceCommandCheck;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -42,7 +44,8 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 
-public final class IncidentResolveProcessor implements TypedRecordProcessor<IncidentRecord> {
+public final class IncidentResolveProcessor
+    implements TypedRecordProcessor<IncidentRecord>, SuspensionAware<IncidentRecord> {
 
   public static final String NO_RETRIES_LEFT_MSG =
       "Expected to resolve incident with key '%d', but job with key '%d' has no retries left. Please update the job retries and retry resolving the incident";
@@ -303,5 +306,10 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
 
   private static boolean isJobRelatedIncident(final long jobKey) {
     return jobKey > 0;
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<IncidentRecord> record) {
+    return record.isInternalCommand() ? SuspensionBehavior.BUFFER : SuspensionBehavior.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.engine.processing.job;
 import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -26,7 +28,8 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 @ExcludeAuthorizationCheck
-public final class JobCancelProcessor implements TypedRecordProcessor<JobRecord> {
+public final class JobCancelProcessor
+    implements TypedRecordProcessor<JobRecord>, SuspensionAware<JobRecord> {
 
   public static final String NO_JOB_FOUND_MESSAGE =
       "Expected to cancel job with key '%d', but no such job was found";
@@ -69,5 +72,11 @@ public final class JobCancelProcessor implements TypedRecordProcessor<JobRecord>
       rejectionWriter.appendRejection(
           record, RejectionType.NOT_FOUND, NO_JOB_FOUND_MESSAGE.formatted(jobKey));
     }
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
+    // cancellation should still work during suspension
+    return SuspensionBehavior.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -18,6 +18,8 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAdH
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBusinessIdAssignmentBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -57,7 +59,8 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecord> {
+public final class JobCompleteProcessor
+    implements TypedRecordProcessor<JobRecord>, SuspensionAware<JobRecord> {
 
   private static final String TL_JOB_COMPLETION_WITH_VARS_NOT_SUPPORTED_MESSAGE =
       """
@@ -623,5 +626,10 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
             b -> b.processDefinition().updateProcessInstance().resourceId(job.getBpmnProcessId())),
         job,
         AuthorizationRejectionMapper.noPrincipal());
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
+    return SuspensionBehavior.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -22,6 +22,8 @@ import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
 import io.camunda.zeebe.engine.processing.common.ValidationException;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -46,7 +48,8 @@ import io.camunda.zeebe.util.Either;
 import java.util.List;
 import org.agrona.DirectBuffer;
 
-public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
+public final class JobFailProcessor
+    implements TypedRecordProcessor<JobRecord>, SuspensionAware<JobRecord> {
 
   private static final DirectBuffer DEFAULT_ERROR_MESSAGE = wrapString("No more retries left.");
   private final IncidentRecord incidentEvent = new IncidentRecord();
@@ -229,5 +232,10 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
             b -> b.processDefinition().updateProcessInstance().resourceId(job.getBpmnProcessId())),
         job,
         AuthorizationRejectionMapper.noPrincipal());
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
+    return SuspensionBehavior.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurAfterBackoffProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurAfterBackoffProcessor.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -23,7 +25,8 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.time.InstantSource;
 
 @ExcludeAuthorizationCheck
-public class JobRecurAfterBackoffProcessor implements TypedRecordProcessor<JobRecord> {
+public class JobRecurAfterBackoffProcessor
+    implements TypedRecordProcessor<JobRecord>, SuspensionAware<JobRecord> {
 
   private static final String NOT_FAILED_JOB_MESSAGE =
       "Expected to back off failed job with key '%d', but %s";
@@ -82,5 +85,10 @@ public class JobRecurAfterBackoffProcessor implements TypedRecordProcessor<JobRe
 
   private boolean hasRecurred(final JobRecord job) {
     return job.getRecurringTime() < clock.millis();
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
+    return SuspensionBehavior.BUFFER;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -20,6 +20,8 @@ import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -53,7 +55,8 @@ import java.util.Optional;
 import java.util.Set;
 import org.agrona.DirectBuffer;
 
-public class JobThrowErrorProcessor implements TypedRecordProcessor<JobRecord> {
+public class JobThrowErrorProcessor
+    implements TypedRecordProcessor<JobRecord>, SuspensionAware<JobRecord> {
 
   /**
    * Marker element ID. This ID is used to indicate that a given catch event could not be found. The
@@ -272,5 +275,10 @@ public class JobThrowErrorProcessor implements TypedRecordProcessor<JobRecord> {
             b -> b.processDefinition().updateProcessInstance().resourceId(job.getBpmnProcessId())),
         job,
         AuthorizationRejectionMapper.noPrincipal());
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
+    return SuspensionBehavior.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -11,6 +11,8 @@ import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -25,7 +27,8 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.time.InstantSource;
 
 @ExcludeAuthorizationCheck
-public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord> {
+public final class JobTimeOutProcessor
+    implements TypedRecordProcessor<JobRecord>, SuspensionAware<JobRecord> {
   public static final String NOT_ACTIVATED_JOB_MESSAGE =
       "Expected to time out activated job with key '%d', but %s";
   private final JobState jobState;
@@ -76,5 +79,13 @@ public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord
 
   private boolean hasTimedOut(final JobRecord job) {
     return job.getDeadline() < clock.millis();
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
+    // an internal time-out re-activates the job, so reject while suspended. Like a timer, the
+    // time-out is not suppressed here and may re-trigger until firing is suppressed and re-armed on
+    // resume.
+    return SuspensionBehavior.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateProcessor.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -21,7 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-public class JobUpdateProcessor implements TypedRecordProcessor<JobRecord> {
+public class JobUpdateProcessor
+    implements TypedRecordProcessor<JobRecord>, SuspensionAware<JobRecord> {
 
   private final JobUpdateBehaviour jobUpdateBehaviour;
   private final TypedRejectionWriter rejectionWriter;
@@ -87,5 +90,10 @@ public class JobUpdateProcessor implements TypedRecordProcessor<JobRecord> {
     rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, errorMessage);
     responseWriter.writeRejectedResponseOnCommand(
         command, RejectionType.INVALID_ARGUMENT, errorMessage);
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
+    return SuspensionBehavior.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -18,7 +20,8 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
-public final class JobUpdateRetriesProcessor implements TypedRecordProcessor<JobRecord> {
+public final class JobUpdateRetriesProcessor
+    implements TypedRecordProcessor<JobRecord>, SuspensionAware<JobRecord> {
 
   private final JobUpdateBehaviour jobUpdateBehaviour;
   private final TypedRejectionWriter rejectionWriter;
@@ -58,5 +61,10 @@ public final class JobUpdateRetriesProcessor implements TypedRecordProcessor<Job
               responseWriter.writeRejectedResponseOnCommand(
                   command, rejection.type(), rejection.reason());
             });
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
+    return SuspensionBehavior.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutProcessor.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -18,7 +20,8 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
-public class JobUpdateTimeoutProcessor implements TypedRecordProcessor<JobRecord> {
+public class JobUpdateTimeoutProcessor
+    implements TypedRecordProcessor<JobRecord>, SuspensionAware<JobRecord> {
 
   private final JobUpdateBehaviour jobUpdateBehaviour;
   private final TypedRejectionWriter rejectionWriter;
@@ -58,5 +61,10 @@ public class JobUpdateTimeoutProcessor implements TypedRecordProcessor<JobRecord
               responseWriter.writeRejectedResponseOnCommand(
                   command, rejection.type(), rejection.reason());
             });
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
+    return SuspensionBehavior.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobYieldProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobYieldProcessor.java
@@ -11,6 +11,8 @@ import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -24,7 +26,8 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.util.List;
 
 @ExcludeAuthorizationCheck
-public final class JobYieldProcessor implements TypedRecordProcessor<JobRecord> {
+public final class JobYieldProcessor
+    implements TypedRecordProcessor<JobRecord>, SuspensionAware<JobRecord> {
   private final JobState jobState;
   private final BpmnJobActivationBehavior jobActivationBehavior;
   private final StateWriter stateWriter;
@@ -57,5 +60,13 @@ public final class JobYieldProcessor implements TypedRecordProcessor<JobRecord> 
             },
             rejection ->
                 rejectionWriter.appendRejection(record, rejection.type(), rejection.reason()));
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
+    // YIELD is an internal command (written by the job-stream error handler when a client is
+    // blocked); buffer it while suspended so the yield is applied once the instance resumes instead
+    // of being lost to a rejection.
+    return SuspensionBehavior.BUFFER;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Collection;
+import java.util.function.LongPredicate;
 import java.util.function.Predicate;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.MutableBoolean;
@@ -218,6 +219,13 @@ public final class MessageCorrelateBehavior {
 
   public void correlateToMessageEvents(
       final MessageData messageData, final Subscriptions correlatingSubscriptions) {
+    correlateToMessageEvents(messageData, correlatingSubscriptions, processInstanceKey -> false);
+  }
+
+  public void correlateToMessageEvents(
+      final MessageData messageData,
+      final Subscriptions correlatingSubscriptions,
+      final LongPredicate skipProcessInstance) {
 
     messageSubscriptionState.visitSubscriptions(
         messageData.tenantId(),
@@ -230,7 +238,8 @@ public final class MessageCorrelateBehavior {
               && !correlatingSubscriptions.contains(
                   subscription.getRecord().getBpmnProcessIdBuffer())
               && businessIdMatches(
-                  messageData.businessId(), subscription.getRecord().getBusinessIdBuffer())) {
+                  messageData.businessId(), subscription.getRecord().getBusinessIdBuffer())
+              && !skipProcessInstance.test(subscription.getRecord().getProcessInstanceKey())) {
 
             final var correlatingSubscription =
                 subscription

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -219,6 +219,7 @@ public final class MessageCorrelateBehavior {
 
   public void correlateToMessageEvents(
       final MessageData messageData, final Subscriptions correlatingSubscriptions) {
+    // TODO(#58766): defer correlations to suspended instances so live messages can retry on resume.
     correlateToMessageEvents(messageData, correlatingSubscriptions, processInstanceKey -> false);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import static io.camunda.zeebe.engine.Engine.ERROR_MESSAGE_SUSPENDED_PI;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import io.camunda.security.core.auth.RequiredAuthorization;
@@ -18,6 +19,8 @@ import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.message.MessageCorrelateBehavior.MessageData;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -30,6 +33,7 @@ import io.camunda.zeebe.engine.state.immutable.MessageStartEventSubscriptionStat
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.immutable.MessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
@@ -45,9 +49,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import org.agrona.collections.MutableBoolean;
+import org.agrona.collections.MutableLong;
 
 public final class MessageCorrelationCorrelateProcessor
-    implements TypedRecordProcessor<MessageCorrelationRecord> {
+    implements TypedRecordProcessor<MessageCorrelationRecord>,
+        SuspensionAware<MessageCorrelationRecord> {
 
   private static final String SUBSCRIPTION_NOT_FOUND =
       "Expected to find subscription for message with name '%s' and correlation key '%s', but none was found.";
@@ -65,6 +72,7 @@ public final class MessageCorrelationCorrelateProcessor
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final MessageCorrelationMetrics metrics;
+  private final SuspensionState suspensionState;
 
   public MessageCorrelationCorrelateProcessor(
       final Writers writers,
@@ -82,13 +90,15 @@ public final class MessageCorrelationCorrelateProcessor
       final boolean businessIdUniquenessEnabled,
       final RoutingInfo routingInfo,
       final int partitionId,
-      final MessageCorrelationMetrics metrics) {
+      final MessageCorrelationMetrics metrics,
+      final SuspensionState suspensionState) {
     stateWriter = writers.state();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     this.keyGenerator = keyGenerator;
     this.cslCheck = cslCheck;
     this.metrics = metrics;
+    this.suspensionState = suspensionState;
     final var eventHandle =
         new EventHandle(
             keyGenerator,
@@ -166,6 +176,32 @@ public final class MessageCorrelationCorrelateProcessor
       return;
     }
 
+    // Suspension enforcement: a suspended process instance must not receive the message, but active
+    // targets still must. Determine whether at least one eligible (start-event or non-suspended)
+    // target exists. If every collected target is suspended, reject before any state write so the
+    // message is preserved for a retry once the instance resumes; the gate cannot evaluate this up
+    // front because the target instances are only known once subscriptions are collected.
+    final var suspendedTargetKey = new MutableLong(-1L);
+    final var hasEligibleTarget = new MutableBoolean(false);
+    tempCorrelatingSubscriptions.visitSubscriptions(
+        subscription -> {
+          if (subscription.isStartEventSubscription()
+              || !suspensionState.isSuspended(subscription.processInstanceKey())) {
+            hasEligibleTarget.set(true);
+          } else {
+            suspendedTargetKey.set(subscription.processInstanceKey());
+          }
+          return true;
+        },
+        true);
+
+    if (!hasEligibleTarget.get() && suspendedTargetKey.get() > 0) {
+      final var message = String.format(ERROR_MESSAGE_SUSPENDED_PI, suspendedTargetKey.get());
+      rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, message);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.INVALID_STATE, message);
+      return;
+    }
+
     // Now that authorization passed, write the message and correlations to state
     final var messageRecord =
         new MessageRecord()
@@ -181,7 +217,8 @@ public final class MessageCorrelationCorrelateProcessor
 
     // Now actually correlate with state writes
     final var blockedProcessIds = new HashSet<String>();
-    correlateBehavior.correlateToMessageEvents(messageData, correlatingSubscriptions);
+    correlateBehavior.correlateToMessageEvents(
+        messageData, correlatingSubscriptions, suspensionState::isSuspended);
     final var delegatedCrossPartition =
         correlateBehavior.correlateToMessageStartEvents(
             messageData, correlatingSubscriptions, blockedProcessIds);
@@ -294,5 +331,10 @@ public final class MessageCorrelationCorrelateProcessor
     }
 
     return Optional.empty();
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<MessageCorrelationRecord> record) {
+    return SuspensionBehavior.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -172,7 +172,8 @@ public final class MessageEventProcessors {
                 businessIdUniquenessEnabled,
                 routingInfo,
                 partitionId,
-                metrics))
+                metrics,
+                processingState.getSuspensionState()))
         .onCommand(
             ValueType.MESSAGE_START_PROCESS_INSTANCE_REQUEST,
             MessageStartProcessInstanceRequestIntent.REQUEST,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -14,6 +14,8 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -35,7 +37,8 @@ import org.agrona.DirectBuffer;
 
 @ExcludeAuthorizationCheck
 public final class ProcessMessageSubscriptionCorrelateProcessor
-    implements TypedRecordProcessor<ProcessMessageSubscriptionRecord> {
+    implements TypedRecordProcessor<ProcessMessageSubscriptionRecord>,
+        SuspensionAware<ProcessMessageSubscriptionRecord> {
 
   private static final String NO_EVENT_OCCURRED_MESSAGE =
       "Expected to correlate a process message subscription with element key '%d' and message name '%s', "
@@ -219,5 +222,11 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
         subscription.getMessageNameBuffer(),
         subscription.getCorrelationKeyBuffer(),
         subscription.getTenantId());
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(
+      final TypedRecord<ProcessMessageSubscriptionRecord> record) {
+    return SuspensionBehavior.BUFFER;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBatchActivateProcessor.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.engine.processing.processinstance;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -27,7 +29,8 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 @ExcludeAuthorizationCheck
 public final class ProcessInstanceBatchActivateProcessor
-    implements TypedRecordProcessor<ProcessInstanceBatchRecord> {
+    implements TypedRecordProcessor<ProcessInstanceBatchRecord>,
+        SuspensionAware<ProcessInstanceBatchRecord> {
 
   public static final String PARENT_NOT_FOUND_ERROR_MESSAGE =
       "Expected to activate child for batch element instance, but no parent element instance found for key '%s'. The parent was likely terminated before processing this batch activation.";
@@ -129,5 +132,11 @@ public final class ProcessInstanceBatchActivateProcessor
         .setBpmnElementType(childElement.getElementType())
         .setBpmnEventType(childElement.getEventType());
     return childInstanceRecord;
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(
+      final TypedRecord<ProcessInstanceBatchRecord> record) {
+    return SuspensionBehavior.BUFFER;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBatchTerminateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBatchTerminateProcessor.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.engine.processing.processinstance;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -24,7 +26,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 @ExcludeAuthorizationCheck
 public final class ProcessInstanceBatchTerminateProcessor
-    implements TypedRecordProcessor<ProcessInstanceBatchRecord> {
+    implements TypedRecordProcessor<ProcessInstanceBatchRecord>,
+        SuspensionAware<ProcessInstanceBatchRecord> {
 
   private final StateWriter stateWriter;
   private final TypedCommandWriter commandWriter;
@@ -61,6 +64,12 @@ public final class ProcessInstanceBatchTerminateProcessor
       stateWriter.appendFollowUpEvent(
           record.getKey(), ProcessInstanceBatchIntent.TERMINATED, recordValue);
     }
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(
+      final TypedRecord<ProcessInstanceBatchRecord> record) {
+    return SuspensionBehavior.PROCESS;
   }
 
   private List<ElementInstance> getChildInstances(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignProcessor.java
@@ -11,6 +11,8 @@ import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -34,7 +36,8 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
  * is only available while Business ID uniqueness is disabled.
  */
 public class ProcessInstanceBusinessIdAssignProcessor
-    implements TypedRecordProcessor<ProcessInstanceBusinessIdRecord> {
+    implements TypedRecordProcessor<ProcessInstanceBusinessIdRecord>,
+        SuspensionAware<ProcessInstanceBusinessIdRecord> {
 
   private static final String ERROR_NOT_FOUND =
       "Expected to assign a business id to process instance with key '%d', but no such process instance was found";
@@ -157,5 +160,11 @@ public class ProcessInstanceBusinessIdAssignProcessor
         .setProcessDefinitionKey(processInstanceRecord.getProcessDefinitionKey())
         .setBpmnProcessId(processInstanceRecord.getBpmnProcessId())
         .setRootProcessInstanceKey(processInstanceRecord.getRootProcessInstanceKey());
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(
+      final TypedRecord<ProcessInstanceBusinessIdRecord> record) {
+    return SuspensionBehavior.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelProcessor.java
@@ -12,6 +12,8 @@ import io.camunda.zeebe.engine.processing.AsyncRequestBehavior;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -33,7 +35,7 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.util.Optional;
 
 public final class ProcessInstanceCancelProcessor
-    implements TypedRecordProcessor<ProcessInstanceRecord> {
+    implements TypedRecordProcessor<ProcessInstanceRecord>, SuspensionAware<ProcessInstanceRecord> {
 
   private static final String MESSAGE_PREFIX =
       "Expected to cancel a process instance with key '%d', but ";
@@ -88,6 +90,11 @@ public final class ProcessInstanceCancelProcessor
         command.getKey(), ProcessInstanceIntent.TERMINATE_ELEMENT, value);
     responseWriter.writeAcceptedResponseOnCommand(
         command.getKey(), ProcessInstanceIntent.ELEMENT_TERMINATING, value, command);
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<ProcessInstanceRecord> record) {
+    return SuspensionBehavior.PROCESS;
   }
 
   private boolean validateCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -23,6 +23,8 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMul
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -64,7 +66,8 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
 
 public class ProcessInstanceMigrationMigrateProcessor
-    implements TypedRecordProcessor<ProcessInstanceMigrationRecord> {
+    implements TypedRecordProcessor<ProcessInstanceMigrationRecord>,
+        SuspensionAware<ProcessInstanceMigrationRecord> {
 
   private static final Logger LOG = Loggers.ENGINE_PROCESSING_LOGGER;
   private static final UnsafeBuffer NIL_VALUE = new UnsafeBuffer(MsgPackHelper.NIL);
@@ -702,6 +705,13 @@ public class ProcessInstanceMigrationMigrateProcessor
                           .setBpmnProcessId(targetProcessDefinition.getBpmnProcessId())
                           .setTenantId(elementInstance.getValue().getTenantId())));
     }
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(
+      final TypedRecord<ProcessInstanceMigrationRecord> record) {
+    // migration restructures a running instance, which is unsafe while suspended; reject.
+    return SuspensionBehavior.REJECT;
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -28,6 +28,8 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCat
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -77,7 +79,8 @@ import org.agrona.Strings;
 import org.slf4j.Logger;
 
 public final class ProcessInstanceModificationModifyProcessor
-    implements TypedRecordProcessor<ProcessInstanceModificationRecord> {
+    implements TypedRecordProcessor<ProcessInstanceModificationRecord>,
+        SuspensionAware<ProcessInstanceModificationRecord> {
 
   private static final Logger LOG = Loggers.ENGINE_PROCESSING_LOGGER;
   private static final String ERROR_MESSAGE_PROCESS_INSTANCE_NOT_FOUND =
@@ -1519,6 +1522,12 @@ public final class ProcessInstanceModificationModifyProcessor
           "Cannot enrich rejection command for process instance modification with key {} because the process instance was not found",
           processInstanceKey);
     }
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(
+      final TypedRecord<ProcessInstanceModificationRecord> record) {
+    return record.isInternalCommand() ? SuspensionBehavior.BUFFER : SuspensionBehavior.REJECT;
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
@@ -70,7 +70,7 @@ public final class ProcessInstanceResumeProcessor
 
     final ProcessInstanceRecord value = elementInstance.getValue();
 
-    // TODO: append a DRAIN command instead of writing RESUMED directly, once chunked
+    // TODO(#57792): append a DRAIN command instead of writing RESUMED directly, once chunked
     // draining of buffered commands is implemented.
     stateWriter.appendFollowUpEvent(command.getKey(), ProcessInstanceIntent.RESUMED, value);
     responseWriter.writeAcceptedResponseOnCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
@@ -11,6 +11,8 @@ import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -29,7 +31,7 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 public final class ProcessInstanceResumeProcessor
-    implements TypedRecordProcessor<ProcessInstanceRecord> {
+    implements TypedRecordProcessor<ProcessInstanceRecord>, SuspensionAware<ProcessInstanceRecord> {
 
   private static final String MESSAGE_PREFIX =
       "Expected to resume a process instance with key '%d', but ";
@@ -68,11 +70,16 @@ public final class ProcessInstanceResumeProcessor
 
     final ProcessInstanceRecord value = elementInstance.getValue();
 
-    // TODO(#57792): append a DRAIN command instead of writing RESUMED directly, once chunked
+    // TODO: append a DRAIN command instead of writing RESUMED directly, once chunked
     // draining of buffered commands is implemented.
     stateWriter.appendFollowUpEvent(command.getKey(), ProcessInstanceIntent.RESUMED, value);
     responseWriter.writeAcceptedResponseOnCommand(
         command.getKey(), ProcessInstanceIntent.RESUMED, value, command);
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<ProcessInstanceRecord> record) {
+    return SuspensionBehavior.PROCESS;
   }
 
   private boolean validateCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
@@ -11,6 +11,8 @@ import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -31,7 +33,7 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 public final class ProcessInstanceSuspendProcessor
-    implements TypedRecordProcessor<ProcessInstanceRecord> {
+    implements TypedRecordProcessor<ProcessInstanceRecord>, SuspensionAware<ProcessInstanceRecord> {
 
   private static final String MESSAGE_PREFIX =
       "Expected to suspend a process instance with key '%d', but ";
@@ -149,5 +151,12 @@ public final class ProcessInstanceSuspendProcessor
       final ProcessInstanceRecord processInstanceRecord) {
     command.getValue().setTenantId(processInstanceRecord.getTenantId());
     command.getValue().setRootProcessInstanceKey(processInstanceRecord.getRootProcessInstanceKey());
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<ProcessInstanceRecord> record) {
+    // reject: a repeated suspend while a marker is present must fail like the processor's own
+    // "already suspended" rejection; buffering would silently swallow it.
+    return SuspensionBehavior.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionAware.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionAware.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.streamprocessor;
+
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+/**
+ * Implemented by {@link TypedRecordProcessor}s whose commands are related to a process instance, in
+ * order to classify how the primary suspension gate (see {@code Engine#process}) should treat the
+ * command while the target process instance carries a suspension marker ({@code SUSPENDED} or
+ * {@code RESUMING}).
+ *
+ * @param <T> the record value type processed by the implementing {@link TypedRecordProcessor}
+ */
+public interface SuspensionAware<T extends UnifiedRecordValue> {
+
+  /**
+   * Classifies how the suspension gate should treat the given command while its target is
+   * suspended.
+   *
+   * @param record the command record being classified
+   * @return the {@link SuspensionBehavior} to apply; never {@code null}
+   */
+  SuspensionBehavior suspensionBehavior(final TypedRecord<T> record);
+
+  enum SuspensionBehavior {
+    /** Process the command immediately, regardless of the suspension marker. */
+    PROCESS,
+    /** Reject the command while any suspension marker (SUSPENDED or RESUMING) is present. */
+    REJECT,
+    /**
+     * Buffer the command while {@code SUSPENDED}; pass it through while {@code RESUMING} so that
+     * commands drained during resume can actually execute.
+     */
+    BUFFER
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerCancelProcessor.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.engine.processing.timer;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -19,7 +21,8 @@ import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 @ExcludeAuthorizationCheck
-public final class TimerCancelProcessor implements TypedRecordProcessor<TimerRecord> {
+public final class TimerCancelProcessor
+    implements TypedRecordProcessor<TimerRecord>, SuspensionAware<TimerRecord> {
   public static final String NO_TIMER_FOUND_MESSAGE =
       "Expected to cancel timer with key '%d', but no such timer was found";
 
@@ -48,5 +51,10 @@ public final class TimerCancelProcessor implements TypedRecordProcessor<TimerRec
     } else {
       stateWriter.appendFollowUpEvent(record.getKey(), TimerIntent.CANCELED, timer);
     }
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<TimerRecord> record) {
+    return SuspensionBehavior.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
@@ -14,6 +14,8 @@ import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -37,7 +39,8 @@ import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
 @ExcludeAuthorizationCheck
-public final class TimerTriggerProcessor implements TypedRecordProcessor<TimerRecord> {
+public final class TimerTriggerProcessor
+    implements TypedRecordProcessor<TimerRecord>, SuspensionAware<TimerRecord> {
 
   private static final String NO_TIMER_FOUND_MESSAGE =
       "Expected to trigger timer with key '%d', but no such timer was found";
@@ -198,5 +201,12 @@ public final class TimerTriggerProcessor implements TypedRecordProcessor<TimerRe
     final Interval refreshedInterval =
         timer.getInterval().withStart(Instant.ofEpochMilli(record.getDueDate()));
     return new RepeatingInterval(repetitions, refreshedInterval);
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<TimerRecord> record) {
+    // firing a timer advances the token, so reject while suspended. Rejecting does not remove the
+    // due timer, so it may strand or re-trigger until firing is suppressed and re-armed on resume.
+    return SuspensionBehavior.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -19,6 +19,8 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUse
 import io.camunda.zeebe.engine.processing.deployment.model.element.TaskListener;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.incident.RetryTypedRecord;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -46,7 +48,8 @@ import java.util.Optional;
 import java.util.Set;
 
 @ExcludeAuthorizationCheck
-public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
+public class UserTaskProcessor
+    implements TypedRecordProcessor<UserTaskRecord>, SuspensionAware<UserTaskRecord> {
 
   private static final String USER_TASK_COMPLETION_REJECTION =
       "Completion of the User Task with key '%d' was denied by Task Listener. Reason to deny: '%s'";
@@ -395,5 +398,10 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
     final var context = new BpmnElementContextImpl();
     context.init(elementInstance.getKey(), elementInstance.getValue(), elementInstance.getState());
     return context;
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<UserTaskRecord> record) {
+    return SuspensionBehavior.REJECT;
   }
 }


### PR DESCRIPTION
## Description

Implements step 1 from [#58802](https://github.com/camunda/camunda/pull/58802#issuecomment-5165013509): add the `SuspensionAware` contract before the suspension gate/check logic is added in step 2.

- Add `SuspensionAware` with explicit `PROCESS`, `REJECT`, and `BUFFER` outcomes.
- Classify process-instance-related processors according to their suspension behavior.
- Add an ArchUnit rule that requires the interface or an explicit whitelist.

The suspension gate/check logic is intentionally not included in this PR.

## Checklist

- [ ] Enable backports when necessary.

## Related issues

Related to #58802