### PR TITLE
ci: load-test: label CI runs with name/namespace

### DIFF
--- a/.github/workflows/camunda-delete-load-test.yml
+++ b/.github/workflows/camunda-delete-load-test.yml
@@ -8,6 +8,8 @@
 # type: CI
 # owner: @camunda/reliability-testing
 name: Delete load test
+run-name: "Delete load test: ${{ inputs.namespace }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/camunda-load-test-metrics.yaml
+++ b/.github/workflows/camunda-load-test-metrics.yaml
@@ -5,6 +5,8 @@
 # type: CI
 # owner: @camunda/reliability-testing
 name: Camunda Load Test Metrics
+run-name: "Camunda Load Test Metrics: ${{ inputs.namespace }}"
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -16,6 +16,8 @@
 #   You must also set the image pull secret to "harbor-registry" in the helm values.
 
 name: Camunda load test
+run-name: "Camunda load test: ${{ inputs.name }}"
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -11,6 +11,8 @@
 # type: CI
 # owner: @camunda/reliability-testing
 name: Camunda Release load test workflow
+run-name: "Camunda Release load test workflow: ${{ inputs.name }}"
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/camunda-verify-and-cleanup-load-test.yml
+++ b/.github/workflows/camunda-verify-and-cleanup-load-test.yml
@@ -4,6 +4,8 @@
 # type: CI
 # owner: @camunda/reliability-testing
 name: Verify and cleanup load test
+run-name: "Verify and cleanup load test: ${{ inputs.namespace }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/camunda-verify-load-test.yml
+++ b/.github/workflows/camunda-verify-load-test.yml
@@ -3,6 +3,8 @@
 # type: CI
 # owner: @camunda/reliability-testing
 name: Verify load test
+run-name: "Verify load test: ${{ inputs.namespace }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/profile-load-test.yml
+++ b/.github/workflows/profile-load-test.yml
@@ -12,6 +12,8 @@
 # type: CI
 # owner: @camunda/zeebe-distributed-platform
 name: Profile running load test
+run-name: "Profile running load test: ${{ inputs.name }}"
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Description

When browsing the list of runs, it will be easier to find out which load test this runs is for.

[Example](https://github.com/camunda/camunda/actions/workflows/camunda-delete-load-test.yml):
<img width="548" height="1058" alt="image" src="https://github.com/user-attachments/assets/4a27303e-dfcc-4f13-a27e-75a844c28ed1" />


`run-name` doc: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#run-name

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://camunda.slack.com/archives/C0A22S6M4TF/p1785766002687389?thread_ts=1785765114.691089&cid=C0A22S6M4TF
