### PR TITLE
refactor: resolve secrets through the store alone instead of pairing it with a cache

### DIFF
--- a/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
@@ -16,11 +16,20 @@ import static org.mockito.Mockito.verify;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
-import io.camunda.secretstore.NoopSecretStore;
+import io.camunda.secretstore.CachingSecretStore;
+import io.camunda.secretstore.SecretErrorCode;
+import io.camunda.secretstore.SecretResolutionResult.Failed;
+import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import io.camunda.secretstore.SecretStore;
 import io.camunda.secretstore.aws.AwsSecretsManagerSecretStore;
 import io.camunda.secretstore.file.FileBasedSecretStore;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.core.env.MapPropertySource;
@@ -42,22 +51,28 @@ class SecretStoreConfigurationTest {
     assertThat(registries).containsKey(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
     final var registry = registries.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
     assertThat(registry.getStores()).containsKey("default");
-    assertThat(registry.getStores().get("default")).isInstanceOf(NoopSecretStore.class);
+    assertThatIsNoopStore(registry.getStores().get("default"));
   }
 
   @Test
-  void shouldBuildFileBasedStoreWhenFileStoreConfigured() {
-    // given
+  void shouldBuildFileBasedStoreWhenFileStoreConfigured(@TempDir final Path secretsDir)
+      throws IOException {
+    // given a directory holding one secret, so the store built for it can be told apart by what it
+    // reads rather than by its type: the registry hands out a store that caches, not the store the
+    // configuration constructed
+    Files.writeString(secretsDir.resolve("token"), "token-value");
     final var resolver =
-        resolverFor(Map.of("camunda.secrets.stores.file.main.path", "/etc/camunda/secrets"));
+        resolverFor(Map.of("camunda.secrets.stores.file.main.path", secretsDir.toString()));
 
     // when
     final var registries = CONFIG.secretStoreRegistries(resolver).byPhysicalTenant();
 
-    // then
+    // then the configured directory is what the store reads
     final var registry = registries.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
     assertThat(registry.getStores()).containsKey("main");
-    assertThat(registry.getStores().get("main")).isInstanceOf(FileBasedSecretStore.class);
+    final var store = registry.getStores().get("main");
+    assertThat(store.list()).containsExactly("token");
+    assertThat(store.resolve(Set.of("token"))).containsEntry("token", new Resolved("token-value"));
   }
 
   @Test
@@ -135,7 +150,7 @@ class SecretStoreConfigurationTest {
     assertThat(registries).containsKey("mytenant");
     final var registry = registries.get("mytenant");
     assertThat(registry.getStores()).containsKey("default");
-    assertThat(registry.getStores().get("default")).isInstanceOf(NoopSecretStore.class);
+    assertThatIsNoopStore(registry.getStores().get("default"));
   }
 
   @Test
@@ -171,8 +186,10 @@ class SecretStoreConfigurationTest {
     // given — AwsSecretsManagerSecretStore.fromConfig() only probes connectivity/credentials
     // best-effort, logging a warning rather than failing, so wiring an aws-secrets-manager store
     // outside a real AWS/LocalStack environment still constructs successfully; the connectivity
-    // error would only surface on first use. Real resolution against credentials is covered at the
-    // integration level by AwsSecretsManagerSecretStoreIT, which runs against LocalStack.
+    // error would only surface on first use. That is also why this asserts which store was wrapped
+    // rather than what it reads, as every read here would go to AWS. Real resolution against
+    // credentials is covered at the integration level by AwsSecretsManagerSecretStoreIT, which runs
+    // against LocalStack.
     final var resolver =
         resolverFor(
             Map.of(
@@ -182,11 +199,13 @@ class SecretStoreConfigurationTest {
     // when
     final var registries = CONFIG.secretStoreRegistries(resolver).byPhysicalTenant();
 
-    // then
+    // then the aws branch is what built the store, not the noop fallback or another store type
     final var registry = registries.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
     assertThat(registry.getStores()).containsKey("aws-main");
     assertThat(registry.getStores().get("aws-main"))
-        .isInstanceOf(AwsSecretsManagerSecretStore.class);
+        .isInstanceOfSatisfying(
+            CachingSecretStore.class,
+            store -> assertThat(store.wraps(AwsSecretsManagerSecretStore.class)).isTrue());
   }
 
   @Test
@@ -261,6 +280,17 @@ class SecretStoreConfigurationTest {
       // not leak
       verify(construction.constructed().get(0)).close();
     }
+  }
+
+  /**
+   * Asserts the store is the noop fallback by what it answers: it holds nothing and reports every
+   * name as missing with the fallback's own message.
+   */
+  private static void assertThatIsNoopStore(final SecretStore store) {
+    assertThat(store.list()).isEmpty();
+    assertThat(store.resolve(Set.of("token")))
+        .containsEntry(
+            "token", new Failed(SecretErrorCode.NOT_FOUND, "No secret store configured", null));
   }
 
   private static PhysicalTenantResolver resolverFor(final Map<String, Object> properties) {

--- a/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
@@ -16,7 +16,6 @@ import static org.mockito.Mockito.verify;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
-import io.camunda.secretstore.CachingSecretStore;
 import io.camunda.secretstore.SecretErrorCode;
 import io.camunda.secretstore.SecretResolutionResult.Failed;
 import io.camunda.secretstore.SecretResolutionResult.Resolved;
@@ -186,7 +185,7 @@ class SecretStoreConfigurationTest {
     // given — AwsSecretsManagerSecretStore.fromConfig() only probes connectivity/credentials
     // best-effort, logging a warning rather than failing, so wiring an aws-secrets-manager store
     // outside a real AWS/LocalStack environment still constructs successfully; the connectivity
-    // error would only surface on first use. That is also why this asserts which store was wrapped
+    // error would only surface on first use. That is also why this asserts which store answers
     // rather than what it reads, as every read here would go to AWS. Real resolution against
     // credentials is covered at the integration level by AwsSecretsManagerSecretStoreIT, which runs
     // against LocalStack.
@@ -202,10 +201,8 @@ class SecretStoreConfigurationTest {
     // then the aws branch is what built the store, not the noop fallback or another store type
     final var registry = registries.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
     assertThat(registry.getStores()).containsKey("aws-main");
-    assertThat(registry.getStores().get("aws-main"))
-        .isInstanceOfSatisfying(
-            CachingSecretStore.class,
-            store -> assertThat(store.wraps(AwsSecretsManagerSecretStore.class)).isTrue());
+    assertThat(registry.getStores().get("aws-main").is(AwsSecretsManagerSecretStore.class))
+        .isTrue();
   }
 
   @Test

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/CachingSecretStore.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/CachingSecretStore.java
@@ -11,22 +11,28 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * A {@link SecretStore} that serves what its {@link SecretCache} holds and caches what the store
- * answers, so a caller resolves secrets through a single call instead of driving store and cache
- * itself.
+ * Makes any {@link SecretStore} a {@link LocallyCachedSecretStore} by putting a {@link SecretCache}
+ * in front of it, so a caller resolves secrets through a single call instead of driving store and
+ * cache itself. The cache is this store's own: no caller is handed one alongside it, and nothing
+ * reaches the wrapped store except through here.
  *
  * <p>Only a resolved value is cached: a failure has to stay retryable, or a secret that was briefly
  * unreadable would stay unresolvable until the process restarts. {@link #list()} goes straight to
  * the store, since a cache holds the values read so far rather than the store's set of secrets.
  *
- * <p>Does not close the store it wraps: whoever configured that store owns its lifecycle.
+ * <p>What the cache holds is also what {@link #lookupLocal} answers with, so a value read by one
+ * caller is what a later cache-only lookup of another sees.
+ *
+ * <p>Does not close the store it wraps, and closing this releases nothing: the wrapped store's
+ * lifecycle belongs to whoever configured it.
  */
 @NullMarked
-public final class CachingSecretStore implements SecretStore {
+public final class CachingSecretStore implements LocallyCachedSecretStore {
 
   private final SecretStore store;
   private final SecretCache cache;
@@ -58,8 +64,43 @@ public final class CachingSecretStore implements SecretStore {
       return results;
     }
 
+    results.putAll(resolveAndCache(misses));
+    return results;
+  }
+
+  @Override
+  public Map<String, SecretResolutionResult> resolveFromStore(final Set<String> names) {
+    return resolveAndCache(names);
+  }
+
+  /** Serves what the cache holds, never reading the wrapped store. */
+  @Override
+  public Optional<String> lookupLocal(final String name) {
+    return cache.get(name);
+  }
+
+  @Override
+  public List<String> list() {
+    return store.list();
+  }
+
+  /**
+   * Whether the store this caches for is of the given type. Visible for testing only: it lets a
+   * configuration test tell the store that was built apart without reading it, which for a cloud
+   * store would mean a call to the cloud provider.
+   *
+   * <p>Deliberately a predicate rather than an accessor for the store: handing the store out is the
+   * uncached read path this wrapper exists to close.
+   */
+  public boolean wraps(final Class<? extends SecretStore> storeType) {
+    return storeType.isInstance(store);
+  }
+
+  /** Asks the store for the given names and caches every value it answers with. */
+  private Map<String, SecretResolutionResult> resolveAndCache(final Set<String> names) {
+    final Map<String, SecretResolutionResult> results = new LinkedHashMap<>();
     store
-        .resolve(misses)
+        .resolve(names)
         .forEach(
             (name, result) -> {
               if (result instanceof final SecretResolutionResult.Resolved resolved) {
@@ -68,10 +109,5 @@ public final class CachingSecretStore implements SecretStore {
               results.put(name, result);
             });
     return results;
-  }
-
-  @Override
-  public List<String> list() {
-    return store.list();
   }
 }

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/CachingSecretStore.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/CachingSecretStore.java
@@ -85,15 +85,15 @@ public final class CachingSecretStore implements LocallyCachedSecretStore {
   }
 
   /**
-   * Whether the store this caches for is of the given type. Visible for testing only: it lets a
-   * configuration test tell the store that was built apart without reading it, which for a cloud
-   * store would mean a call to the cloud provider.
+   * Answers for the store this caches for rather than for this wrapper, so a caller asking which
+   * store was configured gets the same answer whether or not the store had to be wrapped.
    *
-   * <p>Deliberately a predicate rather than an accessor for the store: handing the store out is the
-   * uncached read path this wrapper exists to close.
+   * <p>Delegates rather than testing the wrapped store itself, so the answer still reaches the
+   * innermost store if one wrapper ever sits behind another.
    */
-  public boolean wraps(final Class<? extends SecretStore> storeType) {
-    return storeType.isInstance(store);
+  @Override
+  public boolean is(final Class<? extends SecretStore> storeType) {
+    return store.is(storeType);
   }
 
   /** Asks the store for the given names and caches every value it answers with. */

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/LocallyCachedSecretStore.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/LocallyCachedSecretStore.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A {@link SecretStore} that holds the values it resolved, so {@link #resolve} is cache-first and
+ * the two reads below are possible at all. This is what {@link SecretStoreRegistry} hands out: a
+ * store implementing this natively (an SDK with its own client-side cache) satisfies the contract
+ * without sitting behind a second cache, and any other store is wrapped in a {@link
+ * CachingSecretStore} to satisfy it.
+ *
+ * <p>The two reads exist for the two callers a plain {@link #resolve} does not serve: the engine
+ * needs a lookup that cannot block, and the background resolution needs a read that does not trust
+ * what is held.
+ */
+@NullMarked
+public interface LocallyCachedSecretStore extends SecretStore {
+
+  /**
+   * Returns the value this store already holds for the secret name, without reading the backing
+   * store.
+   *
+   * <p>This is what the engine needs on the job activation path: it runs on the stream processor
+   * thread, where blocking on a file read or an AWS Secrets Manager call would stall processing. A
+   * job whose secret is not held locally is parked and its reference resolved in the background
+   * instead, so a lookup that answers "not held locally" costs the job a wait, not a failure.
+   *
+   * <p>Implementations must neither read the backing store nor block: whatever this answers has to
+   * be answerable from memory. An empty result means "not held locally", not "no such secret" — the
+   * store may well hold it.
+   *
+   * <p>Implementations must not fail either, since a failure here fails the whole activation
+   * command. A failure is nevertheless propagated rather than swallowed: a lookup that cannot
+   * answer is broken, and reporting it as a miss would park every job behind it forever.
+   *
+   * @return the locally held value, or empty if the secret name is not held locally
+   */
+  Optional<String> lookupLocal(String name);
+
+  /**
+   * Resolves the given names against the backing store even where a value for them is already held,
+   * holding on to what the store answers with just as {@link #resolve} does.
+   *
+   * <p>For the caller whose outcome outlives the value: the background resolution writes a durable,
+   * exported record stating that a secret resolved, which an exporter and a later activation both
+   * act on, so it has to ask the store rather than trust a value held since before the secret may
+   * have been deleted. Every other caller wants {@link #resolve}, which is cache-first.
+   */
+  Map<String, SecretResolutionResult> resolveFromStore(Set<String> names);
+}

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStore.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStore.java
@@ -40,6 +40,19 @@ public interface SecretStore extends AutoCloseable {
    */
   List<String> list();
 
+  /**
+   * Whether this is a store of the given type, seeing through any wrapper: a store wrapped for
+   * caching answers for the store it wraps rather than for the wrapper. That lets a caller tell
+   * which store was configured without reading it, which for a cloud store would mean a call to the
+   * provider.
+   *
+   * <p>Visible for testing: only a configuration test needs to tell a store apart by type, since
+   * every other caller resolves through {@link #resolve} regardless of which store answers.
+   */
+  default boolean is(final Class<? extends SecretStore> storeType) {
+    return storeType.isInstance(this);
+  }
+
   @Override
   default void close() {}
 }

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStoreRegistry.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStoreRegistry.java
@@ -12,77 +12,82 @@ import static java.util.Objects.requireNonNull;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Provides the configured {@link SecretStore}s for the current physical tenant, keyed by store ID,
- * along with the {@link SecretCache} in front of each of them.
+ * Provides the configured {@link SecretStore}s for the current physical tenant, keyed by store ID.
  *
- * <p>Every configured store has a cache: a caller may look one up by store ID without handling a
- * missing entry.
+ * <p>A store is the only thing handed out, and always as a {@link LocallyCachedSecretStore}: it
+ * holds what it resolves itself, so a caller resolves secrets through {@link SecretStore#resolve}
+ * alone and cannot read past the cache by accident. A store that does not cache natively is wrapped
+ * in a {@link CachingSecretStore} to make it one. Each store holds its own values, so entries of
+ * different stores never collide.
  */
 @NullMarked
 public final class SecretStoreRegistry {
 
-  private final Map<String, SecretStore> stores;
-  private final Map<String, SecretCache> caches;
-  private final Map<String, SecretStore> cachingStores;
+  private final Map<String, LocallyCachedSecretStore> stores;
 
   public SecretStoreRegistry(final Map<String, SecretStore> stores) {
     this(stores, Map.of());
   }
 
   /**
-   * Creates a registry with the given caches instead of the default in-memory one. A store the
-   * caches do not cover still gets an in-memory cache, so the one-cache-per-store invariant holds
-   * whichever constructor is used. Primarily for tests that need custom cache behavior.
+   * Creates a registry whose stores cache in the given caches instead of the default in-memory one.
+   * This is the seam for a cache implementation other than {@link InMemorySecretCache} — a TTL and
+   * eviction variant, or a test double. A store the caches do not cover still gets an in-memory
+   * cache, and a store that caches natively is left as it is, so every store handed out holds what
+   * it resolved whichever constructor is used.
    */
   public SecretStoreRegistry(
       final Map<String, SecretStore> stores, final Map<String, SecretCache> caches) {
-    this.stores = stores;
-    this.caches = withACachePerStore(stores, caches);
-    cachingStores = cachingStores(stores, this.caches);
-  }
-
-  /** Returns all configured secret stores, keyed by store ID. */
-  public Map<String, SecretStore> getStores() {
-    return stores;
-  }
-
-  /** Returns one cache per configured store, keyed by store ID. */
-  public Map<String, SecretCache> getCaches() {
-    return caches;
+    this.stores = locallyCachedStores(stores, caches);
   }
 
   /**
-   * Returns each configured store wrapped so that resolving goes through the store's cache, keyed
-   * by store ID. This is what a caller that only wants to resolve secrets uses, rather than pairing
-   * a store with its cache itself; {@link #getStores()} and {@link #getCaches()} stay for the
-   * callers that drive the two apart, such as the engine writing a value into the cache without
-   * revealing it.
+   * Returns all configured secret stores, keyed by store ID.
+   *
+   * <p>A lookup in this map is exact: an empty store ID addresses no store, even when a single
+   * store is configured. Only {@link #findStoreForReference} applies the sole-store rule below.
    */
-  public Map<String, SecretStore> getCachingStores() {
-    return cachingStores;
+  public Map<String, LocallyCachedSecretStore> getStores() {
+    return stores;
   }
 
-  private static Map<String, SecretStore> cachingStores(
+  /**
+   * Returns the store the secret reference addresses, or empty when it addresses none.
+   *
+   * <p>The {@code camunda.secrets.<name>} syntax carries no store dimension yet, so an empty store
+   * ID addresses the sole configured store; with several stores an empty store ID is ambiguous and
+   * addresses none.
+   */
+  public Optional<LocallyCachedSecretStore> findStoreForReference(final String storeId) {
+    if (!storeId.isEmpty()) {
+      return Optional.ofNullable(stores.get(storeId));
+    }
+    return stores.size() == 1 ? Optional.of(stores.values().iterator().next()) : Optional.empty();
+  }
+
+  private static Map<String, LocallyCachedSecretStore> locallyCachedStores(
       final Map<String, SecretStore> stores, final Map<String, SecretCache> caches) {
-    final Map<String, SecretStore> caching = new LinkedHashMap<>();
+    final Map<String, LocallyCachedSecretStore> locallyCached = new LinkedHashMap<>();
     stores.forEach(
-        (storeId, store) ->
-            // non-null by the one-cache-per-store invariant withACachePerStore establishes
-            caching.put(
-                storeId, new CachingSecretStore(store, requireNonNull(caches.get(storeId)))));
-    return Collections.unmodifiableMap(caching);
+        (storeId, store) -> locallyCached.put(storeId, locallyCached(storeId, store, caches)));
+    return Collections.unmodifiableMap(locallyCached);
   }
 
-  private static Map<String, SecretCache> withACachePerStore(
-      final Map<String, SecretStore> stores, final Map<String, SecretCache> caches) {
-    final Map<String, SecretCache> perStore = new LinkedHashMap<>(caches);
-    stores
-        .keySet()
-        .forEach(
-            storeId -> perStore.computeIfAbsent(storeId, ignored -> new InMemorySecretCache()));
-    return Collections.unmodifiableMap(perStore);
+  /**
+   * Returns the store itself when it caches natively — wrapping it would put a second cache in
+   * front of its own — and otherwise the store behind the cache configured for it, or a fresh
+   * in-memory one when the configured caches do not cover it.
+   */
+  private static LocallyCachedSecretStore locallyCached(
+      final String storeId, final SecretStore store, final Map<String, SecretCache> caches) {
+    if (store instanceof final LocallyCachedSecretStore locallyCached) {
+      return locallyCached;
+    }
+    final var cache = requireNonNull(caches.getOrDefault(storeId, new InMemorySecretCache()));
+    return new CachingSecretStore(store, cache);
   }
 }

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStoreRegistry.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStoreRegistry.java
@@ -7,10 +7,11 @@
  */
 package io.camunda.secretstore;
 
-import static java.util.Objects.requireNonNull;
-
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.jspecify.annotations.NullMarked;
@@ -37,11 +38,19 @@ public final class SecretStoreRegistry {
    * Creates a registry whose stores cache in the given caches instead of the default in-memory one.
    * This is the seam for a cache implementation other than {@link InMemorySecretCache} — a TTL and
    * eviction variant, or a test double. A store the caches do not cover still gets an in-memory
-   * cache, and a store that caches natively is left as it is, so every store handed out holds what
-   * it resolved whichever constructor is used.
+   * cache, so every store handed out holds what it resolved whichever constructor is used.
+   *
+   * <p>A cache given for a store that caches natively is ignored rather than put in front of it:
+   * the store's own cache stands, so this seam reaches only the stores this registry wraps.
+   *
+   * @throws IllegalArgumentException if a cache is given for a store ID nothing is configured for,
+   *     or if two store IDs are given the same cache instance — the cache is keyed by the bare
+   *     secret name, so a shared instance would let one store's value answer for another store's
+   *     secret of the same name
    */
   public SecretStoreRegistry(
       final Map<String, SecretStore> stores, final Map<String, SecretCache> caches) {
+    rejectUnusableCaches(stores, caches);
     this.stores = locallyCachedStores(stores, caches);
   }
 
@@ -49,24 +58,44 @@ public final class SecretStoreRegistry {
    * Returns all configured secret stores, keyed by store ID.
    *
    * <p>A lookup in this map is exact: an empty store ID addresses no store, even when a single
-   * store is configured. Only {@link #findStoreForReference} applies the sole-store rule below.
+   * store is configured. Reading an empty store ID as the sole configured store is a rule of the
+   * {@code camunda.secrets.<name>} reference syntax and belongs to the caller that knows it.
    */
   public Map<String, LocallyCachedSecretStore> getStores() {
     return stores;
   }
 
   /**
-   * Returns the store the secret reference addresses, or empty when it addresses none.
-   *
-   * <p>The {@code camunda.secrets.<name>} syntax carries no store dimension yet, so an empty store
-   * ID addresses the sole configured store; with several stores an empty store ID is ambiguous and
-   * addresses none.
+   * Rejects a set of caches that cannot be used as given: one for a store that is not configured,
+   * or one instance shared by two store IDs. Both are configuration mistakes rather than states to
+   * recover from, and a shared instance would silently break the collision-freedom this class
+   * documents.
    */
-  public Optional<LocallyCachedSecretStore> findStoreForReference(final String storeId) {
-    if (!storeId.isEmpty()) {
-      return Optional.ofNullable(stores.get(storeId));
+  private static void rejectUnusableCaches(
+      final Map<String, SecretStore> stores, final Map<String, SecretCache> caches) {
+    final var unconfigured = new ArrayList<>(caches.keySet());
+    unconfigured.removeAll(stores.keySet());
+    if (!unconfigured.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Expected a secret cache only for a configured secret store, but got one for "
+              + unconfigured
+              + ", which nothing is configured for; configured stores are "
+              + stores.keySet());
     }
-    return stores.size() == 1 ? Optional.of(stores.values().iterator().next()) : Optional.empty();
+
+    final Map<SecretCache, List<String>> storeIdsByCache = new IdentityHashMap<>();
+    caches.forEach(
+        (storeId, cache) ->
+            storeIdsByCache.computeIfAbsent(cache, c -> new ArrayList<>()).add(storeId));
+    final var shared =
+        storeIdsByCache.values().stream().filter(storeIds -> storeIds.size() > 1).toList();
+    if (!shared.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Expected each secret store to have its own secret cache, but the stores "
+              + shared
+              + " share one; a cache is keyed by the bare secret name, so a shared instance would "
+              + "let one store's value answer for another store's secret of the same name");
+    }
   }
 
   private static Map<String, LocallyCachedSecretStore> locallyCachedStores(
@@ -87,7 +116,7 @@ public final class SecretStoreRegistry {
     if (store instanceof final LocallyCachedSecretStore locallyCached) {
       return locallyCached;
     }
-    final var cache = requireNonNull(caches.getOrDefault(storeId, new InMemorySecretCache()));
+    final var cache = Optional.ofNullable(caches.get(storeId)).orElseGet(InMemorySecretCache::new);
     return new CachingSecretStore(store, cache);
   }
 }

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CachingSecretStoreTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CachingSecretStoreTest.java
@@ -110,6 +110,99 @@ class CachingSecretStoreTest {
     assertThat(names).containsExactly("token");
   }
 
+  @Test
+  void shouldServeALocalLookupFromTheCacheWithoutReadingTheStore() {
+    // given
+    store.holds("token", "token-value");
+    cache.put("token", "cached-value");
+
+    // when
+    final var local = cachingStore.lookupLocal("token");
+
+    // then the store is never read: a local lookup runs where blocking on store I/O is not allowed
+    assertThat(local).contains("cached-value");
+    assertThat(store.resolveCalls).isEmpty();
+  }
+
+  @Test
+  void shouldNotServeALocalLookupForAnUncachedName() {
+    // given a name only the store holds
+    store.holds("token", "token-value");
+
+    // when
+    final var local = cachingStore.lookupLocal("token");
+
+    // then it is reported as not held locally rather than read from the store
+    assertThat(local).isEmpty();
+    assertThat(store.resolveCalls).isEmpty();
+  }
+
+  @Test
+  void shouldServeALocalLookupWithAValueReadFromTheStore() {
+    // given a name resolved once
+    store.holds("token", "token-value");
+    cachingStore.resolve(Set.of("token"));
+
+    // when
+    final var local = cachingStore.lookupLocal("token");
+
+    // then what a resolution read is what a later local lookup sees, so a background resolution
+    // can populate what a non-blocking caller reads
+    assertThat(local).contains("token-value");
+  }
+
+  @Test
+  void shouldNotServeALocalLookupWithAFailedResolution() {
+    // given a name the store cannot read
+    store.fails("token", SecretErrorCode.UNREADABLE);
+    cachingStore.resolve(Set.of("token"));
+
+    // when / then a failure is not cached, so nothing is held locally for it either
+    assertThat(cachingStore.lookupLocal("token")).isEmpty();
+  }
+
+  @Test
+  void shouldAskTheStoreForACachedNameWhenResolvingFromTheStore() {
+    // given a cached value the store no longer holds
+    cache.put("token", "cached-value");
+    store.fails("token", SecretErrorCode.NOT_FOUND);
+
+    // when
+    final var results = cachingStore.resolveFromStore(Set.of("token"));
+
+    // then the store is asked and its answer wins over the cached one: the caller records a durable
+    // outcome, so it must not report a secret the store no longer has as resolved
+    assertThat(store.resolveCalls).containsExactly(Set.of("token"));
+    assertThat(results.get("token"))
+        .isEqualTo(new Failed(SecretErrorCode.NOT_FOUND, "failed: token", null));
+  }
+
+  @Test
+  void shouldCacheAValueResolvedFromTheStore() {
+    // given
+    store.holds("token", "token-value");
+
+    // when
+    cachingStore.resolveFromStore(Set.of("token"));
+
+    // then a resolve bypassing the cache still populates it, which is what makes the value
+    // available to a later cache-only lookup
+    assertThat(cachingStore.lookupLocal("token")).contains("token-value");
+    assertThat(cache.get("token")).contains("token-value");
+  }
+
+  @Test
+  void shouldNotCacheAFailureResolvedFromTheStore() {
+    // given a name the store cannot read
+    store.fails("token", SecretErrorCode.UNREADABLE);
+
+    // when
+    cachingStore.resolveFromStore(Set.of("token"));
+
+    // then nothing is cached for it, so the next resolution retries rather than serving the failure
+    assertThat(cache.get("token")).isEmpty();
+  }
+
   private static final class RecordingSecretStore implements SecretStore {
 
     private final Map<String, String> values = new LinkedHashMap<>();

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CachingSecretStoreTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CachingSecretStoreTest.java
@@ -203,6 +203,32 @@ class CachingSecretStoreTest {
     assertThat(cache.get("token")).isEmpty();
   }
 
+  @Test
+  void shouldAnswerATypeCheckForTheStoreItWraps() {
+    // when / then the wrapper answers for the store it caches for, so a caller can tell which store
+    // was configured whether or not it had to be wrapped
+    assertThat(cachingStore.is(RecordingSecretStore.class)).isTrue();
+  }
+
+  @Test
+  void shouldNotAnswerATypeCheckForAnotherStoreType() {
+    // when / then
+    assertThat(cachingStore.is(NoopSecretStore.class)).isFalse();
+  }
+
+  @Test
+  void shouldNotAnswerATypeCheckForItself() {
+    // when / then the type check is about the configured store, not about how it is held: a caller
+    // asserting a store type must not have to know whether it is wrapped
+    assertThat(cachingStore.is(CachingSecretStore.class)).isFalse();
+  }
+
+  @Test
+  void shouldAnswerATypeCheckForAStoreThatIsNotWrapped() {
+    // when / then an unwrapped store answers for itself, so the same check serves both
+    assertThat(store.is(RecordingSecretStore.class)).isTrue();
+  }
+
   private static final class RecordingSecretStore implements SecretStore {
 
     private final Map<String, String> values = new LinkedHashMap<>();

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretStoreRegistryTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretStoreRegistryTest.java
@@ -9,8 +9,16 @@ package io.camunda.secretstore;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
+import io.camunda.secretstore.SecretResolutionResult.Failed;
+import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class SecretStoreRegistryTest {
@@ -32,29 +40,61 @@ class SecretStoreRegistryTest {
   @Test
   void shouldReturnConfiguredStore() {
     // given
-    final var store = NOOP;
-    final var registry = new SecretStoreRegistry(Map.of("default", store));
+    final var registry = new SecretStoreRegistry(Map.of("default", storeHolding("token", "value")));
 
     // when
     final var stores = registry.getStores();
 
-    // then
+    // then the configured store is what answers under its ID
     assertThat(stores).containsKey("default");
-    assertThat(stores.get("default")).isSameAs(store);
+    assertThat(stores.get("default").resolve(Set.of("token")))
+        .containsEntry("token", new Resolved("value"));
   }
 
   @Test
   void shouldReturnAllConfiguredStores() {
     // given
-    final var storeA = new NoopSecretStore();
-    final var storeB = new NoopSecretStore();
-    final var registry = new SecretStoreRegistry(Map.of("store-a", storeA, "store-b", storeB));
+    final var registry =
+        new SecretStoreRegistry(Map.of("store-a", NOOP, "store-b", new NoopSecretStore()));
 
     // when
     final var stores = registry.getStores();
 
     // then
     assertThat(stores).containsKeys("store-a", "store-b");
+  }
+
+  @Test
+  void shouldNotAllowTheStoresToBeModified() {
+    // given
+    final var registry = new SecretStoreRegistry(Map.of("default", NOOP));
+
+    // when / then the configured stores cannot be swapped out from the outside
+    assertThatThrownBy(() -> registry.getStores().remove("default"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void shouldServeALocalLookupWithAValueAStoreResolved() {
+    // given a store that has resolved a secret once
+    final var registry = new SecretStoreRegistry(Map.of("default", storeHolding("token", "value")));
+    registry.getStores().get("default").resolve(Set.of("token"));
+
+    // when
+    final var local = lookupLocal(registry, "default", "token");
+
+    // then the value a resolution read is what a later local lookup sees: this is what lets a
+    // background resolution unblock the activation that requested it
+    assertThat(local).contains("value");
+  }
+
+  @Test
+  void shouldNotServeALocalLookupForAnUnresolvedName() {
+    // given
+    final var registry = new SecretStoreRegistry(Map.of("default", storeHolding("token", "value")));
+
+    // when / then nothing is held locally until something resolved it
+    assertThat(lookupLocal(registry, "default", "token")).isEmpty();
   }
 
   @Test
@@ -66,45 +106,252 @@ class SecretStoreRegistryTest {
     // when
     final var registry = new SecretStoreRegistry(Map.of("default", NOOP), Map.of("default", cache));
 
-    // then
-    assertThat(registry.getCaches().get("default")).isSameAs(cache);
-  }
-
-  @Test
-  void shouldCreateOneCachePerConfiguredStore() {
-    // given
-    final var registry =
-        new SecretStoreRegistry(Map.of("store-a", NOOP, "store-b", new NoopSecretStore()));
-
-    // when
-    final var caches = registry.getCaches();
-
-    // then - one cache per store, keyed by the same ID
-    assertThat(caches).containsKeys("store-a", "store-b");
+    // then the store caches in the given cache, so what it holds answers a local lookup
+    assertThat(lookupLocal(registry, "default", "token")).contains("value");
   }
 
   @Test
   void shouldCacheAStoreTheProvidedCachesDoNotCover() {
     // given caches covering only one of the two configured stores
     final var cache = new InMemorySecretCache();
-
-    // when
+    cache.put("token", "covered-value");
     final var registry =
         new SecretStoreRegistry(
-            Map.of("store-a", NOOP, "store-b", new NoopSecretStore()), Map.of("store-a", cache));
+            Map.of("store-a", NOOP, "store-b", storeHolding("token", "uncovered-value")),
+            Map.of("store-a", cache));
 
-    // then the uncovered store is cached too, so a caller never has to handle a missing cache
-    assertThat(registry.getCaches().get("store-a")).isSameAs(cache);
-    assertThat(registry.getCaches().get("store-b")).isNotNull();
+    // when the uncovered store resolves a secret
+    registry.getStores().get("store-b").resolve(Set.of("token"));
+
+    // then it cached it too, so a caller never has to handle a store that cannot cache
+    assertThat(lookupLocal(registry, "store-a", "token")).contains("covered-value");
+    assertThat(lookupLocal(registry, "store-b", "token")).contains("uncovered-value");
   }
 
   @Test
-  void shouldNotAllowTheCachesToBeModified() {
-    // given
-    final var registry = new SecretStoreRegistry(Map.of("default", NOOP));
+  void shouldKeepTheCachedValuesOfTwoStoresApart() {
+    // given two stores holding a different value under the same name
+    final var registry =
+        new SecretStoreRegistry(
+            Map.of("store-a", storeHolding("token", "a"), "store-b", storeHolding("token", "b")));
 
-    // when / then the one-cache-per-store invariant cannot be broken from the outside
-    assertThatThrownBy(() -> registry.getCaches().remove("default"))
-        .isInstanceOf(UnsupportedOperationException.class);
+    // when only one of them resolves it
+    registry.getStores().get("store-a").resolve(Set.of("token"));
+
+    // then the other one holds nothing: what a store caches is its own
+    assertThat(lookupLocal(registry, "store-a", "token")).contains("a");
+    assertThat(lookupLocal(registry, "store-b", "token")).isEmpty();
+  }
+
+  @Test
+  void shouldHandOutAStoreThatCachesNativelyAsItIs() {
+    // given a store that already holds what it resolves, as a cloud SDK with a client-side cache
+    // does
+    final var nativelyCaching = new NativelyCachingSecretStore();
+
+    // when
+    final var registry = new SecretStoreRegistry(Map.of("default", nativelyCaching));
+
+    // then it is handed out unwrapped: wrapping it would put a second cache in front of its own
+    assertThat(registry.getStores().get("default")).isSameAs(nativelyCaching);
+  }
+
+  @Test
+  void shouldNotAddressAStoreByAnEmptyStoreIdInTheStoresMap() {
+    // given a single configured store
+    final var registry = new SecretStoreRegistry(Map.of("default", storeHolding("token", "value")));
+
+    // when / then a lookup in the map is exact: only findStoreForReference reads an empty store ID
+    // as the sole store, and only for the caller that addresses a store by secret reference
+    assertThat(registry.getStores().get("")).isNull();
+  }
+
+  @Test
+  void shouldFindTheSoleStoreWhenTheReferenceNamesNone() {
+    // given a single configured store
+    final var store = storeHolding("token", "value");
+    final var registry = new SecretStoreRegistry(Map.of("default", store));
+
+    // when the reference carries no store ID, as camunda.secrets.<name> has no store dimension
+    final var found = registry.findStoreForReference("");
+
+    // then the sole store is addressed rather than none
+    assertThat(found).isPresent();
+    assertThat(found.get().resolve(Set.of("token"))).containsEntry("token", new Resolved("value"));
+  }
+
+  @Test
+  void shouldNotFindAStoreWithoutAStoreIdWhenSeveralStoresAreConfigured() {
+    // given two configured stores
+    final var registry =
+        new SecretStoreRegistry(
+            Map.of("store-a", storeHolding("token", "a"), "store-b", storeHolding("token", "b")));
+
+    // when / then an empty store ID is ambiguous with more than one store, so nothing is guessed
+    assertThat(registry.findStoreForReference("")).isEmpty();
+  }
+
+  @Test
+  void shouldNotFindAnUnconfiguredStore() {
+    // given
+    final var registry = new SecretStoreRegistry(Map.of("default", storeHolding("token", "value")));
+
+    // when / then a store ID nothing is configured for addresses no store rather than any store
+    assertThat(registry.findStoreForReference("other")).isEmpty();
+  }
+
+  @Test
+  void shouldNotFindAStoreWhenNoneIsConfigured() {
+    // given
+    final var registry = new SecretStoreRegistry(Map.of());
+
+    // when / then
+    assertThat(registry.findStoreForReference("")).isEmpty();
+    assertThat(registry.findStoreForReference("default")).isEmpty();
+  }
+
+  @Test
+  void shouldNotReadTheStoreOnALocalLookup() {
+    // given a store that fails the test if it is read at all
+    final var registry = new SecretStoreRegistry(Map.of("default", unreadableStore()));
+
+    // when / then a local lookup runs on the stream processor, where a store read would block
+    // processing; nothing structural stops an implementer from adding one, so it is asserted here
+    assertThat(lookupLocal(registry, "default", "token")).isEmpty();
+    assertThat(lookupLocal(registry, "", "token")).isEmpty();
+  }
+
+  @Test
+  void shouldResolveFromTheStoreDespiteAHeldValue() {
+    // given a store whose held value is stale: it now fails for the name it was resolved for
+    final var store = new MutableSecretStore("token", "value");
+    final var registry = new SecretStoreRegistry(Map.of("default", store));
+    registry.getStores().get("default").resolve(Set.of("token"));
+    store.loses("token");
+
+    // when
+    final var results = registry.getStores().get("default").resolveFromStore(Set.of("token"));
+
+    // then the store is asked and its answer wins over the held value: the background resolution
+    // records a durable outcome, so it must not complete off a value the store no longer has
+    assertThat(store.resolveCalls).containsExactly(Set.of("token"), Set.of("token"));
+    assertThat(results.get("token")).isInstanceOf(Failed.class);
+  }
+
+  @Test
+  void shouldHoldOnToWhatAResolveFromTheStoreRead() {
+    // given a store nothing resolved from yet
+    final var registry = new SecretStoreRegistry(Map.of("default", storeHolding("token", "value")));
+
+    // when it is resolved bypassing what is held, as the background resolution does
+    registry.getStores().get("default").resolveFromStore(Set.of("token"));
+
+    // then the value is held afterwards: this is what unblocks the activation that requested the
+    // background resolution
+    assertThat(lookupLocal(registry, "default", "token")).contains("value");
+  }
+
+  private static Optional<String> lookupLocal(
+      final SecretStoreRegistry registry, final String storeId, final String name) {
+    return registry.findStoreForReference(storeId).flatMap(store -> store.lookupLocal(name));
+  }
+
+  /** A store answering with the given value for the given name, and NOT_FOUND for anything else. */
+  private static SecretStore storeHolding(final String name, final String value) {
+    return new SecretStore() {
+      @Override
+      public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
+        return resultsFor(names, Map.of(name, value));
+      }
+
+      @Override
+      public List<String> list() {
+        return List.of(name);
+      }
+    };
+  }
+
+  /** A store that fails the test when it is read, to assert a code path never reaches one. */
+  private static SecretStore unreadableStore() {
+    return new SecretStore() {
+      @Override
+      public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
+        return fail("the store must not be resolved from");
+      }
+
+      @Override
+      public List<String> list() {
+        return fail("the store must not be listed");
+      }
+    };
+  }
+
+  private static Map<String, SecretResolutionResult> resultsFor(
+      final Set<String> names, final Map<String, String> values) {
+    final Map<String, SecretResolutionResult> results = new LinkedHashMap<>();
+    names.forEach(
+        requested -> {
+          final var value = values.get(requested);
+          results.put(
+              requested,
+              value == null
+                  ? new Failed(SecretErrorCode.NOT_FOUND, "no secret found: " + requested, null)
+                  : new Resolved(value));
+        });
+    return results;
+  }
+
+  /** A store whose set of secrets can change, to tell a held value apart from the store's own. */
+  private static final class MutableSecretStore implements SecretStore {
+
+    private final Map<String, String> values = new LinkedHashMap<>();
+    private final List<Set<String>> resolveCalls = new ArrayList<>();
+
+    private MutableSecretStore(final String name, final String value) {
+      values.put(name, value);
+    }
+
+    @Override
+    public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
+      resolveCalls.add(Set.copyOf(names));
+      return resultsFor(names, values);
+    }
+
+    @Override
+    public List<String> list() {
+      return List.copyOf(values.keySet());
+    }
+
+    void loses(final String name) {
+      values.remove(name);
+    }
+  }
+
+  /**
+   * A store that holds what it resolved itself, standing in for one whose SDK caches client-side.
+   */
+  private static final class NativelyCachingSecretStore implements LocallyCachedSecretStore {
+
+    private final Map<String, String> held = new LinkedHashMap<>();
+
+    @Override
+    public Optional<String> lookupLocal(final String name) {
+      return Optional.ofNullable(held.get(name));
+    }
+
+    @Override
+    public Map<String, SecretResolutionResult> resolveFromStore(final Set<String> names) {
+      return resultsFor(names, held);
+    }
+
+    @Override
+    public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
+      return resolveFromStore(names);
+    }
+
+    @Override
+    public List<String> list() {
+      return List.copyOf(held.keySet());
+    }
   }
 }

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretStoreRegistryTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretStoreRegistryTest.java
@@ -8,12 +8,11 @@
 package io.camunda.secretstore;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 
 import io.camunda.secretstore.SecretResolutionResult.Failed;
 import io.camunda.secretstore.SecretResolutionResult.Resolved;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,8 +53,7 @@ class SecretStoreRegistryTest {
   @Test
   void shouldReturnAllConfiguredStores() {
     // given
-    final var registry =
-        new SecretStoreRegistry(Map.of("store-a", NOOP, "store-b", new NoopSecretStore()));
+    final var registry = new SecretStoreRegistry(Map.of("store-a", NOOP, "store-b", NOOP));
 
     // when
     final var stores = registry.getStores();
@@ -72,29 +70,6 @@ class SecretStoreRegistryTest {
     // when / then the configured stores cannot be swapped out from the outside
     assertThatThrownBy(() -> registry.getStores().remove("default"))
         .isInstanceOf(UnsupportedOperationException.class);
-  }
-
-  @Test
-  void shouldServeALocalLookupWithAValueAStoreResolved() {
-    // given a store that has resolved a secret once
-    final var registry = new SecretStoreRegistry(Map.of("default", storeHolding("token", "value")));
-    registry.getStores().get("default").resolve(Set.of("token"));
-
-    // when
-    final var local = lookupLocal(registry, "default", "token");
-
-    // then the value a resolution read is what a later local lookup sees: this is what lets a
-    // background resolution unblock the activation that requested it
-    assertThat(local).contains("value");
-  }
-
-  @Test
-  void shouldNotServeALocalLookupForAnUnresolvedName() {
-    // given
-    final var registry = new SecretStoreRegistry(Map.of("default", storeHolding("token", "value")));
-
-    // when / then nothing is held locally until something resolved it
-    assertThat(lookupLocal(registry, "default", "token")).isEmpty();
   }
 
   @Test
@@ -144,6 +119,35 @@ class SecretStoreRegistryTest {
   }
 
   @Test
+  void shouldRejectACacheSharedByTwoStores() {
+    // given one cache instance for two stores
+    final var shared = new InMemorySecretCache();
+
+    // when / then a cache is keyed by the bare secret name, so sharing one would let a store answer
+    // with another store's value for the same name
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                new SecretStoreRegistry(
+                    Map.of("store-a", NOOP, "store-b", NOOP),
+                    Map.of("store-a", shared, "store-b", shared)))
+        .withMessageContaining("store-a")
+        .withMessageContaining("store-b");
+  }
+
+  @Test
+  void shouldRejectACacheForAnUnconfiguredStore() {
+    // given a cache for a store ID nothing is configured for
+    final var cache = new InMemorySecretCache();
+
+    // when / then the cache would never be used, which is a configuration mistake rather than a
+    // state to recover from
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new SecretStoreRegistry(Map.of("default", NOOP), Map.of("other", cache)))
+        .withMessageContaining("other");
+  }
+
+  @Test
   void shouldHandOutAStoreThatCachesNativelyAsItIs() {
     // given a store that already holds what it resolves, as a cloud SDK with a client-side cache
     // does
@@ -157,103 +161,25 @@ class SecretStoreRegistryTest {
   }
 
   @Test
-  void shouldNotAddressAStoreByAnEmptyStoreIdInTheStoresMap() {
-    // given a single configured store
-    final var registry = new SecretStoreRegistry(Map.of("default", storeHolding("token", "value")));
-
-    // when / then a lookup in the map is exact: only findStoreForReference reads an empty store ID
-    // as the sole store, and only for the caller that addresses a store by secret reference
-    assertThat(registry.getStores().get("")).isNull();
-  }
-
-  @Test
-  void shouldFindTheSoleStoreWhenTheReferenceNamesNone() {
-    // given a single configured store
-    final var store = storeHolding("token", "value");
-    final var registry = new SecretStoreRegistry(Map.of("default", store));
-
-    // when the reference carries no store ID, as camunda.secrets.<name> has no store dimension
-    final var found = registry.findStoreForReference("");
-
-    // then the sole store is addressed rather than none
-    assertThat(found).isPresent();
-    assertThat(found.get().resolve(Set.of("token"))).containsEntry("token", new Resolved("value"));
-  }
-
-  @Test
-  void shouldNotFindAStoreWithoutAStoreIdWhenSeveralStoresAreConfigured() {
-    // given two configured stores
-    final var registry =
-        new SecretStoreRegistry(
-            Map.of("store-a", storeHolding("token", "a"), "store-b", storeHolding("token", "b")));
-
-    // when / then an empty store ID is ambiguous with more than one store, so nothing is guessed
-    assertThat(registry.findStoreForReference("")).isEmpty();
-  }
-
-  @Test
-  void shouldNotFindAnUnconfiguredStore() {
-    // given
-    final var registry = new SecretStoreRegistry(Map.of("default", storeHolding("token", "value")));
-
-    // when / then a store ID nothing is configured for addresses no store rather than any store
-    assertThat(registry.findStoreForReference("other")).isEmpty();
-  }
-
-  @Test
-  void shouldNotFindAStoreWhenNoneIsConfigured() {
-    // given
-    final var registry = new SecretStoreRegistry(Map.of());
-
-    // when / then
-    assertThat(registry.findStoreForReference("")).isEmpty();
-    assertThat(registry.findStoreForReference("default")).isEmpty();
-  }
-
-  @Test
-  void shouldNotReadTheStoreOnALocalLookup() {
-    // given a store that fails the test if it is read at all
-    final var registry = new SecretStoreRegistry(Map.of("default", unreadableStore()));
-
-    // when / then a local lookup runs on the stream processor, where a store read would block
-    // processing; nothing structural stops an implementer from adding one, so it is asserted here
-    assertThat(lookupLocal(registry, "default", "token")).isEmpty();
-    assertThat(lookupLocal(registry, "", "token")).isEmpty();
-  }
-
-  @Test
-  void shouldResolveFromTheStoreDespiteAHeldValue() {
-    // given a store whose held value is stale: it now fails for the name it was resolved for
-    final var store = new MutableSecretStore("token", "value");
-    final var registry = new SecretStoreRegistry(Map.of("default", store));
-    registry.getStores().get("default").resolve(Set.of("token"));
-    store.loses("token");
+  void shouldIgnoreACacheGivenForAStoreThatCachesNatively() {
+    // given a store that caches natively and a cache configured for it
+    final var nativelyCaching = new NativelyCachingSecretStore();
+    final var cache = new InMemorySecretCache();
+    cache.put("token", "value");
 
     // when
-    final var results = registry.getStores().get("default").resolveFromStore(Set.of("token"));
+    final var registry =
+        new SecretStoreRegistry(Map.of("default", nativelyCaching), Map.of("default", cache));
 
-    // then the store is asked and its answer wins over the held value: the background resolution
-    // records a durable outcome, so it must not complete off a value the store no longer has
-    assertThat(store.resolveCalls).containsExactly(Set.of("token"), Set.of("token"));
-    assertThat(results.get("token")).isInstanceOf(Failed.class);
-  }
-
-  @Test
-  void shouldHoldOnToWhatAResolveFromTheStoreRead() {
-    // given a store nothing resolved from yet
-    final var registry = new SecretStoreRegistry(Map.of("default", storeHolding("token", "value")));
-
-    // when it is resolved bypassing what is held, as the background resolution does
-    registry.getStores().get("default").resolveFromStore(Set.of("token"));
-
-    // then the value is held afterwards: this is what unblocks the activation that requested the
-    // background resolution
-    assertThat(lookupLocal(registry, "default", "token")).contains("value");
+    // then the store's own cache stands and the given one is ignored, so this seam reaches only the
+    // stores the registry wraps
+    assertThat(registry.getStores().get("default")).isSameAs(nativelyCaching);
+    assertThat(lookupLocal(registry, "default", "token")).isEmpty();
   }
 
   private static Optional<String> lookupLocal(
       final SecretStoreRegistry registry, final String storeId, final String name) {
-    return registry.findStoreForReference(storeId).flatMap(store -> store.lookupLocal(name));
+    return registry.getStores().get(storeId).lookupLocal(name);
   }
 
   /** A store answering with the given value for the given name, and NOT_FOUND for anything else. */
@@ -271,21 +197,6 @@ class SecretStoreRegistryTest {
     };
   }
 
-  /** A store that fails the test when it is read, to assert a code path never reaches one. */
-  private static SecretStore unreadableStore() {
-    return new SecretStore() {
-      @Override
-      public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
-        return fail("the store must not be resolved from");
-      }
-
-      @Override
-      public List<String> list() {
-        return fail("the store must not be listed");
-      }
-    };
-  }
-
   private static Map<String, SecretResolutionResult> resultsFor(
       final Set<String> names, final Map<String, String> values) {
     final Map<String, SecretResolutionResult> results = new LinkedHashMap<>();
@@ -299,32 +210,6 @@ class SecretStoreRegistryTest {
                   : new Resolved(value));
         });
     return results;
-  }
-
-  /** A store whose set of secrets can change, to tell a held value apart from the store's own. */
-  private static final class MutableSecretStore implements SecretStore {
-
-    private final Map<String, String> values = new LinkedHashMap<>();
-    private final List<Set<String>> resolveCalls = new ArrayList<>();
-
-    private MutableSecretStore(final String name, final String value) {
-      values.put(name, value);
-    }
-
-    @Override
-    public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
-      resolveCalls.add(Set.copyOf(names));
-      return resultsFor(names, values);
-    }
-
-    @Override
-    public List<String> list() {
-      return List.copyOf(values.keySet());
-    }
-
-    void loses(final String name) {
-      values.remove(name);
-    }
   }
 
   /**

--- a/service/src/main/java/io/camunda/service/SecretServices.java
+++ b/service/src/main/java/io/camunda/service/SecretServices.java
@@ -49,10 +49,11 @@ import org.slf4j.LoggerFactory;
  * batch.
  *
  * <p>Both read the secret stores of this service's physical tenant, taken from the {@link
- * SecretStoreRegistry} the service is constructed with. Resolving is cache-first: a reference whose
- * value is in the store's cache is served from there, and only the remaining references reach the
- * store, whose values are then cached. Listing always polls the stores, since the caches only hold
- * the values read so far rather than the tenant's set of secrets.
+ * SecretStoreRegistry} the service is constructed with. Each store caches what it resolves, so
+ * resolving is cache-first without this service driving a cache itself: a reference whose value the
+ * store already holds is served from there, and only the remaining references reach the backing
+ * store. Listing always polls the stores, since what they hold is the values read so far rather
+ * than the tenant's set of secrets.
  */
 @NullMarked
 public class SecretServices extends PhysicalTenantScopedApiServices<SecretServices> {
@@ -105,10 +106,10 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
   }
 
   /**
-   * Returns the secret stores and caches of this service's physical tenant. {@link #resolve} and
-   * {@link #list} read the field directly, so this exists only so the wiring can be asserted,
-   * deliberately not a production read path: a caller holding the registry could read a value
-   * without the per-reference {@code SECRET:REVEAL} check {@link #resolve} applies.
+   * Returns the secret stores of this service's physical tenant. {@link #resolve} and {@link #list}
+   * read the field directly, so this exists only so the wiring can be asserted, deliberately not a
+   * production read path: a caller holding the registry could read a value without the
+   * per-reference {@code SECRET:REVEAL} check {@link #resolve} applies.
    */
   @VisibleForTesting
   public SecretStoreRegistry getSecretStoreRegistry() {
@@ -183,8 +184,8 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
 
   /**
    * Asks each configured store for the authorized references, adding every outcome to {@code
-   * resolved} or {@code errors}. The stores are the registry's caching ones, so a reference already
-   * cached for a store never reaches it and every value it answers with is cached; this method only
+   * resolved} or {@code errors}. A store caches what it resolves, so a reference it already holds
+   * never reaches its backing store and every value it answers with is cached; this method only
    * decides what each outcome means to the API. A reference nothing answered for is reported as
    * {@code NOT_FOUND}.
    *
@@ -209,7 +210,7 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
     final Set<String> pending = new LinkedHashSet<>(references);
 
     try {
-      for (final var store : secretStoreRegistry.getCachingStores().entrySet()) {
+      for (final var store : secretStoreRegistry.getStores().entrySet()) {
         if (pending.isEmpty()) {
           break;
         }
@@ -345,9 +346,9 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
   }
 
   /**
-   * Enumerates the references of every configured store, sorted and without duplicates. The caches
-   * are deliberately bypassed: they hold the values read so far, which is not the tenant's set of
-   * secrets.
+   * Enumerates the references of every configured store, sorted and without duplicates. A store's
+   * {@code list()} deliberately bypasses what it has cached: that is the values read so far, which
+   * is not the tenant's set of secrets.
    */
   private List<String> listFromStores() {
     final var references = new TreeSet<String>();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.camunda.secretstore.SecretCache;
 import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
@@ -43,10 +42,12 @@ import org.slf4j.LoggerFactory;
  *
  * <ol>
  *   <li>During batch collection, {@link #checkSecrets} looks up the secret references of every job
- *       (stored on the {@link JobRecord} at creation) in the per-store secret caches of the {@link
- *       SecretStoreRegistry}. Jobs with an uncached reference are skipped by the collector without
- *       consuming a batch slot, so jobs behind them can still be activated; jobs whose references
- *       are all cached are appended and registered via {@link #registerForInjection}.
+ *       (stored on the {@link JobRecord} at creation) in what the stores of the {@link
+ *       SecretStoreRegistry} already hold locally, reading no store: this runs on the stream
+ *       processor, where blocking on store I/O would stall processing. Jobs with a reference no
+ *       store holds are skipped by the collector without consuming a batch slot, so jobs behind
+ *       them can still be activated; jobs whose references are all cached are appended and
+ *       registered via {@link #registerForInjection}.
  *   <li>{@link #injectSecretValues} replaces the placeholder text {@code camunda.secrets.<name>} of
  *       the registered jobs with the cached value on a response-only copy of the batch, at the JSON
  *       pointer recorded for each reference. Jobs whose values would grow the response beyond the
@@ -76,7 +77,7 @@ public final class JobSecretInjector {
   /** Reads and writes the msgpack encoding of job variables as Jackson trees. */
   private final ObjectMapper variablesMapper = new ObjectMapper(new MessagePackFactory());
 
-  private final Map<String, SecretCache> caches;
+  private final SecretStoreRegistry secretStoreRegistry;
 
   // accumulated per activation command while the collector checks and appends jobs, consumed
   // (and reset) by injectSecretValues; the collector's reset() bounds a new command
@@ -88,7 +89,7 @@ public final class JobSecretInjector {
   private final Map<SecretReference, List<Long>> jobsWithNonCachedSecrets = new LinkedHashMap<>();
 
   public JobSecretInjector(final SecretStoreRegistry secretStoreRegistry) {
-    caches = secretStoreRegistry.getCaches();
+    this.secretStoreRegistry = secretStoreRegistry;
   }
 
   /** Discards any state accumulated for a previous activation command. */
@@ -100,9 +101,10 @@ public final class JobSecretInjector {
 
   /**
    * Checks each secret reference of the job (stored on the {@link JobRecord} at creation) for a
-   * cached value, materializing the values and the job's secrets once. Every reference is checked,
-   * even after the first miss, so the caller sees all non-cached references of the job. A cache
-   * lookup failure propagates to the caller and fails the activation command.
+   * value its store already holds locally, materializing the values and the job's secrets once. No
+   * store is read, so this cannot block the stream processor. Every reference is checked, even
+   * after the first miss, so the caller sees all non-cached references of the job. A failing lookup
+   * propagates to the caller and fails the activation command.
    *
    * <p>The collector skips a job with any non-cached reference and registers it via {@link
    * #registerForResolution}, so the processor can request the background resolution of the
@@ -174,19 +176,19 @@ public final class JobSecretInjector {
   }
 
   /**
-   * Resolves the reference into the materialized values, or returns {@code false} when it has no
-   * cached value. A reference resolved before is not looked up again. A cache lookup failure is
-   * deliberately not caught here: it propagates and fails the activation command.
+   * Resolves the reference into the materialized values, or returns {@code false} when no store
+   * holds a value for it locally. A reference resolved before is not looked up again. The lookup
+   * reads no store, so it cannot block the stream processor; a lookup failure is deliberately not
+   * caught here: it propagates and fails the activation command.
    */
   private boolean resolveIntoValues(final SecretReference reference) {
     if (values.containsKey(reference)) {
       return true;
     }
-    final SecretCache cache = cacheOf(reference.storeId());
-    if (cache == null) {
-      return false;
-    }
-    final Optional<String> value = cache.get(reference.name());
+    final Optional<String> value =
+        secretStoreRegistry
+            .findStoreForReference(reference.storeId())
+            .flatMap(store -> store.lookupLocal(reference.name()));
     value.ifPresent(cachedValue -> values.put(reference, cachedValue));
     return value.isPresent();
   }
@@ -240,19 +242,6 @@ public final class JobSecretInjector {
     } finally {
       reset();
     }
-  }
-
-  /**
-   * Returns the cache of the store holding the referenced secret, or {@code null} when no store
-   * matches. The {@code camunda.secrets.<name>} syntax carries no store dimension yet, so an empty
-   * store ID addresses the sole configured store; with several stores an empty store ID is
-   * ambiguous and does not resolve.
-   */
-  private SecretCache cacheOf(final String storeId) {
-    if (!storeId.isEmpty()) {
-      return caches.get(storeId);
-    }
-    return caches.size() == 1 ? caches.values().iterator().next() : null;
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.camunda.secretstore.LocallyCachedSecretStore;
 import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
@@ -186,11 +187,25 @@ public final class JobSecretInjector {
       return true;
     }
     final Optional<String> value =
-        secretStoreRegistry
-            .findStoreForReference(reference.storeId())
-            .flatMap(store -> store.lookupLocal(reference.name()));
+        storeFor(reference.storeId()).flatMap(store -> store.lookupLocal(reference.name()));
     value.ifPresent(cachedValue -> values.put(reference, cachedValue));
     return value.isPresent();
+  }
+
+  /**
+   * Returns the store the reference addresses, or empty when it addresses none.
+   *
+   * <p>The {@code camunda.secrets.<name>} syntax carries no store dimension yet, so a reference
+   * written that way has an empty store ID and addresses the sole configured store; with several
+   * stores an empty store ID is ambiguous and addresses none. This rule belongs to the reference
+   * syntax rather than to the registry, whose own lookup is exact.
+   */
+  private Optional<LocallyCachedSecretStore> storeFor(final String storeId) {
+    final var stores = secretStoreRegistry.getStores();
+    if (!storeId.isEmpty()) {
+      return Optional.ofNullable(stores.get(storeId));
+    }
+    return stores.size() == 1 ? Optional.of(stores.values().iterator().next()) : Optional.empty();
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
@@ -7,9 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.secretreference;
 
-import io.camunda.secretstore.SecretCache;
 import io.camunda.secretstore.SecretResolutionResult;
-import io.camunda.secretstore.SecretStore;
 import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.secretstore.SecretStoreUnavailableException;
 import io.camunda.zeebe.engine.EngineConfiguration;
@@ -37,9 +35,13 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Periodically reads all pending secret references from state, resolves them in batches (one batch
- * per store), populates the cache with resolved values, and writes {@link
- * SecretReferenceIntent#RESOLUTION_COMPLETE} or {@link SecretReferenceIntent#RESOLUTION_FAIL}
- * commands.
+ * per store) and writes {@link SecretReferenceIntent#RESOLUTION_COMPLETE} or {@link
+ * SecretReferenceIntent#RESOLUTION_FAIL} commands. The store holds what it reads, which is what
+ * makes a resolved value available to the activation that requested the resolution.
+ *
+ * <p>Resolution goes through {@link
+ * io.camunda.secretstore.LocallyCachedSecretStore#resolveFromStore} rather than the cache-first
+ * {@code resolve}, for the reason given there.
  *
  * <p>Two distinct failure modes:
  *
@@ -67,8 +69,7 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
   private static final Logger LOG = LoggerFactory.getLogger(SecretResolutionScheduler.class);
 
   private final SecretReferenceState secretReferenceState;
-  private final Map<String, SecretStore> secretStores;
-  private final Map<String, SecretCache> secretCaches;
+  private final SecretStoreRegistry secretStoreRegistry;
   private final Duration schedulingInterval;
   private final Duration retryInitialDelay;
   private final Duration retryMaxDelay;
@@ -98,8 +99,7 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
       final SecretStoreRegistry secretStoreRegistry,
       final EngineConfiguration config) {
     secretReferenceState = scheduledTaskStateFactory.get().getSecretReferenceState();
-    secretStores = secretStoreRegistry.getStores();
-    secretCaches = secretStoreRegistry.getCaches();
+    this.secretStoreRegistry = secretStoreRegistry;
     schedulingInterval = config.getSecretResolutionInterval();
     retryInitialDelay = config.getSecretResolutionRetryInitialDelay();
     retryMaxDelay = config.getSecretResolutionRetryMaxDelay();
@@ -211,7 +211,9 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
       return;
     }
 
-    final SecretStore store = secretStores.get(storeId);
+    // an exact lookup: a pending reference is keyed by the store ID its record carries, and this
+    // does not reinterpret an empty one as the sole configured store
+    final var store = secretStoreRegistry.getStores().get(storeId);
     if (store == null) {
       LOG.warn(
           "Secret store '{}' is not configured — failing {} pending secret refs",
@@ -225,15 +227,14 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
     }
 
     try {
-      final Map<String, SecretResolutionResult> results = store.resolve(refs);
-      final SecretCache cache = secretCaches.get(storeId);
+      final var results = store.resolveFromStore(refs);
       results.forEach(
           (ref, result) -> {
             switch (result) {
-              case SecretResolutionResult.Resolved(final String value) -> {
-                cache.put(ref, value);
-                appendResolutionComplete(resultBuilder, storeId, ref);
-              }
+              // the value stays in the store and is never touched here, so the resolution record
+              // carries no secret
+              case final SecretResolutionResult.Resolved ignored ->
+                  appendResolutionComplete(resultBuilder, storeId, ref);
               case SecretResolutionResult.Failed(
                       final var code,
                       final var message,
@@ -245,9 +246,9 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
                     code,
                     message,
                     cause);
-                // All permanent per-secret failures (NOT_FOUND/ACCESS_DENIED/INVALID_REF) map to
-                // NOT_FOUND for now; ResolutionState has no finer per-secret states yet (#57855
-                // will refine).
+                // All permanent per-secret failures (NOT_FOUND/ACCESS_DENIED/INVALID_REF) map
+                // to NOT_FOUND for now; ResolutionState has no finer per-secret states yet
+                // (#57855 will refine).
                 appendResolutionFail(resultBuilder, storeId, ref, ResolutionState.NOT_FOUND);
               }
             }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
@@ -211,8 +211,8 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
       return;
     }
 
-    // an exact lookup: a pending reference is keyed by the store ID its record carries, and this
-    // does not reinterpret an empty one as the sole configured store
+    // a pending reference is keyed by the store ID its record carries, which for a
+    // camunda.secrets.<name> reference is empty and addresses no store here (see #59432)
     final var store = secretStoreRegistry.getStores().get(storeId);
     if (store == null) {
       LOG.warn(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
@@ -329,6 +329,31 @@ final class JobSecretInjectorTest {
     }
 
     @Test
+    void shouldNotResolveReferenceNamingAnUnconfiguredStore() {
+      // given - a store holding the secret, and a reference naming a store next to it that is not
+      // configured
+      final var cache = new InMemorySecretCache();
+      cache.put("token", "resolved");
+      final var registry =
+          new SecretStoreRegistry(
+              Map.of("store-a", new NoopSecretStore()), Map.of("store-a", cache));
+      final var injector = new JobSecretInjector(registry);
+
+      // when
+      final var batch =
+          collect(
+              injector,
+              job(
+                  Map.of("auth", "camunda.secrets.token"),
+                  new SecretRef("store-b", "token", "/auth")));
+
+      // then - the job is skipped rather than served from the store that happens to hold the name:
+      // a named store is looked up exactly, and the sole-store rule is only for a reference that
+      // names none
+      assertThat(jobKeysOf(batch)).isEmpty();
+    }
+
+    @Test
     void shouldNotResolveReferenceWithoutStoreIdWhenSeveralStoresAreConfigured() {
       // given - both stores cache the secret, but the reference names no store, which is
       // ambiguous with more than one configured store

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.secretstore.InMemorySecretCache;
 import io.camunda.secretstore.SecretCache;
 import io.camunda.secretstore.SecretErrorCode;
 import io.camunda.secretstore.SecretResolutionResult;
@@ -224,10 +225,40 @@ final class SecretResolutionSchedulerTest {
     // when
     localScheduler.resolveSecrets(resultBuilder);
 
-    // then the registry's own cache took the value and the reference completes: a configured store
-    // always has a cache, so resolving cannot strand a job by completing it uncached
-    assertThat(registry.getCaches().get("my-store").get("db-password")).contains("v");
+    // then the store's own cache took the value and the reference completes: a configured store
+    // always caches, so resolving cannot strand a job by completing it uncached
+    assertThat(registry.getStores().get("my-store").lookupLocal("db-password")).contains("v");
     verify(resultBuilder).appendCommandRecord(eq(SecretReferenceIntent.RESOLUTION_COMPLETE), any());
+  }
+
+  @Test
+  void shouldFailAReferenceTheStoreHoldsCachedButNoLongerHas() throws Exception {
+    // given a reference the store still holds cached — another partition's scheduler or the resolve
+    // API may have read it since the resolution was requested — but that the store has since lost
+    final var cache = new InMemorySecretCache();
+    cache.put("db-password", "already-held");
+    final var registry =
+        new SecretStoreRegistry(Map.of("my-store", secretStore), Map.of("my-store", cache));
+    final var localScheduler =
+        new SecretResolutionScheduler(
+            () -> scheduledTaskState, registry, new EngineConfiguration());
+    localScheduler.onRecovered(context);
+    stubPending("my-store", "db-password");
+    when(secretStore.resolve(Set.of("db-password")))
+        .thenReturn(
+            Map.of(
+                "db-password",
+                new SecretResolutionResult.Failed(SecretErrorCode.NOT_FOUND, "gone", null)));
+
+    // when
+    localScheduler.resolveSecrets(resultBuilder);
+
+    // then the store is asked even for a cached reference and the reference fails: the completion
+    // record is durable and exported, so it must not claim a secret the store no longer has
+    verify(secretStore).resolve(Set.of("db-password"));
+    verify(resultBuilder).appendCommandRecord(eq(SecretReferenceIntent.RESOLUTION_FAIL), any());
+    verify(resultBuilder, never())
+        .appendCommandRecord(eq(SecretReferenceIntent.RESOLUTION_COMPLETE), any());
   }
 
   @Test


### PR DESCRIPTION

## Description

`SecretStoreRegistry` exposed three views over the same stores — `getStores()`,
`getCaches()` and `getCachingStores()`. Which one a caller had to use was only
clear from context, and nothing stopped a new caller from reading a store while
unintentionally bypassing the cache in front of it.

The cache now belongs to the store. `LocallyCachedSecretStore` is what the
registry hands out: a store that caches natively satisfies the contract as it
is, any other is wrapped in a `CachingSecretStore`. Callers resolve through
`resolve()` alone, and the registry exposes a single view plus `findStore()`,
which owns the rule that an empty store ID addresses the sole configured store
(`camunda.secrets.<name>` carries no store dimension). That rule previously
lived in `JobSecretInjector`.

The two callers `resolve()` does not serve get an explicit method each on the
store, rather than a second registry view:

- `lookupLocal()` — job activation, which runs on the stream processor and must
  not block on store I/O. A job whose secret is not held locally is parked, not
  failed.
- `resolveFromStore()` — background resolution, whose exported record outlives
  the value, so it must ask the store rather than trust a value held since
  before the secret may have been deleted.

`SecretCache` stays as an implementation detail of the store, so the advanced
cache of #56581 (TTL, bounded size, metrics) lands on top without reaching any
caller.

Pure refactor, there should be no behavior change.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #59191
