### PR TITLE
feat: dedicated job state for jobs waiting for secret resolution

### DIFF
--- a/zeebe/docs/adr/0007-810-job-waiting-for-secret-resolution-state.md
+++ b/zeebe/docs/adr/0007-810-job-waiting-for-secret-resolution-state.md
@@ -1,0 +1,157 @@
+# Job state for jobs waiting for secret resolution
+
+**DRI**: Berkay Can
+
+**Status**: Proposed (8.10)
+
+**Purpose**: Defines the persisted job state that marks a job as parked while its secret references
+are resolved in the background: which transitions write it, which commands it accepts, and what it
+means for state compatibility.
+
+**Audience**: Zeebe engineers working on job activation, the secret reference resolution flow, or
+job state, and AI agents reasoning about why a job is not handed out to a worker.
+
+## Context
+
+A job whose secret references are not in the broker's secret cache is not handed out on activation.
+The engine emits `SecretReference.RESOLUTION_REQUESTED`, resolves the references in the background,
+and hands the job out once they are resolved (see [#57846](https://github.com/camunda/camunda/issues/57846)
+and [#57852](https://github.com/camunda/camunda/issues/57852)). Until then the job is parked.
+
+Parking was implemented by removing the job from the activatable index (`JOB_ACTIVATABLE_BY_PRIORITY`)
+while leaving its job state at `ACTIVATABLE`. The waiting condition therefore existed only as the
+absence of an index entry, which has three consequences:
+
+- `DbJobState.updateJobPriority` re-inserts a job into the activatable index when its state is
+  `ACTIVATABLE`, so an `UpdateJob` command that changes the priority of a parked job un-parks it.
+  The job is then handed out with unresolved placeholders in its variables.
+- The reactivation path (`MutableJobState.makeActivatableAfterSecretResolution`) can only document
+  its precondition ("call this on a parked job") in Javadoc. Nothing in the state can be checked, so
+  a caller that reactivates an already-reactivated job silently upserts an index entry instead of
+  being recognised as a no-op.
+- An operator debugging an incident cannot tell a parked job from an activatable one, because both
+  report `ACTIVATABLE`.
+
+The secret reference state already keeps a waiting-jobs index (`(storeId, secretReference) -> jobKey`),
+but it does not answer "is this job parked". Its entry is removed when a permanent resolution failure
+raises an incident for the job, while the job stays parked until the incident is resolved.
+
+## Decision
+
+Add a constant to the persisted `JobState.State` enum:
+
+```java
+WAITING_FOR_SECRET_RESOLUTION((byte) 5)
+```
+
+### Transitions
+
+|              From               |               To                |                                       Written by                                       |
+|---------------------------------|---------------------------------|----------------------------------------------------------------------------------------|
+| `ACTIVATABLE`                   | `WAITING_FOR_SECRET_RESOLUTION` | `SecretReferenceResolutionRequestedApplier` (parking, together with the index removal) |
+| `WAITING_FOR_SECRET_RESOLUTION` | `ACTIVATABLE`                   | `SecretReferenceBatchJobsReactivatedApplier` (all references resolved)                 |
+| `WAITING_FOR_SECRET_RESOLUTION` | `ACTIVATABLE`                   | `IncidentResolvedV4Applier` (a `SECRET_RESOLUTION_ERROR` incident is resolved)         |
+| `WAITING_FOR_SECRET_RESOLUTION` | (job deleted)                   | `JobCanceledV4Applier`, when the element instance or process instance is terminated    |
+
+Parking is the only writer of the new state, and reactivation is its only exit besides deletion. A
+job is never activated, failed, or completed out of it.
+
+### The reactivation precondition is enforced by the state, not documented
+
+`makeActivatableAfterSecretResolution` acts only on a job in `WAITING_FOR_SECRET_RESOLUTION` and
+returns silently otherwise. This replaces both the Javadoc precondition and the caller-side state
+check in `IncidentResolvedV4Applier`.
+
+The guard is a silent skip rather than an exception because a job can legitimately be reactivated
+twice. A job waiting on two references A and B, both of which resolve, is reactivated by the
+`BATCH_JOBS_REACTIVATED` event of A (B is no longer pending at that point, its own reactivation
+command is only queued), and the event of B then calls the method again on a job that is already
+`ACTIVATABLE`. An exception thrown from an event applier is unrecoverable, it fails the partition,
+so a state that the guard rejects must be a no-op.
+
+The eligibility check that keeps an incident-parked job parked stays in the reactivation applier: a
+job with a `SECRET_RESOLUTION_ERROR` incident is in `WAITING_FOR_SECRET_RESOLUTION` like any other
+parked job, so the state alone cannot express it.
+
+### Command surface
+
+|                     Command                     |                           On a parked job                           |
+|-------------------------------------------------|---------------------------------------------------------------------|
+| `CompleteJob`, `FailJob`, `ThrowError`, `Yield` | rejected, `INVALID_STATE`, naming the state in the rejection reason |
+| `UpdateJob` (retries, priority)                 | accepted                                                            |
+| `UpdateJob` (timeout)                           | rejected, the job has no deadline while parked (unchanged)          |
+| `CancelJob`, process instance termination       | accepted, the job is deleted                                        |
+
+Rejecting the worker lifecycle commands follows from leaving the new state out of the valid-state
+lists of their processors. A parked job was withheld from every worker on purpose, so a command that
+claims to act on an activation of it cannot be honoured.
+
+This is a visible behaviour change for one case: a worker whose activation timed out could complete
+the job late while it was `ACTIVATABLE`, and now gets `INVALID_STATE` if the job was parked again in
+the meantime (its secret value expired from the cache before the next activation). The work of that
+activation is lost and the job is handed out again once its references resolve, which is the same
+outcome as any other lost race between a timed-out worker and a new activation.
+
+A priority update is accepted and updates the job record only. The re-insert into the activatable
+index is skipped because it is conditional on the `ACTIVATABLE` state, so the job stays parked and is
+inserted with its new priority when it is reactivated.
+
+### Persistence and compatibility
+
+The enum is persisted in the `JOB_STATES` column family, encoded by name (`EnumValue` writes
+`Enum.toString`). It never reaches the log, the protocol, exported records, or secondary storage, so
+adding a constant is not a record schema change and needs no protocol version handling.
+
+An older broker reading state written by a newer one would fail on `Enum.valueOf`, so the constant
+follows the general no-downgrade rule for 8.10 state. Reading older state is unaffected: no existing
+entry carries the new name.
+
+The two event appliers whose logic changes (`SecretReferenceResolutionRequestedApplier` and the
+`SECRET_RESOLUTION_ERROR` branch of `IncidentResolvedV4Applier`) are updated in place, with their
+golden files regenerated, instead of being registered as new versions. Both were merged after the
+`8.10.0-alpha4` release candidates were cut and are contained in no release tag, so no cluster can
+have replayed them.
+
+## Alternatives considered
+
+- **Keep the absence of an index entry as the waiting marker.** Rejected. Absence is not specific to
+  parking: every job that is not activatable (activated, failed, backing off, error thrown) is absent
+  from the index too, so a caller that finds no entry learns nothing about why. Reconstructing the
+  composite index key from the job record to probe it is possible but answers the wrong question,
+  which is what makes the priority-update bug and the unenforceable reactivation precondition
+  possible in the first place.
+- **Treat the waiting-jobs index in the secret reference state as the marker.** Rejected. It answers
+  "which jobs wait on this reference", not "is this job parked": the entry is removed when a
+  permanent failure raises an incident, while the job stays parked. Consulting it from job state
+  would also couple two states on the hot activation and update paths.
+- **Reuse `FAILED`.** Rejected. `FAILED` carries retry and backoff semantics, participates in the
+  backoff index and in incident resolution, and would make a parked job indistinguishable from a job
+  that a worker failed.
+- **Throw when the reactivation path sees an unexpected state.** Rejected, see above: the
+  double-reactivation path is legitimate and an exception in an applier fails the partition.
+- **Reject `UpdateJob` on a parked job as well.** Rejected. It would fix the un-parking bug by
+  refusing the command instead of by state, and an operator re-prioritising queued work has no reason
+  to be blocked by a pending secret resolution.
+
+## Consequences
+
+- `JobState.State` is no longer a pure lifecycle enum, it also carries a parked-ness that only the
+  secret resolution flow produces. A second reason to park a job would either reuse this constant
+  with the wrong name or add another one.
+- Every future `switch` over `JobState.State` has to answer what a parked job means. The two existing
+  ones (`JobTimeOutProcessor`, `JobRecurAfterBackoffProcessor`) reject with a reason that names the
+  wait.
+- A parked job is distinguishable from an activatable one in the engine's own state, which is what
+  makes it possible to explain a job that is not handed out. Parking is still invisible in exported
+  records: nothing about it reaches secondary storage.
+- Downgrading a broker that has parked at least one job is not possible, in line with the general
+  8.10 state compatibility rule.
+
+## Source
+
+- [Introduce a dedicated job state for jobs waiting for secret resolution (camunda/camunda#58993)](https://github.com/camunda/camunda/issues/58993)
+- [Park jobs and request resolution on activation (camunda/camunda#57846)](https://github.com/camunda/camunda/issues/57846)
+- [Reactivate jobs after secret resolution (camunda/camunda#57852)](https://github.com/camunda/camunda/issues/57852)
+- [Phase 1: resolve secrets for job activation (epic camunda/camunda#56556)](https://github.com/camunda/camunda/issues/56556)
+- [Review discussion that raised it (camunda/camunda#58587)](https://github.com/camunda/camunda/pull/58587#discussion_r3665621244)
+

--- a/zeebe/docs/adr/0007-810-job-waiting-for-secret-resolution-state.md
+++ b/zeebe/docs/adr/0007-810-job-waiting-for-secret-resolution-state.md
@@ -84,13 +84,13 @@ parked job, so the state alone cannot express it.
 
 ### Command surface
 
-|                     Command                     |                           On a parked job                           |
-|-------------------------------------------------|---------------------------------------------------------------------|
-| `CompleteJob`, `FailJob`, `ThrowError`          | rejected, `INVALID_STATE`, naming the state in the rejection reason |
-| `Yield`                                         | rejected, `INVALID_STATE` (unchanged, it needs `ACTIVATED`)         |
-| `UpdateJob` (retries, priority)                 | accepted                                                            |
-| `UpdateJob` (timeout)                           | rejected, the job has no deadline while parked (unchanged)          |
-| `CancelJob`, process instance termination       | accepted, the job is deleted                                        |
+|                  Command                  |                           On a parked job                           |
+|-------------------------------------------|---------------------------------------------------------------------|
+| `CompleteJob`, `FailJob`, `ThrowError`    | rejected, `INVALID_STATE`, naming the state in the rejection reason |
+| `Yield`                                   | rejected, `INVALID_STATE` (unchanged, it needs `ACTIVATED`)         |
+| `UpdateJob` (retries, priority)           | accepted                                                            |
+| `UpdateJob` (timeout)                     | rejected, the job has no deadline while parked (unchanged)          |
+| `CancelJob`, process instance termination | accepted, the job is deleted                                        |
 
 Rejecting the worker lifecycle commands follows from leaving the new state out of the valid-state
 lists of their processors. A parked job was withheld from every worker on purpose, so a command that

--- a/zeebe/docs/adr/0007-810-job-waiting-for-secret-resolution-state.md
+++ b/zeebe/docs/adr/0007-810-job-waiting-for-secret-resolution-state.md
@@ -2,7 +2,7 @@
 
 **DRI**: Berkay Can
 
-**Status**: Proposed (8.10)
+**Status**: Accepted (8.10)
 
 **Purpose**: Defines the persisted job state that marks a job as parked while its secret references
 are resolved in the background: which transitions write it, which commands it accepts, and what it
@@ -75,8 +75,8 @@ The guard is a silent skip rather than an exception because a job can legitimate
 twice. A job waiting on two references A and B, both of which resolve, is reactivated by the
 `BATCH_JOBS_REACTIVATED` event of A (B is no longer pending at that point, its own reactivation
 command is only queued), and the event of B then calls the method again on a job that is already
-`ACTIVATABLE`. An exception thrown from an event applier is unrecoverable, it fails the partition,
-so a state that the guard rejects must be a no-op.
+`ACTIVATABLE`. An exception thrown from an event applier bans the process instance, or fails the
+partition when it happens on replay, so a state that the guard rejects must be a no-op.
 
 The eligibility check that keeps an incident-parked job parked stays in the reactivation applier: a
 job with a `SECRET_RESOLUTION_ERROR` incident is in `WAITING_FOR_SECRET_RESOLUTION` like any other
@@ -116,10 +116,6 @@ An older broker reading state written by a newer one would fail on `Enum.valueOf
 follows the general no-downgrade rule for 8.10 state. Reading older state is unaffected: no existing
 entry carries the new name.
 
-The applier logic this changes is updated in place, with the golden files regenerated, instead of
-being registered as new versions: the whole secret resolution flow is 8.10 development that no minor
-release has shipped yet, so there is no released replay behaviour to preserve.
-
 ## Alternatives considered
 
 - **Keep the absence of an index entry as the waiting marker.** Rejected. Absence is not specific to
@@ -136,7 +132,8 @@ release has shipped yet, so there is no released replay behaviour to preserve.
   backoff index and in incident resolution, and would make a parked job indistinguishable from a job
   that a worker failed.
 - **Throw when the reactivation path sees an unexpected state.** Rejected, see above: the
-  double-reactivation path is legitimate and an exception in an applier fails the partition.
+  double-reactivation path is legitimate, and an exception in an applier bans the process instance or
+  fails the partition on replay.
 - **Reject `UpdateJob` on a parked job as well.** Rejected. It would fix the un-parking bug by
   refusing the command instead of by state, and an operator re-prioritising queued work has no reason
   to be blocked by a pending secret resolution.

--- a/zeebe/docs/adr/0007-810-job-waiting-for-secret-resolution-state.md
+++ b/zeebe/docs/adr/0007-810-job-waiting-for-secret-resolution-state.md
@@ -106,11 +106,13 @@ An older broker reading state written by a newer one would fail on `Enum.valueOf
 follows the general no-downgrade rule for 8.10 state. Reading older state is unaffected: no existing
 entry carries the new name.
 
-The two event appliers whose logic changes (`SecretReferenceResolutionRequestedApplier` and the
+The two pieces of applier logic that change (`SecretReferenceResolutionRequestedApplier` and the
 `SECRET_RESOLUTION_ERROR` branch of `IncidentResolvedV4Applier`) are updated in place, with their
 golden files regenerated, instead of being registered as new versions. Both were merged after the
-`8.10.0-alpha4` release candidates were cut and are contained in no release tag, so no cluster can
-have replayed them.
+`8.10.0-alpha4` candidates were branched: the parking applier is contained in no release tag at all,
+and the incident branch was added to `IncidentResolvedV4Applier` (whose other branches did ship in
+those candidates) after that branch point. No released build ever applied either of them, so no
+cluster can have replayed them.
 
 ## Alternatives considered
 

--- a/zeebe/docs/adr/0007-810-job-waiting-for-secret-resolution-state.md
+++ b/zeebe/docs/adr/0007-810-job-waiting-for-secret-resolution-state.md
@@ -23,8 +23,11 @@ while leaving its job state at `ACTIVATABLE`. The waiting condition therefore ex
 absence of an index entry, which has three consequences:
 
 - `DbJobState.updateJobPriority` re-inserts a job into the activatable index when its state is
-  `ACTIVATABLE`, so an `UpdateJob` command that changes the priority of a parked job un-parks it.
-  The job is then handed out with unresolved placeholders in its variables.
+  `ACTIVATABLE`, so an `UpdateJob` command that changes the priority of a parked job un-parks it. The
+  job is then collected by every following activation, which skips it again for its still-uncached
+  reference, requests the resolution a second time and parks it again. Each of those skips also
+  consumes one of the activation's skip budget (`MAX_UNCACHED_SECRET_JOBS_SKIPPED_PER_ACTIVATION`),
+  so an un-parked job can truncate batches for the jobs behind it.
 - The reactivation path (`MutableJobState.makeActivatableAfterSecretResolution`) can only document
   its precondition ("call this on a parked job") in Javadoc. Nothing in the state can be checked, so
   a caller that reactivates an already-reactivated job silently upserts an index entry instead of
@@ -49,6 +52,7 @@ WAITING_FOR_SECRET_RESOLUTION((byte) 5)
 |              From               |               To                |                                       Written by                                       |
 |---------------------------------|---------------------------------|----------------------------------------------------------------------------------------|
 | `ACTIVATABLE`                   | `WAITING_FOR_SECRET_RESOLUTION` | `SecretReferenceResolutionRequestedApplier` (parking, together with the index removal) |
+| `WAITING_FOR_SECRET_RESOLUTION` | `WAITING_FOR_SECRET_RESOLUTION` | the same applier, for a job that waits on a second reference of the same activation    |
 | `WAITING_FOR_SECRET_RESOLUTION` | `ACTIVATABLE`                   | `SecretReferenceBatchJobsReactivatedApplier` (all references resolved)                 |
 | `WAITING_FOR_SECRET_RESOLUTION` | `ACTIVATABLE`                   | `IncidentResolvedV4Applier` (a `SECRET_RESOLUTION_ERROR` incident is resolved)         |
 | `WAITING_FOR_SECRET_RESOLUTION` | (job deleted)                   | `JobCanceledV4Applier`, when the element instance or process instance is terminated    |
@@ -56,11 +60,16 @@ WAITING_FOR_SECRET_RESOLUTION((byte) 5)
 Parking is the only writer of the new state, and reactivation is its only exit besides deletion. A
 job is never activated, failed, or completed out of it.
 
-### The reactivation precondition is enforced by the state, not documented
+### Both ends of the transition are enforced by the state, not documented
 
-`makeActivatableAfterSecretResolution` acts only on a job in `WAITING_FOR_SECRET_RESOLUTION` and
-returns silently otherwise. This replaces both the Javadoc precondition and the caller-side state
-check in `IncidentResolvedV4Applier`.
+Job state owns the pair: `parkForSecretResolution` acts only on a job that is up for activation, and
+`makeActivatableAfterSecretResolution` acts only on a job in `WAITING_FOR_SECRET_RESOLUTION`. Each
+returns silently otherwise. The reactivation guard replaces both the Javadoc precondition and the
+caller-side state check in `IncidentResolvedV4Applier`.
+
+The error type alone does not mean a job is parked: `SECRET_RESOLUTION_ERROR` is also the incident of
+a job whose secret value injection failed, which stays activatable. The guard is what makes the
+applier's unconditional call correct for both.
 
 The guard is a silent skip rather than an exception because a job can legitimately be reactivated
 twice. A job waiting on two references A and B, both of which resolve, is reactivated by the
@@ -77,7 +86,8 @@ parked job, so the state alone cannot express it.
 
 |                     Command                     |                           On a parked job                           |
 |-------------------------------------------------|---------------------------------------------------------------------|
-| `CompleteJob`, `FailJob`, `ThrowError`, `Yield` | rejected, `INVALID_STATE`, naming the state in the rejection reason |
+| `CompleteJob`, `FailJob`, `ThrowError`          | rejected, `INVALID_STATE`, naming the state in the rejection reason |
+| `Yield`                                         | rejected, `INVALID_STATE` (unchanged, it needs `ACTIVATED`)         |
 | `UpdateJob` (retries, priority)                 | accepted                                                            |
 | `UpdateJob` (timeout)                           | rejected, the job has no deadline while parked (unchanged)          |
 | `CancelJob`, process instance termination       | accepted, the job is deleted                                        |
@@ -106,13 +116,9 @@ An older broker reading state written by a newer one would fail on `Enum.valueOf
 follows the general no-downgrade rule for 8.10 state. Reading older state is unaffected: no existing
 entry carries the new name.
 
-The two pieces of applier logic that change (`SecretReferenceResolutionRequestedApplier` and the
-`SECRET_RESOLUTION_ERROR` branch of `IncidentResolvedV4Applier`) are updated in place, with their
-golden files regenerated, instead of being registered as new versions. Both were merged after the
-`8.10.0-alpha4` candidates were branched: the parking applier is contained in no release tag at all,
-and the incident branch was added to `IncidentResolvedV4Applier` (whose other branches did ship in
-those candidates) after that branch point. No released build ever applied either of them, so no
-cluster can have replayed them.
+The applier logic this changes is updated in place, with the golden files regenerated, instead of
+being registered as new versions: the whole secret resolution flow is 8.10 development that no minor
+release has shipped yet, so there is no released replay behaviour to preserve.
 
 ## Alternatives considered
 

--- a/zeebe/docs/adr/README.md
+++ b/zeebe/docs/adr/README.md
@@ -16,4 +16,5 @@ process-execution data path). These are module-scoped decisions; see the
 | [0004](0004-810-physical-tenant-job-streaming.md)                   | Physical-tenant-aware job streaming: per-group broker services, group-scoped control topics, 8.9-compatible   |
 | [0005](0005-810-job-lease.md)                                       | Job lease: opt-in random opaque fencing token per activation, monotonic, fencing worker lifecycle commands    |
 | [0006](0006-810-late-business-id-assignment.md)                     | Late Business ID assignment: one irreversible forward-only assignment on a running instance (uniqueness off)  |
+| [0007](0007-810-job-waiting-for-secret-resolution-state.md)         | Persisted `WAITING_FOR_SECRET_RESOLUTION` job state for jobs parked while their secret references resolve     |
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -113,8 +113,6 @@ public final class BpmnJobBehavior {
           State.ACTIVATED,
           State.FAILED,
           State.ERROR_THROWN,
-          // a job parked for secret resolution must be canceled with its element instance, or its
-          // record and its waiting entries would outlive the process instance
           State.WAITING_FOR_SECRET_RESOLUTION);
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -108,7 +108,14 @@ public final class BpmnJobBehavior {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(BpmnJobBehavior.class.getPackageName());
   private static final Set<State> CANCELABLE_STATES =
-      EnumSet.of(State.ACTIVATABLE, State.ACTIVATED, State.FAILED, State.ERROR_THROWN);
+      EnumSet.of(
+          State.ACTIVATABLE,
+          State.ACTIVATED,
+          State.FAILED,
+          State.ERROR_THROWN,
+          // a job parked for secret resolution must be canceled with its element instance, or its
+          // record and its waiting entries would outlive the process instance
+          State.WAITING_FOR_SECRET_RESOLUTION);
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private final JobRecord jobRecord = new JobRecord().setVariables(DocumentValue.EMPTY_DOCUMENT);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurAfterBackoffProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurAfterBackoffProcessor.java
@@ -70,6 +70,9 @@ public class JobRecurAfterBackoffProcessor implements TypedRecordProcessor<JobRe
         case ERROR_THROWN:
           textState = "it is in error state";
           break;
+        case WAITING_FOR_SECRET_RESOLUTION:
+          textState = "it is waiting for a secret to be resolved";
+          break;
         default:
           textState = "no such job was found";
           break;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -66,6 +66,8 @@ public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord
             case ACTIVATABLE -> "it must be activated first";
             case FAILED -> "it is marked as failed and is not activated";
             case ERROR_THROWN -> "it has thrown an error and is not activated";
+            case WAITING_FOR_SECRET_RESOLUTION ->
+                "it is waiting for a secret to be resolved and is not activated";
             case NOT_FOUND -> "no such job was found";
           };
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
@@ -53,7 +53,14 @@ public class JobUpdateBehaviour {
             jobState,
             processingStateState.getBannedInstanceState(),
             "update",
-            List.of(State.ACTIVATABLE, State.ACTIVATED, State.FAILED, State.ERROR_THROWN),
+            // a job parked for secret resolution stays updatable: an operator re-prioritising or
+            // topping up the retries of queued work has no reason to wait for the resolution
+            List.of(
+                State.ACTIVATABLE,
+                State.ACTIVATED,
+                State.FAILED,
+                State.ERROR_THROWN,
+                State.WAITING_FOR_SECRET_RESOLUTION),
             List.of(JobLeaseFencingCheck.forUpdateCommand()),
             cslCheck);
     this.cslCheck = cslCheck;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
@@ -53,8 +53,6 @@ public class JobUpdateBehaviour {
             jobState,
             processingStateState.getBannedInstanceState(),
             "update",
-            // a job parked for secret resolution stays updatable: an operator re-prioritising or
-            // topping up the retries of queued work has no reason to wait for the resolution
             List.of(
                 State.ACTIVATABLE,
                 State.ACTIVATED,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedV4Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedV4Applier.java
@@ -58,8 +58,8 @@ final class IncidentResolvedV4Applier implements TypedEventApplier<IncidentInten
       return; // not a job-related incident
     }
     if (value.getErrorType() == ErrorType.SECRET_RESOLUTION_ERROR) {
-      // the job was parked when the incident was raised, so it is reactivated instead of taking the
-      // FAILED/ERROR_THROWN path below; job state reactivates it only if it is still waiting
+      // job state reactivates the job only if it is still parked, so a job that this error type was
+      // raised for without parking it (a failed secret value injection) is left alone
       jobState.makeActivatableAfterSecretResolution(jobKey);
       return;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedV4Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedV4Applier.java
@@ -58,11 +58,9 @@ final class IncidentResolvedV4Applier implements TypedEventApplier<IncidentInten
       return; // not a job-related incident
     }
     if (value.getErrorType() == ErrorType.SECRET_RESOLUTION_ERROR) {
-      // Only ACTIVATABLE jobs are parked for secret resolution (removed from the activatable index
-      // but keeping their state); re-inserting a job in any other state corrupts the index.
-      if (jobState.getState(jobKey) == State.ACTIVATABLE) {
-        jobState.makeActivatableAfterSecretResolution(jobKey);
-      }
+      // the job was parked when the incident was raised, so it is reactivated instead of taking the
+      // FAILED/ERROR_THROWN path below; job state reactivates it only if it is still waiting
+      jobState.makeActivatableAfterSecretResolution(jobKey);
       return;
     }
     final var stateOfJob = jobState.getState(jobKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplier.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.immutable.JobState.State;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -40,11 +39,9 @@ public final class SecretReferenceResolutionRequestedApplier
   }
 
   /**
-   * Records the job as waiting for the secret reference, moves it to {@code
-   * WAITING_FOR_SECRET_RESOLUTION} and removes it from the activatable index, so a long poll does
-   * not collect it again while it waits for the resolution. A job that no longer exists is skipped
-   * entirely, leaving no waiting entry behind for it. Parking a job that already waits on another
-   * reference of the same activation is idempotent.
+   * Records the job as waiting for the secret reference and parks it, so a long poll does not
+   * collect it again while it waits for the resolution. A job that no longer exists is skipped
+   * entirely, leaving no waiting entry behind for it.
    */
   private void parkWaitingJob(
       final String storeId, final String secretReference, final long jobKey) {
@@ -53,7 +50,6 @@ public final class SecretReferenceResolutionRequestedApplier
       return;
     }
     secretReferenceState.addWaitingJob(storeId, secretReference, jobKey);
-    jobState.updateJobState(jobKey, State.WAITING_FOR_SECRET_RESOLUTION);
-    jobState.makeJobNotActivatable(jobKey, job);
+    jobState.parkForSecretResolution(jobKey, job);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplier.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.JobState.State;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -39,10 +40,11 @@ public final class SecretReferenceResolutionRequestedApplier
   }
 
   /**
-   * Records the job as waiting for the secret reference and removes it from the activatable index,
-   * so a long poll does not collect it again while it waits for the resolution. The job keeps its
-   * {@code ACTIVATABLE} state and is reactivated once the secret is resolved. A job that no longer
-   * exists is skipped entirely, leaving no waiting entry behind for it.
+   * Records the job as waiting for the secret reference, moves it to {@code
+   * WAITING_FOR_SECRET_RESOLUTION} and removes it from the activatable index, so a long poll does
+   * not collect it again while it waits for the resolution. A job that no longer exists is skipped
+   * entirely, leaving no waiting entry behind for it. Parking a job that already waits on another
+   * reference of the same activation is idempotent.
    */
   private void parkWaitingJob(
       final String storeId, final String secretReference, final long jobKey) {
@@ -51,6 +53,7 @@ public final class SecretReferenceResolutionRequestedApplier
       return;
     }
     secretReferenceState.addWaitingJob(storeId, secretReference, jobKey);
+    jobState.updateJobState(jobKey, State.WAITING_FOR_SECRET_RESOLUTION);
     jobState.makeJobNotActivatable(jobKey, job);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/JobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/JobState.java
@@ -58,7 +58,13 @@ public interface JobState {
     ACTIVATED((byte) 1),
     FAILED((byte) 2),
     NOT_FOUND((byte) 3),
-    ERROR_THROWN((byte) 4);
+    ERROR_THROWN((byte) 4),
+    /**
+     * The job is parked until its secret references are resolved in the background. It is not in
+     * the activatable index, so it is handed out to no worker, and it leaves this state only by
+     * being reactivated after the resolution or by being deleted.
+     */
+    WAITING_FOR_SECRET_RESOLUTION((byte) 5);
 
     byte value;
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -272,9 +272,26 @@ public final class DbJobState implements JobState, MutableJobState {
       return;
     }
     final JobRecord record = getJob(key);
+    if (record == null) {
+      // the state says the job is parked, so its record must exist; guarded anyway because an
+      // exception in an event applier fails the partition
+      return;
+    }
     updateJobState(key, State.ACTIVATABLE);
     makeJobActivatableByPriority(
         record.getTypeBuffer(), key, record.getTenantId(), record.getPriority());
+  }
+
+  @Override
+  public void parkForSecretResolution(final long key, final JobRecord record) {
+    final State state = getState(key);
+    if (state != State.ACTIVATABLE && state != State.WAITING_FOR_SECRET_RESOLUTION) {
+      // only a job that is up for activation can be withheld from it; parking a job a worker or a
+      // failure already owns would take its state away from it
+      return;
+    }
+    updateJobState(key, State.WAITING_FOR_SECRET_RESOLUTION);
+    makeJobNotActivatable(key, record);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -266,12 +266,15 @@ public final class DbJobState implements JobState, MutableJobState {
 
   @Override
   public void makeActivatableAfterSecretResolution(final long key) {
-    final JobRecord record = getJob(key);
-    if (record != null) {
-      updateJobState(key, State.ACTIVATABLE);
-      makeJobActivatableByPriority(
-          record.getTypeBuffer(), key, record.getTenantId(), record.getPriority());
+    if (!isInState(key, State.WAITING_FOR_SECRET_RESOLUTION)) {
+      // the job is gone, or was already reactivated by another resolved reference of the same
+      // activation; re-inserting it in either case corrupts the activatable index
+      return;
     }
+    final JobRecord record = getJob(key);
+    updateJobState(key, State.ACTIVATABLE);
+    makeJobActivatableByPriority(
+        record.getTypeBuffer(), key, record.getTenantId(), record.getPriority());
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -274,7 +274,7 @@ public final class DbJobState implements JobState, MutableJobState {
     final JobRecord record = getJob(key);
     if (record == null) {
       // the state says the job is parked, so its record must exist; guarded anyway because an
-      // exception in an event applier fails the partition
+      // exception in an event applier bans the process instance, or fails the partition on replay
       return;
     }
     updateJobState(key, State.ACTIVATABLE);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
@@ -61,8 +61,11 @@ public interface MutableJobState extends JobState {
   void yield(long key, JobRecord updatedValue);
 
   /**
-   * Makes a job activatable after its pending secret references have been resolved. Silently does
-   * nothing if the job no longer exists.
+   * Makes a job activatable after its pending secret references have been resolved. Does nothing
+   * unless the job is in {@link State#WAITING_FOR_SECRET_RESOLUTION}, because a job can be
+   * reactivated by more than one resolved reference of the same activation and may be gone by then.
+   * A job that carries a secret resolution incident is still waiting, so keeping it parked until
+   * the incident is resolved is up to the caller.
    */
   void makeActivatableAfterSecretResolution(long key);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
@@ -61,6 +61,14 @@ public interface MutableJobState extends JobState {
   void yield(long key, JobRecord updatedValue);
 
   /**
+   * Parks a job in {@link State#WAITING_FOR_SECRET_RESOLUTION} and removes it from the activatable
+   * index, so it is handed out to no worker while its secret references are resolved. Does nothing
+   * unless the job is up for activation; parking a job that already waits on another reference of
+   * the same activation is idempotent.
+   */
+  void parkForSecretResolution(long key, JobRecord record);
+
+  /**
    * Makes a job activatable after its pending secret references have been resolved. Does nothing
    * unless the job is in {@link State#WAITING_FOR_SECRET_RESOLUTION}, because a job can be
    * reactivated by more than one resolved reference of the same activation and may be gone by then.

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobWaitingForSecretResolutionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobWaitingForSecretResolutionTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.secretstore.NoopSecretStore;
 import io.camunda.secretstore.SecretCache;
 import io.camunda.secretstore.SecretStoreRegistry;
+import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -41,8 +42,6 @@ public final class JobWaitingForSecretResolutionTest {
   private static final String JOB_TYPE = "task-type";
   private static final String SECRET_NAME = "token";
 
-  private final Map<String, String> cachedSecrets = new HashMap<>();
-
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
@@ -54,6 +53,8 @@ public final class JobWaitingForSecretResolutionTest {
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
+
+  private final Map<String, String> cachedSecrets = new HashMap<>();
 
   @Test
   public void shouldParkJobInWaitingState() {
@@ -111,6 +112,36 @@ public final class JobWaitingForSecretResolutionTest {
     // then
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
     assertThat(rejection.getRejectionReason()).contains(State.WAITING_FOR_SECRET_RESOLUTION.name());
+  }
+
+  @Test
+  public void shouldRejectYieldOfWaitingJob() {
+    // given
+    deploy();
+    final long jobKey = parkedJob();
+
+    // when
+    final Record<JobRecordValue> rejection = engine.job().withKey(jobKey).expectRejection().yield();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason()).contains(State.WAITING_FOR_SECRET_RESOLUTION.name());
+  }
+
+  @Test
+  public void shouldRejectTimeoutUpdateOfWaitingJob() {
+    // given - a parked job has no deadline, because it was never handed to a worker
+    deploy();
+    final long jobKey = parkedJob();
+
+    // when
+    final Record<JobRecordValue> rejection =
+        engine.job().withKey(jobKey).withTimeout(1000L).expectRejection().updateTimeout();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(JobUpdateBehaviour.NO_DEADLINE_FOUND_MESSAGE.formatted(jobKey));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobWaitingForSecretResolutionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobWaitingForSecretResolutionTest.java
@@ -159,9 +159,9 @@ public final class JobWaitingForSecretResolutionTest {
     // then - the new priority is applied to the job
     assertThat(updated.getIntent()).isEqualTo(JobIntent.PRIORITY_UPDATED);
     assertThat(updated.getValue().getPriority()).isEqualTo(42);
-    assertThat(jobState(jobKey)).isEqualTo(State.WAITING_FOR_SECRET_RESOLUTION);
 
-    // and - the job is still parked: it is not handed out to the next activation
+    // and - the job is still parked: it is not handed out to the next activation. The parked state
+    // itself is asserted in JobStateTest, where the read cannot race the engine's own transaction.
     final Record<JobBatchRecordValue> activated =
         engine.jobs().withType(JOB_TYPE).withRequestStreamId(2).withRequestId(2L).activate();
     assertThat(activated.getValue().getJobs()).isEmpty();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobWaitingForSecretResolutionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobWaitingForSecretResolutionTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.secretstore.NoopSecretStore;
+import io.camunda.secretstore.SecretCache;
+import io.camunda.secretstore.SecretStoreRegistry;
+import io.camunda.zeebe.engine.state.immutable.JobState.State;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Covers a job parked in {@code WAITING_FOR_SECRET_RESOLUTION}: which commands it accepts while it
+ * waits, and that it stays parked until the resolution reactivates it.
+ */
+public final class JobWaitingForSecretResolutionTest {
+
+  private static final String PROCESS_ID = "process";
+  private static final String TASK_ID = "task";
+  private static final String JOB_TYPE = "task-type";
+  private static final String SECRET_NAME = "token";
+
+  private final Map<String, String> cachedSecrets = new HashMap<>();
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withSecretStoreRegistry(
+              new SecretStoreRegistry(
+                  Map.of("default", new NoopSecretStore()),
+                  Map.of("default", new TestSecretCache())));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldParkJobInWaitingState() {
+    // given
+    deploy();
+    final long jobKey = parkedJob();
+
+    // then
+    assertThat(jobState(jobKey)).isEqualTo(State.WAITING_FOR_SECRET_RESOLUTION);
+  }
+
+  @Test
+  public void shouldRejectCompleteOfWaitingJob() {
+    // given
+    deploy();
+    final long jobKey = parkedJob();
+
+    // when
+    final Record<JobRecordValue> rejection =
+        engine.job().withKey(jobKey).expectRejection().complete();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to complete job with key '%d', but it is in state '%s'"
+                .formatted(jobKey, State.WAITING_FOR_SECRET_RESOLUTION));
+  }
+
+  @Test
+  public void shouldRejectFailOfWaitingJob() {
+    // given
+    deploy();
+    final long jobKey = parkedJob();
+
+    // when
+    final Record<JobRecordValue> rejection =
+        engine.job().withKey(jobKey).withRetries(3).expectRejection().fail();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason()).contains(State.WAITING_FOR_SECRET_RESOLUTION.name());
+  }
+
+  @Test
+  public void shouldRejectThrowErrorOfWaitingJob() {
+    // given
+    deploy();
+    final long jobKey = parkedJob();
+
+    // when
+    final Record<JobRecordValue> rejection =
+        engine.job().withKey(jobKey).withErrorCode("error").expectRejection().throwError();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason()).contains(State.WAITING_FOR_SECRET_RESOLUTION.name());
+  }
+
+  @Test
+  public void shouldKeepJobParkedOnPriorityUpdate() {
+    // given - a parked job whose secret is cached by now, so only the parking keeps it from being
+    // activated
+    deploy();
+    final long jobKey = parkedJob();
+    cachedSecrets.put(SECRET_NAME, "resolved-secret");
+
+    // when
+    final Record<JobRecordValue> updated =
+        engine.job().withKey(jobKey).withPriority(42).withChangeset(Set.of("priority")).update();
+
+    // then - the new priority is applied to the job
+    assertThat(updated.getIntent()).isEqualTo(JobIntent.PRIORITY_UPDATED);
+    assertThat(updated.getValue().getPriority()).isEqualTo(42);
+    assertThat(jobState(jobKey)).isEqualTo(State.WAITING_FOR_SECRET_RESOLUTION);
+
+    // and - the job is still parked: it is not handed out to the next activation
+    final Record<JobBatchRecordValue> activated =
+        engine.jobs().withType(JOB_TYPE).withRequestStreamId(2).withRequestId(2L).activate();
+    assertThat(activated.getValue().getJobs()).isEmpty();
+  }
+
+  @Test
+  public void shouldUpdateRetriesOfWaitingJob() {
+    // given
+    deploy();
+    final long jobKey = parkedJob();
+
+    // when
+    final Record<JobRecordValue> updated =
+        engine.job().withKey(jobKey).withRetries(5).updateRetries();
+
+    // then
+    assertThat(updated.getIntent()).isEqualTo(JobIntent.RETRIES_UPDATED);
+    assertThat(updated.getValue().getRetries()).isEqualTo(5);
+    assertThat(jobState(jobKey)).isEqualTo(State.WAITING_FOR_SECRET_RESOLUTION);
+  }
+
+  @Test
+  public void shouldCancelWaitingJobOnProcessInstanceTermination() {
+    // given
+    deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long jobKey = parkJobOf(processInstanceKey);
+
+    // when
+    engine.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then - the parked job is canceled and gone from state, leaving nothing behind
+    assertThat(RecordingExporter.jobRecords(JobIntent.CANCELED).withRecordKey(jobKey).exists())
+        .isTrue();
+    assertThat(jobState(jobKey)).isEqualTo(State.NOT_FOUND);
+  }
+
+  private State jobState(final long jobKey) {
+    return engine.getProcessingState().getJobState().getState(jobKey);
+  }
+
+  /** Creates an instance and activates once, which parks its job on the uncached secret. */
+  private long parkedJob() {
+    return parkJobOf(engine.processInstance().ofBpmnProcessId(PROCESS_ID).create());
+  }
+
+  private long parkJobOf(final long processInstanceKey) {
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+    final Record<JobBatchRecordValue> activated =
+        engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
+    // the job is withheld from the batch and parked instead, because its secret is not cached
+    assertThat(activated.getValue().getJobs()).isEmpty();
+    return jobKey;
+  }
+
+  private void deploy() {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                TASK_ID,
+                t ->
+                    t.zeebeJobType(JOB_TYPE)
+                        .zeebeInputExpression(
+                            "\"Bearer \" + camunda.secrets." + SECRET_NAME, "authorization"))
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+  }
+
+  /** Serves the test's cached secrets; empty until a test puts a value in. */
+  private final class TestSecretCache implements SecretCache {
+    @Override
+    public Optional<String> get(final String name) {
+      return Optional.ofNullable(cachedSecrets.get(name));
+    }
+
+    @Override
+    public void put(final String name, final String value) {
+      cachedSecrets.put(name, value);
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedApplierTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -113,8 +114,8 @@ public class IncidentResolvedApplierTest {
 
   @Test
   void shouldMakeParkedJobActivatableWhenSecretResolutionIncidentIsResolvedV4() {
-    // given - a job parked for secret resolution keeps the ACTIVATABLE state, so the regular
-    //         FAILED/ERROR_THROWN resolution path does not apply to it
+    // given - a job parked for secret resolution is not FAILED or ERROR_THROWN, so the regular
+    //         resolution path does not apply to it
     final var incidentKey = 1L;
     final var jobKey = 2L;
     final var incidentRecord =
@@ -122,7 +123,6 @@ public class IncidentResolvedApplierTest {
             .setErrorType(ErrorType.SECRET_RESOLUTION_ERROR)
             .setJobKey(jobKey)
             .setElementId(BufferUtil.wrapString("elementId"));
-    when(jobStateMock.getState(jobKey)).thenReturn(State.ACTIVATABLE);
 
     final var v4Applier =
         new IncidentResolvedV4Applier(incidentState, jobStateMock, elementInstanceStateMock);
@@ -130,23 +130,24 @@ public class IncidentResolvedApplierTest {
     // when
     v4Applier.applyState(incidentKey, incidentRecord);
 
-    // then - the job is put back into the activatable index so the next activation attempt
-    //        re-evaluates its secret references
+    // then - the reactivation is delegated to job state, which reactivates the job only if it is
+    //        still waiting; the regular resolution path is not taken
     verify(jobStateMock).makeActivatableAfterSecretResolution(jobKey);
+    verify(jobStateMock, never()).updateJobState(anyLong(), any());
   }
 
   @Test
-  void shouldNotMakeNonParkedJobActivatableWhenSecretResolutionIncidentIsResolvedV4() {
-    // given - the job is no longer parked when the secret-resolution incident is resolved
-    //         (e.g. it was picked up by a worker after a concurrent reactivation)
+  void shouldNotReactivateJobOfNonSecretIncidentWhenResolvedV4() {
+    // given - an incident that is not about secret resolution, raised for a job that is neither
+    //         FAILED nor ERROR_THROWN
     final var incidentKey = 1L;
     final var jobKey = 2L;
     final var incidentRecord =
         new IncidentRecord()
-            .setErrorType(ErrorType.SECRET_RESOLUTION_ERROR)
+            .setErrorType(ErrorType.IO_MAPPING_ERROR)
             .setJobKey(jobKey)
             .setElementId(BufferUtil.wrapString("elementId"));
-    when(jobStateMock.getState(jobKey)).thenReturn(State.ACTIVATED);
+    when(jobStateMock.getState(jobKey)).thenReturn(State.WAITING_FOR_SECRET_RESOLUTION);
 
     final var v4Applier =
         new IncidentResolvedV4Applier(incidentState, jobStateMock, elementInstanceStateMock);
@@ -154,8 +155,9 @@ public class IncidentResolvedApplierTest {
     // when
     v4Applier.applyState(incidentKey, incidentRecord);
 
-    // then - re-inserting a non-parked job into the activatable index would corrupt job state
+    // then - the secret resolution reactivation is reserved for secret resolution incidents
     verify(jobStateMock, never()).makeActivatableAfterSecretResolution(anyLong());
+    verify(jobStateMock, never()).updateJobState(anyLong(), any());
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceBatchJobsReactivatedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceBatchJobsReactivatedApplierTest.java
@@ -45,15 +45,18 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
     applier = new SecretReferenceBatchJobsReactivatedApplier(processingState);
   }
 
-  private JobRecord createActivatedJob(final long jobKey) {
+  /** Creates a job and parks it the way {@code RESOLUTION_REQUESTED} does. */
+  private JobRecord createParkedJob(final long jobKey) {
     final var jobRecord =
         new JobRecord()
             .setType("test")
             .setRetries(3)
-            .setDeadline(256L)
             .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-    jobState.create(jobKey, jobRecord);
-    jobState.activate(jobKey, jobRecord);
+    jobState.insertJobRecordActivatable(jobKey, jobRecord);
+    jobState.makeJobActivatableByPriority(
+        jobRecord.getTypeBuffer(), jobKey, jobRecord.getTenantId(), jobRecord.getPriority());
+    jobState.updateJobState(jobKey, State.WAITING_FOR_SECRET_RESOLUTION);
+    jobState.makeJobNotActivatable(jobKey, jobRecord);
     return jobRecord;
   }
 
@@ -61,7 +64,7 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
   void shouldMakeJobActivatable() {
     // given
     final long jobKey = 1L;
-    final var job = createActivatedJob(jobKey);
+    final var job = createParkedJob(jobKey);
     secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
     secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, jobKey);
     final var value =
@@ -90,7 +93,7 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
   void shouldRemoveWaitingJobEntryFromState() {
     // given
     final long jobKey = 2L;
-    createActivatedJob(jobKey);
+    createParkedJob(jobKey);
     secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
     secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, jobKey);
     final var value =
@@ -118,10 +121,10 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
 
   @Test
   void shouldNotMakeJobActivatableWhenOtherRefsArePending() {
-    // given - job is activated and waiting on two references; one is being resolved (secret1),
+    // given - job is parked and waiting on two references; one is being resolved (secret1),
     //         but the other (secret2) is still pending
     final long jobKey = 4L;
-    createActivatedJob(jobKey);
+    createParkedJob(jobKey);
     secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
     secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, jobKey);
     secretReferenceState.addPendingSecretReference(STORE_ID, "secret2");
@@ -148,8 +151,40 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
         });
     assertThat(stillWaiting.get()).isFalse();
 
-    // but job is NOT made activatable — it still waits on secret2
-    assertThat(jobState.getState(jobKey)).isNotEqualTo(State.ACTIVATABLE);
+    // but job is NOT made activatable, it still waits on secret2
+    assertThat(jobState.getState(jobKey)).isEqualTo(State.WAITING_FOR_SECRET_RESOLUTION);
+  }
+
+  @Test
+  void shouldNotDisturbJobThatWasAlreadyReactivated() {
+    // given - a job waiting on two references that both resolved, so the batch event of the first
+    //         one already reactivated it and a worker activated it since
+    final long jobKey = 6L;
+    final var job = createParkedJob(jobKey);
+    secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
+    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, jobKey);
+    jobState.makeActivatableAfterSecretResolution(jobKey);
+    jobState.activate(jobKey, job.setDeadline(256L));
+    final var value =
+        new SecretReferenceRecord()
+            .setStoreId(STORE_ID)
+            .setSecretReference(SECRET_REF)
+            .addJobKey(jobKey);
+
+    // when - the batch event of the second reference reactivates the same job again
+    applier.applyState(100L, value);
+
+    // then - the activated job is left alone, it is not handed out a second time
+    assertThat(jobState.getState(jobKey)).isEqualTo(State.ACTIVATED);
+    final var activatableJobs = new ArrayList<Long>();
+    jobState.forEachActivatableJobs(
+        job.getTypeBuffer(),
+        List.of(job.getTenantId()),
+        (key, record) -> {
+          activatableJobs.add(key);
+          return true;
+        });
+    assertThat(activatableJobs).isEmpty();
   }
 
   @Test
@@ -157,13 +192,7 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
     // given - a parked job waiting on the secret reference, with an open incident raised for an
     //         earlier failed secret reference of the same job
     final long jobKey = 5L;
-    final var jobRecord =
-        new JobRecord()
-            .setType("test")
-            .setRetries(3)
-            .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-    jobState.create(jobKey, jobRecord);
-    jobState.makeJobNotActivatable(jobKey, jobRecord);
+    final var jobRecord = createParkedJob(jobKey);
     processingState
         .getIncidentState()
         .createIncident(
@@ -186,6 +215,7 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
 
     // then - the waiting entry is removed, but the job stays parked; resolving the incident is
     //        the only path that reactivates it
+    assertThat(jobState.getState(jobKey)).isEqualTo(State.WAITING_FOR_SECRET_RESOLUTION);
     final var activatableJobs = new ArrayList<Long>();
     jobState.forEachActivatableJobs(
         jobRecord.getTypeBuffer(),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceBatchJobsReactivatedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceBatchJobsReactivatedApplierTest.java
@@ -55,8 +55,7 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
     jobState.insertJobRecordActivatable(jobKey, jobRecord);
     jobState.makeJobActivatableByPriority(
         jobRecord.getTypeBuffer(), jobKey, jobRecord.getTenantId(), jobRecord.getPriority());
-    jobState.updateJobState(jobKey, State.WAITING_FOR_SECRET_RESOLUTION);
-    jobState.makeJobNotActivatable(jobKey, jobRecord);
+    jobState.parkForSecretResolution(jobKey, jobRecord);
     return jobRecord;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplierTest.java
@@ -239,9 +239,34 @@ final class SecretReferenceResolutionRequestedApplierTest {
     // when
     applier.applyState(100L, record);
 
-    // then - the job keeps its ACTIVATABLE state but is removed from the activatable index, so a
-    // long poll does not collect it again until it is reactivated
-    assertThat(jobState.isInState(1L, State.ACTIVATABLE)).isTrue();
+    // then - the job waits in its own state and is removed from the activatable index, so a long
+    // poll does not collect it again until it is reactivated
+    assertThat(jobState.isInState(1L, State.WAITING_FOR_SECRET_RESOLUTION)).isTrue();
+    assertThat(activatableKeys(type)).isEmpty();
+  }
+
+  @Test
+  void shouldParkJobWaitingOnASecondSecretReference() {
+    // given - a job already parked on one reference
+    final DirectBuffer type = wrapString("type-a");
+    createActivatableJob(1L, type);
+    applier.applyState(
+        100L,
+        new SecretReferenceRecord()
+            .setStoreId("store-1")
+            .setSecretReference("secret-a")
+            .addJobKey(1L));
+
+    // when - a second reference of the same job is requested
+    applier.applyState(
+        101L,
+        new SecretReferenceRecord()
+            .setStoreId("store-1")
+            .setSecretReference("secret-b")
+            .addJobKey(1L));
+
+    // then - parking an already parked job is idempotent
+    assertThat(jobState.isInState(1L, State.WAITING_FOR_SECRET_RESOLUTION)).isTrue();
     assertThat(activatableKeys(type)).isEmpty();
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
@@ -382,6 +382,49 @@ public final class JobStateTest {
   }
 
   @Test
+  public void shouldMakeWaitingJobActivatableAfterSecretResolution() {
+    // given - a job parked while its secret references are resolved
+    final long jobKey = 1L;
+    final JobRecord jobRecord = newJobRecord();
+    parkJobForSecretResolution(jobKey, jobRecord);
+
+    // when
+    jobState.makeActivatableAfterSecretResolution(jobKey);
+
+    // then
+    assertJobState(jobKey, State.ACTIVATABLE);
+    assertListedAsActivatable(jobKey, jobRecord.getTypeBuffer(), jobRecord.getTenantId());
+  }
+
+  @Test
+  public void shouldNotMakeJobActivatableAfterSecretResolutionWhenItNoLongerWaits() {
+    // given - a job that was already reactivated by another resolved reference of the same
+    // activation, and has been activated by a worker since
+    final long jobKey = 1L;
+    final JobRecord jobRecord = newJobRecord();
+    parkJobForSecretResolution(jobKey, jobRecord);
+    jobState.makeActivatableAfterSecretResolution(jobKey);
+    jobState.activate(jobKey, jobRecord);
+
+    // when - the resolution of the second reference reactivates it again
+    jobState.makeActivatableAfterSecretResolution(jobKey);
+
+    // then - the activated job is left alone; re-inserting it would hand it out twice
+    assertJobState(jobKey, State.ACTIVATED);
+    refuteListedAsActivatable(jobKey, jobRecord.getTypeBuffer());
+  }
+
+  @Test
+  public void shouldIgnoreMakeActivatableAfterSecretResolutionIfJobNotFound() {
+    // given
+    final long jobKey = 999L;
+
+    // when / then - no exception, no state change
+    jobState.makeActivatableAfterSecretResolution(jobKey);
+    assertThat(jobState.exists(jobKey)).isFalse();
+  }
+
+  @Test
   public void shouldKeepJobParkedWhenUpdatingPriorityOfJobWaitingForSecretResolution() {
     // given - a job parked while its secret references are resolved
     final long jobKey = 1L;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
@@ -382,6 +382,22 @@ public final class JobStateTest {
   }
 
   @Test
+  public void shouldKeepJobParkedWhenUpdatingPriorityOfJobWaitingForSecretResolution() {
+    // given - a job parked while its secret references are resolved
+    final long jobKey = 1L;
+    final JobRecord jobRecord = newJobRecord();
+    parkJobForSecretResolution(jobKey, jobRecord);
+
+    // when
+    jobState.updateJobPriority(jobKey, 99);
+
+    // then - the new priority is stored, but the job is not put back into the activatable index
+    assertThat(jobState.getJob(jobKey).getPriority()).isEqualTo(99);
+    assertJobState(jobKey, State.WAITING_FOR_SECRET_RESOLUTION);
+    refuteListedAsActivatable(jobKey, jobRecord.getTypeBuffer());
+  }
+
+  @Test
   public void shouldUpdateDeadline() {
     // given
     final long jobKey = 1L;
@@ -800,6 +816,15 @@ public final class JobStateTest {
   private void createAndActivateJobRecord(final long key, final JobRecord record) {
     jobState.create(key, record);
     jobState.activate(key, record);
+  }
+
+  /** Creates an activatable job and parks it the way the secret resolution flow does. */
+  private void parkJobForSecretResolution(final long key, final JobRecord record) {
+    jobState.insertJobRecordActivatable(key, record);
+    jobState.makeJobActivatableByPriority(
+        record.getTypeBuffer(), key, record.getTenantId(), record.getPriority());
+    jobState.updateJobState(key, State.WAITING_FOR_SECRET_RESOLUTION);
+    jobState.makeJobNotActivatable(key, record);
   }
 
   private JobRecord newJobRecord() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
@@ -382,6 +382,20 @@ public final class JobStateTest {
   }
 
   @Test
+  public void shouldNotParkJobForSecretResolutionWhenItIsNotUpForActivation() {
+    // given - a job a worker already holds
+    final long jobKey = 1L;
+    final JobRecord jobRecord = newJobRecord();
+    createAndActivateJobRecord(jobKey, jobRecord);
+
+    // when
+    jobState.parkForSecretResolution(jobKey, jobRecord);
+
+    // then - the activation keeps the job, parking it would take its state away from the worker
+    assertJobState(jobKey, State.ACTIVATED);
+  }
+
+  @Test
   public void shouldMakeWaitingJobActivatableAfterSecretResolution() {
     // given - a job parked while its secret references are resolved
     final long jobKey = 1L;
@@ -866,8 +880,7 @@ public final class JobStateTest {
     jobState.insertJobRecordActivatable(key, record);
     jobState.makeJobActivatableByPriority(
         record.getTypeBuffer(), key, record.getTenantId(), record.getPriority());
-    jobState.updateJobState(key, State.WAITING_FOR_SECRET_RESOLUTION);
-    jobState.makeJobNotActivatable(key, record);
+    jobState.parkForSecretResolution(key, record);
   }
 
   private JobRecord newJobRecord() {

--- a/zeebe/engine/src/test/resources/state/appliers/golden/Incident_RESOLVED_v4.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/Incident_RESOLVED_v4.golden
@@ -58,8 +58,8 @@ final class IncidentResolvedV4Applier implements TypedEventApplier<IncidentInten
       return; // not a job-related incident
     }
     if (value.getErrorType() == ErrorType.SECRET_RESOLUTION_ERROR) {
-      // the job was parked when the incident was raised, so it is reactivated instead of taking the
-      // FAILED/ERROR_THROWN path below; job state reactivates it only if it is still waiting
+      // job state reactivates the job only if it is still parked, so a job that this error type was
+      // raised for without parking it (a failed secret value injection) is left alone
       jobState.makeActivatableAfterSecretResolution(jobKey);
       return;
     }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/Incident_RESOLVED_v4.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/Incident_RESOLVED_v4.golden
@@ -58,11 +58,9 @@ final class IncidentResolvedV4Applier implements TypedEventApplier<IncidentInten
       return; // not a job-related incident
     }
     if (value.getErrorType() == ErrorType.SECRET_RESOLUTION_ERROR) {
-      // Only ACTIVATABLE jobs are parked for secret resolution (removed from the activatable index
-      // but keeping their state); re-inserting a job in any other state corrupts the index.
-      if (jobState.getState(jobKey) == State.ACTIVATABLE) {
-        jobState.makeActivatableAfterSecretResolution(jobKey);
-      }
+      // the job was parked when the incident was raised, so it is reactivated instead of taking the
+      // FAILED/ERROR_THROWN path below; job state reactivates it only if it is still waiting
+      jobState.makeActivatableAfterSecretResolution(jobKey);
       return;
     }
     final var stateOfJob = jobState.getState(jobKey);

--- a/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_RESOLUTION_REQUESTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_RESOLUTION_REQUESTED_v1.golden
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.immutable.JobState.State;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -40,11 +39,9 @@ public final class SecretReferenceResolutionRequestedApplier
   }
 
   /**
-   * Records the job as waiting for the secret reference, moves it to {@code
-   * WAITING_FOR_SECRET_RESOLUTION} and removes it from the activatable index, so a long poll does
-   * not collect it again while it waits for the resolution. A job that no longer exists is skipped
-   * entirely, leaving no waiting entry behind for it. Parking a job that already waits on another
-   * reference of the same activation is idempotent.
+   * Records the job as waiting for the secret reference and parks it, so a long poll does not
+   * collect it again while it waits for the resolution. A job that no longer exists is skipped
+   * entirely, leaving no waiting entry behind for it.
    */
   private void parkWaitingJob(
       final String storeId, final String secretReference, final long jobKey) {
@@ -53,7 +50,6 @@ public final class SecretReferenceResolutionRequestedApplier
       return;
     }
     secretReferenceState.addWaitingJob(storeId, secretReference, jobKey);
-    jobState.updateJobState(jobKey, State.WAITING_FOR_SECRET_RESOLUTION);
-    jobState.makeJobNotActivatable(jobKey, job);
+    jobState.parkForSecretResolution(jobKey, job);
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_RESOLUTION_REQUESTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_RESOLUTION_REQUESTED_v1.golden
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.JobState.State;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -39,10 +40,11 @@ public final class SecretReferenceResolutionRequestedApplier
   }
 
   /**
-   * Records the job as waiting for the secret reference and removes it from the activatable index,
-   * so a long poll does not collect it again while it waits for the resolution. The job keeps its
-   * {@code ACTIVATABLE} state and is reactivated once the secret is resolved. A job that no longer
-   * exists is skipped entirely, leaving no waiting entry behind for it.
+   * Records the job as waiting for the secret reference, moves it to {@code
+   * WAITING_FOR_SECRET_RESOLUTION} and removes it from the activatable index, so a long poll does
+   * not collect it again while it waits for the resolution. A job that no longer exists is skipped
+   * entirely, leaving no waiting entry behind for it. Parking a job that already waits on another
+   * reference of the same activation is idempotent.
    */
   private void parkWaitingJob(
       final String storeId, final String secretReference, final long jobKey) {
@@ -51,6 +53,7 @@ public final class SecretReferenceResolutionRequestedApplier
       return;
     }
     secretReferenceState.addWaitingJob(storeId, secretReference, jobKey);
+    jobState.updateJobState(jobKey, State.WAITING_FOR_SECRET_RESOLUTION);
     jobState.makeJobNotActivatable(jobKey, job);
   }
 }


### PR DESCRIPTION
## Description

A job whose secret references are not cached was parked on activation by removing it from the
activatable index while its job state stayed `ACTIVATABLE`, so the waiting condition existed only as
the absence of an index entry. Absence is not specific to parking, since every non-activatable job is
absent too, which made the condition impossible to check:

- `updateJobPriority` re-inserts a job into the index when its state is `ACTIVATABLE`, so a priority
  update un-parked a waiting job. Every following activation then collected it, skipped it again for
  its still-uncached reference, requested the resolution a second time and parked it again, and each
  of those skips consumed one slot of the activation's skip budget, which can truncate batches for
  the jobs behind it.
- The reactivation path could only document its precondition in Javadoc. A job waiting on two
  references is reactivated by the batch event of each of them, so once a worker had activated it in
  between, the second reactivation put it back into the index while the first worker still held it,
  and the job was executed twice.
- A parked job was indistinguishable from an activatable one while investigating why it is not handed
  out.

This adds a persisted `JobState.State.WAITING_FOR_SECRET_RESOLUTION` and parks the job in it:

- the priority update falls into the branch that only updates the job record, so the job stays parked
  and is indexed with its new priority when it is reactivated
- job state owns both ends of the transition: `parkForSecretResolution` acts only on a job that is up
  for activation, and `makeActivatableAfterSecretResolution` only on a job that is still parked. A
  job in any other state is left alone, which replaces the Javadoc precondition and the caller-side
  state check in `IncidentResolvedV4Applier`
- `CompleteJob`, `FailJob` and `ThrowError` reject with `INVALID_STATE` naming the state, because the
  new state is absent from their valid-state lists. `Yield` was already rejected, it needs
  `ACTIVATED`. A parked job stays cancelable (or its record and its waiting entries would outlive a
  terminated process instance) and updatable (so an operator can still re-prioritise or top up the
  retries of queued work)

One visible behaviour change: a worker whose activation timed out can no longer complete the job late
if the job was parked again in the meantime, because its secret value expired from the cache before
the next activation. That work is lost and the job is handed out again once its references resolve,
which is the same outcome as any other lost race between a timed-out worker and a new activation.

The enum is persisted in the `JOB_STATES` column family only, never in the log, the protocol,
exported records or secondary storage. The changed applier logic is updated in place with its golden
files regenerated rather than versioned: the whole secret resolution flow is 8.10 development that no
minor release has shipped, so there is no replay behaviour to preserve.

Alternatives considered are recorded in `zeebe/docs/adr/0007-810-job-waiting-for-secret-resolution-state.md`,
since the enum is persisted state. In short: the waiting-jobs index in the secret reference state
cannot serve as the marker, because its entry is removed when a permanent failure raises an incident
while the job stays parked, and `FAILED` carries retry and backoff semantics a parked job must not
have.

No backport: the un-parking and double-activation bugs only exist on unreleased 8.10.

## Related issues

Closes #58993

Part of #56556. Follows #57846 (parking) and #57852 (reactivation).
