### PR TITLE
feat: add structured logs at cross-partition message-start handshake and lock-release boundaries

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetrics.java
@@ -253,14 +253,18 @@ public final class MessageCorrelationMetrics implements StreamProcessorLifecycle
    * M7: stops every outstanding ask-duration timer for an expiring message with {@code
    * outcome=expired} on {@code P_K}. Called for every expiring buffered message; a no-op for the
    * common case with no pending cross-partition ask.
+   *
+   * @return {@code true} if the message had at least one pending cross-partition ask whose timer
+   *     was stopped, {@code false} for the common uncontended case
    */
-  public void expireCrossPartitionAsks(final long messageKey) {
+  public boolean expireCrossPartitionAsks(final long messageKey) {
     final var byProcessDefinition = pendingAskSamples.remove(messageKey);
     if (byProcessDefinition == null) {
-      return;
+      return false;
     }
     final var timer = askDurationTimer(AskOutcome.EXPIRED);
     byProcessDefinition.values().forEach(sample -> sample.stop(timer));
+    return true;
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -247,10 +247,14 @@ public final class BpmnBufferedMessageStartEventBehavior {
             : Optional.<Correlation>empty();
 
     if (correlationKeyCandidate.isEmpty()) {
-      businessIdCandidate.ifPresent(this::triggerCorrelation);
+      if (businessIdCandidate.isPresent()) {
+        traceBufferedRedrive("business_id_only", correlationKeyCandidate, businessIdCandidate);
+        triggerCorrelation(businessIdCandidate.get());
+      }
       return;
     }
     if (businessIdCandidate.isEmpty()) {
+      traceBufferedRedrive("correlation_key_only", correlationKeyCandidate, businessIdCandidate);
       triggerCorrelation(correlationKeyCandidate.get());
       return;
     }
@@ -259,6 +263,7 @@ public final class BpmnBufferedMessageStartEventBehavior {
     final var bid = businessIdCandidate.get();
     if (ck.messageKey == bid.messageKey) {
       // both reasons resolve to the same buffered message: trigger it once
+      traceBufferedRedrive("same_message", correlationKeyCandidate, businessIdCandidate);
       triggerCorrelation(ck);
       return;
     }
@@ -270,11 +275,12 @@ public final class BpmnBufferedMessageStartEventBehavior {
             : "";
     if (businessId.equals(ckBusinessId)) {
       // both candidates carry the freed Business ID — starting both would create two PIs holding
-      // it,
-      // since the first start's hold is not yet applied. Trigger only the earlier (FIFO) one.
+      // it, since the first start's hold is not yet applied. Trigger only the earlier (FIFO) one.
+      traceBufferedRedrive("fifo_collision", correlationKeyCandidate, businessIdCandidate);
       triggerCorrelation(ck.messageKey <= bid.messageKey ? ck : bid);
     } else {
       // different Business IDs (or the correlation-key candidate carries none) — safe to start both
+      traceBufferedRedrive("both_independent", correlationKeyCandidate, businessIdCandidate);
       triggerCorrelation(ck);
       triggerCorrelation(bid);
     }
@@ -301,6 +307,24 @@ public final class BpmnBufferedMessageStartEventBehavior {
             message.getTimeToLive()),
         messageCorrelation.subscriptionKey,
         messageCorrelation.subscriptionRecord);
+  }
+
+  private void traceBufferedRedrive(
+      final String branch,
+      final Optional<Correlation> correlationKeyCandidate,
+      final Optional<Correlation> businessIdCandidate) {
+    if (!LOG.isTraceEnabled()) {
+      return;
+    }
+    LOG.atTrace()
+        .addKeyValue("branch", branch)
+        .addKeyValue(
+            "correlationKeyCandidate",
+            correlationKeyCandidate.map(candidate -> candidate.messageKey).orElse(-1L))
+        .addKeyValue(
+            "businessIdCandidate",
+            businessIdCandidate.map(candidate -> candidate.messageKey).orElse(-1L))
+        .log("Re-driving buffered message(s) on completion");
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -36,8 +36,13 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.InstantSource;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class BpmnBufferedMessageStartEventBehavior {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(BpmnBufferedMessageStartEventBehavior.class);
 
   private final MessageState messageState;
   private final ProcessState processState;
@@ -152,6 +157,12 @@ public final class BpmnBufferedMessageStartEventBehavior {
         processInstanceKey, MessageStartCorrelationKeyLockReleaseIntent.PUSHED, record);
     commandSender.sendCorrelationKeyLockRelease(requestKey, holder);
     metrics.lockReleaseSent(ReleaseTrigger.PUSH);
+
+    LOG.atDebug()
+        .addKeyValue("holderProcessInstanceKey", processInstanceKey)
+        .addKeyValue("targetPartition", Protocol.decodePartitionId(origin.getMessageKey()))
+        .addKeyValue("messageKey", origin.getMessageKey())
+        .log("Pushing correlation-key lock release to P_K");
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/DeferredMessageStartCorrelationResponse.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/DeferredMessageStartCorrelationResponse.java
@@ -19,6 +19,8 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Resolves the synchronous response of a {@code POST /messages/correlation} command that was
@@ -45,6 +47,9 @@ import io.camunda.zeebe.protocol.record.intent.MessageIntent;
  * none and does not emit a duplicate response.
  */
 final class DeferredMessageStartCorrelationResponse {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(DeferredMessageStartCorrelationResponse.class);
 
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
@@ -78,6 +83,11 @@ final class DeferredMessageStartCorrelationResponse {
       return;
     }
     final var requestData = messageCorrelationState.getRequestData(messageKey);
+
+    LOG.atDebug()
+        .addKeyValue("messageKey", messageKey)
+        .addKeyValue("outcome", "correlated")
+        .log("Resolving deferred correlate response");
 
     correlationRecord.reset();
     correlationRecord
@@ -124,6 +134,11 @@ final class DeferredMessageStartCorrelationResponse {
       return;
     }
     final var requestData = messageCorrelationState.getRequestData(messageKey);
+
+    LOG.atDebug()
+        .addKeyValue("messageKey", messageKey)
+        .addKeyValue("outcome", "not_correlated")
+        .log("Resolving deferred correlate response");
 
     correlationRecord.reset();
     correlationRecord

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessor.java
@@ -20,9 +20,13 @@ import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.time.InstantSource;
 import org.agrona.collections.MutableLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ExcludeAuthorizationCheck
 public final class MessageBatchExpireProcessor implements TypedRecordProcessor<MessageBatchRecord> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MessageBatchExpireProcessor.class);
 
   /** The safety margin to ensure that we can always write an empty EXPIRE command at the end. */
   private static final int FOLLOWUP_COMMAND_SAFETY_MARGIN = 8192;
@@ -77,7 +81,12 @@ public final class MessageBatchExpireProcessor implements TypedRecordProcessor<M
                 // M7: a buffered message that carried a pending cross-partition message-start ask
                 // has now blocked the whole TTL window without starting — close its ask timer(s) as
                 // expired. A no-op for every message with no outstanding ask.
-                metrics.expireCrossPartitionAsks(messageKey);
+                if (metrics.expireCrossPartitionAsks(messageKey)) {
+                  LOG.atDebug()
+                      .addKeyValue("messageKey", messageKey)
+                      .log(
+                          "Buffered message expired while its cross-partition ask was still pending");
+                }
                 return true;
               } else {
                 return false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -29,6 +29,8 @@ import java.util.function.LongPredicate;
 import java.util.function.Predicate;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.MutableBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Correlates published messages to message start-event subscriptions and to intermediate message
@@ -80,6 +82,8 @@ import org.agrona.collections.MutableBoolean;
  * start events — honor this invariant.
  */
 public final class MessageCorrelateBehavior {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MessageCorrelateBehavior.class);
 
   private final MessageStartEventSubscriptionState startEventSubscriptionState;
   private final MessageSubscriptionState messageSubscriptionState;
@@ -466,8 +470,17 @@ public final class MessageCorrelateBehavior {
     metrics.startCrossPartitionAsk(
         messageData.messageKey(), subscriptionRecord.getProcessDefinitionKey());
 
+    final int targetPartition = routingInfo.partitionForCorrelationKey(messageData.businessId());
+
+    LOG.atDebug()
+        .addKeyValue("messageKey", messageData.messageKey())
+        .addKeyValue("processDefinitionKey", subscriptionRecord.getProcessDefinitionKey())
+        .addKeyValue("targetPartition", targetPartition)
+        .addKeyValue("tenantId", messageData.tenantId())
+        .log("Delegating message-start to business-ID partition");
+
     commandSender.sendStartProcessInstanceRequest(
-        routingInfo.partitionForCorrelationKey(messageData.businessId()),
+        targetPartition,
         messageData.messageKey(),
         messageData.messageName(),
         messageData.correlationKey(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -239,10 +239,13 @@ public final class MessageCorrelateBehavior {
         subscription -> {
 
           // correlate the message only once per process
-          if (!subscription.isCorrelating()
-              && !correlatingSubscriptions.contains(
-                  subscription.getRecord().getBpmnProcessIdBuffer())
-              && businessIdMatches(
+          if (subscription.isCorrelating()
+              || correlatingSubscriptions.contains(
+                  subscription.getRecord().getBpmnProcessIdBuffer())) {
+            return true;
+          }
+
+          if (businessIdMatches(
                   messageData.businessId(), subscription.getRecord().getBusinessIdBuffer())
               && !skipProcessInstance.test(subscription.getRecord().getProcessInstanceKey())) {
 
@@ -258,6 +261,11 @@ public final class MessageCorrelateBehavior {
                 correlatingSubscription);
 
             correlatingSubscriptions.add(correlatingSubscription);
+          } else {
+            LOG.atTrace()
+                .addKeyValue("messageKey", messageData.messageKey())
+                .addKeyValue("subscriptionKey", subscription.getKey())
+                .log("Skipping subscription: business ID mismatch");
           }
 
           return true;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
@@ -18,8 +18,12 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.InstantSource;
 import org.agrona.collections.MutableBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class MessageCorrelator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MessageCorrelator.class);
 
   private final MessageState messageState;
   private final SubscriptionCommandSender commandSender;
@@ -70,22 +74,30 @@ public final class MessageCorrelator {
     final long messageKey = storedMessage.getMessageKey();
     final var message = storedMessage.getMessage();
 
-    final boolean correlateMessage =
+    final boolean isCorrelatable =
         message.getDeadline() > clock.millis()
             && !messageState.existMessageCorrelation(
-                messageKey, subscriptionRecord.getBpmnProcessIdBuffer())
-            && businessIdMatches(message, subscriptionRecord);
-
-    if (correlateMessage) {
-      subscriptionRecord.setMessageKey(messageKey).setVariables(message.getVariablesBuffer());
-
-      stateWriter.appendFollowUpEvent(
-          subscriptionKey, MessageSubscriptionIntent.CORRELATING, subscriptionRecord);
-
-      sendCorrelateCommand(subscriptionRecord);
+                messageKey, subscriptionRecord.getBpmnProcessIdBuffer());
+    if (!isCorrelatable) {
+      return false;
     }
 
-    return correlateMessage;
+    if (!businessIdMatches(message, subscriptionRecord)) {
+      LOG.atTrace()
+          .addKeyValue("messageKey", messageKey)
+          .addKeyValue("subscriptionKey", subscriptionKey)
+          .log("Skipping subscription: business ID mismatch");
+      return false;
+    }
+
+    subscriptionRecord.setMessageKey(messageKey).setVariables(message.getVariablesBuffer());
+
+    stateWriter.appendFollowUpEvent(
+        subscriptionKey, MessageSubscriptionIntent.CORRELATING, subscriptionRecord);
+
+    sendCorrelateCommand(subscriptionRecord);
+
+    return true;
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageExpireProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageExpireProcessor.java
@@ -14,9 +14,13 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ExcludeAuthorizationCheck
 public final class MessageExpireProcessor implements TypedRecordProcessor<MessageRecord> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MessageExpireProcessor.class);
 
   private final StateWriter stateWriter;
   private final MessageCorrelationMetrics metrics;
@@ -31,6 +35,10 @@ public final class MessageExpireProcessor implements TypedRecordProcessor<Messag
   public void processRecord(final TypedRecord<MessageRecord> record) {
 
     stateWriter.appendFollowUpEvent(record.getKey(), MessageIntent.EXPIRED, record.getValue());
-    metrics.expireCrossPartitionAsks(record.getKey());
+    if (metrics.expireCrossPartitionAsks(record.getKey())) {
+      LOG.atDebug()
+          .addKeyValue("messageKey", record.getKey())
+          .log("Buffered message expired while its cross-partition ask was still pending");
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseQueryProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseQueryProcessor.java
@@ -17,10 +17,13 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartCorrelationKeyLockReleaseRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageStartCorrelationKeyLockReleaseIntent;
 import io.camunda.zeebe.protocol.record.value.MessageStartCorrelationKeyLockReleaseRecordValue.MessageStartLockReleaseHolderValue;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handles the {@link MessageStartCorrelationKeyLockReleaseIntent#QUERY} command on {@code P_B =
@@ -52,6 +55,9 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 @ExcludeAuthorizationCheck
 public final class MessageStartCorrelationKeyLockReleaseQueryProcessor
     implements TypedRecordProcessor<MessageStartCorrelationKeyLockReleaseRecord> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(MessageStartCorrelationKeyLockReleaseQueryProcessor.class);
 
   private final ElementInstanceState elementInstanceState;
   private final BannedInstanceState bannedInstanceState;
@@ -89,6 +95,11 @@ public final class MessageStartCorrelationKeyLockReleaseQueryProcessor
       commandSender.sendCorrelationKeyLockRelease(query.getRequestKey(), holder);
       metrics.lockReleaseSent(ReleaseTrigger.RECONCILIATION);
       cleanUpOriginIfLeftover(holder);
+
+      LOG.atDebug()
+          .addKeyValue("holderProcessInstanceKey", holder.getProcessInstanceKey())
+          .addKeyValue("requestPartition", Protocol.decodePartitionId(query.getRequestKey()))
+          .log("Holder gone; sending reconciliation release");
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseReleaseProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartCorrelationKeyLockReleaseReleaseProcessor.java
@@ -19,8 +19,11 @@ import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartCorrelationKeyLockReleaseRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MessageStartCorrelationKeyLockReleaseIntent;
+import io.camunda.zeebe.protocol.record.value.MessageStartCorrelationKeyLockReleaseRecordValue.MessageStartLockReleaseHolderValue;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handles the {@link MessageStartCorrelationKeyLockReleaseIntent#RELEASE} reply on {@code P_K =
@@ -49,6 +52,9 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 public final class MessageStartCorrelationKeyLockReleaseReleaseProcessor
     implements TypedRecordProcessor<MessageStartCorrelationKeyLockReleaseRecord> {
 
+  private static final Logger LOG =
+      LoggerFactory.getLogger(MessageStartCorrelationKeyLockReleaseReleaseProcessor.class);
+
   private static final String REDUNDANT_RELEASE_REJECTION_REASON =
       """
       Expected to release the correlation-key lock still held by the holder(s) named in the \
@@ -76,10 +82,12 @@ public final class MessageStartCorrelationKeyLockReleaseReleaseProcessor
   @Override
   public void processRecord(final TypedRecord<MessageStartCorrelationKeyLockReleaseRecord> record) {
     final var reply = record.getValue();
+    // getHolders() deep-copies the array on every call, so materialize it once and reuse it.
+    final var reportedHolders = reply.getHolders();
 
     final var releasable =
         new MessageStartCorrelationKeyLockReleaseRecord().setRequestKey(reply.getRequestKey());
-    for (final var holder : reply.getHolders()) {
+    for (final var holder : reportedHolders) {
       final var bpmnProcessId = BufferUtil.wrapString(holder.getBpmnProcessId());
       final var correlationKey = BufferUtil.wrapString(holder.getCorrelationKey());
       if (messageState.getCrossPartitionStartLockHolder(bpmnProcessId, correlationKey)
@@ -101,6 +109,16 @@ public final class MessageStartCorrelationKeyLockReleaseReleaseProcessor
       rejectionWriter.appendRejection(
           record, RejectionType.INVALID_STATE, REDUNDANT_RELEASE_REJECTION_REASON);
       metrics.lockReleased(ReleaseResult.REDUNDANT);
+      if (LOG.isDebugEnabled()) {
+        LOG.atDebug()
+            .addKeyValue(
+                "holderProcessInstanceKeys",
+                reportedHolders.stream()
+                    .map(MessageStartLockReleaseHolderValue::getProcessInstanceKey)
+                    .toList())
+            .log(
+                "Ignoring redundant correlation-key lock release (already released or re-acquired)");
+      }
       return;
     }
 
@@ -111,12 +129,17 @@ public final class MessageStartCorrelationKeyLockReleaseReleaseProcessor
     // ... then pick up the next buffered message for each freed correlation key. This runs after
     // the lock removal above, so the pick-up sees the lock free and can trigger / re-route the next
     // buffered message through the normal correlation logic.
-    for (final var holder : releasable.getHolders()) {
+    final var releasableHolders = releasable.getHolders();
+    for (final var holder : releasableHolders) {
       metrics.lockReleased(ReleaseResult.RELEASED);
       bufferedMessageStartEventBehavior.correlateNextBufferedMessage(
           BufferUtil.wrapString(holder.getBpmnProcessId()),
           BufferUtil.wrapString(holder.getCorrelationKey()),
           holder.getTenantId());
     }
+
+    LOG.atDebug()
+        .addKeyValue("releasedCount", releasableHolders.size())
+        .log("Released correlation-key lock(s)");
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectExpiredProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectExpiredProcessor.java
@@ -15,6 +15,8 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessInstanceRequestRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handles the {@link MessageStartProcessInstanceRequestIntent#REJECT_EXPIRED} command on {@code
@@ -34,6 +36,9 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 public final class MessageStartProcessInstanceRequestRejectExpiredProcessor
     implements TypedRecordProcessor<MessageStartProcessInstanceRequestRecord> {
 
+  private static final Logger LOG =
+      LoggerFactory.getLogger(MessageStartProcessInstanceRequestRejectExpiredProcessor.class);
+
   private final StateWriter stateWriter;
   private final MessageCorrelationMetrics metrics;
 
@@ -45,10 +50,15 @@ public final class MessageStartProcessInstanceRequestRejectExpiredProcessor
 
   @Override
   public void processRecord(final TypedRecord<MessageStartProcessInstanceRequestRecord> record) {
+    final var reply = record.getValue();
     stateWriter.appendFollowUpEvent(
-        record.getKey(),
-        MessageStartProcessInstanceRequestIntent.EXPIRED_REJECTED,
-        record.getValue());
+        record.getKey(), MessageStartProcessInstanceRequestIntent.EXPIRED_REJECTED, reply);
     metrics.crossPartitionReply(ReplyOutcome.REJECTED_EXPIRED);
+
+    LOG.atDebug()
+        .addKeyValue("messageKey", reply.getMessageKey())
+        .addKeyValue("processDefinitionKey", reply.getProcessDefinitionKey())
+        .addKeyValue("outcome", ReplyOutcome.REJECTED_EXPIRED.getLabel())
+        .log("Applied cross-partition message-start reply");
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor.java
@@ -19,6 +19,8 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessIn
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handles the {@link MessageStartProcessInstanceRequestIntent#REJECT_NO_SUBSCRIPTION} command on
@@ -42,6 +44,10 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 @ExcludeAuthorizationCheck
 public final class MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor
     implements TypedRecordProcessor<MessageStartProcessInstanceRequestRecord> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(
+          MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor.class);
 
   private static final String SUBSCRIPTION_NOT_FOUND =
       "Expected to find subscription for message with name '%s' and correlation key '%s', but none was found.";
@@ -69,6 +75,12 @@ public final class MessageStartProcessInstanceRequestRejectNoSubscriptionProcess
     stateWriter.appendFollowUpEvent(
         record.getKey(), MessageStartProcessInstanceRequestIntent.NO_SUBSCRIPTION_REJECTED, reply);
     metrics.crossPartitionReply(ReplyOutcome.REJECTED_NO_SUBSCRIPTION);
+
+    LOG.atDebug()
+        .addKeyValue("messageKey", reply.getMessageKey())
+        .addKeyValue("processDefinitionKey", reply.getProcessDefinitionKey())
+        .addKeyValue("outcome", ReplyOutcome.REJECTED_NO_SUBSCRIPTION.getLabel())
+        .log("Applied cross-partition message-start reply");
 
     deferredCorrelationResponse.writeNotCorrelatedResponse(
         reply,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectUniquenessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectUniquenessProcessor.java
@@ -20,6 +20,8 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handles the {@link MessageStartProcessInstanceRequestIntent#REJECT_UNIQUENESS} command on {@code
@@ -43,6 +45,9 @@ import java.util.Set;
 @ExcludeAuthorizationCheck
 public final class MessageStartProcessInstanceRequestRejectUniquenessProcessor
     implements TypedRecordProcessor<MessageStartProcessInstanceRequestRecord> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(MessageStartProcessInstanceRequestRejectUniquenessProcessor.class);
 
   private static final String BLOCKED_BY_ACTIVE_INSTANCE =
       "Expected to correlate message with name '%s' to a message start event, but a process instance"
@@ -72,6 +77,12 @@ public final class MessageStartProcessInstanceRequestRejectUniquenessProcessor
     stateWriter.appendFollowUpEvent(
         record.getKey(), MessageStartProcessInstanceRequestIntent.UNIQUENESS_REJECTED, reply);
     metrics.crossPartitionReply(ReplyOutcome.REJECTED_UNIQUENESS);
+
+    LOG.atDebug()
+        .addKeyValue("messageKey", reply.getMessageKey())
+        .addKeyValue("processDefinitionKey", reply.getProcessDefinitionKey())
+        .addKeyValue("outcome", ReplyOutcome.REJECTED_UNIQUENESS.getLabel())
+        .log("Applied cross-partition message-start reply");
 
     deferredCorrelationResponse.writeNotCorrelatedResponse(
         reply,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRequestProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRequestProcessor.java
@@ -30,6 +30,8 @@ import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceReques
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.time.InstantSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handles the cross-partition {@link MessageStartProcessInstanceRequestIntent#REQUEST} command on
@@ -91,6 +93,9 @@ import java.time.InstantSource;
 public final class MessageStartProcessInstanceRequestRequestProcessor
     implements TypedRecordProcessor<MessageStartProcessInstanceRequestRecord> {
 
+  private static final Logger LOG =
+      LoggerFactory.getLogger(MessageStartProcessInstanceRequestRequestProcessor.class);
+
   private final MessageStartEventSubscriptionState startEventSubscriptionState;
   private final ElementInstanceState elementInstanceState;
   private final BannedInstanceState bannedInstanceState;
@@ -144,6 +149,11 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
   public void processRecord(final TypedRecord<MessageStartProcessInstanceRequestRecord> record) {
     final var request = record.getValue();
 
+    LOG.atTrace()
+        .addKeyValue("messageKey", request.getMessageKey())
+        .addKeyValue("processDefinitionKey", request.getProcessDefinitionKey())
+        .log("Received cross-partition message-start request");
+
     stateWriter.appendFollowUpEvent(
         record.getKey(), MessageStartProcessInstanceRequestIntent.REQUESTED, request);
 
@@ -159,6 +169,7 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
           request.getBpmnProcessId(),
           request.getTenantId(),
           request.getMessageKey());
+      logRequestOutcome(request, RequestOutcome.REJECTED_EXPIRED);
       return;
     }
 
@@ -166,12 +177,14 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
     if (cachedPiKey != null) {
       commandSender.sendStartProcessInstanceStarted(request, cachedPiKey);
       metrics.crossPartitionRequest(RequestOutcome.DEDUP_HIT);
+      logRequestOutcome(request, RequestOutcome.DEDUP_HIT, cachedPiKey);
       return;
     }
 
     if (!localSubscriptionExists(request)) {
       commandSender.sendStartProcessInstanceNoSubscriptionRejected(request);
       metrics.crossPartitionRequest(RequestOutcome.REJECTED_NO_SUBSCRIPTION);
+      logRequestOutcome(request, RequestOutcome.REJECTED_NO_SUBSCRIPTION);
       return;
     }
 
@@ -183,6 +196,7 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
           request.getBpmnProcessId(),
           request.getTenantId(),
           request.getMessageKey());
+      logRequestOutcome(request, RequestOutcome.REJECTED_UNIQUENESS);
       return;
     }
 
@@ -205,6 +219,7 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
       // Activation failed because the definition is draining/deleted on this partition.
       commandSender.sendStartProcessInstanceNoSubscriptionRejected(request);
       metrics.crossPartitionRequest(RequestOutcome.REJECTED_NOT_ACTIVATABLE);
+      logRequestOutcome(request, RequestOutcome.REJECTED_NOT_ACTIVATABLE);
       return;
     }
 
@@ -225,6 +240,30 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
         request.getTenantId(),
         request.getMessageKey(),
         clock.millis());
+    logRequestOutcome(request, RequestOutcome.STARTED, processInstanceKey);
+  }
+
+  private void logRequestOutcome(
+      final MessageStartProcessInstanceRequestRecord request, final RequestOutcome outcome) {
+    logRequestOutcome(request, outcome, -1L);
+  }
+
+  private void logRequestOutcome(
+      final MessageStartProcessInstanceRequestRecord request,
+      final RequestOutcome outcome,
+      final long processInstanceKey) {
+    if (!LOG.isDebugEnabled()) {
+      return;
+    }
+    var event =
+        LOG.atDebug()
+            .addKeyValue("messageKey", request.getMessageKey())
+            .addKeyValue("processDefinitionKey", request.getProcessDefinitionKey())
+            .addKeyValue("outcome", outcome.getLabel());
+    if (processInstanceKey >= 0) {
+      event = event.addKeyValue("processInstanceKey", processInstanceKey);
+    }
+    event.log("Resolved cross-partition message-start request");
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestStartProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestStartProcessor.java
@@ -22,6 +22,8 @@ import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handles the {@link MessageStartProcessInstanceRequestIntent#START} reply command on {@code P_K},
@@ -73,6 +75,9 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 public final class MessageStartProcessInstanceRequestStartProcessor
     implements TypedRecordProcessor<MessageStartProcessInstanceRequestRecord> {
 
+  private static final Logger LOG =
+      LoggerFactory.getLogger(MessageStartProcessInstanceRequestStartProcessor.class);
+
   private final StateWriter stateWriter;
   private final MessageState messageState;
   private final MessageCorrelationMetrics metrics;
@@ -102,6 +107,13 @@ public final class MessageStartProcessInstanceRequestStartProcessor
     metrics.crossPartitionReply(ReplyOutcome.STARTED);
     metrics.completeCrossPartitionAskStarted(
         reply.getMessageKey(), reply.getProcessDefinitionKey());
+
+    LOG.atDebug()
+        .addKeyValue("messageKey", reply.getMessageKey())
+        .addKeyValue("processDefinitionKey", reply.getProcessDefinitionKey())
+        .addKeyValue("outcome", ReplyOutcome.STARTED.getLabel())
+        .addKeyValue("processInstanceKey", reply.getProcessInstanceKey())
+        .log("Applied cross-partition message-start reply");
 
     // Look up the buffered message once: both the CORRELATED applier and the EXPIRED applier need
     // it (CORRELATED writes a foreign-key reference into MESSAGE_KEY; EXPIRED removes the buffered

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor.java
@@ -18,6 +18,8 @@ import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceReques
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.time.InstantSource;
 import org.agrona.collections.MutableLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Consumes a {@link MessageStartProcessInstanceRequestIntent#SWEEP_EXPIRED_DEDUPS} trigger and
@@ -35,6 +37,9 @@ import org.agrona.collections.MutableLong;
 @ExcludeAuthorizationCheck
 public final class MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor
     implements TypedRecordProcessor<MessageStartProcessInstanceRequestRecord> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor.class);
 
   private final StateWriter stateWriter;
   private final TypedCommandWriter commandWriter;
@@ -87,6 +92,15 @@ public final class MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor
     if (deleted.get() > 0) {
       metrics.dedupSwept((int) deleted.get());
     }
+
+    // Logged per sweep run (not per scheduler tick): the scheduler only writes a
+    // SWEEP_EXPIRED_DEDUPS command after a read-only probe finds an expired entry, so a run with
+    // sweptCount=0 is the rare probe/process race worth surfacing, and hasMore=true flags a
+    // batch-limited sweep that will continue on a follow-up command.
+    LOG.atDebug()
+        .addKeyValue("sweptCount", deleted.get())
+        .addKeyValue("hasMore", hasMore)
+        .log("Swept expired cross-partition message-start dedup entries");
 
     if (hasMore) {
       // Past-deadline dedup entries remain beyond what fit in this batch. Schedule the next cycle

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageStartAskCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageStartAskCheckScheduler.java
@@ -120,11 +120,16 @@ public final class PendingMessageStartAskCheckScheduler
   private void sendAsk(final MessageStartProcessInstanceAsk ask, final long now) {
     final int targetPartitionId = routingInfo.partitionForCorrelationKey(ask.getBusinessIdBuffer());
 
-    LOG.debug(
-        "Retrying pending message-start ask: messageKey={}, processDefinitionKey={}, targetPartition={}",
-        ask.getMessageKey(),
-        ask.getProcessDefinitionKey(),
-        targetPartitionId);
+    if (LOG.isDebugEnabled()) {
+      final long rejectionCount = ask.getRejectionCount();
+      LOG.atDebug()
+          .addKeyValue("messageKey", ask.getMessageKey())
+          .addKeyValue("processDefinitionKey", ask.getProcessDefinitionKey())
+          .addKeyValue("targetPartition", targetPartitionId)
+          .addKeyValue("rejectionCount", rejectionCount)
+          .addKeyValue("backoffMillis", retryIntervalMillis(rejectionCount))
+          .log("Retrying pending message-start ask");
+    }
 
     commandSender.sendDirectStartProcessInstanceRequest(
         targetPartitionId,


### PR DESCRIPTION
## Description

Adds structured, key-value logs (L1–L12) at the critical handshake, polling, and lock-release boundaries of the cross-partition message-start feature. All log statements use class-local loggers and the fluent `LOG.atLevel().addKeyValue(...)` API. Levels follow `docs/observability/logging.md`: DEBUG for engineer diagnostics, TRACE for tight per-record loops. No logging is added in appliers, and only identifiers (keys, partition IDs, counts) are ever logged — never user-supplied values.

### What's logged

| ID | Level | Site | Description |
|----|-------|------|-------------|
| L1 | DEBUG | `MessageCorrelateBehavior#dispatchCrossPartitionStartProcessInstanceAsk` | Delegating message-start to the business-ID partition |
| L2 | TRACE/DEBUG | `MessageStartProcessInstanceRequestRequestProcessor` | Cross-partition REQUEST received (TRACE) + per-outcome resolution (DEBUG) |
| L3 | DEBUG | Reply processors (`Start`, `RejectExpired`, `RejectNoSubscription`, `RejectUniqueness`) | Closing boundary — applied cross-partition message-start reply |
| L4 | DEBUG | `PendingMessageStartAskCheckScheduler` | Retry with enriched `rejectionCount` and `backoffMillis` fields |
| L5 | DEBUG | `BpmnBufferedMessageStartEventBehavior#pushCorrelationKeyLockRelease` | Pushing correlation-key lock release to P_K |
| L6 | DEBUG | `MessageStartCorrelationKeyLockReleaseQueryProcessor` | Holder gone; sending reconciliation release |
| L7 | DEBUG | `MessageStartCorrelationKeyLockReleaseReleaseProcessor` | Released vs redundant release (with count) |
| L8 | DEBUG | `DeferredMessageStartCorrelationResponse` | Resolving deferred correlate response (correlated / not_correlated) |
| L9 | TRACE | `BpmnBufferedMessageStartEventBehavior#traceBufferedRedrive` | Re-drive branch decision (business_id_only, fifo_collision, both_independent, …) |
| L10 | TRACE | `MessageCorrelateBehavior`, `MessageCorrelator` | Skipping subscription: business-ID mismatch |
| L11 | DEBUG | `MessageExpireProcessor`, `MessageBatchExpireProcessor` | Buffered message expired while its cross-partition ask was still pending |
| L12 | DEBUG | `MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor` | Per-run dedup sweep summary (`sweptCount`, `hasMore`) |

### Motivation

Previously, only three log statements existed across the entire feature, making critical boundaries (lost pushes, deferred responses, blocked-then-expired messages) effectively undiagnosable. These structured logs allow engineers to answer *"why didn't my message correlate/start?"* without needing record-stream visibility into the direct-command schedulers.

### Notes
- `MessageCorrelationMetrics#expireCrossPartitionAsks` return type changed to `boolean` to enable conditional logging at call sites (L11).
- The `getHolders()` deep-copy in `MessageStartCorrelationKeyLockReleaseReleaseProcessor` is now materialized once and reused to avoid redundant allocation.
- Existing WARN (misconfigured batch limit) and TRACE (reconciliation query) in `CrossPartitionMessageStartLockReleaseScheduler` are left unchanged.

## Related issues

closes #59141