### PR TITLE
refactor: enforce read-side (search.entities) MyBatis constructor-mapping invariants

### DIFF
--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -36,15 +36,18 @@
   <resultMap id="BatchOperationItemResultMap"
     type="io.camunda.search.entities.BatchOperationEntity$BatchOperationItemEntity">
     <constructor>
-      <idArg column="BATCH_OPERATION_KEY" javaType="java.lang.String"/>
-      <arg column="OPERATION_TYPE" javaType="io.camunda.search.entities.BatchOperationType"/>
-      <arg column="ITEM_KEY" javaType="java.lang.Long"/>
-      <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
-      <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
+      <idArg column="BATCH_OPERATION_KEY" javaType="java.lang.String" name="batchOperationKey"/>
+      <arg column="OPERATION_TYPE" javaType="io.camunda.search.entities.BatchOperationType"
+        name="operationType"/>
+      <arg column="ITEM_KEY" javaType="java.lang.Long" name="itemKey"/>
+      <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long" name="processInstanceKey"/>
+      <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"
+        name="rootProcessInstanceKey"/>
       <arg column="STATE"
-        javaType="io.camunda.search.entities.BatchOperationEntity$BatchOperationItemState"/>
-      <arg column="PROCESSED_DATE" javaType="java.time.OffsetDateTime"/>
-      <arg column="ERROR_MESSAGE" javaType="java.lang.String"/>
+        javaType="io.camunda.search.entities.BatchOperationEntity$BatchOperationItemState"
+        name="state"/>
+      <arg column="PROCESSED_DATE" javaType="java.time.OffsetDateTime" name="processedDate"/>
+      <arg column="ERROR_MESSAGE" javaType="java.lang.String" name="errorMessage"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
@@ -12,16 +12,19 @@
 
   <resultMap id="clusterVariableResultMap" type="io.camunda.search.entities.ClusterVariableEntity">
     <constructor>
-      <idArg column="CLUSTER_VARIABLE_ID" javaType="java.lang.String"/>
+      <idArg column="CLUSTER_VARIABLE_ID" javaType="java.lang.String" name="id"/>
       <arg column="VAR_NAME" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="name"/>
       <arg column="VAR_VALUE" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="VAR_FULL_VALUE" javaType="java.lang.String"/>
-      <arg column="IS_PREVIEW" javaType="boolean"/>
-      <arg column="SCOPE" javaType="io.camunda.search.entities.ClusterVariableScope"/>
-      <arg column="TENANT_ID" javaType="java.lang.String"/>
-      <arg column="KIND" javaType="io.camunda.search.entities.ClusterVariableKind"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="value"/>
+      <arg column="VAR_FULL_VALUE" javaType="java.lang.String" name="fullValue"/>
+      <arg column="IS_PREVIEW" javaType="java.lang.Boolean" name="isPreview"/>
+      <arg column="SCOPE" javaType="io.camunda.search.entities.ClusterVariableScope"
+        name="scope"/>
+      <arg column="TENANT_ID" javaType="java.lang.String" name="tenantId"/>
+      <arg column="KIND" javaType="io.camunda.search.entities.ClusterVariableKind" name="kind"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -469,11 +469,11 @@
   <resultMap id="flowNodeStatisticsResultMap"
     type="io.camunda.search.entities.ProcessFlowNodeStatisticsEntity">
     <constructor>
-      <idArg column="FLOW_NODE_ID" javaType="java.lang.String"/>
-      <arg column="COUNT_ACTIVE" javaType="java.lang.Long"/>
-      <arg column="COUNT_CANCELED" javaType="java.lang.Long"/>
-      <arg column="COUNT_INCIDENTS" javaType="java.lang.Long"/>
-      <arg column="COUNT_COMPLETED" javaType="java.lang.Long"/>
+      <idArg column="FLOW_NODE_ID" javaType="java.lang.String" name="flowNodeId"/>
+      <arg column="COUNT_ACTIVE" javaType="java.lang.Long" name="active"/>
+      <arg column="COUNT_CANCELED" javaType="java.lang.Long" name="canceled"/>
+      <arg column="COUNT_INCIDENTS" javaType="java.lang.Long" name="incidents"/>
+      <arg column="COUNT_COMPLETED" javaType="java.lang.Long" name="completed"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/DecisionDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionDefinitionMapper.xml
@@ -124,20 +124,28 @@
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.DecisionDefinitionEntity">
     <constructor>
-      <idArg column="DECISION_DEFINITION_KEY" javaType="java.lang.Long"/>
+      <idArg column="DECISION_DEFINITION_KEY" javaType="java.lang.Long"
+        name="decisionDefinitionKey"/>
       <arg column="DECISION_DEFINITION_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="decisionDefinitionId"/>
       <arg column="NAME" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="VERSION" javaType="java.lang.Integer"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="name"/>
+      <arg column="VERSION" javaType="java.lang.Integer" name="version"/>
       <arg column="DECISION_REQUIREMENTS_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="DECISION_REQUIREMENTS_KEY" javaType="java.lang.Long"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="decisionRequirementsId"/>
+      <arg column="DECISION_REQUIREMENTS_KEY" javaType="java.lang.Long"
+        name="decisionRequirementsKey"/>
       <arg column="DECISION_REQUIREMENTS_NAME" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="DECISION_REQUIREMENTS_VERSION" javaType="java.lang.Integer"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="decisionRequirementsName"/>
+      <arg column="DECISION_REQUIREMENTS_VERSION" javaType="java.lang.Integer"
+        name="decisionRequirementsVersion"/>
       <arg column="TENANT_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="tenantId"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -203,37 +203,50 @@
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.DecisionInstanceEntity">
     <constructor>
-      <idArg column="DECISION_INSTANCE_ID" javaType="java.lang.String"/>
-      <arg column="DECISION_INSTANCE_KEY" javaType="java.lang.Long"/>
+      <idArg column="DECISION_INSTANCE_ID" javaType="java.lang.String" name="decisionInstanceId"/>
+      <arg column="DECISION_INSTANCE_KEY" javaType="java.lang.Long" name="decisionInstanceKey"/>
       <arg column="STATE"
-        javaType="io.camunda.search.entities.DecisionInstanceEntity$DecisionInstanceState"/>
-      <arg column="EVALUATION_DATE" javaType="java.time.OffsetDateTime"/>
-      <arg column="EVALUATION_FAILURE" javaType="java.lang.String"/>
-      <arg column="EVALUATION_FAILURE_MESSAGE" javaType="java.lang.String"/>
-      <arg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long"/>
-      <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
-      <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
-      <arg column="BUSINESS_ID" javaType="java.lang.String"/>
-      <arg column="FLOW_NODE_INSTANCE_KEY" javaType="java.lang.Long"/>
+        javaType="io.camunda.search.entities.DecisionInstanceEntity$DecisionInstanceState"
+        name="state"/>
+      <arg column="EVALUATION_DATE" javaType="java.time.OffsetDateTime" name="evaluationDate"/>
+      <arg column="EVALUATION_FAILURE" javaType="java.lang.String" name="evaluationFailure"/>
+      <arg column="EVALUATION_FAILURE_MESSAGE" javaType="java.lang.String"
+        name="evaluationFailureMessage"/>
+      <arg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long"
+        name="processDefinitionKey"/>
+      <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long" name="processInstanceKey"/>
+      <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"
+        name="rootProcessInstanceKey"/>
+      <arg column="BUSINESS_ID" javaType="java.lang.String" name="businessId"/>
+      <arg column="FLOW_NODE_INSTANCE_KEY" javaType="java.lang.Long"
+        name="flowNodeInstanceKey"/>
       <arg column="TENANT_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="tenantId"/>
       <arg column="DECISION_DEFINITION_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="DECISION_DEFINITION_KEY" javaType="java.lang.Long"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="decisionDefinitionId"/>
+      <arg column="DECISION_DEFINITION_KEY" javaType="java.lang.Long"
+        name="decisionDefinitionKey"/>
       <arg column="DECISION_DEFINITION_NAME" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="DECISION_DEFINITION_VERSION" javaType="java.lang.Integer"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="decisionDefinitionName"/>
+      <arg column="DECISION_DEFINITION_VERSION" javaType="java.lang.Integer"
+        name="decisionDefinitionVersion"/>
       <arg column="TYPE"
-        javaType="io.camunda.search.entities.DecisionInstanceEntity$DecisionDefinitionType"/>
-      <arg column="ROOT_DECISION_DEFINITION_KEY" javaType="java.lang.Long"/>
+        javaType="io.camunda.search.entities.DecisionInstanceEntity$DecisionDefinitionType"
+        name="decisionDefinitionType"/>
+      <arg column="ROOT_DECISION_DEFINITION_KEY" javaType="java.lang.Long"
+        name="rootDecisionDefinitionKey"/>
       <arg column="RESULT" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="result"/>
       <!-- The list is loaded separately (optional). But we still need a value (NULL) here.
        we use the ObjectTypeHandler because no other typeHandler can map NULL to List -->
       <arg column="EVALUATED_INPUTS" javaType="java.util.List"
-        typeHandler="org.apache.ibatis.type.ObjectTypeHandler"/>
+        typeHandler="org.apache.ibatis.type.ObjectTypeHandler" name="evaluatedInputs"/>
       <arg column="EVALUATED_OUTPUTS" javaType="java.util.List"
-        typeHandler="org.apache.ibatis.type.ObjectTypeHandler"/>
+        typeHandler="org.apache.ibatis.type.ObjectTypeHandler" name="evaluatedOutputs"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/DecisionRequirementsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionRequirementsMapper.xml
@@ -97,17 +97,22 @@
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.DecisionRequirementsEntity">
     <constructor>
-      <idArg column="DECISION_REQUIREMENTS_KEY" javaType="java.lang.Long"/>
+      <idArg column="DECISION_REQUIREMENTS_KEY" javaType="java.lang.Long"
+        name="decisionRequirementsKey"/>
       <arg column="DECISION_REQUIREMENTS_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="decisionRequirementsId"/>
       <arg column="NAME" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="VERSION" javaType="java.lang.Integer"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="name"/>
+      <arg column="VERSION" javaType="java.lang.Integer" name="version"/>
       <arg column="RESOURCE_NAME" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="XML" javaType="java.lang.String"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="resourceName"/>
+      <arg column="XML" javaType="java.lang.String" name="xml"/>
       <arg column="TENANT_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="tenantId"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/DeployedResourceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DeployedResourceMapper.xml
@@ -14,18 +14,21 @@
 
   <resultMap id="resourceResultMap" type="io.camunda.search.entities.DeployedResourceEntity">
     <constructor>
-      <idArg column="RESOURCE_KEY" javaType="java.lang.Long"/>
+      <idArg column="RESOURCE_KEY" javaType="java.lang.Long" name="resourceKey"/>
       <arg column="RESOURCE_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="resourceId"/>
       <arg column="RESOURCE_NAME" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="RESOURCE_TYPE" javaType="java.lang.String"/>
-      <arg column="VERSION" javaType="int"/>
-      <arg column="VERSION_TAG" javaType="java.lang.String"/>
-      <arg column="DEPLOYMENT_KEY" javaType="java.lang.Long"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="resourceName"/>
+      <arg column="RESOURCE_TYPE" javaType="java.lang.String" name="resourceType"/>
+      <arg column="VERSION" javaType="java.lang.Integer" name="version"/>
+      <arg column="VERSION_TAG" javaType="java.lang.String" name="versionTag"/>
+      <arg column="DEPLOYMENT_KEY" javaType="java.lang.Long" name="deploymentKey"/>
       <arg column="TENANT_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="RESOURCE_CONTENT" javaType="[B" jdbcType="BINARY"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="tenantId"/>
+      <arg column="RESOURCE_CONTENT" javaType="[B" jdbcType="BINARY" name="resourceContent"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/FormMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/FormMapper.xml
@@ -14,14 +14,17 @@
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.FormEntity">
     <constructor>
-      <idArg column="FORM_KEY" javaType="java.lang.Long"/>
+      <idArg column="FORM_KEY" javaType="java.lang.Long" name="formKey"/>
       <arg column="TENANT_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="tenantId"/>
       <arg column="FORM_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="formId"/>
       <arg column="SCHEMA_XML" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="VERSION" javaType="java.lang.Long"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="schema"/>
+      <arg column="VERSION" javaType="java.lang.Long" name="version"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
@@ -158,23 +158,32 @@
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.IncidentEntity">
     <constructor>
-      <idArg column="INCIDENT_KEY" javaType="java.lang.Long"/>
-      <arg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long"/>
+      <idArg column="INCIDENT_KEY" javaType="java.lang.Long" name="incidentKey"/>
+      <arg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long"
+        name="processDefinitionKey"/>
       <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
-      <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
-      <arg column="ERROR_TYPE" javaType="io.camunda.search.entities.IncidentEntity$ErrorType"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="processDefinitionId"/>
+      <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long" name="processInstanceKey"/>
+      <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"
+        name="rootProcessInstanceKey"/>
+      <arg column="ERROR_TYPE" javaType="io.camunda.search.entities.IncidentEntity$ErrorType"
+        name="errorType"/>
       <arg column="ERROR_MESSAGE" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="errorMessage"/>
       <arg column="FLOW_NODE_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="FLOW_NODE_INSTANCE_KEY" javaType="java.lang.Long"/>
-      <arg column="CREATION_DATE" javaType="java.time.OffsetDateTime" />
-      <arg column="STATE" javaType="io.camunda.search.entities.IncidentEntity$IncidentState"/>
-      <arg column="JOB_KEY" javaType="java.lang.Long"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="flowNodeId"/>
+      <arg column="FLOW_NODE_INSTANCE_KEY" javaType="java.lang.Long"
+        name="flowNodeInstanceKey"/>
+      <arg column="CREATION_DATE" javaType="java.time.OffsetDateTime" name="creationTime"/>
+      <arg column="STATE" javaType="io.camunda.search.entities.IncidentEntity$IncidentState"
+        name="state"/>
+      <arg column="JOB_KEY" javaType="java.lang.Long" name="jobKey"/>
       <arg column="TENANT_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="tenantId"/>
     </constructor>
 
   </resultMap>
@@ -248,8 +257,18 @@
     ) t
   </select>
 
+  <resultMap id="processInstanceStatisticsByErrorResultMap"
+    type="io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity">
+    <constructor>
+      <idArg column="ERROR_HASH_CODE" javaType="java.lang.Integer" name="errorHashCode"/>
+      <arg column="ERROR_MESSAGE" javaType="java.lang.String" name="errorMessage"/>
+      <arg column="ACTIVE_INSTANCES_WITH_ERROR_COUNT" javaType="java.lang.Long"
+        name="activeInstancesWithErrorCount"/>
+    </constructor>
+  </resultMap>
+
   <select id="processInstanceStatisticsByError" parameterType="io.camunda.db.rdbms.read.domain.IncidentProcessInstanceStatisticsByErrorDbQuery"
-          resultType="io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity">
+          resultMap="processInstanceStatisticsByErrorResultMap">
     SELECT * FROM (
       SELECT
         i.ERROR_MESSAGE_HASH AS ERROR_HASH_CODE,
@@ -326,9 +345,26 @@
     ) t
   </select>
 
+  <resultMap id="processInstanceStatisticsByDefinitionResultMap"
+    type="io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionEntity">
+    <constructor>
+      <idArg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"
+        name="processDefinitionId"/>
+      <arg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long"
+        name="processDefinitionKey"/>
+      <arg column="PROCESS_DEFINITION_NAME" javaType="java.lang.String"
+        name="processDefinitionName"/>
+      <arg column="PROCESS_DEFINITION_VERSION" javaType="java.lang.Integer"
+        name="processDefinitionVersion"/>
+      <arg column="TENANT_ID" javaType="java.lang.String" name="tenantId"/>
+      <arg column="ACTIVE_INSTANCES_WITH_ERROR_COUNT" javaType="java.lang.Long"
+        name="activeInstancesWithErrorCount"/>
+    </constructor>
+  </resultMap>
+
   <select id="processInstanceStatisticsByDefinition"
           parameterType="io.camunda.db.rdbms.read.domain.IncidentProcessInstanceStatisticsByDefinitionDbQuery"
-          resultType="io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionEntity">
+          resultMap="processInstanceStatisticsByDefinitionResultMap">
     SELECT
       pd.PROCESS_DEFINITION_ID AS PROCESS_DEFINITION_ID,
       i.PROCESS_DEFINITION_KEY AS PROCESS_DEFINITION_KEY,

--- a/db/rdbms/src/main/resources/mapper/MappingRuleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MappingRuleMapper.xml
@@ -14,15 +14,19 @@
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.MappingRuleEntity">
     <constructor>
-      <idArg column="MAPPING_RULE_ID" javaType="string"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="MAPPING_RULE_KEY" javaType="long"/>
-      <arg column="CLAIM_NAME" javaType="string"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="CLAIM_VALUE" javaType="string"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="NAME" javaType="string"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
+      <idArg column="MAPPING_RULE_ID" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="mappingRuleId"/>
+      <arg column="MAPPING_RULE_KEY" javaType="java.lang.Long" name="mappingRuleKey"/>
+      <arg column="CLAIM_NAME" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="claimName"/>
+      <arg column="CLAIM_VALUE" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="claimValue"/>
+      <arg column="NAME" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="name"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
@@ -359,11 +359,12 @@
   <resultMap id="processDefinitionStatisticsResultMap"
     type="io.camunda.search.entities.ProcessDefinitionMessageSubscriptionStatisticsEntity">
     <constructor>
-    <idArg column="PROCESS_DEFINITION_ID"  javaType="java.lang.String" />
-    <arg column="TENANT_ID"  javaType="java.lang.String" />
-    <arg column="PROCESS_DEFINITION_KEY"  javaType="java.lang.Long" />
-    <arg column="PROCESS_INSTANCES_WITH_ACTIVE_SUBSCRIPTIONS" javaType="java.lang.Long" />
-    <arg column="ACTIVE_SUBSCRIPTIONS" javaType="java.lang.Long" />
+    <idArg column="PROCESS_DEFINITION_ID" javaType="java.lang.String" name="processDefinitionId" />
+    <arg column="TENANT_ID" javaType="java.lang.String" name="tenantId" />
+    <arg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long" name="processDefinitionKey" />
+    <arg column="PROCESS_INSTANCES_WITH_ACTIVE_SUBSCRIPTIONS" javaType="java.lang.Long"
+      name="processInstancesWithActiveSubscriptions" />
+    <arg column="ACTIVE_SUBSCRIPTIONS" javaType="java.lang.Long" name="activeSubscriptions" />
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/PersistentWebSessionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/PersistentWebSessionMapper.xml
@@ -124,11 +124,13 @@
 
   <resultMap id="persistentWebSessionResultMap" type="io.camunda.search.entities.PersistentWebSessionEntity">
     <constructor>
-      <idArg column="SESSION_ID" javaType="java.lang.String"/>
-      <arg column="CREATION_TIME" javaType="java.lang.Long"/>
-      <arg column="LAST_ACCESSED_TIME" javaType="java.lang.Long"/>
-      <arg column="MAX_INACTIVE_INTERVAL_IN_SECONDS" javaType="java.lang.Long"/>
-      <arg column="ATTRIBUTES" javaType="java.util.Map" typeHandler="io.camunda.db.rdbms.sql.typehandler.MapByteArrayJsonTypeHandler"/>
+      <idArg column="SESSION_ID" javaType="java.lang.String" name="id"/>
+      <arg column="CREATION_TIME" javaType="java.lang.Long" name="creationTime"/>
+      <arg column="LAST_ACCESSED_TIME" javaType="java.lang.Long" name="lastAccessedTime"/>
+      <arg column="MAX_INACTIVE_INTERVAL_IN_SECONDS" javaType="java.lang.Long"
+        name="maxInactiveIntervalInSeconds"/>
+      <arg column="ATTRIBUTES" javaType="java.util.Map" typeHandler="io.camunda.db.rdbms.sql.typehandler.MapByteArrayJsonTypeHandler"
+        name="attributes"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -141,21 +141,26 @@
   <resultMap id="searchResultMap"
     type="io.camunda.search.entities.ProcessDefinitionEntity">
     <constructor>
-      <idArg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long"/>
-      <arg column="NAME" javaType="java.lang.String"/>
+      <idArg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long"
+        name="processDefinitionKey"/>
+      <arg column="NAME" javaType="java.lang.String" name="name"/>
       <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="BPMN_XML" javaType="java.lang.String"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="processDefinitionId"/>
+      <arg column="BPMN_XML" javaType="java.lang.String" name="bpmnXml"/>
       <arg column="RESOURCE_NAME" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="VERSION" javaType="java.lang.Integer"/>
-      <arg column="VERSION_TAG" javaType="java.lang.String"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="resourceName"/>
+      <arg column="VERSION" javaType="java.lang.Integer" name="version"/>
+      <arg column="VERSION_TAG" javaType="java.lang.String" name="versionTag"/>
       <arg column="TENANT_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="FORM_ID" javaType="java.lang.String"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="tenantId"/>
+      <arg column="FORM_ID" javaType="java.lang.String" name="formId"/>
       <arg
         column="STATE"
-        javaType="io.camunda.search.entities.ProcessDefinitionEntity$ProcessDefinitionState"/>
+        javaType="io.camunda.search.entities.ProcessDefinitionEntity$ProcessDefinitionState"
+        name="state"/>
     </constructor>
   </resultMap>
 
@@ -399,8 +404,25 @@
     ) t
   </select>
 
+  <resultMap id="processInstanceStatisticsResultMap"
+    type="io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity">
+    <constructor>
+      <idArg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"
+        name="processDefinitionId"/>
+      <arg column="TENANT_ID" javaType="java.lang.String" name="tenantId"/>
+      <arg column="LATEST_PROCESS_DEFINITION_NAME" javaType="java.lang.String"
+        name="latestProcessDefinitionName"/>
+      <arg column="HAS_MULTIPLE_VERSIONS" javaType="java.lang.Boolean"
+        name="hasMultipleVersions"/>
+      <arg column="ACTIVE_INSTANCES_WITHOUT_INCIDENT_COUNT" javaType="java.lang.Long"
+        name="activeInstancesWithoutIncidentCount"/>
+      <arg column="ACTIVE_INSTANCES_WITH_INCIDENT_COUNT" javaType="java.lang.Long"
+        name="activeInstancesWithIncidentCount"/>
+    </constructor>
+  </resultMap>
+
   <select id="processInstanceStatistics" parameterType="io.camunda.db.rdbms.read.domain.ProcessDefinitionInstanceStatisticsDbQuery"
-    resultType="io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity">
+    resultMap="processInstanceStatisticsResultMap">
     SELECT pi.PROCESS_DEFINITION_ID,
     pi.TENANT_ID,
     (SELECT pd.NAME
@@ -477,7 +499,26 @@
     ) t
   </select>
 
-  <select id="processInstanceVersionStatistics" resultType="io.camunda.search.entities.ProcessDefinitionInstanceVersionStatisticsEntity" parameterType="io.camunda.db.rdbms.read.domain.ProcessDefinitionInstanceVersionStatisticsDbQuery">
+  <resultMap id="processInstanceVersionStatisticsResultMap"
+    type="io.camunda.search.entities.ProcessDefinitionInstanceVersionStatisticsEntity">
+    <constructor>
+      <idArg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"
+        name="processDefinitionId"/>
+      <arg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long"
+        name="processDefinitionKey"/>
+      <arg column="PROCESS_DEFINITION_VERSION" javaType="java.lang.Integer"
+        name="processDefinitionVersion"/>
+      <arg column="PROCESS_DEFINITION_NAME" javaType="java.lang.String"
+        name="processDefinitionName"/>
+      <arg column="TENANT_ID" javaType="java.lang.String" name="tenantId"/>
+      <arg column="ACTIVE_INSTANCES_WITHOUT_INCIDENT_COUNT" javaType="java.lang.Long"
+        name="activeInstancesWithoutIncidentCount"/>
+      <arg column="ACTIVE_INSTANCES_WITH_INCIDENT_COUNT" javaType="java.lang.Long"
+        name="activeInstancesWithIncidentCount"/>
+    </constructor>
+  </resultMap>
+
+  <select id="processInstanceVersionStatistics" resultMap="processInstanceVersionStatisticsResultMap" parameterType="io.camunda.db.rdbms.read.domain.ProcessDefinitionInstanceVersionStatisticsDbQuery">
     SELECT
     pi.PROCESS_DEFINITION_ID,
     pi.PROCESS_DEFINITION_KEY,

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -383,25 +383,35 @@
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.ProcessInstanceEntity">
     <constructor>
-      <idArg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
-      <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
+      <idArg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long" name="processInstanceKey"/>
+      <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"
+        name="rootProcessInstanceKey"/>
       <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="PROCESS_DEFINITION_NAME" javaType="java.lang.String"/>
-      <arg column="PROCESS_DEFINITION_VERSION" javaType="java.lang.Integer"/>
-      <arg column="PROCESS_DEFINITION_VERSION_TAG" javaType="java.lang.String"/>
-      <arg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long"/>
-      <arg column="PARENT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
-      <arg column="PARENT_ELEMENT_INSTANCE_KEY" javaType="java.lang.Long"/>
-      <arg column="START_DATE" javaType="java.time.OffsetDateTime" />
-      <arg column="END_DATE" javaType="java.time.OffsetDateTime" />
-      <arg column="STATE" javaType="io.camunda.search.entities.ProcessInstanceEntity$ProcessInstanceState"/>
-      <arg column="HAS_INCIDENT" javaType="java.lang.Boolean"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="processDefinitionId"/>
+      <arg column="PROCESS_DEFINITION_NAME" javaType="java.lang.String"
+        name="processDefinitionName"/>
+      <arg column="PROCESS_DEFINITION_VERSION" javaType="java.lang.Integer"
+        name="processDefinitionVersion"/>
+      <arg column="PROCESS_DEFINITION_VERSION_TAG" javaType="java.lang.String"
+        name="processDefinitionVersionTag"/>
+      <arg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long"
+        name="processDefinitionKey"/>
+      <arg column="PARENT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"
+        name="parentProcessInstanceKey"/>
+      <arg column="PARENT_ELEMENT_INSTANCE_KEY" javaType="java.lang.Long"
+        name="parentFlowNodeInstanceKey"/>
+      <arg column="START_DATE" javaType="java.time.OffsetDateTime" name="startDate"/>
+      <arg column="END_DATE" javaType="java.time.OffsetDateTime" name="endDate"/>
+      <arg column="STATE" javaType="io.camunda.search.entities.ProcessInstanceEntity$ProcessInstanceState"
+        name="state"/>
+      <arg column="HAS_INCIDENT" javaType="java.lang.Boolean" name="hasIncident"/>
       <arg column="TENANT_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="TREE_PATH" javaType="java.lang.String"/>
-      <arg column="BUSINESS_ID" javaType="java.lang.String"/>
-      <arg column="SUSPENDED_DATE" javaType="java.time.OffsetDateTime"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="tenantId"/>
+      <arg column="TREE_PATH" javaType="java.lang.String" name="treePath"/>
+      <arg column="BUSINESS_ID" javaType="java.lang.String" name="businessId"/>
+      <arg column="SUSPENDED_DATE" javaType="java.time.OffsetDateTime" name="suspendedDate"/>
     </constructor>
     <collection property="tags" ofType="java.lang.String" javaType="java.util.Set">
       <id column="TAG_VALUE"/>

--- a/db/rdbms/src/main/resources/mapper/UserMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserMapper.xml
@@ -87,12 +87,13 @@
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.UserEntity">
     <constructor>
-      <idArg column="USER_KEY" javaType="java.lang.Long"/>
+      <idArg column="USER_KEY" javaType="java.lang.Long" name="userKey"/>
       <arg column="USERNAME" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="NAME" javaType="java.lang.String"/>
-      <arg column="EMAIL" javaType="java.lang.String"/>
-      <arg column="PASSWORD" javaType="java.lang.String"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="username"/>
+      <arg column="NAME" javaType="java.lang.String" name="name"/>
+      <arg column="EMAIL" javaType="java.lang.String" name="email"/>
+      <arg column="PASSWORD" javaType="java.lang.String" name="password"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/VariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/VariableMapper.xml
@@ -128,20 +128,25 @@
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.VariableEntity">
     <constructor>
-      <idArg column="VAR_KEY" javaType="java.lang.Long"/>
+      <idArg column="VAR_KEY" javaType="java.lang.Long" name="variableKey"/>
       <arg column="VAR_NAME" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="name"/>
       <arg column="VAR_VALUE" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="VAR_FULL_VALUE" javaType="java.lang.String"/>
-      <arg column="IS_PREVIEW" javaType="java.lang.Boolean"/>
-      <arg column="SCOPE_KEY" javaType="java.lang.Long"/>
-      <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
-      <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="value"/>
+      <arg column="VAR_FULL_VALUE" javaType="java.lang.String" name="fullValue"/>
+      <arg column="IS_PREVIEW" javaType="java.lang.Boolean" name="isPreview"/>
+      <arg column="SCOPE_KEY" javaType="java.lang.Long" name="scopeKey"/>
+      <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long" name="processInstanceKey"/>
+      <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"
+        name="rootProcessInstanceKey"/>
       <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="processDefinitionId"/>
       <arg column="TENANT_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"
+        name="tenantId"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/WaitStateMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/WaitStateMapper.xml
@@ -123,8 +123,8 @@
   <resultMap id="waitStateStatisticsResultMap"
     type="io.camunda.search.entities.WaitStateStatisticsEntity">
     <constructor>
-      <idArg column="ELEMENT_ID" javaType="java.lang.String"/>
-      <arg column="WAITING_COUNT" javaType="java.lang.Long"/>
+      <idArg column="ELEMENT_ID" javaType="java.lang.String" name="elementId"/>
+      <arg column="WAITING_COUNT" javaType="java.lang.Long" name="waitingCount"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/MapperConfigurationTestSupport.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/MapperConfigurationTestSupport.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.FileInputStream;
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.mapping.ResultFlag;
+import org.apache.ibatis.session.Configuration;
+import org.assertj.core.api.SoftAssertions;
+
+/**
+ * Shared support for tests that enforce constructor-mapping invariants on the mapper XMLs in {@code
+ * src/main/resources/mapper}, parsed via MyBatis's own {@link XMLMapperBuilder} into a real {@link
+ * Configuration} -- the same way production does -- so the checks below reuse MyBatis's own
+ * constructor-arg resolution instead of re-deriving it.
+ *
+ * <p>Used by {@link RdbmsDbModelConstructorArgsMustBeNamedTest} (scoped to {@code
+ * io.camunda.db.rdbms.write.domain}) and {@link SearchEntityConstructorArgsMustBeNamedTest} (scoped
+ * to {@code io.camunda.search.entities}).
+ */
+final class MapperConfigurationTestSupport {
+
+  private static final String MAPPER_DIR = "src/main/resources/mapper";
+
+  private MapperConfigurationTestSupport() {}
+
+  /** Parses every mapper XML into one shared {@link Configuration}, mirroring production. */
+  static Configuration parseAllMapperFiles() throws Exception {
+    final var mapperDir = new File(MAPPER_DIR);
+    assertThat(mapperDir).as("mapper resources directory").isDirectory();
+    final var mapperFiles = mapperDir.listFiles((dir, name) -> name.endsWith(".xml"));
+    assertThat(mapperFiles).as("mapper XML files").isNotEmpty();
+
+    final var configuration = new Configuration();
+    for (final File mapperFile : mapperFiles) {
+      try (var inputStream = new FileInputStream(mapperFile)) {
+        new XMLMapperBuilder(
+                inputStream, configuration, mapperFile.getPath(), configuration.getSqlFragments())
+            .parse();
+      }
+    }
+    return configuration;
+  }
+
+  /**
+   * Asserts every constructor-flagged {@code ResultMapping} whose resultMap target type starts with
+   * {@code packagePrefix} has a non-blank name (from the mapper XML's {@code name=} attribute). A
+   * resultMap with no {@code name=} on any arg is tolerated silently by MyBatis via positional
+   * fallback matching -- this is the one case that check needs to catch, since a name= that doesn't
+   * match a real constructor parameter, or a javaType that doesn't match that parameter's declared
+   * type, already fails loudly as a {@code BuilderException} while parsing, before this assertion
+   * ever runs. Once every arg in a resultMap is named, the mapper XML's declaration order stops
+   * mattering entirely: {@code ResultMap.Builder.build()} re-sorts named constructor args into the
+   * target's actual declared parameter order before storing the resultMap, so a mapper XML with
+   * every arg named and in a different order than the record's constructor is not itself a bug --
+   * this is a property of MyBatis's own resolution, not something this check (or a reviewer
+   * eyeballing column order) needs to separately verify.
+   */
+  static void assertConstructorArgsNamed(
+      final Configuration configuration, final String packagePrefix, final SoftAssertions softly) {
+    for (final String resultMapId : configuration.getResultMapNames()) {
+      if (!resultMapId.contains(".")) {
+        // Short-id alias for the same resultMap, registered under its unqualified id -- skip to
+        // avoid checking every resultMap twice.
+        continue;
+      }
+      final var resultMap = configuration.getResultMap(resultMapId);
+      if (!resultMap.getType().getName().startsWith(packagePrefix)) {
+        continue;
+      }
+      for (final var mapping : resultMap.getResultMappings()) {
+        if (mapping.getFlags().contains(ResultFlag.CONSTRUCTOR)) {
+          softly
+              .assertThat(mapping.getProperty())
+              .as(
+                  "%s <constructor arg column=\"%s\"> must have a non-blank name=",
+                  resultMapId, mapping.getColumn())
+              .isNotBlank();
+        }
+      }
+    }
+  }
+
+  /**
+   * Asserts no statement whose resolved result type starts with {@code packagePrefix} relies on
+   * implicit {@code resultType=} automapping. MyBatis never registers a {@code resultType=}-only
+   * mapping in the shared {@link Configuration} -- it builds an anonymous {@code
+   * "<statementId>-Inline"} {@code ResultMap} attached only to that statement. Its presence here
+   * means the statement has no explicit {@code resultMap=}/{@code <constructor>} and is relying on
+   * implicit automapping instead, which for a record matches SELECT columns to constructor
+   * parameters by JDBC result-set *position*, not by column label (verified directly: a
+   * scrambled-column {@code resultType=} select silently fed a {@code String} column into a {@code
+   * long} constructor parameter and blew up on the type coercion) -- the exact column-order risk
+   * this whole invariant series exists to eliminate, just without an XML block to even name.
+   */
+  static void assertNoImplicitResultType(
+      final Configuration configuration, final String packagePrefix, final SoftAssertions softly) {
+    for (final String statementId : configuration.getMappedStatementNames()) {
+      if (!statementId.contains(".")) {
+        // Short-id alias for the same statement, registered under its unqualified id -- skip to
+        // avoid checking every statement twice.
+        continue;
+      }
+      final var statement = configuration.getMappedStatement(statementId);
+      for (final var resultMap : statement.getResultMaps()) {
+        if (!resultMap.getType().getName().startsWith(packagePrefix)) {
+          continue;
+        }
+        softly
+            .assertThat(resultMap.getId())
+            .as(
+                "%s must use an explicit resultMap= (not resultType=) for %s, since implicit"
+                    + " automapping matches SELECT columns to constructor params by position, not"
+                    + " by name",
+                statementId, resultMap.getType().getSimpleName())
+            .doesNotEndWith("-Inline");
+      }
+    }
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsDbModelConstructorArgsMustBeNamedTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsDbModelConstructorArgsMustBeNamedTest.java
@@ -7,12 +7,7 @@
  */
 package io.camunda.db.rdbms;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.File;
-import java.io.FileInputStream;
 import org.apache.ibatis.builder.xml.XMLMapperBuilder;
-import org.apache.ibatis.mapping.ResultFlag;
 import org.apache.ibatis.session.Configuration;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
@@ -35,95 +30,31 @@ import org.junit.jupiter.api.Test;
  * </ul>
  *
  * Mapper XMLs are parsed with MyBatis's own {@link XMLMapperBuilder} into a real {@link
- * Configuration}, the same way production does. This also means a {@code name=} that does not match
- * any real constructor parameter, or a {@code javaType} that does not match the matching
- * parameter's declared type, already fails loudly here as a {@code BuilderException} while parsing
- * -- MyBatis itself resolves constructor args by exact name-and-type match against the target's
- * real constructor, for every one of these classes' single canonical (record) constructor. Nested
- * {@code <collection>} constructors are covered too: MyBatis registers them as their own resultMap
- * entries, so no separate tree-walking is needed to reach them.
+ * Configuration}, the same way production does (see {@link MapperConfigurationTestSupport}). This
+ * also means a {@code name=} that does not match any real constructor parameter, or a {@code
+ * javaType} that does not match the matching parameter's declared type, already fails loudly here
+ * as a {@code BuilderException} while parsing -- MyBatis itself resolves constructor args by exact
+ * name-and-type match against the target's real constructor, for every one of these classes' single
+ * canonical (record) constructor. Nested {@code <collection>} constructors are covered too: MyBatis
+ * registers them as their own resultMap entries, so no separate tree-walking is needed to reach
+ * them.
  *
- * <p>Read-side {@code *Entity} resultMaps are intentionally out of scope -- only {@code
- * write.domain} DbModels are covered by this series' invariant enforcement.
+ * <p>Read-side {@code *Entity} resultMaps are intentionally out of scope -- see {@link
+ * SearchEntityConstructorArgsMustBeNamedTest} for those.
  */
 class RdbmsDbModelConstructorArgsMustBeNamedTest {
 
-  private static final String MAPPER_DIR = "src/main/resources/mapper";
   private static final String DB_MODEL_PACKAGE_PREFIX = "io.camunda.db.rdbms.write.domain.";
 
   @Test
   void everyDbModelStatementMustUseANamedConstructorResultMap() throws Exception {
-    final var mapperDir = new File(MAPPER_DIR);
-    assertThat(mapperDir).as("mapper resources directory").isDirectory();
-    final var mapperFiles = mapperDir.listFiles((dir, name) -> name.endsWith(".xml"));
-    assertThat(mapperFiles).as("mapper XML files").isNotEmpty();
-
-    final var configuration = new Configuration();
-    for (final File mapperFile : mapperFiles) {
-      try (var inputStream = new FileInputStream(mapperFile)) {
-        new XMLMapperBuilder(
-                inputStream, configuration, mapperFile.getPath(), configuration.getSqlFragments())
-            .parse();
-      }
-    }
+    final var configuration = MapperConfigurationTestSupport.parseAllMapperFiles();
 
     final var softly = new SoftAssertions();
-    checkEveryConstructorArgIsNamed(configuration, softly);
-    checkNoStatementUsesImplicitResultType(configuration, softly);
+    MapperConfigurationTestSupport.assertConstructorArgsNamed(
+        configuration, DB_MODEL_PACKAGE_PREFIX, softly);
+    MapperConfigurationTestSupport.assertNoImplicitResultType(
+        configuration, DB_MODEL_PACKAGE_PREFIX, softly);
     softly.assertAll();
-  }
-
-  private void checkEveryConstructorArgIsNamed(
-      final Configuration configuration, final SoftAssertions softly) {
-    for (final String resultMapId : configuration.getResultMapNames()) {
-      if (!resultMapId.contains(".")) {
-        // Short-id alias for the same resultMap, registered under its unqualified id -- skip to
-        // avoid checking every resultMap twice.
-        continue;
-      }
-      final var resultMap = configuration.getResultMap(resultMapId);
-      if (!resultMap.getType().getName().startsWith(DB_MODEL_PACKAGE_PREFIX)) {
-        continue;
-      }
-      for (final var mapping : resultMap.getResultMappings()) {
-        if (mapping.getFlags().contains(ResultFlag.CONSTRUCTOR)) {
-          softly
-              .assertThat(mapping.getProperty())
-              .as(
-                  "%s <constructor arg column=\"%s\"> must have a non-blank name=",
-                  resultMapId, mapping.getColumn())
-              .isNotBlank();
-        }
-      }
-    }
-  }
-
-  private void checkNoStatementUsesImplicitResultType(
-      final Configuration configuration, final SoftAssertions softly) {
-    for (final String statementId : configuration.getMappedStatementNames()) {
-      if (!statementId.contains(".")) {
-        // Short-id alias for the same statement, registered under its unqualified id -- skip to
-        // avoid checking every statement twice.
-        continue;
-      }
-      final var statement = configuration.getMappedStatement(statementId);
-      for (final var resultMap : statement.getResultMaps()) {
-        if (!resultMap.getType().getName().startsWith(DB_MODEL_PACKAGE_PREFIX)) {
-          continue;
-        }
-        // MyBatis never registers a resultType=-only mapping in the shared Configuration -- it
-        // builds an anonymous "<statementId>-Inline" ResultMap attached only to this statement.
-        // Its presence here means the statement has no explicit <resultMap>/<constructor> and is
-        // relying on implicit automapping instead.
-        softly
-            .assertThat(resultMap.getId())
-            .as(
-                "%s must use an explicit resultMap= (not resultType=) for %s, since implicit"
-                    + " automapping matches SELECT columns to constructor params by position, not"
-                    + " by name",
-                statementId, resultMap.getType().getSimpleName())
-            .doesNotEndWith("-Inline");
-      }
-    }
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/SearchEntityConstructorArgsMustBeNamedTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/SearchEntityConstructorArgsMustBeNamedTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Read-side counterpart to {@link RdbmsDbModelConstructorArgsMustBeNamedTest}: enforces the same
+ * two invariants, scoped to {@code io.camunda.search.entities.*Entity} instead of {@code
+ * io.camunda.db.rdbms.write.domain.*DbModel}.
+ *
+ * <p>Two entities in this package (e.g. {@code ClusterVariableEntity}, {@code
+ * ProcessInstanceEntity}) are deliberately mapped via a non-canonical secondary constructor of a
+ * different arity than the canonical one, so a sibling {@code <collection>} can hydrate a mutable
+ * field (a list/set) separately. This does not affect either check here: a non-blank {@code name=}
+ * and the absence of an implicit {@code resultType=} are both agnostic to *which* constructor
+ * MyBatis resolves against -- they only require that one was resolved by name at all.
+ *
+ * <p>{@code io.camunda.search.entities} records are also constructed via Jackson (Elasticsearch/
+ * OpenSearch document deserialization) elsewhere in the codebase; that path is unaffected by these
+ * checks, which are scoped entirely to this module's MyBatis mapper XMLs.
+ */
+class SearchEntityConstructorArgsMustBeNamedTest {
+
+  private static final String SEARCH_ENTITY_PACKAGE_PREFIX = "io.camunda.search.entities.";
+
+  @Test
+  void everySearchEntityStatementMustUseANamedConstructorResultMap() throws Exception {
+    final var configuration = MapperConfigurationTestSupport.parseAllMapperFiles();
+
+    final var softly = new SoftAssertions();
+    MapperConfigurationTestSupport.assertConstructorArgsNamed(
+        configuration, SEARCH_ENTITY_PACKAGE_PREFIX, softly);
+    MapperConfigurationTestSupport.assertNoImplicitResultType(
+        configuration, SEARCH_ENTITY_PACKAGE_PREFIX, softly);
+    softly.assertAll();
+  }
+}

--- a/qa/archunit-tests/src/test/java/io/camunda/search/entities/SearchEntityArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/search/entities/SearchEntityArchTest.java
@@ -32,8 +32,8 @@ import org.jspecify.annotations.Nullable;
  * <p>These rules enforce:
  *
  * <ol>
- *   <li>All top-level types in {@code io.camunda.search.entities} (excluding enums and interfaces)
- *       must be Java {@code record}s.
+ *   <li>All types in {@code io.camunda.search.entities} (excluding enums and interfaces), nested or
+ *       not, must be Java {@code record}s.
  *   <li>Every record in {@code io.camunda.search.entities} with collection-type fields ({@link
  *       List}, {@link Set}, {@link Map}, {@link Collection}) must declare a compact constructor
  *       that defaults those fields to empty <b>mutable</b> instances (e.g. {@code new
@@ -50,8 +50,9 @@ public final class SearchEntityArchTest {
       Set.of(List.class, Set.class, Map.class, Collection.class);
 
   /**
-   * Every concrete top-level type inside {@code io.camunda.search.entities} must be a Java {@code
-   * record}. Enums and interfaces are excluded.
+   * Every concrete type inside {@code io.camunda.search.entities} must be a Java {@code record},
+   * nested or not. Enums, interfaces, and {@code Builder} classes (mutable by design, not data
+   * carriers) are excluded.
    */
   @ArchTest
   static final ArchRule SEARCH_ENTITIES_MUST_BE_RECORDS =
@@ -63,7 +64,7 @@ public final class SearchEntityArchTest {
           .and()
           .areNotInterfaces()
           .and()
-          .areTopLevelClasses()
+          .haveSimpleNameNotEndingWith("Builder")
           .should(
               new ArchCondition<>("be a Java record") {
                 @Override


### PR DESCRIPTION
## Summary

Extends the write-side invariant series (#58969, #59150, #59219) to the read side: `io.camunda.search.entities.*Entity` records are mapped by the same 38 MyBatis mapper XMLs in `db/rdbms/src/main/resources/mapper/`, with the identical column-order fragility the write-side retrofit closed, never applied here.

- **144 previously-unnamed `<arg>`/`<idArg>` constructor args, across 17 resultMaps in 16 files**, now have `name=`. No column/order/javaType changes — behavior unchanged if done correctly, and a mistake surfaces loudly as a `BuilderException` at parse time.
- **4 statements across 2 files** (`IncidentMapper.xml`, `ProcessDefinitionMapper.xml`) relied on implicit `resultType=` automapping — the same bug class `ExporterPositionMapper.xml`/`AuditLogMapper.xml` were fixed for in #59150. Verified directly (throwaway H2 reproduction) that MyBatis's implicit automapping for a record matches SELECT columns to constructor params by JDBC result-set *position*, not by column label. Converted to explicit `resultMap=` + named `<constructor>`.
- Extracted the shared parse-and-check logic from `RdbmsDbModelConstructorArgsMustBeNamedTest` into `MapperConfigurationTestSupport`, parameterized by package prefix, and added `SearchEntityConstructorArgsMustBeNamedTest` as its read-side sibling — same two checks (non-blank `name=`, no implicit `resultType=`), scoped to `io.camunda.search.entities.` instead of `io.camunda.db.rdbms.write.domain.`.
- Widened `SearchEntityArchTest`'s `SEARCH_ENTITIES_MUST_BE_RECORDS` rule to cover nested types (previously top-level classes only), so a nested type reverting to a mutable class wouldn't go uncaught. Required excluding `Builder` inner classes (legitimately mutable) once nested types were in scope — verified this exclusion is neither over- nor under-inclusive against the current codebase.

Two entities (`ClusterVariableEntity`, `ProcessInstanceEntity`) are deliberately mapped via a non-canonical secondary constructor (different arity than canonical) so a sibling `<collection>` can hydrate a mutable field separately — verified no arity collision exists, and both new checks are agnostic to which constructor MyBatis resolves against.

No record-conversion prerequisite was needed here (unlike the write-side series): every `search.entities` class touched is already a record.

## Test plan

- [x] Sabotage-tested both new checks (missing `name=`, reverted `resultType=` fix) — both fail with the expected message, restored afterward
- [x] Sabotage-tested the widened ArchUnit rule — found 22 real false positives (Builder classes), added the exclusion, confirmed zero violations remain, then confirmed a real nested non-record violation is still caught
- [x] `./mvnw verify -pl db/rdbms -DskipTests=false -Dquickly` (1584 tests, 0 failures)
- [x] `./mvnw verify -pl qa/archunit-tests -DskipTests=false -Dquickly` (all pass except one confirmed pre-existing-on-main failure unrelated to this change, verified via `git stash`)
- [x] `IncidentIT` (102/102) and `ProcessDefinitionIT` (90/90) pass end-to-end across all 6 supported DB vendors (H2, Postgres, MySQL, MariaDB, MSSQL, Oracle)
- [x] `./mvnw install -Dquickly -T1C` (full repo compile)
- [x] Adversarial subagent review, no defects found