### PR TITLE
test: stabilize flaky AI agent visual regression tests

### DIFF
--- a/operate/client/e2e-playwright/visual/processInstanceAiAgent.spec.ts
+++ b/operate/client/e2e-playwright/visual/processInstanceAiAgent.spec.ts
@@ -164,6 +164,11 @@ test.describe('AI agent details', () => {
     await expect(
       processInstancePage.aiAgentDetails.statusOverlay,
     ).toBeVisible();
+    await expect(
+      processInstancePage.aiAgentDetails.statusSection.getByLabel(
+        'Assistant message',
+      ),
+    ).toBeVisible();
 
     const messageExpandButton =
       processInstancePage.aiAgentDetails.conversationHistorySection
@@ -172,6 +177,7 @@ test.describe('AI agent details', () => {
         .getByRole('button', {name: 'Expand'});
 
     await processInstancePage.aiAgentDetails.conversationHistorySectionTrigger.click();
+    await messageExpandButton.scrollIntoViewIfNeeded();
     await messageExpandButton.focus();
     await messageExpandButton.click();
 
@@ -240,6 +246,11 @@ test.describe('AI agent details', () => {
     await expect(
       processInstancePage.aiAgentDetails.statusOverlay,
     ).toBeVisible();
+    await expect(
+      processInstancePage.aiAgentDetails.statusSection.getByLabel(
+        'Assistant message',
+      ),
+    ).toBeVisible();
 
     const viewDocumentsButton =
       processInstancePage.aiAgentDetails.conversationHistorySection
@@ -247,6 +258,7 @@ test.describe('AI agent details', () => {
         .getByRole('button', {name: 'View documents'});
 
     await processInstancePage.aiAgentDetails.conversationHistorySectionTrigger.click();
+    await viewDocumentsButton.scrollIntoViewIfNeeded();
     await viewDocumentsButton.focus();
     await viewDocumentsButton.click();
 


### PR DESCRIPTION
## Description

The `conversation message details modal` and `conversation document lists` visual regression tests in `processInstanceAiAgent.spec.ts` fail intermittently on `main` (INC-6892). Full root-cause writeup and evidence: #59379.

This PR fixes two independent, both-confirmed races in the same tests:

1. **Skeleton race** (first commit): the always-open "Status" section swaps a loading skeleton for the real (taller) assistant message asynchronously; neither test waited for that before screenshotting. Verified deterministic (15/15 stable) in isolation — but turned out not to be the mechanism behind INC-6892 (see below).
2. **Scroll-position race** (second commit, the confirmed cause of INC-6892): `Locator.focus()` doesn't wait for the target to be stable, only attached. Carbon's accordion expands via a CSS transition, so focusing a nested button right after expanding the section can fire mid-transition, and the browser's native focus-triggered scroll lands at an inconsistent offset. Fixed by calling `scrollIntoViewIfNeeded()` before `.focus()`.

The first commit's message attributes INC-6892 to the skeleton race — that was my working theory at the time and turned out to be wrong; this description is the corrected, authoritative account. The CI diff for INC-6892 showed the "AI Agent `<key>`" heading itself missing from the failing screenshot, which only a scroll of the panel explains (a height change below the heading can't move the heading itself).

**Verification:** ran each affected test 15× per color scheme (60 runs total) against the same containerized Linux browser CI uses (`CONTAINERIZED_BROWSER=true npm run test:visual`, Docker locally). Before the second fix: bimodal diffs against the golden (small = arch-only noise, large = arch + wrong scroll). After both fixes: only the small, golden-matching diffs remain, byte-identical across all 15 repeats per group. One caveat: those local runs had to bypass 7 unrelated `statusOverlay` assertions that fail in my local environment for unrelated reasons (a diagram-overlay timing issue, not touched by this PR) — so the measured determinism is on a slightly different timing profile than CI's, though still strong evidence.

**Not changed:** `conversation tool result modal` shares the same `.focus()`-after-accordion-expand pattern and is latently exposed to the same scroll race, but it isn't in the observed failures — its Monaco-editor lazy-load appears to consistently carry it past the race window. Left as-is since it's not flaky in practice, but flagging it here so it's not a surprise later.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #59379