### PR TITLE
fix: activate migrated plan phase exactly once and report uninitialized correctly

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedCurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedCurrentClusterConfiguration.java
@@ -130,10 +130,15 @@ public final class PersistedCurrentClusterConfiguration {
           serializer.decodeCurrentClusterConfiguration(
               content, HEADER_LENGTH, content.length - HEADER_LENGTH);
       case VERSION_LEGACY -> {
+        // One-time migration: activate the pending plan's phase 0 (if any) so this broker
+        // continues driving it forward under the new model, exactly as initPlan would for a
+        // freshly-started plan. fromLegacy() itself stays a pure conversion since it is also used
+        // for repeated, read-only re-derivations elsewhere (see its javadoc).
         final var migratedConfig =
             CurrentClusterConfiguration.fromLegacy(
-                serializer.decodeClusterTopology(
-                    content, HEADER_LENGTH, content.length - HEADER_LENGTH));
+                    serializer.decodeClusterTopology(
+                        content, HEADER_LENGTH, content.length - HEADER_LENGTH))
+                .activatePendingPhase();
         writeToFile(migratedConfig, configurationFile, serializer);
         yield migratedConfig;
       }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -126,6 +126,18 @@ public record CurrentClusterConfiguration(
    *       since recovery is now per-group.
    * </ul>
    *
+   * <p>This is a pure, side-effect-free conversion: the returned pending plan (if any) is built at
+   * phase 0 but is <em>not</em> activated into the default group — the default group's own {@code
+   * pendingChanges} stays empty. Activating phase 0 (via {@link #applyPhase}) is deliberately left
+   * to the caller, because this factory is invoked both for genuine one-time migrations (e.g.
+   * {@code PersistedCurrentClusterConfiguration} upgrading an on-disk v1 file, exactly once per
+   * broker) and for repeated, read-only re-derivations of a legacy view (e.g. {@code
+   * BrokerTopologyManagerImpl#onClusterConfigurationUpdated(ClusterConfiguration)}, invoked on
+   * every gossip update). Auto-activating here would re-run {@code startConfigurationChange} on a
+   * freshly-built (and therefore never-"pending") default group on every such repeated call,
+   * endlessly restarting an already in-progress plan from scratch. Callers that are performing a
+   * genuine one-time migration should call {@link #activatePendingPhase()} explicitly afterwards.
+   *
    * @throws IllegalStateException if the legacy {@code lastChange} has {@code IN_PROGRESS} status
    */
   public static CurrentClusterConfiguration fromLegacy(final ClusterConfiguration legacy) {
@@ -158,11 +170,26 @@ public record CurrentClusterConfiguration(
             Optional.empty(),
             Optional.empty());
 
+    final PhasedChangeState phasedChangeState = toPhasedChangeState(legacy);
     return new CurrentClusterConfiguration(
         INITIAL_VERSION,
         globalConfiguration,
         Map.of(DEFAULT_GROUP, defaultGroup),
-        toPhasedChangeState(legacy));
+        phasedChangeState);
+  }
+
+  /**
+   * Activates the current pending plan's phase (see {@link #applyPhase}) if one is pending,
+   * otherwise returns this configuration unchanged. Mirrors what {@link #initPlan(List)} does for a
+   * freshly-started plan; intended for one-time migration call sites (see {@link
+   * #fromLegacy(ClusterConfiguration)}) that need to take over driving an already-pending plan
+   * rather than starting a new one.
+   *
+   * @throws IllegalStateException if the pending phase targets a sub-configuration that already has
+   *     a change in progress
+   */
+  public CurrentClusterConfiguration activatePendingPhase() {
+    return phasedChangeState.pending().map(this::applyPhase).orElse(this);
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -211,8 +211,19 @@ public record CurrentClusterConfiguration(
    * {@code lastChange} is derived from the {@link PhasedChangeState}. Cross-sub-config change
    * details cannot be represented losslessly in the flat legacy plan, so this projection is
    * intended for display and equivalence checks, not for driving legacy change execution.
+   *
+   * <p>Uninitialized is projected explicitly: {@link #isUninitialized()} is driven by {@code
+   * globalConfiguration}'s own uninitialized sentinel version, which is {@code 0} — distinct from
+   * the legacy {@link ClusterConfiguration}'s sentinel version of {@code -1}. Deriving the legacy
+   * version as {@code Math.max(globalConfiguration.version(), defaultGroup.version())} would
+   * therefore never equal the legacy sentinel, so callers of {@code
+   * ClusterConfiguration#isUninitialized()} on the projection could never observe {@code true}.
    */
   public ClusterConfiguration toLegacyDefault() {
+    if (isUninitialized()) {
+      return ClusterConfiguration.uninitialized();
+    }
+
     final PartitionGroupConfiguration defaultGroup =
         partitionGroups.getOrDefault(DEFAULT_GROUP, PartitionGroupConfiguration.empty(version));
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
@@ -158,8 +158,10 @@ class CurrentClusterConfigurationTest {
               .pendingChanges(Optional.of(pending))
               .build();
 
-      // when
-      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
+      // when — fromLegacy() itself is a pure conversion; activatePendingPhase() is the explicit
+      // step a one-time-migration caller takes to start driving the pending plan (mirrors what
+      // PersistedCurrentClusterConfiguration does when upgrading an on-disk v1 file)
+      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy).activatePendingPhase();
 
       // then — the ops become three phases in order: [global], [default: 2 partition ops], [global]
       final var plan = migrated.phasedChangeState().pending().orElseThrow();
@@ -173,10 +175,120 @@ class CurrentClusterConfigurationTest {
                       CurrentClusterConfiguration.DEFAULT_GROUP,
                       List.of(partitionJoin, partitionLeave))),
               new GlobalPhase(List.of(memberLeave)));
-      // and — the pending change is NOT left on the default group
+      // and — phase 0 (the first global phase) is already activated, like initPlan does
+      assertThat(migrated.globalConfiguration().hasPendingChanges()).isTrue();
+      assertThat(migrated.globalConfiguration().pendingChanges().orElseThrow().pendingOperations())
+          .containsExactly(memberJoin);
+      // and — the pending change is NOT left on the default group, since phase 0 is global
       assertThat(
               migrated.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).pendingChanges())
           .isEmpty();
+    }
+
+    @Test
+    void shouldActivateFirstPhaseOnDefaultGroupWhenItIsAPartitionPhase() {
+      // given — a legacy pending plan whose first (and only) run of operations is partition-scoped
+      final var join = new PartitionJoinOperation(MEMBER_0, 1, 1);
+      final var leave = new PartitionLeaveOperation(MEMBER_0, 1, 1);
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(5)
+              .members(Map.of(MEMBER_0, activeMember()))
+              .pendingChanges(Optional.of(ClusterChangePlan.init(2, List.of(join, leave))))
+              .build();
+
+      // when
+      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy).activatePendingPhase();
+
+      // then — phase 0 is already activated on the default group, mirroring initPlan's semantics
+      final var defaultGroup = migrated.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
+      assertThat(defaultGroup.hasPendingChanges()).isTrue();
+      assertThat(defaultGroup.pendingChanges().orElseThrow().pendingOperations())
+          .containsExactly(join, leave);
+      // and — the global configuration is untouched, since phase 0 targets the default group only
+      assertThat(migrated.globalConfiguration().hasPendingChanges()).isFalse();
+    }
+
+    @Test
+    void shouldAllowActivatingNextPhaseAfterMigration() {
+      // given — a migrated multi-phase plan whose phase 0 is already activated
+      final var memberJoin = new MemberJoinOperation(MEMBER_0);
+      final var partitionJoin = new PartitionJoinOperation(MEMBER_0, 1, 1);
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(5)
+              .members(Map.of(MEMBER_0, activeMember()))
+              .pendingChanges(
+                  Optional.of(ClusterChangePlan.init(2, List.of(memberJoin, partitionJoin))))
+              .build();
+      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy).activatePendingPhase();
+
+      // when — advance to phase 1, exactly as would happen for a plan started via initPlan
+      final var advanced = migrated.activateNextPhase();
+
+      // then — phase 1 (the default-group phase) is now activated
+      assertThat(advanced.phasedChangeState().pending().orElseThrow().currentPhaseIndex())
+          .isEqualTo(1);
+      assertThat(
+              advanced.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).pendingChanges())
+          .isPresent();
+    }
+
+    @Test
+    void shouldNotFailMigrationWhenNoPendingPlanExists() {
+      // given — no pending plan at all
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(5)
+              .members(Map.of(MEMBER_0, activeMember()))
+              .build();
+
+      // when
+      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
+
+      // then — nothing is activated anywhere
+      assertThat(migrated.phasedChangeState().pending()).isEmpty();
+      assertThat(migrated.globalConfiguration().hasPendingChanges()).isFalse();
+      assertThat(
+              migrated
+                  .partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)
+                  .hasPendingChanges())
+          .isFalse();
+    }
+
+    @Test
+    void shouldNotActivateThePendingPlanOnItsOwn() {
+      // given — a legacy pending plan whose first run of operations is partition-scoped
+      final var join = new PartitionJoinOperation(MEMBER_0, 1, 1);
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(5)
+              .members(Map.of(MEMBER_0, activeMember()))
+              .pendingChanges(Optional.of(ClusterChangePlan.init(2, List.of(join))))
+              .build();
+
+      // when — fromLegacy() alone, without the explicit activatePendingPhase() step
+      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
+
+      // then — the plan is recorded (phase 0 exists) but not activated into the default group.
+      // fromLegacy() must stay a pure, repeatable conversion: it is also called on every gossip
+      // update by BrokerTopologyManagerImpl#onClusterConfigurationUpdated(ClusterConfiguration)
+      // purely for read-only topology reporting. If it activated the phase itself, every such call
+      // would call startConfigurationChange again on a freshly-built (never-"pending") default
+      // group, endlessly restarting an already in-progress plan from scratch — this was a real
+      // regression caught by ExporterEnableTest once a broker/gateway kept re-deriving its topology
+      // from repeated legacy gossip.
+      assertThat(migrated.phasedChangeState().pending()).isPresent();
+      assertThat(
+              migrated
+                  .partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)
+                  .hasPendingChanges())
+          .isFalse();
+
+      // and — calling fromLegacy() again on the same input is idempotent (no growing version)
+      final var migratedAgain = CurrentClusterConfiguration.fromLegacy(legacy);
+      assertThat(migratedAgain.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).version())
+          .isEqualTo(migrated.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).version());
     }
 
     @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
@@ -902,6 +902,21 @@ class CurrentClusterConfigurationTest {
       assertThat(projected.members()).isEmpty();
       assertThat(projected.hasPendingChanges()).isFalse();
     }
+
+    @Test
+    void shouldProjectUninitializedAsUninitialized() {
+      // given — a wrapper that has never been initialized (distinct from
+      // CurrentClusterConfiguration.init())
+      final var config = CurrentClusterConfiguration.uninitialized();
+
+      // when
+      final var projected = config.toLegacyDefault();
+
+      // then — the projection must report uninitialized too; deriving the legacy version from the
+      // sub-configs' own (0) uninitialized sentinel could never equal the legacy sentinel (-1),
+      // so this must be handled explicitly rather than falling through to the generic projection
+      assertThat(projected.isUninitialized()).isTrue();
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Summary
Two independent fixes to `CurrentClusterConfiguration`,  found while enabling the new model (PR #59114):

1. **Activate a migrated plan's first phase exactly once during the first migration**
   - `fromLegacy()` migrates a legacy pending plan into a `PhasedChangeState`, but activating phase 0 is required for its operations to actually take effect on the relevant sub-config.
   - `fromLegacy()` is called both for a genuine one-time migration (on-disk v1 file upgrade) and for repeated, read-only re-derivations (e.g. on every gossip update via `BrokerTopologyManagerImpl`, including on a standalone gateway). Auto-activating inside `fromLegacy()` is not correct, because it should not re-activate the phases when receiving legacy configuration via gossip. 
   -  activation is split into a new `activatePendingPhase()`, called only from the one-time migration when reading the legacy version during the startup. 

2. **Report uninitialized correctly from the legacy compat projection** (`392f666b4e6f8d2f36c1577532786344adcab6ee`):
   - `toLegacyDefault()` derived the projected legacy version as `Math.max(globalConfiguration.version(), defaultGroup.version())`. For a genuinely uninitialized `CurrentClusterConfiguration` both are `0`, but the legacy `ClusterConfiguration`'s uninitialized sentinel is `-1` — so the projection's `isUninitialized()` could never be true.
   - Now special-cased: an uninitialized wrapper returns `ClusterConfiguration.uninitialized()` directly.

Part of #56018.