### PR TITLE
fix: document store detect document containment

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -244,6 +244,16 @@
       <groupId>io.camunda</groupId>
       <artifactId>camunda-security-library-api</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-storage-blob</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>document-store</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -246,11 +246,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.azure</groupId>
-      <artifactId>azure-storage-blob</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>document-store</artifactId>
     </dependency>

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreIsolationValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreIsolationValidation.java
@@ -27,8 +27,10 @@ import org.jspecify.annotations.NullMarked;
  * <p>Overlap is broader than equality, because document ids are caller-supplied and concatenated
  * onto the key prefix unchecked. With prefixes {@code tenant} and {@code tenant-b-} in one bucket,
  * a request against the first store for document id {@code -b-invoice} resolves to the second
- * store's {@code tenant-b-invoice}, and deleting it requires nothing further. A prefix nested
- * inside another tenant's is therefore rejected rather than trusted to isolate.
+ * store's {@code tenant-b-invoice}, and deleting it requires nothing further. Adding a separator
+ * changes nothing: {@code docs/} reaches {@code docs/archive/} through the id {@code
+ * archive/invoice}, since no object store treats {@code /} in a document id as a path boundary. Any
+ * prefix nested inside another tenant's is therefore rejected rather than trusted to isolate.
  */
 @NullMarked
 class DocumentStoreIsolationValidation implements CrossTenantValidation {
@@ -51,9 +53,9 @@ class DocumentStoreIsolationValidation implements CrossTenantValidation {
       throw new UnifiedConfigurationException(
           "Physical tenants must not share a document store location, or they would read and write "
               + "into the same backing storage. Use a distinct bucket, container, or path per "
-              + "tenant, and where paths nest, separate them with '/' — a path that continues "
-              + "another's without one is reachable through a caller-supplied document id. "
-              + "Conflicts: "
+              + "tenant, and never nest one tenant's path inside another's — a nested path is "
+              + "reachable through a caller-supplied document id, which no object store bounds at "
+              + "'/'. Conflicts: "
               + String.join("; ", conflicts));
     }
   }

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreIsolationValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreIsolationValidation.java
@@ -16,12 +16,19 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Cross-tenant rule: no two physical tenants may resolve to the same {@link DocumentStoreLocation};
- * sharing one means silently reading and writing to the same backing storage. In-memory stores are
- * excluded — they are ephemeral and process-local.
+ * Cross-tenant rule: no two physical tenants may occupy overlapping document store key spaces, or
+ * they would read and write into the same backing storage.
+ *
+ * <p>Overlap is broader than equality, because document ids are caller-supplied and concatenated
+ * onto the key prefix unchecked. With prefixes {@code tenant} and {@code tenant-b-} in one bucket,
+ * a request against the first store for document id {@code -b-invoice} resolves to the second
+ * store's {@code tenant-b-invoice}, and deleting it requires nothing further. A prefix nested
+ * inside another tenant's is therefore rejected rather than trusted to isolate.
  */
 @NullMarked
 class DocumentStoreIsolationValidation implements CrossTenantValidation {
@@ -32,58 +39,93 @@ class DocumentStoreIsolationValidation implements CrossTenantValidation {
       return;
     }
 
-    final Map<DocumentStoreLocation, Set<String>> tenantsByLocation = new LinkedHashMap<>();
-    resolvedByTenant.forEach(
-        (tenantId, camunda) -> {
-          final Document doc = camunda.getDocument();
-          doc.getAws()
-              .forEach(
-                  (storeId, store) ->
-                      tenantsByLocation
-                          .computeIfAbsent(
-                              DocumentStoreLocation.aws(store), k -> new LinkedHashSet<>())
-                          .add(tenantId));
-          doc.getGcp()
-              .forEach(
-                  (storeId, store) ->
-                      tenantsByLocation
-                          .computeIfAbsent(
-                              DocumentStoreLocation.gcp(store), k -> new LinkedHashSet<>())
-                          .add(tenantId));
-          doc.getAzure()
-              .forEach(
-                  (storeId, store) ->
-                      tenantsByLocation
-                          .computeIfAbsent(
-                              DocumentStoreLocation.azure(store), k -> new LinkedHashSet<>())
-                          .add(tenantId));
-          doc.getLocal()
-              .forEach(
-                  (storeId, store) ->
-                      tenantsByLocation
-                          .computeIfAbsent(
-                              DocumentStoreLocation.local(store), k -> new LinkedHashSet<>())
-                          .add(tenantId));
-          // in-memory stores are intentionally skipped: ephemeral and process-local
-        });
+    final List<TenantStore> stores =
+        resolvedByTenant.entrySet().stream()
+            .flatMap(tenant -> storesOf(tenant.getKey(), tenant.getValue()))
+            .toList();
 
-    final List<String> collisions = new ArrayList<>();
-    tenantsByLocation.forEach(
-        (location, tenantIds) -> {
-          if (tenantIds.size() > 1) {
-            collisions.add(
-                String.format(
-                    "tenants %s share the same document store location [%s]",
-                    tenantIds, location.describe()));
-          }
-        });
+    final List<String> conflicts = new ArrayList<>(sharedLocations(stores));
+    conflicts.addAll(enclosedLocations(stores));
 
-    if (!collisions.isEmpty()) {
+    if (!conflicts.isEmpty()) {
       throw new UnifiedConfigurationException(
           "Physical tenants must not share a document store location, or they would read and write "
               + "into the same backing storage. Use a distinct bucket, container, or path per "
-              + "tenant. Conflicts: "
-              + String.join("; ", collisions));
+              + "tenant, and where paths nest, separate them with '/' — a path that continues "
+              + "another's without one is reachable through a caller-supplied document id. "
+              + "Conflicts: "
+              + String.join("; ", conflicts));
+    }
+  }
+
+  /** In-memory stores are omitted: ephemeral and process-local, they cannot collide. */
+  private static Stream<TenantStore> storesOf(final String tenantId, final Camunda camunda) {
+    final Document doc = camunda.getDocument();
+    return Stream.of(
+            doc.getAws().values().stream().map(DocumentStoreLocation::aws),
+            doc.getGcp().values().stream().map(DocumentStoreLocation::gcp),
+            doc.getAzure().values().stream().map(DocumentStoreLocation::azure),
+            doc.getLocal().values().stream().map(DocumentStoreLocation::local))
+        .flatMap(Function.identity())
+        .map(location -> new TenantStore(tenantId, location));
+  }
+
+  /**
+   * One message per location rather than one per pair of tenants: a location shared by five tenants
+   * is a single misconfiguration, and reporting its ten pairs would bury every other conflict.
+   */
+  private static List<String> sharedLocations(final List<TenantStore> stores) {
+    final Map<DocumentStoreLocation, Set<String>> tenantsByLocation = new LinkedHashMap<>();
+    stores.forEach(
+        store ->
+            tenantsByLocation
+                .computeIfAbsent(store.location(), location -> new LinkedHashSet<>())
+                .add(store.tenantId()));
+    return tenantsByLocation.entrySet().stream()
+        .filter(location -> location.getValue().size() > 1)
+        .map(
+            location ->
+                String.format(
+                    "tenants %s share the same document store location [%s]",
+                    location.getValue(), location.getKey().describe()))
+        .toList();
+  }
+
+  /**
+   * The overlaps that are not one location: each names the enclosing tenant first, since it is the
+   * one able to reach the other's documents. Pairwise, because which tenant encloses which is the
+   * substance of the message. Identical locations are left to {@link #sharedLocations}.
+   */
+  private static List<String> enclosedLocations(final List<TenantStore> stores) {
+    final Set<String> conflicts = new LinkedHashSet<>();
+    for (int i = 0; i < stores.size(); i++) {
+      for (int j = i + 1; j < stores.size(); j++) {
+        final TenantStore first = stores.get(i);
+        final TenantStore second = stores.get(j);
+        if (!first.conflictsWith(second) || first.location().equals(second.location())) {
+          continue;
+        }
+        final boolean firstEncloses =
+            first.location().keyPrefix().length() < second.location().keyPrefix().length();
+        final TenantStore enclosing = firstEncloses ? first : second;
+        final TenantStore enclosed = firstEncloses ? second : first;
+        conflicts.add(
+            String.format(
+                "tenant %s's document store location [%s] encloses tenant %s's [%s]",
+                enclosing.tenantId(),
+                enclosing.location().describe(),
+                enclosed.tenantId(),
+                enclosed.location().describe()));
+      }
+    }
+    return List.copyOf(conflicts);
+  }
+
+  private record TenantStore(String tenantId, DocumentStoreLocation location) {
+
+    /** Overlap within one tenant is not a leak: a tenant may spread documents across its stores. */
+    boolean conflictsWith(final TenantStore other) {
+      return !tenantId.equals(other.tenantId) && location.sharesKeySpaceWith(other.location);
     }
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreLocation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreLocation.java
@@ -73,42 +73,20 @@ record DocumentStoreLocation(String provider, List<String> namespace, String key
   }
 
   /**
-   * Whether the two stores could address a common key. Equal prefixes always can. Otherwise one
-   * prefix has to cover the other, and the key spaces stay apart only where crossing the gap
-   * between them takes a document id carrying a {@code /} — the gap being what the enclosing store
-   * must supply as part of an id to reach the enclosed one. That holds when the enclosing prefix
-   * ends at a separator and the gap crosses another: {@code docs/} reaches {@code docs/archive/} no
-   * other way.
+   * Whether the two stores could address a common key: whenever one key prefix contains the other,
+   * equal prefixes included. Every key of the contained store is then also a key the containing
+   * store addresses, and document ids are caller-supplied and appended to the prefix unchecked.
    *
-   * <p>Both halves are load-bearing. Without the first, {@code temp} would be trusted to isolate
-   * {@code temp/} even though it encloses every key of it. Without the second, {@code docs/} would
-   * be trusted against {@code docs/archive}, which {@code archivex} reaches using ordinary
-   * characters — as does {@code tenant-b-invoice} from a store at the root.
-   *
-   * <p>On AWS and Azure {@link DocumentStorePaths#keyPrefix} coerces every non-empty prefix to end
-   * in {@code /}, so both halves hold for any nesting there, which is what lets one tenant own a
-   * container root while another owns a folder inside it — the layout {@code
-   * DocumentIsolationAzureIT} asserts. GCP keeps its prefix verbatim, so there a root does share a
-   * key space with {@code tenant-b-}, and {@code docs/} shares one with {@code docs/archive}.
-   *
-   * <p>Treating a separator as a boundary rests on document ids not carrying one, which the object
-   * stores do not yet enforce — unlike {@code LocalStorageDocumentStore}.
+   * <p>A separator bounds nothing. {@code docs/} reaches every key of {@code docs/archive/} through
+   * the document id {@code archive/invoice}, because {@code /} is an ordinary character in S3 keys,
+   * GCS object names and Azure blob names alike — none of the three gives it path semantics, and no
+   * store strips it from a document id. So a store at a bucket or container root cannot be isolated
+   * from a folder inside it, and nesting is rejected rather than trusted.
    */
   boolean sharesKeySpaceWith(final DocumentStoreLocation other) {
-    if (!provider.equals(other.provider) || !namespace.equals(other.namespace)) {
-      return false;
-    }
-    if (keyPrefix.equals(other.keyPrefix)) {
-      return true;
-    }
-    final boolean thisEncloses = keyPrefix.length() < other.keyPrefix.length();
-    final String enclosing = thisEncloses ? keyPrefix : other.keyPrefix;
-    final String enclosed = thisEncloses ? other.keyPrefix : keyPrefix;
-    if (!enclosed.startsWith(enclosing)) {
-      return false;
-    }
-    final boolean enclosingEndsAtSeparator = enclosing.isEmpty() || enclosing.endsWith("/");
-    return !enclosingEndsAtSeparator || !enclosed.substring(enclosing.length()).contains("/");
+    return provider.equals(other.provider)
+        && namespace.equals(other.namespace)
+        && (keyPrefix.startsWith(other.keyPrefix) || other.keyPrefix.startsWith(keyPrefix));
   }
 
   String describe() {

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreLocation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreLocation.java
@@ -7,70 +7,221 @@
  */
 package io.camunda.configuration.physicaltenants;
 
+import com.azure.storage.blob.BlobServiceClientBuilder;
 import io.camunda.configuration.Document.AwsStore;
 import io.camunda.configuration.Document.AzureStore;
 import io.camunda.configuration.Document.GcpStore;
 import io.camunda.configuration.Document.LocalStore;
+import io.camunda.document.store.DocumentStorePaths;
+import io.camunda.document.store.gcp.GcpDocumentStoreProvider;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.InvalidPathException;
 import java.util.List;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Location-identity tuple {@code (provider, coordinates)} used to detect whether two physical
- * tenants would share the same backing storage. In-memory stores are excluded — ephemeral and
- * process-local, they cannot collide.
+ * The key space a document store occupies: a {@code namespace} no key can escape — bucket,
+ * container or directory — and the {@code keyPrefix} every key inside it starts with.
+ *
+ * <p>Both are the values the store resolves to at startup, not the configured ones. Each provider
+ * defaults and coerces before addressing its backend, so comparing raw configuration both misses
+ * tenants whose different configuration resolves to one location and rejects tenants whose similar
+ * configuration resolves to two. Every factory mirrors the matching {@code DocumentStoreProvider};
+ * changes to a provider's defaulting must be mirrored here.
+ *
+ * <p>Best-effort and static: it catches configuration that demonstrably names an overlapping key
+ * space, not DNS aliases or distinct endpoints fronting the same backend.
  */
 @NullMarked
-record DocumentStoreLocation(String provider, List<String> coordinates) {
+record DocumentStoreLocation(String provider, List<String> namespace, String keyPrefix) {
 
-  /**
-   * Creates a location for an AWS S3 store. Region is intentionally excluded because S3 bucket
-   * names are globally unique across regions.
-   */
+  private static final Logger LOG = LoggerFactory.getLogger(DocumentStoreLocation.class);
+
+  /** Region is excluded because S3 bucket names are globally unique across regions. */
   static DocumentStoreLocation aws(final AwsStore store) {
     return new DocumentStoreLocation(
         "aws",
-        List.of(
-            normalize(store.getBucketName()),
-            normalize(store.getBucketPath()),
-            normalize(store.getEndpoint())));
+        List.of(normalizeName(store.getBucketName()), normalizeEndpoint(store.getEndpoint())),
+        DocumentStorePaths.keyPrefix(store.getBucketPath()));
   }
 
   static DocumentStoreLocation gcp(final GcpStore store) {
     return new DocumentStoreLocation(
-        "gcp", List.of(normalize(store.getBucketName()), normalize(store.getPrefix())));
+        "gcp",
+        List.of(normalizeName(store.getBucketName())),
+        GcpDocumentStoreProvider.effectivePrefix(store.getPrefix()));
   }
 
-  /**
-   * Creates a location for an Azure Blob Storage store. Connection string is excluded because it
-   * may contain credentials; endpoint + container name + container path unambiguously identify the
-   * location.
-   */
   static DocumentStoreLocation azure(final AzureStore store) {
     return new DocumentStoreLocation(
         "azure",
-        List.of(
-            normalize(store.getContainerName()),
-            normalize(store.getContainerPath()),
-            normalize(store.getEndpoint())));
-  }
-
-  static DocumentStoreLocation local(final LocalStore store) {
-    return new DocumentStoreLocation("local", List.of(normalize(store.getPath())));
-  }
-
-  String describe() {
-    return String.format("provider=%s, coordinates=%s", provider, coordinates);
+        List.of(normalizeName(store.getContainerName()), azureEndpointOf(store)),
+        DocumentStorePaths.keyPrefix(store.getContainerPath()));
   }
 
   /**
-   * Normalizes a store coordinate: null → {@code ""}, trimmed, lowercased, trailing slashes
-   * stripped.
+   * The directory is the whole namespace, with no prefix inside it: {@code
+   * LocalStorageDocumentStore} rejects {@code /}, {@code \} and {@code ..} in a document id, so
+   * nesting isolates here and paths need only be compared for equality.
    */
-  private static String normalize(final @Nullable String value) {
-    if (value == null) {
+  static DocumentStoreLocation local(final LocalStore store) {
+    return new DocumentStoreLocation("local", List.of(storageDirectory(store.getPath())), "");
+  }
+
+  /**
+   * Whether the two stores could address a common key. Equal prefixes always can. Otherwise one
+   * prefix has to cover the other, and the key spaces stay apart only where crossing the gap
+   * between them takes a document id carrying a {@code /} — the gap being what the enclosing store
+   * must supply as part of an id to reach the enclosed one. That holds when the enclosing prefix
+   * ends at a separator and the gap crosses another: {@code docs/} reaches {@code docs/archive/} no
+   * other way.
+   *
+   * <p>Both halves are load-bearing. Without the first, {@code temp} would be trusted to isolate
+   * {@code temp/} even though it encloses every key of it. Without the second, {@code docs/} would
+   * be trusted against {@code docs/archive}, which {@code archivex} reaches using ordinary
+   * characters — as does {@code tenant-b-invoice} from a store at the root.
+   *
+   * <p>On AWS and Azure {@link DocumentStorePaths#keyPrefix} coerces every non-empty prefix to end
+   * in {@code /}, so both halves hold for any nesting there, which is what lets one tenant own a
+   * container root while another owns a folder inside it — the layout {@code
+   * DocumentIsolationAzureIT} asserts. GCP keeps its prefix verbatim, so there a root does share a
+   * key space with {@code tenant-b-}, and {@code docs/} shares one with {@code docs/archive}.
+   *
+   * <p>Treating a separator as a boundary rests on document ids not carrying one, which the object
+   * stores do not yet enforce — unlike {@code LocalStorageDocumentStore}.
+   */
+  boolean sharesKeySpaceWith(final DocumentStoreLocation other) {
+    if (!provider.equals(other.provider) || !namespace.equals(other.namespace)) {
+      return false;
+    }
+    if (keyPrefix.equals(other.keyPrefix)) {
+      return true;
+    }
+    final boolean thisEncloses = keyPrefix.length() < other.keyPrefix.length();
+    final String enclosing = thisEncloses ? keyPrefix : other.keyPrefix;
+    final String enclosed = thisEncloses ? other.keyPrefix : keyPrefix;
+    if (!enclosed.startsWith(enclosing)) {
+      return false;
+    }
+    final boolean enclosingEndsAtSeparator = enclosing.isEmpty() || enclosing.endsWith("/");
+    return !enclosingEndsAtSeparator || !enclosed.substring(enclosing.length()).contains("/");
+  }
+
+  String describe() {
+    return String.format(
+        "provider=%s, namespace=%s, keyPrefix='%s'", provider, namespace, keyPrefix);
+  }
+
+  /**
+   * The blob endpoint the store resolves to, reduced from the connection string whenever one is
+   * set: {@code AzureBlobDocumentStoreProvider} takes that branch on a non-null connection string
+   * and never reads {@code endpoint}, so preferring the endpoint here would compare an account the
+   * store does not address, and two tenants really sharing one account would pass. Without the
+   * reduction they also go undetected whenever they name the account differently.
+   *
+   * <p>The SDK resolves the URL because the rules are not obvious enough to restate: a path-style
+   * {@code BlobEndpoint} keeps its path only when the host is an IP address. Only the URL is read,
+   * so no credential reaches {@link #describe()}, and a rejected connection string yields an empty
+   * endpoint rather than failing here, where the message cannot name the cause.
+   */
+  private static String azureEndpointOf(final AzureStore store) {
+    final String connectionString = store.getConnectionString();
+    if (connectionString == null) {
+      return normalizeEndpoint(store.getEndpoint());
+    }
+    try {
+      return normalizeEndpoint(
+          new BlobServiceClientBuilder()
+              .connectionString(connectionString)
+              .buildClient()
+              .getAccountUrl());
+    } catch (final RuntimeException e) {
+      LOG.warn(
+          "Could not resolve the Azure blob endpoint of container '{}'", store.getContainerName());
       return "";
     }
-    return value.trim().toLowerCase().replaceAll("/+$", "");
+  }
+
+  /** AWS and Azure restrict these names to lower case, so folding case cannot merge two. */
+  private static String normalizeName(final @Nullable String value) {
+    return value == null ? "" : value.trim().toLowerCase();
+  }
+
+  /**
+   * Keeps only what names the backend — scheme, host, port and path. A query, fragment or user info
+   * carries a credential or session state rather than a location, so two tenants reaching one
+   * account with different SAS tokens must still collide, and nothing secret may reach {@link
+   * #describe()}. A value the URI parser cannot resolve is compared as it stands, minus the same
+   * three parts — an unparseable URL is usually one whose token needed escaping, which is exactly
+   * the value that must not be kept.
+   */
+  private static String normalizeEndpoint(final @Nullable String value) {
+    final String endpoint = normalizeName(value);
+    if (endpoint.isEmpty()) {
+      return "";
+    }
+    try {
+      final URI uri = new URI(endpoint);
+      if (uri.getHost() == null) {
+        return withoutCredentials(endpoint);
+      }
+      final StringBuilder identity = new StringBuilder();
+      if (uri.getScheme() != null) {
+        identity.append(uri.getScheme()).append("://");
+      }
+      identity.append(uri.getHost());
+      if (uri.getPort() != -1) {
+        identity.append(':').append(uri.getPort());
+      }
+      final String path = uri.getPath();
+      return identity.append(path == null ? "" : withoutTrailingSlashes(path)).toString();
+    } catch (final URISyntaxException e) {
+      return withoutCredentials(endpoint);
+    }
+  }
+
+  /**
+   * What is left of a URL the parser could not resolve once the parts that may carry a credential
+   * are dropped by hand: everything from a query or fragment onwards, and any user info in front of
+   * the host. An {@code @} past the authority belongs to the path, so it is kept.
+   */
+  private static String withoutCredentials(final String value) {
+    final String location = value.split("[?#]", 2)[0];
+    final int authorityStart = location.indexOf("//");
+    if (authorityStart < 0) {
+      return withoutTrailingSlashes(location);
+    }
+    final int authorityEnd = location.indexOf('/', authorityStart + 2);
+    final int hostStart =
+        location.lastIndexOf('@', authorityEnd < 0 ? location.length() - 1 : authorityEnd) + 1;
+    return withoutTrailingSlashes(
+        hostStart > authorityStart + 1
+            ? location.substring(0, authorityStart + 2) + location.substring(hostStart)
+            : location);
+  }
+
+  private static String withoutTrailingSlashes(final String value) {
+    return value.replaceAll("/+$", "");
+  }
+
+  /**
+   * Folds case regardless of platform, rather than following the host filesystem: a
+   * case-insensitive filesystem would otherwise let two tenants share a directory undetected, and
+   * erring the other way only rejects a configuration whose paths differ by case alone. An unusable
+   * path fails at store creation, so it is compared as configured.
+   */
+  private static String storageDirectory(final @Nullable String value) {
+    if (value == null || value.isBlank()) {
+      return "";
+    }
+    try {
+      return DocumentStorePaths.storageDirectory(value).toString().toLowerCase();
+    } catch (final InvalidPathException e) {
+      return value.toLowerCase();
+    }
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreLocation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreLocation.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.configuration.physicaltenants;
 
-import com.azure.storage.blob.BlobServiceClientBuilder;
 import io.camunda.configuration.Document.AwsStore;
 import io.camunda.configuration.Document.AzureStore;
 import io.camunda.configuration.Document.GcpStore;
 import io.camunda.configuration.Document.LocalStore;
 import io.camunda.document.store.DocumentStorePaths;
+import io.camunda.document.store.azure.AzureBlobDocumentStoreProvider;
 import io.camunda.document.store.gcp.GcpDocumentStoreProvider;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -95,28 +95,15 @@ record DocumentStoreLocation(String provider, List<String> namespace, String key
   }
 
   /**
-   * The blob endpoint the store resolves to, reduced from the connection string whenever one is
-   * set: {@code AzureBlobDocumentStoreProvider} takes that branch on a non-null connection string
-   * and never reads {@code endpoint}, so preferring the endpoint here would compare an account the
-   * store does not address, and two tenants really sharing one account would pass. Without the
-   * reduction they also go undetected whenever they name the account differently.
-   *
-   * <p>The SDK resolves the URL because the rules are not obvious enough to restate: a path-style
-   * {@code BlobEndpoint} keeps its path only when the host is an IP address. Only the URL is read,
-   * so no credential reaches {@link #describe()}, and a rejected connection string yields an empty
-   * endpoint rather than failing here, where the message cannot name the cause.
+   * The blob endpoint the store resolves to. A connection string the SDK rejects yields an empty
+   * endpoint rather than failing here, where the message could not name the cause — and it is
+   * reported without quoting the string, which is the value most likely to carry a credential.
    */
   private static String azureEndpointOf(final AzureStore store) {
-    final String connectionString = store.getConnectionString();
-    if (connectionString == null) {
-      return normalizeEndpoint(store.getEndpoint());
-    }
     try {
       return normalizeEndpoint(
-          new BlobServiceClientBuilder()
-              .connectionString(connectionString)
-              .buildClient()
-              .getAccountUrl());
+          AzureBlobDocumentStoreProvider.effectiveEndpoint(
+              store.getConnectionString(), store.getEndpoint()));
     } catch (final RuntimeException e) {
       LOG.warn(
           "Could not resolve the Azure blob endpoint of container '{}'", store.getContainerName());

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/DocumentStoreIsolationValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/DocumentStoreIsolationValidationTest.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -46,616 +47,6 @@ class DocumentStoreIsolationValidationTest {
   @AfterEach
   void tearDown() {
     UnifiedConfigurationHelper.setCustomEnvironment(null);
-  }
-
-  @Test
-  void shouldFailWhenTwoTenantsShareBucketAndPath() {
-    // given
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", awsCamunda("my-bucket", "shared/path", "us-east-1"),
-            "tenantb", awsCamunda("my-bucket", "shared/path", "us-east-1"));
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("must not share a document store location")
-        .withMessageContaining("tenanta")
-        .withMessageContaining("tenantb");
-  }
-
-  @Test
-  void shouldPassWhenPathsDiffer() {
-    // given
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", awsCamunda("my-bucket", "tenant-a/docs", "us-east-1"),
-            "tenantb", awsCamunda("my-bucket", "tenant-b/docs", "us-east-1"));
-
-    // when / then
-    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
-  }
-
-  @Test
-  void shouldFailIgnoringRegionDifference() {
-    // given S3 bucket names are globally unique, so region is not part of the identity
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", awsCamunda("global-bucket", "shared/path", "us-east-1"),
-            "tenantb", awsCamunda("global-bucket", "shared/path", "eu-west-1"));
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("must not share a document store location")
-        .withMessageContaining("tenanta")
-        .withMessageContaining("tenantb");
-  }
-
-  @Test
-  void shouldTreatTrailingSlashAsEquivalentToNoSlash() {
-    // given the provider coerces a trailing slash, so both resolve to the key prefix "shared/"
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", awsCamunda("my-bucket", "shared", "us-east-1"),
-            "tenantb", awsCamunda("my-bucket", "shared/", "us-east-1"));
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("share the same document store location")
-        .withMessageContaining("tenanta")
-        .withMessageContaining("tenantb");
-  }
-
-  @Test
-  void shouldNormalizeNullBucketPath() {
-    // given null and "" are both "no path"
-    final Map<String, Camunda> resolved = new LinkedHashMap<>();
-    resolved.put("tenanta", awsCamunda("docs", null, "eu-west-1"));
-    resolved.put("tenantb", awsCamunda("docs", "", "eu-west-1"));
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("must not share a document store location")
-        .withMessageContaining("tenanta")
-        .withMessageContaining("tenantb");
-  }
-
-  @Test
-  void shouldNeverCollideOnInMemoryStores() {
-    // given
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", inMemoryCamunda("mem-store"),
-            "tenantb", inMemoryCamunda("mem-store"));
-
-    // when / then
-    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
-  }
-
-  @Test
-  void shouldPassForSingleTenant() {
-    // given
-    final Map<String, Camunda> resolved =
-        tenants("default", awsCamunda("my-bucket", "default/path", "us-east-1"));
-
-    // when / then
-    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
-  }
-
-  @Test
-  void shouldFailWhenTenantInheritsRootLocationAndCollidesWithDefault() {
-    // given a tenant that omits a document override inherits the root location
-    final Camunda defaultTenant = awsCamunda("shared-bucket", "root/path", "us-east-1");
-    final Camunda tenantA = awsCamunda("shared-bucket", "root/path", "us-east-1");
-    final Map<String, Camunda> resolved = tenants("default", defaultTenant, "tenanta", tenantA);
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("must not share a document store location")
-        .withMessageContaining("default")
-        .withMessageContaining("tenanta");
-  }
-
-  @Test
-  void shouldFailWhenGcpTenantOmitsPrefixAndOtherSetsTheProviderDefault() {
-    // given an unset prefix is not "no prefix": GcpDocumentStoreProvider substitutes "temp/"
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", gcpCamunda("shared-bucket", null),
-            "tenantb", gcpCamunda("shared-bucket", "temp/"));
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("must not share a document store location")
-        .withMessageContaining("tenanta")
-        .withMessageContaining("tenantb");
-  }
-
-  @Test
-  void shouldFailWhenGcpPrefixIsAStringPrefixOfAnother() {
-    // given document ids are caller-supplied, so tenant-a asking its own store for "-b-invoice"
-    // resolves to tenant-b's "tenant-b-invoice" — no separator or traversal character involved
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", gcpCamunda("camunda-shared", "tenant"),
-            "tenantb", gcpCamunda("camunda-shared", "tenant-b-"));
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("must not share a document store location")
-        .withMessageContaining("tenanta's document store location")
-        .withMessageContaining("encloses tenant tenantb's");
-  }
-
-  @Test
-  void shouldFailWhenAGcpPrefixIsAnotherWithoutItsTrailingSeparator() {
-    // given "temp" encloses every key of "temp/", which the document id "/invoice" reaches
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", gcpCamunda("camunda-shared", "temp"),
-            "tenantb", gcpCamunda("camunda-shared", "temp/"));
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("tenanta's document store location")
-        .withMessageContaining("encloses tenant tenantb's");
-  }
-
-  @Test
-  void shouldFailWhenAGcpTenantOwnsTheBucketRootAndAnotherASlashFreePrefix() {
-    // given the root tenant reaches tenant-b's "tenant-b-invoice" by asking its own store for that
-    // very id
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", gcpCamunda("camunda-shared", ""),
-            "tenantb", gcpCamunda("camunda-shared", "tenant-b-"));
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("tenanta's document store location")
-        .withMessageContaining("encloses tenant tenantb's");
-  }
-
-  @Test
-  void shouldFailWhenAGcpPrefixContinuesAFolderPrefixWithoutASeparator() {
-    // given "docs/" plus the document id "archivex" reaches tenant-b's "docs/archivex"
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", gcpCamunda("camunda-shared", "docs/"),
-            "tenantb", gcpCamunda("camunda-shared", "docs/archive"));
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("tenanta's document store location")
-        .withMessageContaining("encloses tenant tenantb's");
-  }
-
-  @Test
-  void shouldPassWhenAwsBucketPathsShareAStringPrefixButNotAFolder() {
-    // given the coerced slash makes "tenant/" and "tenant-b-/" — neither encloses the other
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", awsCamunda("camunda-shared", "tenant", "us-east-1"),
-            "tenantb", awsCamunda("camunda-shared", "tenant-b-", "us-east-1"));
-
-    // when / then
-    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
-  }
-
-  @Test
-  void shouldFailWhenAnAwsBucketPathIsNestedBelowASeparator() {
-    // given the separator is no boundary: the document id "nested/invoice" carries tenant-a's store
-    // from "tenant-a/" into tenant-b's "tenant-a/nested/", and S3 keys give '/' no path meaning
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", awsCamunda("camunda-shared", "tenant-a", "us-east-1"),
-            "tenantb", awsCamunda("camunda-shared", "tenant-a/nested", "us-east-1"));
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("tenanta's document store location")
-        .withMessageContaining("encloses tenant tenantb's");
-  }
-
-  @Test
-  void shouldFailWhenOneTenantOwnsTheBucketRootAndAnotherAFolderInside() {
-    // given the root encloses every folder in the bucket, so the id "tenant-b/invoice" reaches them
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", awsCamunda("camunda-shared", null, "us-east-1"),
-            "tenantb", awsCamunda("camunda-shared", "tenant-b", "us-east-1"));
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("tenanta's document store location")
-        .withMessageContaining("encloses tenant tenantb's");
-  }
-
-  @Test
-  void shouldFailForTheContainerRootAndFolderLayout() {
-    // given the layout DocumentIsolationAzureIT used before it moved every tenant into a folder of
-    // its own: two tenants at container roots, two more in folders inside those same containers
-    final String endpoint = "http://localhost:10000/devstoreaccount1";
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", azureEndpointCamunda(endpoint, "container-a", null),
-            "tenantc", azureEndpointCamunda(endpoint, "container-a", "tenantc/"),
-            "tenantb", azureEndpointCamunda(endpoint, "container-b", null),
-            "default", azureEndpointCamunda(endpoint, "container-b", "default/"));
-
-    // when
-    final Throwable thrown = catchThrowable(() -> validation.validate(resolved));
-
-    // then both containers are reported, each naming the root tenant as the enclosing one
-    assertThat(thrown)
-        .isInstanceOf(UnifiedConfigurationException.class)
-        .hasMessageContaining("tenant tenanta's document store location")
-        .hasMessageContaining("encloses tenant tenantc's")
-        .hasMessageContaining("tenant tenantb's document store location")
-        .hasMessageContaining("encloses tenant default's");
-  }
-
-  @Test
-  void shouldPassWhenSiblingFoldersShareAContainer() {
-    // given the layout DocumentIsolationAzureIT asserts isolation for: no prefix contains another,
-    // so no document id can carry one tenant's store into the next
-    final String endpoint = "http://localhost:10000/devstoreaccount1";
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", azureEndpointCamunda(endpoint, "container-a", "tenanta/"),
-            "tenantc", azureEndpointCamunda(endpoint, "container-a", "tenantc/"),
-            "tenantb", azureEndpointCamunda(endpoint, "container-b", "tenantb/"),
-            "default", azureEndpointCamunda(endpoint, "container-b", "default/"));
-
-    // when / then
-    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
-  }
-
-  @Test
-  void shouldPassWhenAwsEndpointsDiffer() {
-    // given the endpoint is part of the namespace, so same-named buckets on two S3-compatible
-    // backends are separate locations
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", awsCamunda("docs", "shared/", "us-east-1", "https://minio-a.internal"),
-            "tenantb", awsCamunda("docs", "shared/", "us-east-1", "https://minio-b.internal"));
-
-    // when / then
-    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
-  }
-
-  @Test
-  void shouldPassWhenLocalPathsAreNested() {
-    // given LocalStorageDocumentStore rejects '/', '\' and '..', so the parent cannot descend
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", localCamunda("/var/camunda/docs"),
-            "tenantb", localCamunda("/var/camunda/docs/tenant-b"));
-
-    // when / then
-    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
-  }
-
-  @Test
-  void shouldPassWhenOneTenantSpreadsDocumentsAcrossOverlappingStores() {
-    // given overlap within a single tenant is not a cross-tenant leak
-    final Camunda tenantA = gcpCamunda("camunda-shared", "tenant-a/");
-    final Map<String, GcpStore> stores = new LinkedHashMap<>(tenantA.getDocument().getGcp());
-    final GcpStore nested = new GcpStore();
-    nested.setBucketName("camunda-shared");
-    nested.setPrefix("tenant-a/nested/");
-    stores.put("secondary", nested);
-    tenantA.getDocument().setGcp(stores);
-    final Map<String, Camunda> resolved =
-        tenants("tenanta", tenantA, "tenantb", gcpCamunda("camunda-shared", "tenant-b/"));
-
-    // when / then
-    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
-  }
-
-  @Test
-  void shouldPassWhenGcpPrefixesDifferOnlyByCase() {
-    // given GCS object names are case-sensitive
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", gcpCamunda("shared-bucket", "TenantA/"),
-            "tenantb", gcpCamunda("shared-bucket", "tenanta/"));
-
-    // when / then
-    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
-  }
-
-  @Test
-  void shouldPassWhenAwsBucketPathsDifferOnlyByCase() {
-    // given S3 object keys are case-sensitive
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", awsCamunda("shared-bucket", "Tenant-A/", "us-east-1"),
-            "tenantb", awsCamunda("shared-bucket", "tenant-a/", "us-east-1"));
-
-    // when / then
-    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
-  }
-
-  @Test
-  void shouldFailWhenAzureReachesTheSameAccountViaConnectionStringAndEndpoint() {
-    // given the account is the location, not the credential mechanism used to reach it; the
-    // endpoint's case and trailing slash are not part of it either
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", azureConnectionStringCamunda(connectionString("acct"), "docs", "shared/"),
-            "tenantb",
-                azureEndpointCamunda("https://ACCT.blob.core.windows.net/", "docs", "shared/"));
-
-    // when / then the account key behind the connection string stays out of the message
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("must not share a document store location")
-        .withMessageContaining("tenanta")
-        .withMessageContaining("tenantb")
-        .withMessageNotContaining("a2V5");
-  }
-
-  @Test
-  void shouldFailWhenAzureReachesTheSameAccountViaEmulatorShorthandAndEndpoint() {
-    // given UseDevelopmentStorage=true is shorthand for the well-known emulator account
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta",
-                azureConnectionStringCamunda("UseDevelopmentStorage=true", "docs", "shared/"),
-            "tenantb",
-                azureEndpointCamunda("http://127.0.0.1:10000/devstoreaccount1", "docs", "shared/"));
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("must not share a document store location")
-        .withMessageContaining("tenanta")
-        .withMessageContaining("tenantb");
-  }
-
-  @Test
-  void shouldFailWhenAzurePathStyleBlobEndpointsDifferOnlyByAccountPath() {
-    // given the SDK reads the path of a path-style BlobEndpoint as a container name and the store
-    // then overrides it, so both address cdn.example.com/docs/shared/ and the path isolates nothing
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta",
-                azureConnectionStringCamunda(
-                    connectionString("accta") + ";BlobEndpoint=https://cdn.example.com/accta",
-                    "docs",
-                    "shared/"),
-            "tenantb",
-                azureConnectionStringCamunda(
-                    connectionString("acctb") + ";BlobEndpoint=https://cdn.example.com/acctb",
-                    "docs",
-                    "shared/"));
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("must not share a document store location")
-        .withMessageContaining("tenanta")
-        .withMessageContaining("tenantb");
-  }
-
-  @Test
-  void shouldFailWhenAnAzureEndpointIsSetBesideTheConnectionStringThatOverridesIt() {
-    // given AzureBlobDocumentStoreProvider takes the connection-string branch whenever one is set
-    // and never reads the endpoint, so tenant-a addresses acct, not the account its endpoint names
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta",
-                azureCamunda(
-                    connectionString("acct"),
-                    "https://other-acct.blob.core.windows.net",
-                    "docs",
-                    "shared/"),
-            "tenantb", azureConnectionStringCamunda(connectionString("acct"), "docs", "shared/"));
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("share the same document store location")
-        .withMessageContaining("tenanta")
-        .withMessageContaining("tenantb");
-  }
-
-  @Test
-  void shouldPassWhenAnIgnoredAzureEndpointNamesAnotherTenantsAccount() {
-    // given the same precedence seen from the other side: tenant-a's endpoint is dead
-    // configuration,
-    // so naming tenant-b's account in it is not a shared location
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta",
-                azureCamunda(
-                    connectionString("accta"),
-                    "https://acctb.blob.core.windows.net",
-                    "docs",
-                    "shared/"),
-            "tenantb",
-                azureEndpointCamunda("https://acctb.blob.core.windows.net", "docs", "shared/"));
-
-    // when / then
-    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
-  }
-
-  @Test
-  void shouldPassWhenAzureConnectionStringsNameDifferentAccounts() {
-    // given
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", azureConnectionStringCamunda(connectionString("accta"), "docs", "shared/"),
-            "tenantb", azureConnectionStringCamunda(connectionString("acctb"), "docs", "shared/"));
-
-    // when / then
-    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
-  }
-
-  @Test
-  void shouldFailWithoutLeakingTheSasWhenAzureEndpointsDifferOnlyByTheirToken() {
-    // given a SAS token is a credential, not a location, so these name one account and must collide
-    // without the signature reaching the error message
-    final String signature = "c2lnbmF0dXJlLXZhbHVl";
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta",
-                azureEndpointCamunda(
-                    "https://acct.blob.core.windows.net?sv=2024-01-01&sig=" + signature,
-                    "docs",
-                    "shared/"),
-            "tenantb",
-                azureEndpointCamunda(
-                    "https://acct.blob.core.windows.net?sv=2025-01-01&sig=other",
-                    "docs",
-                    "shared/"));
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("share the same document store location")
-        .withMessageNotContaining(signature);
-  }
-
-  @Test
-  void shouldFailWithoutLeakingTheSasWhenAnAzureEndpointIsNotAParseableUrl() {
-    // given a token that needed escaping makes the whole endpoint unparseable, which is the value
-    // most likely to carry a credential — so the fallback must still reduce it to the account
-    final String signature = "unescaped-signature-value";
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta",
-                azureEndpointCamunda(
-                    "https://acct.blob.core.windows.net/?sv=2024 01&sig=" + signature,
-                    "docs",
-                    "shared/"),
-            "tenantb",
-                azureEndpointCamunda(
-                    "https://acct.blob.core.windows.net?sv=2025-01-01&sig=other",
-                    "docs",
-                    "shared/"));
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("share the same document store location")
-        .withMessageNotContaining(signature);
-  }
-
-  @Test
-  void shouldFailWithoutLeakingUserInfoWhenAnAzureEndpointIsNotAParseableUrl() {
-    // given user info in front of the host is a credential too, and the parser cannot strip it from
-    // a URL it rejects
-    final String password = "user-info-password";
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta",
-                azureEndpointCamunda(
-                    "https://user:" + password + "@acct.blob.core.windows.net/?sv=2024 01",
-                    "docs",
-                    "shared/"),
-            "tenantb",
-                azureEndpointCamunda("https://acct.blob.core.windows.net", "docs", "shared/"));
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("share the same document store location")
-        .withMessageNotContaining(password);
-  }
-
-  @Test
-  void shouldReportOneConflictPerLocationRatherThanOnePerPairOfTenants() {
-    // given three tenants on one location are one misconfiguration, not three pairs of them
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", awsCamunda("shared-bucket", "shared/", "us-east-1"),
-            "tenantb", awsCamunda("shared-bucket", "shared/", "us-east-1"),
-            "tenantc", awsCamunda("shared-bucket", "shared/", "us-east-1"));
-
-    // when
-    final Throwable thrown = catchThrowable(() -> validation.validate(resolved));
-
-    // then all three are named once, in a single conflict
-    assertThat(thrown)
-        .isInstanceOf(UnifiedConfigurationException.class)
-        .hasMessageContaining("tenants [tenanta, tenantb, tenantc] share the same document store");
-    assertThat(thrown.getMessage().split("share the same document store location", -1)).hasSize(2);
-  }
-
-  @Test
-  void shouldWarnWithoutLeakingTheCredentialWhenAnAzureConnectionStringCannotBeResolved() {
-    // given a connection string naming no account resolves to no endpoint, which must neither be
-    // mistaken for a shared location nor reported by quoting the string the SDK rejected
-    final String accountKey = "c3VwZXItc2VjcmV0LWtleQ==";
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta",
-                azureConnectionStringCamunda(
-                    "AccountKey=" + accountKey + ";EndpointSuffix=core.windows.net", "docs", "a/"),
-            "tenantb", azureEndpointCamunda("https://acct.blob.core.windows.net", "docs", "b/"));
-
-    // when
-    try (final LogCapturer logs = new LogCapturer(DocumentStoreLocation.class.getName())) {
-      assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
-
-      // then the store is named, the credential is not
-      assertThat(logs.warnings())
-          .anySatisfy(warning -> assertThat(warning).contains("docs").doesNotContain(accountKey));
-    }
-  }
-
-  @Test
-  void shouldPassWhenTheSameBucketAndPrefixAreUsedOnDifferentProviders() {
-    // given
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", awsCamunda("shared-bucket", "docs/", "us-east-1"),
-            "tenantb", gcpCamunda("shared-bucket", "docs/"));
-
-    // when / then
-    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
-  }
-
-  @Test
-  void shouldFailWhenLocalPathsDifferOnlyByCase() {
-    // given a case-insensitive filesystem would make these one directory, and the check must not
-    // depend on the platform it happens to run on
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", localCamunda("/var/camunda/Docs"),
-            "tenantb", localCamunda("/var/camunda/docs"));
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("must not share a document store location");
-  }
-
-  @Test
-  void shouldFailWhenLocalPathsDifferOnlyByTrailingSlash() {
-    // given /data and /data/ are the same directory
-    final Map<String, Camunda> resolved =
-        tenants(
-            "tenanta", localCamunda("/var/camunda/docs"),
-            "tenantb", localCamunda("/var/camunda/docs/"));
-
-    // when / then
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("must not share a document store location");
   }
 
   // --- helpers ---------------------------------------------------------------------------------
@@ -759,6 +150,646 @@ class DocumentStoreIsolationValidationTest {
       map.put((String) idThenCamunda[i], (Camunda) idThenCamunda[i + 1]);
     }
     return map;
+  }
+
+  @Nested
+  class Aws {
+
+    @Test
+    void shouldFailWhenTwoTenantsShareBucketAndPath() {
+      // given
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", awsCamunda("my-bucket", "shared/path", "us-east-1"),
+              "tenantb", awsCamunda("my-bucket", "shared/path", "us-east-1"));
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("must not share a document store location")
+          .withMessageContaining("tenanta")
+          .withMessageContaining("tenantb");
+    }
+
+    @Test
+    void shouldPassWhenPathsDiffer() {
+      // given
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", awsCamunda("my-bucket", "tenant-a/docs", "us-east-1"),
+              "tenantb", awsCamunda("my-bucket", "tenant-b/docs", "us-east-1"));
+
+      // when / then
+      assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldFailIgnoringRegionDifference() {
+      // given S3 bucket names are globally unique, so region is not part of the identity
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", awsCamunda("global-bucket", "shared/path", "us-east-1"),
+              "tenantb", awsCamunda("global-bucket", "shared/path", "eu-west-1"));
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("must not share a document store location")
+          .withMessageContaining("tenanta")
+          .withMessageContaining("tenantb");
+    }
+
+    @Test
+    void shouldTreatTrailingSlashAsEquivalentToNoSlash() {
+      // given the provider coerces a trailing slash, so both resolve to the key prefix "shared/"
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", awsCamunda("my-bucket", "shared", "us-east-1"),
+              "tenantb", awsCamunda("my-bucket", "shared/", "us-east-1"));
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("share the same document store location")
+          .withMessageContaining("tenanta")
+          .withMessageContaining("tenantb");
+    }
+
+    @Test
+    void shouldNormalizeNullBucketPath() {
+      // given null and "" are both "no path"
+      final Map<String, Camunda> resolved = new LinkedHashMap<>();
+      resolved.put("tenanta", awsCamunda("docs", null, "eu-west-1"));
+      resolved.put("tenantb", awsCamunda("docs", "", "eu-west-1"));
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("must not share a document store location")
+          .withMessageContaining("tenanta")
+          .withMessageContaining("tenantb");
+    }
+
+    @Test
+    void shouldFailWhenTenantInheritsRootLocationAndCollidesWithDefault() {
+      // given a tenant that omits a document override inherits the root location
+      final Camunda defaultTenant = awsCamunda("shared-bucket", "root/path", "us-east-1");
+      final Camunda tenantA = awsCamunda("shared-bucket", "root/path", "us-east-1");
+      final Map<String, Camunda> resolved = tenants("default", defaultTenant, "tenanta", tenantA);
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("must not share a document store location")
+          .withMessageContaining("default")
+          .withMessageContaining("tenanta");
+    }
+
+    @Test
+    void shouldPassWhenBucketPathsShareAStringPrefixButNotAFolder() {
+      // given the coerced slash makes "tenant/" and "tenant-b-/" — neither encloses the other
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", awsCamunda("camunda-shared", "tenant", "us-east-1"),
+              "tenantb", awsCamunda("camunda-shared", "tenant-b-", "us-east-1"));
+
+      // when / then
+      assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldFailWhenABucketPathIsNestedBelowASeparator() {
+      // given the separator is no boundary: the document id "nested/invoice" carries tenant-a's
+      // store from "tenant-a/" into tenant-b's "tenant-a/nested/", and S3 keys give '/' no path
+      // meaning
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", awsCamunda("camunda-shared", "tenant-a", "us-east-1"),
+              "tenantb", awsCamunda("camunda-shared", "tenant-a/nested", "us-east-1"));
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("tenanta's document store location")
+          .withMessageContaining("encloses tenant tenantb's");
+    }
+
+    @Test
+    void shouldFailWhenOneTenantOwnsTheBucketRootAndAnotherAFolderInside() {
+      // given the root encloses every folder in the bucket, so the id "tenant-b/invoice" reaches
+      // them
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", awsCamunda("camunda-shared", null, "us-east-1"),
+              "tenantb", awsCamunda("camunda-shared", "tenant-b", "us-east-1"));
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("tenanta's document store location")
+          .withMessageContaining("encloses tenant tenantb's");
+    }
+
+    @Test
+    void shouldPassWhenEndpointsDiffer() {
+      // given the endpoint is part of the namespace, so same-named buckets on two S3-compatible
+      // backends are separate locations
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", awsCamunda("docs", "shared/", "us-east-1", "https://minio-a.internal"),
+              "tenantb", awsCamunda("docs", "shared/", "us-east-1", "https://minio-b.internal"));
+
+      // when / then
+      assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldPassWhenBucketPathsDifferOnlyByCase() {
+      // given S3 object keys are case-sensitive
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", awsCamunda("shared-bucket", "Tenant-A/", "us-east-1"),
+              "tenantb", awsCamunda("shared-bucket", "tenant-a/", "us-east-1"));
+
+      // when / then
+      assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+    }
+  }
+
+  @Nested
+  class Gcp {
+
+    @Test
+    void shouldFailWhenATenantOmitsPrefixAndOtherSetsTheProviderDefault() {
+      // given an unset prefix is not "no prefix": GcpDocumentStoreProvider substitutes "temp/"
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", gcpCamunda("shared-bucket", null),
+              "tenantb", gcpCamunda("shared-bucket", "temp/"));
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("must not share a document store location")
+          .withMessageContaining("tenanta")
+          .withMessageContaining("tenantb");
+    }
+
+    @Test
+    void shouldFailWhenAPrefixIsAStringPrefixOfAnother() {
+      // given document ids are caller-supplied, so tenant-a asking its own store for "-b-invoice"
+      // resolves to tenant-b's "tenant-b-invoice" — no separator or traversal character involved
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", gcpCamunda("camunda-shared", "tenant"),
+              "tenantb", gcpCamunda("camunda-shared", "tenant-b-"));
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("must not share a document store location")
+          .withMessageContaining("tenanta's document store location")
+          .withMessageContaining("encloses tenant tenantb's");
+    }
+
+    @Test
+    void shouldFailWhenAPrefixIsAnotherWithoutItsTrailingSeparator() {
+      // given "temp" encloses every key of "temp/", which the document id "/invoice" reaches
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", gcpCamunda("camunda-shared", "temp"),
+              "tenantb", gcpCamunda("camunda-shared", "temp/"));
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("tenanta's document store location")
+          .withMessageContaining("encloses tenant tenantb's");
+    }
+
+    @Test
+    void shouldFailWhenATenantOwnsTheBucketRootAndAnotherASlashFreePrefix() {
+      // given the root tenant reaches tenant-b's "tenant-b-invoice" by asking its own store for
+      // that very id
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", gcpCamunda("camunda-shared", ""),
+              "tenantb", gcpCamunda("camunda-shared", "tenant-b-"));
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("tenanta's document store location")
+          .withMessageContaining("encloses tenant tenantb's");
+    }
+
+    @Test
+    void shouldFailWhenAPrefixContinuesAFolderPrefixWithoutASeparator() {
+      // given "docs/" plus the document id "archivex" reaches tenant-b's "docs/archivex"
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", gcpCamunda("camunda-shared", "docs/"),
+              "tenantb", gcpCamunda("camunda-shared", "docs/archive"));
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("tenanta's document store location")
+          .withMessageContaining("encloses tenant tenantb's");
+    }
+
+    @Test
+    void shouldPassWhenOneTenantSpreadsDocumentsAcrossOverlappingStores() {
+      // given overlap within a single tenant is not a cross-tenant leak
+      final Camunda tenantA = gcpCamunda("camunda-shared", "tenant-a/");
+      final Map<String, GcpStore> stores = new LinkedHashMap<>(tenantA.getDocument().getGcp());
+      final GcpStore nested = new GcpStore();
+      nested.setBucketName("camunda-shared");
+      nested.setPrefix("tenant-a/nested/");
+      stores.put("secondary", nested);
+      tenantA.getDocument().setGcp(stores);
+      final Map<String, Camunda> resolved =
+          tenants("tenanta", tenantA, "tenantb", gcpCamunda("camunda-shared", "tenant-b/"));
+
+      // when / then
+      assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldPassWhenPrefixesDifferOnlyByCase() {
+      // given GCS object names are case-sensitive
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", gcpCamunda("shared-bucket", "TenantA/"),
+              "tenantb", gcpCamunda("shared-bucket", "tenanta/"));
+
+      // when / then
+      assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+    }
+  }
+
+  @Nested
+  class Azure {
+
+    @Test
+    void shouldFailForTheContainerRootAndFolderLayout() {
+      // given the layout DocumentIsolationAzureIT used before it moved every tenant into a folder
+      // of its own: two tenants at container roots, two more in folders inside those same
+      // containers
+      final String endpoint = "http://localhost:10000/devstoreaccount1";
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", azureEndpointCamunda(endpoint, "container-a", null),
+              "tenantc", azureEndpointCamunda(endpoint, "container-a", "tenantc/"),
+              "tenantb", azureEndpointCamunda(endpoint, "container-b", null),
+              "default", azureEndpointCamunda(endpoint, "container-b", "default/"));
+
+      // when
+      final Throwable thrown = catchThrowable(() -> validation.validate(resolved));
+
+      // then both containers are reported, each naming the root tenant as the enclosing one
+      assertThat(thrown)
+          .isInstanceOf(UnifiedConfigurationException.class)
+          .hasMessageContaining("tenant tenanta's document store location")
+          .hasMessageContaining("encloses tenant tenantc's")
+          .hasMessageContaining("tenant tenantb's document store location")
+          .hasMessageContaining("encloses tenant default's");
+    }
+
+    @Test
+    void shouldPassWhenSiblingFoldersShareAContainer() {
+      // given the layout DocumentIsolationAzureIT asserts isolation for: no prefix contains
+      // another, so no document id can carry one tenant's store into the next
+      final String endpoint = "http://localhost:10000/devstoreaccount1";
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", azureEndpointCamunda(endpoint, "container-a", "tenanta/"),
+              "tenantc", azureEndpointCamunda(endpoint, "container-a", "tenantc/"),
+              "tenantb", azureEndpointCamunda(endpoint, "container-b", "tenantb/"),
+              "default", azureEndpointCamunda(endpoint, "container-b", "default/"));
+
+      // when / then
+      assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldFailWhenReachingTheSameAccountViaConnectionStringAndEndpoint() {
+      // given the account is the location, not the credential mechanism used to reach it; the
+      // endpoint's case and trailing slash are not part of it either
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", azureConnectionStringCamunda(connectionString("acct"), "docs", "shared/"),
+              "tenantb",
+                  azureEndpointCamunda("https://ACCT.blob.core.windows.net/", "docs", "shared/"));
+
+      // when / then the account key behind the connection string stays out of the message
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("must not share a document store location")
+          .withMessageContaining("tenanta")
+          .withMessageContaining("tenantb")
+          .withMessageNotContaining("a2V5");
+    }
+
+    @Test
+    void shouldFailWhenReachingTheSameAccountViaEmulatorShorthandAndEndpoint() {
+      // given UseDevelopmentStorage=true is shorthand for the well-known emulator account
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta",
+                  azureConnectionStringCamunda("UseDevelopmentStorage=true", "docs", "shared/"),
+              "tenantb",
+                  azureEndpointCamunda(
+                      "http://127.0.0.1:10000/devstoreaccount1", "docs", "shared/"));
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("must not share a document store location")
+          .withMessageContaining("tenanta")
+          .withMessageContaining("tenantb");
+    }
+
+    @Test
+    void shouldFailWhenPathStyleBlobEndpointsDifferOnlyByAccountPath() {
+      // given the SDK reads the path of a path-style BlobEndpoint as a container name and the store
+      // then overrides it, so both address cdn.example.com/docs/shared/ and the path isolates
+      // nothing
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta",
+                  azureConnectionStringCamunda(
+                      connectionString("accta") + ";BlobEndpoint=https://cdn.example.com/accta",
+                      "docs",
+                      "shared/"),
+              "tenantb",
+                  azureConnectionStringCamunda(
+                      connectionString("acctb") + ";BlobEndpoint=https://cdn.example.com/acctb",
+                      "docs",
+                      "shared/"));
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("must not share a document store location")
+          .withMessageContaining("tenanta")
+          .withMessageContaining("tenantb");
+    }
+
+    @Test
+    void shouldFailWhenAnEndpointIsSetBesideTheConnectionStringThatOverridesIt() {
+      // given AzureBlobDocumentStoreProvider takes the connection-string branch whenever one is set
+      // and never reads the endpoint, so tenant-a addresses acct, not the account its endpoint
+      // names
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta",
+                  azureCamunda(
+                      connectionString("acct"),
+                      "https://other-acct.blob.core.windows.net",
+                      "docs",
+                      "shared/"),
+              "tenantb", azureConnectionStringCamunda(connectionString("acct"), "docs", "shared/"));
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("share the same document store location")
+          .withMessageContaining("tenanta")
+          .withMessageContaining("tenantb");
+    }
+
+    @Test
+    void shouldPassWhenAnIgnoredEndpointNamesAnotherTenantsAccount() {
+      // given the same precedence seen from the other side: tenant-a's endpoint is dead
+      // configuration, so naming tenant-b's account in it is not a shared location
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta",
+                  azureCamunda(
+                      connectionString("accta"),
+                      "https://acctb.blob.core.windows.net",
+                      "docs",
+                      "shared/"),
+              "tenantb",
+                  azureEndpointCamunda("https://acctb.blob.core.windows.net", "docs", "shared/"));
+
+      // when / then
+      assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldPassWhenConnectionStringsNameDifferentAccounts() {
+      // given
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", azureConnectionStringCamunda(connectionString("accta"), "docs", "shared/"),
+              "tenantb",
+                  azureConnectionStringCamunda(connectionString("acctb"), "docs", "shared/"));
+
+      // when / then
+      assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldFailWithoutLeakingTheSasWhenEndpointsDifferOnlyByTheirToken() {
+      // given a SAS token is a credential, not a location, so these name one account and must
+      // collide without the signature reaching the error message
+      final String signature = "c2lnbmF0dXJlLXZhbHVl";
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta",
+                  azureEndpointCamunda(
+                      "https://acct.blob.core.windows.net?sv=2024-01-01&sig=" + signature,
+                      "docs",
+                      "shared/"),
+              "tenantb",
+                  azureEndpointCamunda(
+                      "https://acct.blob.core.windows.net?sv=2025-01-01&sig=other",
+                      "docs",
+                      "shared/"));
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("share the same document store location")
+          .withMessageNotContaining(signature);
+    }
+
+    @Test
+    void shouldFailWithoutLeakingTheSasWhenAnEndpointIsNotAParseableUrl() {
+      // given a token that needed escaping makes the whole endpoint unparseable, which is the value
+      // most likely to carry a credential — so the fallback must still reduce it to the account
+      final String signature = "unescaped-signature-value";
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta",
+                  azureEndpointCamunda(
+                      "https://acct.blob.core.windows.net/?sv=2024 01&sig=" + signature,
+                      "docs",
+                      "shared/"),
+              "tenantb",
+                  azureEndpointCamunda(
+                      "https://acct.blob.core.windows.net?sv=2025-01-01&sig=other",
+                      "docs",
+                      "shared/"));
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("share the same document store location")
+          .withMessageNotContaining(signature);
+    }
+
+    @Test
+    void shouldFailWithoutLeakingUserInfoWhenAnEndpointIsNotAParseableUrl() {
+      // given user info in front of the host is a credential too, and the parser cannot strip it
+      // from a URL it rejects
+      final String password = "user-info-password";
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta",
+                  azureEndpointCamunda(
+                      "https://user:" + password + "@acct.blob.core.windows.net/?sv=2024 01",
+                      "docs",
+                      "shared/"),
+              "tenantb",
+                  azureEndpointCamunda("https://acct.blob.core.windows.net", "docs", "shared/"));
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("share the same document store location")
+          .withMessageNotContaining(password);
+    }
+
+    @Test
+    void shouldWarnWithoutLeakingTheCredentialWhenAConnectionStringCannotBeResolved() {
+      // given a connection string naming no account resolves to no endpoint, which must neither be
+      // mistaken for a shared location nor reported by quoting the string the SDK rejected
+      final String accountKey = "c3VwZXItc2VjcmV0LWtleQ==";
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta",
+                  azureConnectionStringCamunda(
+                      "AccountKey=" + accountKey + ";EndpointSuffix=core.windows.net",
+                      "docs",
+                      "a/"),
+              "tenantb", azureEndpointCamunda("https://acct.blob.core.windows.net", "docs", "b/"));
+
+      // when
+      try (final LogCapturer logs = new LogCapturer(DocumentStoreLocation.class.getName())) {
+        assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+
+        // then the store is named, the credential is not
+        assertThat(logs.warnings())
+            .anySatisfy(warning -> assertThat(warning).contains("docs").doesNotContain(accountKey));
+      }
+    }
+  }
+
+  @Nested
+  class Local {
+
+    @Test
+    void shouldPassWhenPathsAreNested() {
+      // given LocalStorageDocumentStore rejects '/', '\' and '..', so the parent cannot descend
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", localCamunda("/var/camunda/docs"),
+              "tenantb", localCamunda("/var/camunda/docs/tenant-b"));
+
+      // when / then
+      assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldFailWhenPathsDifferOnlyByCase() {
+      // given a case-insensitive filesystem would make these one directory, and the check must not
+      // depend on the platform it happens to run on
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", localCamunda("/var/camunda/Docs"),
+              "tenantb", localCamunda("/var/camunda/docs"));
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("must not share a document store location");
+    }
+
+    @Test
+    void shouldFailWhenPathsDifferOnlyByTrailingSlash() {
+      // given /data and /data/ are the same directory
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", localCamunda("/var/camunda/docs"),
+              "tenantb", localCamunda("/var/camunda/docs/"));
+
+      // when / then
+      assertThatExceptionOfType(UnifiedConfigurationException.class)
+          .isThrownBy(() -> validation.validate(resolved))
+          .withMessageContaining("must not share a document store location");
+    }
+  }
+
+  @Nested
+  class AcrossProviders {
+
+    @Test
+    void shouldNeverCollideOnInMemoryStores() {
+      // given
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", inMemoryCamunda("mem-store"),
+              "tenantb", inMemoryCamunda("mem-store"));
+
+      // when / then
+      assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldPassForSingleTenant() {
+      // given
+      final Map<String, Camunda> resolved =
+          tenants("default", awsCamunda("my-bucket", "default/path", "us-east-1"));
+
+      // when / then
+      assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldPassWhenTheSameBucketAndPrefixAreUsedOnDifferentProviders() {
+      // given
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", awsCamunda("shared-bucket", "docs/", "us-east-1"),
+              "tenantb", gcpCamunda("shared-bucket", "docs/"));
+
+      // when / then
+      assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldReportOneConflictPerLocationRatherThanOnePerPairOfTenants() {
+      // given three tenants on one location are one misconfiguration, not three pairs of them
+      final Map<String, Camunda> resolved =
+          tenants(
+              "tenanta", awsCamunda("shared-bucket", "shared/", "us-east-1"),
+              "tenantb", awsCamunda("shared-bucket", "shared/", "us-east-1"),
+              "tenantc", awsCamunda("shared-bucket", "shared/", "us-east-1"));
+
+      // when
+      final Throwable thrown = catchThrowable(() -> validation.validate(resolved));
+
+      // then all three are named once, in a single conflict
+      assertThat(thrown)
+          .isInstanceOf(UnifiedConfigurationException.class)
+          .hasMessageContaining(
+              "tenants [tenanta, tenantb, tenantc] share the same document store");
+      assertThat(thrown.getMessage().split("share the same document store location", -1))
+          .hasSize(2);
+    }
   }
 
   /** Captures WARN events of a logger; without a log4j2 config the root level would drop them. */

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/DocumentStoreIsolationValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/DocumentStoreIsolationValidationTest.java
@@ -195,8 +195,7 @@ class DocumentStoreIsolationValidationTest {
 
   @Test
   void shouldFailWhenAGcpPrefixIsAnotherWithoutItsTrailingSeparator() {
-    // given "temp" is not a folder, so it encloses every key of "temp/" — the separator that would
-    // bound it belongs to the enclosed prefix, and a document id supplies it just as easily
+    // given "temp" encloses every key of "temp/", which the document id "/invoice" reaches
     final Map<String, Camunda> resolved =
         tenants(
             "tenanta", gcpCamunda("camunda-shared", "temp"),
@@ -211,10 +210,8 @@ class DocumentStoreIsolationValidationTest {
 
   @Test
   void shouldFailWhenAGcpTenantOwnsTheBucketRootAndAnotherASlashFreePrefix() {
-    // given GCP takes the prefix verbatim, so nothing separates the root from "tenant-b-": the root
-    // tenant reaches tenant-b's "tenant-b-invoice" by asking its own store for that very id, with
-    // no
-    // separator involved — unlike an AWS or Azure root, whose folders are always slash-terminated
+    // given the root tenant reaches tenant-b's "tenant-b-invoice" by asking its own store for that
+    // very id
     final Map<String, Camunda> resolved =
         tenants(
             "tenanta", gcpCamunda("camunda-shared", ""),
@@ -229,9 +226,7 @@ class DocumentStoreIsolationValidationTest {
 
   @Test
   void shouldFailWhenAGcpPrefixContinuesAFolderPrefixWithoutASeparator() {
-    // given an enclosing prefix that ends at a separator is not enough on its own: "docs/" plus the
-    // document id "archivex" reaches tenant-b's "docs/archivex", because GCP does not coerce
-    // "docs/archive" into a folder of its own
+    // given "docs/" plus the document id "archivex" reaches tenant-b's "docs/archivex"
     final Map<String, Camunda> resolved =
         tenants(
             "tenanta", gcpCamunda("camunda-shared", "docs/"),
@@ -245,7 +240,7 @@ class DocumentStoreIsolationValidationTest {
   }
 
   @Test
-  void shouldPassWhenAwsBucketPathsShareAStringPrefixButNotADirectory() {
+  void shouldPassWhenAwsBucketPathsShareAStringPrefixButNotAFolder() {
     // given the coerced slash makes "tenant/" and "tenant-b-/" — neither encloses the other
     final Map<String, Camunda> resolved =
         tenants(
@@ -257,41 +252,70 @@ class DocumentStoreIsolationValidationTest {
   }
 
   @Test
-  void shouldPassWhenAwsBucketPathIsNestedBelowASeparator() {
-    // given the coerced "tenant-a/" ends at a separator, so only a document id carrying '/' could
-    // reach the nested path — the boundary holds for every ordinary id
+  void shouldFailWhenAnAwsBucketPathIsNestedBelowASeparator() {
+    // given the separator is no boundary: the document id "nested/invoice" carries tenant-a's store
+    // from "tenant-a/" into tenant-b's "tenant-a/nested/", and S3 keys give '/' no path meaning
     final Map<String, Camunda> resolved =
         tenants(
             "tenanta", awsCamunda("camunda-shared", "tenant-a", "us-east-1"),
             "tenantb", awsCamunda("camunda-shared", "tenant-a/nested", "us-east-1"));
 
     // when / then
-    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta's document store location")
+        .withMessageContaining("encloses tenant tenantb's");
   }
 
   @Test
-  void shouldPassWhenOneTenantOwnsTheBucketRootAndAnotherAFolderInside() {
-    // given the root ends at a separator as much as a folder does, so this layout — supported by
-    // DocumentIsolationAzureIT — stays legal
+  void shouldFailWhenOneTenantOwnsTheBucketRootAndAnotherAFolderInside() {
+    // given the root encloses every folder in the bucket, so the id "tenant-b/invoice" reaches them
     final Map<String, Camunda> resolved =
         tenants(
             "tenanta", awsCamunda("camunda-shared", null, "us-east-1"),
             "tenantb", awsCamunda("camunda-shared", "tenant-b", "us-east-1"));
 
     // when / then
-    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta's document store location")
+        .withMessageContaining("encloses tenant tenantb's");
   }
 
   @Test
-  void shouldPassForTheContainerRootAndFolderLayoutOfDocumentIsolationAzureIT() {
-    // given the layout that IT asserts isolation for: two tenants at container roots, and two more
-    // in folders inside those same containers
+  void shouldFailForTheContainerRootAndFolderLayout() {
+    // given the layout DocumentIsolationAzureIT used before it moved every tenant into a folder of
+    // its own: two tenants at container roots, two more in folders inside those same containers
     final String endpoint = "http://localhost:10000/devstoreaccount1";
     final Map<String, Camunda> resolved =
         tenants(
             "tenanta", azureEndpointCamunda(endpoint, "container-a", null),
             "tenantc", azureEndpointCamunda(endpoint, "container-a", "tenantc/"),
             "tenantb", azureEndpointCamunda(endpoint, "container-b", null),
+            "default", azureEndpointCamunda(endpoint, "container-b", "default/"));
+
+    // when
+    final Throwable thrown = catchThrowable(() -> validation.validate(resolved));
+
+    // then both containers are reported, each naming the root tenant as the enclosing one
+    assertThat(thrown)
+        .isInstanceOf(UnifiedConfigurationException.class)
+        .hasMessageContaining("tenant tenanta's document store location")
+        .hasMessageContaining("encloses tenant tenantc's")
+        .hasMessageContaining("tenant tenantb's document store location")
+        .hasMessageContaining("encloses tenant default's");
+  }
+
+  @Test
+  void shouldPassWhenSiblingFoldersShareAContainer() {
+    // given the layout DocumentIsolationAzureIT asserts isolation for: no prefix contains another,
+    // so no document id can carry one tenant's store into the next
+    final String endpoint = "http://localhost:10000/devstoreaccount1";
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", azureEndpointCamunda(endpoint, "container-a", "tenanta/"),
+            "tenantc", azureEndpointCamunda(endpoint, "container-a", "tenantc/"),
+            "tenantb", azureEndpointCamunda(endpoint, "container-b", "tenantb/"),
             "default", azureEndpointCamunda(endpoint, "container-b", "default/"));
 
     // when / then

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/DocumentStoreIsolationValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/DocumentStoreIsolationValidationTest.java
@@ -7,16 +7,27 @@
  */
 package io.camunda.configuration.physicaltenants;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Document.AwsStore;
+import io.camunda.configuration.Document.AzureStore;
+import io.camunda.configuration.Document.GcpStore;
 import io.camunda.configuration.Document.InMemoryStore;
+import io.camunda.configuration.Document.LocalStore;
 import io.camunda.configuration.UnifiedConfigurationException;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -83,25 +94,23 @@ class DocumentStoreIsolationValidationTest {
 
   @Test
   void shouldTreatTrailingSlashAsEquivalentToNoSlash() {
-    // given normalizer strips trailing slashes, so "shared" and "shared/" resolve to the same
-    // location
+    // given the provider coerces a trailing slash, so both resolve to the key prefix "shared/"
     final Map<String, Camunda> resolved =
         tenants(
             "tenanta", awsCamunda("my-bucket", "shared", "us-east-1"),
             "tenantb", awsCamunda("my-bucket", "shared/", "us-east-1"));
 
-    // when / then error reports normalized value "shared", not "shared/"
+    // when / then
     assertThatExceptionOfType(UnifiedConfigurationException.class)
         .isThrownBy(() -> validation.validate(resolved))
-        .withMessageContaining("must not share a document store location")
+        .withMessageContaining("share the same document store location")
         .withMessageContaining("tenanta")
-        .withMessageContaining("tenantb")
-        .withMessageNotContaining("shared/");
+        .withMessageContaining("tenantb");
   }
 
   @Test
   void shouldNormalizeNullBucketPath() {
-    // given normalize maps null → "" and "" → "", so they collide
+    // given null and "" are both "no path"
     final Map<String, Camunda> resolved = new LinkedHashMap<>();
     resolved.put("tenanta", awsCamunda("docs", null, "eu-west-1"));
     resolved.put("tenantb", awsCamunda("docs", "", "eu-west-1"));
@@ -116,7 +125,7 @@ class DocumentStoreIsolationValidationTest {
 
   @Test
   void shouldNeverCollideOnInMemoryStores() {
-    // given in-memory stores are ephemeral and process-local, excluded from collision detection
+    // given
     final Map<String, Camunda> resolved =
         tenants(
             "tenanta", inMemoryCamunda("mem-store"),
@@ -138,8 +147,7 @@ class DocumentStoreIsolationValidationTest {
 
   @Test
   void shouldFailWhenTenantInheritsRootLocationAndCollidesWithDefault() {
-    // given a non-default tenant that omits a document override inherits the root location;
-    // the resolved config is identical to the default tenant's — a collision must be rejected
+    // given a tenant that omits a document override inherits the root location
     final Camunda defaultTenant = awsCamunda("shared-bucket", "root/path", "us-east-1");
     final Camunda tenantA = awsCamunda("shared-bucket", "root/path", "us-east-1");
     final Map<String, Camunda> resolved = tenants("default", defaultTenant, "tenanta", tenantA);
@@ -152,18 +160,564 @@ class DocumentStoreIsolationValidationTest {
         .withMessageContaining("tenanta");
   }
 
+  @Test
+  void shouldFailWhenGcpTenantOmitsPrefixAndOtherSetsTheProviderDefault() {
+    // given an unset prefix is not "no prefix": GcpDocumentStoreProvider substitutes "temp/"
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", gcpCamunda("shared-bucket", null),
+            "tenantb", gcpCamunda("shared-bucket", "temp/"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("must not share a document store location")
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb");
+  }
+
+  @Test
+  void shouldFailWhenGcpPrefixIsAStringPrefixOfAnother() {
+    // given document ids are caller-supplied, so tenant-a asking its own store for "-b-invoice"
+    // resolves to tenant-b's "tenant-b-invoice" — no separator or traversal character involved
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", gcpCamunda("camunda-shared", "tenant"),
+            "tenantb", gcpCamunda("camunda-shared", "tenant-b-"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("must not share a document store location")
+        .withMessageContaining("tenanta's document store location")
+        .withMessageContaining("encloses tenant tenantb's");
+  }
+
+  @Test
+  void shouldFailWhenAGcpPrefixIsAnotherWithoutItsTrailingSeparator() {
+    // given "temp" is not a folder, so it encloses every key of "temp/" — the separator that would
+    // bound it belongs to the enclosed prefix, and a document id supplies it just as easily
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", gcpCamunda("camunda-shared", "temp"),
+            "tenantb", gcpCamunda("camunda-shared", "temp/"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta's document store location")
+        .withMessageContaining("encloses tenant tenantb's");
+  }
+
+  @Test
+  void shouldFailWhenAGcpTenantOwnsTheBucketRootAndAnotherASlashFreePrefix() {
+    // given GCP takes the prefix verbatim, so nothing separates the root from "tenant-b-": the root
+    // tenant reaches tenant-b's "tenant-b-invoice" by asking its own store for that very id, with
+    // no
+    // separator involved — unlike an AWS or Azure root, whose folders are always slash-terminated
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", gcpCamunda("camunda-shared", ""),
+            "tenantb", gcpCamunda("camunda-shared", "tenant-b-"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta's document store location")
+        .withMessageContaining("encloses tenant tenantb's");
+  }
+
+  @Test
+  void shouldFailWhenAGcpPrefixContinuesAFolderPrefixWithoutASeparator() {
+    // given an enclosing prefix that ends at a separator is not enough on its own: "docs/" plus the
+    // document id "archivex" reaches tenant-b's "docs/archivex", because GCP does not coerce
+    // "docs/archive" into a folder of its own
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", gcpCamunda("camunda-shared", "docs/"),
+            "tenantb", gcpCamunda("camunda-shared", "docs/archive"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta's document store location")
+        .withMessageContaining("encloses tenant tenantb's");
+  }
+
+  @Test
+  void shouldPassWhenAwsBucketPathsShareAStringPrefixButNotADirectory() {
+    // given the coerced slash makes "tenant/" and "tenant-b-/" — neither encloses the other
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", awsCamunda("camunda-shared", "tenant", "us-east-1"),
+            "tenantb", awsCamunda("camunda-shared", "tenant-b-", "us-east-1"));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldPassWhenAwsBucketPathIsNestedBelowASeparator() {
+    // given the coerced "tenant-a/" ends at a separator, so only a document id carrying '/' could
+    // reach the nested path — the boundary holds for every ordinary id
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", awsCamunda("camunda-shared", "tenant-a", "us-east-1"),
+            "tenantb", awsCamunda("camunda-shared", "tenant-a/nested", "us-east-1"));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldPassWhenOneTenantOwnsTheBucketRootAndAnotherAFolderInside() {
+    // given the root ends at a separator as much as a folder does, so this layout — supported by
+    // DocumentIsolationAzureIT — stays legal
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", awsCamunda("camunda-shared", null, "us-east-1"),
+            "tenantb", awsCamunda("camunda-shared", "tenant-b", "us-east-1"));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldPassForTheContainerRootAndFolderLayoutOfDocumentIsolationAzureIT() {
+    // given the layout that IT asserts isolation for: two tenants at container roots, and two more
+    // in folders inside those same containers
+    final String endpoint = "http://localhost:10000/devstoreaccount1";
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", azureEndpointCamunda(endpoint, "container-a", null),
+            "tenantc", azureEndpointCamunda(endpoint, "container-a", "tenantc/"),
+            "tenantb", azureEndpointCamunda(endpoint, "container-b", null),
+            "default", azureEndpointCamunda(endpoint, "container-b", "default/"));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldPassWhenAwsEndpointsDiffer() {
+    // given the endpoint is part of the namespace, so same-named buckets on two S3-compatible
+    // backends are separate locations
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", awsCamunda("docs", "shared/", "us-east-1", "https://minio-a.internal"),
+            "tenantb", awsCamunda("docs", "shared/", "us-east-1", "https://minio-b.internal"));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldPassWhenLocalPathsAreNested() {
+    // given LocalStorageDocumentStore rejects '/', '\' and '..', so the parent cannot descend
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", localCamunda("/var/camunda/docs"),
+            "tenantb", localCamunda("/var/camunda/docs/tenant-b"));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldPassWhenOneTenantSpreadsDocumentsAcrossOverlappingStores() {
+    // given overlap within a single tenant is not a cross-tenant leak
+    final Camunda tenantA = gcpCamunda("camunda-shared", "tenant-a/");
+    final Map<String, GcpStore> stores = new LinkedHashMap<>(tenantA.getDocument().getGcp());
+    final GcpStore nested = new GcpStore();
+    nested.setBucketName("camunda-shared");
+    nested.setPrefix("tenant-a/nested/");
+    stores.put("secondary", nested);
+    tenantA.getDocument().setGcp(stores);
+    final Map<String, Camunda> resolved =
+        tenants("tenanta", tenantA, "tenantb", gcpCamunda("camunda-shared", "tenant-b/"));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldPassWhenGcpPrefixesDifferOnlyByCase() {
+    // given GCS object names are case-sensitive
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", gcpCamunda("shared-bucket", "TenantA/"),
+            "tenantb", gcpCamunda("shared-bucket", "tenanta/"));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldPassWhenAwsBucketPathsDifferOnlyByCase() {
+    // given S3 object keys are case-sensitive
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", awsCamunda("shared-bucket", "Tenant-A/", "us-east-1"),
+            "tenantb", awsCamunda("shared-bucket", "tenant-a/", "us-east-1"));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldFailWhenAzureReachesTheSameAccountViaConnectionStringAndEndpoint() {
+    // given the account is the location, not the credential mechanism used to reach it; the
+    // endpoint's case and trailing slash are not part of it either
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", azureConnectionStringCamunda(connectionString("acct"), "docs", "shared/"),
+            "tenantb",
+                azureEndpointCamunda("https://ACCT.blob.core.windows.net/", "docs", "shared/"));
+
+    // when / then the account key behind the connection string stays out of the message
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("must not share a document store location")
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb")
+        .withMessageNotContaining("a2V5");
+  }
+
+  @Test
+  void shouldFailWhenAzureReachesTheSameAccountViaEmulatorShorthandAndEndpoint() {
+    // given UseDevelopmentStorage=true is shorthand for the well-known emulator account
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta",
+                azureConnectionStringCamunda("UseDevelopmentStorage=true", "docs", "shared/"),
+            "tenantb",
+                azureEndpointCamunda("http://127.0.0.1:10000/devstoreaccount1", "docs", "shared/"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("must not share a document store location")
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb");
+  }
+
+  @Test
+  void shouldFailWhenAzurePathStyleBlobEndpointsDifferOnlyByAccountPath() {
+    // given the SDK reads the path of a path-style BlobEndpoint as a container name and the store
+    // then overrides it, so both address cdn.example.com/docs/shared/ and the path isolates nothing
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta",
+                azureConnectionStringCamunda(
+                    connectionString("accta") + ";BlobEndpoint=https://cdn.example.com/accta",
+                    "docs",
+                    "shared/"),
+            "tenantb",
+                azureConnectionStringCamunda(
+                    connectionString("acctb") + ";BlobEndpoint=https://cdn.example.com/acctb",
+                    "docs",
+                    "shared/"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("must not share a document store location")
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb");
+  }
+
+  @Test
+  void shouldFailWhenAnAzureEndpointIsSetBesideTheConnectionStringThatOverridesIt() {
+    // given AzureBlobDocumentStoreProvider takes the connection-string branch whenever one is set
+    // and never reads the endpoint, so tenant-a addresses acct, not the account its endpoint names
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta",
+                azureCamunda(
+                    connectionString("acct"),
+                    "https://other-acct.blob.core.windows.net",
+                    "docs",
+                    "shared/"),
+            "tenantb", azureConnectionStringCamunda(connectionString("acct"), "docs", "shared/"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("share the same document store location")
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb");
+  }
+
+  @Test
+  void shouldPassWhenAnIgnoredAzureEndpointNamesAnotherTenantsAccount() {
+    // given the same precedence seen from the other side: tenant-a's endpoint is dead
+    // configuration,
+    // so naming tenant-b's account in it is not a shared location
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta",
+                azureCamunda(
+                    connectionString("accta"),
+                    "https://acctb.blob.core.windows.net",
+                    "docs",
+                    "shared/"),
+            "tenantb",
+                azureEndpointCamunda("https://acctb.blob.core.windows.net", "docs", "shared/"));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldPassWhenAzureConnectionStringsNameDifferentAccounts() {
+    // given
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", azureConnectionStringCamunda(connectionString("accta"), "docs", "shared/"),
+            "tenantb", azureConnectionStringCamunda(connectionString("acctb"), "docs", "shared/"));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldFailWithoutLeakingTheSasWhenAzureEndpointsDifferOnlyByTheirToken() {
+    // given a SAS token is a credential, not a location, so these name one account and must collide
+    // without the signature reaching the error message
+    final String signature = "c2lnbmF0dXJlLXZhbHVl";
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta",
+                azureEndpointCamunda(
+                    "https://acct.blob.core.windows.net?sv=2024-01-01&sig=" + signature,
+                    "docs",
+                    "shared/"),
+            "tenantb",
+                azureEndpointCamunda(
+                    "https://acct.blob.core.windows.net?sv=2025-01-01&sig=other",
+                    "docs",
+                    "shared/"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("share the same document store location")
+        .withMessageNotContaining(signature);
+  }
+
+  @Test
+  void shouldFailWithoutLeakingTheSasWhenAnAzureEndpointIsNotAParseableUrl() {
+    // given a token that needed escaping makes the whole endpoint unparseable, which is the value
+    // most likely to carry a credential — so the fallback must still reduce it to the account
+    final String signature = "unescaped-signature-value";
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta",
+                azureEndpointCamunda(
+                    "https://acct.blob.core.windows.net/?sv=2024 01&sig=" + signature,
+                    "docs",
+                    "shared/"),
+            "tenantb",
+                azureEndpointCamunda(
+                    "https://acct.blob.core.windows.net?sv=2025-01-01&sig=other",
+                    "docs",
+                    "shared/"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("share the same document store location")
+        .withMessageNotContaining(signature);
+  }
+
+  @Test
+  void shouldFailWithoutLeakingUserInfoWhenAnAzureEndpointIsNotAParseableUrl() {
+    // given user info in front of the host is a credential too, and the parser cannot strip it from
+    // a URL it rejects
+    final String password = "user-info-password";
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta",
+                azureEndpointCamunda(
+                    "https://user:" + password + "@acct.blob.core.windows.net/?sv=2024 01",
+                    "docs",
+                    "shared/"),
+            "tenantb",
+                azureEndpointCamunda("https://acct.blob.core.windows.net", "docs", "shared/"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("share the same document store location")
+        .withMessageNotContaining(password);
+  }
+
+  @Test
+  void shouldReportOneConflictPerLocationRatherThanOnePerPairOfTenants() {
+    // given three tenants on one location are one misconfiguration, not three pairs of them
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", awsCamunda("shared-bucket", "shared/", "us-east-1"),
+            "tenantb", awsCamunda("shared-bucket", "shared/", "us-east-1"),
+            "tenantc", awsCamunda("shared-bucket", "shared/", "us-east-1"));
+
+    // when
+    final Throwable thrown = catchThrowable(() -> validation.validate(resolved));
+
+    // then all three are named once, in a single conflict
+    assertThat(thrown)
+        .isInstanceOf(UnifiedConfigurationException.class)
+        .hasMessageContaining("tenants [tenanta, tenantb, tenantc] share the same document store");
+    assertThat(thrown.getMessage().split("share the same document store location", -1)).hasSize(2);
+  }
+
+  @Test
+  void shouldWarnWithoutLeakingTheCredentialWhenAnAzureConnectionStringCannotBeResolved() {
+    // given a connection string naming no account resolves to no endpoint, which must neither be
+    // mistaken for a shared location nor reported by quoting the string the SDK rejected
+    final String accountKey = "c3VwZXItc2VjcmV0LWtleQ==";
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta",
+                azureConnectionStringCamunda(
+                    "AccountKey=" + accountKey + ";EndpointSuffix=core.windows.net", "docs", "a/"),
+            "tenantb", azureEndpointCamunda("https://acct.blob.core.windows.net", "docs", "b/"));
+
+    // when
+    try (final LogCapturer logs = new LogCapturer(DocumentStoreLocation.class.getName())) {
+      assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+
+      // then the store is named, the credential is not
+      assertThat(logs.warnings())
+          .anySatisfy(warning -> assertThat(warning).contains("docs").doesNotContain(accountKey));
+    }
+  }
+
+  @Test
+  void shouldPassWhenTheSameBucketAndPrefixAreUsedOnDifferentProviders() {
+    // given
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", awsCamunda("shared-bucket", "docs/", "us-east-1"),
+            "tenantb", gcpCamunda("shared-bucket", "docs/"));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldFailWhenLocalPathsDifferOnlyByCase() {
+    // given a case-insensitive filesystem would make these one directory, and the check must not
+    // depend on the platform it happens to run on
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", localCamunda("/var/camunda/Docs"),
+            "tenantb", localCamunda("/var/camunda/docs"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("must not share a document store location");
+  }
+
+  @Test
+  void shouldFailWhenLocalPathsDifferOnlyByTrailingSlash() {
+    // given /data and /data/ are the same directory
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", localCamunda("/var/camunda/docs"),
+            "tenantb", localCamunda("/var/camunda/docs/"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("must not share a document store location");
+  }
+
   // --- helpers ---------------------------------------------------------------------------------
+
+  private static String connectionString(final String accountName) {
+    return "DefaultEndpointsProtocol=https;AccountName="
+        + accountName
+        + ";AccountKey=a2V5;EndpointSuffix=core.windows.net";
+  }
 
   private static Camunda awsCamunda(
       final String bucketName, final String bucketPath, final String region) {
+    return awsCamunda(bucketName, bucketPath, region, null);
+  }
+
+  private static Camunda awsCamunda(
+      final String bucketName,
+      final String bucketPath,
+      final String region,
+      final String endpoint) {
     final Camunda camunda = new Camunda();
     final AwsStore store = new AwsStore();
     store.setBucketName(bucketName);
     store.setBucketPath(bucketPath);
     store.setRegion(region);
+    store.setEndpoint(endpoint);
     final Map<String, AwsStore> aws = new LinkedHashMap<>();
     aws.put("shared-s3", store);
     camunda.getDocument().setAws(aws);
+    return camunda;
+  }
+
+  private static Camunda gcpCamunda(final String bucketName, final String prefix) {
+    final Camunda camunda = new Camunda();
+    final GcpStore store = new GcpStore();
+    store.setBucketName(bucketName);
+    store.setPrefix(prefix);
+    final Map<String, GcpStore> gcp = new LinkedHashMap<>();
+    gcp.put("shared-gcs", store);
+    camunda.getDocument().setGcp(gcp);
+    return camunda;
+  }
+
+  private static Camunda azureEndpointCamunda(
+      final String endpoint, final String containerName, final String containerPath) {
+    final AzureStore store = new AzureStore();
+    store.setEndpoint(endpoint);
+    return azureCamunda(store, containerName, containerPath);
+  }
+
+  private static Camunda azureConnectionStringCamunda(
+      final String connectionString, final String containerName, final String containerPath) {
+    final AzureStore store = new AzureStore();
+    store.setConnectionString(connectionString);
+    return azureCamunda(store, containerName, containerPath);
+  }
+
+  private static Camunda azureCamunda(
+      final String connectionString,
+      final String endpoint,
+      final String containerName,
+      final String containerPath) {
+    final AzureStore store = new AzureStore();
+    store.setConnectionString(connectionString);
+    store.setEndpoint(endpoint);
+    return azureCamunda(store, containerName, containerPath);
+  }
+
+  private static Camunda azureCamunda(
+      final AzureStore store, final String containerName, final String containerPath) {
+    final Camunda camunda = new Camunda();
+    store.setContainerName(containerName);
+    store.setContainerPath(containerPath);
+    final Map<String, AzureStore> azure = new LinkedHashMap<>();
+    azure.put("shared-blob", store);
+    camunda.getDocument().setAzure(azure);
+    return camunda;
+  }
+
+  private static Camunda localCamunda(final String path) {
+    final Camunda camunda = new Camunda();
+    final LocalStore store = new LocalStore();
+    store.setPath(path);
+    final Map<String, LocalStore> local = new LinkedHashMap<>();
+    local.put("shared-local", store);
+    camunda.getDocument().setLocal(local);
     return camunda;
   }
 
@@ -181,5 +735,39 @@ class DocumentStoreIsolationValidationTest {
       map.put((String) idThenCamunda[i], (Camunda) idThenCamunda[i + 1]);
     }
     return map;
+  }
+
+  /** Captures WARN events of a logger; without a log4j2 config the root level would drop them. */
+  private static final class LogCapturer implements AutoCloseable {
+    private final ListAppender appender = new ListAppender("TestAppender");
+    private final String loggerName;
+
+    private LogCapturer(final String loggerName) {
+      this.loggerName = loggerName;
+      appender.start();
+      Configurator.setLevel(loggerName, Level.WARN);
+      final LoggerContext context = (LoggerContext) LogManager.getContext(false);
+      context
+          .getConfiguration()
+          .getLoggerConfig(loggerName)
+          .addAppender(appender, Level.WARN, null);
+      context.updateLoggers();
+    }
+
+    private List<String> warnings() {
+      // the appender has no layout, so formatted strings live in getEvents(), not getMessages()
+      return appender.getEvents().stream()
+          .map(event -> event.getMessage().getFormattedMessage())
+          .toList();
+    }
+
+    @Override
+    public void close() {
+      final LoggerContext context = (LoggerContext) LogManager.getContext(false);
+      context.getConfiguration().getLoggerConfig(loggerName).removeAppender("TestAppender");
+      context.updateLoggers();
+      appender.stop();
+      appender.clear();
+    }
   }
 }

--- a/document/store/pom.xml
+++ b/document/store/pom.xml
@@ -98,6 +98,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/document/store/src/main/java/io/camunda/document/store/DocumentStorePaths.java
+++ b/document/store/src/main/java/io/camunda/document/store/DocumentStorePaths.java
@@ -24,7 +24,7 @@ public final class DocumentStorePaths {
 
   /**
    * The key prefix an object store prepends to a document id: unset becomes empty, and a non-empty
-   * prefix always ends in {@code /} so a document id cannot extend it past a directory boundary.
+   * prefix always ends in {@code /} so its keys group under one folder instead of beside it.
    */
   public static String keyPrefix(final @Nullable String configuredPath) {
     final String path = Objects.requireNonNullElse(configuredPath, "");

--- a/document/store/src/main/java/io/camunda/document/store/DocumentStorePaths.java
+++ b/document/store/src/main/java/io/camunda/document/store/DocumentStorePaths.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.store;
+
+import java.nio.file.Path;
+import java.util.Objects;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * How configured store locations become the values a store addresses. Every caller derives them
+ * here so that a location can never be computed two ways — configuration validation compares what
+ * the stores will actually use.
+ */
+@NullMarked
+public final class DocumentStorePaths {
+
+  private DocumentStorePaths() {}
+
+  /**
+   * The key prefix an object store prepends to a document id: unset becomes empty, and a non-empty
+   * prefix always ends in {@code /} so a document id cannot extend it past a directory boundary.
+   */
+  public static String keyPrefix(final @Nullable String configuredPath) {
+    final String path = Objects.requireNonNullElse(configuredPath, "");
+    return path.isEmpty() || path.endsWith("/") ? path : path + "/";
+  }
+
+  /** The directory a local store writes into. Trailing separators are not part of the identity. */
+  public static Path storageDirectory(final String configuredPath) {
+    return Path.of(configuredPath);
+  }
+}

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
@@ -10,6 +10,7 @@ package io.camunda.document.store.aws;
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
 import io.camunda.document.api.DocumentStoreProvider;
+import io.camunda.document.store.DocumentStorePaths;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Objects;
@@ -78,7 +79,8 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
   }
 
   private static String getBucketPath(final DocumentStoreConfigurationRecord configuration) {
-    String bucketPath = Objects.requireNonNullElse(configuration.properties().get(BUCKET_PATH), "");
+    final String bucketPath =
+        Objects.requireNonNullElse(configuration.properties().get(BUCKET_PATH), "");
 
     if (INVALID_CHARACTERS.matcher(bucketPath).find()) {
       throw new IllegalArgumentException(
@@ -89,11 +91,7 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
               + " is invalid. Must not contain \\ character'");
     }
 
-    if (!bucketPath.isEmpty() && !bucketPath.endsWith("/")) {
-      bucketPath = bucketPath + "/";
-    }
-
-    return bucketPath;
+    return DocumentStorePaths.keyPrefix(bucketPath);
   }
 
   private static URI getEndpoint(final DocumentStoreConfigurationRecord configuration) {

--- a/document/store/src/main/java/io/camunda/document/store/azure/AzureBlobDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/azure/AzureBlobDocumentStoreProvider.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.document.store.azure;
 
+import com.azure.storage.blob.BlobServiceClientBuilder;
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
 import io.camunda.document.api.DocumentStoreProvider;
@@ -15,6 +16,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.regex.Pattern;
+import org.jspecify.annotations.Nullable;
 
 public class AzureBlobDocumentStoreProvider implements DocumentStoreProvider {
 
@@ -62,6 +64,27 @@ public class AzureBlobDocumentStoreProvider implements DocumentStoreProvider {
       return AzureBlobDocumentStoreFactory.createWithDefaultCredential(
           endpoint, containerName, containerPath, executorService);
     }
+  }
+
+  /**
+   * The blob endpoint a store built from these two properties addresses. A connection string takes
+   * precedence, and {@link #createDocumentStore} never reads the endpoint on that branch, so the
+   * account the SDK derives from the string is the answer — a configured endpoint beside it is dead
+   * configuration. Only the URL is read, so no credential is returned.
+   *
+   * <p>The SDK resolves it because the rules are not obvious enough to restate: a path-style {@code
+   * BlobEndpoint} keeps its path only when the host is an IP address. A connection string the SDK
+   * rejects throws, which callers comparing configuration are expected to handle.
+   */
+  public static String effectiveEndpoint(
+      final @Nullable String connectionString, final @Nullable String endpoint) {
+    if (connectionString == null) {
+      return Objects.requireNonNullElse(endpoint, "");
+    }
+    return new BlobServiceClientBuilder()
+        .connectionString(connectionString)
+        .buildClient()
+        .getAccountUrl();
   }
 
   private static String getContainerPath(final DocumentStoreConfigurationRecord configuration) {

--- a/document/store/src/main/java/io/camunda/document/store/azure/AzureBlobDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/azure/AzureBlobDocumentStoreProvider.java
@@ -10,6 +10,7 @@ package io.camunda.document.store.azure;
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
 import io.camunda.document.api.DocumentStoreProvider;
+import io.camunda.document.store.DocumentStorePaths;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -64,7 +65,7 @@ public class AzureBlobDocumentStoreProvider implements DocumentStoreProvider {
   }
 
   private static String getContainerPath(final DocumentStoreConfigurationRecord configuration) {
-    String containerPath =
+    final String containerPath =
         Objects.requireNonNullElse(configuration.properties().get(CONTAINER_PATH), "");
 
     if (INVALID_CHARACTERS.matcher(containerPath).find()) {
@@ -76,10 +77,6 @@ public class AzureBlobDocumentStoreProvider implements DocumentStoreProvider {
               + " is invalid. Must not contain \\ character'");
     }
 
-    if (!containerPath.isEmpty() && !containerPath.endsWith("/")) {
-      containerPath = containerPath + "/";
-    }
-
-    return containerPath;
+    return DocumentStorePaths.keyPrefix(containerPath);
   }
 }

--- a/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStoreProvider.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
+import org.jspecify.annotations.Nullable;
 
 public class GcpDocumentStoreProvider implements DocumentStoreProvider {
 
@@ -25,6 +26,14 @@ public class GcpDocumentStoreProvider implements DocumentStoreProvider {
   private static final String PREFIX_PROPERTY = "PREFIX";
 
   private static final String DEFAULT_PREFIX = "temp/";
+
+  /**
+   * The prefix this provider prepends to a document id, used verbatim — unlike AWS and Azure it
+   * gains no trailing separator, so {@code "tenant"} and {@code "tenant-b-"} share a key space.
+   */
+  public static String effectivePrefix(final @Nullable String configuredPrefix) {
+    return configuredPrefix == null ? DEFAULT_PREFIX : configuredPrefix;
+  }
 
   @Override
   public DocumentStore createDocumentStore(
@@ -64,7 +73,6 @@ public class GcpDocumentStoreProvider implements DocumentStoreProvider {
   }
 
   private String getPrefixProperty(final DocumentStoreConfigurationRecord configuration) {
-    return Optional.ofNullable(configuration.properties().get(PREFIX_PROPERTY))
-        .orElse(DEFAULT_PREFIX);
+    return effectivePrefix(configuration.properties().get(PREFIX_PROPERTY));
   }
 }

--- a/document/store/src/main/java/io/camunda/document/store/localstorage/LocalStorageDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/localstorage/LocalStorageDocumentStoreProvider.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
 import io.camunda.document.api.DocumentStoreProvider;
+import io.camunda.document.store.DocumentStorePaths;
 import java.nio.file.Path;
 import java.util.concurrent.ExecutorService;
 
@@ -41,7 +42,7 @@ public class LocalStorageDocumentStoreProvider implements DocumentStoreProvider 
     }
 
     try {
-      return Path.of(pathString);
+      return DocumentStorePaths.storageDirectory(pathString);
     } catch (final Exception e) {
       throw new IllegalArgumentException(
           "Failed to configure document store with id '"

--- a/document/store/src/test/java/io/camunda/document/store/azure/AzureBlobDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/azure/AzureBlobDocumentStoreProviderTest.java
@@ -189,4 +189,67 @@ class AzureBlobDocumentStoreProviderTest {
                   eq(connectionString), eq(containerName), eq("documents/"), any()));
     }
   }
+
+  @Test
+  void shouldResolveTheEffectiveEndpointFromAConnectionString() {
+    // given
+    final String connectionString = connectionString("acct");
+
+    // when
+    final String endpoint =
+        AzureBlobDocumentStoreProvider.effectiveEndpoint(connectionString, null);
+
+    // then
+    assertThat(endpoint).startsWith("https://").contains("acct.blob.core.windows.net");
+  }
+
+  @Test
+  void shouldPreferTheConnectionStringOverAConfiguredEndpoint() {
+    // given createDocumentStore takes the connection-string branch whenever one is set and never
+    // reads the endpoint, so a configured endpoint beside it is dead configuration
+    final String connectionString = connectionString("accta");
+
+    // when
+    final String endpoint =
+        AzureBlobDocumentStoreProvider.effectiveEndpoint(
+            connectionString, "https://acctb.blob.core.windows.net");
+
+    // then
+    assertThat(endpoint).contains("accta").doesNotContain("acctb");
+  }
+
+  @Test
+  void shouldUseTheConfiguredEndpointWhenNoConnectionStringIsSet() {
+    // given / when
+    final String endpoint =
+        AzureBlobDocumentStoreProvider.effectiveEndpoint(
+            null, "https://acct.blob.core.windows.net");
+
+    // then
+    assertThat(endpoint).isEqualTo("https://acct.blob.core.windows.net");
+  }
+
+  @Test
+  void shouldResolveNoEffectiveEndpointWhenNeitherIsSet() {
+    // given createDocumentStore rejects that configuration, so there is no endpoint to name
+    // when / then
+    assertThat(AzureBlobDocumentStoreProvider.effectiveEndpoint(null, null)).isEmpty();
+  }
+
+  @Test
+  void shouldThrowWhenTheConnectionStringNamesNoAccount() {
+    // given callers comparing configuration rely on this being a RuntimeException they can catch,
+    // rather than a silently empty endpoint that would hide a shared location
+    final String connectionString = "AccountKey=a2V5;EndpointSuffix=core.windows.net";
+
+    // when / then
+    assertThatExceptionOfType(RuntimeException.class)
+        .isThrownBy(() -> AzureBlobDocumentStoreProvider.effectiveEndpoint(connectionString, null));
+  }
+
+  private static String connectionString(final String accountName) {
+    return "DefaultEndpointsProtocol=https;AccountName="
+        + accountName
+        + ";AccountKey=a2V5;EndpointSuffix=core.windows.net";
+  }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/AbstractDocumentIsolationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/AbstractDocumentIsolationIT.java
@@ -32,17 +32,20 @@ import org.junit.jupiter.api.Test;
  * <ul>
  *   <li><b>Local</b>: 4 separate directories, one per store — trivially isolated.
  *   <li><b>GCP</b>: 1 shared bucket for all 4 stores; isolation via prefix ({@code tenanta/},
- *       {@code tenantb/}, {@code tenantc/}, {@code ""} for default).
- *   <li><b>AWS</b>: 2 buckets — {@code bucket-a} holds store-a (no prefix) + store-c (prefix {@code
- *       tenantc/}); {@code bucket-b} holds store-b (no prefix) + store-default (prefix {@code
+ *       {@code tenantb/}, {@code tenantc/}, {@code default/}).
+ *   <li><b>AWS</b>: 2 buckets — {@code bucket-a} holds store-a ({@code tenanta/}) + store-c ({@code
+ *       tenantc/}); {@code bucket-b} holds store-b ({@code tenantb/}) + store-default ({@code
  *       default/}).
- *   <li><b>Azure</b>: 2 containers — {@code container-a} holds store-a (no prefix) + store-c
- *       (prefix {@code tenantc/}); {@code container-b} holds store-b (no prefix) + store-default
- *       (prefix {@code default/}).
+ *   <li><b>Azure</b>: 2 containers — {@code container-a} holds store-a ({@code tenanta/}) + store-c
+ *       ({@code tenantc/}); {@code container-b} holds store-b ({@code tenantb/}) + store-default
+ *       ({@code default/}).
  * </ul>
  *
  * <p>AWS and Azure are the hardest cases: tenanta and tenantc share the same bucket/container, so
- * isolation is purely prefix-level.
+ * isolation is purely prefix-level. Every prefix is a sibling folder — no store sits at a bucket or
+ * container root, because a root encloses every prefix inside it and {@code
+ * DocumentStoreIsolationValidation} rejects that at startup: {@code /} in a caller-supplied
+ * document id is an ordinary character, so nesting is reachable rather than isolated.
  */
 abstract class AbstractDocumentIsolationIT {
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAwsIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAwsIT.java
@@ -68,10 +68,14 @@ final class DocumentIsolationAwsIT extends AbstractDocumentIsolationIT {
         .withProperty("camunda.document.default-store-id", STORE_DEFAULT)
         .withProperty("camunda.physical-tenants.tenanta.document.aws.store-a.bucket-name", BUCKET_A)
         .withProperty(
+            "camunda.physical-tenants.tenanta.document.aws.store-a.bucket-path", "tenanta/")
+        .withProperty(
             "camunda.physical-tenants.tenanta.document.aws.store-a.region", MINIO.region())
         .withProperty("camunda.physical-tenants.tenanta.document.default-store-id", STORE_A)
         .withProperty("camunda.physical-tenants.tenanta.document.assigned[0]", STORE_A)
         .withProperty("camunda.physical-tenants.tenantb.document.aws.store-b.bucket-name", BUCKET_B)
+        .withProperty(
+            "camunda.physical-tenants.tenantb.document.aws.store-b.bucket-path", "tenantb/")
         .withProperty(
             "camunda.physical-tenants.tenantb.document.aws.store-b.region", MINIO.region())
         .withProperty("camunda.physical-tenants.tenantb.document.default-store-id", STORE_B)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAzureIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAzureIT.java
@@ -50,12 +50,16 @@ final class DocumentIsolationAzureIT extends AbstractDocumentIsolationIT {
         .withProperty(
             "camunda.physical-tenants.tenanta.document.azure.store-a.container-name", CONTAINER_A)
         .withProperty(
+            "camunda.physical-tenants.tenanta.document.azure.store-a.container-path", "tenanta/")
+        .withProperty(
             "camunda.physical-tenants.tenanta.document.azure.store-a.connection-string",
             AZURITE.externalConnectionString())
         .withProperty("camunda.physical-tenants.tenanta.document.default-store-id", STORE_A)
         .withProperty("camunda.physical-tenants.tenanta.document.assigned[0]", STORE_A)
         .withProperty(
             "camunda.physical-tenants.tenantb.document.azure.store-b.container-name", CONTAINER_B)
+        .withProperty(
+            "camunda.physical-tenants.tenantb.document.azure.store-b.container-path", "tenantb/")
         .withProperty(
             "camunda.physical-tenants.tenantb.document.azure.store-b.connection-string",
             AZURITE.externalConnectionString())

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationGcpIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationGcpIT.java
@@ -60,7 +60,7 @@ final class DocumentIsolationGcpIT extends AbstractDocumentIsolationIT {
 
     BROKER
         .withProperty("camunda.document.gcp.store-default.bucket-name", SHARED_BUCKET)
-        .withProperty("camunda.document.gcp.store-default.prefix", "")
+        .withProperty("camunda.document.gcp.store-default.prefix", "default/")
         .withProperty("camunda.document.default-store-id", STORE_DEFAULT)
         .withProperty(
             "camunda.physical-tenants.tenanta.document.gcp.store-a.bucket-name", SHARED_BUCKET)


### PR DESCRIPTION
# Document store isolation — behaviour before and after

`DocumentStoreIsolationValidation` rejects physical tenants that would read and write into the same document storage. This compares its behaviour before and after the change, per provider.

## What changed, in one line

Before, a location was the **configured** values, lowercased and stripped of trailing slashes, compared for **equality**. After, it is what the store **resolves to at startup**, split into a
`namespace` that must match exactly and a `keyPrefix` that may not enclose or be enclosed by another tenant's — unconditionally, with no exception for an enclosing prefix that ends at a separator.

```
before:  (provider, [coordinates…])              collide if coordinates are equal
after:   (provider, [namespace…], keyPrefix)     collide if namespace equal AND
                                                   one keyPrefix is a prefix of the other
```

Containment matters, without qualification, because a document id is caller-supplied and appended to the prefix as given: `tenant` + `-b-invoice` and `tenant-b-` + `invoice` are the same object, and
`docs/` + `archive/invoice` and `docs/archive/` + `invoice` are too. A `/` is an ordinary character to every object storage service — it draws no boundary a backend enforces — so an enclosing prefix that
happens to end at a separator is no safer than one that doesn't. Any nesting is rejected at startup; there is no layout where one tenant may own a bucket or container root while another owns a folder
inside it. `DocumentIsolationAzureIT`, `DocumentIsolationAwsIT` and `DocumentIsolationGcpIT` were updated to give every tenant sharing a bucket or container its own sibling prefix instead.

### Legend

| symbol | meaning |
|---|---|
| ✗ | rejected at startup |
| ✓ | accepted, cluster boots |
| **FN fixed** | previously accepted although the tenants really shared storage — a silent cross-tenant leak, now caught |
| **FP fixed** | previously rejected although the tenants were isolated — a valid configuration, now accepted |
| — | behaviour unchanged |

---

## AWS S3

**Namespace:** bucket + endpoint. **Key prefix:** `bucket-path`, coerced to end in `/`, case preserved. **Excluded:** `region`, `bucket-ttl`, `force-path-style`, `chunked-encoding-enabled`, `support-legacy-md5`.

| tenant A | tenant B | before | after | change |
|---|---|---|---|---|
| `bucket-path: shared/path` | same | ✗ | ✗ | — |
| `bucket-path: shared` | `bucket-path: shared/` | ✗ — both normalise to `shared` | ✗ — provider coerces both to `shared/` | — |
| `bucket-path:` unset | `bucket-path: ""` | ✗ — both `""` | ✗ — both `""` | — |
| `bucket-path: tenant-a/docs` | `bucket-path: tenant-b/docs` | ✓ | ✓ | — |
| `region: us-east-1` | `region: eu-west-1`, rest identical | ✗ — region not compared | ✗ | — |
| `force-path-style: true` | `false`, rest identical | ✗ | ✗ — URL form only; bucket and key passed explicitly | — |
| `bucket-path: tenant` | `bucket-path: tenant-b-` | ✓ | ✓ — coerced to `tenant/` and `tenant-b-/`, neither a prefix of the other | — |
| `bucket-path:` unset | `bucket-path: tenant-b` | ✓ | ✗ — the root prefix `""` is a prefix of every other key | **FN fixed** |
| `bucket-path: tenant-a` | `bucket-path: tenant-a/nested` | ✓ | ✗ — `tenant-a/` is a prefix of `tenant-a/nested/` | **FN fixed** |
| `endpoint: https://minio-a` | `https://minio-b`, same bucket + path | ✓ | ✓ — different namespace | — |
| `endpoint: https://MINIO/` | `https://minio` | ✗ | ✗ — host lowercased, trailing slash stripped | — |
| `bucket-path: Tenant-A/` | `bucket-path: tenant-a/` | ✗ — both lowercased | ✓ — S3 keys are case-sensitive | **FP fixed** |

---

## GCP Cloud Storage

**Namespace:** bucket. **Key prefix:** `prefix` verbatim, defaulting to `temp/` when unset — `GcpDocumentStore` inserts **no separator**, so a prefix is not necessarily a directory.

| tenant A | tenant B | before | after | change |
|---|---|---|---|---|
| `prefix: docs/` | `prefix: docs/` | ✗ | ✗ | — |
| `prefix: a/` | `prefix: b/` | ✓ | ✓ | — |
| `bucket-name: bucket-a` | `bucket-name: bucket-b`, same prefix | ✓ | ✓ | — |
| `prefix: docs/` | `prefix: docs/archive/` | ✓ | ✗ — `docs/` is a prefix of `docs/archive/` | **FN fixed** |
| `prefix: temp` | `prefix: temp/` | ✗ | ✗ — `temp` is a prefix of `temp/` | — |
| `prefix:` unset | `prefix: temp/` | ✓ — `""` vs `temp` | ✗ — the provider substitutes `temp/`, so both write `temp/<id>` | **FN fixed** |
| `prefix:` unset | `prefix: temp` | ✓ | ✗ — resolves to `temp/`, which `temp` is a prefix of | **FN fixed** |
| `prefix: tenant` | `prefix: tenant-b-` | ✓ | ✗ — `tenant` is a prefix of `tenant-b-` | **FN fixed** |
| `prefix: ""` | `prefix: tenant-b-` | ✓ — `""` vs `tenant-b-` | ✗ — the bucket root is a prefix of every object name in it | **FN fixed** |
| `prefix: TenantA/` | `prefix: tenanta/` | ✗ — both lowercased | ✓ — GCS object names are case-sensitive | **FP fixed** |

The unset-prefix rows are why the default now comes from `GcpDocumentStoreProvider.effectivePrefix`
rather than being restated.

---

## Azure Blob Storage

**Namespace:** container + the blob endpoint the store resolves to. **Key prefix:** `container-path`, coerced to end in `/`, case preserved.

Before, `connection-string` was excluded from the identity because it carries a credential, so every connection-string store collapsed to an empty endpoint. After, the endpoint is resolved through the
same SDK call the store makes, and reduced to scheme, host, port and path — a query, fragment or user info is dropped, since a SAS token is a credential rather than a location.

| tenant A | tenant B | before | after | change |
|---|---|---|---|---|
| `connection-string` for `acct` | same, same container + path | ✗ | ✗ | — |
| `container-name: docs-a` | `docs-b`, same path + account | ✓ | ✓ | — |
| `container-path: a` | `container-path: a/nested` | ✓ | ✗ — `a/` is a prefix of `a/nested/` | **FN fixed** |
| container root | `container-path: tenantc/`, same container | ✓ — the layout `DocumentIsolationAzureIT` used to assert isolation for | ✗ — the root prefix `""` is a prefix of every other key; the IT was updated to give both tenants a sibling prefix instead | **FN fixed** |
| `BlobEndpoint=https://cdn.example.com/accta` | `…/acctb` | ✗ — both endpoints `""` | ✗ — the SDK reads the path as a container and the store overrides it, so both address `cdn.example.com/docs/…` | — (before: right outcome, wrong reason) |
| `connection-string` for `accta` | `connection-string` for `acctb`, same container + path | ✗ — both endpoints `""`, so two accounts looked identical | ✓ — different resolved endpoints | **FP fixed** |
| `container-path: Tenant-A/` | `container-path: tenant-a/` | ✗ — both lowercased | ✓ — blob names are case-sensitive | **FP fixed** |
| `connection-string` for `acct` | `endpoint: https://acct.blob.core.windows.net` | ✓ — `""` vs the URL | ✗ — one account reached two ways | **FN fixed** |
| `connection-string` for `acct` | `endpoint: https://ACCT.blob.core.windows.net/` | ✓ | ✗ — same, after host lowercasing and slash stripping | **FN fixed** |
| `UseDevelopmentStorage=true` | `endpoint: http://127.0.0.1:10000/devstoreaccount1` | ✓ | ✗ — emulator shorthand resolves to that endpoint | **FN fixed** |
| `endpoint: …?sv=…&sig=A` | `endpoint: …?sv=…&sig=B`, same account | ✓ — tokens compared as part of the location | ✗ — a SAS is a credential; it is also no longer printed in the error | **FN fixed** |

---

## Local filesystem

**Namespace:** the configured directory through `Path.of`, case-folded. **Key prefix:** always empty, so only the directory decides. Unaffected by the containment simplification, since two distinct directories never share a namespace in the first place.

| tenant A | tenant B | before | after | change |
|---|---|---|---|---|
| `path: /var/docs` | `path: /var/docs` | ✗ | ✗ | — |
| `path: /var/docs` | `path: /var/docs/` | ✗ | ✗ — same directory | — |
| `path: /var/docs` | `path: /var/other` | ✓ | ✓ | — |
| `path: /var/docs` | `path: /var/docs/tenant-b` | ✓ | ✓ — different directories; `LocalStorageDocumentStore` rejects `/`, `\` and `..` in a document id, so the parent cannot descend into the child even though nesting is otherwise rejected for the object stores | — |
| `path: /var/Docs` | `path: /var/docs` | ✗ | ✗ — folded regardless of platform, since a case-insensitive filesystem makes these one directory | — |
| `path: \var\docs` | `path: /var/docs` | ✓ — separators compared as written | ✗ on Windows, ✓ on Linux — `Path.of` gives the platform's answer | **FN fixed** (Windows) |

---

## Other known limitations

- **Aliases are not resolved.** Two endpoint URLs or DNS names fronting the same backend are treated
  as separate locations.
- **Legacy `DOCUMENT_*` environment configuration is not compared.** Stores declared only through
  legacy environment variables, and properties that fall back to them, are resolved after this check
  runs and so are invisible to it.
- **Local paths are case-folded regardless of platform**, so on a case-sensitive filesystem two
  directories differing only in case are reported as a collision.
- **The document id charset is unrestricted at the storage layer.** Nothing rejects a document id for
  its characters; only the configuration that would let one matter is rejected, at startup.
- **Nested local directories are not compared.** `path: /var/docs` and `path: /var/docs/tenant-b` are
  two namespaces with empty prefixes, so containment never applies to them. Harmless in practice:
  `LocalStorageDocumentStore` rejects `/`, `\` and `..` in a document id, so the parent cannot descend
  into the child.

---

Closes #56448