### PR TITLE
fix: add a compatibility handler for old heartbeat requests

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/HeartbeatHandler.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/HeartbeatHandler.java
@@ -12,6 +12,7 @@ import io.atomix.cluster.messaging.impl.ProtocolReply.Status;
 import io.atomix.utils.net.Address;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.handler.timeout.IdleStateHandler;
@@ -269,6 +270,32 @@ abstract sealed class HeartbeatHandler extends ChannelDuplexHandler {
       heartbeatRequestEncoder.wrapAndApplyHeader(heartbeatRequestBuffer, 0, messageHeaderEncoder);
       heartbeatRequestEncoder.sentAt(System.currentTimeMillis());
       return heartbeatRequestBuffer.byteArray();
+    }
+  }
+
+  /**
+   * Compatibility handler for an 8.7 server sharing a connection with an 8.8 client during a
+   * rolling upgrade.
+   *
+   * <p>Before heartbeats became client-initiated, the TCP server sent unsolicited heartbeats as a
+   * {@link ProtocolRequest}. An 8.8 client connected to such a legacy server never installs a
+   * {@link Server} handler and expects only {@link ProtocolReply} messages, so the request would
+   * otherwise reach the {@code MessageDispatcher} and fail with a {@code ClassCastException}.
+   *
+   * <p>This handler consumes the legacy heartbeat without replying. An 8.7 server doesn't expect
+   * any reply for heartbeats, and would error if it received one.
+   */
+  static final class LegacyServerHeartbeatHandler extends ChannelInboundHandlerAdapter {
+
+    @Override
+    public void channelRead(final ChannelHandlerContext context, final Object message) {
+      if (message instanceof final ProtocolRequest request
+          && HEARTBEAT_SUBJECT.equals(request.subject())) {
+        ReferenceCountUtil.release(message);
+        return;
+      }
+
+      context.fireChannelRead(message);
     }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -1162,6 +1162,15 @@ public final class NettyMessagingService implements ManagedMessagingService {
           protocolVersion,
           context.channel().remoteAddress());
       super.activateProtocolVersion(context, connection, protocolVersion, isClient);
+      // Installed unconditionally, before heartbeat setup negotiation, so a legacy (pre-8.8)
+      // server's unsolicited heartbeat request is recognized even if negotiation hasn't completed
+      // yet, or never will because the legacy peer doesn't understand it.
+      context
+          .pipeline()
+          .addBefore(
+              MESSAGE_DISPATCHER_NAME,
+              "legacy-server-heartbeat",
+              new HeartbeatHandler.LegacyServerHeartbeatHandler());
       if (heartbeatsEnabled) {
         context
             .pipeline()

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/HeartbeatHandlerTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/HeartbeatHandlerTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.messaging.impl.HeartbeatHandler.LegacyServerHeartbeatHandler;
+import io.atomix.cluster.messaging.impl.ProtocolReply.Status;
+import io.atomix.utils.net.Address;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class HeartbeatHandlerTest {
+
+  private final List<Object> forwardedMessages = new ArrayList<>();
+  private final EmbeddedChannel channel =
+      new EmbeddedChannel(
+          new LegacyServerHeartbeatHandler(),
+          new SimpleChannelInboundHandler<Object>() {
+            @Override
+            protected void channelRead0(final ChannelHandlerContext ctx, final Object msg) {
+              forwardedMessages.add(msg);
+            }
+          });
+
+  @Test
+  void shouldNotReplyToLegacyHeartbeatRequest() {
+    // given
+    final var request =
+        new ProtocolRequest(
+            42L, Address.from(26602), HeartbeatHandler.HEARTBEAT_SUBJECT, new byte[0]);
+
+    // when
+    channel.writeInbound(request);
+
+    // then
+    assertThat((Object) channel.readOutbound()).isNull();
+  }
+
+  @Test
+  void shouldConsumeALegacyHeartbeatRequestDecodedFromTheWire() {
+    // given
+    final var request =
+        new ProtocolRequest(
+            42L, Address.from(26602), HeartbeatHandler.HEARTBEAT_SUBJECT, new byte[0]);
+    final var protocol = ProtocolVersion.latest().createProtocol(Address.from(26602));
+    final var encoderChannel = new EmbeddedChannel(protocol.newEncoder());
+    encoderChannel.writeOutbound(request);
+    final ByteBuf encoded = encoderChannel.readOutbound();
+
+    final var wireChannel =
+        new EmbeddedChannel(
+            protocol.newDecoder(),
+            new LegacyServerHeartbeatHandler(),
+            new SimpleChannelInboundHandler<Object>() {
+              @Override
+              protected void channelRead0(final ChannelHandlerContext ctx, final Object msg) {
+                forwardedMessages.add(msg);
+              }
+            });
+
+    // when
+    wireChannel.writeInbound(encoded);
+
+    // then
+    assertThat(forwardedMessages).isEmpty();
+    assertThat((Object) wireChannel.readOutbound()).isNull();
+    assertThat(wireChannel.isOpen()).isTrue();
+  }
+
+  @Test
+  void shouldNotForwardLegacyHeartbeatRequestToNextHandler() {
+    // given
+    final var request =
+        new ProtocolRequest(
+            42L, Address.from(26602), HeartbeatHandler.HEARTBEAT_SUBJECT, new byte[0]);
+
+    // when
+    channel.writeInbound(request);
+
+    // then
+    assertThat(forwardedMessages).isEmpty();
+  }
+
+  @Test
+  void shouldKeepChannelOpenAfterLegacyHeartbeatRequest() {
+    // given
+    final var request =
+        new ProtocolRequest(
+            42L, Address.from(26602), HeartbeatHandler.HEARTBEAT_SUBJECT, new byte[0]);
+
+    // when
+    channel.writeInbound(request);
+
+    // then
+    assertThat(channel.isOpen()).isTrue();
+  }
+
+  @Test
+  void shouldForwardRequestsWithOtherSubjectsUnchanged() {
+    // given
+    final var request = new ProtocolRequest(1L, Address.from(26602), "some-subject", new byte[0]);
+
+    // when
+    channel.writeInbound(request);
+
+    // then
+    assertThat(forwardedMessages).containsExactly(request);
+    assertThat((Object) channel.readOutbound()).isNull();
+  }
+
+  @Test
+  void shouldForwardProtocolRepliesUnchanged() {
+    // given
+    final var reply = new ProtocolReply(1L, new byte[0], Status.OK);
+
+    // when
+    channel.writeInbound(reply);
+
+    // then
+    assertThat(forwardedMessages).containsExactly(reply);
+    assertThat((Object) channel.readOutbound()).isNull();
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -34,6 +34,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
@@ -46,6 +48,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -948,6 +951,52 @@ final class NettyMessagingServiceTest {
       final var timeout = defaultConfig().getHeartbeatTimeout().toSeconds() + 1;
       assertThatThrownBy(() -> channel.closeFuture().get(timeout, TimeUnit.SECONDS))
           .isInstanceOf(TimeoutException.class);
+    }
+
+    @Test
+    void shouldConsumeLegacyHeartbeatRequestFromServerWithoutReplyingOrDisruptingTheConnection() {
+      // given
+      final var subject = nextSubject();
+      final BiFunction<Address, byte[], byte[]> pongHandler = (address, bytes) -> "pong".getBytes();
+      netty2.registerHandler(subject, pongHandler, MoreExecutors.directExecutor());
+
+      final var clientChannel =
+          netty1.getChannelPool().getChannel(netty2.address(), subject).join();
+      Awaitility.await("Until the legacy heartbeat compat handler is installed")
+          .until(() -> clientChannel.pipeline().get("legacy-server-heartbeat") != null);
+
+      final var capturedReplies = new CopyOnWriteArrayList<ProtocolReply>();
+      clientChannel
+          .pipeline()
+          .addAfter(
+              "encoder",
+              "reply-capture",
+              new ChannelOutboundHandlerAdapter() {
+                @Override
+                public void write(
+                    final ChannelHandlerContext ctx,
+                    final Object msg,
+                    final ChannelPromise promise) {
+                  if (msg instanceof final ProtocolReply reply) {
+                    capturedReplies.add(reply);
+                  }
+                  ctx.write(msg, promise);
+                }
+              });
+
+      // when
+      final var heartbeatRequest =
+          new ProtocolRequest(
+              4242L, netty2.address(), HeartbeatHandler.HEARTBEAT_SUBJECT, new byte[0]);
+      clientChannel.pipeline().fireChannelRead(heartbeatRequest);
+
+      // then
+      final var response =
+          netty1.sendAndReceive(netty2.address(), subject, "ping".getBytes()).join();
+      assertThat(response).isEqualTo("pong".getBytes());
+      assertThat(netty1.getChannelPool().getChannel(netty2.address(), subject).join())
+          .isEqualTo(clientChannel);
+      assertThat(capturedReplies).isEmpty();
     }
   }
 }


### PR DESCRIPTION
During a rolling upgrade from 8.7 to 8.8, an old 8.7 server can send a heartbeat as an unsolicited ProtocolRequest message. The new 8.8 client expects to trigger heartbeats itself, and only accepts ProtocolReply messages for heartbeats. When the ProtocolRequest message is received, we get a ClassCastException and log an error.

To fix this, we add a handler which runs before the message dispatcher and consumes a legacy heartbeat request without replying, per the 8.7 behaviour.

Closes #26602.