### PR TITLE
Implement cancelChange for the new multi-group model

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
@@ -73,6 +73,9 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
 
   @Override
   public ActorFuture<ClusterConfiguration> cancelChange(final long changeId) {
+    if (clusterTopologyManager.isUsingNewConfig()) {
+      return cancelChangeNewModel(changeId);
+    }
     final ActorFuture<ClusterConfiguration> future = executor.createFuture();
     executor.run(
         () ->
@@ -357,6 +360,52 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
   // ---------------------------------------------------------------------------
   // New multi-partition-group model.
   // ---------------------------------------------------------------------------
+
+  private ActorFuture<ClusterConfiguration> cancelChangeNewModel(final long changeId) {
+    final ActorFuture<ClusterConfiguration> future = executor.createFuture();
+    executor.run(
+        () ->
+            clusterTopologyManager.updateMultiConfiguration(
+                currentConfiguration -> {
+                  if (!validateCancelNewModel(changeId, currentConfiguration, future)) {
+                    return currentConfiguration;
+                  }
+                  LOG.warn("Cancelling configuration change '{}'.", changeId);
+                  final var cancelledConfiguration = currentConfiguration.cancelPendingChanges();
+                  future.complete(cancelledConfiguration.toLegacyDefault());
+                  return cancelledConfiguration;
+                }));
+    return future;
+  }
+
+  private boolean validateCancelNewModel(
+      final long changeId,
+      final CurrentClusterConfiguration currentConfiguration,
+      final ActorFuture<ClusterConfiguration> future) {
+    if (currentConfiguration.isUninitialized()) {
+      failFuture(
+          future,
+          new InvalidRequest(
+              "Cannot cancel change " + changeId + " because the topology is not initialized"));
+      return false;
+    }
+    final var pendingPlan = currentConfiguration.phasedChangeState().pending();
+    if (pendingPlan.isEmpty()) {
+      failFuture(
+          future,
+          new InvalidRequest(
+              "Cannot cancel change " + changeId + " because no change is in progress"));
+      return false;
+    }
+    if (pendingPlan.orElseThrow().id() != changeId) {
+      failFuture(
+          future,
+          new InvalidRequest(
+              "Cannot cancel change " + changeId + " because it is not the current change"));
+      return false;
+    }
+    return true;
+  }
 
   private ActorFuture<ConfigurationChangeResult> applyOrDryRunNewModel(
       final boolean dryRun, final ConfigurationChangeRequest request) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
@@ -365,16 +365,26 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
     final ActorFuture<ClusterConfiguration> future = executor.createFuture();
     executor.run(
         () ->
-            clusterTopologyManager.updateMultiConfiguration(
-                currentConfiguration -> {
-                  if (!validateCancelNewModel(changeId, currentConfiguration, future)) {
-                    return currentConfiguration;
-                  }
-                  LOG.warn("Cancelling configuration change '{}'.", changeId);
-                  final var cancelledConfiguration = currentConfiguration.cancelPendingChanges();
-                  future.complete(cancelledConfiguration.toLegacyDefault());
-                  return cancelledConfiguration;
-                }));
+            clusterTopologyManager
+                .updateMultiConfiguration(
+                    currentConfiguration -> {
+                      if (!validateCancelNewModel(changeId, currentConfiguration, future)) {
+                        return currentConfiguration;
+                      }
+                      LOG.warn("Cancelling configuration change '{}'.", changeId);
+                      return currentConfiguration.cancelPendingChanges();
+                    })
+                .onComplete(
+                    (updatedConfiguration, error) -> {
+                      if (error != null) {
+                        failFuture(future, error);
+                        return;
+                      }
+                      if (!future.isDone()) {
+                        future.complete(updatedConfiguration.toLegacyDefault());
+                      }
+                    },
+                    executor));
     return future;
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -384,6 +384,29 @@ public record CurrentClusterConfiguration(
   }
 
   /**
+   * Cancels the pending plan: clears the pending change on every sub-configuration that has one
+   * (the global configuration and/or any partition group targeted by the plan's phases so far), and
+   * moves the plan into {@code lastChange} with {@link PhasedChangePlanStatus#CANCELLED}. This is
+   * an unsafe operation and should be used only as a last resort when a plan is stuck — already
+   * applied operations are not reverted, so sub-configurations affected by earlier phases may be
+   * left in an intermediate state.
+   *
+   * @return {@code this} if no plan is pending
+   */
+  public CurrentClusterConfiguration cancelPendingChanges() {
+    if (phasedChangeState.pending().isEmpty()) {
+      return this;
+    }
+    var result = updateGlobalConfiguration(GlobalConfiguration::cancelPendingChanges);
+    for (final var groupId : partitionGroups.keySet()) {
+      result =
+          result.updatePartitionGroupConfig(
+              groupId, PartitionGroupConfiguration::cancelPendingChanges);
+    }
+    return result.completePlan(PhasedChangePlanStatus.CANCELLED);
+  }
+
+  /**
    * Returns the number of members in the cluster that are not {@link BrokerState.State#LEFT} or
    * {@link BrokerState.State#UNINITIALIZED}.
    */

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelConfigurationChangeCoordinatorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelConfigurationChangeCoordinatorTest.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
@@ -260,5 +261,95 @@ final class NewModelConfigurationChangeCoordinatorTest {
         .failsWithin(Duration.ofSeconds(5))
         .withThrowableOfType(ExecutionException.class)
         .withCauseInstanceOf(ConcurrentModificationException.class);
+  }
+
+  @Test
+  void shouldCancelOngoingChange() {
+    // given — a plan is pending; its only operation targets member 1, so on member 0 it never
+    // drains on its own
+    wire(MEMBER_0, twoMemberCluster());
+    manager
+        .updateMultiConfiguration(
+            c -> c.initPlan(List.of(new GlobalPhase(List.of(new MemberLeaveOperation(MEMBER_1))))))
+        .join();
+    final var changeId = configuration().phasedChangeState().pending().orElseThrow().id();
+
+    // when
+    final var cancelled = coordinator.cancelChange(changeId).join();
+
+    // then — the returned (legacy-projected) configuration and the real one both reflect the
+    // cancellation: no pending plan, cleared on every sub-config that had one, marked CANCELLED
+    assertThat(cancelled.pendingChanges()).isEmpty();
+    final var config = configuration();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    assertThat(config.globalConfiguration().hasPendingChanges()).isFalse();
+    assertThat(config.phasedChangeState().lastChange())
+        .hasValueSatisfying(
+            last -> {
+              assertThat(last.id()).isEqualTo(changeId);
+              assertThat(last.status()).isEqualTo(PhasedChangePlanStatus.CANCELLED);
+            });
+  }
+
+  @Test
+  void shouldClearPendingChangesOnAllTargetedGroupsWhenCancelling() {
+    // given — a plan whose first (and only) phase targets the default group and never drains
+    // because its operation targets member 1
+    wire(MEMBER_0, twoMemberCluster());
+    manager
+        .updateMultiConfiguration(
+            c ->
+                c.initPlan(
+                    List.of(
+                        new PartitionGroupParallelPhase(
+                            Map.of(
+                                CurrentClusterConfiguration.DEFAULT_GROUP,
+                                List.of(new PartitionLeaveOperation(MEMBER_1, 1, 1)))))))
+        .join();
+    final var changeId = configuration().phasedChangeState().pending().orElseThrow().id();
+
+    // when
+    coordinator.cancelChange(changeId).join();
+
+    // then
+    final var defaultGroup =
+        configuration().partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
+    assertThat(defaultGroup.hasPendingChanges()).isFalse();
+  }
+
+  @Test
+  void shouldRejectCancelWhenNoChangeIsInProgress() {
+    // given — no pending plan
+    wire(MEMBER_0, twoMemberCluster());
+
+    // when
+    final var cancelFuture = coordinator.cancelChange(1);
+
+    // then
+    assertThat(cancelFuture)
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(InvalidRequest.class);
+  }
+
+  @Test
+  void shouldRejectCancelWithWrongChangeId() {
+    // given — a plan is pending with some id
+    wire(MEMBER_0, twoMemberCluster());
+    manager
+        .updateMultiConfiguration(
+            c -> c.initPlan(List.of(new GlobalPhase(List.of(new MemberLeaveOperation(MEMBER_1))))))
+        .join();
+    final var changeId = configuration().phasedChangeState().pending().orElseThrow().id();
+
+    // when — cancelling a different id
+    final var cancelFuture = coordinator.cancelChange(changeId + 1);
+
+    // then — rejected, and the pending plan is left untouched
+    assertThat(cancelFuture)
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(InvalidRequest.class);
+    assertThat(configuration().phasedChangeState().pending()).isPresent();
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
@@ -14,6 +14,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
@@ -66,6 +67,8 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
@@ -590,8 +593,32 @@ final class NewModelManagementApiEndpointsTest {
         .hasMessageContaining("recovery mode");
   }
 
-  // cancelTopologyChange on the new model is implemented separately (issue #58398); not covered
-  // here.
+  @Test
+  void shouldCancelTopologyChangeEndToEnd() {
+    // given — a pending plan whose operation targets a member other than the local one, so it
+    // never drains on its own
+    wire(
+        singleActiveMember()
+            .addMember(ID_1, MemberState.initializeAsActive(Map.of()))
+            .updateMember(ID_0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig))));
+    manager
+        .updateMultiConfiguration(
+            c -> c.initPlan(List.of(new GlobalPhase(List.of(new MemberLeaveOperation(ID_1))))))
+        .join();
+    final var changeId =
+        manager.getMultiConfiguration().join().phasedChangeState().pending().orElseThrow().id();
+
+    // when — cancelled via the management API endpoint
+    final var response = handler.cancelTopologyChange(new CancelChangeRequest(changeId)).join();
+
+    // then — no pending change remains, on both the response and the real configuration
+    assertThat(response.pendingChanges()).isEmpty();
+    final var config = manager.getMultiConfiguration().join();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    assertThat(config.phasedChangeState().lastChange())
+        .hasValueSatisfying(
+            last -> assertThat(last.status()).isEqualTo(PhasedChangePlanStatus.CANCELLED));
+  }
 
   @Test
   void shouldGetTopology() {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
@@ -717,6 +717,96 @@ class CurrentClusterConfigurationTest {
   }
 
   @Nested
+  class CancelPendingChanges {
+
+    @Test
+    void shouldReturnSameConfigWhenNoPlanIsPending() {
+      // given
+      final var config = CurrentClusterConfiguration.init();
+
+      // when
+      final var cancelled = config.cancelPendingChanges();
+
+      // then
+      assertThat(cancelled).isEqualTo(config);
+    }
+
+    @Test
+    void shouldClearPendingChangesOnGlobalConfigurationForGlobalPhase() {
+      // given
+      final var config =
+          CurrentClusterConfiguration.init()
+              .initPlan(List.of(new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_0)))));
+      final var changeId = config.phasedChangeState().pending().orElseThrow().id();
+
+      // when
+      final var cancelled = config.cancelPendingChanges();
+
+      // then
+      assertThat(cancelled.globalConfiguration().hasPendingChanges()).isFalse();
+      assertThat(cancelled.phasedChangeState().pending()).isEmpty();
+      assertThat(cancelled.phasedChangeState().lastChange()).isPresent();
+      assertThat(cancelled.phasedChangeState().lastChange().orElseThrow().id()).isEqualTo(changeId);
+      assertThat(cancelled.phasedChangeState().lastChange().orElseThrow().status())
+          .isEqualTo(PhasedChangePlanStatus.CANCELLED);
+    }
+
+    @Test
+    void shouldClearPendingChangesOnEveryTargetedPartitionGroup() {
+      // given — a plan targeting groups "a" and "b" in a single parallel phase
+      final var config =
+          config(
+                  global(1, Map.of()),
+                  Map.of("a", group(1, Map.of()), "b", group(1, Map.of())),
+                  PhasedChangeState.empty())
+              .initPlan(
+                  List.of(
+                      new PartitionGroupParallelPhase(
+                          Map.of(
+                              "a",
+                              List.of(new DeleteHistoryOperation(MEMBER_0)),
+                              "b",
+                              List.of(new DeleteHistoryOperation(MEMBER_0))))));
+
+      // when
+      final var cancelled = config.cancelPendingChanges();
+
+      // then
+      assertThat(cancelled.partitionGroup("a").hasPendingChanges()).isFalse();
+      assertThat(cancelled.partitionGroup("b").hasPendingChanges()).isFalse();
+      assertThat(cancelled.phasedChangeState().pending()).isEmpty();
+      assertThat(cancelled.phasedChangeState().lastChange().orElseThrow().status())
+          .isEqualTo(PhasedChangePlanStatus.CANCELLED);
+    }
+
+    @Test
+    void shouldNotClearPendingChangesOnGroupNotYetTargetedByCurrentPhase() {
+      // given — a two-phase plan: phase 0 targets group "a", phase 1 (not yet activated) targets
+      // "b"
+      final var config =
+          config(
+                  global(1, Map.of()),
+                  Map.of("a", group(1, Map.of()), "b", group(1, Map.of())),
+                  PhasedChangeState.empty())
+              .initPlan(
+                  List.of(
+                      new PartitionGroupParallelPhase(
+                          Map.of("a", List.of(new DeleteHistoryOperation(MEMBER_0)))),
+                      new PartitionGroupParallelPhase(
+                          Map.of("b", List.of(new DeleteHistoryOperation(MEMBER_0))))));
+
+      // when — cancel while phase 0 is still active
+      final var cancelled = config.cancelPendingChanges();
+
+      // then — only the already-activated group "a" is cleared; "b" is untouched, still at its
+      // original version since it was never activated
+      assertThat(cancelled.partitionGroup("a").hasPendingChanges()).isFalse();
+      assertThat(cancelled.partitionGroup("b")).isEqualTo(group(1, Map.of()));
+      assertThat(cancelled.phasedChangeState().pending()).isEmpty();
+    }
+  }
+
+  @Nested
   class ToLegacyDefault {
 
     @Test


### PR DESCRIPTION
## Summary
- `ConfigurationChangeCoordinator.cancelChange` only cancelled a pending change on the legacy single-group `ClusterConfiguration`; on the new multi-partition-group model (`CurrentClusterConfiguration`) it silently went through the legacy path and ignored pending changes on the global configuration or any partition group.
- Added `CurrentClusterConfiguration.cancelPendingChanges()`, which clears the pending change on the global configuration and on every partition group that has one, then completes the phased plan as `CANCELLED`.
- `ConfigurationChangeCoordinatorImpl.cancelChange` now dispatches to a new `cancelChangeNewModel` path when the manager is using the new model (mirroring the existing `isUsingNewConfig()` dispatch for `applyOperations`/`simulateOperations`), with the same validation semantics as the legacy path (uninitialized / no change in progress / wrong change id).

Closes #58398
