### PR TITLE
feat: add discovered-by dropdown to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1. bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1. bug_report.yml
@@ -72,6 +72,20 @@ body:
       default: null
     validations:
       required: true
+  - type: dropdown
+    id: discovered-by
+    attributes:
+      label: <!-- Discovered by -->
+      description: Was this found during a specific testing activity? Leave as "Not applicable" for customer reports, code review, etc.
+      options:
+        - <!-- Not applicable+ -->
+        - <!-- Load Tests+ -->
+        - <!-- Chaos Days+ -->
+        - <!-- Game Day+ -->
+        - <!-- QA Automation Found+ -->
+      default: 0
+    validations:
+      required: false
   - type: textarea
     id: description
     attributes:

--- a/.github/opened_issue_labeler.yml
+++ b/.github/opened_issue_labeler.yml
@@ -68,3 +68,11 @@ affects/8.9:
   '(-8.9)'
 affects/8.10:
   '(-8.10)'
+discovered-by/load-tests:
+  '(Load Tests\+)'
+discovered-by/chaos-day:
+  '(Chaos Days\+)'
+discovered-by/gameday:
+  '(Game Day\+)'
+qa/automation-found:
+  '(QA Automation Found\+)'


### PR DESCRIPTION
## Description

The `discovered-by/load-tests`, `discovered-by/chaos-day`, `discovered-by/gameday`, and `qa/automation-found` labels track which testing activity surfaced a bug, but none of them are part of `1. bug_report.yml`'s fields today - they have to be added by hand after the issue is created, which means they get missed (e.g. [#59358](https://github.com/camunda/camunda/issues/59358) was filed without one and had to be patched afterward).

This adds a "Discovered by" dropdown (Not applicable / Load Tests / Chaos Days / Game Day / QA Automation Found) to the bug report template, and wires it into `.github/opened_issue_labeler.yml` so the existing labeler bot applies the right label automatically on issue open - the same mechanism already used for `component/*`, `severity/*`, `likelihood/*`, and `affects/*`. No new automation surface, just a new field feeding the one that already exists.

Verified the new marker patterns don't collide with any existing labeler regex (in particular, the `+` suffix was chosen deliberately since the existing `Load Tests-` marker for `component/load-tests` would otherwise also match).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

Not applicable to either checklist item: this only changes an issue template and its labeler config, not code, CI behavior, docs, or the E2E test suite - so no backport and no E2E run are needed.

## Related issues

Related to #59358 (the issue that surfaced this gap)
