### PR TITLE
docs: add 8.10 release timeline dates

### DIFF
--- a/monorepo-docs-site/static/release-timeline/timeline.json
+++ b/monorepo-docs-site/static/release-timeline/timeline.json
@@ -177,6 +177,22 @@
       "description": "Final camunda/camunda artifacts should be tested and available for the overall C8 release train."
     },
     {
+      "title": "Stable branch creation for 8.10",
+      "start": "2026-08-18",
+      "end": "2026-08-25",
+      "branch": "stable/8.10",
+      "note": "Features for 8.10 should be backported here, from main.",
+      "description": "Monorepo Release Manager creates the new stable branch from main, adjusting CI workflows as necessary. Features should be merged to main and backported here."
+    },
+    {
+      "title": "Feature freeze of 8.10.0",
+      "start": "2026-08-25",
+      "end": "2026-09-22",
+      "branch": "stable/8.10",
+      "note": "No new features, scope extensions, or risky changes are allowed on this branch anymore without exemption.",
+      "description": "Lock the scope for the minor release. Allow only stabilization, fixes, testing improvements and late features with exemptions."
+    },
+    {
       "title": "Code freeze of 8.10.0-alpha5",
       "start": "2026-08-25",
       "end": "2026-09-01",
@@ -189,6 +205,38 @@
       "start": "2026-09-01",
       "end": "2026-09-01",
       "branch": "release-8.10.0-alpha5",
+      "note": "No more merges.",
+      "description": "Final camunda/camunda artifacts should be tested and available for the overall C8 release train."
+    },
+    {
+      "title": "Code freeze of 8.10.0",
+      "start": "2026-09-22",
+      "end": "2026-10-05",
+      "branch": "release-8.10.0",
+      "note": "Only bug fixes found during QA should be backported to this branch.",
+      "description": "During this phase, release candidates are built from the branch until the release date whenever new fixes need QA validation."
+    },
+    {
+      "title": "Release of 8.10.0",
+      "start": "2026-10-06",
+      "end": "2026-10-06",
+      "branch": "release-8.10.0",
+      "note": "No more merges.",
+      "description": "Final camunda/camunda artifacts should be tested and available for the overall C8 release train."
+    },
+    {
+      "title": "Code freeze of 8.11.0-alpha1",
+      "start": "2026-10-27",
+      "end": "2026-11-03",
+      "branch": "release-8.11.0-alpha1",
+      "note": "Only bug fixes found during QA should be backported to this branch.",
+      "description": "During this phase, release candidates are built from the branch until the release date whenever new fixes need QA validation."
+    },
+    {
+      "title": "Release of 8.11.0-alpha1",
+      "start": "2026-11-03",
+      "end": "2026-11-03",
+      "branch": "release-8.11.0-alpha1",
       "note": "No more merges.",
       "description": "Final camunda/camunda artifacts should be tested and available for the overall C8 release train."
     }


### PR DESCRIPTION
## Description

Since the 8.10 minor release is slowly approaching, make sure we have the relevant dates in the https://camunda.github.io/camunda/release-timeline/ website

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

None
