### PR TITLE
fix: tolerate stale legacy-derived phases when merging PhasedChangePlan

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PhasedChangePlan.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PhasedChangePlan.java
@@ -11,6 +11,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
 
@@ -25,6 +26,17 @@ import org.jspecify.annotations.NullMarked;
  * <p>Merge rule (gossip convergence): if plan IDs are equal, the higher {@code currentPhaseIndex}
  * wins. If plan IDs differ, the higher plan ID always wins — plan IDs are monotonically increasing,
  * so the higher ID is always the newer plan.
+ *
+ * <p>One legitimate source of same-ID plans with unequal phases: {@link
+ * CurrentClusterConfiguration#fromLegacy} re-derives a plan's phases from a legacy {@code
+ * ClusterChangePlan}'s <em>remaining</em> operations every time it is called, so a plan
+ * reconstructed this way after some operations already completed carries fewer operations in its
+ * current phase than the same plan tracked natively (where the phase list stays fixed and progress
+ * is tracked separately). When one side's phases are otherwise identical to the other's except for
+ * such a trailing-operations shrink within the current phase, that side is recognized as a stale,
+ * lossily-reconstructed view of the same phase and the more complete side wins; any other kind of
+ * mismatch (different phase kinds/counts, or operations that aren't a trailing subset) still
+ * throws.
  */
 @NullMarked
 public record PhasedChangePlan(
@@ -74,13 +86,96 @@ public record PhasedChangePlan(
   public PhasedChangePlan merge(final PhasedChangePlan other) {
     if (id == other.id) {
       if (!phases.equals(other.phases())) {
-        throw new IllegalStateException(
-            "Cannot merge plans with the same ID but different phases: %s vs %s"
-                .formatted(phases, other.phases()));
+        final var morePhases = moreCompletePhases(phases, other.phases());
+        if (morePhases.isEmpty()) {
+          throw new IllegalStateException(
+              "Cannot merge plans with the same ID but different phases: %s vs %s"
+                  .formatted(phases, other.phases()));
+        }
+        return new PhasedChangePlan(
+            id, Math.max(currentPhaseIndex, other.currentPhaseIndex), morePhases.get(), startedAt);
       }
       return currentPhaseIndex >= other.currentPhaseIndex ? this : other;
     }
     return id > other.id ? this : other;
+  }
+
+  /**
+   * If {@code a} and {@code b} differ only in that the current phase's operations on one side are a
+   * trailing subset of the operations on the other (see the class-level javadoc for why this
+   * happens), returns the side with the fuller operations list. Otherwise returns empty, meaning
+   * the mismatch is a genuine conflict.
+   */
+  private static Optional<List<Phase>> moreCompletePhases(
+      final List<Phase> a, final List<Phase> b) {
+    if (a.size() != b.size()) {
+      return Optional.empty();
+    }
+    List<Phase> fuller = null;
+    for (int i = 0; i < a.size(); i++) {
+      final var phaseA = a.get(i);
+      final var phaseB = b.get(i);
+      if (phaseA.equals(phaseB)) {
+        continue;
+      }
+      final var fullerPhase = fullerPhase(phaseA, phaseB);
+      if (fullerPhase.isEmpty() || fuller != null) {
+        // either a genuine mismatch, or a second phase already differed - not the single-phase
+        // trailing-shrink case this method recognizes
+        return Optional.empty();
+      }
+      fuller = fullerPhase.get() == phaseA ? a : b;
+    }
+    return Optional.ofNullable(fuller);
+  }
+
+  private static Optional<Phase> fullerPhase(final Phase a, final Phase b) {
+    if (a instanceof GlobalPhase globalA && b instanceof GlobalPhase globalB) {
+      // a is the trailing subset of b => b is fuller, and vice versa
+      return isTrailingSubset(globalA.operations(), globalB.operations())
+          ? Optional.of(b)
+          : isTrailingSubset(globalB.operations(), globalA.operations())
+              ? Optional.of(a)
+              : Optional.empty();
+    }
+    if (a instanceof PartitionGroupParallelPhase partitionA
+        && b instanceof PartitionGroupParallelPhase partitionB) {
+      if (!partitionA.groupOperations().keySet().equals(partitionB.groupOperations().keySet())) {
+        return Optional.empty();
+      }
+      boolean aIsFuller = false;
+      boolean bIsFuller = false;
+      for (final var entry : partitionA.groupOperations().entrySet()) {
+        final var opsA = entry.getValue();
+        // keySets were checked equal above, so this is always present
+        final var opsB = Objects.requireNonNull(partitionB.groupOperations().get(entry.getKey()));
+        if (opsA.equals(opsB)) {
+          continue;
+        }
+        // opsA is the trailing subset of opsB => b is fuller for this group, and vice versa
+        if (isTrailingSubset(opsA, opsB)) {
+          bIsFuller = true;
+        } else if (isTrailingSubset(opsB, opsA)) {
+          aIsFuller = true;
+        } else {
+          return Optional.empty();
+        }
+      }
+      if (aIsFuller == bIsFuller) {
+        // either no group differed after all, or groups disagree on which side is fuller
+        return Optional.empty();
+      }
+      return Optional.of(aIsFuller ? a : b);
+    }
+    return Optional.empty();
+  }
+
+  /** Returns {@code true} if {@code shorter} equals the trailing elements of {@code longer}. */
+  private static <T> boolean isTrailingSubset(final List<T> shorter, final List<T> longer) {
+    if (shorter.size() >= longer.size()) {
+      return false;
+    }
+    return longer.subList(longer.size() - shorter.size(), longer.size()).equals(shorter);
   }
 
   /**

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PhasedChangePlanTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PhasedChangePlanTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
@@ -162,6 +163,54 @@ class PhasedChangePlanTest {
       // when / then — higher plan ID wins
       assertThat(olderPlan.merge(newerPlan)).isSameAs(newerPlan);
       assertThat(newerPlan.merge(olderPlan)).isSameAs(newerPlan);
+    }
+
+    @Test
+    void shouldPreferFullerPhaseWhenSameIdAndOneSideIsATrailingSubsetOfTheOther() {
+      // given — same plan id; one side is a lossy re-derivation (e.g. via
+      // CurrentClusterConfiguration#fromLegacy) that only knows about the two operations still
+      // remaining after the first two of an original four completed
+      final var join1 = new PartitionJoinOperation(MEMBER_1, 1, 1);
+      final var join2 = new PartitionJoinOperation(MEMBER_1, 2, 1);
+      final var join3 = new PartitionJoinOperation(MEMBER_2, 1, 1);
+      final var join4 = new PartitionJoinOperation(MEMBER_2, 2, 1);
+      final var fullPlan =
+          PhasedChangePlan.init(
+              7L,
+              List.of(
+                  new PartitionGroupParallelPhase(
+                      Map.of("groupA", List.of(join1, join2, join3, join4)))),
+              Instant.EPOCH);
+      final var staleReconstruction =
+          PhasedChangePlan.init(
+              7L,
+              List.of(new PartitionGroupParallelPhase(Map.of("groupA", List.of(join3, join4)))),
+              Instant.EPOCH);
+
+      // when / then — the fuller (non-lossy) side wins regardless of merge direction
+      assertThat(fullPlan.merge(staleReconstruction).phases()).isEqualTo(fullPlan.phases());
+      assertThat(staleReconstruction.merge(fullPlan).phases()).isEqualTo(fullPlan.phases());
+    }
+
+    @Test
+    void shouldThrowWhenSameIdAndPhasesDifferButNeitherIsATrailingSubsetOfTheOther() {
+      // given — same plan id, but the operations are genuinely incompatible (not a shrink of one
+      // another), which must still surface as a loud failure rather than silently pick a side
+      final var join1 = new PartitionJoinOperation(MEMBER_1, 1, 1);
+      final var join2 = new PartitionJoinOperation(MEMBER_2, 1, 1);
+      final var planA =
+          PhasedChangePlan.init(
+              7L,
+              List.of(new PartitionGroupParallelPhase(Map.of("groupA", List.of(join1)))),
+              Instant.EPOCH);
+      final var planB =
+          PhasedChangePlan.init(
+              7L,
+              List.of(new PartitionGroupParallelPhase(Map.of("groupA", List.of(join2)))),
+              Instant.EPOCH);
+
+      // when / then
+      assertThatThrownBy(() -> planA.merge(planB)).isInstanceOf(IllegalStateException.class);
     }
   }
 


### PR DESCRIPTION
## Summary
- `PhasedChangePlan.merge()` threw `IllegalStateException: Cannot merge plans with the same ID but different phases` when a lossy `CurrentClusterConfiguration.fromLegacy()` reconstruction (phases re-derived from a legacy plan's *remaining* operations) collided with a natively-tracked plan under the same id but a fixed phase list.
- `ClusterConfigurationManagerImpl.onGossipReceivedCurrent` swallowed that exception as a WARN, dropping the whole gossip update and leaving the broker that was supposed to apply the next operation permanently stuck.
- `merge()` now recognizes the specific shape — same id, same phase count and kinds, one side's operations a trailing subset of the other's — and picks the fuller (non-lossy) side instead of throwing. Any other same-id mismatch (different phase kinds/counts, or operations that aren't a trailing subset) still throws, since that reflects a genuine conflict.

Cherry-picked from `c4b8b352b4088625c66f914b2ffe755f6f90a7f3` on `dd-enable-new-model` (part of PR #59114), as a standalone fix.

Part of #56018.

## Test plan
- [x] `PhasedChangePlanTest` (16 tests) passes
- [x] `zeebe/dynamic-config` full module suite passes