### PR TITLE
fix: logging on secondary storage disabled

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/condition/ConditionalOnSecondaryStorageDisabled.java
+++ b/dist/src/main/java/io/camunda/application/commons/condition/ConditionalOnSecondaryStorageDisabled.java
@@ -41,8 +41,8 @@ public @interface ConditionalOnSecondaryStorageDisabled {
             "Secondary storage is disabled ({}={}). Some features such as webapps will not start "
                 + "unless a secondary storage is configured. See {} config.",
             DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE,
-            DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE,
-            DatabaseType.NONE);
+            DatabaseType.NONE,
+            DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE);
       }
       return disabled;
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Just a small log message fix.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/issues/58953
