### PR TITLE
ci: report the real dispatch outcome in the AlwaysGreen triage Slack summary

### DIFF
--- a/.github/scripts/alwaysgreen/classify.py
+++ b/.github/scripts/alwaysgreen/classify.py
@@ -234,15 +234,17 @@ def saas_surface_from_counts(counts: SpecCounts, *, has_artifacts: bool) -> str:
 # Spec → source path
 # ---------------------------------------------------------------------------
 
-_ROOTDIR_SUITE_RE = re.compile(r"/dist/tests/(?P<suite>(?:SM-|c8Run-)?\d+\.\d+)/?$")
+_ROOTDIR_SUITE_RE = re.compile(r"/tests/(?P<suite>(?:SM-)?\d+\.\d+)/?$")
 
 
 def suite_from_rootdir(root_dir: str | None) -> str | None:
     """Extract the test-suite directory (e.g. `SM-8.10`) from `config.rootDir`.
 
-    The helm chart points Playwright at the published npm package, so the report's
-    `file` fields are bare basenames like `smoke-tests.spec.js`. `rootDir` carries
-    the resolved suite directory and is the reliable way to recover it.
+    Both surfaces report bare basenames like `smoke-tests.spec.js`: the helm chart
+    points Playwright at the published npm package (`.../dist/tests/SM-8.10`) and
+    the SaaS run executes in the e2e repo checkout (`.../tests/8.10`). `rootDir` is
+    the reliable way to recover the suite in either layout. AlwaysGreen runs only
+    SM and SaaS, so no c8Run prefix is matched.
     """
     if not root_dir:
         return None

--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -190,7 +190,12 @@ def saas_candidate(run_id: str, base_ref: str, job_name: str, workdir: Path) -> 
                     counts.flaky + c.flaky,
                     counts.setup_failed + c.setup_failed,
                 )
-                cand.specs.extend(classify.failing_specs(report))
+                suite = classify.suite_from_rootdir(
+                    ((report.get("config") or {}).get("rootDir"))
+                    if isinstance(report, dict)
+                    else None
+                )
+                cand.specs.extend(classify.failing_specs(report, suite=suite))
         else:
             has_reports = False
 

--- a/.github/scripts/alwaysgreen/test_classify.py
+++ b/.github/scripts/alwaysgreen/test_classify.py
@@ -220,9 +220,16 @@ def test_suite_recovered_from_rootdir():
     assert classify.suite_from_rootdir(root) == "SM-8.10"
 
 
+def test_suite_recovered_from_saas_rootdir():
+    # The SaaS run executes in the e2e repo checkout, which has no `dist` segment.
+    root = "/home/runner/_work/c8-cross-component-e2e-tests/c8-cross-component-e2e-tests/tests/8.10"
+    assert classify.suite_from_rootdir(root) == "8.10"
+
+
 def test_suite_is_none_when_rootdir_unhelpful():
     assert classify.suite_from_rootdir("") is None
     assert classify.suite_from_rootdir("/some/other/dir") is None
+    assert classify.suite_from_rootdir("/w/repo/tests/unit") is None
 
 
 def test_compiled_basename_maps_to_source_path():

--- a/.github/workflows/alwaysgreen-triage.yml
+++ b/.github/workflows/alwaysgreen-triage.yml
@@ -208,9 +208,6 @@ jobs:
             echo ""
             echo "- run: ${{ steps.target.outputs.run_id }} (\`${{ steps.target.outputs.base_ref }}\`)"
             echo "- mode: ${{ steps.mode.outputs.mode }} (dispatch=${{ steps.mode.outputs.dispatch }})"
-            blame_reviewer=$(jq -r '.blame.reviewer // "unresolved"' /tmp/alwaysgreen-plan.json)
-            blame_via=$(jq -r '.blame.via // "-"' /tmp/alwaysgreen-plan.json)
-            echo "- blame: ${blame_reviewer} (via ${blame_via})"
             echo ""
             candidates=$(jq '.dispatches | length' /tmp/alwaysgreen-plan.json)
             if [ "$candidates" -gt 0 ] && [ "${{ steps.mode.outputs.dispatch }}" = "true" ]; then
@@ -259,6 +256,7 @@ jobs:
           PARENT_TS: ${{ inputs.parent_slack_ts }}
           PARENT_CHANNEL: ${{ inputs.parent_slack_channel }}
           PLAN_OUTCOME: ${{ steps.plan.outcome }}
+          DISPATCHED: ${{ steps.mode.outputs.dispatch }}
         run: |
           set -euo pipefail
           base_ref='${{ steps.target.outputs.base_ref }}'
@@ -266,12 +264,15 @@ jobs:
           count=$(jq '.dispatches | length' /tmp/alwaysgreen-plan.json)
           failing_url=$(jq -r '.run_url // ""' /tmp/alwaysgreen-plan.json)
           surfaces=$(jq -r '[.dispatches[].surface] | join(", ")' /tmp/alwaysgreen-plan.json)
-          reviewer=$(jq -r 'if .blame.reviewer then "<https://github.com/\(.blame.reviewer)|@\(.blame.reviewer)>" else "unresolved" end' /tmp/alwaysgreen-plan.json)
 
           if [ "${PLAN_OUTCOME}" != "success" ]; then
-            text=":warning: *AlwaysGreen triage failed* on \`${base_ref}\` — no agent dispatched"$'\n'"Triage: <${RUN_URL}|↗>"
+            text=":warning: *AlwaysGreen triage failed* on \`${base_ref}\` — no agent dispatched"$'\n'"<${RUN_URL}|Triage run ↗>"
+          elif [ "${count}" != "0" ] && [ "${DISPATCHED}" = "true" ]; then
+            text=":robot_face: *AlwaysGreen fix agent dispatched* on \`${base_ref}\`"$'\n'"${count} agent(s): ${surfaces}"$'\n'"<${failing_url}|Failing run ↗> · <${RUN_URL}|Triage run ↗>"
           elif [ "${count}" != "0" ]; then
-            text=":robot_face: *AlwaysGreen fix agent dispatched* on \`${base_ref}\`"$'\n'"${count} agent(s): ${surfaces}"$'\n'"Failing run: <${failing_url}|↗> · Triage: <${RUN_URL}|↗> · Blame: ${reviewer}"
+            # Candidates found but the gate is closed. Say so plainly: an announced
+            # dispatch that never happened is worse than no message at all.
+            text=":mag: *AlwaysGreen: would dispatch — withheld* on \`${base_ref}\`"$'\n'"${count} agent(s) held back: ${surfaces}"$'\n'"Fix-agent dispatch is off for this run."$'\n'"<${failing_url}|Failing run ↗> · <${RUN_URL}|Triage run ↗>"
           else
             # Nothing actionable. Name the reasons so the thread explains itself without
             # anyone opening the run.
@@ -280,8 +281,12 @@ jobs:
               | if length == 0 then "no failing job mapped to a known surface"
                 else (group_by(.) | map("\(.[0]) x\(length)") | join(", ")) end' \
               /tmp/alwaysgreen-plan.json 2>/dev/null || echo "unknown")
-            text=":information_source: *AlwaysGreen triage: nothing to dispatch* on \`${base_ref}\`"$'\n'"${reasons}"$'\n'"Triage: <${RUN_URL}|↗>"
+            text=":information_source: *AlwaysGreen triage: nothing to dispatch* on \`${base_ref}\`"$'\n'"${reasons}"$'\n'"<${RUN_URL}|Triage run ↗>"
           fi
+
+          # Kept so the post-dispatch step can append agent links via chat.update
+          # without rebuilding the message and drifting from this wording.
+          printf '%s' "$text" > /tmp/slack-text.txt
 
           # Thread onto the post-failure-feedback message when the caller handed one
           # down, so one failure produces one Slack thread. Falling back to a new
@@ -307,8 +312,13 @@ jobs:
           # The fix agent must reply as a sibling in the SAME thread, so pass the parent
           # ts through when threading; our own reply's ts would nest nothing useful.
           out_ts="${PARENT_TS:-$(jq -r '.ts // ""' <<<"$resp")}"
-          echo "ts=${out_ts}" >> "$GITHUB_OUTPUT"
-          echo "channel=$(jq -r --arg c "$channel" '.channel // $c' <<<"$resp")" >> "$GITHUB_OUTPUT"
+          {
+            echo "ts=${out_ts}"
+            # This message's own ts, which is NOT out_ts when threading: editing the
+            # parent's ts would overwrite the post-failure-feedback message instead.
+            echo "self_ts=$(jq -r '.ts // ""' <<<"$resp")"
+            echo "channel=$(jq -r --arg c "$channel" '.channel // $c' <<<"$resp")"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Dispatch fix agents
         # outcome, not just count: a failed discovery leaves count empty, and '' != '0'
@@ -332,6 +342,11 @@ jobs:
                         '{ts: $ts, channel: $channel}')
           failing_run_url=$(jq -r '.run_url' /tmp/alwaysgreen-plan.json)
 
+          # Only runs created from here on can be ours; earlier runs carry the same
+          # run-name and would otherwise be matched by mistake on a repeat replay.
+          started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          : > /tmp/agent-runs.tsv
+
           jq -c '.dispatches[]' /tmp/alwaysgreen-plan.json | while read -r d; do
             key=$(jq -r '.dispatch_key' <<<"$d")
             echo "Dispatching ${key}"
@@ -347,7 +362,56 @@ jobs:
               -f triage_run_url="${TRIAGE_RUN_URL}" \
               -f blame="${blame_json}" \
               -f slack="${slack_json}"
+
+            # `gh workflow run` returns no run id, so resolve it from the run-name,
+            # which carries the dispatch key verbatim. Poll: the run takes a moment
+            # to appear, and two dispatches would otherwise race on "newest run".
+            url=""
+            for _ in 1 2 3 4 5 6 7 8; do
+              sleep 3
+              url=$(gh run list --repo "${GITHUB_REPOSITORY}" \
+                      --workflow "${FIX_WORKFLOW}" --limit 20 \
+                      --json url,displayTitle,createdAt \
+                    | jq -r --arg t "AlwaysGreen fix [${key}]" --arg since "${started_at}" \
+                        'map(select(.displayTitle == $t and .createdAt >= $since))
+                         | (.[0].url // "")')
+              [ -n "$url" ] && break
+            done
+            if [ -n "$url" ]; then
+              printf '%s\t%s\n' "${key}" "${url}" >> /tmp/agent-runs.tsv
+            else
+              echo "::warning::Dispatched ${key} but could not resolve its run URL."
+            fi
           done
+
+      # The Slack summary is posted before dispatch, because the fix agent needs its
+      # ts to reply in-thread. So the agent links can only be added afterwards.
+      - name: Add agent links to Slack
+        # hashFiles() cannot see outside GITHUB_WORKSPACE, so the file checks live in
+        # the script rather than in this condition.
+        if: ${{ always() && steps.slack.outputs.self_ts != '' }}
+        continue-on-error: true
+        env:
+          SLACK_TOKEN: ${{ steps.slack-secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
+          SLACK_TS: ${{ steps.slack.outputs.self_ts }}
+          SLACK_CHANNEL: ${{ steps.slack.outputs.channel }}
+        run: |
+          set -euo pipefail
+          [ -s /tmp/agent-runs.tsv ] || { echo "No agent runs to link."; exit 0; }
+          [ -s /tmp/slack-text.txt ] || { echo "No posted message to update."; exit 0; }
+
+          links=$(awk -F'\t' '{printf "%s<%s|%s ↗>", sep, $2, $1; sep=" · "}' /tmp/agent-runs.tsv)
+          text="$(cat /tmp/slack-text.txt)"$'\n'"Agents: ${links}"
+
+          # A threaded reply is updated by its own ts; chat.update needs no thread_ts.
+          payload=$(jq -nc --arg channel "${SLACK_CHANNEL}" --arg ts "${SLACK_TS}" --arg text "$text" \
+            '{channel: $channel, ts: $ts, text: $text}')
+          resp=$(curl -sS -X POST https://slack.com/api/chat.update \
+            -H "Authorization: Bearer ${SLACK_TOKEN}" \
+            -H 'Content-Type: application/json; charset=utf-8' \
+            -d "$payload" || echo '{}')
+          [ "$(jq -r '.ok // false' <<<"$resp")" = "true" ] \
+            || echo "::warning::Slack update failed: $(jq -r '.error // "unknown"' <<<"$resp")"
 
       - name: Flag discovery failure
         if: ${{ steps.mode.outputs.active == 'true' && steps.plan.outcome != 'success' }}


### PR DESCRIPTION
## Description

Follow-up to #59043. Three defects in the AlwaysGreen triage Slack summary, all
found while replaying past failing runs against the merged workflow.

**The summary announced a dispatch that never happened.** The message text
branched only on `count != 0`, so any run with candidates claimed "fix agent
dispatched" even when the gate withheld them. Every dry-run triage has been
reporting a dispatch, and once `ALWAYSGREEN_FIX_AGENT` is flipped to `enabled`
there would be no way to tell a real dispatch from a withheld one in Slack. The
job summary already got this right (`### Would dispatch — withheld`); the Slack
text now branches on the same value.

**The links did not link.** The label was a bare `↗`, which Slack converts to
`:arrow_upper_right:` and renders as plain text, so neither the failing run nor
the triage run was reachable from the message. The arrow is kept, with a word in
front of it, matching the nightly triage's `<url|agent run ↗>`.

**The dispatched fix-agent runs were not linked at all.** They are now appended
after dispatch via `chat.update`. Two details worth review:

- Each run is resolved from its `run-name`, which carries the dispatch key
  verbatim, and restricted to runs created after the dispatch loop started.
  Matching on newest-run (as `scripts/triage-dispatch.sh` does in the e2e repo)
  hands both keys the same URL when two agents are dispatched back to back.
- The update targets a new `self_ts` output rather than `ts`. `ts` is the
  *parent* ts when triage threads onto post-failure-feedback, so updating it
  would have overwritten that parent message.

Also drops the blame line from both summaries: it read `blame: unresolved (via
bot-unresolved)` for every renovate-authored failure, which is most of them.
Blame is still passed to the fix agent, where it drives reviewer assignment.

**SaaS failing specs reached the fix agent as bare basenames.** `smoke-tests.spec.ts`
where the SM path produces `tests/SM-8.10/smoke-tests.spec.ts`. The agent decides
whether an entry is a real test failure or a CI-job failure by testing the path
against the checkout, so a genuine SaaS Playwright failure was classified as a job
failure and diagnosed from run logs rather than from artifacts and traces.

The suite is already in the report — the SaaS path just never read it.
`saas_candidate` called `failing_specs` without a suite, and `_ROOTDIR_SUITE_RE`
required a `/dist/tests/` prefix that only the helm surface has: SaaS runs in the
e2e repo checkout, where `rootDir` is `.../tests/8.10`. Both are fixed, and the
c8Run alternative is dropped from the pattern since AlwaysGreen only runs SM and
SaaS.

## Verification

Replayed against past failing runs. Slack output captured in #test-metrics via a
temporary branch; the channel override and a temporary force-dispatch step were
reverted before this PR — the only change here is the one in the diff.

| Target run | Result |
|---|---|
| [30739867468](https://github.com/camunda/camunda/actions/runs/30739867468) | `saas-infra` → suppressed `surface-not-in-increment`. Correct: the downstream run failed at `create-organizations`, so no tests ran and no artifacts exist. |
| [30523482980](https://github.com/camunda/camunda/actions/runs/30523482980) | 1 dispatch, `sm-smoke-e2e`, 3/3 failed attempts → `deterministic: true`. |
| [30521290146](https://github.com/camunda/camunda/actions/runs/30521290146) | 2 dispatches, both surfaces. SaaS path followed into the e2e repo: `total=15 failed=2 flaky=4` → the 4 flaky specs correctly excluded. Both agents dispatched, both links rendered and correctly mapped to their surfaces. |

Repeat dispatch was also confirmed to be suppressed as `agent-already-running`
while the previous pair was still in flight.

The suite-path fix is covered by unit tests (`test_suite_recovered_from_saas_rootdir`,
plus a `/tests/unit` negative so the relaxed pattern cannot over-match). The full
`.github/scripts/alwaysgreen` suite passes locally: 67 tests, 0 failures.
`actionlint -shellcheck=shellcheck` passes locally and on CI.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Follow-up to #59043
