### PR TITLE
feat: add manual testing option to discovered-by dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/1. bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1. bug_report.yml
@@ -83,6 +83,7 @@ body:
         - <!-- Chaos Days+ -->
         - <!-- Game Day+ -->
         - <!-- QA Automation Found+ -->
+        - <!-- Manual Testing+ -->
       default: 0
     validations:
       required: false

--- a/.github/opened_issue_labeler.yml
+++ b/.github/opened_issue_labeler.yml
@@ -76,3 +76,5 @@ discovered-by/gameday:
   '(Game Day\+)'
 qa/automation-found:
   '(QA Automation Found\+)'
+discovered-by/manual-testing:
+  '(Manual Testing\+)'


### PR DESCRIPTION
## Description

Follow-up to [#59361](https://github.com/camunda/camunda/pull/59361), which added the "Discovered by" dropdown to `1. bug_report.yml`. [@mschoe requested](https://github.com/camunda/camunda/pull/59361#discussion_r3711061026) a catch-all option for manual test discovery, since the current options (Load Tests / Chaos Days / Game Day / QA Automation Found) don't cover it and "Not applicable" is meant for customer reports and code review only.

Adds a "Manual Testing" option, wired to a new `discovered-by/manual-testing` label via the existing labeler mechanism in `.github/opened_issue_labeler.yml`, the same pattern already used for the other options.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)). Not applicable: this only changes an issue template and its labeler config, not code, CI behavior, or docs.
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR. Not applicable.

## Related issues

Follow-up to #59361