### PR TITLE
Batch agent instance completion to avoid exceeding record batch size at scale

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/AgentInstancesCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/AgentInstancesCfg.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import io.camunda.zeebe.engine.EngineConfiguration;
+
+public final class AgentInstancesCfg implements ConfigurationEntry {
+
+  private int completionBatchLimit =
+      EngineConfiguration.DEFAULT_AGENT_INSTANCE_COMPLETION_BATCH_LIMIT;
+
+  @Override
+  public void init(final BrokerCfg globalConfig, final String brokerBase) {
+    if (completionBatchLimit < 1) {
+      throw new IllegalArgumentException(
+          "Agent instance completion batch limit must be at least 1 but was %d"
+              .formatted(completionBatchLimit));
+    }
+  }
+
+  public int getCompletionBatchLimit() {
+    return completionBatchLimit;
+  }
+
+  public void setCompletionBatchLimit(final int completionBatchLimit) {
+    this.completionBatchLimit = completionBatchLimit;
+  }
+
+  @Override
+  public String toString() {
+    return "AgentInstancesCfg{completionBatchLimit=" + completionBatchLimit + '}';
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -27,6 +27,7 @@ public final class EngineCfg implements ConfigurationEntry {
   private ExpressionCfg expression = new ExpressionCfg();
   private ProcessInstanceCreationCfg processInstanceCreation = new ProcessInstanceCreationCfg();
   private StartupCfg startup = new StartupCfg();
+  private AgentInstancesCfg agentInstances = new AgentInstancesCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -43,6 +44,7 @@ public final class EngineCfg implements ConfigurationEntry {
     expression.init(globalConfig, brokerBase);
     processInstanceCreation.init(globalConfig, brokerBase);
     startup.init(globalConfig, brokerBase);
+    agentInstances.init(globalConfig, brokerBase);
   }
 
   public MessagesCfg getMessages() {
@@ -157,6 +159,14 @@ public final class EngineCfg implements ConfigurationEntry {
     startup = startupCfg;
   }
 
+  public AgentInstancesCfg getAgentInstances() {
+    return agentInstances;
+  }
+
+  public void setAgentInstances(final AgentInstancesCfg agentInstances) {
+    this.agentInstances = agentInstances;
+  }
+
   @Override
   public String toString() {
     return "EngineCfg{"
@@ -188,6 +198,8 @@ public final class EngineCfg implements ConfigurationEntry {
         + processInstanceCreation
         + ", startup="
         + startup
+        + ", agentInstances="
+        + agentInstances
         + '}';
   }
 
@@ -246,6 +258,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setMessageStartLockReleasePollBatchLimit(
             processInstanceCreation.getMessageStartLockReleasePollBatchLimit())
         .setIncludeVariablesInJobCompletedEvent(jobs.isIncludeVariablesInJobCompletedEvent())
-        .setEnableRpaReexportMigration(startup.isRpaReexportMigrationEnabled());
+        .setEnableRpaReexportMigration(startup.isRpaReexportMigrationEnabled())
+        .setAgentInstanceCompletionBatchLimit(agentInstances.getCompletionBatchLimit());
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -83,6 +83,8 @@ final class EngineCfgTest {
         .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_MAX_DELAY);
     assertThat(configuration.getSecretResolutionRetryBackoffFactor())
         .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_BACKOFF_FACTOR);
+    assertThat(configuration.getAgentInstanceCompletionBatchLimit())
+        .isEqualTo(EngineConfiguration.DEFAULT_AGENT_INSTANCE_COMPLETION_BATCH_LIMIT);
   }
 
   @Test
@@ -124,6 +126,7 @@ final class EngineCfgTest {
     assertThat(configuration.isEnableRpaReexportMigration()).isFalse();
     assertThat(configuration.getGroupNameCacheCapacity()).isEqualTo(2000);
     assertThat(configuration.isCandidateGroupNameResolution()).isFalse();
+    assertThat(configuration.getAgentInstanceCompletionBatchLimit()).isEqualTo(50);
   }
 
   void assertListenerCfg(

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/engine/AgentInstancesCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/engine/AgentInstancesCfgTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import org.junit.jupiter.api.Test;
+
+final class AgentInstancesCfgTest {
+
+  @Test
+  void shouldAcceptDefaultValues() {
+    // given
+    final var cfg = new AgentInstancesCfg();
+
+    // when - then
+    assertThatCode(() -> cfg.init(new BrokerCfg(), "")).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectCompletionBatchLimitBelowOne() {
+    // given
+    final var cfg = new AgentInstancesCfg();
+    cfg.setCompletionBatchLimit(0);
+
+    // when - then
+    assertThatThrownBy(() -> cfg.init(new BrokerCfg(), ""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Agent instance completion batch limit must be at least 1 but was 0");
+  }
+
+  @Test
+  void shouldRejectNegativeCompletionBatchLimit() {
+    // given
+    final var cfg = new AgentInstancesCfg();
+    cfg.setCompletionBatchLimit(-100);
+
+    // when - then
+    assertThatThrownBy(() -> cfg.init(new BrokerCfg(), ""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Agent instance completion batch limit must be at least 1 but was -100");
+  }
+}

--- a/zeebe/broker/src/test/resources/system/engine.yaml
+++ b/zeebe/broker/src/test/resources/system/engine.yaml
@@ -48,3 +48,5 @@ zeebe:
           businessIdUniquenessEnabled: true
         startup:
           rpaReexportMigrationEnabled: false
+        agentInstances:
+          completionBatchLimit: 50

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -78,6 +78,7 @@ public final class EngineConfiguration {
   public static final Duration DEFAULT_MESSAGE_START_DEDUP_EXPIRATION_SWEEP_INTERVAL =
       Duration.ofSeconds(30);
   public static final int DEFAULT_MESSAGE_START_DEDUP_EXPIRATION_SWEEP_BATCH_LIMIT = 100;
+  public static final int DEFAULT_AGENT_INSTANCE_COMPLETION_BATCH_LIMIT = 20;
 
   /**
    * Cadence at which the pending message-start ask scheduler runs and the minimum age an ask must
@@ -179,6 +180,7 @@ public final class EngineConfiguration {
       DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_INTERVAL;
   private int messageStartLockReleasePollBatchLimit =
       DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_BATCH_LIMIT;
+  private int agentInstanceCompletionBatchLimit = DEFAULT_AGENT_INSTANCE_COMPLETION_BATCH_LIMIT;
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;
@@ -689,6 +691,20 @@ public final class EngineConfiguration {
   public EngineConfiguration setEnableRpaReexportMigration(
       final boolean enableRpaReexportMigration) {
     this.enableRpaReexportMigration = enableRpaReexportMigration;
+    return this;
+  }
+
+  /**
+   * Maximum number of agent instances completed per {@code AGENT_INSTANCE_BATCH:COMPLETE} cycle
+   * when a process instance with agent instances attached ends.
+   */
+  public int getAgentInstanceCompletionBatchLimit() {
+    return agentInstanceCompletionBatchLimit;
+  }
+
+  public EngineConfiguration setAgentInstanceCompletionBatchLimit(
+      final int agentInstanceCompletionBatchLimit) {
+    this.agentInstanceCompletionBatchLimit = agentInstanceCompletionBatchLimit;
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -511,7 +511,7 @@ public final class EngineProcessors {
         clock);
 
     AgentInstanceProcessors.addAgentInstanceProcessors(
-        keyGenerator, typedRecordProcessors, writers, cslCheck, processingState);
+        keyGenerator, typedRecordProcessors, writers, cslCheck, processingState, config);
 
     AgentHistoryProcessors.addAgentHistoryProcessors(
         keyGenerator, typedRecordProcessors, writers, cslCheck, processingState);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceBatchCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceBatchCompleteProcessor.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agentinstance;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.AgentInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.agrona.collections.MutableInteger;
+import org.agrona.collections.MutableLong;
+
+/**
+ * Completes the agent instances of a process instance in bounded-size batches, so that the
+ * individual {@link AgentInstanceIntent#COMPLETE} commands issued for a process instance with a
+ * large number of agent instances never risk exceeding the maximum record-batch size in a single
+ * write. Follows up with another {@link AgentInstanceBatchIntent#COMPLETE} command carrying a
+ * resume cursor when more agent instances remain, and finishes with {@link
+ * AgentInstanceBatchIntent#COMPLETED} once every agent instance of the process instance has been
+ * visited.
+ */
+@ExcludeAuthorizationCheck
+public final class AgentInstanceBatchCompleteProcessor
+    implements TypedRecordProcessor<AgentInstanceBatchRecord> {
+
+  private static final int FOLLOWUP_COMMAND_SAFETY_MARGIN =
+      new AgentInstanceBatchRecord()
+          .setProcessInstanceKey(Long.MAX_VALUE)
+          .setProcessDefinitionKey(Long.MAX_VALUE)
+          .setAgentInstanceKey(Long.MAX_VALUE)
+          .getLength();
+
+  private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
+  private final KeyGenerator keyGenerator;
+  private final AgentInstanceState agentInstanceState;
+  private final int batchLimit;
+
+  public AgentInstanceBatchCompleteProcessor(
+      final Writers writers,
+      final KeyGenerator keyGenerator,
+      final AgentInstanceState agentInstanceState,
+      final int batchLimit) {
+    stateWriter = writers.state();
+    commandWriter = writers.command();
+    this.keyGenerator = keyGenerator;
+    this.agentInstanceState = agentInstanceState;
+    this.batchLimit = batchLimit;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<AgentInstanceBatchRecord> record) {
+    final var value = record.getValue();
+    final var processInstanceKey = value.getProcessInstanceKey();
+    final var visited = new MutableInteger(0);
+    final var lastVisitedKey = new MutableLong(value.getAgentInstanceKey());
+
+    final var hasMore =
+        agentInstanceState.visitAgentInstanceKeysByProcessInstanceKey(
+            processInstanceKey,
+            value.getAgentInstanceKey(),
+            agentInstanceKey -> {
+              final var command =
+                  new AgentInstanceRecord()
+                      .setAgentInstanceKey(agentInstanceKey)
+                      .setProcessInstanceKey(processInstanceKey);
+              if (!commandWriter.canWriteCommandOfLength(
+                      command.getLength() + FOLLOWUP_COMMAND_SAFETY_MARGIN)
+                  || visited.get() >= batchLimit) {
+                return false;
+              }
+              commandWriter.appendFollowUpCommand(
+                  agentInstanceKey, AgentInstanceIntent.COMPLETE, command);
+              lastVisitedKey.set(agentInstanceKey);
+              visited.increment();
+              return true;
+            });
+
+    if (hasMore) {
+      final var nextBatch =
+          new AgentInstanceBatchRecord()
+              .setProcessInstanceKey(processInstanceKey)
+              .setProcessDefinitionKey(value.getProcessDefinitionKey())
+              .setAgentInstanceKey(lastVisitedKey.get());
+      commandWriter.appendFollowUpCommand(
+          keyGenerator.nextKey(), AgentInstanceBatchIntent.COMPLETE, nextBatch);
+    } else {
+      stateWriter.appendFollowUpEvent(record.getKey(), AgentInstanceBatchIntent.COMPLETED, value);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceProcessors.java
@@ -7,11 +7,13 @@
  */
 package io.camunda.zeebe.engine.processing.agentinstance;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
@@ -24,7 +26,8 @@ public final class AgentInstanceProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
       final CslAuthorizationCheck cslCheck,
-      final ProcessingState processingState) {
+      final ProcessingState processingState,
+      final EngineConfiguration config) {
     typedRecordProcessors.onCommand(
         ValueType.AGENT_INSTANCE,
         AgentInstanceIntent.CREATE,
@@ -37,5 +40,13 @@ public final class AgentInstanceProcessors {
         ValueType.AGENT_INSTANCE,
         AgentInstanceIntent.COMPLETE,
         new AgentInstanceCompleteProcessor(writers, processingState));
+    typedRecordProcessors.onCommand(
+        ValueType.AGENT_INSTANCE_BATCH,
+        AgentInstanceBatchIntent.COMPLETE,
+        new AgentInstanceBatchCompleteProcessor(
+            writers,
+            keyGenerator,
+            processingState.getAgentInstanceState(),
+            config.getAgentInstanceCompletionBatchLimit()));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AgentInstanceBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AgentInstanceBehavior.java
@@ -10,32 +10,31 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.immutable.AgentInstanceState;
-import io.camunda.zeebe.engine.state.immutable.ProcessingState;
-import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
-import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceBatchRecord;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceBatchIntent;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 public final class AgentInstanceBehavior {
 
   private final TypedCommandWriter commandWriter;
-  private final AgentInstanceState agentInstanceState;
+  private final KeyGenerator keyGenerator;
 
-  public AgentInstanceBehavior(final ProcessingState processingState, final Writers writers) {
+  public AgentInstanceBehavior(final Writers writers, final KeyGenerator keyGenerator) {
     commandWriter = writers.command();
-    agentInstanceState = processingState.getAgentInstanceState();
+    this.keyGenerator = keyGenerator;
   }
 
-  /** Completes every agent instance still associated with the given process instance. */
+  /**
+   * Triggers the batched completion of every agent instance still associated with the given process
+   * instance, by writing a single {@link AgentInstanceBatchIntent#COMPLETE} command.
+   */
   public void completeAgentInstancesOfProcessInstance(final BpmnElementContext context) {
     final long processInstanceKey = context.getProcessInstanceKey();
-    for (final long agentInstanceKey :
-        agentInstanceState.getAgentInstanceKeysByProcessInstanceKey(processInstanceKey)) {
-      commandWriter.appendFollowUpCommand(
-          agentInstanceKey,
-          AgentInstanceIntent.COMPLETE,
-          new AgentInstanceRecord()
-              .setAgentInstanceKey(agentInstanceKey)
-              .setProcessInstanceKey(processInstanceKey));
-    }
+    commandWriter.appendFollowUpCommand(
+        keyGenerator.nextKey(),
+        AgentInstanceBatchIntent.COMPLETE,
+        new AgentInstanceBatchRecord()
+            .setProcessInstanceKey(processInstanceKey)
+            .setProcessDefinitionKey(context.getProcessDefinitionKey()));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -299,7 +299,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             variableBehavior,
             processingState);
 
-    agentInstanceBehavior = new AgentInstanceBehavior(processingState, writers);
+    agentInstanceBehavior = new AgentInstanceBehavior(writers, processingState.getKeyGenerator());
 
     processDeletionBehavior =
         new BpmnProcessDeletionBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agentinstance/DbAgentInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agentinstance/DbAgentInstanceState.java
@@ -18,6 +18,8 @@ import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.LongPredicate;
+import org.agrona.collections.MutableBoolean;
 
 public final class DbAgentInstanceState implements MutableAgentInstanceState {
 
@@ -65,6 +67,30 @@ public final class DbAgentInstanceState implements MutableAgentInstanceState {
           keys.add(key.second().getValue());
         });
     return keys;
+  }
+
+  @Override
+  public boolean visitAgentInstanceKeysByProcessInstanceKey(
+      final long piKey, final long startAtAgentInstanceKey, final LongPredicate visitor) {
+    processInstanceKey.wrapLong(piKey);
+    agentInstanceKey.wrapLong(Math.max(startAtAgentInstanceKey, 0));
+
+    // If startAtAgentInstanceKey is a negative value we should use null instead. This will make
+    // it so we start the iteration at the first agent instance of the process instance.
+    final var startAt = startAtAgentInstanceKey < 0 ? null : processInstanceKeyAndAgentInstanceKey;
+
+    final var hasMore = new MutableBoolean(false);
+    byProcessInstanceKeyColumnFamily.whileEqualPrefix(
+        processInstanceKey,
+        startAt,
+        key -> {
+          final var continueIterating = visitor.test(key.second().getValue());
+          if (!continueIterating) {
+            hasMore.set(true);
+          }
+          return continueIterating;
+        });
+    return hasMore.get();
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.AsyncRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
@@ -216,6 +217,7 @@ public final class EventAppliers implements EventApplier {
     register(
         AgentInstanceIntent.MIGRATED,
         new AgentInstanceMigratedApplier(state.getAgentInstanceState()));
+    register(AgentInstanceBatchIntent.COMPLETED, NOOP_EVENT_APPLIER);
   }
 
   private void registerJobMetricsBatchEventAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentInstanceState.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import java.util.List;
+import java.util.function.LongPredicate;
 
 public interface AgentInstanceState {
 
@@ -21,4 +22,18 @@ public interface AgentInstanceState {
    * @return the keys of all agent instances currently associated with the given process instance
    */
   List<Long> getAgentInstanceKeysByProcessInstanceKey(long processInstanceKey);
+
+  /**
+   * Visits the keys of agent instances associated with the given process instance, in ascending key
+   * order, starting at (or just after, if it no longer exists) {@code startAtAgentInstanceKey}. The
+   * visitor controls how many keys are visited by returning {@code false} once it doesn't want to
+   * see more (e.g. because a batch limit was reached).
+   *
+   * @param startAtAgentInstanceKey the key to resume iteration from, or {@code -1} to start from
+   *     the beginning
+   * @return {@code true} if there are more agent instance keys left beyond what the visitor
+   *     accepted, {@code false} if iteration reached the end
+   */
+  boolean visitAgentInstanceKeysByProcessInstanceKey(
+      long processInstanceKey, long startAtAgentInstanceKey, LongPredicate visitor);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceBatchCompleteProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceBatchCompleteProcessorTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agentinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.MockTypedRecord;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+@ExtendWith(ProcessingStateExtension.class)
+final class AgentInstanceBatchCompleteProcessorTest {
+
+  private static final long PROCESS_INSTANCE_KEY = 10L;
+  private static final long PROCESS_DEFINITION_KEY = 20L;
+  private static final long NEXT_BATCH_KEY = 999L;
+
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  private MutableAgentInstanceState agentInstanceState;
+  private StateWriter stateWriter;
+  private TypedCommandWriter commandWriter;
+  private KeyGenerator keyGenerator;
+
+  @BeforeEach
+  void setUp() {
+    agentInstanceState = processingState.getAgentInstanceState();
+
+    stateWriter = mock(StateWriter.class);
+    commandWriter = mock(TypedCommandWriter.class);
+    when(commandWriter.canWriteCommandOfLength(anyInt())).thenReturn(true);
+    keyGenerator = mock(KeyGenerator.class);
+    when(keyGenerator.nextKey()).thenReturn(NEXT_BATCH_KEY);
+  }
+
+  private AgentInstanceBatchCompleteProcessor createProcessor(final int batchLimit) {
+    final var writers = mock(Writers.class);
+    when(writers.state()).thenReturn(stateWriter);
+    when(writers.command()).thenReturn(commandWriter);
+    return new AgentInstanceBatchCompleteProcessor(
+        writers, keyGenerator, agentInstanceState, batchLimit);
+  }
+
+  private void insertAgentInstance(final long agentInstanceKey, final long processInstanceKey) {
+    agentInstanceState.insert(
+        agentInstanceKey, new AgentInstanceRecord().setProcessInstanceKey(processInstanceKey));
+  }
+
+  private MockTypedRecord<AgentInstanceBatchRecord> command(
+      final long key, final AgentInstanceBatchRecord value) {
+    return new MockTypedRecord<>(key, new RecordMetadata(), value);
+  }
+
+  @Test
+  void shouldCompleteEveryVisitedAgentInstanceUpToTheLimit() {
+    // given
+    insertAgentInstance(1L, PROCESS_INSTANCE_KEY);
+    insertAgentInstance(2L, PROCESS_INSTANCE_KEY);
+    final var value =
+        new AgentInstanceBatchRecord()
+            .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+            .setProcessDefinitionKey(PROCESS_DEFINITION_KEY);
+
+    // when
+    createProcessor(100).processRecord(command(500L, value));
+
+    // then
+    verify(commandWriter).appendFollowUpCommand(eq(1L), eq(AgentInstanceIntent.COMPLETE), any());
+    verify(commandWriter).appendFollowUpCommand(eq(2L), eq(AgentInstanceIntent.COMPLETE), any());
+  }
+
+  @Test
+  void shouldWriteCompletedEventWhenEveryAgentInstanceHasBeenVisited() {
+    // given
+    insertAgentInstance(1L, PROCESS_INSTANCE_KEY);
+    final var value =
+        new AgentInstanceBatchRecord()
+            .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+            .setProcessDefinitionKey(PROCESS_DEFINITION_KEY);
+
+    // when
+    createProcessor(100).processRecord(command(500L, value));
+
+    // then
+    verify(stateWriter)
+        .appendFollowUpEvent(eq(500L), eq(AgentInstanceBatchIntent.COMPLETED), eq(value));
+    verify(commandWriter, never())
+        .appendFollowUpCommand(anyLong(), eq(AgentInstanceBatchIntent.COMPLETE), any());
+  }
+
+  @Test
+  void shouldRescheduleWithResumeCursorWhenBatchLimitIsReached() {
+    // given - three agent instances but the batch limit only allows two per cycle
+    insertAgentInstance(1L, PROCESS_INSTANCE_KEY);
+    insertAgentInstance(2L, PROCESS_INSTANCE_KEY);
+    insertAgentInstance(3L, PROCESS_INSTANCE_KEY);
+    final var value =
+        new AgentInstanceBatchRecord()
+            .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+            .setProcessDefinitionKey(PROCESS_DEFINITION_KEY);
+
+    // when
+    createProcessor(2).processRecord(command(500L, value));
+
+    // then - only the first two agent instances are completed in this cycle
+    verify(commandWriter).appendFollowUpCommand(eq(1L), eq(AgentInstanceIntent.COMPLETE), any());
+    verify(commandWriter).appendFollowUpCommand(eq(2L), eq(AgentInstanceIntent.COMPLETE), any());
+    verify(commandWriter, never())
+        .appendFollowUpCommand(eq(3L), eq(AgentInstanceIntent.COMPLETE), any());
+
+    // and - a follow-up batch command resumes from the last visited key with a fresh key
+    final var followUpCaptor = ArgumentCaptor.forClass(AgentInstanceBatchRecord.class);
+    verify(commandWriter)
+        .appendFollowUpCommand(
+            eq(NEXT_BATCH_KEY), eq(AgentInstanceBatchIntent.COMPLETE), followUpCaptor.capture());
+    final var followUp = followUpCaptor.getValue();
+    assertThat(followUp.getProcessInstanceKey())
+        .as("the follow-up batch command must keep completing the same process instance")
+        .isEqualTo(PROCESS_INSTANCE_KEY);
+    assertThat(followUp.getProcessDefinitionKey())
+        .as("the follow-up batch command must carry the process definition key forward unchanged")
+        .isEqualTo(PROCESS_DEFINITION_KEY);
+    assertThat(followUp.getAgentInstanceKey())
+        .as("the follow-up batch command must resume from the last completed agent instance key")
+        .isEqualTo(2L);
+
+    // and - no terminal COMPLETED event is written while agent instances remain
+    verify(stateWriter, never())
+        .appendFollowUpEvent(anyLong(), eq(AgentInstanceBatchIntent.COMPLETED), any());
+  }
+
+  @Test
+  void shouldRescheduleWhenCommandWriterHasNoCapacityForTheNextCommand() {
+    // given - two agent instances, but the command writer runs out of space after the first
+    insertAgentInstance(1L, PROCESS_INSTANCE_KEY);
+    insertAgentInstance(2L, PROCESS_INSTANCE_KEY);
+    when(commandWriter.canWriteCommandOfLength(anyInt())).thenReturn(true, false);
+    final var value =
+        new AgentInstanceBatchRecord()
+            .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+            .setProcessDefinitionKey(PROCESS_DEFINITION_KEY);
+
+    // when
+    createProcessor(100).processRecord(command(500L, value));
+
+    // then
+    verify(commandWriter, times(1))
+        .appendFollowUpCommand(anyLong(), eq(AgentInstanceIntent.COMPLETE), any());
+    verify(commandWriter).appendFollowUpCommand(eq(1L), eq(AgentInstanceIntent.COMPLETE), any());
+    verify(commandWriter)
+        .appendFollowUpCommand(eq(NEXT_BATCH_KEY), eq(AgentInstanceBatchIntent.COMPLETE), any());
+  }
+
+  @Test
+  void shouldReserveCapacityForTheFollowUpBatchCommandWhenCheckingCapacity() {
+    // given - the follow-up AGENT_INSTANCE_BATCH:COMPLETE command must always fit, even if the
+    // record batch is otherwise full right after the last visited agent instance
+    insertAgentInstance(1L, PROCESS_INSTANCE_KEY);
+    final var value =
+        new AgentInstanceBatchRecord()
+            .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+            .setProcessDefinitionKey(PROCESS_DEFINITION_KEY);
+    final var agentInstanceCommand =
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(1L)
+            .setProcessInstanceKey(PROCESS_INSTANCE_KEY);
+    final var followUpBatchCommandWorstCaseLength =
+        new AgentInstanceBatchRecord()
+            .setProcessInstanceKey(Long.MAX_VALUE)
+            .setProcessDefinitionKey(Long.MAX_VALUE)
+            .setAgentInstanceKey(Long.MAX_VALUE)
+            .getLength();
+
+    // when
+    createProcessor(100).processRecord(command(500L, value));
+
+    // then - the checked length reserves room for the self-chaining follow-up command on top of
+    // the agent instance command itself
+    verify(commandWriter)
+        .canWriteCommandOfLength(
+            agentInstanceCommand.getLength() + followUpBatchCommandWorstCaseLength);
+  }
+
+  @Test
+  void shouldWriteCompletedEventWhenProcessInstanceHasNoAgentInstances() {
+    // given - no agent instances stored for this process instance
+    final var value =
+        new AgentInstanceBatchRecord()
+            .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+            .setProcessDefinitionKey(PROCESS_DEFINITION_KEY);
+
+    // when
+    createProcessor(100).processRecord(command(500L, value));
+
+    // then
+    verify(commandWriter, never())
+        .appendFollowUpCommand(anyLong(), eq(AgentInstanceIntent.COMPLETE), any());
+    verify(commandWriter, never())
+        .appendFollowUpCommand(anyLong(), eq(AgentInstanceBatchIntent.COMPLETE), any());
+    verify(stateWriter)
+        .appendFollowUpEvent(eq(500L), eq(AgentInstanceBatchIntent.COMPLETED), eq(value));
+  }
+
+  @Test
+  void shouldResumeFromTheCursorCarriedByTheBatchCommand() {
+    // given - agent instance 1 was already completed in a previous cycle: its AGENT_INSTANCE:
+    // COMPLETE command was processed and AgentInstanceCompletedApplier deleted it from state
+    // before this follow-up AGENT_INSTANCE_BATCH:COMPLETE command could be processed, so only
+    // agent instance 2 remains for this cycle to visit
+    insertAgentInstance(2L, PROCESS_INSTANCE_KEY);
+    final var value =
+        new AgentInstanceBatchRecord()
+            .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+            .setProcessDefinitionKey(PROCESS_DEFINITION_KEY)
+            .setAgentInstanceKey(1L);
+
+    // when
+    createProcessor(100).processRecord(command(500L, value));
+
+    // then - iteration resumes just past the already-deleted cursor, at agent instance 2
+    verify(commandWriter).appendFollowUpCommand(eq(2L), eq(AgentInstanceIntent.COMPLETE), any());
+    verify(commandWriter, never())
+        .appendFollowUpCommand(eq(1L), eq(AgentInstanceIntent.COMPLETE), any());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceBatchCompleteSelfChainingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceBatchCompleteSelfChainingTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agentinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Kept separate from {@code AgentInstanceCompleteOnProcessInstanceLifecycleTest}, which relies on
+ * the default {@code agentInstanceCompletionBatchLimit} (20) — this class configures a small
+ * test-only limit so that completing more agent instances than that limit forces {@code
+ * AgentInstanceBatchCompleteProcessor} to self-chain multiple {@code
+ * AgentInstanceBatchIntent.COMPLETE} cycles, mirroring {@code ExpireMessageSelfChainingTest} for
+ * {@code MessageBatch}.
+ */
+public final class AgentInstanceBatchCompleteSelfChainingTest {
+
+  private static final int BATCH_LIMIT = 2;
+  private static final int AGENT_INSTANCE_COUNT = 5;
+  private static final String PROCESS_ID = "agent-instance-batch-complete-process";
+  private static final String AGENT_TASK_ID = "agent-task";
+  private static final String AGENT_JOB_TYPE =
+      JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX + "-batch-complete-self-chaining-test";
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withEngineConfig(cfg -> cfg.setAgentInstanceCompletionBatchLimit(BATCH_LIMIT));
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldSelfChainAgentInstanceBatchCompleteWhenExceedingBatchLimit() {
+    // given — a single process instance with AGENT_INSTANCE_COUNT (5) parallel agentic service
+    // task iterations, each carrying its own agent instance, so that completing the process
+    // instance must complete more agent instances than BATCH_LIMIT (2) allows per cycle
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    AGENT_TASK_ID,
+                    task ->
+                        task.zeebeJobType(AGENT_JOB_TYPE)
+                            .multiInstance(
+                                mi ->
+                                    mi.parallel()
+                                        .zeebeInputCollectionExpression("=[1,2,3,4,5]")
+                                        .zeebeInputElement("item")))
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final List<Long> elementInstanceKeys =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(AGENT_TASK_ID)
+            .limit(AGENT_INSTANCE_COUNT)
+            .map(Record::getKey)
+            .toList();
+    final List<Long> agentInstanceKeys =
+        elementInstanceKeys.stream()
+            .map(
+                elementInstanceKey ->
+                    ENGINE
+                        .agentInstances()
+                        .withElementInstanceKey(elementInstanceKey)
+                        .create()
+                        .getKey())
+            .toList();
+
+    // when — every agentic job completes, letting the multi-instance body, and in turn the
+    // process instance, complete
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withType(AGENT_JOB_TYPE)
+                .limit(AGENT_INSTANCE_COUNT)
+                .count())
+        .as("all %d agentic jobs are created before they are activated", AGENT_INSTANCE_COUNT)
+        .isEqualTo(AGENT_INSTANCE_COUNT);
+    final var jobBatch =
+        ENGINE
+            .jobs()
+            .withType(AGENT_JOB_TYPE)
+            .withMaxJobsToActivate(AGENT_INSTANCE_COUNT)
+            .activate();
+    jobBatch.getValue().getJobKeys().forEach(jobKey -> ENGINE.job().withKey(jobKey).complete());
+
+    // then — completing 5 agent instances with a batch limit of 2 must take exactly 3 self-chained
+    // cycles: 2, then 2, then the final 1, followed by a single terminal COMPLETED
+    assertThat(
+            RecordingExporter.agentInstanceBatchRecords(AgentInstanceBatchIntent.COMPLETE)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(3)
+                .count())
+        .as(
+            "completing %d agent instances with a batch limit of %d requires exactly 3"
+                + " self-chained AGENT_INSTANCE_BATCH:COMPLETE commands (2, 2, then 1)",
+            AGENT_INSTANCE_COUNT, BATCH_LIMIT)
+        .isEqualTo(3);
+    assertThat(
+            RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(AGENT_INSTANCE_COUNT)
+                .map(Record::getKey))
+        .as("every one of the %d agent instances reaches COMPLETED", AGENT_INSTANCE_COUNT)
+        .containsExactlyInAnyOrderElementsOf(agentInstanceKeys);
+    assertThat(
+            RecordingExporter.agentInstanceBatchRecords(AgentInstanceBatchIntent.COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .as("a single terminal AGENT_INSTANCE_BATCH:COMPLETED is written once exhausted")
+        .isTrue();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/agentinstance/AgentInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/agentinstance/AgentInstanceStateTest.java
@@ -16,6 +16,8 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
+import java.util.ArrayList;
+import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Rule;
@@ -170,5 +172,151 @@ public final class AgentInstanceStateTest {
   public void shouldNoOpOnDeleteOfMissingRecord() {
     // given / when / then
     assertThatCode(() -> agentInstanceState.delete(9999L)).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void shouldVisitAgentInstanceKeysInAscendingOrder() {
+    // given
+    final long processInstanceKey = 100L;
+    final long firstAgentInstanceKey = 1L;
+    final long secondAgentInstanceKey = 2L;
+    final long thirdAgentInstanceKey = 3L;
+    insertAgentInstance(thirdAgentInstanceKey, processInstanceKey);
+    insertAgentInstance(firstAgentInstanceKey, processInstanceKey);
+    insertAgentInstance(secondAgentInstanceKey, processInstanceKey);
+
+    // when
+    final List<Long> visited = new ArrayList<>();
+    final var hasMore =
+        agentInstanceState.visitAgentInstanceKeysByProcessInstanceKey(
+            processInstanceKey,
+            -1L,
+            key -> {
+              visited.add(key);
+              return true;
+            });
+
+    // then
+    assertThat(visited)
+        .describedAs("agent instance keys are visited in ascending key order")
+        .containsExactly(firstAgentInstanceKey, secondAgentInstanceKey, thirdAgentInstanceKey);
+    assertThat(hasMore)
+        .describedAs("no more keys remain once the visitor accepted all of them")
+        .isFalse();
+  }
+
+  @Test
+  public void shouldReportHasMoreWhenVisitorStopsEarly() {
+    // given
+    final long processInstanceKey = 100L;
+    final long firstAgentInstanceKey = 1L;
+    final long secondAgentInstanceKey = 2L;
+    insertAgentInstance(firstAgentInstanceKey, processInstanceKey);
+    insertAgentInstance(secondAgentInstanceKey, processInstanceKey);
+
+    // when
+    final List<Long> visited = new ArrayList<>();
+    final var hasMore =
+        agentInstanceState.visitAgentInstanceKeysByProcessInstanceKey(
+            processInstanceKey,
+            -1L,
+            key -> {
+              visited.add(key);
+              return false;
+            });
+
+    // then
+    assertThat(visited)
+        .describedAs("iteration stops as soon as the visitor returns false")
+        .containsExactly(firstAgentInstanceKey);
+    assertThat(hasMore)
+        .describedAs("keys remain unvisited beyond the one the visitor accepted")
+        .isTrue();
+  }
+
+  @Test
+  public void shouldResumeIterationAtStartAtAgentInstanceKey() {
+    // given
+    final long processInstanceKey = 100L;
+    final long firstAgentInstanceKey = 1L;
+    final long secondAgentInstanceKey = 2L;
+    final long thirdAgentInstanceKey = 3L;
+    insertAgentInstance(firstAgentInstanceKey, processInstanceKey);
+    insertAgentInstance(secondAgentInstanceKey, processInstanceKey);
+    insertAgentInstance(thirdAgentInstanceKey, processInstanceKey);
+
+    // when
+    final List<Long> visited = new ArrayList<>();
+    final var hasMore =
+        agentInstanceState.visitAgentInstanceKeysByProcessInstanceKey(
+            processInstanceKey,
+            secondAgentInstanceKey,
+            key -> {
+              visited.add(key);
+              return true;
+            });
+
+    // then
+    assertThat(visited)
+        .describedAs("iteration resumes at startAtAgentInstanceKey (inclusive)")
+        .containsExactly(secondAgentInstanceKey, thirdAgentInstanceKey);
+    assertThat(hasMore).isFalse();
+  }
+
+  @Test
+  public void shouldResumeJustAfterADeletedStartAtAgentInstanceKey() {
+    // given
+    final long processInstanceKey = 100L;
+    final long deletedAgentInstanceKey = 1L;
+    final long remainingAgentInstanceKey = 2L;
+    insertAgentInstance(deletedAgentInstanceKey, processInstanceKey);
+    insertAgentInstance(remainingAgentInstanceKey, processInstanceKey);
+    agentInstanceState.delete(deletedAgentInstanceKey);
+
+    // when
+    final List<Long> visited = new ArrayList<>();
+    final var hasMore =
+        agentInstanceState.visitAgentInstanceKeysByProcessInstanceKey(
+            processInstanceKey,
+            deletedAgentInstanceKey,
+            key -> {
+              visited.add(key);
+              return true;
+            });
+
+    // then
+    assertThat(visited)
+        .describedAs("iteration resumes just after a startAtAgentInstanceKey that no longer exists")
+        .containsExactly(remainingAgentInstanceKey);
+    assertThat(hasMore).isFalse();
+  }
+
+  @Test
+  public void shouldNotVisitAnyKeysWhenProcessInstanceHasNoAgentInstances() {
+    // given / when
+    final List<Long> visited = new ArrayList<>();
+    final var hasMore =
+        agentInstanceState.visitAgentInstanceKeysByProcessInstanceKey(
+            9999L,
+            -1L,
+            key -> {
+              visited.add(key);
+              return true;
+            });
+
+    // then
+    assertThat(visited).isEmpty();
+    assertThat(hasMore)
+        .describedAs("no keys to visit means nothing is left to resume from")
+        .isFalse();
+  }
+
+  private void insertAgentInstance(final long agentInstanceKey, final long processInstanceKey) {
+    agentInstanceState.insert(
+        agentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.INITIALIZING));
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -128,6 +128,7 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
       case GLOBAL_LISTENER -> index.globalListener;
       case AGENT_INSTANCE -> index.agentInstance;
       case AGENT_HISTORY -> index.agentHistory;
+      case AGENT_INSTANCE_BATCH -> index.agentInstanceBatch;
       default -> false;
     };
   }
@@ -266,6 +267,7 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
 
     public boolean agentInstance = true;
     public boolean agentHistory = true;
+    public boolean agentInstanceBatch = false;
 
     // index settings
     private Integer numberOfShards = null;

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
@@ -220,6 +220,9 @@ public class ElasticsearchExporterSchemaManager {
       if (index.agentHistory) {
         createValueIndexTemplate(ValueType.AGENT_HISTORY, version);
       }
+      if (index.agentInstanceBatch) {
+        createValueIndexTemplate(ValueType.AGENT_INSTANCE_BATCH, version);
+      }
     }
 
     indexTemplatesCreated.add(version);

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-batch-template.json
@@ -1,0 +1,36 @@
+{
+  "index_patterns": [
+    "zeebe-record_agent-instance-batch_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 1,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-agent-instance-batch": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "processInstanceKey": {
+              "type": "long"
+            },
+            "processDefinitionKey": {
+              "type": "long"
+            },
+            "agentInstanceKey": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -87,6 +87,7 @@ final class TestSupport {
       case GLOBAL_LISTENER -> config.globalListener = value;
       case AGENT_INSTANCE -> config.agentInstance = value;
       case AGENT_HISTORY -> config.agentHistory = value;
+      case AGENT_INSTANCE_BATCH -> config.agentInstanceBatch = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -173,6 +173,7 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
       case GLOBAL_LISTENER -> index.globalListener;
       case AGENT_INSTANCE -> index.agentInstance;
       case AGENT_HISTORY -> index.agentHistory;
+      case AGENT_INSTANCE_BATCH -> index.agentInstanceBatch;
       default -> false;
     };
   }
@@ -295,6 +296,7 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
 
     public boolean agentInstance = true;
     public boolean agentHistory = true;
+    public boolean agentInstanceBatch = false;
 
     // index settings
     private Integer numberOfShards = null;

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterSchemaManager.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterSchemaManager.java
@@ -194,6 +194,9 @@ public class OpensearchExporterSchemaManager {
       if (index.agentHistory) {
         createValueIndexTemplate(ValueType.AGENT_HISTORY, version);
       }
+      if (index.agentInstanceBatch) {
+        createValueIndexTemplate(ValueType.AGENT_INSTANCE_BATCH, version);
+      }
     }
 
     indexTemplatesCreated.add(version);

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-batch-template.json
@@ -1,0 +1,42 @@
+{
+  "index_patterns": [
+    "zeebe-record_agent-instance-batch_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "index": {
+        "number_of_shards": "1",
+        "number_of_replicas": "1",
+        "queries": {
+          "cache": {
+            "enabled": false
+          }
+        }
+      }
+    },
+    "aliases": {
+      "zeebe-record-agent-instance-batch": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "processInstanceKey": {
+              "type": "long"
+            },
+            "processDefinitionKey": {
+              "type": "long"
+            },
+            "agentInstanceKey": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -88,6 +88,7 @@ final class TestSupport {
       case GLOBAL_LISTENER -> config.globalListener = value;
       case AGENT_INSTANCE -> config.agentInstance = value;
       case AGENT_HISTORY -> config.agentHistory = value;
+      case AGENT_INSTANCE_BATCH -> config.agentInstanceBatch = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.AsyncRequestRecord;
 import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
@@ -231,6 +232,7 @@ public class UnifiedRecordValue extends UnpackedObject implements RecordValue {
       case ValueType.GLOBAL_LISTENER -> new GlobalListenerRecord();
       case ValueType.AGENT_HISTORY -> new AgentHistoryRecord();
       case ValueType.AGENT_INSTANCE -> new AgentInstanceRecord();
+      case ValueType.AGENT_INSTANCE_BATCH -> new AgentInstanceBatchRecord();
       case ValueType.SECRET_REFERENCE -> new SecretReferenceRecord();
       case ValueType.SBE_UNKNOWN -> null;
       case ValueType.NULL_VAL -> null;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceBatchRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceBatchRecord.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.agentinstance;
+
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceBatchRecordValue;
+
+public final class AgentInstanceBatchRecord extends UnifiedRecordValue
+    implements AgentInstanceBatchRecordValue {
+
+  private final LongProperty processInstanceKeyProperty = new LongProperty("processInstanceKey");
+  private final LongProperty processDefinitionKeyProperty =
+      new LongProperty("processDefinitionKey", -1L);
+
+  /**
+   * The agent instance key to resume iteration from on the next batch cycle. Defaults to {@code -1}
+   * to signal that iteration should start from the beginning.
+   */
+  private final LongProperty agentInstanceKeyProperty = new LongProperty("agentInstanceKey", -1L);
+
+  public AgentInstanceBatchRecord() {
+    super(3);
+    declareProperty(processInstanceKeyProperty)
+        .declareProperty(processDefinitionKeyProperty)
+        .declareProperty(agentInstanceKeyProperty);
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProperty.getValue();
+  }
+
+  public AgentInstanceBatchRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProperty.setValue(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKeyProperty.getValue();
+  }
+
+  public AgentInstanceBatchRecord setProcessDefinitionKey(final long processDefinitionKey) {
+    processDefinitionKeyProperty.setValue(processDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public long getAgentInstanceKey() {
+    return agentInstanceKeyProperty.getValue();
+  }
+
+  public AgentInstanceBatchRecord setAgentInstanceKey(final long agentInstanceKey) {
+    agentInstanceKeyProperty.setValue(agentInstanceKey);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProce
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryEmbeddedToolCall;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceTool;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
@@ -5154,6 +5155,37 @@ final class JsonSerializableToJsonTest {
           "metrics": { "inputTokens": 0, "outputTokens": 0, "modelCalls": 0, "toolCalls": 0 },
           "tools": [],
           "changedAttributes": []
+        }
+        """
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////////// AgentInstanceBatchRecord /////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "AgentInstanceBatchRecord",
+        (Supplier<UnifiedRecordValue>)
+            () ->
+                new AgentInstanceBatchRecord()
+                    .setProcessInstanceKey(2251799813685248L)
+                    .setProcessDefinitionKey(2251799813685100L)
+                    .setAgentInstanceKey(2251799813685251L),
+        """
+        {
+          "processInstanceKey": 2251799813685248,
+          "processDefinitionKey": 2251799813685100,
+          "agentInstanceKey": 2251799813685251
+        }
+        """
+      },
+      {
+        "Empty AgentInstanceBatchRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> new AgentInstanceBatchRecord().setProcessInstanceKey(123L),
+        """
+        {
+          "processInstanceKey": 123,
+          "processDefinitionKey": -1,
+          "agentInstanceKey": -1
         }
         """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceBatchRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceBatchRecord.golden
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.agentinstance;
+
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceBatchRecordValue;
+
+public final class AgentInstanceBatchRecord extends UnifiedRecordValue
+    implements AgentInstanceBatchRecordValue {
+
+  private final LongProperty processInstanceKeyProperty = new LongProperty("processInstanceKey");
+  private final LongProperty processDefinitionKeyProperty =
+      new LongProperty("processDefinitionKey", -1L);
+
+  /**
+   * The agent instance key to resume iteration from on the next batch cycle. Defaults to {@code -1}
+   * to signal that iteration should start from the beginning.
+   */
+  private final LongProperty agentInstanceKeyProperty = new LongProperty("agentInstanceKey", -1L);
+
+  public AgentInstanceBatchRecord() {
+    super(3);
+    declareProperty(processInstanceKeyProperty)
+        .declareProperty(processDefinitionKeyProperty)
+        .declareProperty(agentInstanceKeyProperty);
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProperty.getValue();
+  }
+
+  public AgentInstanceBatchRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProperty.setValue(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKeyProperty.getValue();
+  }
+
+  public AgentInstanceBatchRecord setProcessDefinitionKey(final long processDefinitionKey) {
+    processDefinitionKeyProperty.setValue(processDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public long getAgentInstanceKey() {
+    return agentInstanceKeyProperty.getValue();
+  }
+
+  public AgentInstanceBatchRecord setAgentInstanceKey(final long agentInstanceKey) {
+    agentInstanceKeyProperty.setValue(agentInstanceKey);
+    return this;
+  }
+}

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ImplRecordValuePopulator.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ImplRecordValuePopulator.java
@@ -21,6 +21,8 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.ValueTypeMapping;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -105,7 +107,7 @@ final class ImplRecordValuePopulator {
       if (typeArgs.length > 0
           && typeArgs[0] instanceof final Class<?> enumClass
           && enumClass.isEnum()) {
-        final Object[] enumConstants = enumClass.getEnumConstants();
+        final Object[] enumConstants = enumConstantsFor(enumClass);
         if (enumConstants.length > 0) {
           final Object randomEnum = enumConstants[random.nextInt(enumConstants.length)];
           final EnumProperty enumProperty = (EnumProperty<?>) field.get(implInstance);
@@ -113,6 +115,19 @@ final class ImplRecordValuePopulator {
         }
       }
     }
+  }
+
+  /**
+   * Returns the constants to randomly pick from for the given enum type. For {@link ValueType},
+   * this excludes {@link ValueType#NULL_VAL} and {@link ValueType#SBE_UNKNOWN}, as these are
+   * synthetic placeholder values created by SBE and are never valid on an actual record - picking
+   * one here would produce a record value with an inner value type that no consumer can handle.
+   */
+  private static Object[] enumConstantsFor(final Class<?> enumClass) {
+    if (enumClass == ValueType.class) {
+      return ValueTypeMapping.getAcceptedValueTypes().toArray();
+    }
+    return enumClass.getEnumConstants();
   }
 
   private static void populateStringProperty(

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.AsyncRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
@@ -89,6 +90,7 @@ import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.AsyncRequestRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
@@ -393,6 +395,9 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.AGENT_INSTANCE,
         new Mapping<>(AgentInstanceRecordValue.class, AgentInstanceIntent.class));
+    mapping.put(
+        ValueType.AGENT_INSTANCE_BATCH,
+        new Mapping<>(AgentInstanceBatchRecordValue.class, AgentInstanceBatchIntent.class));
     mapping.put(
         ValueType.AGENT_HISTORY,
         new Mapping<>(AgentHistoryRecordValue.class, AgentHistoryIntent.class));

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AgentInstanceBatchIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AgentInstanceBatchIntent.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum AgentInstanceBatchIntent implements Intent {
+  COMPLETE(0, false),
+  COMPLETED(1, true);
+
+  private final short value;
+  private final boolean event;
+
+  AgentInstanceBatchIntent(final int value, final boolean event) {
+    this.value = (short) value;
+    this.event = event;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    return event;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return COMPLETE;
+      case 1:
+        return COMPLETED;
+      default:
+        return UNKNOWN;
+    }
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -53,6 +53,7 @@ public interface Intent {
     map.put(ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION, AdHocSubProcessInstructionIntent.class);
     map.put(ValueType.AGENT_HISTORY, AgentHistoryIntent.class);
     map.put(ValueType.AGENT_INSTANCE, AgentInstanceIntent.class);
+    map.put(ValueType.AGENT_INSTANCE_BATCH, AgentInstanceBatchIntent.class);
     map.put(ValueType.ASYNC_REQUEST, AsyncRequestIntent.class);
     map.put(ValueType.AUTHORIZATION, AuthorizationIntent.class);
     map.put(ValueType.BATCH_OPERATION_CHUNK, BatchOperationChunkIntent.class);

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceBatchRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceBatchRecordValue.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+/**
+ * Represents a batch action performed for the agent instances of a process instance: completing
+ * every agent instance still associated with a process instance that has ended. Instead of writing
+ * a COMPLETE command for every agent instance in one go, this command batches that work into
+ * smaller chunks, following the same approach as {@link ProcessInstanceBatchRecordValue}.
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableAgentInstanceBatchRecordValue.Builder.class)
+public interface AgentInstanceBatchRecordValue extends RecordValue, ProcessInstanceRelated {
+
+  /**
+   * @return the agent instance key to resume iteration from on the next batch cycle, or {@code -1}
+   *     if iteration should start from the beginning (there is no previous cycle to resume from)
+   */
+  long getAgentInstanceKey();
+}

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -100,6 +100,7 @@
       <validValue name="PROCESS_INSTANCE_BUSINESS_ID">74</validValue>
       <validValue name="SECRET_REFERENCE">75</validValue>
       <validValue name="PROCESS_INSTANCE_BUFFERED_COMMAND">76</validValue>
+      <validValue name="AGENT_INSTANCE_BATCH">77</validValue>
 
       <!-- Management records / record not related to process automation -->
       <!-- value 252 was used for "REDISTRIBUTION, do not use-->

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
@@ -57,6 +57,8 @@ final class IntentEncodingDecodingTest {
     result.addAll(buildParameterSets(AgentHistoryIntent.class, AgentHistoryIntent::from));
     result.addAll(buildParameterSets(AgentInstanceIntent.class, AgentInstanceIntent::from));
     result.addAll(
+        buildParameterSets(AgentInstanceBatchIntent.class, AgentInstanceBatchIntent::from));
+    result.addAll(
         buildParameterSets(
             AdHocSubProcessInstructionIntent.class, AdHocSubProcessInstructionIntent::from));
     result.addAll(buildParameterSets(AsyncRequestIntent.class, AsyncRequestIntent::from));

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AgentInstanceBatchRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AgentInstanceBatchRecordStream.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceBatchRecordValue;
+import java.util.stream.Stream;
+
+public final class AgentInstanceBatchRecordStream
+    extends ExporterRecordStream<AgentInstanceBatchRecordValue, AgentInstanceBatchRecordStream> {
+
+  public AgentInstanceBatchRecordStream(
+      final Stream<Record<AgentInstanceBatchRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected AgentInstanceBatchRecordStream supply(
+      final Stream<Record<AgentInstanceBatchRecordValue>> wrappedStream) {
+    return new AgentInstanceBatchRecordStream(wrappedStream);
+  }
+
+  public AgentInstanceBatchRecordStream withProcessInstanceKey(final long processInstanceKey) {
+    return valueFilter(v -> v.getProcessInstanceKey() == processInstanceKey);
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -76,6 +76,7 @@ import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.AsyncRequestRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
@@ -346,6 +347,7 @@ public class CompactRecordLogger {
     valueLoggers.put(ValueType.GLOBAL_LISTENER, this::summarizeGlobalListener);
     valueLoggers.put(RESOURCE_REEXPORT, this::summarizeResourceReexport);
     valueLoggers.put(ValueType.AGENT_INSTANCE, this::summarizeAgentInstance);
+    valueLoggers.put(ValueType.AGENT_INSTANCE_BATCH, this::summarizeAgentInstanceBatch);
     valueLoggers.put(ValueType.AGENT_HISTORY, this::summarizeAgentHistory);
     valueLoggers.put(ValueType.SECRET_REFERENCE, this::summarizeSecretReference);
   }
@@ -559,6 +561,20 @@ public class CompactRecordLogger {
               changedAttributes.stream()
                   .map(CompactRecordLogger::abbreviateToFirstLetters)
                   .toList());
+    }
+
+    return result.toString();
+  }
+
+  private String summarizeAgentInstanceBatch(final Record<?> record) {
+    final var value = (AgentInstanceBatchRecordValue) record.getValue();
+    final var result = new StringBuilder();
+
+    result.append(
+        summarizeProcessInformation(
+            value.getProcessDefinitionKey(), value.getProcessInstanceKey()));
+    if (value.getAgentInstanceKey() != -1) {
+      result.append(" next AI:").append(shortenKey(value.getAgentInstanceKey()));
     }
 
     return result.toString();

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
@@ -64,6 +65,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.AsyncRequestRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
@@ -354,6 +356,16 @@ public final class RecordingExporter implements Exporter {
 
   public static AgentInstanceRecordStream agentInstanceRecords(final AgentInstanceIntent intent) {
     return agentInstanceRecords().withIntent(intent);
+  }
+
+  public static AgentInstanceBatchRecordStream agentInstanceBatchRecords() {
+    return new AgentInstanceBatchRecordStream(
+        records(ValueType.AGENT_INSTANCE_BATCH, AgentInstanceBatchRecordValue.class));
+  }
+
+  public static AgentInstanceBatchRecordStream agentInstanceBatchRecords(
+      final AgentInstanceBatchIntent intent) {
+    return agentInstanceBatchRecords().withIntent(intent);
   }
 
   public static AgentHistoryRecordStream agentHistoryRecords() {


### PR DESCRIPTION
## Description

When a process instance completes, terminates, or is cancelled, the engine issues one `AgentInstance:COMPLETE` command per active agent instance to clean it up. For process instances with a very large number of agent instances, issuing this many individual follow-up commands/events in a single batch can push the record batch for that command past the `EXCEEDED_BATCH_RECORD_SIZE` rejection threshold, blocking process instance completion at scale.

This PR introduces an `AgentInstanceBatch:COMPLETE` -> `COMPLETED` command that completes agent instances belonging to a process instance in bounded chunks (`agentInstanceCompletionBatchLimit`, configurable via broker YAML, default `20`). The processor resumes from a cursor and self-chains a new `AgentInstanceBatch:COMPLETE` follow-up command until all agent instances for the process instance are completed, so the number of records written per processing round stays bounded regardless of how many agent instances exist on the process instance.

Key changes:
- New `AGENT_INSTANCE_BATCH` protocol value type, `AgentInstanceBatchIntent` (`COMPLETE`/`COMPLETED`), and `AgentInstanceBatchRecordValue`/`AgentInstanceBatchRecord`.
- `AgentInstanceBatch:COMPLETED` is a NOOP-applied event (no state changes; the underlying `AgentInstance:COMPLETE`/`COMPLETED` commands/events still own state transitions).
- `AgentInstanceState` gains a resumable key visitor (`visitAgentInstanceKeysByProcessInstanceKey`) to iterate agent instance keys for a process instance starting from an optional cursor.
- New `agentInstanceCompletionBatchLimit` engine configuration option, exposed via `zeebe.broker.experimental.engine.agentInstances` YAML config.
- New `AgentInstanceBatchCompleteProcessor` drives the bounded batching and self-chaining cycle.
- `AgentInstanceBehavior.completeAgentInstancesOfProcessInstance()` now issues a single `AgentInstanceBatch:COMPLETE` command instead of one `AgentInstance:COMPLETE` command per agent instance.
- Exporters (Elasticsearch/Opensearch) and `CompactRecordLogger` updated to support the new record type.

> [!NOTE]
> The `fix: exclude synthetic ValueType placeholders when randomizing nested value types` commit looks unrelated at first glance. Adding `AGENT_INSTANCE_BATCH` to `ValueType` shifted the fixed-seed random index that `ImplRecordValuePopulator` (in `zeebe-protocol-test-util`) uses to pick a nested value type for records like `CommandDistributionRecord`. That code never excluded the synthetic `NULL_VAL`/`SBE_UNKNOWN` placeholders (unlike everywhere else in `ProtocolFactory`), so the shift caused it to pick `SBE_UNKNOWN` as the nested value type, which the Elasticsearch/Opensearch exporter integration tests then failed to deserialize on read-back. This is a pre-existing latent bug in the shared test utility, exposed - not caused - by adding the new value type, so it's fixed here to keep CI green.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57562

