### PR TITLE
Name ad-hoc inner instance by entry element on RDBMS

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/FlowNodeInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/FlowNodeInstanceMapper.java
@@ -22,6 +22,8 @@ public interface FlowNodeInstanceMapper extends ProcessInstanceDependantMapper {
 
   void updateIncident(UpdateIncidentDto dto);
 
+  void updateNameIfNull(UpdateNameDto dto);
+
   Long count(FlowNodeInstanceDbQuery filter);
 
   List<FlowNodeInstanceDbModel> search(FlowNodeInstanceDbQuery filter);
@@ -32,4 +34,6 @@ public interface FlowNodeInstanceMapper extends ProcessInstanceDependantMapper {
       OffsetDateTime endDate) {}
 
   record UpdateIncidentDto(long flowNodeInstanceKey, Long incidentKey) {}
+
+  record UpdateNameDto(long flowNodeInstanceKey, String flowNodeName) {}
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/FlowNodeInstanceDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/FlowNodeInstanceDbModel.java
@@ -129,6 +129,10 @@ public record FlowNodeInstanceDbModel(
       return this;
     }
 
+    public String flowNodeName() {
+      return flowNodeName;
+    }
+
     public FlowNodeInstanceDbModelBuilder flowNodeName(final String flowNodeName) {
       this.flowNodeName = flowNodeName;
       return this;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
@@ -41,7 +41,8 @@ public class DefaultExecutionQueue implements ExecutionQueue {
       Set.of(
           Pattern.compile(".*update.*HistoryCleanupDate$"),
           Pattern.compile(".*\\.createIfNotExists$"),
-          Pattern.compile("io.camunda.db.rdbms.sql.BatchOperationMapper.activate"));
+          Pattern.compile("io.camunda.db.rdbms.sql.BatchOperationMapper.activate"),
+          Pattern.compile("io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.updateNameIfNull"));
 
   private final SqlSessionFactory sessionFactory;
   private final List<PreFlushListener> preFlushListeners = new ArrayList<>();

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/FlowNodeInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/FlowNodeInstanceWriter.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.write.service;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.EndFlowNodeDto;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.UpdateIncidentDto;
+import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.UpdateNameDto;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel;
 import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel.FlowNodeInstanceDbModelBuilder;
@@ -21,6 +22,7 @@ import io.camunda.db.rdbms.write.queue.ListParameterUpsertMerger;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
+import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
 import java.time.OffsetDateTime;
 import java.util.function.Function;
 
@@ -56,12 +58,23 @@ public class FlowNodeInstanceWriter extends ProcessInstanceDependant implements 
   }
 
   public void update(final FlowNodeInstanceDbModel flowNode) {
+    // ELEMENT_MIGRATED / ANCESTOR_MIGRATED go through this full-row update, but the migrated
+    // record carries no resolved ad-hoc-subprocess inner-instance name (it's only known from the
+    // entry child's ELEMENT_ACTIVATING, handled separately by updateName). Route those rows
+    // through a statement that leaves FLOW_NODE_NAME untouched instead of expressing the guard as
+    // a cross-type SQL comparison/CASE against the NVARCHAR name column, which trips a charset
+    // mismatch on Oracle.
+    final var statementId =
+        flowNode.type() == FlowNodeType.AD_HOC_SUB_PROCESS_INNER_INSTANCE
+                && flowNode.flowNodeName() == null
+            ? "io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.updateKeepingName"
+            : "io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.update";
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.FLOW_NODE,
             WriteStatementType.UPDATE,
             flowNode.flowNodeInstanceKey(),
-            "io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.update",
+            statementId,
             flowNode));
   }
 
@@ -81,7 +94,21 @@ public class FlowNodeInstanceWriter extends ProcessInstanceDependant implements 
   }
 
   public void updateName(final long flowNodeInstanceKey, final String flowNodeName) {
-    // no-op stub; real set-if-null behavior added in the green step
+    final boolean wasMerged =
+        mergeToQueue(
+            flowNodeInstanceKey,
+            b -> b.flowNodeName(b.flowNodeName() == null ? flowNodeName : b.flowNodeName()));
+
+    if (!wasMerged) {
+      final var dto = new UpdateNameDto(flowNodeInstanceKey, flowNodeName);
+      executionQueue.executeInQueue(
+          new QueueItem(
+              ContextType.FLOW_NODE,
+              WriteStatementType.UPDATE,
+              flowNodeInstanceKey,
+              "io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.updateNameIfNull",
+              dto));
+    }
   }
 
   public void createIncident(final long flowNodeInstanceKey, final long incidentKey) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/FlowNodeInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/FlowNodeInstanceWriter.java
@@ -80,6 +80,10 @@ public class FlowNodeInstanceWriter extends ProcessInstanceDependant implements 
     }
   }
 
+  public void updateName(final long flowNodeInstanceKey, final String flowNodeName) {
+    // no-op stub; real set-if-null behavior added in the green step
+  }
+
   public void createIncident(final long flowNodeInstanceKey, final long incidentKey) {
     updateIncident(flowNodeInstanceKey, incidentKey);
   }

--- a/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
@@ -233,19 +233,40 @@
     SELECT * FROM dual
   </insert>
 
+  <!--
+    Shared by `update` and `updateKeepingName`, which differ only in whether they also write
+    FLOW_NODE_NAME. Keeping the common columns in one place stops a newly added column from being
+    added to one statement and silently skipped by the other.
+  -->
+  <sql id="updateColumnsExceptName">
+    FLOW_NODE_ID             = #{flowNodeId},
+    FLOW_NODE_SCOPE_KEY      = #{flowNodeScopeKey},
+    PROCESS_INSTANCE_KEY     = #{processInstanceKey},
+    PROCESS_DEFINITION_ID    = #{processDefinitionId},
+    PROCESS_DEFINITION_KEY   = #{processDefinitionKey},
+    TYPE                     = #{type},
+    STATE                    = #{state},
+    START_DATE               = #{startDate, jdbcType=TIMESTAMP},
+    END_DATE                 = #{endDate, jdbcType=TIMESTAMP},
+    TENANT_ID                = #{tenantId}
+  </sql>
+
   <update id="update" parameterType="io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel">
     UPDATE ${prefix}FLOW_NODE_INSTANCE
-    SET FLOW_NODE_ID             = #{flowNodeId},
-        FLOW_NODE_NAME           = #{flowNodeName},
-        FLOW_NODE_SCOPE_KEY      = #{flowNodeScopeKey},
-        PROCESS_INSTANCE_KEY     = #{processInstanceKey},
-        PROCESS_DEFINITION_ID    = #{processDefinitionId},
-        PROCESS_DEFINITION_KEY   = #{processDefinitionKey},
-        TYPE                     = #{type},
-        STATE                    = #{state},
-        START_DATE               = #{startDate, jdbcType=TIMESTAMP},
-        END_DATE                 = #{endDate, jdbcType=TIMESTAMP},
-        TENANT_ID                = #{tenantId}
+    SET FLOW_NODE_NAME = #{flowNodeName},
+        <include refid="io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.updateColumnsExceptName"/>
+    WHERE FLOW_NODE_INSTANCE_KEY = #{flowNodeInstanceKey}
+  </update>
+
+  <!--
+    Same as `update`, but leaves FLOW_NODE_NAME untouched. Used instead of `update` when the
+    incoming model is an ad-hoc-subprocess inner instance with no resolved name yet, so a
+    migration (ELEMENT_MIGRATED / ANCESTOR_MIGRATED) can't clobber an already-resolved inner
+    instance name back to null. See FlowNodeInstanceWriter#update for the selection logic.
+  -->
+  <update id="updateKeepingName" parameterType="io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel">
+    UPDATE ${prefix}FLOW_NODE_INSTANCE
+    SET <include refid="io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.updateColumnsExceptName"/>
     WHERE FLOW_NODE_INSTANCE_KEY = #{flowNodeInstanceKey}
   </update>
 
@@ -262,6 +283,14 @@
     UPDATE ${prefix}FLOW_NODE_INSTANCE
     SET INCIDENT_KEY = #{incidentKey}
     WHERE FLOW_NODE_INSTANCE_KEY = #{flowNodeInstanceKey}
+  </update>
+
+  <update id="updateNameIfNull"
+    parameterType="io.camunda.db.rdbms.sql.FlowNodeInstanceMapper$UpdateNameDto">
+    UPDATE ${prefix}FLOW_NODE_INSTANCE
+    SET FLOW_NODE_NAME = #{flowNodeName}
+    WHERE FLOW_NODE_INSTANCE_KEY = #{flowNodeInstanceKey}
+      AND FLOW_NODE_NAME IS NULL
   </update>
 
   <update id="incrementSubprocessIncidentCount" parameterType="java.lang.Long">

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
@@ -552,6 +552,9 @@ class DefaultExecutionQueueTest {
     "io.camunda.db.rdbms.sql.SequenceFlowMapper.updateHistoryCleanupDate,true",
     "io.camunda.db.rdbms.sql.SequenceFlowMapper.createIfNotExists,true",
     "io.camunda.db.rdbms.sql.BatchOperationMapper.activate,true",
+    // set-if-null: affects no rows whenever the name is already resolved, which is the normal
+    // outcome of a second ad-hoc entry activation on the same inner instance
+    "io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.updateNameIfNull,true",
     "some.other.Statement,false"
   })
   void shouldIgnoreWhenNoRowsAffectedMatchesPatterns(

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/FlowNodeInstanceWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/FlowNodeInstanceWriterTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
+import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.UpdateNameDto;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel;
 import io.camunda.db.rdbms.write.queue.BatchInsertDto;
@@ -110,5 +111,41 @@ class FlowNodeInstanceWriterTest {
                     1L,
                     "io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.updateStateAndEndDate",
                     new FlowNodeInstanceMapper.EndFlowNodeDto(1L, FlowNodeState.COMPLETED, NOW))));
+  }
+
+  @Test
+  void shouldEnqueueSetIfNullNameUpdate() {
+    // given
+    when(executionQueue.tryMergeWithExistingQueueItem(any())).thenReturn(false);
+
+    // when
+    writer.updateName(123L, "List users");
+
+    // then
+    verify(executionQueue)
+        .executeInQueue(
+            eq(
+                new QueueItem(
+                    ContextType.FLOW_NODE,
+                    WriteStatementType.UPDATE,
+                    123L,
+                    "io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.updateNameIfNull",
+                    new UpdateNameDto(123L, "List users"))));
+  }
+
+  @Test
+  void shouldFoldNameUpdateIntoPendingInsert() {
+    // given
+    when(executionQueue.tryMergeWithExistingQueueItem(any(ListParameterUpsertMerger.class)))
+        .thenReturn(true);
+
+    // when
+    writer.updateName(123L, "List users");
+
+    // then
+    // the name update must attempt to fold into the still-queued insert; when it merges, nothing
+    // extra is enqueued
+    verify(executionQueue).tryMergeWithExistingQueueItem(any(ListParameterUpsertMerger.class));
+    verify(executionQueue, never()).executeInQueue(any(QueueItem.class));
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AdHocSubProcessInnerInstanceNameIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AdHocSubProcessInnerInstanceNameIT.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import java.time.Duration;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Pins the behaviour that the synthetic <em>inner instance</em> of an ad-hoc subprocess surfaces in
@@ -33,18 +32,11 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
  * "List users". The name must also survive completion of the inner instance / process instance
  * (guarding the null-clobber regression where a later write could overwrite the resolved name).
  *
- * <p>Disabled on RDBMS: the naming lives only in the camunda-exporter (Elasticsearch/OpenSearch).
- * The RDBMS exporter has no equivalent handler, so the inner instance name stays null there and
- * this test's await would time out. RDBMS parity is out of scope for 8.10.
+ * <p>The naming applies across all supported databases, so this test runs on the full multi-db
+ * matrix (Elasticsearch/OpenSearch and RDBMS alike).
  */
 @MultiDbTest
 @CompatibilityTest
-@DisabledIfSystemProperty(
-    named = "test.integration.camunda.database.type",
-    matches = "rdbms.*$",
-    disabledReason =
-        "Inner-instance naming is implemented only in the camunda-exporter (ES/OS); "
-            + "the RDBMS exporter has no equivalent, so the name stays null on RDBMS.")
 public class AdHocSubProcessInnerInstanceNameIT {
 
   private static CamundaClient camundaClient;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AdHocSubProcessInnerInstanceNameSameBatchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AdHocSubProcessInnerInstanceNameSameBatchIT.java
@@ -24,37 +24,39 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
- * Reproduces the production bug (#58803): if two exporter handlers touch the same cached entity
- * within one flush batch — {@code FlowNodeInstanceNameFromAdHocActivityHandler}, which resolves an
- * ad-hoc inner instance's name, and {@code FlowNodeInstanceFromProcessInstanceHandler}, which
- * always nulls that field back out for the inner instance's own lifecycle records — the second
- * handler's null-write can clobber the first handler's resolved name right before its {@code
- * flush()} runs, throwing a {@code NullPointerException}. See {@code
- * ExporterBatchWriterFlowNodeInstanceNameClobberTest} (camunda-exporter module) for this mechanism
- * pinned in isolation; this test additionally proves the fix survives the real broker -&gt;
- * exporter -&gt; search-index path.
+ * Pins that an ad-hoc sub-process inner instance keeps the name resolved from its entry element
+ * even when the entry element's activation and the inner instance's completion are written by the
+ * same exporter flush batch.
  *
- * <p>{@code @MultiDbTest}'s managed default ({@code bulk.size=1}) flushes after every record, so
- * two records can never share a batch. This test instead runs its own {@link TestStandaloneBroker}
- * with {@code bulk.size=5000}/{@code bulk.delay=5s} so the entry child's activation and the inner
- * instance's completion have room to land in the same flush batch — the condition this bug
- * requires, and which the sibling {@code AdHocSubProcessInnerInstanceNameIT} structurally cannot
- * reach.
+ * <p>On Elasticsearch/OpenSearch this reproduces the production bug (#58803): if two exporter
+ * handlers touch the same cached entity within one flush batch — {@code
+ * FlowNodeInstanceNameFromAdHocActivityHandler}, which resolves an ad-hoc inner instance's name,
+ * and {@code FlowNodeInstanceFromProcessInstanceHandler}, which always nulls that field back out
+ * for the inner instance's own lifecycle records — the second handler's null-write can clobber the
+ * first handler's resolved name right before its {@code flush()} runs, throwing a {@code
+ * NullPointerException}. See {@code ExporterBatchWriterFlowNodeInstanceNameClobberTest}
+ * (camunda-exporter module) for this mechanism pinned in isolation; this test additionally proves
+ * the fix survives the real broker -&gt; exporter -&gt; search-index path.
  *
- * <p>Disabled on RDBMS: the naming lives only in the camunda-exporter (Elasticsearch/OpenSearch).
- * The RDBMS exporter has no equivalent handler, so the inner instance name stays null there and
- * this test's await would time out for an unrelated reason.
+ * <p>On RDBMS the write path has no equivalent clobber: the name write merges into the inner
+ * instance's still-queued insert, and where it cannot merge, the flush orders the set-if-null
+ * {@code updateNameIfNull} statement after every other statement of the batch that writes {@code
+ * FLOW_NODE_NAME} — {@code insert} (all inserts precede all updates) and the full-row {@code
+ * update}. Only {@code updateStateAndEndDate} sorts after it, and it writes disjoint columns. There
+ * the test is a parity regression pin over the same condition rather than a reproduction — it is
+ * expected to pass on arrival and to fail only if the RDBMS write path starts dropping an
+ * already-resolved name.
+ *
+ * <p>{@code @MultiDbTest}'s managed defaults flush after every record ({@code bulk.size=1} on
+ * ES/OS, a zero flush interval on RDBMS), so two records can never share a batch. This test instead
+ * runs its own {@link TestStandaloneBroker} configured to batch generously on whichever secondary
+ * storage is active, so the entry child's activation and the inner instance's completion have room
+ * to land in the same flush batch — the condition this bug requires, and which the sibling {@code
+ * AdHocSubProcessInnerInstanceNameIT} structurally cannot reach.
  */
 @MultiDbTest
-@DisabledIfSystemProperty(
-    named = "test.integration.camunda.database.type",
-    matches = "rdbms.*$",
-    disabledReason =
-        "Inner-instance naming is implemented only in the camunda-exporter (ES/OS); "
-            + "the RDBMS exporter has no equivalent, so the name stays null on RDBMS.")
 public class AdHocSubProcessInnerInstanceNameSameBatchIT {
 
   @MultiDbTestApplication(managedLifecycle = false)
@@ -64,10 +66,21 @@ public class AdHocSubProcessInnerInstanceNameSameBatchIT {
   static void setUp() {
     STANDALONE_CAMUNDA.withUnifiedConfig(
         c -> {
-          // See class javadoc for why these specific values reproduce the bug.
-          final var bulk = c.getData().getSecondaryStorage().getDocumentBasedDatabase().getBulk();
-          bulk.setSize(5000);
-          bulk.setDelay(Duration.ofSeconds(5));
+          // See class javadoc for why batching is what makes this test meaningful. The knobs are
+          // per-storage: getDocumentBasedDatabase() returns null on RDBMS, and each storage
+          // has its own "flush after every record" default that has to be lifted.
+          final var secondaryStorage = c.getData().getSecondaryStorage();
+          if (secondaryStorage.getType().isRdbms()) {
+            final var rdbms = secondaryStorage.getRdbms();
+            // Both matter: the exporter flushes per record if either the interval is zero or the
+            // queue size is non-positive.
+            rdbms.setQueueSize(5000);
+            rdbms.setFlushInterval(Duration.ofSeconds(5));
+          } else {
+            final var bulk = secondaryStorage.getDocumentBasedDatabase().getBulk();
+            bulk.setSize(5000);
+            bulk.setDelay(Duration.ofSeconds(5));
+          }
         });
 
     STANDALONE_CAMUNDA.start();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceIT.java
@@ -267,6 +267,107 @@ public class FlowNodeInstanceIT {
         .isEqualTo(instance.flowNodeInstanceKey());
   }
 
+  @TestTemplate
+  public void shouldWriteInnerInstanceNameWhenNull(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader();
+
+    // a null name is persisted as SQL NULL (the reader coalesces NULL to "" via nullToEmpty), so
+    // the green updateNameIfNull can safely key off "FLOW_NODE_NAME IS NULL"
+    final var instance =
+        FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstance(
+            rdbmsWriters, b -> b.flowNodeName(null));
+
+    // when
+    rdbmsWriters
+        .getFlowNodeInstanceWriter()
+        .updateName(instance.flowNodeInstanceKey(), "List users");
+    rdbmsWriters.flush();
+
+    // then
+    final var actual = reader.findOne(instance.flowNodeInstanceKey()).orElseThrow();
+    assertThat(actual.flowNodeName()).isEqualTo("List users");
+  }
+
+  @TestTemplate
+  public void shouldNotOverwriteAlreadySetName(final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader();
+
+    final var instance =
+        FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstance(
+            rdbmsWriters, b -> b.flowNodeName("Existing"));
+
+    // when
+    rdbmsWriters.getFlowNodeInstanceWriter().updateName(instance.flowNodeInstanceKey(), "New");
+    rdbmsWriters.flush();
+
+    // then
+    // an already-set name must survive a second write (the multi-entry / re-activation case)
+    final var actual = reader.findOne(instance.flowNodeInstanceKey()).orElseThrow();
+    assertThat(actual.flowNodeName()).isEqualTo("Existing");
+  }
+
+  @TestTemplate
+  public void shouldKeepFirstEntryNameWhenMultipleActivateBeforeFlush(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader();
+
+    final var instance =
+        FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstance(
+            rdbmsWriters, b -> b.flowNodeName(null));
+
+    // when
+    // two entry elements activate before a single flush: first-writer-wins
+    rdbmsWriters.getFlowNodeInstanceWriter().updateName(instance.flowNodeInstanceKey(), "first");
+    rdbmsWriters.getFlowNodeInstanceWriter().updateName(instance.flowNodeInstanceKey(), "second");
+    rdbmsWriters.flush();
+
+    // then
+    final var actual = reader.findOne(instance.flowNodeInstanceKey()).orElseThrow();
+    assertThat(actual.flowNodeName()).isEqualTo("first");
+  }
+
+  /**
+   * Same first-writer-wins outcome as {@link
+   * #shouldKeepFirstEntryNameWhenMultipleActivateBeforeFlush}, but over the other of the two write
+   * paths: there the row is already inserted, so the name goes through the SQL {@code
+   * updateNameIfNull} statement; here the row's insert is still queued, so the name folds into the
+   * pending {@code BatchInsertDto} in memory and no update statement is ever issued.
+   */
+  @TestTemplate
+  public void shouldKeepFirstEntryNameWhenMergedIntoPendingInsert(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader();
+
+    // deliberately not flushed: the insert has to stay queued for the merge path to be reached
+    final var instance = FlowNodeInstanceFixtures.createRandomized(b -> b.flowNodeName(null));
+    rdbmsWriters.getFlowNodeInstanceWriter().create(instance);
+
+    // when
+    // two entry elements activate before the inner instance's own insert is flushed
+    rdbmsWriters.getFlowNodeInstanceWriter().updateName(instance.flowNodeInstanceKey(), "first");
+    rdbmsWriters.getFlowNodeInstanceWriter().updateName(instance.flowNodeInstanceKey(), "second");
+    rdbmsWriters.flush();
+
+    // then
+    final var actual = reader.findOne(instance.flowNodeInstanceKey()).orElseThrow();
+    assertThat(actual.flowNodeName())
+        .describedAs("the first resolved name must survive the merge into the still-queued insert")
+        .isEqualTo("first");
+  }
+
   private static void compareFlowNodeInstance(
       final FlowNodeInstanceEntity actual, final FlowNodeInstanceDbModel expected) {
     assertThat(actual)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceIT.java
@@ -17,11 +17,13 @@ import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.FlowNodeInstanceDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel;
+import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel.FlowNodeInstanceDbModelBuilder;
 import io.camunda.it.rdbms.db.fixtures.FlowNodeInstanceFixtures;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
+import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.FlowNodeInstanceQuery;
@@ -311,6 +313,83 @@ public class FlowNodeInstanceIT {
     // an already-set name must survive a second write (the multi-entry / re-activation case)
     final var actual = reader.findOne(instance.flowNodeInstanceKey()).orElseThrow();
     assertThat(actual.flowNodeName()).isEqualTo("Existing");
+  }
+
+  @TestTemplate
+  public void shouldKeepInnerInstanceNameOnMigration(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader();
+
+    // a flow node instance whose inner-instance name was already resolved to "List users"
+    final var instance =
+        FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstance(
+            rdbmsWriters,
+            b -> b.flowNodeName("List users").type(FlowNodeType.AD_HOC_SUB_PROCESS_INNER_INSTANCE));
+
+    // when
+    // ELEMENT_MIGRATED handling writes the full model via update(); the migrated model carries no
+    // resolved inner-instance name (null). The update mapper must not clobber the existing name.
+    rdbmsWriters
+        .getFlowNodeInstanceWriter()
+        .update(instance.copy(b -> ((FlowNodeInstanceDbModelBuilder) b).flowNodeName(null)));
+    rdbmsWriters.flush();
+
+    // then
+    final var actual = reader.findOne(instance.flowNodeInstanceKey()).orElseThrow();
+    assertThat(actual.flowNodeName()).isEqualTo("List users");
+  }
+
+  @TestTemplate
+  public void shouldClearNormalElementNameOnMigrationWhenNull(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader();
+
+    final var instance =
+        FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstance(
+            rdbmsWriters, b -> b.flowNodeName("Old").type(FlowNodeType.SERVICE_TASK));
+
+    // when
+    rdbmsWriters
+        .getFlowNodeInstanceWriter()
+        .update(instance.copy(b -> ((FlowNodeInstanceDbModelBuilder) b).flowNodeName(null)));
+    rdbmsWriters.flush();
+
+    // then
+    // a null name during migration must still clear an ordinary (non-inner-instance) element's
+    // name; the null-skip guard is scoped to AD_HOC_SUB_PROCESS_INNER_INSTANCE and must not
+    // overreach to other flow node types
+    final var actual = reader.findOne(instance.flowNodeInstanceKey()).orElseThrow();
+    assertThat(actual.flowNodeName()).isEmpty();
+  }
+
+  @TestTemplate
+  public void shouldUpdateNameOnMigrationWhenProvided(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader();
+
+    final var instance =
+        FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstance(
+            rdbmsWriters, b -> b.flowNodeName("Old"));
+
+    // when
+    rdbmsWriters
+        .getFlowNodeInstanceWriter()
+        .update(instance.copy(b -> ((FlowNodeInstanceDbModelBuilder) b).flowNodeName("New")));
+    rdbmsWriters.flush();
+
+    // then
+    // a legitimate non-null name update must not be blocked by the null-skip guard
+    final var actual = reader.findOne(instance.flowNodeInstanceKey()).orElseThrow();
+    assertThat(actual.flowNodeName()).isEqualTo("New");
   }
 
   @TestTemplate

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceIT.java
@@ -23,6 +23,7 @@ import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
+import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -445,6 +446,47 @@ public class FlowNodeInstanceIT {
     assertThat(actual.flowNodeName())
         .describedAs("the first resolved name must survive the merge into the still-queued insert")
         .isEqualTo("first");
+  }
+
+  /**
+   * RDBMS analogue of the ES/OS same-batch regression behind #58803: on ES/OS, one shared cached
+   * entity per id let the inner instance's own completion clobber the name resolved by the entry
+   * child's activation when both landed in the same flush. On RDBMS both writes instead target the
+   * same still-queued insert independently — this pins that merging a name resolution and a
+   * completion into that one pending insert preserves both, rather than the second merge
+   * overwriting the first.
+   */
+  @TestTemplate
+  public void shouldKeepNameAndApplyFinishWhenBothMergeIntoPendingInsert(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader();
+
+    // deliberately not flushed: the insert has to stay queued for both merges to be reached
+    final var instance = FlowNodeInstanceFixtures.createRandomized(b -> b.flowNodeName(null));
+    rdbmsWriters.getFlowNodeInstanceWriter().create(instance);
+
+    // when
+    rdbmsWriters
+        .getFlowNodeInstanceWriter()
+        .updateName(instance.flowNodeInstanceKey(), "List users");
+    rdbmsWriters
+        .getFlowNodeInstanceWriter()
+        .finish(instance.flowNodeInstanceKey(), FlowNodeState.COMPLETED, NOW);
+    rdbmsWriters.flush();
+
+    // then
+    final var actual = reader.findOne(instance.flowNodeInstanceKey()).orElseThrow();
+    assertThat(actual.flowNodeName())
+        .describedAs(
+            "the resolved name must survive merging into the same pending insert as finish()")
+        .isEqualTo("List users");
+    assertThat(actual.state())
+        .describedAs(
+            "finish() merging into the pending insert must still apply the completed state")
+        .isEqualTo(FlowNodeState.COMPLETED);
   }
 
   private static void compareFlowNodeInstance(

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -28,6 +28,7 @@ import io.camunda.exporter.rdbms.handlers.DecisionInstanceExportHandler;
 import io.camunda.exporter.rdbms.handlers.DecisionRequirementsExportHandler;
 import io.camunda.exporter.rdbms.handlers.FlowNodeExportHandler;
 import io.camunda.exporter.rdbms.handlers.FlowNodeInstanceIncidentExportHandler;
+import io.camunda.exporter.rdbms.handlers.FlowNodeInstanceNameFromAdHocActivityHandler;
 import io.camunda.exporter.rdbms.handlers.FormExportHandler;
 import io.camunda.exporter.rdbms.handlers.GlobalListenerExportHandler;
 import io.camunda.exporter.rdbms.handlers.GroupExportHandler;
@@ -289,6 +290,10 @@ public class RdbmsExporterWrapper implements Exporter {
             rdbmsWriters.getFlowNodeInstanceWriter(),
             cacheRegistry.processCache(),
             rdbmsWriters.getErrorMessageSize()));
+    builder.withHandler(
+        ValueType.PROCESS_INSTANCE,
+        new FlowNodeInstanceNameFromAdHocActivityHandler(
+            rdbmsWriters.getFlowNodeInstanceWriter(), cacheRegistry.processCache()));
     builder.withHandler(
         ValueType.VARIABLE, new VariableExportHandler(rdbmsWriters.getVariableWriter()));
     builder.withHandler(

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/FlowNodeInstanceNameFromAdHocActivityHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/FlowNodeInstanceNameFromAdHocActivityHandler.java
@@ -11,15 +11,21 @@ import io.camunda.db.rdbms.write.service.FlowNodeInstanceWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 
 /**
  * Names the synthetic ad-hoc sub-process "inner instance" element after its activated entry
  * element, so RDBMS reaches parity with the ES/OS exporter.
  *
- * <p>This is a no-op stub introduced together with the red TDD tests; the real behavior is added in
- * the subsequent green step.
+ * <p>Activating an element inside an ad-hoc subprocess creates a synthetic <em>inner instance</em>:
+ * a scope that owns the activated element together with everything reachable from it. That inner
+ * instance has no name of its own, so this handler reacts to the entry child's {@code
+ * ELEMENT_ACTIVATING} record and writes the child's resolved name onto the parent inner-instance
+ * row (keyed by {@code flowScopeKey}), using set-if-null semantics so a later re-activation of a
+ * different entry element cannot overwrite an already-resolved name.
  */
 public class FlowNodeInstanceNameFromAdHocActivityHandler
     implements RdbmsExportHandler<ProcessInstanceRecordValue> {
@@ -36,11 +42,24 @@ public class FlowNodeInstanceNameFromAdHocActivityHandler
 
   @Override
   public boolean canExport(final Record<ProcessInstanceRecordValue> record) {
-    return false;
+    if (record.getIntent() != ProcessInstanceIntent.ELEMENT_ACTIVATING) {
+      return false;
+    }
+    final var value = record.getValue();
+    return processCache
+        .get(value.getProcessDefinitionKey())
+        .map(CachedProcessEntity::adHocActivityIds)
+        .map(ids -> ids.contains(value.getElementId()))
+        .orElse(false);
   }
 
   @Override
   public void export(final Record<ProcessInstanceRecordValue> record) {
-    // no-op stub; real behavior added in the green step
+    final var value = record.getValue();
+    final var name =
+        ProcessCacheUtil.getFlowNodeName(
+                processCache, value.getProcessDefinitionKey(), value.getElementId())
+            .orElse(value.getElementId());
+    flowNodeInstanceWriter.updateName(value.getFlowScopeKey(), name);
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/FlowNodeInstanceNameFromAdHocActivityHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/FlowNodeInstanceNameFromAdHocActivityHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import io.camunda.db.rdbms.write.service.FlowNodeInstanceWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+
+/**
+ * Names the synthetic ad-hoc sub-process "inner instance" element after its activated entry
+ * element, so RDBMS reaches parity with the ES/OS exporter.
+ *
+ * <p>This is a no-op stub introduced together with the red TDD tests; the real behavior is added in
+ * the subsequent green step.
+ */
+public class FlowNodeInstanceNameFromAdHocActivityHandler
+    implements RdbmsExportHandler<ProcessInstanceRecordValue> {
+
+  private final FlowNodeInstanceWriter flowNodeInstanceWriter;
+  private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
+
+  public FlowNodeInstanceNameFromAdHocActivityHandler(
+      final FlowNodeInstanceWriter flowNodeInstanceWriter,
+      final ExporterEntityCache<Long, CachedProcessEntity> processCache) {
+    this.flowNodeInstanceWriter = flowNodeInstanceWriter;
+    this.processCache = processCache;
+  }
+
+  @Override
+  public boolean canExport(final Record<ProcessInstanceRecordValue> record) {
+    return false;
+  }
+
+  @Override
+  public void export(final Record<ProcessInstanceRecordValue> record) {
+    // no-op stub; real behavior added in the green step
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/FlowNodeInstanceNameFromAdHocActivityHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/FlowNodeInstanceNameFromAdHocActivityHandlerTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.db.rdbms.write.service.FlowNodeInstanceWriter;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class FlowNodeInstanceNameFromAdHocActivityHandlerTest {
+
+  private static final long PROCESS_DEFINITION_KEY = 42L;
+  private static final long PARENT_INNER_INSTANCE_KEY = 999L;
+
+  private final FlowNodeInstanceWriter writer = mock(FlowNodeInstanceWriter.class);
+
+  @SuppressWarnings("unchecked")
+  private final ExporterEntityCache<Long, CachedProcessEntity> processCache =
+      mock(ExporterEntityCache.class);
+
+  private final FlowNodeInstanceNameFromAdHocActivityHandler handler =
+      new FlowNodeInstanceNameFromAdHocActivityHandler(writer, processCache);
+
+  @Test
+  void shouldExportActivatingAdHocEntryElement() {
+    // given
+    when(processCache.get(PROCESS_DEFINITION_KEY))
+        .thenReturn(
+            Optional.of(cachedProcess(Map.of("listUsers", "List users"), Set.of("listUsers"))));
+    final var record =
+        record(ProcessInstanceIntent.ELEMENT_ACTIVATING, "listUsers", PARENT_INNER_INSTANCE_KEY);
+
+    // when
+    final boolean canExport = handler.canExport(record);
+
+    // then
+    assertThat(canExport).isTrue();
+  }
+
+  @Test
+  void shouldNotExportNonAdHocElement() {
+    // given
+    when(processCache.get(PROCESS_DEFINITION_KEY))
+        .thenReturn(
+            Optional.of(cachedProcess(Map.of("listUsers", "List users"), Set.of("listUsers"))));
+    final var record =
+        record(ProcessInstanceIntent.ELEMENT_ACTIVATING, "someTask", PARENT_INNER_INSTANCE_KEY);
+
+    // when
+    final boolean canExport = handler.canExport(record);
+
+    // then
+    assertThat(canExport).isFalse();
+  }
+
+  @Test
+  void shouldNotExportNonActivatingIntent() {
+    // given
+    when(processCache.get(PROCESS_DEFINITION_KEY))
+        .thenReturn(
+            Optional.of(cachedProcess(Map.of("listUsers", "List users"), Set.of("listUsers"))));
+    final var record =
+        record(ProcessInstanceIntent.ELEMENT_COMPLETED, "listUsers", PARENT_INNER_INSTANCE_KEY);
+
+    // when
+    final boolean canExport = handler.canExport(record);
+
+    // then
+    assertThat(canExport).isFalse();
+  }
+
+  @Test
+  void shouldNotExportWhenProcessNotInCache() {
+    // given
+    when(processCache.get(PROCESS_DEFINITION_KEY)).thenReturn(Optional.empty());
+    final var record =
+        record(ProcessInstanceIntent.ELEMENT_ACTIVATING, "listUsers", PARENT_INNER_INSTANCE_KEY);
+
+    // when
+    final boolean canExport = handler.canExport(record);
+
+    // then
+    assertThat(canExport).isFalse();
+  }
+
+  @Test
+  void shouldWriteEntryNameOntoParentInnerInstanceRow() {
+    // given
+    when(processCache.get(PROCESS_DEFINITION_KEY))
+        .thenReturn(
+            Optional.of(cachedProcess(Map.of("listUsers", "List users"), Set.of("listUsers"))));
+    final var record =
+        record(ProcessInstanceIntent.ELEMENT_ACTIVATING, "listUsers", PARENT_INNER_INSTANCE_KEY);
+
+    // when
+    handler.export(record);
+
+    // then
+    // the resolved name must target the PARENT inner-instance row (flowScopeKey), not the
+    // activating child element's own key
+    verify(writer).updateName(PARENT_INNER_INSTANCE_KEY, "List users");
+  }
+
+  @Test
+  void shouldFallbackToElementIdWhenEntryUnnamed() {
+    // given
+    // the entry element is an ad-hoc activity but carries no name in the cached model. The map is
+    // not empty but holds another element's name, so a lookup under the wrong key would surface
+    // "Some other name" instead of silently falling back.
+    when(processCache.get(PROCESS_DEFINITION_KEY))
+        .thenReturn(
+            Optional.of(
+                cachedProcess(Map.of("someOtherElement", "Some other name"), Set.of("listUsers"))));
+    final var record =
+        record(ProcessInstanceIntent.ELEMENT_ACTIVATING, "listUsers", PARENT_INNER_INSTANCE_KEY);
+
+    // when
+    handler.export(record);
+
+    // then
+    // unnamed entry element falls back to its element id
+    verify(writer).updateName(PARENT_INNER_INSTANCE_KEY, "listUsers");
+  }
+
+  private static CachedProcessEntity cachedProcess(
+      final Map<String, String> flowNodesMap, final Set<String> adHocActivityIds) {
+    return new CachedProcessEntity(
+        "process name", 1, null, List.of(), flowNodesMap, false, Map.of(), adHocActivityIds);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Record<ProcessInstanceRecordValue> record(
+      final ProcessInstanceIntent intent, final String elementId, final long flowScopeKey) {
+    final var value = mock(ProcessInstanceRecordValue.class);
+    when(value.getProcessDefinitionKey()).thenReturn(PROCESS_DEFINITION_KEY);
+    when(value.getElementId()).thenReturn(elementId);
+    when(value.getFlowScopeKey()).thenReturn(flowScopeKey);
+    final var record = mock(Record.class);
+    when(record.getValue()).thenReturn(value);
+    when(record.getIntent()).thenReturn(intent);
+    return record;
+  }
+}


### PR DESCRIPTION
## Description

On RDBMS, an ad-hoc subprocess's inner instance still surfaces under its synthetic id (`<ahspId>#innerInstance`) instead of a readable name, unlike ES/OS which already resolves it (#58307). This closes that parity gap by naming the inner instance at write time in the RDBMS exporter: react to the entry child's `ELEMENT_ACTIVATING`, resolve its name (falling back to the element id), and write it onto the parent inner-instance row with first-writer-wins (set-if-null) semantics.

Migration required a separate guard: `ELEMENT_MIGRATED`/`ANCESTOR_MIGRATED` go through a full-row update that would otherwise null out an already-resolved name. Expressing that guard as a SQL `CASE`/`COALESCE` breaks cross-database (Oracle charset mismatch, Postgres type inference), so the guard is resolved in Java instead, by routing to a statement that omits the name column.

Verified against all six supported RDBMS flavors (H2, PostgreSQL, MariaDB, MySQL, Oracle, MSSQL) plus the existing ES/OS acceptance suite. Proof added in the form of two E2E ITs (`AdHocSubProcessInnerInstanceNameSameBatchIT` and `AdHocSubProcessInnerInstanceNameSameBatchIT`) plus several unit tests against edge cases.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) — not backporting; this is new RDBMS behavior that hasn't shipped in any release, so there's nothing to reconcile on `stable/*` (same reasoning as #58920 for the ES/OS side of this feature).

## Related issues

closes #58431