### PR TITLE
feat: add cross-partition ask duration and release-to-start latency metrics

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetrics.java
@@ -48,22 +48,27 @@ import java.util.Set;
  *
  * <p>The release-to-start timer (M16) measures, purely on {@code P_B}, the wait between a business
  * id being released by a completing holder and a cross-partition ask that was <em>blocked on that
- * business id</em> actually starting. A single in-memory map {@code businessId → }{@link
- * ContendedBusinessId} makes it leak-free: each entry holds the message keys of the asks currently
- * uniqueness-rejected (blocked) on that business id, plus the timestamp at which the holder last
- * freed it (armed only while an ask is blocked). Asks are added when the REQUEST processor rejects
- * them on uniqueness and pruned per ask when they start or are rejected as expired.
+ * business id</em> actually starting. It is tracked per <em>uniqueness domain</em> — the {@code
+ * (tenantId, processDefinitionId, businessId)} triple that scopes the uniqueness lock — not by
+ * business id alone: the same business id may be held, freed and reused independently in different
+ * process definitions or tenants, and all of them hash to the same {@code P_B}, so a
+ * business-id-only key would let an unrelated domain's free clobber another's measurement. A single
+ * in-memory map {@code domain → }{@link ContendedDomain} makes it leak-free: each entry holds the
+ * message keys of the asks currently uniqueness-rejected (blocked) in that domain, plus the
+ * timestamp at which the holder last freed it (armed only while an ask is blocked). Asks are added
+ * when the REQUEST processor rejects them on uniqueness and pruned per ask when they start or are
+ * rejected as expired.
  *
  * <p>Gating both the free capture and the measurement on the <em>messageKey</em> of an actually
  * blocked ask is what keeps the histogram honest: an uncontended completion never arms a free, and
  * an uncontended reuse of a business id (whose messageKey was never blocked) is never measured — so
  * the timer records contention latency only, not benign business-id reuse gaps. All access is from
  * the processing actor on {@code P_B}, and the map is bounded to the most recent {@value
- * #MAX_TRACKED_BLOCKED_BUSINESS_IDS} contended business ids and cleared on recovery.
+ * #MAX_TRACKED_CONTENDED_DOMAINS} contended domains and cleared on recovery.
  */
 public final class MessageCorrelationMetrics implements StreamProcessorLifecycleAware {
 
-  private static final int MAX_TRACKED_BLOCKED_BUSINESS_IDS = 10_000;
+  private static final int MAX_TRACKED_CONTENDED_DOMAINS = 10_000;
 
   private final MeterRegistry registry;
 
@@ -84,16 +89,16 @@ public final class MessageCorrelationMetrics implements StreamProcessorLifecycle
   private final Map<Long, Map<Long, Timer.Sample>> pendingAskSamples = new HashMap<>();
 
   /**
-   * Contended business ids on {@code P_B}: each entry tracks the cross-partition asks currently
-   * blocked (uniqueness-rejected) on the business id and, once its holder completes, the time at
-   * which it was last freed. Entries are created when the REQUEST processor rejects an ask on
-   * uniqueness and removed once no ask remains blocked (each starts or is rejected as expired).
-   * Bounded and insertion-ordered: the eldest contended business id is evicted past {@link
-   * #MAX_TRACKED_BLOCKED_BUSINESS_IDS} so a business id whose blocked asks never resolve ages out
-   * instead of leaking.
+   * Contended uniqueness domains on {@code P_B}: each entry tracks the cross-partition asks
+   * currently blocked (uniqueness-rejected) in that {@code (tenantId, processDefinitionId,
+   * businessId)} domain and, once its holder completes, the time at which it was last freed.
+   * Entries are created when the REQUEST processor rejects an ask on uniqueness and removed once no
+   * ask remains blocked (each starts or is rejected as expired). Bounded and insertion-ordered: the
+   * eldest domain is evicted past {@link #MAX_TRACKED_CONTENDED_DOMAINS} so a domain whose blocked
+   * asks never resolve ages out instead of leaking.
    */
-  private final Map<String, ContendedBusinessId> contendedByBusinessId =
-      boundedByInsertionOrder(MAX_TRACKED_BLOCKED_BUSINESS_IDS);
+  private final Map<ContentionKey, ContendedDomain> contendedByDomain =
+      boundedByInsertionOrder(MAX_TRACKED_CONTENDED_DOMAINS);
 
   private final Counter askCounter;
   private final Counter askRetryCounter;
@@ -260,31 +265,45 @@ public final class MessageCorrelationMetrics implements StreamProcessorLifecycle
 
   /**
    * M16: records that a cross-partition ask ({@code messageKey}) was just rejected on {@code P_B}
-   * because {@code businessId} is held by an active holder — i.e. the ask is now blocked and
-   * retrying. Tracking the ask by its message key lets a later free arm the release clock and lets
-   * the eventual start be attributed only to an ask that was genuinely blocked.
+   * because {@code businessId} is held by an active holder in the {@code (tenantId,
+   * processDefinitionId, businessId)} uniqueness domain — i.e. the ask is now blocked and retrying.
+   * Tracking the ask by its message key within that domain lets a later free arm the release clock
+   * and lets the eventual start be attributed only to an ask that was genuinely blocked, without an
+   * unrelated domain that happens to share the business id interfering.
    */
-  public void recordAskBlockedOnBusinessId(final String businessId, final long messageKey) {
+  public void recordAskBlockedOnBusinessId(
+      final String businessId,
+      final String processDefinitionId,
+      final String tenantId,
+      final long messageKey) {
     if (businessId == null || businessId.isEmpty()) {
       return;
     }
-    contendedByBusinessId
-        .computeIfAbsent(businessId, k -> new ContendedBusinessId())
+    contendedByDomain
+        .computeIfAbsent(
+            new ContentionKey(tenantId, processDefinitionId, businessId),
+            k -> new ContendedDomain())
         .blockedMessageKeys
         .add(messageKey);
   }
 
   /**
    * M16: records that a holder just freed {@code businessId} on {@code P_B} at {@code
-   * freedAtMillis}. The release time is armed only while an ask is actually blocked on the business
-   * id; an uncontended completion is ignored, so a subsequent benign reuse cannot be misattributed.
-   * A newer free overwrites an older one (measure from the most recent release).
+   * freedAtMillis} in the {@code (tenantId, processDefinitionId, businessId)} uniqueness domain.
+   * The release time is armed only while an ask is actually blocked in that domain; an uncontended
+   * completion is ignored, so a subsequent benign reuse cannot be misattributed. A newer free
+   * overwrites an older one (measure from the most recent release).
    */
-  public void recordBusinessIdFreed(final String businessId, final long freedAtMillis) {
+  public void recordBusinessIdFreed(
+      final String businessId,
+      final String processDefinitionId,
+      final String tenantId,
+      final long freedAtMillis) {
     if (businessId == null || businessId.isEmpty()) {
       return;
     }
-    final var contended = contendedByBusinessId.get(businessId);
+    final var contended =
+        contendedByDomain.get(new ContentionKey(tenantId, processDefinitionId, businessId));
     if (contended != null) {
       contended.freedAtMillis = freedAtMillis;
     }
@@ -292,18 +311,32 @@ public final class MessageCorrelationMetrics implements StreamProcessorLifecycle
 
   /**
    * M16: on a cross-partition ask ({@code messageKey}) decided {@code started} on {@code P_B} at
-   * {@code startedAtMillis}, records the release-to-start latency when the ask was blocked on
-   * {@code businessId} and a free was captured, then prunes the ask. A start whose message key was
-   * never blocked (a first-time or uncontended start) is ignored entirely. A blocked start whose
-   * holder was freed without a completion transition (banned/migrated) is pruned but not recorded —
+   * {@code startedAtMillis}, records the release-to-start latency when the ask was blocked in the
+   * {@code (tenantId, processDefinitionId, businessId)} uniqueness domain and a free was captured,
+   * then prunes the ask. A start whose message key was never blocked (a first-time or uncontended
+   * start) is ignored entirely. A blocked start whose holder was freed without a completion
+   * transition (banned, or migrated to a different process definition) is pruned but not recorded —
    * that blind spot is documented on the meter.
+   *
+   * <p>The uniqueness constraint admits only one active holder per domain, so a single free can
+   * unblock only one ask; any further blocked ask must wait for its own fresh free. The captured
+   * free is therefore consumed here (armed for exactly one measurement) and disarmed once used.
+   * This keeps a second blocked ask that starts without a fresh free — its interim holder was
+   * banned or migrated and emitted no completion — from being misattributed against the stale
+   * earlier release, honouring the documented blind spot rather than recording an inflated
+   * duration.
    */
   public void recordReleaseToStart(
-      final String businessId, final long messageKey, final long startedAtMillis) {
+      final String businessId,
+      final String processDefinitionId,
+      final String tenantId,
+      final long messageKey,
+      final long startedAtMillis) {
     if (businessId == null || businessId.isEmpty()) {
       return;
     }
-    final var contended = contendedByBusinessId.get(businessId);
+    final var key = new ContentionKey(tenantId, processDefinitionId, businessId);
+    final var contended = contendedByDomain.get(key);
     if (contended == null || !contended.blockedMessageKeys.remove(messageKey)) {
       return;
     }
@@ -312,29 +345,36 @@ public final class MessageCorrelationMetrics implements StreamProcessorLifecycle
       if (elapsedMillis >= 0) {
         releaseToStartTimer.record(Duration.ofMillis(elapsedMillis));
       }
+      contended.freedAtMillis = null;
     }
     if (contended.blockedMessageKeys.isEmpty()) {
-      contendedByBusinessId.remove(businessId);
+      contendedByDomain.remove(key);
     }
   }
 
   /**
-   * M16: drops a cross-partition ask ({@code messageKey}) that was blocked on {@code businessId}
-   * but has now been rejected as expired — it will stop retrying and never start, so it must no
-   * longer gate the release capture. Without this, a stale blocked entry would let a later
-   * uncontended reuse of the business id be misattributed as release-to-start latency.
+   * M16: drops a cross-partition ask ({@code messageKey}) that was blocked in the {@code (tenantId,
+   * processDefinitionId, businessId)} uniqueness domain but has now been rejected as expired — it
+   * will stop retrying and never start, so it must no longer gate the release capture. Without
+   * this, a stale blocked entry would let a later uncontended reuse of the business id be
+   * misattributed as release-to-start latency.
    */
-  public void discardBlockedAsk(final String businessId, final long messageKey) {
+  public void discardBlockedAsk(
+      final String businessId,
+      final String processDefinitionId,
+      final String tenantId,
+      final long messageKey) {
     if (businessId == null || businessId.isEmpty()) {
       return;
     }
-    final var contended = contendedByBusinessId.get(businessId);
+    final var key = new ContentionKey(tenantId, processDefinitionId, businessId);
+    final var contended = contendedByDomain.get(key);
     if (contended == null) {
       return;
     }
     contended.blockedMessageKeys.remove(messageKey);
     if (contended.blockedMessageKeys.isEmpty()) {
-      contendedByBusinessId.remove(businessId);
+      contendedByDomain.remove(key);
     }
   }
 
@@ -342,7 +382,7 @@ public final class MessageCorrelationMetrics implements StreamProcessorLifecycle
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
     // Samples belong to the previous leadership term; recording them would produce bogus durations.
     pendingAskSamples.clear();
-    contendedByBusinessId.clear();
+    contendedByDomain.clear();
   }
 
   private Timer askDurationTimer(final AskOutcome outcome) {
@@ -387,12 +427,20 @@ public final class MessageCorrelationMetrics implements StreamProcessorLifecycle
   }
 
   /**
-   * Per-business-id M16 tracking state (see {@link #contendedByBusinessId}): the message keys of
-   * the cross-partition asks currently blocked on the business id, and the time its holder last
-   * freed it ({@code null} until a completion arms it). Mutated only from the processing actor on
-   * {@code P_B}, so it needs no synchronisation.
+   * Identifies a uniqueness domain on {@code P_B} — the {@code (tenantId, processDefinitionId,
+   * businessId)} triple that scopes the business-id uniqueness lock. Used as the M16 tracking key
+   * so the same business id reused across different process definitions or tenants (all of which
+   * hash to the same {@code P_B}) is tracked independently rather than conflated.
    */
-  private static final class ContendedBusinessId {
+  private record ContentionKey(String tenantId, String processDefinitionId, String businessId) {}
+
+  /**
+   * Per-domain M16 tracking state (see {@link #contendedByDomain}): the message keys of the
+   * cross-partition asks currently blocked in the domain, and the time its holder last freed it
+   * ({@code null} until a completion arms it). Mutated only from the processing actor on {@code
+   * P_B}, so it needs no synchronisation.
+   */
+  private static final class ContendedDomain {
     private final Set<Long> blockedMessageKeys = new LinkedHashSet<>();
     private Long freedAtMillis;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetrics.java
@@ -7,16 +7,23 @@
  */
 package io.camunda.zeebe.engine.metrics;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.AskOutcome;
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.BlockReason;
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.MessageCorrelationKeyNames;
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReleaseResult;
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReleaseTrigger;
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReplyOutcome;
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.RequestOutcome;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -28,8 +35,15 @@ import java.util.Objects;
  * <p>All recording happens on live leader-only paths (command processors, behaviors and
  * schedulers), never in event appliers, so replay does not double-count. Counters tagged by a
  * closed enum are registered lazily per tag value using the {@link EnumMap} idiom.
+ *
+ * <p>The cross-partition ask-duration timer (M7) keeps an in-memory {@link Timer.Sample} per
+ * outstanding ask. Those samples are mutated only from the processing actor (the ask is started by
+ * a behavior, stopped by the STARTED reply processor or the message-expiry processor, all on {@code
+ * P_K}), never from the scheduler actors that touch the counters, so a plain {@link HashMap} is
+ * safe. They are dropped on recovery ({@link #onRecovered}): samples from a previous leadership
+ * term would otherwise record meaningless durations.
  */
-public final class MessageCorrelationMetrics {
+public final class MessageCorrelationMetrics implements StreamProcessorLifecycleAware {
 
   private final MeterRegistry registry;
 
@@ -40,6 +54,14 @@ public final class MessageCorrelationMetrics {
   private final Map<ReleaseResult, Counter> lockReleaseCounters =
       new EnumMap<>(ReleaseResult.class);
   private final Map<BlockReason, Counter> blockedCounters = new EnumMap<>(BlockReason.class);
+  private final Map<AskOutcome, Timer> askDurationTimers = new EnumMap<>(AskOutcome.class);
+
+  /**
+   * Outstanding ask-duration samples keyed by {@code messageKey → processDefinitionKey}. A single
+   * message can fan out to several process definitions, and expiry must close all of them by
+   * messageKey alone, hence the nested map.
+   */
+  private final Map<Long, Map<Long, Timer.Sample>> pendingAskSamples = new HashMap<>();
 
   private final Counter askCounter;
   private final Counter askRetryCounter;
@@ -152,6 +174,66 @@ public final class MessageCorrelationMetrics {
                     MessageCorrelationKeyNames.REASON.asString(),
                     r.getLabel()))
         .increment();
+  }
+
+  /**
+   * M7: starts the ask-duration timer for a cross-partition ask newly dispatched from {@code P_K}.
+   * No-op if a sample for this {@code (messageKey, processDefinitionKey)} already exists, so
+   * retries keep accruing against the original dispatch rather than restarting the clock.
+   */
+  public void startCrossPartitionAsk(final long messageKey, final long processDefinitionKey) {
+    pendingAskSamples
+        .computeIfAbsent(messageKey, k -> new HashMap<>())
+        .computeIfAbsent(processDefinitionKey, k -> Timer.start(registry));
+  }
+
+  /**
+   * M7: stops the ask-duration timer with {@code outcome=started} when {@code P_K} processes the
+   * STARTED reply. No-op if no sample is tracked (e.g. after a leader change cleared it).
+   */
+  public void completeCrossPartitionAskStarted(
+      final long messageKey, final long processDefinitionKey) {
+    final var byProcessDefinition = pendingAskSamples.get(messageKey);
+    if (byProcessDefinition == null) {
+      return;
+    }
+    final var sample = byProcessDefinition.remove(processDefinitionKey);
+    if (byProcessDefinition.isEmpty()) {
+      pendingAskSamples.remove(messageKey);
+    }
+    if (sample != null) {
+      sample.stop(askDurationTimer(AskOutcome.STARTED));
+    }
+  }
+
+  /**
+   * M7: stops every outstanding ask-duration timer for an expiring message with {@code
+   * outcome=expired} on {@code P_K}. Called for every expiring buffered message; a no-op for the
+   * common case with no pending cross-partition ask.
+   */
+  public void expireCrossPartitionAsks(final long messageKey) {
+    final var byProcessDefinition = pendingAskSamples.remove(messageKey);
+    if (byProcessDefinition == null) {
+      return;
+    }
+    final var timer = askDurationTimer(AskOutcome.EXPIRED);
+    byProcessDefinition.values().forEach(sample -> sample.stop(timer));
+  }
+
+  @Override
+  public void onRecovered(final ReadonlyStreamProcessorContext context) {
+    // Samples belong to the previous leadership term; recording them would produce bogus durations.
+    pendingAskSamples.clear();
+  }
+
+  private Timer askDurationTimer(final AskOutcome outcome) {
+    return askDurationTimers.computeIfAbsent(
+        outcome,
+        o ->
+            MicrometerUtil.buildTimer(MessageCorrelationMetricsDoc.CROSS_PARTITION_ASK_DURATION)
+                .tag(MessageCorrelationKeyNames.OUTCOME.asString(), o.getLabel())
+                .minimumExpectedValue(Duration.ofMillis(10))
+                .register(registry));
   }
 
   private Counter registerCounter(final MessageCorrelationMetricsDoc doc) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetrics.java
@@ -24,8 +24,11 @@ import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Instruments the Business-ID message-start correlation feature: the cross-partition uniqueness
@@ -42,8 +45,25 @@ import java.util.Objects;
  * P_K}), never from the scheduler actors that touch the counters, so a plain {@link HashMap} is
  * safe. They are dropped on recovery ({@link #onRecovered}): samples from a previous leadership
  * term would otherwise record meaningless durations.
+ *
+ * <p>The release-to-start timer (M16) measures, purely on {@code P_B}, the wait between a business
+ * id being released by a completing holder and a cross-partition ask that was <em>blocked on that
+ * business id</em> actually starting. A single in-memory map {@code businessId → }{@link
+ * ContendedBusinessId} makes it leak-free: each entry holds the message keys of the asks currently
+ * uniqueness-rejected (blocked) on that business id, plus the timestamp at which the holder last
+ * freed it (armed only while an ask is blocked). Asks are added when the REQUEST processor rejects
+ * them on uniqueness and pruned per ask when they start or are rejected as expired.
+ *
+ * <p>Gating both the free capture and the measurement on the <em>messageKey</em> of an actually
+ * blocked ask is what keeps the histogram honest: an uncontended completion never arms a free, and
+ * an uncontended reuse of a business id (whose messageKey was never blocked) is never measured — so
+ * the timer records contention latency only, not benign business-id reuse gaps. All access is from
+ * the processing actor on {@code P_B}, and the map is bounded to the most recent {@value
+ * #MAX_TRACKED_BLOCKED_BUSINESS_IDS} contended business ids and cleared on recovery.
  */
 public final class MessageCorrelationMetrics implements StreamProcessorLifecycleAware {
+
+  private static final int MAX_TRACKED_BLOCKED_BUSINESS_IDS = 10_000;
 
   private final MeterRegistry registry;
 
@@ -63,11 +83,24 @@ public final class MessageCorrelationMetrics implements StreamProcessorLifecycle
    */
   private final Map<Long, Map<Long, Timer.Sample>> pendingAskSamples = new HashMap<>();
 
+  /**
+   * Contended business ids on {@code P_B}: each entry tracks the cross-partition asks currently
+   * blocked (uniqueness-rejected) on the business id and, once its holder completes, the time at
+   * which it was last freed. Entries are created when the REQUEST processor rejects an ask on
+   * uniqueness and removed once no ask remains blocked (each starts or is rejected as expired).
+   * Bounded and insertion-ordered: the eldest contended business id is evicted past {@link
+   * #MAX_TRACKED_BLOCKED_BUSINESS_IDS} so a business id whose blocked asks never resolve ages out
+   * instead of leaking.
+   */
+  private final Map<String, ContendedBusinessId> contendedByBusinessId =
+      boundedByInsertionOrder(MAX_TRACKED_BLOCKED_BUSINESS_IDS);
+
   private final Counter askCounter;
   private final Counter askRetryCounter;
   private final Counter lockReleaseQueryCounter;
   private final Counter dedupSweptCounter;
   private final DistributionSummary lockReleaseQueryBatchSize;
+  private final Timer releaseToStartTimer;
 
   public MessageCorrelationMetrics(final MeterRegistry registry) {
     this.registry = Objects.requireNonNull(registry, "must specify a registry");
@@ -82,6 +115,11 @@ public final class MessageCorrelationMetrics implements StreamProcessorLifecycle
         DistributionSummary.builder(batchSizeDoc.getName())
             .description(batchSizeDoc.getDescription())
             .serviceLevelObjectives(batchSizeDoc.getDistributionSLOs())
+            .register(registry);
+
+    releaseToStartTimer =
+        MicrometerUtil.buildTimer(MessageCorrelationMetricsDoc.RELEASE_TO_START_DURATION)
+            .minimumExpectedValue(Duration.ofMillis(10))
             .register(registry);
   }
 
@@ -220,10 +258,91 @@ public final class MessageCorrelationMetrics implements StreamProcessorLifecycle
     byProcessDefinition.values().forEach(sample -> sample.stop(timer));
   }
 
+  /**
+   * M16: records that a cross-partition ask ({@code messageKey}) was just rejected on {@code P_B}
+   * because {@code businessId} is held by an active holder — i.e. the ask is now blocked and
+   * retrying. Tracking the ask by its message key lets a later free arm the release clock and lets
+   * the eventual start be attributed only to an ask that was genuinely blocked.
+   */
+  public void recordAskBlockedOnBusinessId(final String businessId, final long messageKey) {
+    if (businessId == null || businessId.isEmpty()) {
+      return;
+    }
+    contendedByBusinessId
+        .computeIfAbsent(businessId, k -> new ContendedBusinessId())
+        .blockedMessageKeys
+        .add(messageKey);
+  }
+
+  /**
+   * M16: records that a holder just freed {@code businessId} on {@code P_B} at {@code
+   * freedAtMillis}. The release time is armed only while an ask is actually blocked on the business
+   * id; an uncontended completion is ignored, so a subsequent benign reuse cannot be misattributed.
+   * A newer free overwrites an older one (measure from the most recent release).
+   */
+  public void recordBusinessIdFreed(final String businessId, final long freedAtMillis) {
+    if (businessId == null || businessId.isEmpty()) {
+      return;
+    }
+    final var contended = contendedByBusinessId.get(businessId);
+    if (contended != null) {
+      contended.freedAtMillis = freedAtMillis;
+    }
+  }
+
+  /**
+   * M16: on a cross-partition ask ({@code messageKey}) decided {@code started} on {@code P_B} at
+   * {@code startedAtMillis}, records the release-to-start latency when the ask was blocked on
+   * {@code businessId} and a free was captured, then prunes the ask. A start whose message key was
+   * never blocked (a first-time or uncontended start) is ignored entirely. A blocked start whose
+   * holder was freed without a completion transition (banned/migrated) is pruned but not recorded —
+   * that blind spot is documented on the meter.
+   */
+  public void recordReleaseToStart(
+      final String businessId, final long messageKey, final long startedAtMillis) {
+    if (businessId == null || businessId.isEmpty()) {
+      return;
+    }
+    final var contended = contendedByBusinessId.get(businessId);
+    if (contended == null || !contended.blockedMessageKeys.remove(messageKey)) {
+      return;
+    }
+    if (contended.freedAtMillis != null) {
+      final var elapsedMillis = startedAtMillis - contended.freedAtMillis;
+      if (elapsedMillis >= 0) {
+        releaseToStartTimer.record(Duration.ofMillis(elapsedMillis));
+      }
+    }
+    if (contended.blockedMessageKeys.isEmpty()) {
+      contendedByBusinessId.remove(businessId);
+    }
+  }
+
+  /**
+   * M16: drops a cross-partition ask ({@code messageKey}) that was blocked on {@code businessId}
+   * but has now been rejected as expired — it will stop retrying and never start, so it must no
+   * longer gate the release capture. Without this, a stale blocked entry would let a later
+   * uncontended reuse of the business id be misattributed as release-to-start latency.
+   */
+  public void discardBlockedAsk(final String businessId, final long messageKey) {
+    if (businessId == null || businessId.isEmpty()) {
+      return;
+    }
+    final var contended = contendedByBusinessId.get(businessId);
+    if (contended == null) {
+      return;
+    }
+    contended.blockedMessageKeys.remove(messageKey);
+    if (contended.blockedMessageKeys.isEmpty()) {
+      contendedByBusinessId.remove(businessId);
+    }
+  }
+
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
     // Samples belong to the previous leadership term; recording them would produce bogus durations.
     pendingAskSamples.clear();
+    contendedByBusinessId.clear();
   }
 
   private Timer askDurationTimer(final AskOutcome outcome) {
@@ -251,5 +370,30 @@ public final class MessageCorrelationMetrics implements StreamProcessorLifecycle
         .description(doc.getDescription())
         .tag(tagKey, tagValue)
         .register(registry);
+  }
+
+  /**
+   * A fixed-capacity map that evicts the oldest-inserted entry once it grows past {@code
+   * maxEntries}, so a best-effort tracking map cannot grow without bound. Eviction is by insertion
+   * order (FIFO), not access order, and happens synchronously on {@code put}.
+   */
+  private static <K, V> Map<K, V> boundedByInsertionOrder(final int maxEntries) {
+    return new LinkedHashMap<>() {
+      @Override
+      protected boolean removeEldestEntry(final Map.Entry<K, V> eldest) {
+        return size() > maxEntries;
+      }
+    };
+  }
+
+  /**
+   * Per-business-id M16 tracking state (see {@link #contendedByBusinessId}): the message keys of
+   * the cross-partition asks currently blocked on the business id, and the time its holder last
+   * freed it ({@code null} until a completion arms it). Mutated only from the processing actor on
+   * {@code P_B}, so it needs no synchronisation.
+   */
+  private static final class ContendedBusinessId {
+    private final Set<Long> blockedMessageKeys = new LinkedHashSet<>();
+    private Long freedAtMillis;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsDoc.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
 import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Meter.Type;
+import java.time.Duration;
 
 /**
  * Documents the meters that instrument the Business-ID message-start correlation feature: the
@@ -432,6 +433,66 @@ public enum MessageCorrelationMetricsDoc implements ExtendedMeterDocumentation {
     public KeyName[] getAdditionalKeyNames() {
       return PartitionKeyNames.values();
     }
+  },
+
+  /**
+   * Duration a cross-partition message-start ask stays outstanding on {@code P_K}: from the moment
+   * the ask is first dispatched until it reaches a terminal outcome, tagged by that outcome. {@code
+   * started} is the round-trip to a {@code P_B} success reply (including every intervening retry
+   * and back-off), the number spike #58900 investigates as the blocked cross-partition start
+   * latency; {@code expired} is the ask whose buffered message hit its TTL on {@code P_K} before
+   * any success — the whole-window-blocked outcome. Rejections do not stop the timer: the ask is
+   * retried and the blocked time keeps accruing until it either starts or expires. Samples are
+   * in-memory and best-effort — they are dropped on leader change (see {@link
+   * MessageCorrelationMetrics}).
+   */
+  CROSS_PARTITION_ASK_DURATION {
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(10),
+      Duration.ofMillis(100),
+      Duration.ofMillis(500),
+      Duration.ofSeconds(1),
+      Duration.ofSeconds(5),
+      Duration.ofSeconds(10),
+      Duration.ofSeconds(30),
+      Duration.ofMinutes(1),
+      Duration.ofMinutes(5),
+      Duration.ofMinutes(10),
+      Duration.ofMinutes(30),
+      Duration.ofHours(1),
+      Duration.ofHours(5),
+      Duration.ofHours(10),
+    };
+
+    @Override
+    public String getName() {
+      return "zeebe.message.start.cross.partition.asks.duration";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Duration a cross-partition message-start ask stays outstanding on the correlation-key partition (P_K), from first dispatch to a started or expired terminal.";
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {MessageCorrelationKeyNames.OUTCOME};
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
   };
 
   public enum MessageCorrelationKeyNames implements KeyName {
@@ -548,6 +609,22 @@ public enum MessageCorrelationMetricsDoc implements ExtendedMeterDocumentation {
     private final String label;
 
     BlockReason(final String label) {
+      this.label = label;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+  }
+
+  /** Terminal outcome of a cross-partition message-start ask ({@code outcome} tag). */
+  public enum AskOutcome {
+    STARTED("started"),
+    EXPIRED("expired");
+
+    private final String label;
+
+    AskOutcome(final String label) {
       this.label = label;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsDoc.java
@@ -493,6 +493,62 @@ public enum MessageCorrelationMetricsDoc implements ExtendedMeterDocumentation {
     public KeyName[] getAdditionalKeyNames() {
       return PartitionKeyNames.values();
     }
+  },
+
+  /**
+   * Release-to-start latency on {@code P_B = hash(businessId)}: the time between a business id
+   * being freed by a completing/terminating holder and a cross-partition message-start that was
+   * blocked on that business id (uniqueness-rejected and retrying) actually starting here. It
+   * isolates the uniqueness back-pressure component of the cross-partition start latency under
+   * contention — {@link #CROSS_PARTITION_ASK_DURATION} measures the whole ask round-trip on {@code
+   * P_K}, whereas this measures only the wait for the contended business id to be released. Only
+   * asks that were actually blocked are measured (tracked by message key), so uncontended
+   * business-id reuse never pollutes the histogram. Best-effort and in-memory: it is bounded to the
+   * most recent contended business ids, misses holders freed without a completion transition
+   * (banned or migrated), and is dropped on leader change (see {@link MessageCorrelationMetrics}).
+   */
+  RELEASE_TO_START_DURATION {
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(10),
+      Duration.ofMillis(100),
+      Duration.ofMillis(500),
+      Duration.ofSeconds(1),
+      Duration.ofSeconds(5),
+      Duration.ofSeconds(10),
+      Duration.ofSeconds(30),
+      Duration.ofMinutes(1),
+      Duration.ofMinutes(5),
+      Duration.ofMinutes(10),
+      Duration.ofMinutes(30),
+      Duration.ofHours(1),
+      Duration.ofHours(5),
+      Duration.ofHours(10),
+    };
+
+    @Override
+    public String getName() {
+      return "zeebe.message.start.cross.partition.release.to.start.duration";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Latency on the business-id partition (P_B) between a business id being freed by a completing holder and a cross-partition message-start blocked on it actually starting.";
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
   };
 
   public enum MessageCorrelationKeyNames implements KeyName {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -209,16 +209,17 @@ public final class BpmnBufferedMessageStartEventBehavior {
       final BpmnElementContext context,
       final DirectBuffer correlationKey,
       final String businessId) {
+    final var bpmnProcessId = context.getBpmnProcessId();
+    final var tenantId = context.getTenantId();
     if (businessIdUniquenessEnabled && businessId != null && !businessId.isEmpty()) {
       // M16: this holder just released the businessId uniqueness lock on P_B. Report the release so
       // an ask blocked on it can measure its release-to-start latency; the recorder arms this only
       // while an ask is actually blocked, so uncontended completions are ignored. Reported before
       // the process-null guard below so the free is captured even when the latest version has since
       // drained.
-      metrics.recordBusinessIdFreed(businessId, clock.millis());
+      metrics.recordBusinessIdFreed(
+          businessId, BufferUtil.bufferAsString(bpmnProcessId), tenantId, clock.millis());
     }
-    final var bpmnProcessId = context.getBpmnProcessId();
-    final var tenantId = context.getTenantId();
     final var process = processState.getLatestProcessVersionByProcessId(bpmnProcessId, tenantId);
     if (process == null) {
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -209,6 +209,14 @@ public final class BpmnBufferedMessageStartEventBehavior {
       final BpmnElementContext context,
       final DirectBuffer correlationKey,
       final String businessId) {
+    if (businessIdUniquenessEnabled && businessId != null && !businessId.isEmpty()) {
+      // M16: this holder just released the businessId uniqueness lock on P_B. Report the release so
+      // an ask blocked on it can measure its release-to-start latency; the recorder arms this only
+      // while an ask is actually blocked, so uncontended completions are ignored. Reported before
+      // the process-null guard below so the free is captured even when the latest version has since
+      // drained.
+      metrics.recordBusinessIdFreed(businessId, clock.millis());
+    }
     final var bpmnProcessId = context.getBpmnProcessId();
     final var tenantId = context.getTenantId();
     final var process = processState.getLatestProcessVersionByProcessId(bpmnProcessId, tenantId);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/DeferredMessageStartCorrelationResponse.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/DeferredMessageStartCorrelationResponse.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.state.immutable.MessageCorrelationState;
@@ -49,6 +50,7 @@ final class DeferredMessageStartCorrelationResponse {
   private final TypedResponseWriter responseWriter;
   private final MessageCorrelationState messageCorrelationState;
   private final MessageState messageState;
+  private final MessageCorrelationMetrics metrics;
   private final MessageCorrelationRecord correlationRecord = new MessageCorrelationRecord();
   private final MessageRecord expiredMessageRecord = new MessageRecord();
 
@@ -56,11 +58,13 @@ final class DeferredMessageStartCorrelationResponse {
       final StateWriter stateWriter,
       final TypedResponseWriter responseWriter,
       final MessageCorrelationState messageCorrelationState,
-      final MessageState messageState) {
+      final MessageState messageState,
+      final MessageCorrelationMetrics metrics) {
     this.stateWriter = stateWriter;
     this.responseWriter = responseWriter;
     this.messageCorrelationState = messageCorrelationState;
     this.messageState = messageState;
+    this.metrics = metrics;
   }
 
   /**
@@ -161,5 +165,6 @@ final class DeferredMessageStartCorrelationResponse {
     expiredMessageRecord.reset();
     expiredMessageRecord.wrap(storedMessage.getMessage());
     stateWriter.appendFollowUpEvent(messageKey, MessageIntent.EXPIRED, expiredMessageRecord);
+    metrics.expireCrossPartitionAsks(messageKey);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -32,6 +33,7 @@ public final class MessageBatchExpireProcessor implements TypedRecordProcessor<M
   private final int batchLimit;
   private final boolean appendMessageBodyOnExpired;
   private final InstantSource clock;
+  private final MessageCorrelationMetrics metrics;
 
   private final MessageRecord emptyDeleteMessageCommand =
       new MessageRecord().setName("").setCorrelationKey("").setTimeToLive(-1L);
@@ -42,13 +44,15 @@ public final class MessageBatchExpireProcessor implements TypedRecordProcessor<M
       final MessageState messageState,
       final int batchLimit,
       final boolean appendMessageBodyOnExpired,
-      final InstantSource clock) {
+      final InstantSource clock,
+      final MessageCorrelationMetrics metrics) {
     this.stateWriter = stateWriter;
     this.commandWriter = commandWriter;
     this.messageState = messageState;
     this.batchLimit = batchLimit;
     this.appendMessageBodyOnExpired = appendMessageBodyOnExpired;
     this.clock = clock;
+    this.metrics = metrics;
   }
 
   @Override
@@ -70,6 +74,10 @@ public final class MessageBatchExpireProcessor implements TypedRecordProcessor<M
                   && expiredCount.getAndIncrement() < batchLimit) {
                 stateWriter.appendFollowUpEvent(
                     messageKey, MessageIntent.EXPIRED, expiredMessageRecord);
+                // M7: a buffered message that carried a pending cross-partition message-start ask
+                // has now blocked the whole TTL window without starting — close its ask timer(s) as
+                // expired. A no-op for every message with no outstanding ask.
+                metrics.expireCrossPartitionAsks(messageKey);
                 return true;
               } else {
                 return false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -453,6 +453,8 @@ public final class MessageCorrelateBehavior {
         messageData.messageKey(), MessageStartProcessInstanceRequestIntent.REQUESTED, askRecord);
 
     metrics.crossPartitionAskSent();
+    metrics.startCrossPartitionAsk(
+        messageData.messageKey(), subscriptionRecord.getProcessDefinitionKey());
 
     commandSender.sendStartProcessInstanceRequest(
         routingInfo.partitionForCorrelationKey(messageData.businessId()),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -64,6 +64,7 @@ public final class MessageCorrelationCorrelateProcessor
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
+  private final MessageCorrelationMetrics metrics;
 
   public MessageCorrelationCorrelateProcessor(
       final Writers writers,
@@ -87,6 +88,7 @@ public final class MessageCorrelationCorrelateProcessor
     rejectionWriter = writers.rejection();
     this.keyGenerator = keyGenerator;
     this.cslCheck = cslCheck;
+    this.metrics = metrics;
     final var eventHandle =
         new EventHandle(
             keyGenerator,
@@ -233,6 +235,7 @@ public final class MessageCorrelationCorrelateProcessor
 
     // Message Correlate command cannot have a TTL. As a result the message expires immediately.
     stateWriter.appendFollowUpEvent(messageKey, MessageIntent.EXPIRED, messageRecord);
+    metrics.expireCrossPartitionAsks(messageKey);
   }
 
   private MessageData createMessageData(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -109,7 +109,9 @@ public final class MessageEventProcessors {
                 clock,
                 metrics))
         .onCommand(
-            ValueType.MESSAGE, MessageIntent.EXPIRE, new MessageExpireProcessor(writers.state()))
+            ValueType.MESSAGE,
+            MessageIntent.EXPIRE,
+            new MessageExpireProcessor(writers.state(), metrics))
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CREATE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -106,7 +106,8 @@ public final class MessageEventProcessors {
                 messageState,
                 config.getMessagesTtlCheckerBatchLimit(),
                 featureFlags.enableMessageBodyOnExpired(),
-                clock))
+                clock,
+                metrics))
         .onCommand(
             ValueType.MESSAGE, MessageIntent.EXPIRE, new MessageExpireProcessor(writers.state()))
         .onCommand(
@@ -277,6 +278,9 @@ public final class MessageEventProcessors {
                 scheduledTaskStateFactory.get().getMessageState(),
                 config::getMessageStartLockReleasePollInterval,
                 config::getMessageStartLockReleasePollBatchLimit,
-                metrics));
+                metrics))
+        // Clears the recorder's in-memory ask-duration samples on recovery: they belong to the
+        // previous leadership term and must not be recorded (M7).
+        .withListener(metrics);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageExpireProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageExpireProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -18,14 +19,18 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 public final class MessageExpireProcessor implements TypedRecordProcessor<MessageRecord> {
 
   private final StateWriter stateWriter;
+  private final MessageCorrelationMetrics metrics;
 
-  public MessageExpireProcessor(final StateWriter stateWriter) {
+  public MessageExpireProcessor(
+      final StateWriter stateWriter, final MessageCorrelationMetrics metrics) {
     this.stateWriter = stateWriter;
+    this.metrics = metrics;
   }
 
   @Override
   public void processRecord(final TypedRecord<MessageRecord> record) {
 
     stateWriter.appendFollowUpEvent(record.getKey(), MessageIntent.EXPIRED, record.getValue());
+    metrics.expireCrossPartitionAsks(record.getKey());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -60,6 +60,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
   private final CslAuthorizationCheck cslCheck;
   private final RoutingInfo routingInfo;
   private final VariableBehavior variableBehavior;
+  private final MessageCorrelationMetrics metrics;
 
   public MessagePublishProcessor(
       final int partitionId,
@@ -89,6 +90,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
     this.cslCheck = cslCheck;
     this.routingInfo = routingInfo;
     this.variableBehavior = variableBehavior;
+    this.metrics = metrics;
     final var eventHandle =
         new EventHandle(
             keyGenerator,
@@ -197,6 +199,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
     if (messageRecord.getTimeToLive() <= 0L) {
       // avoid that the message can be correlated again by writing the EXPIRED event as a follow-up
       stateWriter.appendFollowUpEvent(messageKey, MessageIntent.EXPIRED, messageRecord);
+      metrics.expireCrossPartitionAsks(messageKey);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor.java
@@ -60,7 +60,7 @@ public final class MessageStartProcessInstanceRequestRejectNoSubscriptionProcess
     this.metrics = metrics;
     deferredCorrelationResponse =
         new DeferredMessageStartCorrelationResponse(
-            stateWriter, responseWriter, messageCorrelationState, messageState);
+            stateWriter, responseWriter, messageCorrelationState, messageState, metrics);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectUniquenessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectUniquenessProcessor.java
@@ -63,7 +63,7 @@ public final class MessageStartProcessInstanceRequestRejectUniquenessProcessor
     this.metrics = metrics;
     deferredCorrelationResponse =
         new DeferredMessageStartCorrelationResponse(
-            stateWriter, responseWriter, messageCorrelationState, messageState);
+            stateWriter, responseWriter, messageCorrelationState, messageState, metrics);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRequestProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRequestProcessor.java
@@ -154,7 +154,11 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
       // backs the pending ask off (removal stays owned by P_K's message-expiry path).
       commandSender.sendStartProcessInstanceExpiredRejected(request);
       metrics.crossPartitionRequest(RequestOutcome.REJECTED_EXPIRED);
-      metrics.discardBlockedAsk(request.getBusinessId(), request.getMessageKey());
+      metrics.discardBlockedAsk(
+          request.getBusinessId(),
+          request.getBpmnProcessId(),
+          request.getTenantId(),
+          request.getMessageKey());
       return;
     }
 
@@ -174,7 +178,11 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
     if (businessIdUniquenessEnabled && isBusinessIdAlreadyHeld(request)) {
       commandSender.sendStartProcessInstanceUniquenessRejected(request);
       metrics.crossPartitionRequest(RequestOutcome.REJECTED_UNIQUENESS);
-      metrics.recordAskBlockedOnBusinessId(request.getBusinessId(), request.getMessageKey());
+      metrics.recordAskBlockedOnBusinessId(
+          request.getBusinessId(),
+          request.getBpmnProcessId(),
+          request.getTenantId(),
+          request.getMessageKey());
       return;
     }
 
@@ -211,7 +219,12 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
 
     commandSender.sendStartProcessInstanceStarted(request, processInstanceKey);
     metrics.crossPartitionRequest(RequestOutcome.STARTED);
-    metrics.recordReleaseToStart(request.getBusinessId(), request.getMessageKey(), clock.millis());
+    metrics.recordReleaseToStart(
+        request.getBusinessId(),
+        request.getBpmnProcessId(),
+        request.getTenantId(),
+        request.getMessageKey(),
+        clock.millis());
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRequestProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRequestProcessor.java
@@ -154,6 +154,7 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
       // backs the pending ask off (removal stays owned by P_K's message-expiry path).
       commandSender.sendStartProcessInstanceExpiredRejected(request);
       metrics.crossPartitionRequest(RequestOutcome.REJECTED_EXPIRED);
+      metrics.discardBlockedAsk(request.getBusinessId(), request.getMessageKey());
       return;
     }
 
@@ -173,6 +174,7 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
     if (businessIdUniquenessEnabled && isBusinessIdAlreadyHeld(request)) {
       commandSender.sendStartProcessInstanceUniquenessRejected(request);
       metrics.crossPartitionRequest(RequestOutcome.REJECTED_UNIQUENESS);
+      metrics.recordAskBlockedOnBusinessId(request.getBusinessId(), request.getMessageKey());
       return;
     }
 
@@ -209,6 +211,7 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
 
     commandSender.sendStartProcessInstanceStarted(request, processInstanceKey);
     metrics.crossPartitionRequest(RequestOutcome.STARTED);
+    metrics.recordReleaseToStart(request.getBusinessId(), request.getMessageKey(), clock.millis());
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestStartProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestStartProcessor.java
@@ -92,7 +92,7 @@ public final class MessageStartProcessInstanceRequestStartProcessor
     this.metrics = metrics;
     deferredCorrelationResponse =
         new DeferredMessageStartCorrelationResponse(
-            stateWriter, responseWriter, messageCorrelationState, messageState);
+            stateWriter, responseWriter, messageCorrelationState, messageState, metrics);
   }
 
   @Override
@@ -153,6 +153,7 @@ public final class MessageStartProcessInstanceRequestStartProcessor
       expiredMessageRecord.wrap(storedMessage.getMessage());
       stateWriter.appendFollowUpEvent(
           reply.getMessageKey(), MessageIntent.EXPIRED, expiredMessageRecord);
+      metrics.expireCrossPartitionAsks(reply.getMessageKey());
     }
 
     // (iv) If the cross-partition start was triggered by a synchronous correlate command (rather

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestStartProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestStartProcessor.java
@@ -100,6 +100,8 @@ public final class MessageStartProcessInstanceRequestStartProcessor
     final var reply = record.getValue();
 
     metrics.crossPartitionReply(ReplyOutcome.STARTED);
+    metrics.completeCrossPartitionAskStarted(
+        reply.getMessageKey(), reply.getProcessDefinitionKey());
 
     // Look up the buffered message once: both the CORRELATED applier and the EXPIRED applier need
     // it (CORRELATED writes a foreign-key reference into MESSAGE_KEY; EXPIRED removes the buffered

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsTest.java
@@ -32,6 +32,9 @@ final class MessageCorrelationMetricsTest {
   private static final String RELEASE_TO_START_METRIC =
       "zeebe.message.start.cross.partition.release.to.start.duration";
 
+  private static final String PROCESS_ID = "process-1";
+  private static final String TENANT = "tenant-1";
+
   private SimpleMeterRegistry registry;
   private MessageCorrelationMetrics metrics;
 
@@ -226,12 +229,12 @@ final class MessageCorrelationMetricsTest {
   @Test
   void shouldRecordReleaseToStartFromFreeToStart() {
     // given a cross-partition ask (messageKey 100) is blocked on a held businessId
-    metrics.recordAskBlockedOnBusinessId("biz-1", 100L);
+    blockAsk("biz-1", 100L);
     // and its holder frees the businessId at t=1000
-    metrics.recordBusinessIdFreed("biz-1", 1_000L);
+    freeBusinessId("biz-1", 1_000L);
 
     // when the blocked ask starts at t=1250
-    metrics.recordReleaseToStart("biz-1", 100L, 1_250L);
+    releaseToStart("biz-1", 100L, 1_250L);
 
     // then the release-to-start latency is recorded once as 250ms (M16)
     final var timer = registry.get(RELEASE_TO_START_METRIC).timer();
@@ -242,10 +245,10 @@ final class MessageCorrelationMetricsTest {
   @Test
   void shouldNotRecordReleaseToStartWhenBusinessIdWasNotFreed() {
     // given a blocked ask whose holder never reported a free (e.g. banned/migrated)
-    metrics.recordAskBlockedOnBusinessId("biz-1", 100L);
+    blockAsk("biz-1", 100L);
 
     // when it starts anyway
-    metrics.recordReleaseToStart("biz-1", 100L, 1_250L);
+    releaseToStart("biz-1", 100L, 1_250L);
 
     // then nothing is recorded — there is no release time to measure from (M16)
     assertThat(registry.get(RELEASE_TO_START_METRIC).timer().count()).isZero();
@@ -254,10 +257,10 @@ final class MessageCorrelationMetricsTest {
   @Test
   void shouldNotRecordReleaseToStartForUncontendedCompletionAndReuse() {
     // given a holder frees a businessId that no ask was ever blocked on (uncontended)
-    metrics.recordBusinessIdFreed("biz-1", 1_000L);
+    freeBusinessId("biz-1", 1_000L);
 
     // when a fresh, never-blocked start later reuses that businessId
-    metrics.recordReleaseToStart("biz-1", 100L, 9_999_000L);
+    releaseToStart("biz-1", 100L, 9_999_000L);
 
     // then it is not measured — a benign reuse gap must not pollute the histogram (M16)
     assertThat(registry.get(RELEASE_TO_START_METRIC).timer().count()).isZero();
@@ -266,15 +269,15 @@ final class MessageCorrelationMetricsTest {
   @Test
   void shouldMeasureOnlyTheBlockedAskNotAnUncontendedStartOnTheSameBusinessId() {
     // given ask 100 is blocked on a businessId that is then freed
-    metrics.recordAskBlockedOnBusinessId("biz-1", 100L);
-    metrics.recordBusinessIdFreed("biz-1", 1_000L);
+    blockAsk("biz-1", 100L);
+    freeBusinessId("biz-1", 1_000L);
 
     // when a different, never-blocked ask 200 starts on the same businessId first
-    metrics.recordReleaseToStart("biz-1", 200L, 1_100L);
+    releaseToStart("biz-1", 200L, 1_100L);
 
     // then it is ignored, and only the genuinely blocked ask 100 is measured when it starts (M16)
     assertThat(registry.get(RELEASE_TO_START_METRIC).timer().count()).isZero();
-    metrics.recordReleaseToStart("biz-1", 100L, 1_300L);
+    releaseToStart("biz-1", 100L, 1_300L);
     final var timer = registry.get(RELEASE_TO_START_METRIC).timer();
     assertThat(timer.count()).isEqualTo(1L);
     assertThat(timer.max(TimeUnit.MILLISECONDS)).isEqualTo(300.0);
@@ -283,12 +286,12 @@ final class MessageCorrelationMetricsTest {
   @Test
   void shouldConsumeBlockedAskSoASecondStartDoesNotRecordAgain() {
     // given a blocked ask already measured by its start
-    metrics.recordAskBlockedOnBusinessId("biz-1", 100L);
-    metrics.recordBusinessIdFreed("biz-1", 1_000L);
-    metrics.recordReleaseToStart("biz-1", 100L, 1_250L);
+    blockAsk("biz-1", 100L);
+    freeBusinessId("biz-1", 1_000L);
+    releaseToStart("biz-1", 100L, 1_250L);
 
     // when a second start (e.g. a dedup-hit retry) fires for the same ask
-    metrics.recordReleaseToStart("biz-1", 100L, 1_900L);
+    releaseToStart("biz-1", 100L, 1_900L);
 
     // then it is a no-op: the ask was pruned, so exactly one sample stands (M16)
     assertThat(registry.get(RELEASE_TO_START_METRIC).timer().count()).isEqualTo(1L);
@@ -297,12 +300,12 @@ final class MessageCorrelationMetricsTest {
   @Test
   void shouldMeasureReleaseToStartFromMostRecentFree() {
     // given the businessId is freed, re-taken and freed again before the blocked ask starts
-    metrics.recordAskBlockedOnBusinessId("biz-1", 100L);
-    metrics.recordBusinessIdFreed("biz-1", 1_000L);
-    metrics.recordBusinessIdFreed("biz-1", 2_000L);
+    blockAsk("biz-1", 100L);
+    freeBusinessId("biz-1", 1_000L);
+    freeBusinessId("biz-1", 2_000L);
 
     // when the blocked cross-partition ask finally starts
-    metrics.recordReleaseToStart("biz-1", 100L, 2_100L);
+    releaseToStart("biz-1", 100L, 2_100L);
 
     // then the latency is measured from the most recent release, not the first (M16)
     assertThat(registry.get(RELEASE_TO_START_METRIC).timer().max(TimeUnit.MILLISECONDS))
@@ -310,17 +313,36 @@ final class MessageCorrelationMetricsTest {
   }
 
   @Test
+  void shouldNotMeasureSecondBlockedAskAgainstAStaleFreeWhenItsHolderDidNotComplete() {
+    // given two asks blocked on the same businessId, freed once, letting the first through
+    blockAsk("biz-1", 100L);
+    blockAsk("biz-1", 200L);
+    freeBusinessId("biz-1", 1_000L);
+    releaseToStart("biz-1", 100L, 1_100L);
+
+    // when the second ask starts without a fresh free (its interim holder was banned/migrated and
+    // never reported a completion)
+    releaseToStart("biz-1", 200L, 5_000L);
+
+    // then only the first ask is measured; the stale free is consumed and does not inflate the
+    // second — that holder-not-completed case is the documented blind spot (M16)
+    final var timer = registry.get(RELEASE_TO_START_METRIC).timer();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.max(TimeUnit.MILLISECONDS)).isEqualTo(100.0);
+  }
+
+  @Test
   void shouldMeasureEachConcurrentlyBlockedAskFromItsOwnRelease() {
     // given two asks are blocked on the same businessId
-    metrics.recordAskBlockedOnBusinessId("biz-1", 100L);
-    metrics.recordAskBlockedOnBusinessId("biz-1", 200L);
+    blockAsk("biz-1", 100L);
+    blockAsk("biz-1", 200L);
 
     // when the first free lets ask 100 through (which re-holds the id), then a second free lets ask
     // 200 through
-    metrics.recordBusinessIdFreed("biz-1", 1_000L);
-    metrics.recordReleaseToStart("biz-1", 100L, 1_100L);
-    metrics.recordBusinessIdFreed("biz-1", 2_000L);
-    metrics.recordReleaseToStart("biz-1", 200L, 2_200L);
+    freeBusinessId("biz-1", 1_000L);
+    releaseToStart("biz-1", 100L, 1_100L);
+    freeBusinessId("biz-1", 2_000L);
+    releaseToStart("biz-1", 200L, 2_200L);
 
     // then each ask is measured once from its own release (M16)
     final var timer = registry.get(RELEASE_TO_START_METRIC).timer();
@@ -329,14 +351,34 @@ final class MessageCorrelationMetricsTest {
   }
 
   @Test
+  void shouldTrackTheSameBusinessIdInDifferentDomainsIndependently() {
+    // given the same businessId is contended in two different process definitions — the same hash
+    // {@code P_B} and metrics instance, but distinct uniqueness domains — each with its own ask
+    metrics.recordAskBlockedOnBusinessId("biz-1", "process-a", "tenant-1", 100L);
+    metrics.recordAskBlockedOnBusinessId("biz-1", "process-b", "tenant-1", 200L);
+
+    // when only the first domain's holder frees the businessId
+    metrics.recordBusinessIdFreed("biz-1", "process-a", "tenant-1", 1_000L);
+
+    // and both asks start
+    metrics.recordReleaseToStart("biz-1", "process-a", "tenant-1", 100L, 1_400L);
+    metrics.recordReleaseToStart("biz-1", "process-b", "tenant-1", 200L, 5_000L);
+
+    // then only the freed domain is measured — the other domain's free never leaked across (M16)
+    final var timer = registry.get(RELEASE_TO_START_METRIC).timer();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.max(TimeUnit.MILLISECONDS)).isEqualTo(400.0);
+  }
+
+  @Test
   void shouldDiscardBlockedAskOnExpirySoALaterReuseIsNotMeasured() {
     // given a blocked ask that is then rejected as expired (it will stop retrying)
-    metrics.recordAskBlockedOnBusinessId("biz-1", 100L);
-    metrics.discardBlockedAsk("biz-1", 100L);
+    blockAsk("biz-1", 100L);
+    discardAsk("biz-1", 100L);
 
     // when the holder later frees the businessId and a fresh reuse starts
-    metrics.recordBusinessIdFreed("biz-1", 1_000L);
-    metrics.recordReleaseToStart("biz-1", 200L, 5_000L);
+    freeBusinessId("biz-1", 1_000L);
+    releaseToStart("biz-1", 200L, 5_000L);
 
     // then nothing is recorded — the stale blocked ask no longer arms the release (M16)
     assertThat(registry.get(RELEASE_TO_START_METRIC).timer().count()).isZero();
@@ -345,14 +387,14 @@ final class MessageCorrelationMetricsTest {
   @Test
   void shouldClearBlockedAndFreedBusinessIdsOnRecovery() {
     // given a blocked-and-freed businessId tracked in the previous leadership term
-    metrics.recordAskBlockedOnBusinessId("biz-1", 100L);
-    metrics.recordBusinessIdFreed("biz-1", 1_000L);
+    blockAsk("biz-1", 100L);
+    freeBusinessId("biz-1", 1_000L);
 
     // when recovery drops the in-memory maps
     metrics.onRecovered(null);
 
     // then a subsequent start is a no-op — the stale tracking is gone (M16)
-    metrics.recordReleaseToStart("biz-1", 100L, 1_250L);
+    releaseToStart("biz-1", 100L, 1_250L);
     assertThat(registry.get(RELEASE_TO_START_METRIC).timer().count()).isZero();
   }
 
@@ -385,5 +427,22 @@ final class MessageCorrelationMetricsTest {
 
   private double blockedCount(final String reason) {
     return taggedCount("zeebe.message.start.blocked.total", "reason", reason);
+  }
+
+  private void blockAsk(final String businessId, final long messageKey) {
+    metrics.recordAskBlockedOnBusinessId(businessId, PROCESS_ID, TENANT, messageKey);
+  }
+
+  private void freeBusinessId(final String businessId, final long freedAtMillis) {
+    metrics.recordBusinessIdFreed(businessId, PROCESS_ID, TENANT, freedAtMillis);
+  }
+
+  private void releaseToStart(
+      final String businessId, final long messageKey, final long startedAtMillis) {
+    metrics.recordReleaseToStart(businessId, PROCESS_ID, TENANT, messageKey, startedAtMillis);
+  }
+
+  private void discardAsk(final String businessId, final long messageKey) {
+    metrics.discardBlockedAsk(businessId, PROCESS_ID, TENANT, messageKey);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReleaseTrigg
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.ReplyOutcome;
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetricsDoc.RequestOutcome;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,6 +29,8 @@ final class MessageCorrelationMetricsTest {
 
   private static final String ASK_DURATION_METRIC =
       "zeebe.message.start.cross.partition.asks.duration";
+  private static final String RELEASE_TO_START_METRIC =
+      "zeebe.message.start.cross.partition.release.to.start.duration";
 
   private SimpleMeterRegistry registry;
   private MessageCorrelationMetrics metrics;
@@ -218,6 +221,139 @@ final class MessageCorrelationMetricsTest {
     // then a subsequent terminal is a no-op — the stale sample is gone (M7)
     metrics.completeCrossPartitionAskStarted(1L, 100L);
     assertThat(registry.find(ASK_DURATION_METRIC).timers()).isEmpty();
+  }
+
+  @Test
+  void shouldRecordReleaseToStartFromFreeToStart() {
+    // given a cross-partition ask (messageKey 100) is blocked on a held businessId
+    metrics.recordAskBlockedOnBusinessId("biz-1", 100L);
+    // and its holder frees the businessId at t=1000
+    metrics.recordBusinessIdFreed("biz-1", 1_000L);
+
+    // when the blocked ask starts at t=1250
+    metrics.recordReleaseToStart("biz-1", 100L, 1_250L);
+
+    // then the release-to-start latency is recorded once as 250ms (M16)
+    final var timer = registry.get(RELEASE_TO_START_METRIC).timer();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.max(TimeUnit.MILLISECONDS)).isEqualTo(250.0);
+  }
+
+  @Test
+  void shouldNotRecordReleaseToStartWhenBusinessIdWasNotFreed() {
+    // given a blocked ask whose holder never reported a free (e.g. banned/migrated)
+    metrics.recordAskBlockedOnBusinessId("biz-1", 100L);
+
+    // when it starts anyway
+    metrics.recordReleaseToStart("biz-1", 100L, 1_250L);
+
+    // then nothing is recorded — there is no release time to measure from (M16)
+    assertThat(registry.get(RELEASE_TO_START_METRIC).timer().count()).isZero();
+  }
+
+  @Test
+  void shouldNotRecordReleaseToStartForUncontendedCompletionAndReuse() {
+    // given a holder frees a businessId that no ask was ever blocked on (uncontended)
+    metrics.recordBusinessIdFreed("biz-1", 1_000L);
+
+    // when a fresh, never-blocked start later reuses that businessId
+    metrics.recordReleaseToStart("biz-1", 100L, 9_999_000L);
+
+    // then it is not measured — a benign reuse gap must not pollute the histogram (M16)
+    assertThat(registry.get(RELEASE_TO_START_METRIC).timer().count()).isZero();
+  }
+
+  @Test
+  void shouldMeasureOnlyTheBlockedAskNotAnUncontendedStartOnTheSameBusinessId() {
+    // given ask 100 is blocked on a businessId that is then freed
+    metrics.recordAskBlockedOnBusinessId("biz-1", 100L);
+    metrics.recordBusinessIdFreed("biz-1", 1_000L);
+
+    // when a different, never-blocked ask 200 starts on the same businessId first
+    metrics.recordReleaseToStart("biz-1", 200L, 1_100L);
+
+    // then it is ignored, and only the genuinely blocked ask 100 is measured when it starts (M16)
+    assertThat(registry.get(RELEASE_TO_START_METRIC).timer().count()).isZero();
+    metrics.recordReleaseToStart("biz-1", 100L, 1_300L);
+    final var timer = registry.get(RELEASE_TO_START_METRIC).timer();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.max(TimeUnit.MILLISECONDS)).isEqualTo(300.0);
+  }
+
+  @Test
+  void shouldConsumeBlockedAskSoASecondStartDoesNotRecordAgain() {
+    // given a blocked ask already measured by its start
+    metrics.recordAskBlockedOnBusinessId("biz-1", 100L);
+    metrics.recordBusinessIdFreed("biz-1", 1_000L);
+    metrics.recordReleaseToStart("biz-1", 100L, 1_250L);
+
+    // when a second start (e.g. a dedup-hit retry) fires for the same ask
+    metrics.recordReleaseToStart("biz-1", 100L, 1_900L);
+
+    // then it is a no-op: the ask was pruned, so exactly one sample stands (M16)
+    assertThat(registry.get(RELEASE_TO_START_METRIC).timer().count()).isEqualTo(1L);
+  }
+
+  @Test
+  void shouldMeasureReleaseToStartFromMostRecentFree() {
+    // given the businessId is freed, re-taken and freed again before the blocked ask starts
+    metrics.recordAskBlockedOnBusinessId("biz-1", 100L);
+    metrics.recordBusinessIdFreed("biz-1", 1_000L);
+    metrics.recordBusinessIdFreed("biz-1", 2_000L);
+
+    // when the blocked cross-partition ask finally starts
+    metrics.recordReleaseToStart("biz-1", 100L, 2_100L);
+
+    // then the latency is measured from the most recent release, not the first (M16)
+    assertThat(registry.get(RELEASE_TO_START_METRIC).timer().max(TimeUnit.MILLISECONDS))
+        .isEqualTo(100.0);
+  }
+
+  @Test
+  void shouldMeasureEachConcurrentlyBlockedAskFromItsOwnRelease() {
+    // given two asks are blocked on the same businessId
+    metrics.recordAskBlockedOnBusinessId("biz-1", 100L);
+    metrics.recordAskBlockedOnBusinessId("biz-1", 200L);
+
+    // when the first free lets ask 100 through (which re-holds the id), then a second free lets ask
+    // 200 through
+    metrics.recordBusinessIdFreed("biz-1", 1_000L);
+    metrics.recordReleaseToStart("biz-1", 100L, 1_100L);
+    metrics.recordBusinessIdFreed("biz-1", 2_000L);
+    metrics.recordReleaseToStart("biz-1", 200L, 2_200L);
+
+    // then each ask is measured once from its own release (M16)
+    final var timer = registry.get(RELEASE_TO_START_METRIC).timer();
+    assertThat(timer.count()).isEqualTo(2L);
+    assertThat(timer.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(300.0);
+  }
+
+  @Test
+  void shouldDiscardBlockedAskOnExpirySoALaterReuseIsNotMeasured() {
+    // given a blocked ask that is then rejected as expired (it will stop retrying)
+    metrics.recordAskBlockedOnBusinessId("biz-1", 100L);
+    metrics.discardBlockedAsk("biz-1", 100L);
+
+    // when the holder later frees the businessId and a fresh reuse starts
+    metrics.recordBusinessIdFreed("biz-1", 1_000L);
+    metrics.recordReleaseToStart("biz-1", 200L, 5_000L);
+
+    // then nothing is recorded — the stale blocked ask no longer arms the release (M16)
+    assertThat(registry.get(RELEASE_TO_START_METRIC).timer().count()).isZero();
+  }
+
+  @Test
+  void shouldClearBlockedAndFreedBusinessIdsOnRecovery() {
+    // given a blocked-and-freed businessId tracked in the previous leadership term
+    metrics.recordAskBlockedOnBusinessId("biz-1", 100L);
+    metrics.recordBusinessIdFreed("biz-1", 1_000L);
+
+    // when recovery drops the in-memory maps
+    metrics.onRecovered(null);
+
+    // then a subsequent start is a no-op — the stale tracking is gone (M16)
+    metrics.recordReleaseToStart("biz-1", 100L, 1_250L);
+    assertThat(registry.get(RELEASE_TO_START_METRIC).timer().count()).isZero();
   }
 
   private double counter(final String name) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsTest.java
@@ -26,6 +26,9 @@ import org.junit.jupiter.api.Test;
  */
 final class MessageCorrelationMetricsTest {
 
+  private static final String ASK_DURATION_METRIC =
+      "zeebe.message.start.cross.partition.asks.duration";
+
   private SimpleMeterRegistry registry;
   private MessageCorrelationMetrics metrics;
 
@@ -147,6 +150,74 @@ final class MessageCorrelationMetricsTest {
     // then each reason is counted independently under its own tag (M14)
     assertThat(blockedCount("correlation_key")).isEqualTo(1.0);
     assertThat(blockedCount("business_id")).isEqualTo(2.0);
+  }
+
+  @Test
+  void shouldRecordAskDurationAsStarted() {
+    // given a dispatched cross-partition ask
+    metrics.startCrossPartitionAsk(1L, 100L);
+
+    // when the STARTED reply lands on P_K
+    metrics.completeCrossPartitionAskStarted(1L, 100L);
+
+    // then the ask duration is recorded under outcome=started (M7)
+    final var timer = registry.find(ASK_DURATION_METRIC).tag("outcome", "started").timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+  }
+
+  @Test
+  void shouldRecordAskDurationAsExpiredForEveryPendingProcessDefinition() {
+    // given a single message fanned out to two process definitions
+    metrics.startCrossPartitionAsk(1L, 100L);
+    metrics.startCrossPartitionAsk(1L, 200L);
+
+    // when the buffered message expires
+    metrics.expireCrossPartitionAsks(1L);
+
+    // then both outstanding samples are recorded under outcome=expired (M7)
+    final var timer = registry.find(ASK_DURATION_METRIC).tag("outcome", "expired").timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(2L);
+  }
+
+  @Test
+  void shouldNotRecordAskDurationWhenNoSampleIsTracked() {
+    // when a terminal fires for an ask that was never started (e.g. after a leader change)
+    metrics.completeCrossPartitionAskStarted(1L, 100L);
+    metrics.expireCrossPartitionAsks(2L);
+
+    // then no ask-duration timer is ever registered (M7)
+    assertThat(registry.find(ASK_DURATION_METRIC).timers()).isEmpty();
+  }
+
+  @Test
+  void shouldStartAskDurationOnlyOncePerMessageAndProcessDefinition() {
+    // given a dispatched ask that is re-dispatched (retried) before any terminal
+    metrics.startCrossPartitionAsk(1L, 100L);
+    metrics.startCrossPartitionAsk(1L, 100L);
+
+    // when the STARTED reply lands once
+    metrics.completeCrossPartitionAskStarted(1L, 100L);
+
+    // then exactly one duration is recorded and nothing is left to expire (M7)
+    assertThat(registry.get(ASK_DURATION_METRIC).tag("outcome", "started").timer().count())
+        .isEqualTo(1L);
+    metrics.expireCrossPartitionAsks(1L);
+    assertThat(registry.find(ASK_DURATION_METRIC).tag("outcome", "expired").timer()).isNull();
+  }
+
+  @Test
+  void shouldClearPendingAskSamplesOnRecovery() {
+    // given a dispatched ask
+    metrics.startCrossPartitionAsk(1L, 100L);
+
+    // when recovery drops the in-memory samples of the previous leadership term
+    metrics.onRecovered(null);
+
+    // then a subsequent terminal is a no-op — the stale sample is gone (M7)
+    metrics.completeCrossPartitionAskStarted(1L, 100L);
+    assertThat(registry.find(ASK_DURATION_METRIC).timers()).isEmpty();
   }
 
   private double counter(final String name) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessorTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
@@ -29,6 +30,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.stream.impl.records.UnwrittenRecord;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -44,6 +46,8 @@ public final class MessageBatchExpireProcessorTest {
   private final TypedCommandWriter commandWriter = Mockito.mock(TypedCommandWriter.class);
   private final MessageState messageState = Mockito.mock(MessageState.class);
   private final Clock clock = Clock.fixed(Instant.ofEpochMilli(NOW), ZoneId.systemDefault());
+  private final MessageCorrelationMetrics metrics =
+      new MessageCorrelationMetrics(new SimpleMeterRegistry());
 
   @Test
   public void shouldExpireMessagesFromState() {
@@ -198,7 +202,13 @@ public final class MessageBatchExpireProcessorTest {
     // default: always have space unless explicitly stubbed otherwise per test
     when(stateWriter.canWriteEventOfLength(anyInt())).thenReturn(true);
     return new MessageBatchExpireProcessor(
-        stateWriter, commandWriter, messageState, batchLimit, appendMessageBodyOnExpired, clock);
+        stateWriter,
+        commandWriter,
+        messageState,
+        batchLimit,
+        appendMessageBodyOnExpired,
+        clock,
+        metrics);
   }
 
   private UnwrittenRecord emptyBatchRecord() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionMetricsTest.java
@@ -41,6 +41,9 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
   // Same stable routing constants as the handshake test: hash("ck-1") and hash("biz-1") land on
   // different partitions so the cross-partition arm is exercised (re-asserted at @Before).
   private static final String CORRELATION_KEY = "ck-1";
+  // A second correlation key that hashes to a partition other than P_B and other than P_K, so a
+  // duplicate-businessId correlate from it is delegated to P_B and rejected on its own P_K.
+  private static final String SECOND_CORRELATION_KEY = "ck-2";
   private static final String BUSINESS_ID = "biz-1";
 
   private static final String PROCESS_ID = "wf-cross";
@@ -88,6 +91,14 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
                 + " cross-partition arm is actually exercised",
             CORRELATION_KEY, BUSINESS_ID)
         .isNotEqualTo(partitionFor(BUSINESS_ID));
+    assertThat(partitionFor(SECOND_CORRELATION_KEY))
+        .as(
+            "SECOND_CORRELATION_KEY (%s) must hash to a partition other than P_B (%s) and other than"
+                + " CORRELATION_KEY (%s), so the second correlate is delegated to P_B and rejected on"
+                + " its own P_K",
+            SECOND_CORRELATION_KEY, BUSINESS_ID, CORRELATION_KEY)
+        .isNotEqualTo(partitionFor(BUSINESS_ID))
+        .isNotEqualTo(partitionFor(CORRELATION_KEY));
   }
 
   @Test
@@ -241,6 +252,48 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
         .isGreaterThanOrEqualTo(1L);
     assertThat(timerCount(pK, ASK_DURATION_METRIC, "outcome", "started"))
         .as("M7: a message that never starts records no started sample")
+        .isZero();
+  }
+
+  @Test
+  public void shouldRecordAskDurationAsExpiredWhenCrossPartitionCorrelateIsRejected() {
+    // given a first synchronous correlate started a holder PI on P_B that owns the businessId
+    deployAndAwaitStartEventSubscriptionsOnAllPartitions(MESSAGE_START_PROCESS);
+    engine
+        .messageCorrelation()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey(CORRELATION_KEY)
+        .withBusinessId(BUSINESS_ID)
+        .correlate();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withElementType(BpmnElementType.PROCESS)
+        .withBpmnProcessId(PROCESS_ID)
+        .await();
+
+    // when a second synchronous correlate reuses the same businessId from a different P_K: it is
+    // delegated to P_B, rejected on uniqueness, and its buffered correlate message is expired on
+    // the second P_K by the deferred-response path — not by the TTL sweeper
+    final var notCorrelated =
+        engine
+            .messageCorrelation()
+            .withName(MESSAGE_NAME)
+            .withCorrelationKey(SECOND_CORRELATION_KEY)
+            .withBusinessId(BUSINESS_ID)
+            .expectNotCorrelated()
+            .correlate();
+    RecordingExporter.messageRecords(MessageIntent.EXPIRED)
+        .withPartitionId(partitionFor(SECOND_CORRELATION_KEY))
+        .withRecordKey(notCorrelated.getKey())
+        .getFirst();
+
+    // then the ask dispatched from the second P_K terminates as expired via the deferred-response
+    // expiry path (M7), never as started
+    final int secondPk = partitionFor(SECOND_CORRELATION_KEY);
+    assertThat(timerCount(secondPk, ASK_DURATION_METRIC, "outcome", "expired"))
+        .as("M7: a rejected synchronous correlate records the ask duration as expired on its P_K")
+        .isGreaterThanOrEqualTo(1L);
+    assertThat(timerCount(secondPk, ASK_DURATION_METRIC, "outcome", "started"))
+        .as("M7: the rejected correlate never records a started sample on its P_K")
         .isZero();
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionMetricsTest.java
@@ -56,8 +56,12 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
   private static final String ASKS_METRIC = "zeebe.message.start.cross.partition.asks.total";
   private static final String ASK_DURATION_METRIC =
       "zeebe.message.start.cross.partition.asks.duration";
+  private static final String RELEASE_TO_START_METRIC =
+      "zeebe.message.start.cross.partition.release.to.start.duration";
 
   private static final Duration MESSAGE_TTL = Duration.ofSeconds(5);
+  private static final Duration ASK_RETRY_INTERVAL = Duration.ofSeconds(1);
+  private static final String HOLDER_TIMER_DURATION = "PT2S";
 
   private static final BpmnModelInstance MESSAGE_START_PROCESS =
       Bpmn.createExecutableProcess(PROCESS_ID)
@@ -78,10 +82,29 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
           .connectTo("task")
           .done();
 
+  // A holder that parks on an intermediate timer (so it can be completed on a clock-controlled
+  // schedule on P_B, which the engine job client cannot reach) plus a message-start arm. Used by
+  // the release-to-start (M16) test: the holder blocks the first ask, its timer fires and frees the
+  // businessId, and a retried ask then starts.
+  private static final BpmnModelInstance TIMER_HOLDER_AND_MESSAGE_START_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent("noneStart")
+          .intermediateCatchEvent("holderTimer", e -> e.timerWithDuration(HOLDER_TIMER_DURATION))
+          .endEvent()
+          .moveToProcess(PROCESS_ID)
+          .startEvent(START_EVENT_ID)
+          .message(MESSAGE_NAME)
+          .endEvent()
+          .done();
+
   @Rule
   public final EngineRule engine =
       EngineRule.multiplePartition(PARTITION_COUNT)
-          .withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
+          .withEngineConfig(
+              config ->
+                  config
+                      .setBusinessIdUniquenessEnabled(true)
+                      .setMessageStartAskRetryInterval(ASK_RETRY_INTERVAL));
 
   @Before
   public void assertCrossPartitionRouting() {
@@ -136,6 +159,9 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
     assertThat(counter(pK, REPLIES_METRIC, "outcome", "started"))
         .as("M2: the STARTED reply is processed on P_K")
         .isEqualTo(1.0);
+    assertThat(timerCount(pB, RELEASE_TO_START_METRIC, null, null))
+        .as("M16: a clean, uncontended start was never blocked, so records no release-to-start")
+        .isZero();
   }
 
   @Test
@@ -295,6 +321,56 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
     assertThat(timerCount(secondPk, ASK_DURATION_METRIC, "outcome", "started"))
         .as("M7: the rejected correlate never records a started sample on its P_K")
         .isZero();
+  }
+
+  @Test
+  public void shouldRecordReleaseToStartWhenBlockedAskStartsAfterHolderFreesBusinessId() {
+    // given a holder PI parked on a timer holds the businessId on P_B
+    deployAndAwaitStartEventSubscriptionsOnAllPartitions(TIMER_HOLDER_AND_MESSAGE_START_PROCESS);
+    final long holderPiKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .onPartition(partitionFor(BUSINESS_ID))
+            .withBusinessId(BUSINESS_ID)
+            .create();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(holderPiKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .getFirst();
+
+    // and a cross-partition message-start is blocked on the same businessId (kept and retried)
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey(CORRELATION_KEY)
+        .withBusinessId(BUSINESS_ID)
+        .withTimeToLive(Duration.ofMinutes(5))
+        .publish();
+    RecordingExporter.records()
+        .withIntent(MessageStartProcessInstanceRequestIntent.UNIQUENESS_REJECTED)
+        .getFirst();
+
+    // when the holder's timer fires, completing it and freeing the businessId on P_B
+    engine.increaseTime(Duration.ofSeconds(3));
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(holderPiKey)
+        .filterRootScope()
+        .await();
+
+    // and the retry scheduler re-dispatches the ask, which now starts a fresh PI on P_B
+    engine.increaseTime(ASK_RETRY_INTERVAL.multipliedBy(64).plusSeconds(1));
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+        .withElementType(BpmnElementType.PROCESS)
+        .withBpmnProcessId(PROCESS_ID)
+        .filter(r -> r.getValue().getProcessInstanceKey() != holderPiKey)
+        .getFirst();
+
+    // then P_B records the release-to-start latency once (M16)
+    final int pB = partitionFor(BUSINESS_ID);
+    assertThat(timerCount(pB, RELEASE_TO_START_METRIC, null, null))
+        .as("M16: the wait from businessId release to the blocked ask starting is recorded on P_B")
+        .isEqualTo(1L);
   }
 
   private double counter(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionMetricsTest.java
@@ -9,17 +9,20 @@ package io.camunda.zeebe.engine.processing.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.Duration;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,6 +51,10 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
       "zeebe.message.start.cross.partition.requests.total";
   private static final String REPLIES_METRIC = "zeebe.message.start.cross.partition.replies.total";
   private static final String ASKS_METRIC = "zeebe.message.start.cross.partition.asks.total";
+  private static final String ASK_DURATION_METRIC =
+      "zeebe.message.start.cross.partition.asks.duration";
+
+  private static final Duration MESSAGE_TTL = Duration.ofSeconds(5);
 
   private static final BpmnModelInstance MESSAGE_START_PROCESS =
       Bpmn.createExecutableProcess(PROCESS_ID)
@@ -163,6 +170,80 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
         .isGreaterThanOrEqualTo(1.0);
   }
 
+  @Test
+  public void shouldRecordAskDurationAsStartedForCleanCrossPartitionStart() {
+    // given
+    deployAndAwaitStartEventSubscriptionsOnAllPartitions(MESSAGE_START_PROCESS);
+
+    // when the cross-partition handshake completes successfully
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey(CORRELATION_KEY)
+        .withBusinessId(BUSINESS_ID)
+        .publish();
+
+    // and P_K processes the STARTED reply (which writes CORRELATED for the start subscription)
+    RecordingExporter.messageStartEventSubscriptionRecords(
+            MessageStartEventSubscriptionIntent.CORRELATED)
+        .withMessageName(MESSAGE_NAME)
+        .getFirst();
+
+    // then the ask duration is recorded once on P_K, tagged started (M7)
+    final int pK = partitionFor(CORRELATION_KEY);
+    assertThat(timerCount(pK, ASK_DURATION_METRIC, "outcome", "started"))
+        .as("M7: the cross-partition ask duration is recorded as started on P_K")
+        .isEqualTo(1L);
+    assertThat(timerCount(pK, ASK_DURATION_METRIC, "outcome", "expired"))
+        .as("M7: a clean start records no expired sample")
+        .isZero();
+  }
+
+  @Test
+  public void shouldRecordAskDurationAsExpiredWhenBlockedMessageExpiresAtTtl() {
+    // given a holder PI that keeps the businessId held on P_B so every ask is rejected
+    deployAndAwaitStartEventSubscriptionsOnAllPartitions(DUAL_START_PROCESS);
+    final long holderKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .onPartition(partitionFor(BUSINESS_ID))
+            .withBusinessId(BUSINESS_ID)
+            .create();
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .filter(r -> r.getValue().getProcessInstanceKey() == holderKey)
+        .getFirst();
+
+    // when a message-start publish asks P_B for the same businessId with a finite TTL
+    final var blocked =
+        engine
+            .message()
+            .withName(MESSAGE_NAME)
+            .withCorrelationKey(CORRELATION_KEY)
+            .withBusinessId(BUSINESS_ID)
+            .withTimeToLive(MESSAGE_TTL.toMillis())
+            .publish();
+    RecordingExporter.messageStartProcessInstanceRequestRecords(
+            MessageStartProcessInstanceRequestIntent.UNIQUENESS_REJECTED)
+        .getFirst();
+
+    // and time advances past the messageDeadline so the buffered message expires on P_K
+    engine.increaseTime(
+        MESSAGE_TTL.plus(EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL));
+    RecordingExporter.messageRecords(MessageIntent.EXPIRED)
+        .withRecordKey(blocked.getKey())
+        .getFirst();
+
+    // then the ask duration is recorded on P_K tagged expired, never started (M7)
+    final int pK = partitionFor(CORRELATION_KEY);
+    assertThat(timerCount(pK, ASK_DURATION_METRIC, "outcome", "expired"))
+        .as("M7: a never-freed holder lets the ask duration terminate as expired on P_K")
+        .isGreaterThanOrEqualTo(1L);
+    assertThat(timerCount(pK, ASK_DURATION_METRIC, "outcome", "started"))
+        .as("M7: a message that never starts records no started sample")
+        .isZero();
+  }
+
   private double counter(
       final int partition, final String name, final String tagKey, final String tagValue) {
     var search = engine.getMeterRegistry(partition).find(name);
@@ -171,6 +252,16 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
     }
     final var counter = search.counter();
     return counter != null ? counter.count() : 0.0;
+  }
+
+  private long timerCount(
+      final int partition, final String name, final String tagKey, final String tagValue) {
+    var search = engine.getMeterRegistry(partition).find(name);
+    if (tagKey != null) {
+      search = search.tag(tagKey, tagValue);
+    }
+    final var timer = search.timer();
+    return timer != null ? timer.count() : 0L;
   }
 
   private void deployAndAwaitStartEventSubscriptionsOnAllPartitions(


### PR DESCRIPTION
## Description

Implements two latency timers for the cross-partition message-start path, providing direct observability into the blocked-start latency under business-id uniqueness contention — previously invisible because neither partition alone could compute it from existing records.

### M7 — `zeebe.message.start.cross.partition.asks.duration`

Measures how long a cross-partition message-start ask stays outstanding on the correlation-key partition (`P_K`), from first dispatch to a terminal outcome, tagged by `outcome` (`started` | `expired`):

- **Start**: a `Timer.Sample` is keyed by `(messageKey, processDefinitionKey)` when the ask is first dispatched in `MessageCorrelateBehavior`. Retries do not restart the clock — blocked time is the point of the measurement.
- **Stop (started)**: sample is stopped in `MessageStartProcessInstanceRequestStartProcessor` when the STARTED reply arrives.
- **Stop (expired)**: all outstanding samples for a messageKey are stopped in `MessageExpireProcessor`, `MessageBatchExpireProcessor`, `MessageCorrelationCorrelateProcessor`, and the deferred-response expiry path.
- In-memory samples are dropped on leader change (`onRecovered`) so stale leadership-term samples never produce bogus durations.

### M16 — `zeebe.message.start.cross.partition.release.to.start.duration`

Measures, purely on `P_B`, the wait between a business-id being freed by a completing holder and a cross-partition ask that was *blocked on that business-id* actually starting. Isolates the uniqueness back-pressure component of the start latency:

- Implemented entirely inside `MessageCorrelationMetrics` via two bounded in-memory structures: a `(messageKey → processDefinitionKey → Timer.Sample)` map for asks and an insertion-ordered `businessId → ContendedBusinessId` LRU map (capped at 10,000) tracking blocked asks and their holder's free timestamp.
- Only asks that were genuinely uniqueness-rejected are tracked; uncontended completions and benign business-id reuse never pollute the histogram.
- Cleared on recovery; zero protocol change, zero persisted state.
- Known blind spots documented on the meter: holders freed via ban/migration (no completion transition), and samples lost on leader change.

### Both timers

- Use explicit SLO buckets: 10 ms → 10 h.
- `MessageCorrelationMetrics` now implements `StreamProcessorLifecycleAware` and is registered as a stream-processor listener so `onRecovered` is invoked automatically.

## Testing

- **Unit tests** (`MessageCorrelationMetricsTest`): 15 new test cases covering the full lifecycle of M7 and M16, including edge cases (retries, concurrent blocked asks, recovery, expired discards, and uncontended reuse guards).
- **Multi-partition integration tests** (`MessageStartProcessInstanceCrossPartitionMetricsTest`): 4 new end-to-end tests asserting M7 and M16 on the correct per-partition meter registries, including a timer-holder scenario that drives the full release-to-start flow.

## Related issues

closes #59140