### PR TITLE
ci: skip AlwaysGreen Slack alerts for draft PRs

### DIFF
--- a/.github/actions/post-failure-feedback/action.yml
+++ b/.github/actions/post-failure-feedback/action.yml
@@ -38,6 +38,21 @@ inputs:
       (refs/heads/gh-readonly-queue/<base>/pr-<N>-<sha>). Empty to skip the PR comment.
     required: false
     default: ""
+  pr_is_draft:
+    description: >
+      Draft state of `pr` when the caller already knows it — on a pull_request
+      trigger pass ${{ github.event.pull_request.draft }}, on merge_group pass
+      "false" (a draft cannot enter a merge queue). Empty means resolve it via
+      the API, which needs github_token.
+    required: false
+    default: ""
+  skip_on_draft:
+    description: >
+      Skip the Slack message when `pr` is a draft PR. The job summary and the PR
+      comment are still posted, so the author keeps the verdict in place. Set to
+      "false" to alert on drafts too.
+    required: false
+    default: "true"
   cookbook_url:
     description: "Debugging cookbook link"
     required: false
@@ -82,6 +97,8 @@ runs:
         FB_EVIDENCE: ${{ inputs.evidence }}
         FB_REPO: ${{ inputs.repo || github.repository }}
         FB_PR: ${{ inputs.pr }}
+        FB_PR_IS_DRAFT: ${{ inputs.pr_is_draft }}
+        FB_SKIP_ON_DRAFT: ${{ inputs.skip_on_draft }}
         FB_COOKBOOK_URL: ${{ inputs.cookbook_url }}
         FB_SLACK_CHANNEL: ${{ inputs.slack_channel }}
         SLACK_BOT_TOKEN: ${{ inputs.slack_bot_token }}

--- a/.github/actions/post-failure-feedback/feedback.mjs
+++ b/.github/actions/post-failure-feedback/feedback.mjs
@@ -6,6 +6,8 @@
 //   FB_EVIDENCE        optional free-text evidence (e.g. failing step name)
 //   FB_REPO            owner/repo of the failing run (for links)
 //   FB_PR              PR number, or a merge_group head_ref to extract it from, or empty
+//   FB_PR_IS_DRAFT     "true"/"false" when the caller knows it; empty → resolve via API
+//   FB_SKIP_ON_DRAFT   "false" to Slack-alert on draft PRs too (default: skip)
 //   FB_COOKBOOK_URL    debugging cookbook link
 //   FB_SLACK_CHANNEL   Slack channel id/name (optional → skip Slack)
 //   GH_TOKEN           token with PR write on FB_REPO (optional → skip PR comment)
@@ -114,6 +116,8 @@ function model() {
     repo: env('FB_REPO'),
     cookbook: env('FB_COOKBOOK_URL'),
     pr,
+    prIsDraft: env('FB_PR_IS_DRAFT').toLowerCase(),
+    skipOnDraft: env('FB_SKIP_ON_DRAFT', 'true').toLowerCase() !== 'false',
   };
 }
 
@@ -218,12 +222,50 @@ async function setStepOutput(name, value) {
   }
 }
 
+// Draft state of m.pr: the caller-supplied value first (no API call), then the
+// API. Returns null when it can't be determined — that is treated as "not a
+// draft" so an unresolvable lookup never silences a real failure.
+async function resolveDraft(m) {
+  if (!m.pr) return false;
+  if (m.prIsDraft === 'true') return true;
+  if (m.prIsDraft === 'false') return false;
+  if (!m.repo || !env('GH_TOKEN')) return null;
+  try {
+    const {stdout} = await gh([
+      'api',
+      `repos/${m.repo}/pulls/${m.pr}`,
+      '--jq',
+      '.draft',
+    ]);
+    const draft = stdout.trim();
+    if (draft === 'true') return true;
+    if (draft === 'false') return false;
+    return null;
+  } catch (e) {
+    console.error(`[feedback] draft lookup failed: ${e.message || e}`);
+    return null;
+  }
+}
+
 async function postSlack(m) {
   const channel = env('FB_SLACK_CHANNEL');
   const token = env('SLACK_BOT_TOKEN');
   if (!channel || !token) {
     console.log('[feedback] Slack skipped (no channel/token)');
     return;
+  }
+  // Draft PRs are work in progress: their failures are expected often enough
+  // that alerting on them is noise for everyone but the author, who still gets
+  // the job summary and the PR comment.
+  if (m.skipOnDraft) {
+    const draft = await resolveDraft(m);
+    if (draft === true) {
+      console.log(`[feedback] Slack skipped (PR #${m.pr} is a draft)`);
+      return;
+    }
+    if (draft === null) {
+      console.log('[feedback] draft state unresolved — posting to Slack anyway');
+    }
   }
   try {
     const res = await fetch('https://slack.com/api/chat.postMessage', {

--- a/.github/actions/post-failure-feedback/feedback.mjs
+++ b/.github/actions/post-failure-feedback/feedback.mjs
@@ -223,8 +223,9 @@ async function setStepOutput(name, value) {
 }
 
 // Draft state of m.pr: the caller-supplied value first (no API call), then the
-// API. Returns null when it can't be determined — that is treated as "not a
-// draft" so an unresolvable lookup never silences a real failure.
+// API. Returns false when there is no PR at all (e.g. a push run), and null when
+// a PR exists but the state can't be determined — null is treated as "not a
+// draft", so an unresolvable lookup never silences a real failure.
 async function resolveDraft(m) {
   if (!m.pr) return false;
   if (m.prIsDraft === 'true') return true;

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -711,6 +711,10 @@ jobs:
           status: failure
           evidence: ${{ steps.classify.outputs.evidence || 'Helm chart Integration Tests failed.' }}
           pr: ${{ github.event.merge_group.head_ref || github.event.pull_request.number }}
+          # merge_group is never a draft (a draft cannot enter the queue), and a
+          # pull_request event carries its own flag — so the draft gate costs no
+          # API call here and needs no extra token scope.
+          pr_is_draft: ${{ github.event.merge_group && 'false' || github.event.pull_request.draft }}
           # Existing AlwaysGreen alerting channel (#alwaysgreen-reliability), same
           # as alwaysgreen-streak-detector.yml.
           slack_channel: "C0AK0AVKRL0"

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -1147,7 +1147,12 @@ jobs:
       - format-identifier
       - helm-deploy-status
       - trigger-saas-e2e
-    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    # Same draft gate as the Slack alert above, for the same reason: unfinished work
+    # is expected to fail, and dispatching a fix agent at it wastes an agent run and
+    # can open a PR against a moving target. No-op until a pull_request trigger is
+    # added — merge_group is never a draft and push carries no PR.
+    if: ${{ always() && contains(needs.*.result, 'failure')
+            && !github.event.pull_request.draft }}
     uses: camunda/camunda/.github/workflows/alwaysgreen-triage.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
Ports the AlwaysGreen draft-PR gate into this repo's copy of `post-failure-feedback`, from the canonical action in camunda/team-test-automation#158. Agreed in [this thread](https://camunda.slack.com/archives/C0AK0AVKRL0/p1785831294832409) with Web Modeler and QA: alerting `#alwaysgreen-reliability` on expected failures from unfinished work is noise, and we'll see more of it while large refactors are in progress.

`skip_on_draft` (default `true`) suppresses **the Slack message only** for draft PRs — the job summary and the upserted PR comment still render, so the author keeps the verdict where they're working.

The same draft state now also gates the `alwaysgreen-triage` job. The alert gate alone
would still hand a draft PR's failure to the fix agent, which costs an agent run and can
open a PR against a branch that is still moving. Expected failures from unfinished work
should not produce either an alert or a fix attempt.

## No behaviour change here today

`docker-build-helm-integration.yml` triggers on `push`, `merge_group` and `workflow_dispatch`, and a draft can't enter a merge queue. This is convergence plus readiness for a `pull_request` trigger, not a fix for live noise in this repo — the live path was in `camunda-hub` (camunda/camunda-hub#27154).

That applies to the triage gate as well: with no `pull_request` trigger,
`github.event.pull_request.draft` is empty and the job runs exactly as before. Note the
gate lives in the caller, so `stable/8.9` picks it up through its own copy — #59388 needs
the same line.

## The caller passes the draft state instead of looking it up

```yaml
pr_is_draft: ${{ github.event.merge_group && 'false' || github.event.pull_request.draft }}
```

`merge_group` is never a draft; a `pull_request` event carries its own flag. So the gate costs no API call and **needs no extra token scope**. That matters: the API fallback (`GET /repos/{owner}/{repo}/pulls/{n}`) requires `pull-requests: read`, and in a job with an explicit `permissions:` block every unlisted scope is `none` — reviewers caught exactly that on the hub PR, where the lookup 403'd and the gate silently fell through to fail-open.

Resolves per event: `merge_group` → `false`, `pull_request` draft → `true`, `pull_request` ready → `false`, `push` → `''` (and `pr` is empty too, so the gate no-ops).

## Fails open

An unresolvable draft lookup is treated as *not* a draft, so a token or API problem can never silently mute alerting. Runs with no PR at all (push to `main`) always alert.

## Verification

- `feedback.mjs` exercised against a stubbed `gh`: draft-via-API, ready-via-API, caller-supplied draft/ready (confirms no API call is made), `skip_on_draft=false`, failed lookup, no-PR, and the `merge_group` `head_ref` form. Slack payload captured with a `fetch` stub to confirm the rendered verdict and medic mention are unchanged.
- `actionlint` clean on the changed workflow (the pre-existing `gcp-perf-core-8-default` runner-label warning at line 410 is untouched and needs an `actionlint.yaml` config).
- Applied with an idempotent sync script — re-running it produces no diff — so this copy keeps its local comment-upsert implementation. `test-infra` and the medic map were already present here.

## Backports

Labelled for `stable/8.7`, `8.8` and `8.9` so the backport action opens those PRs on merge; all four copies of the action then match.

