### PR TITLE
feat: persist and complete deleteHistory when fully deleted

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessDeletionBehavior.java
@@ -88,7 +88,8 @@ public final class BpmnProcessDeletionBehavior {
             .setKey(process.getKey())
             .setResourceName(process.getResourceName())
             .setTenantId(process.getTenantId())
-            .setDeploymentKey(process.getDeploymentKey());
+            .setDeploymentKey(process.getDeploymentKey())
+            .setDeleteHistory(process.isDeleteHistory());
     // the locally-minted key identifies the reporting partition to ProcessDeleteCompleteProcessor
     final long key = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(key, ProcessIntent.DELETING, processRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionBehavior.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.historydeletion;
+
+import io.camunda.search.filter.DecisionInstanceFilter;
+import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/**
+ * Creates the batch operation that deletes a deleted resource's history: one item per instance,
+ * then the resource itself.
+ *
+ * <p>Uses anonymous authentication — the caller was already authorized to delete the resource, so
+ * this is an internal consequence. Create it only on the partition that received the original
+ * command; it distributes itself to the others.
+ */
+public final class HistoryDeletionBehavior {
+
+  private final KeyGenerator keyGenerator;
+  private final TypedCommandWriter commandWriter;
+
+  public HistoryDeletionBehavior(
+      final KeyGenerator keyGenerator, final TypedCommandWriter commandWriter) {
+    this.keyGenerator = keyGenerator;
+    this.commandWriter = commandWriter;
+  }
+
+  /**
+   * Deletes the history of every instance of the given process definition, and of the definition
+   * itself.
+   *
+   * @return the key of the created batch operation
+   */
+  public long deleteProcessInstanceHistory(final long eventKey, final long processDefinitionKey) {
+    final var filter =
+        new ProcessInstanceFilter.Builder().processDefinitionKeys(processDefinitionKey).build();
+    return createBatchOperation(
+        eventKey,
+        BatchOperationType.DELETE_PROCESS_INSTANCE,
+        MsgPackConverter.convertToMsgPack(filter),
+        new HistoryDeletionRecord()
+            .setResourceKey(processDefinitionKey)
+            .setResourceType(HistoryDeletionType.PROCESS_DEFINITION));
+  }
+
+  /**
+   * Deletes the history of every instance of the decisions belonging to the given decision
+   * requirements, and of the decision requirements themselves.
+   *
+   * @return the key of the created batch operation
+   */
+  public long deleteDecisionInstanceHistory(
+      final long eventKey, final long decisionRequirementsKey) {
+    final var filter =
+        new DecisionInstanceFilter.Builder()
+            .decisionRequirementsKeys(decisionRequirementsKey)
+            .build();
+    return createBatchOperation(
+        eventKey,
+        BatchOperationType.DELETE_DECISION_INSTANCE,
+        MsgPackConverter.convertToMsgPack(filter),
+        new HistoryDeletionRecord()
+            .setResourceKey(decisionRequirementsKey)
+            .setResourceType(HistoryDeletionType.DECISION_REQUIREMENTS));
+  }
+
+  private long createBatchOperation(
+      final long eventKey,
+      final BatchOperationType batchOperationType,
+      final byte[] entityFilter,
+      final HistoryDeletionRecord followUpCommand) {
+    final long batchOperationKey = keyGenerator.nextKey();
+    final var batchOperationRecord =
+        new BatchOperationCreationRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setBatchOperationType(batchOperationType)
+            .setEntityFilter(new UnsafeBuffer(entityFilter))
+            .setAuthentication(
+                new UnsafeBuffer(
+                    MsgPackConverter.convertToMsgPack(CamundaAuthentication.anonymous())))
+            .setFollowUpCommand(
+                ValueType.HISTORY_DELETION, HistoryDeletionIntent.DELETE, followUpCommand);
+    commandWriter.appendFollowUpCommand(
+        eventKey, BatchOperationIntent.CREATE, batchOperationRecord);
+    return batchOperationKey;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ProcessDeleteCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ProcessDeleteCompleteProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.resource;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.historydeletion.HistoryDeletionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -24,8 +25,9 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 /**
  * Aggregates per-partition drain reports on the deployment partition. Each report clears the
  * reporting partition ({@link ProcessIntent#DELETE_COMPLETED}); once none remain, the definition is
- * marked gone cluster-wide ({@link ProcessIntent#FULLY_DELETED}). Physical removal already happened
- * locally on each partition (see {@code BpmnProcessDeletionBehavior}).
+ * marked gone cluster-wide ({@link ProcessIntent#FULLY_DELETED}) and its history is deleted if the
+ * deletion asked for it. Physical removal already happened locally on each partition (see {@code
+ * BpmnProcessDeletionBehavior}).
  */
 @ExcludeAuthorizationCheck
 public final class ProcessDeleteCompleteProcessor
@@ -36,6 +38,7 @@ public final class ProcessDeleteCompleteProcessor
   private final TypedRejectionWriter rejectionWriter;
   private final ProcessState processState;
   private final CommandDistributionBehavior commandDistributionBehavior;
+  private final HistoryDeletionBehavior historyDeletionBehavior;
 
   public ProcessDeleteCompleteProcessor(
       final int currentPartitionId,
@@ -47,6 +50,8 @@ public final class ProcessDeleteCompleteProcessor
     rejectionWriter = writers.rejection();
     processState = processingState.getProcessState();
     this.commandDistributionBehavior = commandDistributionBehavior;
+    historyDeletionBehavior =
+        new HistoryDeletionBehavior(processingState.getKeyGenerator(), writers.command());
   }
 
   @Override
@@ -95,12 +100,12 @@ public final class ProcessDeleteCompleteProcessor
 
   private void finishProcessDelete(
       final TypedRecord<ProcessRecord> command, final ProcessRecord process) {
+    // delete the history first, then emit FULLY_DELETED as the terminal marker of the deletion
+    if (process.isDeleteHistory()) {
+      historyDeletionBehavior.deleteProcessInstanceHistory(
+          command.getKey(), process.getProcessDefinitionKey());
+    }
+
     stateWriter.appendFollowUpEvent(command.getKey(), ProcessIntent.FULLY_DELETED, process);
-
-    deleteHistory(command.getKey(), command);
-  }
-
-  private void deleteHistory(final long eventKey, final TypedRecord<ProcessRecord> command) {
-    // TODO delete history https://github.com/camunda/camunda/issues/56973
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -11,21 +11,18 @@ import static io.camunda.zeebe.engine.state.instance.TimerInstance.NO_ELEMENT_IN
 import static io.camunda.zeebe.protocol.ZbColumnFamilies.PROCESS_CACHE_BY_ID_AND_VERSION;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
-import io.camunda.search.filter.DecisionInstanceFilter;
-import io.camunda.search.filter.ProcessInstanceFilter;
-import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.core.authz.TenantAccess;
 import io.camunda.zeebe.engine.metrics.ProcessDefinitionMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.deployment.StartEventSubscriptionManager;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.historydeletion.HistoryDeletionBehavior;
 import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.identity.authorization.exception.ForbiddenException;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -44,28 +41,21 @@ import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.ResourceState;
 import io.camunda.zeebe.engine.state.immutable.TenantState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
-import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
-import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
-import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
-import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.ResourceType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -76,7 +66,6 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,7 +77,6 @@ public class ResourceDeletionDeleteProcessor
       List.of(ResourceType.PROCESS_DEFINITION, ResourceType.DECISION_REQUIREMENTS);
 
   private final StateWriter stateWriter;
-  private final TypedCommandWriter commandWriter;
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final KeyGenerator keyGenerator;
@@ -107,6 +95,7 @@ public class ResourceDeletionDeleteProcessor
   private final ResourceState resourceState;
   private final TenantState tenantState;
   private final ProcessDefinitionMetrics processDefinitionMetrics;
+  private final HistoryDeletionBehavior historyDeletionBehavior;
 
   public ResourceDeletionDeleteProcessor(
       final Writers writers,
@@ -118,7 +107,6 @@ public class ResourceDeletionDeleteProcessor
       final CslAuthorizationCheck cslCheck,
       final ProcessDefinitionMetrics processDefinitionMetrics) {
     stateWriter = writers.state();
-    commandWriter = writers.command();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     this.keyGenerator = keyGenerator;
@@ -140,6 +128,7 @@ public class ResourceDeletionDeleteProcessor
     resourceState = processingState.getResourceState();
     tenantState = processingState.getTenantState();
     this.processDefinitionMetrics = processDefinitionMetrics;
+    historyDeletionBehavior = new HistoryDeletionBehavior(keyGenerator, writers.command());
   }
 
   @Override
@@ -451,25 +440,8 @@ public class ResourceDeletionDeleteProcessor
       final long processDefinitionKey,
       final long eventKey,
       final ResourceDeletionRecord resourceDeletionRecord) {
-    final var filter =
-        new ProcessInstanceFilter.Builder().processDefinitionKeys(processDefinitionKey).build();
-    final long batchOperationKey = keyGenerator.nextKey();
-    final var batchOperationRecord =
-        new BatchOperationCreationRecord()
-            .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE)
-            .setEntityFilter(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(filter)))
-            .setAuthentication(
-                new UnsafeBuffer(
-                    MsgPackConverter.convertToMsgPack(CamundaAuthentication.anonymous())))
-            .setFollowUpCommand(
-                ValueType.HISTORY_DELETION,
-                HistoryDeletionIntent.DELETE,
-                new HistoryDeletionRecord()
-                    .setResourceKey(processDefinitionKey)
-                    .setResourceType(HistoryDeletionType.PROCESS_DEFINITION));
-    commandWriter.appendFollowUpCommand(
-        eventKey, BatchOperationIntent.CREATE, batchOperationRecord);
+    final long batchOperationKey =
+        historyDeletionBehavior.deleteProcessInstanceHistory(eventKey, processDefinitionKey);
 
     resourceDeletionRecord.setBatchOperationKey(batchOperationKey);
     resourceDeletionRecord.setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE);
@@ -479,27 +451,8 @@ public class ResourceDeletionDeleteProcessor
       final long decisionRequirementsKey,
       final long eventKey,
       final ResourceDeletionRecord resourceDeletionRecord) {
-    final var filter =
-        new DecisionInstanceFilter.Builder()
-            .decisionRequirementsKeys(decisionRequirementsKey)
-            .build();
-    final long batchOperationKey = keyGenerator.nextKey();
-    final var batchOperationRecord =
-        new BatchOperationCreationRecord()
-            .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE)
-            .setEntityFilter(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(filter)))
-            .setAuthentication(
-                new UnsafeBuffer(
-                    MsgPackConverter.convertToMsgPack(CamundaAuthentication.anonymous())))
-            .setFollowUpCommand(
-                ValueType.HISTORY_DELETION,
-                HistoryDeletionIntent.DELETE,
-                new HistoryDeletionRecord()
-                    .setResourceKey(decisionRequirementsKey)
-                    .setResourceType(HistoryDeletionType.DECISION_REQUIREMENTS));
-    commandWriter.appendFollowUpCommand(
-        eventKey, BatchOperationIntent.CREATE, batchOperationRecord);
+    final long batchOperationKey =
+        historyDeletionBehavior.deleteDecisionInstanceHistory(eventKey, decisionRequirementsKey);
 
     resourceDeletionRecord.setBatchOperationKey(batchOperationKey);
     resourceDeletionRecord.setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessDrainingApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessDrainingApplier.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
@@ -24,6 +23,6 @@ public class ProcessDrainingApplier implements TypedEventApplier<ProcessIntent, 
 
   @Override
   public void applyState(final long key, final ProcessRecord value) {
-    processState.updateProcessState(value, PersistedProcessState.DRAINING);
+    processState.markDraining(value);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -271,6 +271,18 @@ public final class DbProcessState implements MutableProcessState {
   }
 
   @Override
+  public void markDraining(final ProcessRecord processRecord) {
+    tenantIdKey.wrapString(processRecord.getTenantId());
+    processDefinitionKey.wrapLong(processRecord.getProcessDefinitionKey());
+
+    final var process = processColumnFamily.get(tenantAwareProcessDefinitionKey);
+    process.setState(PersistedProcessState.DRAINING);
+    process.setDeleteHistory(processRecord.isDeleteHistory());
+    processColumnFamily.update(tenantAwareProcessDefinitionKey, process);
+    updateInMemoryState(process);
+  }
+
+  @Override
   public void setMissingDeploymentKey(
       final String tenantId, final long processDefinitionKey, final long deploymentKey) {
     tenantIdKey.wrapString(tenantId);
@@ -343,6 +355,20 @@ public final class DbProcessState implements MutableProcessState {
 
     versionManager.deleteResourceVersion(
         processRecord.getBpmnProcessId(), processRecord.getVersion(), processRecord.getTenantId());
+  }
+
+  @Override
+  public void addPendingDeletion(final long processDefinitionKey, final int partitionId) {
+    this.processDefinitionKey.wrapLong(processDefinitionKey);
+    pendingDeletionPartitionId.wrapInt(partitionId);
+    pendingProcessDeletionsPerPartitionColumnFamily.insert(pendingDeletionKey, DbNil.INSTANCE);
+  }
+
+  @Override
+  public void removePendingDeletion(final long processDefinitionKey, final int partitionId) {
+    this.processDefinitionKey.wrapLong(processDefinitionKey);
+    pendingDeletionPartitionId.wrapInt(partitionId);
+    pendingProcessDeletionsPerPartitionColumnFamily.deleteExisting(pendingDeletionKey);
   }
 
   private void invalidateCaches(
@@ -624,6 +650,26 @@ public final class DbProcessState implements MutableProcessState {
         });
   }
 
+  @Override
+  public boolean hasPendingDeletion(final long processDefinitionKey, final int partitionId) {
+    this.processDefinitionKey.wrapLong(processDefinitionKey);
+    pendingDeletionPartitionId.wrapInt(partitionId);
+    return pendingProcessDeletionsPerPartitionColumnFamily.exists(pendingDeletionKey);
+  }
+
+  @Override
+  public boolean hasPendingDeletion(final long processDefinitionKey) {
+    this.processDefinitionKey.wrapLong(processDefinitionKey);
+    final var hasPending = new MutableBoolean();
+    pendingProcessDeletionsPerPartitionColumnFamily.whileEqualPrefix(
+        this.processDefinitionKey,
+        ignored -> {
+          hasPending.set(true);
+          return false;
+        });
+    return hasPending.get();
+  }
+
   private DeployedProcess lookupProcessByIdAndPersistedVersion(
       final long latestVersion, final String tenantId) {
     tenantIdKey.wrapString(tenantId);
@@ -696,40 +742,6 @@ public final class DbProcessState implements MutableProcessState {
     }
     // does not exist in persistence and in memory state
     return null;
-  }
-
-  @Override
-  public void addPendingDeletion(final long processDefinitionKey, final int partitionId) {
-    this.processDefinitionKey.wrapLong(processDefinitionKey);
-    pendingDeletionPartitionId.wrapInt(partitionId);
-    pendingProcessDeletionsPerPartitionColumnFamily.insert(pendingDeletionKey, DbNil.INSTANCE);
-  }
-
-  @Override
-  public void removePendingDeletion(final long processDefinitionKey, final int partitionId) {
-    this.processDefinitionKey.wrapLong(processDefinitionKey);
-    pendingDeletionPartitionId.wrapInt(partitionId);
-    pendingProcessDeletionsPerPartitionColumnFamily.deleteExisting(pendingDeletionKey);
-  }
-
-  @Override
-  public boolean hasPendingDeletion(final long processDefinitionKey, final int partitionId) {
-    this.processDefinitionKey.wrapLong(processDefinitionKey);
-    pendingDeletionPartitionId.wrapInt(partitionId);
-    return pendingProcessDeletionsPerPartitionColumnFamily.exists(pendingDeletionKey);
-  }
-
-  @Override
-  public boolean hasPendingDeletion(final long processDefinitionKey) {
-    this.processDefinitionKey.wrapLong(processDefinitionKey);
-    final var hasPending = new MutableBoolean();
-    pendingProcessDeletionsPerPartitionColumnFamily.whileEqualPrefix(
-        this.processDefinitionKey,
-        ignored -> {
-          hasPending.set(true);
-          return false;
-        });
-    return hasPending.get();
   }
 
   record TenantIdAndProcessIdAndVersion(String tenantId, DirectBuffer processId, long Version) {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeployedProcess.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeployedProcess.java
@@ -56,6 +56,10 @@ public final class DeployedProcess {
     return persistedProcess.getState() == PersistedProcessState.DRAINING;
   }
 
+  public boolean isDeleteHistory() {
+    return persistedProcess.isDeleteHistory();
+  }
+
   public String getTenantId() {
     return persistedProcess.getTenantId();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.transformation.Transf
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
@@ -44,9 +45,10 @@ public final class PersistedProcess extends UnpackedObject
   private final StringProperty versionTagProp = new StringProperty("versionTag", "");
   private final ArrayProperty<TransformerVersion> transformerVersionsProp =
       new ArrayProperty<>("transformerVersions", TransformerVersion::new);
+  private final BooleanProperty deleteHistoryProp = new BooleanProperty("deleteHistory", false);
 
   public PersistedProcess() {
-    super(10);
+    super(11);
     declareProperty(versionProp)
         .declareProperty(keyProp)
         .declareProperty(bpmnProcessIdProp)
@@ -56,7 +58,8 @@ public final class PersistedProcess extends UnpackedObject
         .declareProperty(tenantIdProp)
         .declareProperty(deploymentKeyProp)
         .declareProperty(versionTagProp)
-        .declareProperty(transformerVersionsProp);
+        .declareProperty(transformerVersionsProp)
+        .declareProperty(deleteHistoryProp);
   }
 
   @Override
@@ -75,6 +78,7 @@ public final class PersistedProcess extends UnpackedObject
     tenantIdProp.setValue(processRecord.getTenantId());
     deploymentKeyProp.setValue(processRecord.getDeploymentKey());
     versionTagProp.setValue(processRecord.getVersionTag());
+    deleteHistoryProp.setValue(false);
 
     transformerVersionsProp.reset();
     processRecord
@@ -130,6 +134,15 @@ public final class PersistedProcess extends UnpackedObject
 
   public PersistedProcess setState(final PersistedProcessState state) {
     stateProp.setValue(state);
+    return this;
+  }
+
+  public boolean isDeleteHistory() {
+    return deleteHistoryProp.getValue();
+  }
+
+  public PersistedProcess setDeleteHistory(final boolean deleteHistory) {
+    deleteHistoryProp.setValue(deleteHistory);
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
@@ -69,6 +69,7 @@ public final class PersistedProcess extends UnpackedObject
   }
 
   public void wrap(final ProcessRecord processRecord, final long processDefinitionKey) {
+    reset();
     bpmnProcessIdProp.setValue(processRecord.getBpmnProcessIdBuffer());
     resourceNameProp.setValue(processRecord.getResourceNameBuffer());
     resourceProp.setValue(processRecord.getResourceBuffer());
@@ -78,9 +79,7 @@ public final class PersistedProcess extends UnpackedObject
     tenantIdProp.setValue(processRecord.getTenantId());
     deploymentKeyProp.setValue(processRecord.getDeploymentKey());
     versionTagProp.setValue(processRecord.getVersionTag());
-    deleteHistoryProp.setValue(false);
 
-    transformerVersionsProp.reset();
     processRecord
         .getTransformerVersions()
         .forEach(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessState.java
@@ -34,6 +34,13 @@ public interface MutableProcessState extends ProcessState {
   void updateProcessState(final ProcessRecord processRecord, final PersistedProcessState state);
 
   /**
+   * Marks a definition {@link PersistedProcessState#DRAINING}, remembering from the record whether
+   * its instances' history must be deleted once drained. Updates both the ColumnFamily and the
+   * in-memory cache.
+   */
+  void markDraining(final ProcessRecord processRecord);
+
+  /**
    * Sets the deployment key of a process that was not previously associated with a deployment. This
    * method updates both the ColumnFamily and the in memory cache. Throws an exception if the
    * process is already associated with another deployment.

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
@@ -481,6 +481,55 @@ public class DrainingProcessDefinitionTest {
   }
 
   @Test
+  public void shouldCarryDeleteHistoryIntentOnDrainReport() {
+    // given - a draining definition whose deletion also requested its history to be deleted
+    final var processId = helper.getBpmnProcessId();
+    final var metadata = deployWithJob(processId);
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+    awaitJobCreated(processInstanceKey);
+    drain(metadata, true);
+
+    // when - the last active instance completes
+    engine.job().ofInstance(processInstanceKey).withType(JOB_TYPE).complete();
+
+    // then - the report carries the intent, since this partition removes the definition locally
+    // right away and the deployment partition can no longer read it from state
+    final var report =
+        RecordingExporter.processRecords()
+            .withRecordType(RecordType.COMMAND)
+            .withIntent(ProcessIntent.DELETE_COMPLETE)
+            .withProcessDefinitionKey(metadata.getProcessDefinitionKey())
+            .getFirst();
+    Assertions.assertThat(((ProcessRecord) report.getValue()).isDeleteHistory())
+        .describedAs("the drain report carries the history deletion intent")
+        .isTrue();
+  }
+
+  @Test
+  public void shouldNotCarryDeleteHistoryIntentWhenNotRequested() {
+    // given - a draining definition whose deletion did not request history deletion
+    final var processId = helper.getBpmnProcessId();
+    final var metadata = deployWithJob(processId);
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+    awaitJobCreated(processInstanceKey);
+    drain(metadata);
+
+    // when - the last active instance completes
+    engine.job().ofInstance(processInstanceKey).withType(JOB_TYPE).complete();
+
+    // then
+    final var report =
+        RecordingExporter.processRecords()
+            .withRecordType(RecordType.COMMAND)
+            .withIntent(ProcessIntent.DELETE_COMPLETE)
+            .withProcessDefinitionKey(metadata.getProcessDefinitionKey())
+            .getFirst();
+    Assertions.assertThat(((ProcessRecord) report.getValue()).isDeleteHistory())
+        .describedAs("the drain report does not request history deletion")
+        .isFalse();
+  }
+
+  @Test
   public void shouldReportDrainedWhenLastDrainingInstanceTerminates() {
     // given
     final var processId = helper.getBpmnProcessId();
@@ -706,6 +755,10 @@ public class DrainingProcessDefinitionTest {
    * change lands, and remove this injection helper.
    */
   private void drain(final ProcessMetadataValue metadata) {
+    drain(metadata, false);
+  }
+
+  private void drain(final ProcessMetadataValue metadata, final boolean deleteHistory) {
     engine.stop();
     engine.writeRecords(
         RecordToWrite.event()
@@ -717,7 +770,8 @@ public class DrainingProcessDefinitionTest {
                     .setBpmnProcessId(metadata.getBpmnProcessId())
                     .setVersion(metadata.getVersion())
                     .setResourceName(metadata.getResourceName())
-                    .setTenantId(metadata.getTenantId())));
+                    .setTenantId(metadata.getTenantId())
+                    .setDeleteHistory(deleteHistory)));
     engine.start();
 
     RecordingExporter.processRecords()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
@@ -8,7 +8,14 @@
 package io.camunda.zeebe.engine.processing.resource;
 
 import static io.camunda.zeebe.protocol.record.RecordAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
+import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationHelper;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.EngineRule;
@@ -21,7 +28,10 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.ConditionalEvaluationIntent;
+import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
@@ -30,18 +40,25 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionRecordValue;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import io.camunda.zeebe.protocol.record.value.NestedRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 /**
  * Verifies that no new process instances can be created for a process definition that is in the
@@ -52,12 +69,28 @@ public class DrainingProcessDefinitionTest {
 
   private static final String JOB_TYPE = "task";
 
-  @Rule public final EngineRule engine = EngineRule.singlePartition();
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
+
+  private final SearchClientsProxy searchClientsProxy = Mockito.mock(SearchClientsProxy.class);
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition().withSearchClientsProxy(searchClientsProxy);
+
+  @Before
+  public void setUp() {
+    // the finalize-time history deletion creates a DELETE_PROCESS_INSTANCE batch operation, whose
+    // execution queries secondary storage; return no items so it completes cleanly rather than
+    // fail-looping in tests that only assert on the created batch operation
+    when(searchClientsProxy.withSecurityContext(any())).thenReturn(searchClientsProxy);
+    when(searchClientsProxy.searchProcessInstances(any(ProcessInstanceQuery.class)))
+        .thenReturn(
+            new SearchQueryResult.Builder<ProcessInstanceEntity>().items(List.of()).build());
+  }
 
   @Test
   public void shouldRejectCreateInstanceByProcessIdWhenDraining() {
@@ -256,9 +289,8 @@ public class DrainingProcessDefinitionTest {
         RecordingExporter.incidentRecords(IncidentIntent.CREATED)
             .withProcessInstanceKey(parentInstanceKey)
             .getFirst();
-    Assertions.assertThat(incident.getValue().getErrorType())
-        .isEqualTo(ErrorType.CALLED_ELEMENT_ERROR);
-    Assertions.assertThat(incident.getValue().getErrorMessage())
+    assertThat(incident.getValue().getErrorType()).isEqualTo(ErrorType.CALLED_ELEMENT_ERROR);
+    assertThat(incident.getValue().getErrorMessage())
         .isEqualTo(
             "Expected to call process with BPMN process id '%s' and version %d (key %d), but it is being deleted."
                 .formatted(
@@ -321,7 +353,7 @@ public class DrainingProcessDefinitionTest {
     // then - no instance is spawned and no phantom process instance key leaks into the TRIGGERED
     // event
     assertNoInstanceSpawned(metadata.getProcessDefinitionKey());
-    Assertions.assertThat(triggered.getValue().getProcessInstanceKey())
+    assertThat(triggered.getValue().getProcessInstanceKey())
         .describedAs("TRIGGERED timer of a draining definition carries no phantom instance key")
         .isEqualTo(-1L);
   }
@@ -337,7 +369,7 @@ public class DrainingProcessDefinitionTest {
     engine.message().withName("start-message").withCorrelationKey("key").publish();
 
     // then - the message is not correlated to a phantom instance and no instance is spawned
-    Assertions.assertThat(
+    assertThat(
             RecordingExporter.<Boolean>expectNoMatchingRecords(
                 records ->
                     RecordingExporter.messageStartEventSubscriptionRecords(
@@ -381,7 +413,7 @@ public class DrainingProcessDefinitionTest {
     final var evaluated =
         RecordingExporter.conditionalEvaluationRecords(ConditionalEvaluationIntent.EVALUATED)
             .getFirst();
-    Assertions.assertThat(evaluated.getValue().getStartedProcessInstances())
+    assertThat(evaluated.getValue().getStartedProcessInstances())
         .describedAs("a draining definition is not reported as a started instance")
         .isEmpty();
     assertNoInstanceSpawned(metadata.getProcessDefinitionKey());
@@ -401,7 +433,7 @@ public class DrainingProcessDefinitionTest {
   }
 
   private void assertNoInstanceSpawned(final long processDefinitionKey) {
-    Assertions.assertThat(
+    assertThat(
             RecordingExporter.<Boolean>expectNoMatchingRecords(
                 records ->
                     RecordingExporter.processInstanceRecords(
@@ -470,7 +502,7 @@ public class DrainingProcessDefinitionTest {
     // reports it has finished draining (DELETE_COMPLETE) so ProcessDeleteCompleteProcessor can
     // aggregate the per-partition reports cluster-wide.
     assertDeletedLocally(metadata.getProcessDefinitionKey());
-    Assertions.assertThat(
+    assertThat(
             RecordingExporter.processRecords()
                 .withRecordType(RecordType.COMMAND)
                 .withIntent(ProcessIntent.DELETE_COMPLETE)
@@ -500,7 +532,7 @@ public class DrainingProcessDefinitionTest {
             .withIntent(ProcessIntent.DELETE_COMPLETE)
             .withProcessDefinitionKey(metadata.getProcessDefinitionKey())
             .getFirst();
-    Assertions.assertThat(((ProcessRecord) report.getValue()).isDeleteHistory())
+    assertThat(((ProcessRecord) report.getValue()).isDeleteHistory())
         .describedAs("the drain report carries the history deletion intent")
         .isTrue();
   }
@@ -524,7 +556,7 @@ public class DrainingProcessDefinitionTest {
             .withIntent(ProcessIntent.DELETE_COMPLETE)
             .withProcessDefinitionKey(metadata.getProcessDefinitionKey())
             .getFirst();
-    Assertions.assertThat(((ProcessRecord) report.getValue()).isDeleteHistory())
+    assertThat(((ProcessRecord) report.getValue()).isDeleteHistory())
         .describedAs("the drain report does not request history deletion")
         .isFalse();
   }
@@ -543,7 +575,7 @@ public class DrainingProcessDefinitionTest {
 
     // then - the definition is removed locally and this partition reports drained
     assertDeletedLocally(metadata.getProcessDefinitionKey());
-    Assertions.assertThat(
+    assertThat(
             RecordingExporter.processRecords()
                 .withRecordType(RecordType.COMMAND)
                 .withIntent(ProcessIntent.DELETE_COMPLETE)
@@ -578,7 +610,7 @@ public class DrainingProcessDefinitionTest {
     engine.job().ofInstance(secondInstanceKey).withType(JOB_TYPE).complete();
 
     // then - this partition reports drained only after the last instance completes
-    Assertions.assertThat(
+    assertThat(
             RecordingExporter.processRecords()
                 .withRecordType(RecordType.COMMAND)
                 .withIntent(ProcessIntent.DELETE_COMPLETE)
@@ -619,7 +651,7 @@ public class DrainingProcessDefinitionTest {
 
     // then - the draining child definition is reported drained (finalize fires for child processes
     // too)
-    Assertions.assertThat(
+    assertThat(
             RecordingExporter.processRecords()
                 .withRecordType(RecordType.COMMAND)
                 .withIntent(ProcessIntent.DELETE_COMPLETE)
@@ -634,20 +666,13 @@ public class DrainingProcessDefinitionTest {
   @Test
   public void shouldFullyDeleteWhenAllPartitionsReportDrained() {
     // given - a draining definition whose per-partition drain reports are outstanding for three
-    // partitions. Seeding the aggregation set happens at delete time (out of this change's scope),
-    // so it is injected here directly to drive the deployment-partition aggregation.
+    // partitions
     final var processId = helper.getBpmnProcessId();
     final var metadata = deploy(processId);
     drain(metadata);
     final long processDefinitionKey = metadata.getProcessDefinitionKey();
 
-    engine.pauseProcessing(Protocol.DEPLOYMENT_PARTITION);
-    final var processState =
-        ((MutableProcessingState) engine.getProcessingState()).getProcessState();
-    processState.addPendingDeletion(processDefinitionKey, 1);
-    processState.addPendingDeletion(processDefinitionKey, 2);
-    processState.addPendingDeletion(processDefinitionKey, 3);
-    engine.resumeProcessing(Protocol.DEPLOYMENT_PARTITION);
+    seedPendingDeletions(processDefinitionKey, 1, 2, 3);
 
     // when - each partition reports it has finished draining (as the deployment partition receives
     // them: a locally-keyed report for partition 1 and forwarded reports for partitions 2 and 3)
@@ -658,7 +683,7 @@ public class DrainingProcessDefinitionTest {
 
     // then - each report clears its reporting partition (DELETE_COMPLETED) and, once the last one
     // arrives, the definition is reported gone cluster-wide exactly once (FULLY_DELETED)
-    Assertions.assertThat(
+    assertThat(
             RecordingExporter.processRecords()
                 .withIntent(ProcessIntent.FULLY_DELETED)
                 .withProcessDefinitionKey(processDefinitionKey)
@@ -666,7 +691,7 @@ public class DrainingProcessDefinitionTest {
                 .count())
         .describedAs("the definition is reported fully deleted exactly once")
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             RecordingExporter.processRecords()
                 .withIntent(ProcessIntent.DELETE_COMPLETED)
                 .withProcessDefinitionKey(processDefinitionKey)
@@ -676,10 +701,121 @@ public class DrainingProcessDefinitionTest {
         .isEqualTo(3);
   }
 
+  @Test
+  public void shouldDeleteHistoryWhenAllPartitionsReportDrained() {
+    // given - a draining definition whose deletion also requested its history to be deleted
+    final var processId = helper.getBpmnProcessId();
+    final var metadata = deploy(processId);
+    drain(metadata, true);
+    final long processDefinitionKey = metadata.getProcessDefinitionKey();
+    seedPendingDeletions(processDefinitionKey, 1, 2, 3);
+
+    // when - the last partition reports it has finished draining
+    engine.writeRecords(
+        drainReport(processDefinitionKey, metadata, 1, true),
+        drainReport(processDefinitionKey, metadata, 2, true),
+        drainReport(processDefinitionKey, metadata, 3, true));
+
+    // then - the history of all its instances is deleted, followed by the definition itself. One
+    // batch operation covers every partition; it distributes itself from here.
+    final var batchOperation =
+        RecordingExporter.batchOperationCreationRecords()
+            .withIntent(BatchOperationIntent.CREATE)
+            .getFirst()
+            .getValue();
+    assertThat(batchOperation.getBatchOperationType())
+        .isEqualTo(BatchOperationType.DELETE_PROCESS_INSTANCE);
+    assertThat(batchOperation.getEntityFilter())
+        .describedAs("the history of this definition's instances is deleted")
+        .contains(
+            "\"processDefinitionKeyOperations\":[{\"operator\":\"EQUALS\",\"values\":[%s]}]"
+                .formatted(processDefinitionKey));
+    assertThat(batchOperation.getFollowUpCommand())
+        .isNotNull()
+        .extracting(NestedRecordValue::getIntent, NestedRecordValue::getValueType)
+        .containsExactly(HistoryDeletionIntent.DELETE, ValueType.HISTORY_DELETION);
+    assertThat(batchOperation.getFollowUpCommand().getRecordValue())
+        .describedAs("the definition itself is deleted from secondary storage afterwards")
+        .asInstanceOf(InstanceOfAssertFactories.type(HistoryDeletionRecordValue.class))
+        .extracting(
+            HistoryDeletionRecordValue::getResourceKey, HistoryDeletionRecordValue::getResourceType)
+        .containsExactly(processDefinitionKey, HistoryDeletionType.PROCESS_DEFINITION);
+  }
+
+  @Test
+  public void shouldNotDeleteHistoryWhenNotRequested() {
+    // given - a draining definition whose deletion did not request history deletion
+    final var processId = helper.getBpmnProcessId();
+    final var metadata = deploy(processId);
+    drain(metadata);
+    final long processDefinitionKey = metadata.getProcessDefinitionKey();
+    seedPendingDeletions(processDefinitionKey, 1, 2, 3);
+
+    // when - all partitions report they have finished draining
+    engine.writeRecords(
+        drainReport(processDefinitionKey, metadata, 1),
+        drainReport(processDefinitionKey, metadata, 2),
+        drainReport(processDefinitionKey, metadata, 3));
+
+    // then - the definition is gone cluster-wide, but its history is kept. The window is bounded by
+    // FULLY_DELETED (the terminal marker, emitted after any history deletion) so the absence check
+    // does not block.
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == ProcessIntent.FULLY_DELETED)
+                .batchOperationCreationRecords()
+                .withIntent(BatchOperationIntent.CREATE)
+                .exists())
+        .describedAs("no history is deleted when the deletion did not ask for it")
+        .isFalse();
+  }
+
+  @Test
+  public void shouldDeleteHistoryOnlyOnceWhenDrainReportIsRedelivered() {
+    // given - a draining definition that has already drained cluster-wide
+    final var processId = helper.getBpmnProcessId();
+    final var metadata = deploy(processId);
+    drain(metadata, true);
+    final long processDefinitionKey = metadata.getProcessDefinitionKey();
+    seedPendingDeletions(processDefinitionKey, 1, 2);
+
+    // when - the last partition's report is delivered twice
+    engine.writeRecords(
+        drainReport(processDefinitionKey, metadata, 1, true),
+        drainReport(processDefinitionKey, metadata, 2, true),
+        drainReport(processDefinitionKey, metadata, 2, true));
+
+    // then - the redelivered report is rejected (proving the idempotency guard was exercised)
+    RecordingExporter.processRecords()
+        .onlyCommandRejections()
+        .withIntent(ProcessIntent.DELETE_COMPLETE)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .limit(1)
+        .await();
+    // and the history is deleted exactly once. The window is bounded by FULLY_DELETED (emitted once
+    // on the report that cleared the last partition) so the count does not block.
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == ProcessIntent.FULLY_DELETED)
+                .batchOperationCreationRecords()
+                .withIntent(BatchOperationIntent.CREATE)
+                .count())
+        .describedAs("the history of the definition's instances is deleted exactly once")
+        .isEqualTo(1);
+  }
+
   private RecordToWrite drainReport(
       final long processDefinitionKey,
       final ProcessMetadataValue metadata,
       final int reportingPartitionId) {
+    return drainReport(processDefinitionKey, metadata, reportingPartitionId, false);
+  }
+
+  private RecordToWrite drainReport(
+      final long processDefinitionKey,
+      final ProcessMetadataValue metadata,
+      final int reportingPartitionId,
+      final boolean deleteHistory) {
     // the report key encodes the reporting partition; the in-partition portion is irrelevant, the
     // processor only decodes the partition from it
     final long reportKey =
@@ -694,11 +830,24 @@ public class DrainingProcessDefinitionTest {
                 .setBpmnProcessId(metadata.getBpmnProcessId())
                 .setVersion(metadata.getVersion())
                 .setResourceName(metadata.getResourceName())
-                .setTenantId(metadata.getTenantId()));
+                .setTenantId(metadata.getTenantId())
+                .setDeleteHistory(deleteHistory));
+  }
+
+  private void seedPendingDeletions(final long processDefinitionKey, final int... partitionIds) {
+    // seeding the aggregation set happens at delete time (#56978), so it is injected here directly
+    // to drive the deployment-partition aggregation
+    engine.pauseProcessing(Protocol.DEPLOYMENT_PARTITION);
+    final var processState =
+        ((MutableProcessingState) engine.getProcessingState()).getProcessState();
+    for (final int partitionId : partitionIds) {
+      processState.addPendingDeletion(processDefinitionKey, partitionId);
+    }
+    engine.resumeProcessing(Protocol.DEPLOYMENT_PARTITION);
   }
 
   private void assertDeletedLocally(final long processDefinitionKey) {
-    Assertions.assertThat(
+    assertThat(
             RecordingExporter.processRecords()
                 .withIntent(ProcessIntent.DELETED)
                 .withProcessDefinitionKey(processDefinitionKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
@@ -834,13 +834,63 @@ public final class ProcessStateTest {
     processState.putProcess(processDefinitionKey, processRecord);
 
     // when
-    processState.updateProcessState(processRecord, PersistedProcessState.DRAINING);
+    processState.markDraining(processRecord);
 
     // then - the process is still retrievable by key and tenant, now in the DRAINING state
     final var drainingProcess =
         processState.getProcessByKeyAndTenant(processDefinitionKey, processRecord.getTenantId());
     assertThat(drainingProcess).isNotNull();
     assertThat(drainingProcess.getState()).isEqualTo(PersistedProcessState.DRAINING);
+  }
+
+  @Test
+  public void shouldRememberDeleteHistoryIntentWhileDraining() {
+    // given
+    final long processDefinitionKey = 100L;
+    final var processRecord = creatingProcessRecord(processingState).setKey(processDefinitionKey);
+    processState.putProcess(processDefinitionKey, processRecord);
+
+    // when - the deletion that started the draining requested history deletion
+    processState.markDraining(processRecord.setDeleteHistory(true));
+
+    // then - the intent is readable once the definition has drained, much later
+    final var drainingProcess =
+        processState.getProcessByKeyAndTenant(processDefinitionKey, processRecord.getTenantId());
+    assertThat(drainingProcess.isDeleteHistory()).isTrue();
+  }
+
+  @Test
+  public void shouldNotRememberDeleteHistoryIntentWhenNotRequested() {
+    // given
+    final long processDefinitionKey = 100L;
+    final var processRecord = creatingProcessRecord(processingState).setKey(processDefinitionKey);
+    processState.putProcess(processDefinitionKey, processRecord);
+
+    // when - the deletion did not request history deletion
+    processState.markDraining(processRecord);
+
+    // then
+    final var drainingProcess =
+        processState.getProcessByKeyAndTenant(processDefinitionKey, processRecord.getTenantId());
+    assertThat(drainingProcess.isDeleteHistory()).isFalse();
+  }
+
+  @Test
+  public void shouldNotApplyDeleteHistoryIntentToAnotherDefinition() {
+    // given - a draining definition whose history must be deleted
+    final var drainingRecord = creatingProcessRecord(processingState, "drainingProcess");
+    processState.putProcess(drainingRecord.getProcessDefinitionKey(), drainingRecord);
+    processState.markDraining(drainingRecord.setDeleteHistory(true));
+
+    // when - another definition is deployed afterwards
+    final var otherRecord = creatingProcessRecord(processingState, "otherProcess");
+    processState.putProcess(otherRecord.getProcessDefinitionKey(), otherRecord);
+
+    // then - it does not inherit the other definition's history deletion intent
+    final var otherProcess =
+        processState.getProcessByKeyAndTenant(
+            otherRecord.getProcessDefinitionKey(), otherRecord.getTenantId());
+    assertThat(otherProcess.isDeleteHistory()).isFalse();
   }
 
   @Test

--- a/zeebe/engine/src/test/resources/state/appliers/golden/Process_DRAINING_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/Process_DRAINING_v1.golden
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
@@ -24,6 +23,6 @@ public class ProcessDrainingApplier implements TypedEventApplier<ProcessIntent, 
 
   @Override
   public void applyState(final long key, final ProcessRecord value) {
-    processState.updateProcessState(value, PersistedProcessState.DRAINING);
+    processState.markDraining(value);
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
@@ -40,9 +41,10 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   private final StringProperty versionTagProp = new StringProperty("versionTag", "");
   private final ArrayProperty<TransformerVersion> transformerVersionsProp =
       new ArrayProperty<>("transformerVersions", TransformerVersion::new);
+  private final BooleanProperty deleteHistoryProp = new BooleanProperty("deleteHistory", false);
 
   public ProcessRecord() {
-    super(10);
+    super(11);
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(keyProp)
@@ -52,7 +54,8 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
         .declareProperty(tenantIdProp)
         .declareProperty(deploymentKeyProp)
         .declareProperty(versionTagProp)
-        .declareProperty(transformerVersionsProp);
+        .declareProperty(transformerVersionsProp)
+        .declareProperty(deleteHistoryProp);
   }
 
   public ProcessRecord wrap(final ProcessMetadata metadata, final byte[] resource) {
@@ -251,6 +254,22 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
       result.put(entry.getSlotId(), entry.getVersion());
     }
     return result;
+  }
+
+  /**
+   * Whether the instances' history must be deleted once the definition is gone cluster-wide.
+   * Carried on {@code DRAINING} to be persisted with the draining definition, then back on the
+   * {@code DELETE_COMPLETE} drain report so the deployment partition knows whether to delete it.
+   * Excluded from JSON export — engine-internal coordination.
+   */
+  @JsonIgnore
+  public boolean isDeleteHistory() {
+    return deleteHistoryProp.getValue();
+  }
+
+  public ProcessRecord setDeleteHistory(final boolean deleteHistory) {
+    deleteHistoryProp.setValue(deleteHistory);
+    return this;
   }
 
   /** A single (slotId, version) pair persisted inside the transformer-versions array. */

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessRecord.golden
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
@@ -22,8 +23,8 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -40,9 +41,10 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   private final StringProperty versionTagProp = new StringProperty("versionTag", "");
   private final ArrayProperty<TransformerVersion> transformerVersionsProp =
       new ArrayProperty<>("transformerVersions", TransformerVersion::new);
+  private final BooleanProperty deleteHistoryProp = new BooleanProperty("deleteHistory", false);
 
   public ProcessRecord() {
-    super(10);
+    super(11);
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(keyProp)
@@ -52,7 +54,8 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
         .declareProperty(tenantIdProp)
         .declareProperty(deploymentKeyProp)
         .declareProperty(versionTagProp)
-        .declareProperty(transformerVersionsProp);
+        .declareProperty(transformerVersionsProp)
+        .declareProperty(deleteHistoryProp);
   }
 
   public ProcessRecord wrap(final ProcessMetadata metadata, final byte[] resource) {
@@ -222,28 +225,53 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   }
 
   /**
-   * Sets the per-slot transformer versions frozen at deploy time. Only slots whose version is
-   * greater than the default (1) are stored; callers must filter before passing this map.
+   * Sets the per-slot transformer versions frozen at deploy time. Entries are sorted by slot ID
+   * before writing so the msgpack array is always in a deterministic order regardless of the input
+   * map's iteration order. Version-1 entries are stored but redundant — {@link
+   * io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer#currentVersionsById()}
+   * omits them automatically, so callers using that method need not filter.
    */
   public ProcessRecord setTransformerVersions(final Map<Integer, Integer> versions) {
     transformerVersionsProp.reset();
-    versions.forEach(
-        (slotId, version) -> {
-          final var entry = transformerVersionsProp.add();
-          entry.setSlotId(slotId);
-          entry.setVersion(version);
-        });
+    new TreeMap<>(versions)
+        .forEach(
+            (slotId, version) -> {
+              final var entry = transformerVersionsProp.add();
+              entry.setSlotId(slotId);
+              entry.setVersion(version);
+            });
     return this;
   }
 
-  /** Returns the stored slot→version pairs. Absent entries default to version 1. */
+  /**
+   * Returns the stored slot→version pairs sorted by slot ID. Absent entries default to version 1.
+   * Excluded from JSON export — engine-internal state not exposed to external consumers.
+   */
   @JsonIgnore
   public Map<Integer, Integer> getTransformerVersions() {
-    final Map<Integer, Integer> result = new HashMap<>();
+    final Map<Integer, Integer> result = new TreeMap<>();
     for (final TransformerVersion entry : transformerVersionsProp) {
       result.put(entry.getSlotId(), entry.getVersion());
     }
     return result;
+  }
+
+  /**
+   * Whether the history of this process definition's instances must be deleted once the definition
+   * is gone. Carried on the {@code DRAINING} event so it can be persisted with the draining
+   * definition, and carried back on the {@code DELETE_COMPLETE} drain report so the deployment
+   * partition knows whether to delete the history when the definition has drained cluster-wide.
+   *
+   * <p>Excluded from JSON export — engine-internal coordination not exposed to external consumers.
+   */
+  @JsonIgnore
+  public boolean isDeleteHistory() {
+    return deleteHistoryProp.getValue();
+  }
+
+  public ProcessRecord setDeleteHistory(final boolean deleteHistory) {
+    deleteHistoryProp.setValue(deleteHistory);
+    return this;
   }
 
   /** A single (slotId, version) pair persisted inside the transformer-versions array. */


### PR DESCRIPTION
## Description

- Delete history when a draining definition is fully deleted
- Remember deleteHistory intent while a definition is draining

## Related issues

closes #56979
