### PR TITLE
test: merge sibling CCSM import IT scenarios to cut redundant setup/teardown

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeProcessInstanceImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeProcessInstanceImportIT.java
@@ -95,32 +95,36 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
 
   @Test
   public void
-      importCompletedZeebeProcessInstanceDataInOneBatch_allDataSavedToOptimizeProcessInstance() {
-    // given
-    final String processName = "someProcess";
-    final ProcessInstanceEvent deployedInstance =
-        deployAndStartInstanceForProcess(createStartEndProcess(processName));
+      importCompletedRunningAndCanceledZeebeProcessInstanceData_allDataSavedToOptimizeProcessInstance() {
+    // Covers three independent terminal-state scenarios for the same "import from scratch, assert
+    // all fields" flow: scenario 1 a completed instance, scenario 2 a still-running instance,
+    // scenario 3 a canceled (externally terminated) instance.
 
-    // when
+    // given (completed)
+    final String processNameA = "someProcess";
+    final ProcessInstanceEvent deployedInstanceA =
+        deployAndStartInstanceForProcess(createStartEndProcess(processNameA));
+
+    // when (completed)
     waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
-        6, deployedInstance.getProcessInstanceKey());
+        6, deployedInstanceA.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
 
-    // then
-    final Map<String, List<ZeebeProcessInstanceRecordDto>> exportedEvents =
-        getZeebeExportedProcessInstanceEventsByElementId();
+    // then (completed)
+    final Map<String, List<ZeebeProcessInstanceRecordDto>> exportedEventsA =
+        getZeebeExportedProcessInstanceEventsByElementId(deployedInstanceA.getProcessInstanceKey());
     assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
         .singleElement()
         .satisfies(
             savedInstance -> {
               assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(deployedInstance.getProcessInstanceKey()));
+                  .isEqualTo(String.valueOf(deployedInstanceA.getProcessInstanceKey()));
               assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(deployedInstance.getProcessDefinitionKey()));
+                  .isEqualTo(String.valueOf(deployedInstanceA.getProcessDefinitionKey()));
               assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(deployedInstance.getBpmnProcessId());
+                  .isEqualTo(deployedInstanceA.getBpmnProcessId());
               assertThat(savedInstance.getProcessDefinitionVersion())
-                  .isEqualTo(String.valueOf(deployedInstance.getVersion()));
+                  .isEqualTo(String.valueOf(deployedInstanceA.getVersion()));
               assertThat(savedInstance.getDataSource().getName())
                   .isEqualTo(getConfiguredZeebeName());
               assertThat(savedInstance.getState())
@@ -132,26 +136,145 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
               assertThat(savedInstance.getStartDate())
                   .isEqualTo(
                       getExpectedStartDateForEvents(
-                          exportedEvents.get(deployedInstance.getBpmnProcessId())));
+                          exportedEventsA.get(deployedInstanceA.getBpmnProcessId())));
               assertThat(savedInstance.getEndDate())
                   .isEqualTo(
                       getExpectedEndDateForEvents(
-                          exportedEvents.get(deployedInstance.getBpmnProcessId())));
+                          exportedEventsA.get(deployedInstanceA.getBpmnProcessId())));
               assertThat(savedInstance.getDuration())
                   .isEqualTo(
                       getExpectedDurationForEvents(
-                          exportedEvents.get(deployedInstance.getBpmnProcessId())));
+                          exportedEventsA.get(deployedInstanceA.getBpmnProcessId())));
               assertThat(savedInstance.getFlowNodeInstances())
                   .hasSize(2)
                   .containsExactlyInAnyOrder(
                       createFlowNodeInstance(
-                          deployedInstance,
-                          exportedEvents,
+                          deployedInstanceA,
+                          exportedEventsA,
                           START_EVENT,
                           BpmnElementType.START_EVENT),
                       createFlowNodeInstance(
-                          deployedInstance, exportedEvents, END_EVENT, BpmnElementType.END_EVENT));
+                          deployedInstanceA,
+                          exportedEventsA,
+                          END_EVENT,
+                          BpmnElementType.END_EVENT));
             });
+
+    // given (running)
+    final String processNameB = "someProcess";
+    final ProcessInstanceEvent deployedInstanceB =
+        deployAndStartInstanceForProcess(createSimpleUserTaskProcess(processNameB));
+
+    // when (running)
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        4, deployedInstanceB.getProcessInstanceKey());
+    importAllZeebeEntitiesFromScratch();
+
+    // then (running)
+    final Map<String, List<ZeebeProcessInstanceRecordDto>> exportedEventsB =
+        getZeebeExportedProcessInstanceEventsByElementId(deployedInstanceB.getProcessInstanceKey());
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances()).hasSize(2);
+    final ProcessInstanceDto savedInstanceB =
+        getProcessInstanceForId(String.valueOf(deployedInstanceB.getProcessInstanceKey()));
+    assertThat(savedInstanceB.getProcessInstanceId())
+        .isEqualTo(String.valueOf(deployedInstanceB.getProcessInstanceKey()));
+    assertThat(savedInstanceB.getProcessDefinitionId())
+        .isEqualTo(String.valueOf(deployedInstanceB.getProcessDefinitionKey()));
+    assertThat(savedInstanceB.getProcessDefinitionKey())
+        .isEqualTo(deployedInstanceB.getBpmnProcessId());
+    assertThat(savedInstanceB.getProcessDefinitionVersion())
+        .isEqualTo(String.valueOf(deployedInstanceB.getVersion()));
+    assertThat(savedInstanceB.getDataSource().getName()).isEqualTo(getConfiguredZeebeName());
+    assertThat(savedInstanceB.getState()).isEqualTo(ProcessInstanceConstants.ACTIVE_STATE);
+    assertThat(savedInstanceB.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+    assertThat(savedInstanceB.getBusinessKey()).isNull();
+    assertThat(savedInstanceB.getIncidents()).isEmpty();
+    assertThat(savedInstanceB.getVariables()).isEmpty();
+    assertThat(savedInstanceB.getStartDate())
+        .isEqualTo(
+            getExpectedStartDateForEvents(
+                exportedEventsB.get(deployedInstanceB.getBpmnProcessId())));
+    assertThat(savedInstanceB.getEndDate()).isNull();
+    assertThat(savedInstanceB.getDuration()).isNull();
+    final FlowNodeInstanceDto userTaskFlowNodeInstanceB =
+        new FlowNodeInstanceDto(
+            String.valueOf(deployedInstanceB.getBpmnProcessId()),
+            String.valueOf(deployedInstanceB.getVersion()),
+            ZEEBE_DEFAULT_TENANT_ID,
+            String.valueOf(deployedInstanceB.getProcessInstanceKey()),
+            USER_TASK,
+            getBpmnElementTypeNameForType(BpmnElementType.USER_TASK),
+            String.valueOf(exportedEventsB.get(USER_TASK).get(0).getKey()));
+    userTaskFlowNodeInstanceB.setStartDate(
+        getExpectedStartDateForEvents(exportedEventsB.get(USER_TASK)));
+    userTaskFlowNodeInstanceB.setCanceled(false);
+    assertThat(savedInstanceB.getFlowNodeInstances())
+        .hasSize(2)
+        .containsExactlyInAnyOrder(
+            createFlowNodeInstance(
+                deployedInstanceB, exportedEventsB, START_EVENT, BpmnElementType.START_EVENT),
+            userTaskFlowNodeInstanceB);
+
+    // given (canceled)
+    final String processNameC = "someProcess";
+    final ProcessInstanceEvent deployedInstanceC =
+        deployAndStartInstanceForProcess(createSimpleServiceTaskProcess(processNameC));
+
+    // We wait for the service task to be exported before cancelling the process
+    // (1 * process event, 2 * "start_event" events). Then again for the import of cancellation
+    // events (2 cancel events)
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        4, deployedInstanceC.getProcessInstanceKey());
+    zeebeExtension.cancelProcessInstance(deployedInstanceC.getProcessInstanceKey());
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        6, deployedInstanceC.getProcessInstanceKey());
+
+    // when (canceled)
+    importAllZeebeEntitiesFromScratch();
+
+    // then (canceled)
+    final Map<String, List<ZeebeProcessInstanceRecordDto>> exportedEventsC =
+        getZeebeExportedProcessInstanceEventsByElementId(deployedInstanceC.getProcessInstanceKey());
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances()).hasSize(3);
+    final ProcessInstanceDto savedInstanceC =
+        getProcessInstanceForId(String.valueOf(deployedInstanceC.getProcessInstanceKey()));
+    assertThat(savedInstanceC.getProcessInstanceId())
+        .isEqualTo(String.valueOf(deployedInstanceC.getProcessInstanceKey()));
+    assertThat(savedInstanceC.getProcessDefinitionId())
+        .isEqualTo(String.valueOf(deployedInstanceC.getProcessDefinitionKey()));
+    assertThat(savedInstanceC.getProcessDefinitionKey())
+        .isEqualTo(deployedInstanceC.getBpmnProcessId());
+    assertThat(savedInstanceC.getProcessDefinitionVersion())
+        .isEqualTo(String.valueOf(deployedInstanceC.getVersion()));
+    assertThat(savedInstanceC.getDataSource().getName()).isEqualTo(getConfiguredZeebeName());
+    assertThat(savedInstanceC.getState())
+        .isEqualTo(ProcessInstanceConstants.EXTERNALLY_TERMINATED_STATE);
+    assertThat(savedInstanceC.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+    assertThat(savedInstanceC.getBusinessKey()).isNull();
+    assertThat(savedInstanceC.getIncidents()).isEmpty();
+    assertThat(savedInstanceC.getVariables()).isEmpty();
+    assertThat(savedInstanceC.getStartDate())
+        .isEqualTo(
+            getExpectedStartDateForEvents(
+                exportedEventsC.get(deployedInstanceC.getBpmnProcessId())));
+    assertThat(savedInstanceC.getEndDate())
+        .isEqualTo(
+            getExpectedEndDateForEvents(exportedEventsC.get(deployedInstanceC.getBpmnProcessId())));
+    assertThat(savedInstanceC.getDuration())
+        .isEqualTo(
+            getExpectedDurationForEvents(
+                exportedEventsC.get(deployedInstanceC.getBpmnProcessId())));
+    assertThat(savedInstanceC.getFlowNodeInstances())
+        .hasSize(2)
+        .containsExactlyInAnyOrder(
+            createFlowNodeInstance(
+                deployedInstanceC, exportedEventsC, START_EVENT, BpmnElementType.START_EVENT),
+            createFlowNodeInstance(
+                deployedInstanceC,
+                exportedEventsC,
+                SERVICE_TASK,
+                BpmnElementType.SERVICE_TASK,
+                true));
   }
 
   @Test
@@ -220,141 +343,6 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
                           assertThat(flowNodeInstance.getTotalDurationInMs()).isNotNull())
                   .extracting(FlowNodeInstanceDto::getFlowNodeId)
                   .containsExactlyInAnyOrder(START_EVENT, END_EVENT);
-            });
-  }
-
-  @Test
-  public void importRunningZeebeProcessInstanceData_allDataSavedToOptimizeProcessInstance() {
-    // given
-    final String processName = "someProcess";
-    final ProcessInstanceEvent deployedInstance =
-        deployAndStartInstanceForProcess(createSimpleUserTaskProcess(processName));
-
-    // when
-    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
-        4, deployedInstance.getProcessInstanceKey());
-    importAllZeebeEntitiesFromScratch();
-
-    // then
-    final Map<String, List<ZeebeProcessInstanceRecordDto>> exportedEvents =
-        getZeebeExportedProcessInstanceEventsByElementId();
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(deployedInstance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(deployedInstance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(deployedInstance.getBpmnProcessId());
-              assertThat(savedInstance.getProcessDefinitionVersion())
-                  .isEqualTo(String.valueOf(deployedInstance.getVersion()));
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getState()).isEqualTo(ProcessInstanceConstants.ACTIVE_STATE);
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getBusinessKey()).isNull();
-              assertThat(savedInstance.getIncidents()).isEmpty();
-              assertThat(savedInstance.getVariables()).isEmpty();
-              assertThat(savedInstance.getStartDate())
-                  .isEqualTo(
-                      getExpectedStartDateForEvents(
-                          exportedEvents.get(deployedInstance.getBpmnProcessId())));
-              assertThat(savedInstance.getEndDate()).isNull();
-              assertThat(savedInstance.getDuration()).isNull();
-              final FlowNodeInstanceDto flowNodeInstanceDto =
-                  new FlowNodeInstanceDto(
-                      String.valueOf(deployedInstance.getBpmnProcessId()),
-                      String.valueOf(deployedInstance.getVersion()),
-                      ZEEBE_DEFAULT_TENANT_ID,
-                      String.valueOf(deployedInstance.getProcessInstanceKey()),
-                      USER_TASK,
-                      getBpmnElementTypeNameForType(BpmnElementType.USER_TASK),
-                      String.valueOf(exportedEvents.get(USER_TASK).get(0).getKey()));
-              flowNodeInstanceDto.setStartDate(
-                  getExpectedStartDateForEvents(exportedEvents.get(USER_TASK)));
-              flowNodeInstanceDto.setCanceled(false);
-              assertThat(savedInstance.getFlowNodeInstances())
-                  .hasSize(2)
-                  .containsExactlyInAnyOrder(
-                      createFlowNodeInstance(
-                          deployedInstance,
-                          exportedEvents,
-                          START_EVENT,
-                          BpmnElementType.START_EVENT),
-                      flowNodeInstanceDto);
-            });
-  }
-
-  @Test
-  public void importCanceledZeebeProcessInstanceData_allDataSavedToOptimizeProcessInstance() {
-    // given
-    final String processName = "someProcess";
-    final ProcessInstanceEvent deployedInstance =
-        deployAndStartInstanceForProcess(createSimpleServiceTaskProcess(processName));
-
-    // We wait for the service task to be exported before cancelling the process
-    // (1 * process event, 2 * "start_event" events). Then again for the import of cancellation
-    // events (2 cancel events)
-    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
-        4, deployedInstance.getProcessInstanceKey());
-    zeebeExtension.cancelProcessInstance(deployedInstance.getProcessInstanceKey());
-    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
-        6, deployedInstance.getProcessInstanceKey());
-
-    // when
-    importAllZeebeEntitiesFromScratch();
-
-    // then
-    final Map<String, List<ZeebeProcessInstanceRecordDto>> exportedEvents =
-        getZeebeExportedProcessInstanceEventsByElementId();
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(deployedInstance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(deployedInstance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(deployedInstance.getBpmnProcessId());
-              assertThat(savedInstance.getProcessDefinitionVersion())
-                  .isEqualTo(String.valueOf(deployedInstance.getVersion()));
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getState())
-                  .isEqualTo(ProcessInstanceConstants.EXTERNALLY_TERMINATED_STATE);
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getBusinessKey()).isNull();
-              assertThat(savedInstance.getIncidents()).isEmpty();
-              assertThat(savedInstance.getVariables()).isEmpty();
-              assertThat(savedInstance.getStartDate())
-                  .isEqualTo(
-                      getExpectedStartDateForEvents(
-                          exportedEvents.get(deployedInstance.getBpmnProcessId())));
-              assertThat(savedInstance.getEndDate())
-                  .isEqualTo(
-                      getExpectedEndDateForEvents(
-                          exportedEvents.get(deployedInstance.getBpmnProcessId())));
-              assertThat(savedInstance.getDuration())
-                  .isEqualTo(
-                      getExpectedDurationForEvents(
-                          exportedEvents.get(deployedInstance.getBpmnProcessId())));
-              assertThat(savedInstance.getFlowNodeInstances())
-                  .hasSize(2)
-                  .containsExactlyInAnyOrder(
-                      createFlowNodeInstance(
-                          deployedInstance,
-                          exportedEvents,
-                          START_EVENT,
-                          BpmnElementType.START_EVENT),
-                      createFlowNodeInstance(
-                          deployedInstance,
-                          exportedEvents,
-                          SERVICE_TASK,
-                          BpmnElementType.SERVICE_TASK,
-                          true));
             });
   }
 
@@ -522,46 +510,25 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
   }
 
   @Test
-  public void importZeebeProcessInstanceData_processContainsLoop() {
-    // given
-    final String processName = "someProcess";
-    final ProcessInstanceEvent deployedInstance =
-        deployAndStartInstanceForProcess(createLoopingProcess(processName));
+  public void importZeebeProcessInstanceData_processStartedDuringProcessAndProcessContainsLoop() {
+    // Covers two independent structural edge cases: scenario 1 a process started partway through
+    // (before two end events); scenario 2 a process containing a looping service task. Scenario 1
+    // goes first because its "started before element" helper doesn't expose the started
+    // instance's key, so it can only rely on the (otherwise unscoped) class-wide event-count wait
+    // being safe — true only while it is the sole instance in the index.
 
-    // when
-    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
-        1, deployedInstance.getProcessInstanceKey());
-    zeebeExtension.completeTaskForInstanceWithJobType(SERVICE_TASK, Map.of("loop", true));
-    zeebeExtension.completeTaskForInstanceWithJobType(SERVICE_TASK, Map.of("loop", false));
-    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
-        18, deployedInstance.getProcessInstanceKey());
-    importAllZeebeEntitiesFromScratch();
-
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            instance ->
-                assertThat(instance.getFlowNodeInstances())
-                    .filteredOn(
-                        flowNodeInstance -> flowNodeInstance.getFlowNodeId().equals(SERVICE_TASK))
-                    .hasSizeGreaterThan(1));
-  }
-
-  @Test
-  public void importZeebeProcessInstanceData_processStartedDuringProcess() {
-    // given
-    final String processName = "someProcess";
-    final Process process =
-        zeebeExtension.deployProcess(createSingleStartDoubleEndEventProcess(processName));
+    // given (started during process)
+    final String processNameA = "someProcess";
+    final Process processA =
+        zeebeExtension.deployProcess(createSingleStartDoubleEndEventProcess(processNameA));
     zeebeExtension.startProcessInstanceBeforeElementWithIds(
-        process.getBpmnProcessId(), END_EVENT, END_EVENT_2);
+        processA.getBpmnProcessId(), END_EVENT, END_EVENT_2);
 
-    // when
+    // when (started during process)
     waitUntilMinimumProcessInstanceEventsExportedCount(6);
     importAllZeebeEntitiesFromScratch();
 
-    // then
+    // then (started during process)
     assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
         .singleElement()
         .satisfies(
@@ -574,47 +541,46 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
                       BpmnElementType.END_EVENT.getElementTypeName().get(),
                       BpmnElementType.END_EVENT.getElementTypeName().get());
             });
-  }
 
-  @Test
-  public void importZeebeProcessInstanceData_processContainsTerminateEndEvent() {
-    // given
-    final String processName = "someProcess";
-    final ProcessInstanceEvent deployedInstance =
-        deployAndStartInstanceForProcess(createTerminateEndEventProcess(processName));
+    // given (contains loop)
+    final String processNameB = "someProcess";
+    final ProcessInstanceEvent deployedInstanceB =
+        deployAndStartInstanceForProcess(createLoopingProcess(processNameB));
 
-    // when
+    // when (contains loop)
     waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
-        6, deployedInstance.getProcessInstanceKey());
+        1, deployedInstanceB.getProcessInstanceKey());
+    zeebeExtension.completeTaskForInstanceWithJobType(SERVICE_TASK, Map.of("loop", true));
+    zeebeExtension.completeTaskForInstanceWithJobType(SERVICE_TASK, Map.of("loop", false));
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        18, deployedInstanceB.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
 
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            instance ->
-                assertThat(instance.getFlowNodeInstances())
-                    .extracting(FlowNodeInstanceDto::getFlowNodeType)
-                    .containsExactlyInAnyOrder(
-                        BpmnElementType.START_EVENT.getElementTypeName().get(),
-                        BpmnElementType.END_EVENT.getElementTypeName().get()));
+    // then (contains loop)
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances()).hasSize(2);
+    final ProcessInstanceDto savedInstanceB =
+        getProcessInstanceForId(String.valueOf(deployedInstanceB.getProcessInstanceKey()));
+    assertThat(savedInstanceB.getFlowNodeInstances())
+        .filteredOn(flowNodeInstance -> flowNodeInstance.getFlowNodeId().equals(SERVICE_TASK))
+        .hasSizeGreaterThan(1);
   }
 
   @Test
-  public void importZeebeProcessInstanceData_processContainsInclusiveGateway() {
-    // given
-    final String processName = "someProcess";
-    final Process process =
-        zeebeExtension.deployProcess(createInclusiveGatewayProcess(processName));
-    final long instanceKey =
-        zeebeExtension.startProcessInstanceWithVariables(
-            process.getBpmnProcessId(), Map.of("varName", "a,b"));
+  public void importZeebeProcessInstanceData_processContainsTerminateEndEventAndInclusiveGateway() {
+    // Covers two independent BPMN-construct checks: scenario 1 a process with a terminate end
+    // event; scenario 2 a process with an inclusive gateway.
 
-    // when
-    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(8, instanceKey);
+    // given (terminate end event)
+    final String processNameA = "someProcess";
+    final ProcessInstanceEvent deployedInstanceA =
+        deployAndStartInstanceForProcess(createTerminateEndEventProcess(processNameA));
+
+    // when (terminate end event)
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        6, deployedInstanceA.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
 
-    // then
+    // then (terminate end event)
     assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
         .singleElement()
         .satisfies(
@@ -623,9 +589,30 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
                     .extracting(FlowNodeInstanceDto::getFlowNodeType)
                     .containsExactlyInAnyOrder(
                         BpmnElementType.START_EVENT.getElementTypeName().get(),
-                        BpmnElementType.INCLUSIVE_GATEWAY.getElementTypeName().get(),
-                        BpmnElementType.END_EVENT.getElementTypeName().get(),
                         BpmnElementType.END_EVENT.getElementTypeName().get()));
+
+    // given (inclusive gateway)
+    final String processNameB = "someProcess";
+    final Process processB =
+        zeebeExtension.deployProcess(createInclusiveGatewayProcess(processNameB));
+    final long instanceKeyB =
+        zeebeExtension.startProcessInstanceWithVariables(
+            processB.getBpmnProcessId(), Map.of("varName", "a,b"));
+
+    // when (inclusive gateway)
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(8, instanceKeyB);
+    importAllZeebeEntitiesFromScratch();
+
+    // then (inclusive gateway)
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances()).hasSize(2);
+    final ProcessInstanceDto savedInstanceB = getProcessInstanceForId(String.valueOf(instanceKeyB));
+    assertThat(savedInstanceB.getFlowNodeInstances())
+        .extracting(FlowNodeInstanceDto::getFlowNodeType)
+        .containsExactlyInAnyOrder(
+            BpmnElementType.START_EVENT.getElementTypeName().get(),
+            BpmnElementType.INCLUSIVE_GATEWAY.getElementTypeName().get(),
+            BpmnElementType.END_EVENT.getElementTypeName().get(),
+            BpmnElementType.END_EVENT.getElementTypeName().get());
   }
 
   @DisabledIf("isZeebeVersionPre86")
@@ -655,17 +642,22 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
   }
 
   @Test
-  public void importSendTaskZeebeProcessInstanceData_flowNodeInstancesCreatedCorrectly() {
-    // given
-    final ProcessInstanceEvent processInstance =
+  public void
+      importSendTaskAndNewBpmnElementsIntroducedWith820ZeebeProcessInstanceData_flowNodeInstancesCreatedCorrectly() {
+    // Covers two independent BPMN-construct checks: scenario 1 a process with a send task;
+    // scenario 2 a process with the new 8.2.0 elements (data stores, date objects, link events,
+    // escalation events, undefined tasks).
+
+    // given (send task)
+    final ProcessInstanceEvent processInstanceA =
         deployAndStartInstanceForProcess(createSendTaskProcess("someProcess"));
 
-    // when
+    // when (send task)
     waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
-        1, processInstance.getProcessInstanceKey());
+        1, processInstanceA.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
 
-    // then
+    // then (send task)
     assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
         .singleElement()
         .satisfies(
@@ -677,10 +669,10 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
                             assertThat(flowNodeInstanceDto)
                                 .hasFieldOrPropertyWithValue(
                                     FlowNodeInstanceDto.Fields.definitionKey,
-                                    processInstance.getBpmnProcessId())
+                                    processInstanceA.getBpmnProcessId())
                                 .hasFieldOrPropertyWithValue(
                                     FlowNodeInstanceDto.Fields.definitionVersion,
-                                    String.valueOf(processInstance.getVersion()))
+                                    String.valueOf(processInstanceA.getVersion()))
                                 .hasFieldOrPropertyWithValue(
                                     FlowNodeInstanceDto.Fields.tenantId, ZEEBE_DEFAULT_TENANT_ID))
                     .extracting(
@@ -691,40 +683,36 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
                             getBpmnElementTypeNameForType(BpmnElementType.START_EVENT)),
                         Tuple.tuple(
                             SEND_TASK, getBpmnElementTypeNameForType(BpmnElementType.SEND_TASK))));
-  }
 
-  @Test
-  public void importZeebeProcessInstanceData_processContainsNewBpmnElementsIntroducedWith820() {
-    // given a process that contains the following:
+    // given (new 8.2.0 elements) a process that contains the following:
     // data stores, date objects, link events, escalation events, undefined tasks
     final BpmnModelInstance model =
         readProcessDiagramAsInstance("/bpmn/compatibility/adventure.bpmn");
-    final String processId = zeebeExtension.deployProcess(model).getBpmnProcessId();
-    final long instanceKey =
+    final String processIdB = zeebeExtension.deployProcess(model).getBpmnProcessId();
+    final long instanceKeyB =
         zeebeExtension.startProcessInstanceWithVariables(
-            processId, Map.of("space", true, "time", true));
+            processIdB, Map.of("space", true, "time", true));
 
-    // when
-    waitUntilInstanceRecordWithElementIdForInstanceExported("milkAdventureEndEventId", instanceKey);
+    // when (new 8.2.0 elements)
+    waitUntilInstanceRecordWithElementIdForInstanceExported(
+        "milkAdventureEndEventId", instanceKeyB);
     importAllZeebeEntitiesFromScratch();
 
-    // then all new events were imported
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            instance ->
-                assertThat(instance.getFlowNodeInstances())
-                    .extracting(FlowNodeInstanceDto::getFlowNodeId)
-                    .contains(
-                        "linkIntermediateThrowEventId",
-                        "linkIntermediateCatchEventId",
-                        "undefinedTaskId",
-                        "escalationIntermediateThrowEventId",
-                        "escalationNonInterruptingBoundaryEventId",
-                        "escalationBoundaryEventId",
-                        "escalationNonInterruptingStartEventId",
-                        "escalationStartEventId",
-                        "escalationEndEventId"));
+    // then (new 8.2.0 elements) all new events were imported
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances()).hasSize(2);
+    final ProcessInstanceDto savedInstanceB = getProcessInstanceForId(String.valueOf(instanceKeyB));
+    assertThat(savedInstanceB.getFlowNodeInstances())
+        .extracting(FlowNodeInstanceDto::getFlowNodeId)
+        .contains(
+            "linkIntermediateThrowEventId",
+            "linkIntermediateCatchEventId",
+            "undefinedTaskId",
+            "escalationIntermediateThrowEventId",
+            "escalationNonInterruptingBoundaryEventId",
+            "escalationBoundaryEventId",
+            "escalationNonInterruptingStartEventId",
+            "escalationStartEventId",
+            "escalationEndEventId");
   }
 
   @DisabledIf("isZeebeVersionPre83")
@@ -1076,6 +1064,27 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
   private String getBpmnElementTypeNameForType(final BpmnElementType type) {
     return type.getElementTypeName()
         .orElseThrow(() -> new OptimizeRuntimeException("Cannot find name for type: " + type));
+  }
+
+  /**
+   * Scopes {@code AbstractCCSMIT.getZeebeExportedProcessInstanceEventsByElementId()} to a single
+   * process instance. Needed once a test has more than one instance's records sitting in the shared
+   * export index at the same time (e.g. a merged test covering multiple terminal-state scenarios
+   * sequentially) — the unscoped query groups records by elementId only, so records from multiple
+   * instances sharing an elementId (e.g. every process shares "someProcess" as its bpmnProcessId,
+   * or START_EVENT as its start-event id) would otherwise be mixed together.
+   */
+  private Map<String, List<ZeebeProcessInstanceRecordDto>>
+      getZeebeExportedProcessInstanceEventsByElementId(final long processInstanceKey) {
+    return getZeebeExportedProcessInstanceEventsByElementId().entrySet().stream()
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey,
+                entry ->
+                    entry.getValue().stream()
+                        .filter(
+                            event -> event.getValue().getProcessInstanceKey() == processInstanceKey)
+                        .toList()));
   }
 
   private ProcessInstanceDto getProcessInstanceForId(final String processInstanceId) {

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeUserTaskImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeUserTaskImportIT.java
@@ -27,8 +27,12 @@ import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
 import io.camunda.optimize.dto.optimize.importing.UserTaskIdentityOperationType;
 import io.camunda.optimize.dto.optimize.persistence.AssigneeOperationDto;
 import io.camunda.optimize.dto.optimize.query.process.FlowNodeInstanceDto;
+import io.camunda.optimize.dto.zeebe.ZeebeRecordDto;
 import io.camunda.optimize.dto.zeebe.usertask.ZeebeUserTaskDataDto;
 import io.camunda.optimize.dto.zeebe.usertask.ZeebeUserTaskRecordDto;
+import io.camunda.optimize.exception.OptimizeIntegrationTestException;
+import io.camunda.optimize.service.db.DatabaseConstants;
+import io.camunda.optimize.test.it.extension.db.TermsQueryContainer;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import java.time.Duration;
 import java.time.OffsetDateTime;
@@ -84,46 +88,49 @@ public class ZeebeUserTaskImportIT extends AbstractCCSMIT {
   }
 
   @Test
-  public void importCompletedUnclaimedZeebeUserTaskData_viaWriter() {
-    // import all data for completed usertask (creation and completion) in one batch, hence the
-    // upsert inserts the new instance created with the logic in the writer
-    // given
-    final ProcessInstanceEvent instance =
+  public void importCompletedUnclaimedZeebeUserTaskData_viaWriterAndViaUpdateScript() {
+    // Covers both import code paths for a completed (unclaimed) user task: scenario 1 imports
+    // creation and completion together in one batch (upsert via the writer); scenario 2 imports
+    // creation and completion as two separate batches (upsert via the update script).
+
+    // given (writer path)
+    final ProcessInstanceEvent instanceA =
         deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
     waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    List<ZeebeUserTaskRecordDto> userTaskEvents = getZeebeExportedUserTaskEvents();
-    zeebeExtension.completeZeebeUserTask(getExpectedUserTaskInstanceIdFromRecords(userTaskEvents));
+    List<ZeebeUserTaskRecordDto> userTaskEventsA =
+        getZeebeExportedUserTaskEvents(instanceA.getProcessInstanceKey());
+    zeebeExtension.completeZeebeUserTask(getExpectedUserTaskInstanceIdFromRecords(userTaskEventsA));
     waitUntilUserTaskRecordWithIntentExported(COMPLETED);
     // remove all zeebe records except userTask ones to test userTask import only
     removeAllZeebeExportRecordsExceptUserTaskRecords();
 
-    // when
+    // when (writer path)
     importAllZeebeEntitiesFromScratch();
 
-    // then
-    userTaskEvents = getZeebeExportedUserTaskEvents();
-    final OffsetDateTime expectedEndDate =
-        getExpectedEndDateForCompletedUserTaskEvents(userTaskEvents);
-    final FlowNodeInstanceDto expectedUserTask =
-        createRunningUserTaskInstance(instance, userTaskEvents);
-    expectedUserTask.setDueDate(EXPECTED_DUE_DATE);
-    expectedUserTask.setEndDate(expectedEndDate);
-    expectedUserTask.setIdleDurationInMs(0L);
-    expectedUserTask.setTotalDurationInMs(
-        getExpectedTotalDurationForCompletedUserTask(userTaskEvents));
-    expectedUserTask.setWorkDurationInMs(
-        getExpectedTotalDurationForCompletedUserTask(userTaskEvents));
+    // then (writer path)
+    userTaskEventsA = getZeebeExportedUserTaskEvents(instanceA.getProcessInstanceKey());
+    final OffsetDateTime expectedEndDateA =
+        getExpectedEndDateForCompletedUserTaskEvents(userTaskEventsA);
+    final FlowNodeInstanceDto expectedUserTaskA =
+        createRunningUserTaskInstance(instanceA, userTaskEventsA);
+    expectedUserTaskA.setDueDate(EXPECTED_DUE_DATE);
+    expectedUserTaskA.setEndDate(expectedEndDateA);
+    expectedUserTaskA.setIdleDurationInMs(0L);
+    expectedUserTaskA.setTotalDurationInMs(
+        getExpectedTotalDurationForCompletedUserTask(userTaskEventsA));
+    expectedUserTaskA.setWorkDurationInMs(
+        getExpectedTotalDurationForCompletedUserTask(userTaskEventsA));
 
     assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
         .singleElement()
         .satisfies(
             savedInstance -> {
               assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
+                  .isEqualTo(String.valueOf(instanceA.getProcessInstanceKey()));
               assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
+                  .isEqualTo(String.valueOf(instanceA.getProcessDefinitionKey()));
               assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
+                  .isEqualTo(instanceA.getBpmnProcessId());
               assertThat(savedInstance.getDataSource().getName())
                   .isEqualTo(getConfiguredZeebeName());
               assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
@@ -131,108 +138,104 @@ public class ZeebeUserTaskImportIT extends AbstractCCSMIT {
                   .singleElement() // only the userTask was imported because all other records were
                   // removed
                   .usingRecursiveComparison()
-                  .isEqualTo(expectedUserTask);
+                  .isEqualTo(expectedUserTaskA);
             });
-  }
 
-  @Test
-  public void importCompletedUnclaimedZeebeUserTaskData_viaUpdateScript() {
-    // import completed userTask data after the first userTask record was already imported, hence
-    // the upsert uses the logic from the update script
-    // given
-    final ProcessInstanceEvent instance =
+    // given (update-script path)
+    final ProcessInstanceEvent instanceB =
         deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
-
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+    waitUntilUserTaskRecordExportedForInstance(instanceB.getProcessInstanceKey());
     // remove all zeebe records except userTask ones to test userTask import only
     removeAllZeebeExportRecordsExceptUserTaskRecords();
     importAllZeebeEntitiesFromScratch();
-    final List<ZeebeUserTaskRecordDto> runningUserTaskEvents = getZeebeExportedUserTaskEvents();
-    final FlowNodeInstanceDto expectedUserTask =
-        createRunningUserTaskInstance(instance, runningUserTaskEvents);
-    List<ZeebeUserTaskRecordDto> userTaskEvents = getZeebeExportedUserTaskEvents();
-    zeebeExtension.completeZeebeUserTask(getExpectedUserTaskInstanceIdFromRecords(userTaskEvents));
-    waitUntilUserTaskRecordWithIntentExported(COMPLETED);
+    final List<ZeebeUserTaskRecordDto> runningUserTaskEventsB =
+        getZeebeExportedUserTaskEvents(instanceB.getProcessInstanceKey());
+    final FlowNodeInstanceDto expectedUserTaskB =
+        createRunningUserTaskInstance(instanceB, runningUserTaskEventsB);
+    List<ZeebeUserTaskRecordDto> userTaskEventsB =
+        getZeebeExportedUserTaskEvents(instanceB.getProcessInstanceKey());
+    zeebeExtension.completeZeebeUserTask(getExpectedUserTaskInstanceIdFromRecords(userTaskEventsB));
+    waitUntilUserTaskRecordWithIntentExportedForInstance(
+        COMPLETED, instanceB.getProcessInstanceKey());
     // remove all zeebe records except userTask ones to test userTask import only
     removeAllZeebeExportRecordsExceptUserTaskRecords();
 
-    // when
+    // when (update-script path)
     importAllZeebeEntitiesFromLastIndex();
 
-    // then
-    userTaskEvents = getZeebeExportedUserTaskEvents();
-    final OffsetDateTime expectedEndDate =
-        getExpectedEndDateForCompletedUserTaskEvents(userTaskEvents);
-    expectedUserTask.setDueDate(EXPECTED_DUE_DATE);
-    expectedUserTask.setEndDate(expectedEndDate);
-    expectedUserTask.setIdleDurationInMs(0L);
-    expectedUserTask.setTotalDurationInMs(
-        getExpectedTotalDurationForCompletedUserTask(userTaskEvents));
-    expectedUserTask.setWorkDurationInMs(
-        getExpectedTotalDurationForCompletedUserTask(userTaskEvents));
+    // then (update-script path)
+    userTaskEventsB = getZeebeExportedUserTaskEvents(instanceB.getProcessInstanceKey());
+    final OffsetDateTime expectedEndDateB =
+        getExpectedEndDateForCompletedUserTaskEvents(userTaskEventsB);
+    expectedUserTaskB.setDueDate(EXPECTED_DUE_DATE);
+    expectedUserTaskB.setEndDate(expectedEndDateB);
+    expectedUserTaskB.setIdleDurationInMs(0L);
+    expectedUserTaskB.setTotalDurationInMs(
+        getExpectedTotalDurationForCompletedUserTask(userTaskEventsB));
+    expectedUserTaskB.setWorkDurationInMs(
+        getExpectedTotalDurationForCompletedUserTask(userTaskEventsB));
 
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getFlowNodeInstances())
-                  .singleElement() // only the userTask was imported because all other records were
-                  // removed
-                  .usingRecursiveComparison()
-                  .isEqualTo(expectedUserTask);
-            });
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances()).hasSize(2);
+    final ProcessInstanceDto savedInstanceB =
+        getProcessInstanceForId(String.valueOf(instanceB.getProcessInstanceKey()));
+    assertThat(savedInstanceB.getProcessInstanceId())
+        .isEqualTo(String.valueOf(instanceB.getProcessInstanceKey()));
+    assertThat(savedInstanceB.getProcessDefinitionId())
+        .isEqualTo(String.valueOf(instanceB.getProcessDefinitionKey()));
+    assertThat(savedInstanceB.getProcessDefinitionKey()).isEqualTo(instanceB.getBpmnProcessId());
+    assertThat(savedInstanceB.getDataSource().getName()).isEqualTo(getConfiguredZeebeName());
+    assertThat(savedInstanceB.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+    assertThat(savedInstanceB.getFlowNodeInstances())
+        .singleElement() // only the userTask was imported because all other records were removed
+        .usingRecursiveComparison()
+        .isEqualTo(expectedUserTaskB);
   }
 
   @Test
-  public void importCanceledUnclaimedZeebeUserTaskData_viaWriter() {
-    // import all data for canceled usertask (creation and cancellation) in one batch, hence the
-    // upsert inserts the new instance
-    // created with the logic in the writer
-    final ProcessInstanceEvent instance =
+  public void importCanceledUnclaimedZeebeUserTaskData_viaWriterAndViaUpdateScript() {
+    // Covers both import code paths for a canceled (unclaimed) user task: scenario 1 imports
+    // creation and cancellation together in one batch (upsert via the writer); scenario 2 imports
+    // creation and cancellation as two separate batches (upsert via the update script).
+
+    // given (writer path)
+    final ProcessInstanceEvent instanceA =
         deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
     waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    zeebeExtension.cancelProcessInstance(instance.getProcessInstanceKey());
+    zeebeExtension.cancelProcessInstance(instanceA.getProcessInstanceKey());
     waitUntilUserTaskRecordWithIntentExported(UserTaskIntent.CANCELED);
     // remove all zeebe records except userTask ones to test userTask import only
     removeAllZeebeExportRecordsExceptUserTaskRecords();
 
-    // when
+    // when (writer path)
     importAllZeebeEntitiesFromScratch();
 
-    // then the import in one batch correctly set all fields in the new instance document
-    final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
-    final FlowNodeInstanceDto expectedUserTask =
-        createRunningUserTaskInstance(instance, exportedEvents);
-    final OffsetDateTime expectedEndDate =
-        getExpectedEndDateForCanceledUserTaskEvents(exportedEvents);
-    final Long expectedTotalAndIdleDuration =
-        Duration.between(expectedUserTask.getStartDate(), expectedEndDate).toMillis();
-    expectedUserTask.setDueDate(EXPECTED_DUE_DATE);
-    expectedUserTask.setEndDate(expectedEndDate);
-    expectedUserTask.setTotalDurationInMs(expectedTotalAndIdleDuration);
-    expectedUserTask.setIdleDurationInMs(expectedTotalAndIdleDuration);
-    expectedUserTask.setWorkDurationInMs(0L);
-    expectedUserTask.setCanceled(true);
+    // then (writer path) the import in one batch correctly set all fields in the new instance
+    // document
+    final List<ZeebeUserTaskRecordDto> exportedEventsA =
+        getZeebeExportedUserTaskEvents(instanceA.getProcessInstanceKey());
+    final FlowNodeInstanceDto expectedUserTaskA =
+        createRunningUserTaskInstance(instanceA, exportedEventsA);
+    final OffsetDateTime expectedEndDateA =
+        getExpectedEndDateForCanceledUserTaskEvents(exportedEventsA);
+    final Long expectedTotalAndIdleDurationA =
+        Duration.between(expectedUserTaskA.getStartDate(), expectedEndDateA).toMillis();
+    expectedUserTaskA.setDueDate(EXPECTED_DUE_DATE);
+    expectedUserTaskA.setEndDate(expectedEndDateA);
+    expectedUserTaskA.setTotalDurationInMs(expectedTotalAndIdleDurationA);
+    expectedUserTaskA.setIdleDurationInMs(expectedTotalAndIdleDurationA);
+    expectedUserTaskA.setWorkDurationInMs(0L);
+    expectedUserTaskA.setCanceled(true);
 
     assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
         .singleElement()
         .satisfies(
             savedInstance -> {
               assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
+                  .isEqualTo(String.valueOf(instanceA.getProcessInstanceKey()));
               assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
+                  .isEqualTo(String.valueOf(instanceA.getProcessDefinitionKey()));
               assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
+                  .isEqualTo(instanceA.getBpmnProcessId());
               assertThat(savedInstance.getDataSource().getName())
                   .isEqualTo(getConfiguredZeebeName());
               assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
@@ -240,117 +243,115 @@ public class ZeebeUserTaskImportIT extends AbstractCCSMIT {
                   .singleElement() // only userTask was imported because all other records were
                   // removed
                   .usingRecursiveComparison()
-                  .isEqualTo(expectedUserTask);
+                  .isEqualTo(expectedUserTaskA);
             });
-  }
 
-  @Test
-  public void importCanceledUnclaimedZeebeUserTaskData_viaUpdateScript() {
-    // import canceled userTask data after the first userTask record was already imported, hence the
-    // upsert uses the logic  from the update script
-    // given
-    final ProcessInstanceEvent instance =
+    // given (update-script path)
+    final ProcessInstanceEvent instanceB =
         deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+    waitUntilUserTaskRecordExportedForInstance(instanceB.getProcessInstanceKey());
     removeAllZeebeExportRecordsExceptUserTaskRecords();
     importAllZeebeEntitiesFromScratch();
-    zeebeExtension.cancelProcessInstance(instance.getProcessInstanceKey());
-    waitUntilUserTaskRecordWithIntentExported(UserTaskIntent.CANCELED);
+    zeebeExtension.cancelProcessInstance(instanceB.getProcessInstanceKey());
+    waitUntilUserTaskRecordWithIntentExportedForInstance(
+        UserTaskIntent.CANCELED, instanceB.getProcessInstanceKey());
     // remove all zeebe records except userTask ones to test userTask import only
     removeAllZeebeExportRecordsExceptUserTaskRecords();
 
-    // when
+    // when (update-script path)
     importAllZeebeEntitiesFromLastIndex();
 
-    // then the import over two batches correctly updates all fields with the update script
-    final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
-    final FlowNodeInstanceDto expectedUserTask =
-        createRunningUserTaskInstance(instance, exportedEvents);
-    final OffsetDateTime expectedEndDate =
-        getExpectedEndDateForCanceledUserTaskEvents(exportedEvents);
-    expectedUserTask.setDueDate(EXPECTED_DUE_DATE);
-    expectedUserTask.setEndDate(expectedEndDate);
-    expectedUserTask.setTotalDurationInMs(
-        Duration.between(expectedUserTask.getStartDate(), expectedEndDate).toMillis());
-    expectedUserTask.setIdleDurationInMs(
-        Duration.between(expectedUserTask.getStartDate(), expectedEndDate).toMillis());
-    expectedUserTask.setWorkDurationInMs(0L);
-    expectedUserTask.setCanceled(true);
+    // then (update-script path) the import over two batches correctly updates all fields with the
+    // update script
+    final List<ZeebeUserTaskRecordDto> exportedEventsB =
+        getZeebeExportedUserTaskEvents(instanceB.getProcessInstanceKey());
+    final FlowNodeInstanceDto expectedUserTaskB =
+        createRunningUserTaskInstance(instanceB, exportedEventsB);
+    final OffsetDateTime expectedEndDateB =
+        getExpectedEndDateForCanceledUserTaskEvents(exportedEventsB);
+    expectedUserTaskB.setDueDate(EXPECTED_DUE_DATE);
+    expectedUserTaskB.setEndDate(expectedEndDateB);
+    expectedUserTaskB.setTotalDurationInMs(
+        Duration.between(expectedUserTaskB.getStartDate(), expectedEndDateB).toMillis());
+    expectedUserTaskB.setIdleDurationInMs(
+        Duration.between(expectedUserTaskB.getStartDate(), expectedEndDateB).toMillis());
+    expectedUserTaskB.setWorkDurationInMs(0L);
+    expectedUserTaskB.setCanceled(true);
 
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances()).hasSize(2);
+    final ProcessInstanceDto savedInstanceB =
+        getProcessInstanceForId(String.valueOf(instanceB.getProcessInstanceKey()));
+    assertThat(savedInstanceB.getProcessInstanceId())
+        .isEqualTo(String.valueOf(instanceB.getProcessInstanceKey()));
+    assertThat(savedInstanceB.getProcessDefinitionId())
+        .isEqualTo(String.valueOf(instanceB.getProcessDefinitionKey()));
+    assertThat(savedInstanceB.getProcessDefinitionKey()).isEqualTo(instanceB.getBpmnProcessId());
+    assertThat(savedInstanceB.getDataSource().getName()).isEqualTo(getConfiguredZeebeName());
+    assertThat(savedInstanceB.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+    assertThat(savedInstanceB.getFlowNodeInstances())
+        // only userTask was imported because all other records were removed
         .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getFlowNodeInstances())
-                  // only userTask was imported because all other records were removed
-                  .singleElement()
-                  .usingRecursiveComparison()
-                  .isEqualTo(expectedUserTask);
-            });
+        .usingRecursiveComparison()
+        .isEqualTo(expectedUserTaskB);
   }
 
   @Test
-  public void importCanceledClaimedZeebeUserTaskData_viaWriter() {
-    // import all data for canceled usertask in one batch, hence the upsert inserts the new instance
-    // created with the logic in the writer
-    // given
-    final ProcessInstanceEvent instance =
+  public void importCanceledClaimedZeebeUserTaskData_viaWriterAndViaUpdateScript() {
+    // Covers both import code paths for a canceled (claimed) user task: scenario 1 imports
+    // creation, claim, and cancellation together in one batch (upsert via the writer); scenario 2
+    // imports them as two separate batches (upsert via the update script).
+
+    // given (writer path)
+    final ProcessInstanceEvent instanceA =
         deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
     waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
+    List<ZeebeUserTaskRecordDto> exportedEventsA =
+        getZeebeExportedUserTaskEvents(instanceA.getProcessInstanceKey());
     zeebeExtension.assignUserTask(
-        getExpectedUserTaskInstanceIdFromRecords(exportedEvents), ASSIGNEE_ID);
-    zeebeExtension.cancelProcessInstance(instance.getProcessInstanceKey());
+        getExpectedUserTaskInstanceIdFromRecords(exportedEventsA), ASSIGNEE_ID);
+    zeebeExtension.cancelProcessInstance(instanceA.getProcessInstanceKey());
     waitUntilUserTaskRecordWithIntentExported(CANCELED);
     // remove all zeebe records except userTask ones to test userTask import only
     removeAllZeebeExportRecordsExceptUserTaskRecords();
 
-    // when
+    // when (writer path)
     importAllZeebeEntitiesFromScratch();
 
-    // then
-    exportedEvents = getZeebeExportedUserTaskEvents();
-    final FlowNodeInstanceDto expectedUserTask =
-        createRunningUserTaskInstance(instance, exportedEvents);
-    final OffsetDateTime expectedEndDate =
-        getExpectedEndDateForCanceledUserTaskEvents(exportedEvents);
-    final OffsetDateTime assignDate = getTimestampForAssignedUserTaskEvents(exportedEvents);
-    expectedUserTask.setAssignee(ASSIGNEE_ID);
-    expectedUserTask.setDueDate(EXPECTED_DUE_DATE);
-    expectedUserTask.setEndDate(expectedEndDate);
-    expectedUserTask.setTotalDurationInMs(
-        Duration.between(expectedUserTask.getStartDate(), expectedEndDate).toMillis());
-    expectedUserTask.setIdleDurationInMs(
-        Duration.between(expectedUserTask.getStartDate(), assignDate).toMillis());
-    expectedUserTask.setWorkDurationInMs(Duration.between(assignDate, expectedEndDate).toMillis());
-    expectedUserTask.setAssigneeOperations(
+    // then (writer path)
+    exportedEventsA = getZeebeExportedUserTaskEvents(instanceA.getProcessInstanceKey());
+    final FlowNodeInstanceDto expectedUserTaskA =
+        createRunningUserTaskInstance(instanceA, exportedEventsA);
+    final OffsetDateTime expectedEndDateA =
+        getExpectedEndDateForCanceledUserTaskEvents(exportedEventsA);
+    final OffsetDateTime assignDateA = getTimestampForAssignedUserTaskEvents(exportedEventsA);
+    expectedUserTaskA.setAssignee(ASSIGNEE_ID);
+    expectedUserTaskA.setDueDate(EXPECTED_DUE_DATE);
+    expectedUserTaskA.setEndDate(expectedEndDateA);
+    expectedUserTaskA.setTotalDurationInMs(
+        Duration.between(expectedUserTaskA.getStartDate(), expectedEndDateA).toMillis());
+    expectedUserTaskA.setIdleDurationInMs(
+        Duration.between(expectedUserTaskA.getStartDate(), assignDateA).toMillis());
+    expectedUserTaskA.setWorkDurationInMs(
+        Duration.between(assignDateA, expectedEndDateA).toMillis());
+    expectedUserTaskA.setAssigneeOperations(
         List.of(
             createAssigneeOperationDto(
-                getExpectedIdFromRecords(exportedEvents, ASSIGNED),
+                getExpectedIdFromRecords(exportedEventsA, ASSIGNED),
                 CLAIM_OPERATION_TYPE,
                 ASSIGNEE_ID,
-                getTimestampForAssignedUserTaskEvents(exportedEvents))));
-    expectedUserTask.setCanceled(true);
+                getTimestampForAssignedUserTaskEvents(exportedEventsA))));
+    expectedUserTaskA.setCanceled(true);
 
     assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
         .singleElement()
         .satisfies(
             savedInstance -> {
               assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
+                  .isEqualTo(String.valueOf(instanceA.getProcessInstanceKey()));
               assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
+                  .isEqualTo(String.valueOf(instanceA.getProcessDefinitionKey()));
               assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
+                  .isEqualTo(instanceA.getBpmnProcessId());
               assertThat(savedInstance.getDataSource().getName())
                   .isEqualTo(getConfiguredZeebeName());
               assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
@@ -358,68 +359,119 @@ public class ZeebeUserTaskImportIT extends AbstractCCSMIT {
                   // only userTask was imported because all other records were removed
                   .singleElement()
                   .usingRecursiveComparison()
-                  .isEqualTo(expectedUserTask);
+                  .isEqualTo(expectedUserTaskA);
             });
-  }
 
-  @Test
-  public void importCanceledClaimedZeebeUserTaskData_viaUpdateScript() {
-    // import canceled userTask data after the first userTask records were already imported, hence
-    // the upsert uses the logic from the update script
-    // given
-    final ProcessInstanceEvent instance =
+    // given (update-script path)
+    final ProcessInstanceEvent instanceB =
         deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
+    waitUntilUserTaskRecordExportedForInstance(instanceB.getProcessInstanceKey());
+    List<ZeebeUserTaskRecordDto> exportedEventsB =
+        getZeebeExportedUserTaskEvents(instanceB.getProcessInstanceKey());
     zeebeExtension.assignUserTask(
-        getExpectedUserTaskInstanceIdFromRecords(exportedEvents), ASSIGNEE_ID);
-    waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
+        getExpectedUserTaskInstanceIdFromRecords(exportedEventsB), ASSIGNEE_ID);
+    waitUntilUserTaskRecordWithIntentExportedForInstance(
+        ASSIGNED, instanceB.getProcessInstanceKey());
 
     // remove all zeebe records except userTask ones to test userTask import only
     removeAllZeebeExportRecordsExceptUserTaskRecords();
     importAllZeebeEntitiesFromScratch();
 
-    zeebeExtension.cancelProcessInstance(instance.getProcessInstanceKey());
-    waitUntilUserTaskRecordWithIntentExported(UserTaskIntent.CANCELED);
+    zeebeExtension.cancelProcessInstance(instanceB.getProcessInstanceKey());
+    waitUntilUserTaskRecordWithIntentExportedForInstance(
+        UserTaskIntent.CANCELED, instanceB.getProcessInstanceKey());
     removeAllZeebeExportRecordsExceptUserTaskRecords();
 
-    // when
+    // when (update-script path)
     importAllZeebeEntitiesFromLastIndex();
 
-    // then
-    exportedEvents = getZeebeExportedUserTaskEvents();
-    final OffsetDateTime expectedEndDate =
-        getExpectedEndDateForCanceledUserTaskEvents(exportedEvents);
-    final OffsetDateTime assignDate = getTimestampForAssignedUserTaskEvents(exportedEvents);
-    final FlowNodeInstanceDto expectedUserTask =
-        createRunningUserTaskInstance(instance, exportedEvents);
-    expectedUserTask.setAssignee(ASSIGNEE_ID);
-    expectedUserTask.setDueDate(EXPECTED_DUE_DATE);
-    expectedUserTask.setEndDate(expectedEndDate);
-    expectedUserTask.setTotalDurationInMs(
-        Duration.between(expectedUserTask.getStartDate(), expectedEndDate).toMillis());
-    expectedUserTask.setIdleDurationInMs(
-        Duration.between(expectedUserTask.getStartDate(), assignDate).toMillis());
-    expectedUserTask.setWorkDurationInMs(Duration.between(assignDate, expectedEndDate).toMillis());
-    expectedUserTask.setAssigneeOperations(
+    // then (update-script path)
+    exportedEventsB = getZeebeExportedUserTaskEvents(instanceB.getProcessInstanceKey());
+    final OffsetDateTime expectedEndDateB =
+        getExpectedEndDateForCanceledUserTaskEvents(exportedEventsB);
+    final OffsetDateTime assignDateB = getTimestampForAssignedUserTaskEvents(exportedEventsB);
+    final FlowNodeInstanceDto expectedUserTaskB =
+        createRunningUserTaskInstance(instanceB, exportedEventsB);
+    expectedUserTaskB.setAssignee(ASSIGNEE_ID);
+    expectedUserTaskB.setDueDate(EXPECTED_DUE_DATE);
+    expectedUserTaskB.setEndDate(expectedEndDateB);
+    expectedUserTaskB.setTotalDurationInMs(
+        Duration.between(expectedUserTaskB.getStartDate(), expectedEndDateB).toMillis());
+    expectedUserTaskB.setIdleDurationInMs(
+        Duration.between(expectedUserTaskB.getStartDate(), assignDateB).toMillis());
+    expectedUserTaskB.setWorkDurationInMs(
+        Duration.between(assignDateB, expectedEndDateB).toMillis());
+    expectedUserTaskB.setAssigneeOperations(
         List.of(
             createAssigneeOperationDto(
-                getExpectedIdFromRecords(exportedEvents, ASSIGNED),
+                getExpectedIdFromRecords(exportedEventsB, ASSIGNED),
                 CLAIM_OPERATION_TYPE,
                 ASSIGNEE_ID,
-                getTimestampForAssignedUserTaskEvents(exportedEvents))));
-    expectedUserTask.setCanceled(true);
+                getTimestampForAssignedUserTaskEvents(exportedEventsB))));
+    expectedUserTaskB.setCanceled(true);
 
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances()).hasSize(2);
+    final ProcessInstanceDto savedInstanceB =
+        getProcessInstanceForId(String.valueOf(instanceB.getProcessInstanceKey()));
+    assertThat(savedInstanceB.getProcessInstanceId())
+        .isEqualTo(String.valueOf(instanceB.getProcessInstanceKey()));
+    assertThat(savedInstanceB.getProcessDefinitionId())
+        .isEqualTo(String.valueOf(instanceB.getProcessDefinitionKey()));
+    assertThat(savedInstanceB.getProcessDefinitionKey()).isEqualTo(instanceB.getBpmnProcessId());
+    assertThat(savedInstanceB.getDataSource().getName()).isEqualTo(getConfiguredZeebeName());
+    assertThat(savedInstanceB.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+    assertThat(savedInstanceB.getFlowNodeInstances())
+        // only userTask was imported because all other records were removed
+        .singleElement()
+        .usingRecursiveComparison()
+        .isEqualTo(expectedUserTaskB);
+  }
+
+  @Test
+  public void importClaimOperation_viaWriterAndViaUpdateScript() {
+    // Covers both import code paths for a claim operation: scenario 1 imports creation and claim
+    // together in one batch (upsert via the writer); scenario 2 imports creation and claim as two
+    // separate batches (upsert via the update script).
+
+    // given (writer path)
+    final ProcessInstanceEvent instanceA =
+        deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, null));
+    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+    List<ZeebeUserTaskRecordDto> exportedEventsA =
+        getZeebeExportedUserTaskEvents(instanceA.getProcessInstanceKey());
+    zeebeExtension.assignUserTask(
+        getExpectedUserTaskInstanceIdFromRecords(exportedEventsA), ASSIGNEE_ID);
+    waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
+    // remove all zeebe records except userTask ones to test userTask import only
+    removeAllZeebeExportRecordsExceptUserTaskRecords();
+
+    // when (writer path)
+    importAllZeebeEntitiesFromScratch();
+
+    // then (writer path)
+    exportedEventsA = getZeebeExportedUserTaskEvents(instanceA.getProcessInstanceKey());
+    final FlowNodeInstanceDto expectedUserTaskA =
+        createRunningUserTaskInstance(instanceA, exportedEventsA);
+    expectedUserTaskA.setIdleDurationInMs(
+        getDurationInMsBetweenStartAndFirstAssignOperation(exportedEventsA));
+    expectedUserTaskA.setAssignee(ASSIGNEE_ID);
+    expectedUserTaskA.setAssigneeOperations(
+        List.of(
+            createAssigneeOperationDto(
+                getExpectedIdFromRecords(exportedEventsA, ASSIGNED),
+                CLAIM_OPERATION_TYPE,
+                ASSIGNEE_ID,
+                getTimestampForZeebeAssignEvents(exportedEventsA, ASSIGNEE_ID))));
     assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
         .singleElement()
         .satisfies(
             savedInstance -> {
               assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
+                  .isEqualTo(String.valueOf(instanceA.getProcessInstanceKey()));
               assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
+                  .isEqualTo(String.valueOf(instanceA.getProcessDefinitionKey()));
               assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
+                  .isEqualTo(instanceA.getBpmnProcessId());
               assertThat(savedInstance.getDataSource().getName())
                   .isEqualTo(getConfiguredZeebeName());
               assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
@@ -427,125 +479,67 @@ public class ZeebeUserTaskImportIT extends AbstractCCSMIT {
                   // only userTask was imported because all other records were removed
                   .singleElement()
                   .usingRecursiveComparison()
-                  .isEqualTo(expectedUserTask);
+                  .isEqualTo(expectedUserTaskA);
             });
-  }
 
-  @Test
-  public void importClaimOperation_viaWriter() {
-    // import assignee usertask operations in one batch, hence the upsert inserts the new instance
-    // created with the logic in the writer
-    // given
-    final ProcessInstanceEvent instance =
+    // given (update-script path)
+    final ProcessInstanceEvent instanceB =
         deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, null));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
-    zeebeExtension.assignUserTask(
-        getExpectedUserTaskInstanceIdFromRecords(exportedEvents), ASSIGNEE_ID);
-    waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
-    // remove all zeebe records except userTask ones to test userTask import only
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
-
-    // when
-    importAllZeebeEntitiesFromScratch();
-
-    // then
-    exportedEvents = getZeebeExportedUserTaskEvents();
-    final FlowNodeInstanceDto expectedUserTask =
-        createRunningUserTaskInstance(instance, exportedEvents);
-    expectedUserTask.setIdleDurationInMs(
-        getDurationInMsBetweenStartAndFirstAssignOperation(exportedEvents));
-    expectedUserTask.setAssignee(ASSIGNEE_ID);
-    expectedUserTask.setAssigneeOperations(
-        List.of(
-            createAssigneeOperationDto(
-                getExpectedIdFromRecords(exportedEvents, ASSIGNED),
-                CLAIM_OPERATION_TYPE,
-                ASSIGNEE_ID,
-                getTimestampForZeebeAssignEvents(exportedEvents, ASSIGNEE_ID))));
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getFlowNodeInstances())
-                  // only userTask was imported because all other records were removed
-                  .singleElement()
-                  .usingRecursiveComparison()
-                  .isEqualTo(expectedUserTask);
-            });
-  }
-
-  @Test
-  public void importClaimOperation_viaUpdateScript() {
-    // import assignee userTask data after the first userTask records were already imported, hence
-    // the upsert uses the logic from the update script
-    // given
-    final ProcessInstanceEvent instance =
-        deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, null));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+    waitUntilUserTaskRecordExportedForInstance(instanceB.getProcessInstanceKey());
     removeAllZeebeExportRecordsExceptUserTaskRecords();
     importAllZeebeEntitiesFromScratch();
 
-    List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
+    List<ZeebeUserTaskRecordDto> exportedEventsB =
+        getZeebeExportedUserTaskEvents(instanceB.getProcessInstanceKey());
     zeebeExtension.assignUserTask(
-        getExpectedUserTaskInstanceIdFromRecords(exportedEvents), ASSIGNEE_ID);
-    waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
+        getExpectedUserTaskInstanceIdFromRecords(exportedEventsB), ASSIGNEE_ID);
+    waitUntilUserTaskRecordWithIntentExportedForInstance(
+        ASSIGNED, instanceB.getProcessInstanceKey());
     // remove all zeebe records except userTask ones to test userTask import only
     removeAllZeebeExportRecordsExceptUserTaskRecords();
 
-    // when
+    // when (update-script path)
     importAllZeebeEntitiesFromLastIndex();
 
-    // then
-    exportedEvents = getZeebeExportedUserTaskEvents();
-    final FlowNodeInstanceDto expectedUserTask =
-        createRunningUserTaskInstance(instance, exportedEvents);
-    expectedUserTask.setIdleDurationInMs(
-        getDurationInMsBetweenStartAndFirstAssignOperation(exportedEvents));
-    expectedUserTask.setAssignee(ASSIGNEE_ID);
-    expectedUserTask.setAssigneeOperations(
+    // then (update-script path)
+    exportedEventsB = getZeebeExportedUserTaskEvents(instanceB.getProcessInstanceKey());
+    final FlowNodeInstanceDto expectedUserTaskB =
+        createRunningUserTaskInstance(instanceB, exportedEventsB);
+    expectedUserTaskB.setIdleDurationInMs(
+        getDurationInMsBetweenStartAndFirstAssignOperation(exportedEventsB));
+    expectedUserTaskB.setAssignee(ASSIGNEE_ID);
+    expectedUserTaskB.setAssigneeOperations(
         List.of(
             createAssigneeOperationDto(
-                getExpectedIdFromRecords(exportedEvents, ASSIGNED),
+                getExpectedIdFromRecords(exportedEventsB, ASSIGNED),
                 CLAIM_OPERATION_TYPE,
                 ASSIGNEE_ID,
-                getTimestampForZeebeAssignEvents(exportedEvents, ASSIGNEE_ID))));
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+                getTimestampForZeebeAssignEvents(exportedEventsB, ASSIGNEE_ID))));
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances()).hasSize(2);
+    final ProcessInstanceDto savedInstanceB =
+        getProcessInstanceForId(String.valueOf(instanceB.getProcessInstanceKey()));
+    assertThat(savedInstanceB.getProcessInstanceId())
+        .isEqualTo(String.valueOf(instanceB.getProcessInstanceKey()));
+    assertThat(savedInstanceB.getProcessDefinitionId())
+        .isEqualTo(String.valueOf(instanceB.getProcessDefinitionKey()));
+    assertThat(savedInstanceB.getProcessDefinitionKey()).isEqualTo(instanceB.getBpmnProcessId());
+    assertThat(savedInstanceB.getDataSource().getName()).isEqualTo(getConfiguredZeebeName());
+    assertThat(savedInstanceB.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+    assertThat(savedInstanceB.getFlowNodeInstances())
+        // only userTask was imported because all other records were removed
         .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getFlowNodeInstances())
-                  // only userTask was imported because all other records were removed
-                  .singleElement()
-                  .usingRecursiveComparison()
-                  .isEqualTo(expectedUserTask);
-            });
+        .usingRecursiveComparison()
+        .isEqualTo(expectedUserTaskB);
   }
 
   @Test
-  public void importUnclaimOperation_viaWriter() {
-    // import assignee usertask operations in one batch, hence the upsert inserts the new instance
-    // created with the logic in the writer
-    // given
-    final ProcessInstanceEvent instance =
+  public void importUnclaimOperation_viaWriterAndViaUpdateScript() {
+    // Covers both import code paths for an unclaim operation: scenario 1 imports creation and
+    // unclaim together in one batch (upsert via the writer); scenario 2 imports them as two
+    // separate batches (upsert via the update script).
+
+    // given (writer path)
+    final ProcessInstanceEvent instanceA =
         deployAndStartInstanceForProcess(
             createSimpleNativeUserTaskProcessWithAssignee(TEST_PROCESS, null, ASSIGNEE_ID));
     waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
@@ -567,127 +561,124 @@ public class ZeebeUserTaskImportIT extends AbstractCCSMIT {
     // remove all zeebe records except userTask ones to test userTask import only
     removeAllZeebeExportRecordsExceptUserTaskRecords();
 
-    // when
+    // when (writer path)
     importAllZeebeEntitiesFromScratch();
 
-    // then
-    final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
+    // then (writer path)
+    final List<ZeebeUserTaskRecordDto> exportedEventsA =
+        getZeebeExportedUserTaskEvents(instanceA.getProcessInstanceKey());
     assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
         .singleElement()
         .satisfies(
             savedInstance -> {
               assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
+                  .isEqualTo(String.valueOf(instanceA.getProcessInstanceKey()));
               assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
+                  .isEqualTo(String.valueOf(instanceA.getProcessDefinitionKey()));
               assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
+                  .isEqualTo(instanceA.getBpmnProcessId());
               assertThat(savedInstance.getDataSource().getName())
                   .isEqualTo(getConfiguredZeebeName());
               assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              final FlowNodeInstanceDto runningUserTaskInstance =
-                  createRunningUserTaskInstance(instance, exportedEvents);
-              runningUserTaskInstance.setIdleDurationInMs(0L);
-              runningUserTaskInstance.setWorkDurationInMs(
+              final FlowNodeInstanceDto runningUserTaskInstanceA =
+                  createRunningUserTaskInstance(instanceA, exportedEventsA);
+              runningUserTaskInstanceA.setIdleDurationInMs(0L);
+              runningUserTaskInstanceA.setWorkDurationInMs(
                   isZeebeVersion87_OrLater()
-                      ? getDurationInMsBetweenStartDateAndLastAssignedOperation(exportedEvents)
-                      : getDurationInMsBetweenStartAndFirstAssignOperation(exportedEvents));
-              runningUserTaskInstance.setAssigneeOperations(
+                      ? getDurationInMsBetweenStartDateAndLastAssignedOperation(exportedEventsA)
+                      : getDurationInMsBetweenStartAndFirstAssignOperation(exportedEventsA));
+              runningUserTaskInstanceA.setAssigneeOperations(
                   List.of(
                       createAssigneeOperationDto(
-                          getExpectedIdFromRecords(exportedEvents, CREATING),
+                          getExpectedIdFromRecords(exportedEventsA, CREATING),
                           CLAIM_OPERATION_TYPE,
                           ASSIGNEE_ID,
-                          getExpectedStartDateForUserTaskEvents(exportedEvents)),
+                          getExpectedStartDateForUserTaskEvents(exportedEventsA)),
                       createAssigneeOperationDto(
-                          getExpectedIdFromRecords(exportedEvents, ASSIGNED),
+                          getExpectedIdFromRecords(exportedEventsA, ASSIGNED),
                           UNCLAIM_OPERATION_TYPE,
                           null,
-                          getTimestampForLastZeebeEventsWithIntent(exportedEvents, ASSIGNED))));
+                          getTimestampForLastZeebeEventsWithIntent(exportedEventsA, ASSIGNED))));
               assertThat(savedInstance.getFlowNodeInstances())
                   // only userTask was imported because all other records were removed
                   .singleElement()
                   .usingRecursiveComparison()
-                  .isEqualTo(runningUserTaskInstance);
+                  .isEqualTo(runningUserTaskInstanceA);
             });
-  }
 
-  @Test
-  public void importUnclaimOperation_viaUpdateScript() {
-    // import assignee userTask data after the first userTask records were already imported, hence
-    // the upsert uses the logic from the update script
-    // given
-    final ProcessInstanceEvent instance =
+    // given (update-script path)
+    final ProcessInstanceEvent instanceB =
         deployAndStartInstanceForProcess(
             createSimpleNativeUserTaskProcessWithAssignee(TEST_PROCESS, null, ASSIGNEE_ID));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+    waitUntilUserTaskRecordExportedForInstance(instanceB.getProcessInstanceKey());
     // remove all zeebe records except userTask ones to test userTask import only
     removeAllZeebeExportRecordsExceptUserTaskRecords();
     importAllZeebeEntitiesFromScratch();
 
-    List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
+    List<ZeebeUserTaskRecordDto> exportedEventsB =
+        getZeebeExportedUserTaskEvents(instanceB.getProcessInstanceKey());
 
     if (isZeebeVersion87_OrLater()) {
       // to wait for `ASSIGNED` event triggered by Zeebe after UT creation with the defined
       // `assignee`
-      waitUntilUserTaskRecordWithIntentExported(1, ASSIGNED);
+      waitUntilUserTaskRecordWithIntentExportedForInstance(
+          1, ASSIGNED, instanceB.getProcessInstanceKey());
       zeebeExtension.unassignUserTask(
-          getExpectedUserTaskInstanceIdFromRecords(getZeebeExportedUserTaskEvents()));
+          getExpectedUserTaskInstanceIdFromRecords(
+              getZeebeExportedUserTaskEvents(instanceB.getProcessInstanceKey())));
       // wait for the 2nd `ASSIGNED` event triggered by UT unassign operation
-      waitUntilUserTaskRecordWithIntentExported(2, ASSIGNED);
+      waitUntilUserTaskRecordWithIntentExportedForInstance(
+          2, ASSIGNED, instanceB.getProcessInstanceKey());
     } else {
-      zeebeExtension.unassignUserTask(getExpectedUserTaskInstanceIdFromRecords(exportedEvents));
-      waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
+      zeebeExtension.unassignUserTask(getExpectedUserTaskInstanceIdFromRecords(exportedEventsB));
+      waitUntilUserTaskRecordWithIntentExportedForInstance(
+          ASSIGNED, instanceB.getProcessInstanceKey());
     }
     // remove all zeebe records except userTask ones to test userTask import only
     removeAllZeebeExportRecordsExceptUserTaskRecords();
 
-    // when
+    // when (update-script path)
     importAllZeebeEntitiesFromLastIndex();
 
-    // then
-    exportedEvents = getZeebeExportedUserTaskEvents();
-    final FlowNodeInstanceDto expectedUserTask =
-        createRunningUserTaskInstance(instance, exportedEvents);
-    expectedUserTask.setIdleDurationInMs(0L);
-    expectedUserTask.setWorkDurationInMs(
+    // then (update-script path)
+    exportedEventsB = getZeebeExportedUserTaskEvents(instanceB.getProcessInstanceKey());
+    final FlowNodeInstanceDto expectedUserTaskB =
+        createRunningUserTaskInstance(instanceB, exportedEventsB);
+    expectedUserTaskB.setIdleDurationInMs(0L);
+    expectedUserTaskB.setWorkDurationInMs(
         isZeebeVersion87_OrLater()
-            ? getDurationInMsBetweenStartDateAndLastAssignedOperation(exportedEvents)
-            : getDurationInMsBetweenStartAndFirstAssignOperation(exportedEvents));
-    expectedUserTask.setAssigneeOperations(
+            ? getDurationInMsBetweenStartDateAndLastAssignedOperation(exportedEventsB)
+            : getDurationInMsBetweenStartAndFirstAssignOperation(exportedEventsB));
+    expectedUserTaskB.setAssigneeOperations(
         List.of(
             createAssigneeOperationDto(
-                getExpectedIdFromRecords(exportedEvents, CREATING),
+                getExpectedIdFromRecords(exportedEventsB, CREATING),
                 CLAIM_OPERATION_TYPE,
                 ASSIGNEE_ID,
-                getExpectedStartDateForUserTaskEvents(exportedEvents)),
+                getExpectedStartDateForUserTaskEvents(exportedEventsB)),
             createAssigneeOperationDto(
-                getExpectedIdFromRecords(exportedEvents, ASSIGNED),
+                getExpectedIdFromRecords(exportedEventsB, ASSIGNED),
                 UNCLAIM_OPERATION_TYPE,
                 null,
                 isZeebeVersion87_OrLater()
-                    ? getTimestampForZeebeLastAssignedEvents(exportedEvents, "")
-                    : getTimestampForZeebeUnassignEvent(exportedEvents))));
+                    ? getTimestampForZeebeLastAssignedEvents(exportedEventsB, "")
+                    : getTimestampForZeebeUnassignEvent(exportedEventsB))));
 
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances()).hasSize(2);
+    final ProcessInstanceDto savedInstanceB =
+        getProcessInstanceForId(String.valueOf(instanceB.getProcessInstanceKey()));
+    assertThat(savedInstanceB.getProcessInstanceId())
+        .isEqualTo(String.valueOf(instanceB.getProcessInstanceKey()));
+    assertThat(savedInstanceB.getProcessDefinitionId())
+        .isEqualTo(String.valueOf(instanceB.getProcessDefinitionKey()));
+    assertThat(savedInstanceB.getProcessDefinitionKey()).isEqualTo(instanceB.getBpmnProcessId());
+    assertThat(savedInstanceB.getDataSource().getName()).isEqualTo(getConfiguredZeebeName());
+    assertThat(savedInstanceB.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+    assertThat(savedInstanceB.getFlowNodeInstances())
+        // only userTask was imported because all other records were removed
         .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getFlowNodeInstances())
-                  // only userTask was imported because all other records were removed
-                  .singleElement()
-                  .usingRecursiveComparison()
-                  .isEqualTo(expectedUserTask);
-            });
+        .usingRecursiveComparison()
+        .isEqualTo(expectedUserTaskB);
   }
 
   @Test
@@ -739,59 +730,65 @@ public class ZeebeUserTaskImportIT extends AbstractCCSMIT {
   }
 
   @Test
-  public void importMultipleAssigneeOperations_viaWriter() {
-    // given
+  public void importMultipleAssigneeOperations_viaWriterAndViaUpdateScript() {
+    // Covers both import code paths for a sequence of claim/unclaim/claim operations: scenario 1
+    // imports creation and all assignee operations together in one batch (upsert via the writer);
+    // scenario 2 imports them as two separate batches (upsert via the update script).
     final String assigneeId1 = ASSIGNEE_ID + "1";
     final String assigneeId2 = ASSIGNEE_ID + "2";
-    final ProcessInstanceEvent instance =
+
+    // given (writer path)
+    final ProcessInstanceEvent instanceA =
         deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, null));
     waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    final List<ZeebeUserTaskRecordDto> userTaskEvents = getZeebeExportedUserTaskEvents();
-    final long userTaskInstanceId = getExpectedUserTaskInstanceIdFromRecords(userTaskEvents);
-    zeebeExtension.assignUserTask(userTaskInstanceId, assigneeId1);
-    zeebeExtension.unassignUserTask(userTaskInstanceId);
-    zeebeExtension.assignUserTask(userTaskInstanceId, assigneeId2);
-    zeebeExtension.completeZeebeUserTask(userTaskInstanceId);
+    final List<ZeebeUserTaskRecordDto> userTaskEventsA =
+        getZeebeExportedUserTaskEvents(instanceA.getProcessInstanceKey());
+    final long userTaskInstanceIdA = getExpectedUserTaskInstanceIdFromRecords(userTaskEventsA);
+    zeebeExtension.assignUserTask(userTaskInstanceIdA, assigneeId1);
+    zeebeExtension.unassignUserTask(userTaskInstanceIdA);
+    zeebeExtension.assignUserTask(userTaskInstanceIdA, assigneeId2);
+    zeebeExtension.completeZeebeUserTask(userTaskInstanceIdA);
     waitUntilUserTaskRecordWithIntentExported(COMPLETED);
 
     // remove all zeebe records except userTask ones to test userTask import only
     removeAllZeebeExportRecordsExceptUserTaskRecords();
 
-    // when
+    // when (writer path)
     importAllZeebeEntitiesFromScratch();
 
-    // then
-    final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
-    final FlowNodeInstanceDto runningUserTaskInstance =
-        createRunningUserTaskInstance(instance, exportedEvents);
-    runningUserTaskInstance.setEndDate(
-        getExpectedEndDateForCompletedUserTaskEvents(exportedEvents));
-    runningUserTaskInstance.setIdleDurationInMs(
-        getDurationInMsBetweenStartAndFirstAssignOperation(exportedEvents)
-            + getDurationInMsBetweenAssignOperations(exportedEvents, "", assigneeId2));
-    runningUserTaskInstance.setWorkDurationInMs(
-        getDurationInMsBetweenAssignOperations(exportedEvents, assigneeId1, "")
-            + getDurationInMsBetweenLastAssignOperationAndEnd(exportedEvents, assigneeId2));
-    runningUserTaskInstance.setTotalDurationInMs(
-        getExpectedTotalDurationForCompletedUserTask(exportedEvents));
-    runningUserTaskInstance.setAssignee(assigneeId2);
-    runningUserTaskInstance.setAssigneeOperations(
+    // then (writer path)
+    final List<ZeebeUserTaskRecordDto> exportedEventsA =
+        getZeebeExportedUserTaskEvents(instanceA.getProcessInstanceKey());
+    final FlowNodeInstanceDto runningUserTaskInstanceA =
+        createRunningUserTaskInstance(instanceA, exportedEventsA);
+    runningUserTaskInstanceA.setEndDate(
+        getExpectedEndDateForCompletedUserTaskEvents(exportedEventsA));
+    runningUserTaskInstanceA.setIdleDurationInMs(
+        getDurationInMsBetweenStartAndFirstAssignOperation(exportedEventsA)
+            + getDurationInMsBetweenAssignOperations(exportedEventsA, "", assigneeId2));
+    runningUserTaskInstanceA.setWorkDurationInMs(
+        getDurationInMsBetweenAssignOperations(exportedEventsA, assigneeId1, "")
+            + getDurationInMsBetweenLastAssignOperationAndEnd(exportedEventsA, assigneeId2));
+    runningUserTaskInstanceA.setTotalDurationInMs(
+        getExpectedTotalDurationForCompletedUserTask(exportedEventsA));
+    runningUserTaskInstanceA.setAssignee(assigneeId2);
+    runningUserTaskInstanceA.setAssigneeOperations(
         List.of(
             createAssigneeOperationDto(
-                getExpectedIdFromAssignRecordsWithAssigneeId(exportedEvents, assigneeId1),
+                getExpectedIdFromAssignRecordsWithAssigneeId(exportedEventsA, assigneeId1),
                 CLAIM_OPERATION_TYPE,
                 assigneeId1,
-                getTimestampForZeebeAssignEvents(exportedEvents, assigneeId1)),
+                getTimestampForZeebeAssignEvents(exportedEventsA, assigneeId1)),
             createAssigneeOperationDto(
-                getExpectedIdFromAssignRecordsWithAssigneeId(exportedEvents, ""),
+                getExpectedIdFromAssignRecordsWithAssigneeId(exportedEventsA, ""),
                 UNCLAIM_OPERATION_TYPE,
                 null,
-                getTimestampForZeebeUnassignEvent(exportedEvents)),
+                getTimestampForZeebeUnassignEvent(exportedEventsA)),
             createAssigneeOperationDto(
-                getExpectedIdFromAssignRecordsWithAssigneeId(exportedEvents, assigneeId2),
+                getExpectedIdFromAssignRecordsWithAssigneeId(exportedEventsA, assigneeId2),
                 CLAIM_OPERATION_TYPE,
                 assigneeId2,
-                getTimestampForZeebeAssignEvents(exportedEvents, assigneeId2))));
+                getTimestampForZeebeAssignEvents(exportedEventsA, assigneeId2))));
     assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
         .singleElement()
         .satisfies(
@@ -799,76 +796,74 @@ public class ZeebeUserTaskImportIT extends AbstractCCSMIT {
                 assertThat(savedInstance.getFlowNodeInstances())
                     .singleElement()
                     .usingRecursiveComparison()
-                    .isEqualTo(runningUserTaskInstance));
-  }
+                    .isEqualTo(runningUserTaskInstanceA));
 
-  @Test
-  public void importMultipleAssigneeOperations_viaUpdateScript() {
-    // given
-    final String assigneeId1 = ASSIGNEE_ID + "1";
-    final String assigneeId2 = ASSIGNEE_ID + "2";
-    final ProcessInstanceEvent instance =
+    // given (update-script path)
+    final ProcessInstanceEvent instanceB =
         deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, null));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    final List<ZeebeUserTaskRecordDto> userTaskEvents = getZeebeExportedUserTaskEvents();
-    final long userTaskInstanceId = getExpectedUserTaskInstanceIdFromRecords(userTaskEvents);
-    zeebeExtension.assignUserTask(userTaskInstanceId, assigneeId1);
-    waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
+    waitUntilUserTaskRecordExportedForInstance(instanceB.getProcessInstanceKey());
+    final List<ZeebeUserTaskRecordDto> userTaskEventsB =
+        getZeebeExportedUserTaskEvents(instanceB.getProcessInstanceKey());
+    final long userTaskInstanceIdB = getExpectedUserTaskInstanceIdFromRecords(userTaskEventsB);
+    zeebeExtension.assignUserTask(userTaskInstanceIdB, assigneeId1);
+    waitUntilUserTaskRecordWithIntentExportedForInstance(
+        ASSIGNED, instanceB.getProcessInstanceKey());
     // remove all zeebe records except userTask ones to test userTask import only
     removeAllZeebeExportRecordsExceptUserTaskRecords();
     importAllZeebeEntitiesFromScratch();
 
-    zeebeExtension.unassignUserTask(userTaskInstanceId);
-    zeebeExtension.assignUserTask(userTaskInstanceId, assigneeId2);
-    zeebeExtension.completeZeebeUserTask(userTaskInstanceId);
-    waitUntilUserTaskRecordWithIntentExported(COMPLETED);
+    zeebeExtension.unassignUserTask(userTaskInstanceIdB);
+    zeebeExtension.assignUserTask(userTaskInstanceIdB, assigneeId2);
+    zeebeExtension.completeZeebeUserTask(userTaskInstanceIdB);
+    waitUntilUserTaskRecordWithIntentExportedForInstance(
+        COMPLETED, instanceB.getProcessInstanceKey());
 
     // remove all zeebe records except userTask ones to test userTask import only
     removeAllZeebeExportRecordsExceptUserTaskRecords();
 
-    // when
+    // when (update-script path)
     importAllZeebeEntitiesFromLastIndex();
 
-    // then
-    final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
-    final FlowNodeInstanceDto runningUserTaskInstance =
-        createRunningUserTaskInstance(instance, exportedEvents);
-    runningUserTaskInstance.setEndDate(
-        getExpectedEndDateForCompletedUserTaskEvents(exportedEvents));
-    runningUserTaskInstance.setIdleDurationInMs(
-        getDurationInMsBetweenStartAndFirstAssignOperation(exportedEvents)
-            + getDurationInMsBetweenAssignOperations(exportedEvents, "", assigneeId2));
-    runningUserTaskInstance.setWorkDurationInMs(
-        getDurationInMsBetweenAssignOperations(exportedEvents, assigneeId1, "")
-            + getDurationInMsBetweenLastAssignOperationAndEnd(exportedEvents, assigneeId2));
-    runningUserTaskInstance.setTotalDurationInMs(
-        getExpectedTotalDurationForCompletedUserTask(exportedEvents));
-    runningUserTaskInstance.setAssignee(assigneeId2);
-    runningUserTaskInstance.setAssigneeOperations(
+    // then (update-script path)
+    final List<ZeebeUserTaskRecordDto> exportedEventsB =
+        getZeebeExportedUserTaskEvents(instanceB.getProcessInstanceKey());
+    final FlowNodeInstanceDto runningUserTaskInstanceB =
+        createRunningUserTaskInstance(instanceB, exportedEventsB);
+    runningUserTaskInstanceB.setEndDate(
+        getExpectedEndDateForCompletedUserTaskEvents(exportedEventsB));
+    runningUserTaskInstanceB.setIdleDurationInMs(
+        getDurationInMsBetweenStartAndFirstAssignOperation(exportedEventsB)
+            + getDurationInMsBetweenAssignOperations(exportedEventsB, "", assigneeId2));
+    runningUserTaskInstanceB.setWorkDurationInMs(
+        getDurationInMsBetweenAssignOperations(exportedEventsB, assigneeId1, "")
+            + getDurationInMsBetweenLastAssignOperationAndEnd(exportedEventsB, assigneeId2));
+    runningUserTaskInstanceB.setTotalDurationInMs(
+        getExpectedTotalDurationForCompletedUserTask(exportedEventsB));
+    runningUserTaskInstanceB.setAssignee(assigneeId2);
+    runningUserTaskInstanceB.setAssigneeOperations(
         List.of(
             createAssigneeOperationDto(
-                getExpectedIdFromAssignRecordsWithAssigneeId(exportedEvents, assigneeId1),
+                getExpectedIdFromAssignRecordsWithAssigneeId(exportedEventsB, assigneeId1),
                 CLAIM_OPERATION_TYPE,
                 assigneeId1,
-                getTimestampForZeebeAssignEvents(exportedEvents, assigneeId1)),
+                getTimestampForZeebeAssignEvents(exportedEventsB, assigneeId1)),
             createAssigneeOperationDto(
-                getExpectedIdFromAssignRecordsWithAssigneeId(exportedEvents, ""),
+                getExpectedIdFromAssignRecordsWithAssigneeId(exportedEventsB, ""),
                 UNCLAIM_OPERATION_TYPE,
                 null,
-                getTimestampForZeebeUnassignEvent(exportedEvents)),
+                getTimestampForZeebeUnassignEvent(exportedEventsB)),
             createAssigneeOperationDto(
-                getExpectedIdFromAssignRecordsWithAssigneeId(exportedEvents, assigneeId2),
+                getExpectedIdFromAssignRecordsWithAssigneeId(exportedEventsB, assigneeId2),
                 CLAIM_OPERATION_TYPE,
                 assigneeId2,
-                getTimestampForZeebeAssignEvents(exportedEvents, assigneeId2))));
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+                getTimestampForZeebeAssignEvents(exportedEventsB, assigneeId2))));
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances()).hasSize(2);
+    final ProcessInstanceDto savedInstanceB =
+        getProcessInstanceForId(String.valueOf(instanceB.getProcessInstanceKey()));
+    assertThat(savedInstanceB.getFlowNodeInstances())
         .singleElement()
-        .satisfies(
-            savedInstance ->
-                assertThat(savedInstance.getFlowNodeInstances())
-                    .singleElement()
-                    .usingRecursiveComparison()
-                    .isEqualTo(runningUserTaskInstance));
+        .usingRecursiveComparison()
+        .isEqualTo(runningUserTaskInstanceB);
   }
 
   @Test
@@ -1032,6 +1027,68 @@ public class ZeebeUserTaskImportIT extends AbstractCCSMIT {
 
   private List<ZeebeUserTaskRecordDto> getZeebeExportedUserTaskEvents() {
     return getZeebeExportedUserTaskEventsByElementId().get(USER_TASK);
+  }
+
+  /**
+   * Scopes {@link #getZeebeExportedUserTaskEvents()} to a single process instance. Needed once a
+   * test has more than one instance's user-task records sitting in the shared export index at the
+   * same time (e.g. merged tests covering two import-path scenarios sequentially) — the unscoped
+   * query groups records by elementId only, so records from multiple instances using the same
+   * element id would otherwise be mixed together.
+   */
+  private List<ZeebeUserTaskRecordDto> getZeebeExportedUserTaskEvents(
+      final long processInstanceKey) {
+    return getZeebeExportedUserTaskEvents().stream()
+        .filter(event -> event.getValue().getProcessInstanceKey() == processInstanceKey)
+        .toList();
+  }
+
+  /**
+   * Instance-scoped variants of {@code AbstractCCSMIT.waitUntilUserTaskRecordWithElementIdExported}
+   * / {@code waitUntilUserTaskRecordWithIntentExported}. The inherited helpers only check "at least
+   * N records with this elementId/intent exist" across the whole class-scoped export index — in a
+   * merged test where an earlier scenario's instance already satisfies that count, the inherited
+   * wait would return immediately without actually waiting for the current scenario's own record to
+   * land, racing the assertions that follow.
+   */
+  private void waitUntilUserTaskRecordExportedForInstance(final long processInstanceKey) {
+    final TermsQueryContainer query = new TermsQueryContainer();
+    query.addTermQuery(
+        ZeebeUserTaskRecordDto.Fields.value + "." + ZeebeUserTaskDataDto.Fields.elementId,
+        USER_TASK);
+    query.addTermQuery(
+        ZeebeUserTaskRecordDto.Fields.value + "." + ZeebeUserTaskDataDto.Fields.processInstanceKey,
+        String.valueOf(processInstanceKey));
+    waitUntilRecordMatchingQueryExported(DatabaseConstants.ZEEBE_USER_TASK_INDEX_NAME, query);
+  }
+
+  private void waitUntilUserTaskRecordWithIntentExportedForInstance(
+      final UserTaskIntent intent, final long processInstanceKey) {
+    waitUntilUserTaskRecordWithIntentExportedForInstance(1, intent, processInstanceKey);
+  }
+
+  private void waitUntilUserTaskRecordWithIntentExportedForInstance(
+      final long minRecordCount, final UserTaskIntent intent, final long processInstanceKey) {
+    final TermsQueryContainer query = new TermsQueryContainer();
+    query.addTermQuery(
+        ZeebeUserTaskRecordDto.Fields.value + "." + ZeebeUserTaskDataDto.Fields.elementId,
+        USER_TASK);
+    query.addTermQuery(ZeebeRecordDto.Fields.intent, intent.name());
+    query.addTermQuery(
+        ZeebeUserTaskRecordDto.Fields.value + "." + ZeebeUserTaskDataDto.Fields.processInstanceKey,
+        String.valueOf(processInstanceKey));
+    waitUntilRecordMatchingQueryExported(
+        minRecordCount, DatabaseConstants.ZEEBE_USER_TASK_INDEX_NAME, query);
+  }
+
+  private ProcessInstanceDto getProcessInstanceForId(final String processInstanceId) {
+    return databaseIntegrationTestExtension.getAllProcessInstances().stream()
+        .filter(instance -> instance.getProcessInstanceId().equals(processInstanceId))
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new OptimizeIntegrationTestException(
+                    "No process instance with id " + processInstanceId + " found"));
   }
 
   private AssigneeOperationDto createAssigneeOperationDto(

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableCreationImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableCreationImportIT.java
@@ -93,93 +93,85 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
   }
 
   @Test
-  public void variableImportWorksForLongStrings() {
+  public void variableImportWorksForLongStringsAndDateStrings() {
+    // Covers two independent variable-content edge cases on the same instance: a too-long string
+    // value, and a date-formatted string value.
+
     // given
     final Process deployedProcess = zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
     // see https://www.elastic.co/guide/en/elasticsearch/reference/7.15/ignore-above.html
-    final String variableName = "longStringVar";
+    final String longStringVariableName = "longStringVar";
     // use a too long value of a length > 32766
     final String largeValue = RandomStringUtils.randomAlphabetic(32767);
-    final Map<String, Object> variables = Map.of(variableName, largeValue);
+    final String dateVariableName = "date";
+    final String dateVariableValue = "2025-10-10";
+    final String parsedDateValue = "2025-10-10T00:00:00.000+0000";
+    final Map<String, Object> variables =
+        Map.of(longStringVariableName, largeValue, dateVariableName, dateVariableValue);
     final Long processInstanceKey =
         zeebeExtension.startProcessInstanceWithVariables(
             deployedProcess.getBpmnProcessId(), variables);
 
     // when
     waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKey);
-    waitUntilMinimumVariableDocumentsForInstanceExportedCount(1, processInstanceKey);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(2, processInstanceKey);
     importAllZeebeEntitiesFromScratch();
-
-    // when
     final ProcessInstanceDto importedProcessInstance =
         getProcessInstanceForId(String.valueOf(processInstanceKey));
+
+    // then (long string)
     assertThat(importedProcessInstance.getVariables())
+        .filteredOn(variable -> variable.getName().equals(longStringVariableName))
         .singleElement()
         .satisfies(
             variable -> {
-              assertThat(variable.getName()).isEqualTo(variableName);
+              assertThat(variable.getName()).isEqualTo(longStringVariableName);
               assertThat(variable.getValue().get(0)).isEqualTo(largeValue);
             });
-  }
 
-  @Test
-  public void variableImportWorksForDateStrings() {
-    // given
-    final Process deployedProcess = zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
-    final String variableName = "date";
-    final String variableValue = "2025-10-10";
-    final String parsedDateValue = "2025-10-10T00:00:00.000+0000";
-    final Map<String, Object> variables = Map.of(variableName, variableValue);
-    final Long processInstanceKey =
-        zeebeExtension.startProcessInstanceWithVariables(
-            deployedProcess.getBpmnProcessId(), variables);
-
-    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKey);
-    waitUntilMinimumVariableDocumentsForInstanceExportedCount(1, processInstanceKey);
-    importAllZeebeEntitiesFromScratch();
-
-    // when
-    final ProcessInstanceDto importedProcessInstance =
-        getProcessInstanceForId(String.valueOf(processInstanceKey));
-
-    // then
+    // then (date string)
     assertThat(importedProcessInstance.getVariables())
+        .filteredOn(variable -> variable.getName().equals(dateVariableName))
         .singleElement()
         .satisfies(
             variable -> {
-              assertThat(variable.getName()).isEqualTo(variableName);
+              assertThat(variable.getName()).isEqualTo(dateVariableName);
               assertThat(variable.getType()).isEqualTo(DATE.getId());
               assertThat(variable.getValue().getFirst()).isEqualTo(parsedDateValue);
             });
   }
 
   @Test
-  public void variableObjectImportDoesNotParseDigitOnlyStringsAsDates() {
+  public void variableObjectAndListImportDoNotParseDigitOnlyStringsAsDates() {
+    // Covers two independent variable-shape edge cases on the same instance: an object-shaped and
+    // a list-shaped variable, both containing digit-only strings that must not be parsed as dates.
+
     // given
     final Map<String, Object> numericStringMap =
         generateNumericStringsOfLengthXInRange(10, 20).stream()
             .collect(Collectors.toMap(str -> String.valueOf(str.length()), str -> str));
-
-    final Map<String, Object> variables = Map.of("numericStrings", numericStringMap);
+    final var numericStringList = generateNumericStringsOfLengthXInRange(10, 20);
+    final Map<String, Object> variables =
+        Map.of("numericStrings", numericStringMap, "numericStringsList", numericStringList);
 
     final Process deployedProcess = zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
     final long processInstanceKey =
         zeebeExtension.startProcessInstanceWithVariables(
             deployedProcess.getBpmnProcessId(), variables);
     waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKey);
-    waitUntilMinimumVariableDocumentsForInstanceExportedCount(1, processInstanceKey);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(2, processInstanceKey);
 
     // when
     importAllZeebeEntitiesFromScratch();
     final ProcessInstanceDto instance = getProcessInstanceForId(String.valueOf(processInstanceKey));
 
-    // then
+    // then (object-shaped)
     assertThat(instance.getVariables())
         .extracting(
             SimpleProcessVariableDto::getName,
             SimpleProcessVariableDto::getType,
             SimpleProcessVariableDto::getValue)
-        .containsExactlyInAnyOrder(
+        .contains(
             Tuple.tuple(
                 "numericStrings",
                 OBJECT.getId(),
@@ -215,35 +207,18 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
                 "numericStrings.20",
                 STRING.getId(),
                 Collections.singletonList("12345678901234567890")));
-  }
 
-  @Test
-  public void variableListImportDoesNotParseDigitOnlyStringsAsDates() {
-    // given
-    final var numericStringList = generateNumericStringsOfLengthXInRange(10, 20);
-
-    final Process deployedProcess = zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
-    final long processInstanceKey =
-        zeebeExtension.startProcessInstanceWithVariables(
-            deployedProcess.getBpmnProcessId(), Map.of("numericStrings", numericStringList));
-
-    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKey);
-    waitUntilMinimumVariableDocumentsForInstanceExportedCount(1, processInstanceKey);
-
-    // when
-    importAllZeebeEntitiesFromScratch();
-    final ProcessInstanceDto instance = getProcessInstanceForId(String.valueOf(processInstanceKey));
-
-    // then
+    // then (list-shaped)
     assertThat(instance.getVariables())
         .extracting(
             SimpleProcessVariableDto::getName,
             SimpleProcessVariableDto::getType,
             SimpleProcessVariableDto::getValue)
-        .containsExactlyInAnyOrder(
-            Tuple.tuple("numericStrings", STRING.getId(), numericStringList),
+        .contains(
+            Tuple.tuple("numericStringsList", STRING.getId(), numericStringList),
             // additional _listSize variable for lists
-            Tuple.tuple("numericStrings._listSize", LONG.getId(), Collections.singletonList("11")));
+            Tuple.tuple(
+                "numericStringsList._listSize", LONG.getId(), Collections.singletonList("11")));
   }
 
   @Test
@@ -411,23 +386,31 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
   }
 
   @Test
-  public void zeebeVariableImport_importObjectVariables() {
-    // given
-    final Map<String, Object> variables = Map.of("objectVar", PERSON_VARIABLES);
+  public void
+      zeebeVariableImport_importObjectVariablesAndWhenObjectVariablesAreExcludedInConfiguration() {
+    // Covers two independent object-variable-import scenarios: scenario 1 imports the full nested
+    // object value under the default configuration; scenario 2 imports with object-variable-value
+    // inclusion turned off, so only the plain (non-object) variable survives. Scenario 2 must run
+    // last since it mutates shared configuration, only reset by the next test method's @BeforeEach.
 
-    final Process deployedProcess = zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
-    final long processInstanceKey =
+    // given (default config)
+    final Map<String, Object> variablesA = Map.of("objectVar", PERSON_VARIABLES);
+
+    final Process deployedProcessA =
+        zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
+    final long processInstanceKeyA =
         zeebeExtension.startProcessInstanceWithVariables(
-            deployedProcess.getBpmnProcessId(), variables);
-    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKey);
-    waitUntilMinimumVariableDocumentsForInstanceExportedCount(1, processInstanceKey);
+            deployedProcessA.getBpmnProcessId(), variablesA);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKeyA);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(1, processInstanceKeyA);
 
-    // when
+    // when (default config)
     importAllZeebeEntitiesFromScratch();
-    final ProcessInstanceDto instance = getProcessInstanceForId(String.valueOf(processInstanceKey));
+    final ProcessInstanceDto instanceA =
+        getProcessInstanceForId(String.valueOf(processInstanceKeyA));
 
-    // then
-    assertThat(instance.getVariables())
+    // then (default config)
+    assertThat(instanceA.getVariables())
         .extracting(
             SimpleProcessVariableDto::getName,
             SimpleProcessVariableDto::getType,
@@ -457,31 +440,29 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
             Tuple.tuple("objectVar.likes", STRING.getId(), List.of("optimize", "garlic")),
             // additional _listSize variable for lists
             Tuple.tuple("objectVar.likes._listSize", LONG.getId(), Collections.singletonList("2")));
-  }
 
-  @Test
-  public void
-      zeebeVariableImport_importObjectVariablesWhenObjectVariablesAreExcludedInConfiguration() {
-    // given
+    // given (object variables excluded in configuration)
     embeddedOptimizeExtension
         .getConfigurationService()
         .getConfiguredZeebe()
         .setIncludeObjectVariableValue(false);
-    final Map<String, Object> variables = Map.of("objectVar", PERSON_VARIABLES, "boolVar", true);
+    final Map<String, Object> variablesB = Map.of("objectVar", PERSON_VARIABLES, "boolVar", true);
 
-    final Process deployedProcess = zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
-    final long processInstanceKey =
+    final Process deployedProcessB =
+        zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
+    final long processInstanceKeyB =
         zeebeExtension.startProcessInstanceWithVariables(
-            deployedProcess.getBpmnProcessId(), variables);
-    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKey);
-    waitUntilMinimumVariableDocumentsForInstanceExportedCount(1, processInstanceKey);
+            deployedProcessB.getBpmnProcessId(), variablesB);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKeyB);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(1, processInstanceKeyB);
 
-    // when
+    // when (object variables excluded in configuration)
     importAllZeebeEntitiesFromScratch();
-    final ProcessInstanceDto instance = getProcessInstanceForId(String.valueOf(processInstanceKey));
+    final ProcessInstanceDto instanceB =
+        getProcessInstanceForId(String.valueOf(processInstanceKeyB));
 
-    // then
-    assertThat(instance.getVariables())
+    // then (object variables excluded in configuration)
+    assertThat(instanceB.getVariables())
         .extracting(
             SimpleProcessVariableDto::getName,
             SimpleProcessVariableDto::getType,

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableCreationImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableCreationImportIT.java
@@ -167,11 +167,15 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
 
     // then (object-shaped)
     assertThat(instance.getVariables())
+        .filteredOn(
+            variable ->
+                variable.getName().equals("numericStrings")
+                    || variable.getName().startsWith("numericStrings."))
         .extracting(
             SimpleProcessVariableDto::getName,
             SimpleProcessVariableDto::getType,
             SimpleProcessVariableDto::getValue)
-        .contains(
+        .containsExactlyInAnyOrder(
             Tuple.tuple(
                 "numericStrings",
                 OBJECT.getId(),
@@ -210,11 +214,15 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
 
     // then (list-shaped)
     assertThat(instance.getVariables())
+        .filteredOn(
+            variable ->
+                variable.getName().equals("numericStringsList")
+                    || variable.getName().startsWith("numericStringsList."))
         .extracting(
             SimpleProcessVariableDto::getName,
             SimpleProcessVariableDto::getType,
             SimpleProcessVariableDto::getValue)
-        .contains(
+        .containsExactlyInAnyOrder(
             Tuple.tuple("numericStringsList", STRING.getId(), numericStringList),
             // additional _listSize variable for lists
             Tuple.tuple(

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableUpdateImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableUpdateImportIT.java
@@ -41,42 +41,41 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
 
   @Test
   public void
-      zeebeVariableImport_importRecordsForTheCreationAndTheUpdateOfProcessVariablesOnSameBatch() {
-    // given
-    final long processInstanceKey = deployProcessAndStartProcessInstanceWithVariables(VARIABLES);
-    zeebeExtension.addVariablesToScope(processInstanceKey, UPDATED_VARIABLES, true);
+      zeebeVariableImport_importRecordsForTheCreationAndTheUpdateOfProcessVariablesOnSameAndOnDifferentBatch() {
+    // Covers two independent variable-update batching scenarios: scenario 1 imports creation and
+    // update together in one batch; scenario 2 imports them as two separate batches.
+
+    // given (same batch)
+    final long processInstanceKeyA = deployProcessAndStartProcessInstanceWithVariables(VARIABLES);
+    zeebeExtension.addVariablesToScope(processInstanceKeyA, UPDATED_VARIABLES, true);
     waitUntilDefinitionWithIdExported(PROCESS_ID);
     waitUntilMinimumVariableDocumentsWithUpdatedIntentForInstanceExportedCount(
-        5, processInstanceKey);
+        5, processInstanceKeyA);
 
-    // when
+    // when (same batch)
     importAllZeebeEntitiesFromScratch();
 
-    // then
-    final ProcessInstanceDto savedProcessInstance =
-        getProcessInstanceForId(String.valueOf(processInstanceKey));
-    assertThatVariablesHaveBeenImportedForProcessInstance(savedProcessInstance);
-  }
+    // then (same batch)
+    final ProcessInstanceDto savedProcessInstanceA =
+        getProcessInstanceForId(String.valueOf(processInstanceKeyA));
+    assertThatVariablesHaveBeenImportedForProcessInstance(savedProcessInstanceA);
 
-  @Test
-  public void
-      zeebeVariableImport_importRecordsForTheCreationAndTheUpdateOfProcessVariablesOnDifferentBatch() {
-    // given
-    final long processInstanceKey = deployProcessAndStartProcessInstanceWithVariables(VARIABLES);
+    // given (different batch)
+    final long processInstanceKeyB = deployProcessAndStartProcessInstanceWithVariables(VARIABLES);
     waitUntilMinimumVariableDocumentsWithCreatedIntentForInstanceExportedCount(
-        5, processInstanceKey);
+        5, processInstanceKeyB);
     importAllZeebeEntitiesFromScratch();
-    zeebeExtension.addVariablesToScope(processInstanceKey, UPDATED_VARIABLES, true);
+    zeebeExtension.addVariablesToScope(processInstanceKeyB, UPDATED_VARIABLES, true);
     waitUntilMinimumVariableDocumentsWithUpdatedIntentForInstanceExportedCount(
-        5, processInstanceKey);
+        5, processInstanceKeyB);
 
-    // when
+    // when (different batch)
     importAllZeebeEntitiesFromLastIndex();
 
-    // then
-    final ProcessInstanceDto savedProcessInstance =
-        getProcessInstanceForId(String.valueOf(processInstanceKey));
-    assertThatVariablesHaveBeenImportedForProcessInstance(savedProcessInstance);
+    // then (different batch)
+    final ProcessInstanceDto savedProcessInstanceB =
+        getProcessInstanceForId(String.valueOf(processInstanceKeyB));
+    assertThatVariablesHaveBeenImportedForProcessInstance(savedProcessInstanceB);
   }
 
   @Test
@@ -314,63 +313,66 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
   }
 
   @Test
-  public void zeebeVariableImport_updateVariableSeveralTimesInSameBatch() {
-    // given
-    final long processInstanceKey =
+  public void zeebeVariableImport_updateVariableSeveralTimesInSameAndInSeveralBatches() {
+    // Covers two independent variable-update batching scenarios: scenario 1 updates the variable
+    // twice, importing both updates in one batch; scenario 2 updates it twice again on a fresh
+    // instance, importing each update as its own batch (forced via maxImportPageSize=1). Scenario
+    // 2 must run last since it mutates shared configuration, only reset by the next test method's
+    // @BeforeEach.
+
+    // given (same batch)
+    final long processInstanceKeyA =
         deployProcessAndStartProcessInstanceWithVariables(Map.of("var1", "someValue"));
     waitUntilMinimumVariableDocumentsWithCreatedIntentForInstanceExportedCount(
-        1, processInstanceKey);
+        1, processInstanceKeyA);
     importAllZeebeEntitiesFromScratch();
-    zeebeExtension.addVariablesToScope(processInstanceKey, Map.of("var1", "firstUpdate"), true);
-    zeebeExtension.addVariablesToScope(processInstanceKey, Map.of("var1", "secondUpdate"), true);
+    zeebeExtension.addVariablesToScope(processInstanceKeyA, Map.of("var1", "firstUpdate"), true);
+    zeebeExtension.addVariablesToScope(processInstanceKeyA, Map.of("var1", "secondUpdate"), true);
     importAllZeebeEntitiesFromLastIndex();
     waitUntilMinimumVariableDocumentsWithUpdatedIntentForInstanceExportedCount(
-        2, processInstanceKey);
+        2, processInstanceKeyA);
 
-    // when
+    // when (same batch)
     importAllZeebeEntitiesFromLastIndex();
 
-    // then
-    final ProcessInstanceDto savedProcessInstance =
-        getProcessInstanceForId(String.valueOf(processInstanceKey));
-    assertThat(savedProcessInstance.getVariables())
+    // then (same batch)
+    final ProcessInstanceDto savedProcessInstanceA =
+        getProcessInstanceForId(String.valueOf(processInstanceKeyA));
+    assertThat(savedProcessInstanceA.getVariables())
         .extracting(
             SimpleProcessVariableDto::getName,
             SimpleProcessVariableDto::getValue,
             SimpleProcessVariableDto::getType)
         .containsExactlyInAnyOrder(
             Tuple.tuple("var1", Collections.singletonList("secondUpdate"), STRING_TYPE));
-  }
 
-  @Test
-  public void zeebeVariableImport_updateVariableSeveralTimesInSeveralBatches() {
-    // given
+    // given (several batches)
     embeddedOptimizeExtension
         .getConfigurationService()
         .getConfiguredZeebe()
         .setMaxImportPageSize(1);
     embeddedOptimizeExtension.reloadConfiguration();
-    final long processInstanceKey =
+    final long processInstanceKeyB =
         deployProcessAndStartProcessInstanceWithVariables(Map.of("var1", "someValue"));
     waitUntilMinimumVariableDocumentsWithCreatedIntentForInstanceExportedCount(
-        1, processInstanceKey);
+        1, processInstanceKeyB);
     importAllZeebeEntitiesFromScratch();
-    zeebeExtension.addVariablesToScope(processInstanceKey, Map.of("var1", "firstUpdate"), true);
+    zeebeExtension.addVariablesToScope(processInstanceKeyB, Map.of("var1", "firstUpdate"), true);
     waitUntilMinimumVariableDocumentsWithUpdatedIntentForInstanceExportedCount(
-        1, processInstanceKey);
+        1, processInstanceKeyB);
     importAllZeebeEntitiesFromLastIndex();
-    zeebeExtension.addVariablesToScope(processInstanceKey, Map.of("var1", "secondUpdate"), true);
+    zeebeExtension.addVariablesToScope(processInstanceKeyB, Map.of("var1", "secondUpdate"), true);
     waitUntilMinimumVariableDocumentsWithUpdatedIntentForInstanceExportedCount(
-        2, processInstanceKey);
+        2, processInstanceKeyB);
 
-    // when
+    // when (several batches)
     importAllZeebeEntitiesFromLastIndex();
     importAllZeebeEntitiesFromLastIndex();
 
-    // then
-    final ProcessInstanceDto savedProcessInstance =
-        getProcessInstanceForId(String.valueOf(processInstanceKey));
-    assertThat(savedProcessInstance.getVariables())
+    // then (several batches)
+    final ProcessInstanceDto savedProcessInstanceB =
+        getProcessInstanceForId(String.valueOf(processInstanceKeyB));
+    assertThat(savedProcessInstanceB.getVariables())
         .extracting(
             SimpleProcessVariableDto::getName,
             SimpleProcessVariableDto::getValue,


### PR DESCRIPTION
## Summary

Optimize's CCSM (Camunda 8/Zeebe) import ITs pay a per-`@Test` setup/teardown
cost (Awaitility-polled record cleanup, Optimize data delete, index refresh)
on top of a class-scoped Zeebe broker and ES/OS extension. Several test
classes had sibling `@Test` methods asserting independent things but each
paying for their own full cycle - merging them into single tests running
each scenario sequentially cuts that per-method overhead without changing
what is covered.

- `ZeebeUserTaskImportIT`: 16 -> 10 tests (six writer/update-script pairs)
- `ZeebeProcessInstanceImportIT`: 22 -> 17 tests (one triple merge, three
  narrow BPMN-construct pairs)
- `ZeebeVariableCreationImportIT`: 16 -> 13 tests (two shared-instance
  content-variation pairs, one config-toggle pair)
- `ZeebeVariableUpdateImportIT`: 11 -> 9 tests (two batching-scenario pairs)

`ZeebeAgentInstanceImportIT` was evaluated and deliberately left alone -
every test there shares one hardcoded process-instance-key constant, so
merging would require changing the file's own shared seed-data helper
rather than just recombining test bodies.

Two scoping bugs were found and fixed as part of this work (not introduced
by later commits - caught before they could land): `ZeebeUserTaskImportIT`
and `ZeebeProcessInstanceImportIT` had expected-value helpers and wait
helpers that queried the shared Zeebe export index unscoped by process
instance. That was harmless between separate test methods (cleanup runs
first), but once two scenarios' records coexist inside one merged test the
second scenario's helpers could pick up the first scenario's leftover
records. Added local instance-scoped variants and used them for every
scenario after the first.

## Measured impact

Timed the 4 changed files before and after locally (stashed/restored the
diff, ran `-Dit.test=<4 files> -Pccsm-it` both times): test count dropped
25% (65 -> 49) but wall-clock time was flat within noise (~3:22-3:24 both
runs). The per-method cleanup cost this change targets turns out to be
small next to the actual dominant cost - the `waitUntilMinimum...ExportedCount`
calls waiting on Zeebe's async export to Elasticsearch, which is unchanged
by this merge since the same number of deploy/wait/import cycles still run,
just wrapped in fewer `@Test` methods.

Opening as a draft pending a CI timing comparison, since local timing may
not represent CI's network/latency profile.

## Test plan

- [x] All 4 modified files pass locally (`ccsm-it` profile against local
      Elasticsearch)
- [x] Adversarial review pass (fresh subagent + GitHub Copilot CLI) run
      before push; one regression found and fixed
      (`ad737d13f08` - a merged assertion had lost exhaustiveness)
- [ ] Compare CI job timing for `optimize-it-elasticsearch / ccsm-test`
      against a `main` baseline