### PR TITLE
Require a reader-and-action test for inline comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,6 +279,11 @@ Load extra context on demand — only when relevant, only if the files exist.
   Please add `@Nullable` and `@NullMarked` annotations in classes where they are missing in order to increase coverage.
   You should do that in a separate `refactor: ` commit.
 
+### Code comments
+
+Before writing an inline comment, name the reader and what they would do differently for having
+read it. If you can't name both, don't write it.
+
 ### Testing conventions
 
 - Test behavior, not implementation — assert on observable outcomes rather than internal state.


### PR DESCRIPTION
## Description

Inline comments that restate the line beneath them, re-derive a mechanism the commit body already covers, or excuse code that should just be deleted don't help anyone — no reader acts differently for having read them. This adds a one-line test to `AGENTS.md`: before writing an inline comment, name the reader and the action they'd take differently for having read it, or don't write it.

The rule has lived in my personal CLAUDE.md for a while and has been working well there, refined through a review session against a real PR where several inline comments were flagged as excessive (see the commit body for the alternatives considered and rejected along the way). That track record is why I want to lift it into `AGENTS.md`, so every contributor gets the same test instead of it depending on individual review habits.

## Checklist

## Related issues
