### PR TITLE
docs: add dedup-check step and gh CLI fallback to create-issue skill

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -14,6 +14,16 @@ missing parent links, wrong component labels, and skipped required fields.
 gh auth status  # must succeed
 ```
 
+If this fails (e.g. "the token in default is invalid"), do not abort - the `gh` CLI's stored
+token can go invalid on its own even while other tools keep working. Switch to the equivalent
+`mcp__github__*` tools for the rest of this skill's flow instead of the `gh` examples shown below:
+`mcp__github__search_issues` for the dedup check in Step 1.5, `mcp__github__issue_write` (method
+`create`/`update`) for the `gh issue create` calls in Steps 6-7, `mcp__github__sub_issue_write` for
+the parent sub-issue registration, and `mcp__github__list_issue_types` plus the `type` parameter on
+`issue_write` for setting the native GitHub Issue Type - `issue_write` accepts `type` directly,
+which is simpler than the GraphQL-mutation approach shown in Step 7, so prefer it when working from
+MCP tools.
+
 ## Procedure
 
 ### Step 1 — Read available templates
@@ -38,6 +48,28 @@ its `labels:` field to infer the `kind/` label.
 | Tech debt, cleanup             | `6. tech debt.yml`         | `kind/tech-debt`       |
 
 If the issue type is ambiguous, ask the user to pick one before proceeding.
+
+### Step 1.5 - Check for existing issues
+
+Before drafting anything, search for likely duplicates. Build a query from the issue's
+likely title keywords and search with `mcp__github__search_issues` (owner `camunda`, repo
+`camunda`):
+
+```
+mcp__github__search_issues(owner="camunda", repo="camunda", query="<title keywords> repo:camunda/camunda")
+```
+
+Broad queries can exceed the tool's max-output-token limit. When that happens, the tool saves
+its result to a file instead of returning it inline and the response says so - do not try to
+read that file whole. Grep it for the compact per-issue fields instead:
+
+```bash
+grep -oE '"number":[0-9]+,"state":"[a-z]+","title":"[^"]*"' <saved-result-file>
+```
+
+If a close match turns up, surface it to the user before proceeding - show the issue number,
+state, and title, and ask whether to link the new work to it, comment on the existing issue
+instead, or proceed with a new issue anyway. Do not silently create a near-duplicate.
 
 ### Step 2 — Read the template and collect field values
 


### PR DESCRIPTION
## Description

A real session using the `create-issue` project skill (`.claude/skills/create-issue/SKILL.md`) surfaced two gaps:

1. **No duplicate-check step.** The skill went straight from reading templates into drafting a body, with no step that searched for existing issues first - risking a near-duplicate being created silently.
2. **No `gh` CLI fallback.** Every command example assumes a valid `gh` token. Mid-session, `gh auth status` started reporting "the token in default is invalid" even though other tools (including the `mcp__github__*` tools) kept working, with no guidance in the skill on how to recover.

This PR is a `.claude/skills` improvement only - no functional/product code changes.

### What was added

- **New Step 1.5 - Check for existing issues**, inserted between the existing Step 1 (read templates) and Step 2 (collect field values), before drafting begins. It has the model search `mcp__github__search_issues` using the likely title keywords, handles the case where a broad query exceeds the tool's max-output-token limit (result saved to a file - grep it for the compact per-issue fields instead of reading it whole), and requires surfacing any close match to the user (link/dedupe/proceed) instead of silently creating a near-duplicate.
- **A fallback note after Prerequisites**: if `gh auth status` fails, switch to the equivalent `mcp__github__*` tools (`search_issues`, `issue_write` for create/update, `sub_issue_write` for the parent relationship, `list_issue_types` + the `type` parameter on `issue_write`) for the rest of the flow instead of the `gh` CLI examples shown in the skill. Also notes that `issue_write`'s `type` parameter is simpler than the GraphQL-mutation approach the skill currently uses in Step 7.

No other steps were renumbered.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) - not applicable, this only changes a local agent skill file, not versioned product docs.
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR. - not applicable.

## Related issues

No related issue - filed directly from gaps found in a real session using this skill.