### PR TITLE
fix: correctly advance the coordinator role and inconsistency detection for the new cluster-config model

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -9,11 +9,9 @@ package io.camunda.zeebe.broker.bootstrap;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.Loggers;
-import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.broker.partitioning.PartitionModeHandler;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
@@ -23,7 +21,6 @@ import org.slf4j.Logger;
 
 final class PartitionManagerStep extends AbstractBrokerStartupStep {
   private static final Logger LOGGER = Loggers.SYSTEM_LOGGER;
-  private static final int ERROR_CODE_ON_INCONSISTENT_TOPOLOGY = 3;
 
   private final String physicalTenantId;
   private TopologyManagerImpl topologyManager;
@@ -103,11 +100,6 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
             .andThen(ignore -> topologyManager.closeAsync(), concurrencyControl),
         (ok, error) -> {
           brokerShutdownContext.removePartitionManager(physicalTenantId);
-          if (PartitionManager.isDefaultPhysicalTenant(physicalTenantId)) {
-            brokerShutdownContext
-                .getClusterConfigurationService()
-                .removeInconsistentConfigurationListener();
-          }
           if (error != null) {
             shutdownFuture.completeExceptionally(error);
           } else {
@@ -121,19 +113,6 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
 
     final var clusterCfg = brokerStartupContext.getBrokerConfiguration().getCluster();
     final MemberId memberId = MemberId.from(clusterCfg.getZone(), clusterCfg.getNodeId());
-
-    if (PartitionManager.isDefaultPhysicalTenant(physicalTenantId)) {
-      brokerStartupContext
-          .getClusterConfigurationService()
-          .registerInconsistentConfigurationListener(
-              (newTopology, oldTopology) -> {
-                shutdownOnInconsistentTopology(
-                    memberId,
-                    brokerStartupContext.getSpringBrokerBridge(),
-                    newTopology,
-                    oldTopology);
-              });
-    }
 
     if (isRecovering(brokerStartupContext, memberId)) {
       LOGGER.info("Partition group in recovery, starting RecoveryPartitionManager");
@@ -153,26 +132,6 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
       final BrokerStartupContext brokerStartupContext, final TopologyManagerImpl topologyManager) {
     return PartitionManager.createRecoveryPartitionManager(
         brokerStartupContext, physicalTenantId, topologyManager);
-  }
-
-  private void shutdownOnInconsistentTopology(
-      final MemberId memberId,
-      final SpringBrokerBridge springBrokerBridge,
-      final ClusterConfiguration newTopology,
-      final ClusterConfiguration oldTopology) {
-    LOGGER.warn(
-        """
-          Received a newer topology which has a different state for this broker.
-          State of this broker in new topology :'{}'
-          State of this broker in old topology: '{}'
-          This usually happens when the topology was changed forcefully when this broker was unreachable or this broker encountered a data loss. Shutting down the broker. Please restart the broker to use the new topology.
-        """,
-        newTopology.getMember(memberId),
-        oldTopology.getMember(memberId));
-    springBrokerBridge.initiateShutdown(
-        ERROR_CODE_ON_INCONSISTENT_TOPOLOGY,
-        "Inconsistent cluster topology detected - topology was changed while broker was"
-            + " unreachable or broker encountered data loss");
   }
 
   private boolean isRecovering(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.broker.partitioning.topology;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationManager.InconsistentConfigurationListener;
@@ -31,9 +33,15 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DynamicClusterConfigurationService
     implements ClusterConfigurationService, ClusterConfigurationUpdateListener {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(DynamicClusterConfigurationService.class);
+  private static final int ERROR_CODE_ON_INCONSISTENT_TOPOLOGY = 3;
 
   private final Map<String, PartitionDistribution> partitionDistributionPerPhysicalTenant =
       new HashMap<>();
@@ -120,6 +128,8 @@ public class DynamicClusterConfigurationService
             clusterConfigurationManagerService.addUpdateListener(
                 brokerStartupContext.getBrokerClient().getTopologyManager());
             clusterConfigurationManagerService.addUpdateListener(this);
+            registerInconsistentConfigurationListener(
+                inconsistentConfigurationListener(brokerStartupContext));
             clusterConfigurationManagerService
                 .getClusterConfiguration()
                 .onComplete(
@@ -225,11 +235,68 @@ public class DynamicClusterConfigurationService
   public ActorFuture<Void> closeAsync() {
     partitionDistributionPerPhysicalTenant.clear();
     currentClusterConfiguration = null;
+    removeInconsistentConfigurationListener();
     if (clusterConfigurationManagerService != null) {
       return clusterConfigurationManagerService.closeAsync();
     } else {
       return CompletableActorFuture.completed(null);
     }
+  }
+
+  /**
+   * Builds the listener that shuts the broker down when its own state was changed in the local
+   * configuration without its participation, e.g. by a force-* operation while this broker was
+   * unreachable. Registered once per broker in {@link #start(BrokerStartupContext)}, covering every
+   * physical tenant's partition group, rather than once per {@code PartitionManagerStep} gated to
+   * the default tenant only.
+   */
+  private InconsistentConfigurationListener inconsistentConfigurationListener(
+      final BrokerStartupContext brokerStartupContext) {
+    final var memberId =
+        brokerStartupContext.getClusterServices().getMembershipService().getLocalMember().id();
+    final var springBrokerBridge = brokerStartupContext.getSpringBrokerBridge();
+
+    return new InconsistentConfigurationListener() {
+      @Override
+      public void onInconsistentConfiguration(
+          final ClusterConfiguration newTopology, final ClusterConfiguration oldTopology) {
+        shutdownOnInconsistentTopology(memberId, springBrokerBridge, newTopology, oldTopology);
+      }
+
+      @Override
+      public void onInconsistentConfiguration(
+          final CurrentClusterConfiguration newConfiguration,
+          final CurrentClusterConfiguration oldConfiguration) {
+        LOGGER.warn(
+            "Received a newer cluster configuration which differs for this broker across partition groups. Shutting down broker. oldVersion={}, newVersion={}",
+            oldConfiguration.version(),
+            newConfiguration.version());
+        springBrokerBridge.initiateShutdown(
+            ERROR_CODE_ON_INCONSISTENT_TOPOLOGY,
+            "Inconsistent cluster topology detected - topology was changed while broker was"
+                + " unreachable or broker encountered data loss");
+      }
+    };
+  }
+
+  private void shutdownOnInconsistentTopology(
+      final MemberId memberId,
+      final SpringBrokerBridge springBrokerBridge,
+      final ClusterConfiguration newTopology,
+      final ClusterConfiguration oldTopology) {
+    LOGGER.warn(
+        """
+          Received a newer topology which has a different state for this broker.
+          State of this broker in new topology :'{}'
+          State of this broker in old topology: '{}'
+          This usually happens when the topology was changed forcefully when this broker was unreachable or this broker encountered a data loss. Shutting down the broker. Please restart the broker to use the new topology.
+        """,
+        newTopology.getMember(memberId),
+        oldTopology.getMember(memberId));
+    springBrokerBridge.initiateShutdown(
+        ERROR_CODE_ON_INCONSISTENT_TOPOLOGY,
+        "Inconsistent cluster topology detected - topology was changed while broker was"
+            + " unreachable or broker encountered data loss");
   }
 
   private static ActorFuture<Void> startClusterTopologyManager(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManager.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManager.java
@@ -63,5 +63,23 @@ public interface ClusterConfigurationManager {
      */
     void onInconsistentConfiguration(
         ClusterConfiguration newConfiguration, ClusterConfiguration oldConfiguration);
+
+    /**
+     * New-model counterpart of {@link #onInconsistentConfiguration(ClusterConfiguration,
+     * ClusterConfiguration)}, invoked when the local member's state differs, in any partition
+     * group, between the old and newly-merged {@link CurrentClusterConfiguration}. Defaults to
+     * projecting both configurations to their legacy default-group view so that listeners written
+     * against the legacy model keep working unchanged; override this directly to react to
+     * inconsistencies in a specific, non-default partition group.
+     *
+     * @param newConfiguration new configuration after merging
+     * @param oldConfiguration the local configuration before merging
+     */
+    default void onInconsistentConfiguration(
+        final CurrentClusterConfiguration newConfiguration,
+        final CurrentClusterConfiguration oldConfiguration) {
+      onInconsistentConfiguration(
+          newConfiguration.toLegacyDefault(), oldConfiguration.toLegacyDefault());
+    }
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -174,13 +174,8 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     backoffRetry = new ExponentialBackoffRetryDelay(maxRetryDelay, minRetryDelay);
     useNewConfig = true;
     coordinatorSupplier =
-        ClusterConfigurationCoordinatorSupplier.ofMembers(
-            () ->
-                this.persistedCurrentConfiguration
-                    .getConfiguration()
-                    .globalConfiguration()
-                    .members()
-                    .keySet());
+        ClusterConfigurationCoordinatorSupplier.from(
+            () -> this.persistedCurrentConfiguration.getConfiguration());
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.util.VisibleForTesting;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -400,6 +401,66 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
         mergedConfiguration.getMember(localMemberId), oldConfiguration.getMember(localMemberId));
   }
 
+  /**
+   * New-model counterpart of {@link #isConflictingConfiguration(ClusterConfiguration,
+   * ClusterConfiguration)}. The legacy model has a single partition group, so the local member's
+   * state is checked once; the new model has one {@link PartitionGroupConfiguration} per physical
+   * tenant, so the local member's state is checked in every group it appears in, in either
+   * configuration.
+   */
+  private boolean isConflictingConfiguration(
+      final CurrentClusterConfiguration mergedConfiguration,
+      final CurrentClusterConfiguration oldConfiguration) {
+    final var groupIds = new HashSet<>(oldConfiguration.partitionGroups().keySet());
+    groupIds.addAll(mergedConfiguration.partitionGroups().keySet());
+    return groupIds.stream()
+        .anyMatch(groupId -> isConflictingGroup(groupId, mergedConfiguration, oldConfiguration));
+  }
+
+  private boolean isConflictingGroup(
+      final String groupId,
+      final CurrentClusterConfiguration mergedConfiguration,
+      final CurrentClusterConfiguration oldConfiguration) {
+    final var mergedGroup = mergedConfiguration.partitionGroup(groupId);
+    final var oldGroup = oldConfiguration.partitionGroup(groupId);
+    final var mergedMemberState =
+        mergedGroup == null ? null : mergedGroup.members().get(localMemberId);
+    final var oldMemberState = oldGroup == null ? null : oldGroup.members().get(localMemberId);
+    if (mergedMemberState == null
+        && oldMemberState != null
+        && wasTargetedByCurrentPlan(oldConfiguration, groupId)) {
+      // The member's zero-partition entry was pruned from this group as part of the current
+      // plan's own operations targeting it (e.g. it is leaving this group as one of the plan's
+      // steps). A faster peer's gossip can report that removal before the local apply catches up;
+      // that race is expected, not a forced/unexpected change, so it's not a conflict. Mirrors the
+      // LEFT-member exclusion in isConflictingConfiguration(ClusterConfiguration,
+      // ClusterConfiguration) above. A removal the member was never an operation-target for (e.g. a
+      // force-reconfigure applied by another member on its behalf) still falls through and
+      // conflicts, since {@code wasTargetedByCurrentPlan} only returns true for the former.
+      return false;
+    }
+    return !Objects.equals(mergedMemberState, oldMemberState);
+  }
+
+  /**
+   * Returns {@code true} if the current (unmutated, per-phase) plan has an operation targeting
+   * {@link #localMemberId} within {@code groupId}'s {@link PartitionGroupParallelPhase}s, whether
+   * already completed or still pending. Phases are fixed at plan creation and never mutated, so
+   * this reflects the member's original involvement in the plan regardless of how far it has since
+   * progressed.
+   */
+  private boolean wasTargetedByCurrentPlan(
+      final CurrentClusterConfiguration configuration, final String groupId) {
+    return configuration.phasedChangeState().pending().stream()
+        .flatMap(plan -> plan.phases().stream())
+        .filter(PartitionGroupParallelPhase.class::isInstance)
+        .map(PartitionGroupParallelPhase.class::cast)
+        .map(phase -> phase.groupOperations().get(groupId))
+        .filter(Objects::nonNull)
+        .flatMap(List::stream)
+        .anyMatch(operation -> operation.memberId().equals(localMemberId));
+  }
+
   private boolean shouldApplyConfigurationChangeOperation(
       final ClusterConfiguration mergedConfiguration) {
     // Configuration change operation should be applied only once. The operation is removed
@@ -590,9 +651,17 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
             final var local = persistedCurrentConfiguration.getConfiguration();
             final var merged = local.merge(receivedConfiguration);
             if (!merged.equals(local)) {
+              final var isConflictingConfiguration = isConflictingConfiguration(merged, local);
               updateLocalCurrentConfiguration(merged)
                   .ifRightOrLeft(
-                      applied -> applyNewConfigurationChangeOperation(),
+                      applied -> {
+                        if (isConflictingConfiguration
+                            && onInconsistentConfigurationDetected != null) {
+                          onInconsistentConfigurationDetected.onInconsistentConfiguration(
+                              applied, local);
+                        }
+                        applyNewConfigurationChangeOperation();
+                      },
                       error ->
                           LOG.warn(
                               "Failed to process cluster configuration received via gossip. '{}'",

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedCurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedCurrentClusterConfiguration.java
@@ -17,6 +17,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.zip.CRC32C;
+import org.jspecify.annotations.NonNull;
 
 /**
  * The multi-partition-group counterpart of {@link PersistedClusterConfiguration}. Reads and writes
@@ -48,12 +49,12 @@ public final class PersistedCurrentClusterConfiguration {
 
   private final Path configurationFile;
   private final ClusterConfigurationSerializer serializer;
-  private CurrentClusterConfiguration configuration;
+  private @NonNull CurrentClusterConfiguration configuration;
 
   private PersistedCurrentClusterConfiguration(
       final Path configurationFile,
       final ClusterConfigurationSerializer serializer,
-      final CurrentClusterConfiguration configuration) {
+      final @NonNull CurrentClusterConfiguration configuration) {
     this.configurationFile = configurationFile;
     this.serializer = serializer;
     this.configuration = configuration;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedCurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedCurrentClusterConfiguration.java
@@ -17,7 +17,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.zip.CRC32C;
-import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * The multi-partition-group counterpart of {@link PersistedClusterConfiguration}. Reads and writes
@@ -41,6 +41,7 @@ import org.jspecify.annotations.NonNull;
  *
  * First-boot migration after an upgrade is therefore automatic and requires no separate step.
  */
+@NullMarked
 public final class PersistedCurrentClusterConfiguration {
 
   static final byte VERSION_LEGACY = 1;
@@ -49,12 +50,12 @@ public final class PersistedCurrentClusterConfiguration {
 
   private final Path configurationFile;
   private final ClusterConfigurationSerializer serializer;
-  private @NonNull CurrentClusterConfiguration configuration;
+  private CurrentClusterConfiguration configuration;
 
   private PersistedCurrentClusterConfiguration(
       final Path configurationFile,
       final ClusterConfigurationSerializer serializer,
-      final @NonNull CurrentClusterConfiguration configuration) {
+      final CurrentClusterConfiguration configuration) {
     this.configurationFile = configurationFile;
     this.serializer = serializer;
     this.configuration = configuration;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationCoordinatorSupplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationCoordinatorSupplier.java
@@ -10,10 +10,13 @@ package io.camunda.zeebe.dynamic.config.api;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 public interface ClusterConfigurationCoordinatorSupplier {
   MemberId getDefaultCoordinator();
@@ -74,11 +77,47 @@ public interface ClusterConfigurationCoordinatorSupplier {
 
   static ClusterConfigurationCoordinatorSupplier from(
       final Supplier<CurrentClusterConfiguration> clusterTopologySupplier) {
-    return ofMembers(() -> clusterTopologySupplier.get().globalConfiguration().members().keySet());
+    return ofMembers(() -> getActiveMembers(clusterTopologySupplier.get()));
   }
 
   static ClusterConfigurationCoordinatorSupplier of(
       final Supplier<ClusterConfiguration> clusterTopologySupplier) {
     return ofMembers(() -> clusterTopologySupplier.get().members().keySet());
+  }
+
+  private static Set<MemberId> getActiveMembers(
+      final CurrentClusterConfiguration currentClusterConfiguration) {
+    final var toBeRemovedMembers =
+        currentClusterConfiguration
+            .phasedChangeState()
+            .pending()
+            .map(
+                plan ->
+                    plan.phases().stream()
+                        .filter(phase -> phase instanceof GlobalPhase)
+                        .flatMap(
+                            phase ->
+                                ((GlobalPhase) phase)
+                                    .operations().stream()
+                                        .filter(
+                                            op ->
+                                                op
+                                                    instanceof
+                                                    GlobalChangeOperation.MemberRemoveOperation)
+                                        .map(
+                                            op ->
+                                                ((GlobalChangeOperation.MemberRemoveOperation) op)
+                                                    .memberToRemove()))
+                        .toList());
+
+    final var result =
+        toBeRemovedMembers
+            .map(
+                memberIds ->
+                    currentClusterConfiguration.getMembers().stream()
+                        .filter(member -> !memberIds.contains(member))
+                        .collect(Collectors.toSet()))
+            .orElseGet(currentClusterConfiguration::getMembers);
+    return result;
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplNewConfigTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplNewConfigTest.java
@@ -13,6 +13,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.StaticInitializer;
+import io.camunda.zeebe.dynamic.config.ClusterConfigurationManager.InconsistentConfigurationListener;
 import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor.NoopClusterChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.ClusterMembershipChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeAppliersImpl;
@@ -28,6 +29,8 @@ import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState.State;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
@@ -38,6 +41,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
@@ -54,6 +58,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -321,6 +327,274 @@ final class ClusterConfigurationManagerImplNewConfigTest {
     final var config = configuration(manager);
     assertThat(config.globalConfiguration().getMember(MEMBER_1).state()).isEqualTo(State.ACTIVE);
     assertThat(config.globalConfiguration().hasPendingChanges()).isFalse();
+  }
+
+  @Test
+  void shouldDetectInconsistencyWhenLocalMemberStateDiffersInAnyPartitionGroup() {
+    // given — member 0 replicates partition 1 in the "default" group, and partition 2 in a second
+    // group ("tenanta")
+    final var manager = newManager(MEMBER_0);
+    final var defaultGroup =
+        new PartitionGroupConfiguration(
+            1,
+            0,
+            Map.of(
+                MEMBER_0,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(1, partitionConfig))),
+                MEMBER_1,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(2, partitionConfig)))),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var tenantAGroup =
+        new PartitionGroupConfiguration(
+            1,
+            0,
+            Map.of(
+                MEMBER_0,
+                BrokerPartitionState.initialize(
+                    Map.of(2, PartitionState.active(1, partitionConfig)))),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var global =
+        new GlobalConfiguration(
+            1,
+            Optional.empty(),
+            Map.of(
+                MEMBER_0, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
+                MEMBER_1, new BrokerState(0, Instant.EPOCH, State.ACTIVE)),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var seeded =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            global,
+            Map.of(
+                CurrentClusterConfiguration.DEFAULT_GROUP, defaultGroup, "tenanta", tenantAGroup),
+            PhasedChangeState.empty());
+    manager.updateMultiConfiguration(ignored -> seeded).join();
+
+    final var newConfigSeen = new AtomicReference<CurrentClusterConfiguration>();
+    final var oldConfigSeen = new AtomicReference<CurrentClusterConfiguration>();
+    manager.registerTopologyChangedListener(
+        new InconsistentConfigurationListener() {
+          @Override
+          public void onInconsistentConfiguration(
+              final ClusterConfiguration newConfiguration,
+              final ClusterConfiguration oldConfiguration) {
+            org.assertj.core.api.Assertions.fail(
+                "Expected CurrentClusterConfiguration overload to be used for inconsistency detection");
+          }
+
+          @Override
+          public void onInconsistentConfiguration(
+              final CurrentClusterConfiguration newConfiguration,
+              final CurrentClusterConfiguration oldConfiguration) {
+            newConfigSeen.set(newConfiguration);
+            oldConfigSeen.set(oldConfiguration);
+          }
+        });
+
+    // when — a force-scale-down is received via gossip: member 0 is stripped out of the "tenanta"
+    // group's configuration without its own participation (the "default" group is untouched)
+    final var forcedTenantAGroup =
+        new PartitionGroupConfiguration(
+            2, 0, Map.of(), Optional.empty(), Optional.empty(), Optional.empty());
+    final var received =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            global,
+            Map.of(
+                CurrentClusterConfiguration.DEFAULT_GROUP,
+                defaultGroup,
+                "tenanta",
+                forcedTenantAGroup),
+            PhasedChangeState.empty());
+    manager.onGossipReceivedCurrent(received);
+
+    // then — the inconsistency listener fires even though only a non-default group changed
+    Awaitility.await("Inconsistency listener is invoked")
+        .untilAsserted(() -> assertThat(newConfigSeen.get()).isNotNull());
+    assertThat(oldConfigSeen.get().partitionGroup("tenanta").members()).containsKey(MEMBER_0);
+    assertThat(newConfigSeen.get().partitionGroup("tenanta").members()).isEmpty();
+  }
+
+  @Test
+  void shouldNotDetectInconsistencyWhenMemberLeavesGroupAsPartOfCurrentPlan() {
+    // given — member 0 replicates partition 1 in the "default" group, and a plan is under way
+    // whose (unmutated) phase 0 has member 0 leaving that group as one of its steps. No partition
+    // group applier is registered, so the manager cannot apply this operation locally itself --
+    // simulating the race where a peer's gossip reports the completion before the local apply
+    // would otherwise catch up.
+    final var persisted =
+        PersistedCurrentClusterConfiguration.ofFile(
+            tmp.resolve("config-no-appliers.meta"), new ProtoBufSerializer());
+    final var manager =
+        new ClusterConfigurationManagerImpl(
+            executor,
+            MEMBER_0,
+            persisted,
+            new TopologyManagerMetrics(new SimpleMeterRegistry()),
+            Duration.ofMillis(1),
+            Duration.ofMillis(1));
+    manager.setCurrentConfigurationGossiper(ignored -> {});
+    final var leaveOperation = new PartitionLeaveOperation(MEMBER_0, 1, 1);
+    final var group =
+        new PartitionGroupConfiguration(
+            2,
+            0,
+            Map.of(
+                MEMBER_0,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(1, partitionConfig))),
+                MEMBER_1,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(2, partitionConfig)))),
+            Optional.empty(),
+            // The phase has been activated: its operation is copied into the group's own pending
+            // changes, matching what applyPhase does. Without this, maybeAdvancePhase would see the
+            // group as trivially drained (no pending changes) and immediately complete the whole
+            // plan before the gossip-receive below even runs.
+            Optional.of(ClusterChangePlan.init(1, List.of(leaveOperation))),
+            Optional.empty());
+    final var global =
+        new GlobalConfiguration(
+            1,
+            Optional.empty(),
+            Map.of(
+                MEMBER_0, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
+                MEMBER_1, new BrokerState(0, Instant.EPOCH, State.ACTIVE)),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var plan =
+        PhasedChangePlan.init(
+            1,
+            List.of(
+                new PartitionGroupParallelPhase(
+                    Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, List.of(leaveOperation)))),
+            Instant.EPOCH);
+    final var seeded =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            global,
+            Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, group),
+            new PhasedChangeState(Optional.of(plan), Optional.empty()));
+    manager.updateMultiConfiguration(ignored -> seeded).join();
+
+    final var listenerCalled = new AtomicBoolean(false);
+    manager.registerTopologyChangedListener(
+        (newConfiguration, oldConfiguration) -> listenerCalled.set(true));
+
+    // when — a faster peer's gossip reports member 0 already pruned from the group (its
+    // zero-partition entry removed) before the local apply of its own leave operation catches up;
+    // the overall plan (phase 0, unmutated) still lists member 0 as one of the phase's operations
+    final var groupWithoutMember0 =
+        new PartitionGroupConfiguration(
+            3,
+            0,
+            Map.of(
+                MEMBER_1,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(2, partitionConfig)))),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var received =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            global,
+            Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, groupWithoutMember0),
+            new PhasedChangeState(Optional.of(plan), Optional.empty()));
+    manager.onGossipReceivedCurrent(received);
+
+    // then — the merge is applied (member 0 is gone from the group), but no inconsistency is
+    // reported, since member 0 was itself an operation-target in the group's current plan
+    Awaitility.await("Configuration is merged")
+        .untilAsserted(
+            () ->
+                assertThat(
+                        configuration(manager)
+                            .partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)
+                            .hasMember(MEMBER_0))
+                    .isFalse());
+    assertThat(listenerCalled).describedAs("Inconsistency listener is never invoked").isFalse();
+  }
+
+  @Test
+  void shouldNotDetectInconsistencyWhenNoPartitionGroupChangesForLocalMember() {
+    // given — member 0 replicates partition 1 in the "default" group
+    final var manager = newManager(MEMBER_0);
+    final var defaultGroup =
+        new PartitionGroupConfiguration(
+            1,
+            0,
+            Map.of(
+                MEMBER_0,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(1, partitionConfig))),
+                MEMBER_1,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(2, partitionConfig)))),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var global =
+        new GlobalConfiguration(
+            1,
+            Optional.empty(),
+            Map.of(
+                MEMBER_0, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
+                MEMBER_1, new BrokerState(0, Instant.EPOCH, State.ACTIVE)),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var seeded =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            global,
+            Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, defaultGroup),
+            PhasedChangeState.empty());
+    manager.updateMultiConfiguration(ignored -> seeded).join();
+
+    final var listenerCalled = new AtomicBoolean(false);
+    manager.registerTopologyChangedListener(
+        (newConfiguration, oldConfiguration) -> listenerCalled.set(true));
+
+    // when — a gossip update changes only member 1's state; member 0's state is untouched in every
+    // group
+    final var newBrokerState = new BrokerState(1, Instant.EPOCH, State.LEAVING);
+    final var receivedGlobal =
+        new GlobalConfiguration(
+            1,
+            Optional.empty(),
+            Map.of(
+                MEMBER_0,
+                new BrokerState(0, Instant.EPOCH, State.ACTIVE),
+                MEMBER_1,
+                newBrokerState),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var received =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            receivedGlobal,
+            Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, defaultGroup),
+            PhasedChangeState.empty());
+    manager.onGossipReceivedCurrent(received);
+
+    // then
+    Awaitility.await("Configuration is merged")
+        .untilAsserted(
+            () ->
+                assertThat(configuration(manager).globalConfiguration().getMember(MEMBER_1).state())
+                    .isEqualTo(State.LEAVING));
+    assertThat(listenerCalled).describedAs("Inconsistency listener is never invoked").isFalse();
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/NonZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/NonZoneAwareClusterEndpointIT.java
@@ -114,6 +114,7 @@ final class NonZoneAwareClusterEndpointIT extends ClusterEndpointIT {
         // then
         assertThat(response.getPlannedChanges()).isNotEmpty();
         Awaitility.await()
+            .ignoreExceptions()
             .atMost(Duration.ofMinutes(1))
             .untilAsserted(() -> assertThat(actuator.getTopology().getPendingChange()).isNull());
         if (i == 0 && !scenario.delayedReplacementBrokerIds().isEmpty()) {


### PR DESCRIPTION
## Summary
Bugs identified during enabling the feature flag for the new model (PR #59114)

1. **`fix: advance phase during force removal of coordinator`** — `ClusterConfigurationCoordinatorSupplier.from(...)` now excludes members that have a pending `MemberRemoveOperation` targeting them from the set considered for coordinator election. Without this, force-removing the current coordinator could leave the plan unable to advance, since the removed member (still the lowest id) would keep being selected as coordinator.

2. **`fix: invoke inconsistent-configuration listener for the new cluster-config model`** — `ClusterConfigurationManagerImpl` never invoked the inconsistent-configuration listener for the new model. A broker whose own state was force-changed without its participation (e.g. a force scale-down while it was still up) never detected the inconsistency and never shut itself down, unlike the legacy model. Detection now compares the local member's state across every partition group, not just a single default group. The listener's registration was also moved from `PartitionManagerStep` (gated to the default physical tenant, one instance per tenant) to `DynamicClusterConfigurationService#start()` (once per broker, covering every tenant).

Part of #56018.