### PR TITLE
feat: add shared Operate operation button components

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/call-hierarchy.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/call-hierarchy.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {CallHierarchy} from '@camunda/camunda-api-zod-schemas/8.10';
+
+function createCallHierarchy(overrides?: Partial<CallHierarchy>): CallHierarchy {
+	return {
+		processInstanceKey: '2251799813685252',
+		processDefinitionKey: '2251799813685251',
+		processDefinitionName: 'Root Process',
+		...overrides,
+	};
+}
+
+export {createCallHierarchy};

--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
@@ -152,6 +152,11 @@ const mockQueryAuditLogsEndpoint = createEndpointMock({
 	method: endpoints.queryAuditLogs.method,
 });
 
+const mockGetProcessInstanceCallHierarchyEndpoint = createEndpointMock({
+	endpoint: endpoints.getProcessInstanceCallHierarchy.getUrl({processInstanceKey: ':processInstanceKey'}),
+	method: endpoints.getProcessInstanceCallHierarchy.method,
+});
+
 export {
 	mockCurrentUserEndpoint,
 	mockLoginEndpoint,
@@ -181,4 +186,5 @@ export {
 	mockQueryDecisionInstancesEndpoint,
 	mockCreateDecisionInstancesDeletionBatchOperationEndpoint,
 	mockQueryAuditLogsEndpoint,
+	mockGetProcessInstanceCallHierarchyEndpoint,
 };

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/OperationItem/DangerButton.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/OperationItem/DangerButton.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useTranslation} from 'react-i18next';
+import {Button, type ButtonSize} from '@carbon/react';
+
+type ItemProps = {
+	type: 'DELETE';
+	onClick: () => void;
+	title: string;
+	disabled?: boolean;
+	size?: ButtonSize;
+};
+
+const TYPE_DETAILS: Readonly<Record<ItemProps['type'], {testId: string}>> = {
+	DELETE: {testId: 'delete-operation'},
+};
+
+const DangerButton: React.FC<ItemProps> = ({title, onClick, type, disabled, size}) => {
+	const {t} = useTranslation();
+	const {testId} = TYPE_DETAILS[type];
+
+	return (
+		<li>
+			<Button
+				kind="danger--ghost"
+				iconDescription={title}
+				onClick={onClick}
+				disabled={disabled}
+				data-testid={testId}
+				title={title}
+				aria-label={title}
+				size={size}
+			>
+				{t('operate.shared.operations.deleteButtonLabel')}
+			</Button>
+		</li>
+	);
+};
+
+export {DangerButton};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/OperationItem/OperationItem.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/OperationItem/OperationItem.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Error, Tools, RetryFailed, type CarbonIconType} from '@carbon/react/icons';
+import {Button, type ButtonSize} from '@carbon/react';
+
+type ItemProps = {
+	type: 'RESOLVE_INCIDENT' | 'CANCEL_PROCESS_INSTANCE' | 'ENTER_MODIFICATION_MODE';
+	onClick: React.ComponentProps<'button'>['onClick'];
+	title: string;
+	disabled?: boolean;
+	size?: ButtonSize;
+};
+
+const TYPE_DETAILS: Readonly<Record<ItemProps['type'], {icon?: CarbonIconType; testId: string}>> = {
+	RESOLVE_INCIDENT: {icon: RetryFailed, testId: 'retry-operation'},
+	CANCEL_PROCESS_INSTANCE: {icon: Error, testId: 'cancel-operation'},
+	ENTER_MODIFICATION_MODE: {icon: Tools, testId: 'enter-modification-mode'},
+};
+
+const OperationItem: React.FC<ItemProps> = ({title, onClick, type, disabled, size}) => {
+	const {icon, testId} = TYPE_DETAILS[type];
+
+	return (
+		<li>
+			<Button
+				kind="ghost"
+				renderIcon={icon}
+				tooltipPosition="left"
+				iconDescription={title}
+				onClick={onClick}
+				disabled={disabled}
+				data-testid={testId}
+				title={title}
+				aria-label={title}
+				hasIconOnly
+				size={size}
+			/>
+		</li>
+	);
+};
+
+export {OperationItem};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/OperationItems/OperationItems.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/OperationItems/OperationItems.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {Ul} from './styled';
+
+type Props = {
+	children: React.ReactNode;
+};
+
+const OperationItems: React.FC<Props> = (props) => {
+	return <Ul {...props}>{React.Children.toArray(props.children)}</Ul>;
+};
+
+export {OperationItems};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/OperationItems/styled.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/OperationItems/styled.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+
+const Ul = styled.ul`
+	display: inline-flex;
+	flex-direction: row;
+`;
+
+export {Ul};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/Cancel.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/Cancel.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import {type ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.10';
+import {OperationItem} from '#/operate/shared/OperationItem/OperationItem';
+import {CancelConfirmationModal} from './CancelConfirmationModal';
+
+type Props = {
+	processInstanceKey: ProcessInstance['processInstanceKey'];
+	onExecute: () => void;
+	disabled?: boolean;
+};
+
+const Cancel: React.FC<Props> = ({processInstanceKey, onExecute, disabled = false}) => {
+	const {t} = useTranslation();
+	const [isCancellationModalVisible, setIsCancellationModalVisible] = useState(false);
+
+	return (
+		<>
+			<OperationItem
+				type="CANCEL_PROCESS_INSTANCE"
+				onClick={() => setIsCancellationModalVisible(true)}
+				title={t('operate.shared.operations.cancelTitle', {processInstanceKey})}
+				disabled={disabled}
+				size="sm"
+			/>
+			{isCancellationModalVisible && (
+				<CancelConfirmationModal
+					processInstanceKey={processInstanceKey}
+					open={isCancellationModalVisible}
+					onConfirm={() => {
+						setIsCancellationModalVisible(false);
+						onExecute();
+					}}
+					onCancel={() => setIsCancellationModalVisible(false)}
+				/>
+			)}
+		</>
+	);
+};
+
+export {Cancel};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/CancelConfirmationModal.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/CancelConfirmationModal.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useTranslation} from 'react-i18next';
+import {Modal, Link} from '@carbon/react';
+import {type ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.10';
+import {useCallHierarchy} from './Operations.queries';
+
+type Props = {
+	processInstanceKey: ProcessInstance['processInstanceKey'];
+	open: boolean;
+	onConfirm: () => void;
+	onCancel: () => void;
+};
+
+const CancelConfirmationModal: React.FC<Props> = ({processInstanceKey, open, onConfirm, onCancel}) => {
+	const {t} = useTranslation();
+	const {data: callHierarchy} = useCallHierarchy(processInstanceKey, {enabled: open});
+	const rootInstanceId = callHierarchy?.[0]?.processInstanceKey;
+
+	if (rootInstanceId) {
+		return (
+			<Modal
+				open={open}
+				preventCloseOnClickOutside
+				modalHeading={t('operate.shared.operations.cancelRootInstanceModal.heading')}
+				passiveModal
+				onRequestClose={onCancel}
+				size="md"
+				data-testid="passive-cancellation-modal"
+			>
+				<p>
+					{t('operate.shared.operations.cancelRootInstanceModal.bodyBeforeLink')}{' '}
+					<Link
+						href={`/operate/processes/${rootInstanceId}`}
+						title={t('operate.shared.operations.cancelRootInstanceModal.linkTitle', {rootInstanceId})}
+					>
+						{rootInstanceId}
+					</Link>{' '}
+					{t('operate.shared.operations.cancelRootInstanceModal.bodyAfterLink')}
+				</p>
+			</Modal>
+		);
+	}
+
+	return (
+		<Modal
+			open={open}
+			preventCloseOnClickOutside
+			modalHeading={t('operate.shared.operations.cancelConfirmationModal.heading')}
+			primaryButtonText={t('operate.shared.operations.cancelConfirmationModal.applyButton')}
+			secondaryButtonText={t('operate.shared.operations.cancelConfirmationModal.cancelButton')}
+			onRequestSubmit={onConfirm}
+			onRequestClose={onCancel}
+			size="md"
+			data-testid="confirm-cancellation-modal"
+		>
+			<p>{t('operate.shared.operations.cancelConfirmationModal.body', {processInstanceKey})}</p>
+			<p>{t('operate.shared.operations.cancelConfirmationModal.hint')}</p>
+		</Modal>
+	);
+};
+
+export {CancelConfirmationModal};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/CancelConfirmationModal.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/CancelConfirmationModal.tsx
@@ -7,8 +7,10 @@
  */
 
 import {useTranslation} from 'react-i18next';
-import {Modal, Link} from '@carbon/react';
+import {InlineLoading, InlineNotification, Link, Modal} from '@carbon/react';
 import {type ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.10';
+import {getBootConfig} from '#/shared/config/getBootConfig';
+import {mergePathname} from '#/shared/http/mergePathname';
 import {useCallHierarchy} from './Operations.queries';
 
 type Props = {
@@ -20,10 +22,12 @@ type Props = {
 
 const CancelConfirmationModal: React.FC<Props> = ({processInstanceKey, open, onConfirm, onCancel}) => {
 	const {t} = useTranslation();
-	const {data: callHierarchy} = useCallHierarchy(processInstanceKey, {enabled: open});
+	const {data: callHierarchy, isError, isPending} = useCallHierarchy(processInstanceKey, {enabled: open});
 	const rootInstanceId = callHierarchy?.[0]?.processInstanceKey;
 
 	if (rootInstanceId) {
+		const rootInstancePath = mergePathname(getBootConfig().contextPath, `/operate/processes/${rootInstanceId}`);
+
 		return (
 			<Modal
 				open={open}
@@ -37,7 +41,7 @@ const CancelConfirmationModal: React.FC<Props> = ({processInstanceKey, open, onC
 				<p>
 					{t('operate.shared.operations.cancelRootInstanceModal.bodyBeforeLink')}{' '}
 					<Link
-						href={`/operate/processes/${rootInstanceId}`}
+						href={rootInstancePath}
 						title={t('operate.shared.operations.cancelRootInstanceModal.linkTitle', {rootInstanceId})}
 					>
 						{rootInstanceId}
@@ -55,6 +59,7 @@ const CancelConfirmationModal: React.FC<Props> = ({processInstanceKey, open, onC
 			modalHeading={t('operate.shared.operations.cancelConfirmationModal.heading')}
 			primaryButtonText={t('operate.shared.operations.cancelConfirmationModal.applyButton')}
 			secondaryButtonText={t('operate.shared.operations.cancelConfirmationModal.cancelButton')}
+			primaryButtonDisabled={isPending || isError}
 			onRequestSubmit={onConfirm}
 			onRequestClose={onCancel}
 			size="md"
@@ -62,6 +67,17 @@ const CancelConfirmationModal: React.FC<Props> = ({processInstanceKey, open, onC
 		>
 			<p>{t('operate.shared.operations.cancelConfirmationModal.body', {processInstanceKey})}</p>
 			<p>{t('operate.shared.operations.cancelConfirmationModal.hint')}</p>
+			{isPending && (
+				<InlineLoading description={t('operate.shared.operations.cancelConfirmationModal.verificationLoading')} />
+			)}
+			{isError && (
+				<InlineNotification
+					kind="error"
+					hideCloseButton
+					role="alert"
+					title={t('operate.shared.operations.cancelConfirmationModal.verificationError')}
+				/>
+			)}
 		</Modal>
 	);
 };

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/Delete.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/Delete.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import {type ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.10';
+import {DangerButton} from '#/operate/shared/OperationItem/DangerButton';
+import {DeleteConfirmationModal} from './DeleteConfirmationModal';
+
+type Props = {
+	processInstanceKey: ProcessInstance['processInstanceKey'];
+	onExecute: () => void;
+	disabled?: boolean;
+};
+
+const Delete: React.FC<Props> = ({processInstanceKey, onExecute, disabled = false}) => {
+	const {t} = useTranslation();
+	const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
+
+	return (
+		<>
+			<DangerButton
+				type="DELETE"
+				onClick={() => setIsDeleteModalVisible(true)}
+				title={t('operate.shared.operations.deleteTitle', {processInstanceKey})}
+				disabled={disabled}
+				size="sm"
+			/>
+			{isDeleteModalVisible && (
+				<DeleteConfirmationModal
+					processInstanceKey={processInstanceKey}
+					open={isDeleteModalVisible}
+					onConfirm={() => {
+						setIsDeleteModalVisible(false);
+						onExecute();
+					}}
+					onCancel={() => setIsDeleteModalVisible(false)}
+				/>
+			)}
+		</>
+	);
+};
+
+export {Delete};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/DeleteConfirmationModal.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/DeleteConfirmationModal.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useTranslation} from 'react-i18next';
+import {Modal} from '@carbon/react';
+import {type ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.10';
+
+type Props = {
+	processInstanceKey: ProcessInstance['processInstanceKey'];
+	open: boolean;
+	onConfirm: () => void;
+	onCancel: () => void;
+};
+
+const DeleteConfirmationModal: React.FC<Props> = ({processInstanceKey, open, onConfirm, onCancel}) => {
+	const {t} = useTranslation();
+
+	return (
+		<Modal
+			open={open}
+			danger
+			preventCloseOnClickOutside
+			modalHeading={t('operate.shared.operations.deleteConfirmationModal.heading')}
+			primaryButtonText={t('operate.shared.operations.deleteConfirmationModal.deleteButton')}
+			secondaryButtonText={t('operate.shared.operations.deleteConfirmationModal.cancelButton')}
+			onRequestSubmit={onConfirm}
+			onRequestClose={onCancel}
+			size="md"
+			data-testid="confirm-deletion-modal"
+		>
+			<p>{t('operate.shared.operations.deleteConfirmationModal.body', {processInstanceKey})}</p>
+			<p>{t('operate.shared.operations.deleteConfirmationModal.hint')}</p>
+		</Modal>
+	);
+};
+
+export {DeleteConfirmationModal};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/OperationRenderer.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/OperationRenderer.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useTranslation} from 'react-i18next';
+import {OperationItem} from '#/operate/shared/OperationItem/OperationItem';
+import {Cancel} from './Cancel';
+import {Delete} from './Delete';
+import {ResolveIncident} from './ResolveIncident';
+import type {OperationConfig} from './types';
+
+type Props = {
+	operation: OperationConfig;
+	processInstanceKey: string;
+};
+
+const OperationRenderer: React.FC<Props> = ({operation, processInstanceKey}) => {
+	const {t} = useTranslation();
+	const baseProps = {
+		processInstanceKey,
+		onExecute: operation.onExecute,
+		disabled: operation.disabled,
+	};
+
+	switch (operation.type) {
+		case 'RESOLVE_INCIDENT':
+			return <ResolveIncident {...baseProps} />;
+		case 'CANCEL_PROCESS_INSTANCE':
+			return <Cancel {...baseProps} />;
+		case 'DELETE_PROCESS_INSTANCE':
+			return <Delete {...baseProps} />;
+		case 'ENTER_MODIFICATION_MODE':
+			return (
+				<OperationItem
+					type="ENTER_MODIFICATION_MODE"
+					onClick={operation.onExecute}
+					title={operation.label || t('operate.shared.operations.modifyTitle', {processInstanceKey})}
+					disabled={operation.disabled}
+					size="sm"
+				/>
+			);
+		default:
+			return null;
+	}
+};
+
+export {OperationRenderer};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/Operations.queries.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/Operations.queries.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {queryOptions, useQuery} from '@tanstack/react-query';
+import type {ProcessInstance, GetProcessInstanceCallHierarchyResponseBody} from '@camunda/camunda-api-zod-schemas/8.10';
+import {request} from '#/shared/http/request';
+import {endpoints} from '#/shared/http/endpoints';
+
+function callHierarchyOptions(processInstanceKey: ProcessInstance['processInstanceKey']) {
+	return queryOptions({
+		queryKey: ['processInstanceCallHierarchy', processInstanceKey] as const,
+		queryFn: async (): Promise<GetProcessInstanceCallHierarchyResponseBody> => {
+			const {response, error} = await request(endpoints.getProcessInstanceCallHierarchy({processInstanceKey}));
+			if (error !== null) {
+				throw error;
+			}
+			return response.json();
+		},
+	});
+}
+
+function useCallHierarchy(processInstanceKey: ProcessInstance['processInstanceKey'], {enabled}: {enabled: boolean}) {
+	return useQuery({
+		...callHierarchyOptions(processInstanceKey),
+		enabled,
+	});
+}
+
+export {useCallHierarchy};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/Operations.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/Operations.test.tsx
@@ -1,0 +1,248 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, expect, vi} from 'vitest';
+import {render} from 'vitest-browser-react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {HttpResponse} from 'msw';
+import {it} from '#/vitest-modules/test-extend';
+import {mockGetProcessInstanceCallHierarchyEndpoint} from '#/shared-test-modules/mock-handlers';
+import {createCallHierarchy} from '#/shared-test-modules/api-mocks/call-hierarchy';
+import {Operations} from './Operations';
+
+const PROCESS_INSTANCE_KEY = 'instance_1';
+
+function getWrapper() {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: {retry: false},
+		},
+	});
+
+	const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
+
+	return Wrapper;
+}
+
+describe('<Operations />', () => {
+	it('should render retry, cancel, modify and delete buttons', async ({worker}) => {
+		worker.use(mockGetProcessInstanceCallHierarchyEndpoint({successResponse: HttpResponse.json([])}));
+
+		const screen = await render(
+			<Operations
+				operations={[
+					{type: 'RESOLVE_INCIDENT', onExecute: vi.fn()},
+					{type: 'CANCEL_PROCESS_INSTANCE', onExecute: vi.fn()},
+					{type: 'ENTER_MODIFICATION_MODE', onExecute: vi.fn()},
+					{type: 'DELETE_PROCESS_INSTANCE', onExecute: vi.fn()},
+				]}
+				processInstanceKey={PROCESS_INSTANCE_KEY}
+			/>,
+			{wrapper: getWrapper()},
+		);
+
+		await expect.element(screen.getByTitle(`Retry Instance ${PROCESS_INSTANCE_KEY}`)).toBeVisible();
+		await expect.element(screen.getByTitle(`Cancel Instance ${PROCESS_INSTANCE_KEY}`)).toBeVisible();
+		await expect.element(screen.getByTitle(`Modify Instance ${PROCESS_INSTANCE_KEY}`)).toBeVisible();
+		await expect.element(screen.getByTitle(`Delete Instance ${PROCESS_INSTANCE_KEY}`)).toBeVisible();
+	});
+
+	it('should render no buttons when operations array is empty', async () => {
+		const screen = await render(<Operations operations={[]} processInstanceKey={PROCESS_INSTANCE_KEY} />, {
+			wrapper: getWrapper(),
+		});
+
+		expect(screen.getByTitle(`Retry Instance ${PROCESS_INSTANCE_KEY}`).elements()).toHaveLength(0);
+		expect(screen.getByTitle(`Cancel Instance ${PROCESS_INSTANCE_KEY}`).elements()).toHaveLength(0);
+		expect(screen.getByTitle(`Modify Instance ${PROCESS_INSTANCE_KEY}`).elements()).toHaveLength(0);
+		expect(screen.getByTitle(`Delete Instance ${PROCESS_INSTANCE_KEY}`).elements()).toHaveLength(0);
+	});
+
+	it('should execute resolve incident operation', async () => {
+		const onExecute = vi.fn();
+
+		const screen = await render(
+			<Operations operations={[{type: 'RESOLVE_INCIDENT', onExecute}]} processInstanceKey={PROCESS_INSTANCE_KEY} />,
+			{wrapper: getWrapper()},
+		);
+
+		await screen.getByRole('button', {name: /retry instance/i}).click();
+
+		expect(onExecute).toHaveBeenCalled();
+	});
+
+	it('should execute cancel operation', async ({worker}) => {
+		worker.use(mockGetProcessInstanceCallHierarchyEndpoint({successResponse: HttpResponse.json([])}));
+		const onExecute = vi.fn();
+
+		const screen = await render(
+			<Operations
+				operations={[{type: 'CANCEL_PROCESS_INSTANCE', onExecute}]}
+				processInstanceKey={PROCESS_INSTANCE_KEY}
+			/>,
+			{wrapper: getWrapper()},
+		);
+
+		await screen.getByRole('button', {name: /cancel instance/i}).click();
+		await screen.getByRole('button', {name: 'Apply', exact: true}).click();
+
+		expect(onExecute).toHaveBeenCalled();
+	});
+
+	it('should execute delete operation', async () => {
+		const onExecute = vi.fn();
+
+		const screen = await render(
+			<Operations
+				operations={[{type: 'DELETE_PROCESS_INSTANCE', onExecute}]}
+				processInstanceKey={PROCESS_INSTANCE_KEY}
+			/>,
+			{wrapper: getWrapper()},
+		);
+
+		await screen.getByRole('button', {name: /delete instance/i}).click();
+		await screen.getByRole('button', {name: /^delete$/i}).click();
+
+		expect(onExecute).toHaveBeenCalled();
+	});
+
+	it('should execute modify operation', async () => {
+		const onExecute = vi.fn();
+
+		const screen = await render(
+			<Operations
+				operations={[{type: 'ENTER_MODIFICATION_MODE', onExecute}]}
+				processInstanceKey={PROCESS_INSTANCE_KEY}
+			/>,
+			{wrapper: getWrapper()},
+		);
+
+		await screen.getByRole('button', {name: /modify instance/i}).click();
+
+		expect(onExecute).toHaveBeenCalled();
+	});
+
+	it('should show loading state', async () => {
+		const screen = await render(
+			<Operations
+				operations={[{type: 'CANCEL_PROCESS_INSTANCE', onExecute: vi.fn()}]}
+				processInstanceKey={PROCESS_INSTANCE_KEY}
+				isLoading
+			/>,
+			{wrapper: getWrapper()},
+		);
+
+		await expect.element(screen.getByTestId('operation-spinner')).toBeVisible();
+	});
+
+	it('should hide loading state', async () => {
+		const screen = await render(
+			<Operations
+				operations={[{type: 'CANCEL_PROCESS_INSTANCE', onExecute: vi.fn()}]}
+				processInstanceKey={PROCESS_INSTANCE_KEY}
+				isLoading={false}
+			/>,
+			{wrapper: getWrapper()},
+		);
+
+		expect(screen.getByTestId('operation-spinner').elements()).toHaveLength(0);
+	});
+
+	it('should show cancel confirmation modal', async ({worker}) => {
+		worker.use(mockGetProcessInstanceCallHierarchyEndpoint({successResponse: HttpResponse.json([])}));
+
+		const screen = await render(
+			<Operations
+				operations={[{type: 'CANCEL_PROCESS_INSTANCE', onExecute: vi.fn()}]}
+				processInstanceKey={PROCESS_INSTANCE_KEY}
+			/>,
+			{wrapper: getWrapper()},
+		);
+
+		await screen.getByRole('button', {name: /cancel instance/i}).click();
+
+		const modalText = `About to cancel Instance ${PROCESS_INSTANCE_KEY}. In case there are called instances, these will be canceled too.`;
+		await expect.element(screen.getByText(modalText)).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Apply', exact: true})).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Cancel', exact: true})).toBeVisible();
+	});
+
+	it('should show delete confirmation modal', async () => {
+		const screen = await render(
+			<Operations
+				operations={[{type: 'DELETE_PROCESS_INSTANCE', onExecute: vi.fn()}]}
+				processInstanceKey={PROCESS_INSTANCE_KEY}
+			/>,
+			{wrapper: getWrapper()},
+		);
+
+		await screen.getByRole('button', {name: /delete instance/i}).click();
+
+		const modalText = `About to delete Instance ${PROCESS_INSTANCE_KEY}.`;
+		await expect.element(screen.getByText(modalText)).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: /^delete$/i})).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Cancel', exact: true})).toBeVisible();
+	});
+
+	it('should show root instance warning modal when call hierarchy has parents', async ({worker}) => {
+		worker.use(
+			mockGetProcessInstanceCallHierarchyEndpoint({
+				successResponse: HttpResponse.json([
+					createCallHierarchy({processInstanceKey: '3', processDefinitionName: 'some root process'}),
+					createCallHierarchy({processInstanceKey: '2', processDefinitionName: 'some parent process'}),
+				]),
+			}),
+		);
+
+		const screen = await render(
+			<Operations
+				operations={[{type: 'CANCEL_PROCESS_INSTANCE', onExecute: vi.fn()}]}
+				processInstanceKey={PROCESS_INSTANCE_KEY}
+			/>,
+			{wrapper: getWrapper()},
+		);
+
+		await screen.getByRole('button', {name: /cancel instance/i}).click();
+
+		await expect.element(screen.getByTestId('passive-cancellation-modal')).toBeVisible();
+		await expect.element(screen.getByText(/to cancel this instance, the root instance/i)).toBeVisible();
+		expect(screen.getByRole('button', {name: 'Cancel', exact: true}).elements()).toHaveLength(0);
+		expect(screen.getByRole('button', {name: 'Apply', exact: true}).elements()).toHaveLength(0);
+	});
+
+	it('should not trigger callbacks when disabled', async () => {
+		const onExecute = vi.fn();
+
+		const screen = await render(
+			<Operations
+				operations={[
+					{type: 'CANCEL_PROCESS_INSTANCE', onExecute, disabled: true},
+					{type: 'DELETE_PROCESS_INSTANCE', onExecute, disabled: true},
+					{type: 'RESOLVE_INCIDENT', onExecute, disabled: true},
+					{type: 'ENTER_MODIFICATION_MODE', onExecute, disabled: true},
+				]}
+				processInstanceKey={PROCESS_INSTANCE_KEY}
+			/>,
+			{wrapper: getWrapper()},
+		);
+
+		const cancelButton = screen.getByRole('button', {name: /cancel instance/i});
+		const deleteButton = screen.getByRole('button', {name: /delete instance/i});
+		const retryButton = screen.getByRole('button', {name: /retry instance/i});
+		const modifyButton = screen.getByRole('button', {name: /modify instance/i});
+
+		await expect.element(cancelButton).toBeDisabled();
+		await expect.element(deleteButton).toBeDisabled();
+		await expect.element(retryButton).toBeDisabled();
+		await expect.element(modifyButton).toBeDisabled();
+
+		expect(onExecute).not.toHaveBeenCalled();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/Operations.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/Operations.test.tsx
@@ -8,6 +8,7 @@
 
 import {describe, expect, vi} from 'vitest';
 import {render} from 'vitest-browser-react';
+import {userEvent} from 'vitest/browser';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {HttpResponse} from 'msw';
 import {it} from '#/vitest-modules/test-extend';
@@ -73,7 +74,7 @@ describe('<Operations />', () => {
 			{wrapper: getWrapper()},
 		);
 
-		await screen.getByRole('button', {name: /retry instance/i}).click();
+		await userEvent.click(screen.getByRole('button', {name: /retry instance/i}));
 
 		expect(onExecute).toHaveBeenCalled();
 	});
@@ -90,8 +91,10 @@ describe('<Operations />', () => {
 			{wrapper: getWrapper()},
 		);
 
-		await screen.getByRole('button', {name: /cancel instance/i}).click();
-		await screen.getByRole('button', {name: 'Apply', exact: true}).click();
+		await userEvent.click(screen.getByRole('button', {name: /cancel instance/i}));
+		const applyButton = screen.getByRole('button', {name: 'Apply', exact: true});
+		await expect.element(applyButton).toBeEnabled();
+		await userEvent.click(applyButton);
 
 		expect(onExecute).toHaveBeenCalled();
 	});
@@ -107,8 +110,8 @@ describe('<Operations />', () => {
 			{wrapper: getWrapper()},
 		);
 
-		await screen.getByRole('button', {name: /delete instance/i}).click();
-		await screen.getByRole('button', {name: /^delete$/i}).click();
+		await userEvent.click(screen.getByRole('button', {name: /delete instance/i}));
+		await userEvent.click(screen.getByRole('button', {name: /^delete$/i}));
 
 		expect(onExecute).toHaveBeenCalled();
 	});
@@ -124,7 +127,7 @@ describe('<Operations />', () => {
 			{wrapper: getWrapper()},
 		);
 
-		await screen.getByRole('button', {name: /modify instance/i}).click();
+		await userEvent.click(screen.getByRole('button', {name: /modify instance/i}));
 
 		expect(onExecute).toHaveBeenCalled();
 	});
@@ -166,12 +169,61 @@ describe('<Operations />', () => {
 			{wrapper: getWrapper()},
 		);
 
-		await screen.getByRole('button', {name: /cancel instance/i}).click();
+		await userEvent.click(screen.getByRole('button', {name: /cancel instance/i}));
 
 		const modalText = `About to cancel Instance ${PROCESS_INSTANCE_KEY}. In case there are called instances, these will be canceled too.`;
 		await expect.element(screen.getByText(modalText)).toBeVisible();
-		await expect.element(screen.getByRole('button', {name: 'Apply', exact: true})).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Apply', exact: true})).toBeEnabled();
 		await expect.element(screen.getByRole('button', {name: 'Cancel', exact: true})).toBeVisible();
+	});
+
+	it('should disable cancellation while the call hierarchy is loading', async ({worker}) => {
+		worker.use(
+			mockGetProcessInstanceCallHierarchyEndpoint({
+				successResponse: HttpResponse.json([]),
+				delay: 'infinite',
+			}),
+		);
+		const onExecute = vi.fn();
+
+		const screen = await render(
+			<Operations
+				operations={[{type: 'CANCEL_PROCESS_INSTANCE', onExecute}]}
+				processInstanceKey={PROCESS_INSTANCE_KEY}
+			/>,
+			{wrapper: getWrapper()},
+		);
+
+		await userEvent.click(screen.getByRole('button', {name: /cancel instance/i}));
+
+		await expect.element(screen.getByText('Checking whether this instance can be canceled...')).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Apply', exact: true})).toBeDisabled();
+		expect(onExecute).not.toHaveBeenCalled();
+	});
+
+	it('should disable cancellation when the call hierarchy cannot be loaded', async ({worker}) => {
+		worker.use(
+			mockGetProcessInstanceCallHierarchyEndpoint({
+				successResponse: HttpResponse.json({}, {status: 500}),
+			}),
+		);
+		const onExecute = vi.fn();
+
+		const screen = await render(
+			<Operations
+				operations={[{type: 'CANCEL_PROCESS_INSTANCE', onExecute}]}
+				processInstanceKey={PROCESS_INSTANCE_KEY}
+			/>,
+			{wrapper: getWrapper()},
+		);
+
+		await userEvent.click(screen.getByRole('button', {name: /cancel instance/i}));
+
+		await expect
+			.element(screen.getByRole('alert'))
+			.toHaveTextContent('Cancellation availability could not be checked. Close this dialog and try again.');
+		await expect.element(screen.getByRole('button', {name: 'Apply', exact: true})).toBeDisabled();
+		expect(onExecute).not.toHaveBeenCalled();
 	});
 
 	it('should show delete confirmation modal', async () => {
@@ -183,7 +235,7 @@ describe('<Operations />', () => {
 			{wrapper: getWrapper()},
 		);
 
-		await screen.getByRole('button', {name: /delete instance/i}).click();
+		await userEvent.click(screen.getByRole('button', {name: /delete instance/i}));
 
 		const modalText = `About to delete Instance ${PROCESS_INSTANCE_KEY}.`;
 		await expect.element(screen.getByText(modalText)).toBeVisible();
@@ -209,10 +261,11 @@ describe('<Operations />', () => {
 			{wrapper: getWrapper()},
 		);
 
-		await screen.getByRole('button', {name: /cancel instance/i}).click();
+		await userEvent.click(screen.getByRole('button', {name: /cancel instance/i}));
 
 		await expect.element(screen.getByTestId('passive-cancellation-modal')).toBeVisible();
 		await expect.element(screen.getByText(/to cancel this instance, the root instance/i)).toBeVisible();
+		await expect.element(screen.getByRole('link', {name: '3'})).toHaveAttribute('href', '/operate/processes/3');
 		expect(screen.getByRole('button', {name: 'Cancel', exact: true}).elements()).toHaveLength(0);
 		expect(screen.getByRole('button', {name: 'Apply', exact: true}).elements()).toHaveLength(0);
 	});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/Operations.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/Operations.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useTranslation} from 'react-i18next';
+import {OperationItems} from '#/operate/shared/OperationItems/OperationItems';
+import {InlineLoading} from '@carbon/react';
+import {OperationsContainer} from './styled';
+import {OperationRenderer} from './OperationRenderer';
+import type {OperationConfig} from './types';
+
+type Props = {
+	operations: OperationConfig[];
+	processInstanceKey: string;
+	isLoading?: boolean;
+	loadingMessage?: string;
+};
+
+const Operations: React.FC<Props> = ({operations, processInstanceKey, isLoading = false, loadingMessage}) => {
+	const {t} = useTranslation();
+
+	return (
+		<OperationsContainer orientation="horizontal">
+			{isLoading ? (
+				<InlineLoading
+					data-testid="operation-spinner"
+					title={loadingMessage || t('operate.shared.operations.loadingMessage', {processInstanceKey})}
+				/>
+			) : null}
+			<OperationItems>
+				{operations.map((operation) => (
+					<OperationRenderer key={operation.type} operation={operation} processInstanceKey={processInstanceKey} />
+				))}
+			</OperationItems>
+		</OperationsContainer>
+	);
+};
+
+export {Operations};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/ResolveIncident.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/ResolveIncident.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useTranslation} from 'react-i18next';
+import {type ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.10';
+import {OperationItem} from '#/operate/shared/OperationItem/OperationItem';
+
+type Props = {
+	processInstanceKey: ProcessInstance['processInstanceKey'];
+	onExecute: () => void;
+	disabled?: boolean;
+};
+
+const ResolveIncident: React.FC<Props> = ({processInstanceKey, onExecute, disabled = false}) => {
+	const {t} = useTranslation();
+
+	return (
+		<OperationItem
+			type="RESOLVE_INCIDENT"
+			onClick={onExecute}
+			title={t('operate.shared.operations.retryTitle', {processInstanceKey})}
+			disabled={disabled}
+			size="sm"
+		/>
+	);
+};
+
+export {ResolveIncident};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/styled.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/styled.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Stack} from '@carbon/react';
+import styled from 'styled-components';
+
+const OperationsContainer = styled(Stack)`
+	.cds--popover[role='tooltip'] {
+		display: none;
+	}
+`;
+
+export {OperationsContainer};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/types.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Operations/types.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+type OperationType =
+	'RESOLVE_INCIDENT' | 'CANCEL_PROCESS_INSTANCE' | 'DELETE_PROCESS_INSTANCE' | 'ENTER_MODIFICATION_MODE';
+
+type OperationConfig = {
+	type: OperationType;
+	onExecute: () => void;
+	disabled?: boolean;
+	label?: string;
+};
+
+export type {OperationConfig};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
@@ -29,6 +29,7 @@ import {
 	type AuditLog,
 	type DecisionInstance,
 	type Variable,
+	type ProcessInstance,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 import {getBootConfig} from '#/shared/config/getBootConfig';
 import {mergePathname} from './mergePathname';
@@ -357,6 +358,13 @@ const endpoints = {
 			...BASE_REQUEST_OPTIONS,
 			method: unifiedAPIEndpoints.queryAuditLogs.method,
 			body: JSON.stringify(body),
+			headers: {'Content-Type': 'application/json'},
+		}),
+
+	getProcessInstanceCallHierarchy: ({processInstanceKey}: Pick<ProcessInstance, 'processInstanceKey'>) =>
+		new Request(getFullURL(unifiedAPIEndpoints.getProcessInstanceCallHierarchy.getUrl({processInstanceKey})), {
+			...BASE_REQUEST_OPTIONS,
+			method: unifiedAPIEndpoints.getProcessInstanceCallHierarchy.method,
 			headers: {'Content-Type': 'application/json'},
 		}),
 };

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
@@ -648,6 +648,34 @@
 					"message": "Daten konnten nicht abgerufen werden",
 					"additionalInfo": "Laden Sie die Seite neu, um es erneut zu versuchen"
 				},
+				"operations": {
+					"loadingMessage": "Instanz {{processInstanceKey}} hat geplante Operationen",
+					"retryTitle": "Instanz {{processInstanceKey}} wiederholen",
+					"cancelTitle": "Instanz {{processInstanceKey}} abbrechen",
+					"modifyTitle": "Instanz {{processInstanceKey}} ändern",
+					"deleteTitle": "Instanz {{processInstanceKey}} löschen",
+					"deleteButtonLabel": "Löschen",
+					"cancelConfirmationModal": {
+						"heading": "Operation anwenden",
+						"applyButton": "Anwenden",
+						"cancelButton": "Abbrechen",
+						"body": "Instanz {{processInstanceKey}} wird abgebrochen. Falls es aufgerufene Instanzen gibt, werden diese ebenfalls abgebrochen.",
+						"hint": "Klicken Sie auf \"Anwenden\", um fortzufahren."
+					},
+					"cancelRootInstanceModal": {
+						"heading": "Instanz abbrechen",
+						"bodyBeforeLink": "Um diese Instanz abzubrechen, muss die Root-Instanz",
+						"bodyAfterLink": "abgebrochen werden. Wenn die Root-Instanz abgebrochen wird, werden alle aufgerufenen Instanzen automatisch abgebrochen.",
+						"linkTitle": "Root-Instanz {{rootInstanceId}} anzeigen"
+					},
+					"deleteConfirmationModal": {
+						"heading": "Instanz löschen",
+						"deleteButton": "Löschen",
+						"cancelButton": "Abbrechen",
+						"body": "Instanz {{processInstanceKey}} wird gelöscht.",
+						"hint": "Klicken Sie auf \"Löschen\", um fortzufahren."
+					}
+				},
 				"panelHeader": {
 					"resultCount_one": "{{count}} Ergebnis",
 					"resultCount_other": "{{count}} Ergebnisse",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
@@ -660,7 +660,9 @@
 						"applyButton": "Anwenden",
 						"cancelButton": "Abbrechen",
 						"body": "Instanz {{processInstanceKey}} wird abgebrochen. Falls es aufgerufene Instanzen gibt, werden diese ebenfalls abgebrochen.",
-						"hint": "Klicken Sie auf \"Anwenden\", um fortzufahren."
+						"hint": "Klicken Sie auf \"Anwenden\", um fortzufahren.",
+						"verificationLoading": "Es wird geprüft, ob diese Instanz abgebrochen werden kann...",
+						"verificationError": "Es konnte nicht geprüft werden, ob diese Instanz abgebrochen werden kann. Schließen Sie diesen Dialog und versuchen Sie es erneut."
 					},
 					"cancelRootInstanceModal": {
 						"heading": "Instanz abbrechen",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
@@ -662,6 +662,34 @@
 					"message": "Data could not be fetched",
 					"additionalInfo": "Refresh the page to try again"
 				},
+				"operations": {
+					"loadingMessage": "Instance {{processInstanceKey}} has scheduled Operations",
+					"retryTitle": "Retry Instance {{processInstanceKey}}",
+					"cancelTitle": "Cancel Instance {{processInstanceKey}}",
+					"modifyTitle": "Modify Instance {{processInstanceKey}}",
+					"deleteTitle": "Delete Instance {{processInstanceKey}}",
+					"deleteButtonLabel": "Delete",
+					"cancelConfirmationModal": {
+						"heading": "Apply Operation",
+						"applyButton": "Apply",
+						"cancelButton": "Cancel",
+						"body": "About to cancel Instance {{processInstanceKey}}. In case there are called instances, these will be canceled too.",
+						"hint": "Click \"Apply\" to proceed."
+					},
+					"cancelRootInstanceModal": {
+						"heading": "Cancel Instance",
+						"bodyBeforeLink": "To cancel this instance, the root instance",
+						"bodyAfterLink": "needs to be canceled. When the root instance is canceled all the called instances will be canceled automatically.",
+						"linkTitle": "View root instance {{rootInstanceId}}"
+					},
+					"deleteConfirmationModal": {
+						"heading": "Delete Instance",
+						"deleteButton": "Delete",
+						"cancelButton": "Cancel",
+						"body": "About to delete Instance {{processInstanceKey}}.",
+						"hint": "Click \"Delete\" to proceed."
+					}
+				},
 				"panelHeader": {
 					"resultCount_one": "{{count}} result",
 					"resultCount_other": "{{count}} results",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
@@ -674,7 +674,9 @@
 						"applyButton": "Apply",
 						"cancelButton": "Cancel",
 						"body": "About to cancel Instance {{processInstanceKey}}. In case there are called instances, these will be canceled too.",
-						"hint": "Click \"Apply\" to proceed."
+						"hint": "Click \"Apply\" to proceed.",
+						"verificationLoading": "Checking whether this instance can be canceled...",
+						"verificationError": "Cancellation availability could not be checked. Close this dialog and try again."
 					},
 					"cancelRootInstanceModal": {
 						"heading": "Cancel Instance",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
@@ -663,7 +663,7 @@
 					"additionalInfo": "Refresh the page to try again"
 				},
 				"operations": {
-					"loadingMessage": "Instance {{processInstanceKey}} has scheduled Operations",
+					"loadingMessage": "Instance {{processInstanceKey}} has scheduled operations",
 					"retryTitle": "Retry Instance {{processInstanceKey}}",
 					"cancelTitle": "Cancel Instance {{processInstanceKey}}",
 					"modifyTitle": "Modify Instance {{processInstanceKey}}",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
@@ -648,6 +648,34 @@
 					"message": "No se pudieron recuperar los datos",
 					"additionalInfo": "Actualice la página para intentarlo de nuevo"
 				},
+				"operations": {
+					"loadingMessage": "La instancia {{processInstanceKey}} tiene operaciones programadas",
+					"retryTitle": "Reintentar instancia {{processInstanceKey}}",
+					"cancelTitle": "Cancelar instancia {{processInstanceKey}}",
+					"modifyTitle": "Modificar instancia {{processInstanceKey}}",
+					"deleteTitle": "Eliminar instancia {{processInstanceKey}}",
+					"deleteButtonLabel": "Eliminar",
+					"cancelConfirmationModal": {
+						"heading": "Aplicar operación",
+						"applyButton": "Aplicar",
+						"cancelButton": "Cancelar",
+						"body": "Se cancelará la instancia {{processInstanceKey}}. Si existen instancias llamadas, también se cancelarán.",
+						"hint": "Haga clic en \"Aplicar\" para continuar."
+					},
+					"cancelRootInstanceModal": {
+						"heading": "Cancelar instancia",
+						"bodyBeforeLink": "Para cancelar esta instancia, la instancia raíz",
+						"bodyAfterLink": "debe cancelarse. Cuando se cancela la instancia raíz, todas las instancias llamadas se cancelan automáticamente.",
+						"linkTitle": "Ver instancia raíz {{rootInstanceId}}"
+					},
+					"deleteConfirmationModal": {
+						"heading": "Eliminar instancia",
+						"deleteButton": "Eliminar",
+						"cancelButton": "Cancelar",
+						"body": "Se eliminará la instancia {{processInstanceKey}}.",
+						"hint": "Haga clic en \"Eliminar\" para continuar."
+					}
+				},
 				"panelHeader": {
 					"resultCount_one": "{{count}} resultado",
 					"resultCount_other": "{{count}} resultados",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
@@ -660,7 +660,9 @@
 						"applyButton": "Aplicar",
 						"cancelButton": "Cancelar",
 						"body": "Se cancelará la instancia {{processInstanceKey}}. Si existen instancias llamadas, también se cancelarán.",
-						"hint": "Haga clic en \"Aplicar\" para continuar."
+						"hint": "Haga clic en \"Aplicar\" para continuar.",
+						"verificationLoading": "Comprobando si esta instancia se puede cancelar...",
+						"verificationError": "No se pudo comprobar si esta instancia se puede cancelar. Cierre este diálogo e inténtelo de nuevo."
 					},
 					"cancelRootInstanceModal": {
 						"heading": "Cancelar instancia",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
@@ -651,6 +651,34 @@
 					"message": "Les données n'ont pas pu être récupérées",
 					"additionalInfo": "Actualisez la page pour réessayer"
 				},
+				"operations": {
+					"loadingMessage": "L'instance {{processInstanceKey}} a des opérations planifiées",
+					"retryTitle": "Réessayer l'instance {{processInstanceKey}}",
+					"cancelTitle": "Annuler l'instance {{processInstanceKey}}",
+					"modifyTitle": "Modifier l'instance {{processInstanceKey}}",
+					"deleteTitle": "Supprimer l'instance {{processInstanceKey}}",
+					"deleteButtonLabel": "Supprimer",
+					"cancelConfirmationModal": {
+						"heading": "Appliquer l'opération",
+						"applyButton": "Appliquer",
+						"cancelButton": "Annuler",
+						"body": "L'instance {{processInstanceKey}} va être annulée. Si des instances appelées existent, elles seront également annulées.",
+						"hint": "Cliquez sur \"Appliquer\" pour continuer."
+					},
+					"cancelRootInstanceModal": {
+						"heading": "Annuler l'instance",
+						"bodyBeforeLink": "Pour annuler cette instance, l'instance racine",
+						"bodyAfterLink": "doit être annulée. Lorsque l'instance racine est annulée, toutes les instances appelées sont automatiquement annulées.",
+						"linkTitle": "Voir l'instance racine {{rootInstanceId}}"
+					},
+					"deleteConfirmationModal": {
+						"heading": "Supprimer l'instance",
+						"deleteButton": "Supprimer",
+						"cancelButton": "Annuler",
+						"body": "L'instance {{processInstanceKey}} va être supprimée.",
+						"hint": "Cliquez sur \"Supprimer\" pour continuer."
+					}
+				},
 				"panelHeader": {
 					"resultCount_one": "{{count}} résultat",
 					"resultCount_other": "{{count}} résultats",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
@@ -663,7 +663,9 @@
 						"applyButton": "Appliquer",
 						"cancelButton": "Annuler",
 						"body": "L'instance {{processInstanceKey}} va être annulée. Si des instances appelées existent, elles seront également annulées.",
-						"hint": "Cliquez sur \"Appliquer\" pour continuer."
+						"hint": "Cliquez sur \"Appliquer\" pour continuer.",
+						"verificationLoading": "Vérification de la possibilité d'annuler cette instance...",
+						"verificationError": "Impossible de vérifier si cette instance peut être annulée. Fermez cette boîte de dialogue et réessayez."
 					},
 					"cancelRootInstanceModal": {
 						"heading": "Annuler l'instance",


### PR DESCRIPTION
## Description

Ports the shared operation button components (`Operations`, `OperationItems`, `OperationItem` including `DangerButton`) from `operate/client/src/modules/components/` to `webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/`.

These are the cancel/delete/retry/modify action buttons used per process instance. They are a prerequisite for the Processes toolbar (#55987), the per-row `InstanceOperations` (#55986), and the Batch Operation details page (#58004).

The cancel-confirmation modal's root-instance lookup needed a call-hierarchy query that didn't exist yet in the unified app, so this PR also adds `getProcessInstanceCallHierarchy` to `shared/http/endpoints.ts` and a colocated query in `Operations.queries.ts`.

Note: since the Process Instance page doesn't exist yet in the unified app, the link to a called instance's root process instance uses a plain `href` rather than a typed router `Link`, matching the existing pattern in `Decisions/InstancesTable.tsx` for the same not-yet-built route.

## Checklist
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57678

## Translation note

The new German, French, and Spanish cancellation-verification messages were LLM-translated; native-speaker review is requested.