### PR TITLE
ci: tolerate transient test-summary action failures

### DIFF
--- a/.github/actions/analyze-test-runs/action.yml
+++ b/.github/actions/analyze-test-runs/action.yml
@@ -20,13 +20,6 @@ outputs:
 runs:
   using: composite
   steps:
-  - name: Test Summary
-    uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4
-    if: ${{ inputs.skipSummary == 'false' }}
-    with:
-      paths: |
-        **/target/failsafe-reports/TEST-*.xml
-        **/target/surefire-reports/TEST-*.xml
   - name: Find flaky tests
     id: find-flakes
     shell: bash
@@ -85,3 +78,11 @@ runs:
         cat $unfinished >> $GITHUB_STEP_SUMMARY
       fi
       exit 0
+  - name: Test Summary
+    uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4
+    if: ${{ always() && inputs.skipSummary == 'false' }}
+    continue-on-error: true
+    with:
+      paths: |
+        **/target/failsafe-reports/TEST-*.xml
+        **/target/surefire-reports/TEST-*.xml


### PR DESCRIPTION

## Description

The Analyze Test Runs step failed a stable/8.8 push run across five unrelated matrix jobs simultaneously with a GitHub action-download resolution timeout for test-summary/action, redding CI without any underlying test/code regression. That step is purely a decorative job-summary renderer, not the pass/fail gate (the following Find flaky tests step is), so a transient failure to fetch it shouldn't fail the job.


## Related issues

relates [#inc-6907-unsuccessful-job-ci-operate-unit-testscorefeatures-on-stable8-8](https://camunda.slack.com/archives/C0BMG5Z786N)
