### PR TITLE
ci: run AlwaysGreen triage for stable/8.9 failures

### DIFF
--- a/.github/actions/post-failure-feedback/action.yml
+++ b/.github/actions/post-failure-feedback/action.yml
@@ -72,10 +72,22 @@ inputs:
     required: false
     default: ""
 
+outputs:
+  slack_ts:
+    description: >
+      Timestamp of the Slack message that was posted, so a later job can reply in its
+      thread instead of starting a second top-level message. Empty when Slack was
+      skipped or the post failed.
+    value: ${{ steps.feedback.outputs.slack_ts }}
+  slack_channel:
+    description: "Channel id the message was posted to. Empty when nothing was posted."
+    value: ${{ steps.feedback.outputs.slack_channel }}
+
 runs:
   using: composite
   steps:
     - name: Render & post failure feedback
+      id: feedback
       shell: bash
       env:
         FB_CATEGORY: ${{ inputs.failure_category }}

--- a/.github/actions/post-failure-feedback/feedback.mjs
+++ b/.github/actions/post-failure-feedback/feedback.mjs
@@ -237,6 +237,18 @@ async function resolveDraft(m) {
   }
 }
 
+// Publishes the posted message's identity so a later job in the same run can reply in
+// its thread instead of opening a second top-level message for the same failure.
+async function setStepOutput(name, value) {
+  const file = process.env.GITHUB_OUTPUT;
+  if (!file || !value) return;
+  try {
+    await appendFile(file, `${name}=${value}\n`);
+  } catch (e) {
+    console.error(`[feedback] could not write output ${name}: ${e.message || e}`);
+  }
+}
+
 async function postSlack(m) {
   const channel = env('FB_SLACK_CHANNEL');
   const token = env('SLACK_BOT_TOKEN');
@@ -268,7 +280,9 @@ async function postSlack(m) {
     });
     const j = await res.json();
     if (!j.ok) throw new Error(j.error || 'unknown');
-    console.log(`[feedback] posted to Slack ${channel}`);
+    console.log(`[feedback] posted to Slack ${channel} (ts=${j.ts})`);
+    await setStepOutput('slack_ts', j.ts);
+    await setStepOutput('slack_channel', j.channel || channel);
   } catch (e) {
     console.error(`[feedback] Slack post failed: ${e.message || e}`);
   }

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -646,6 +646,11 @@ jobs:
     permissions:
       contents: read
       actions: read
+    # Surfaced so alwaysgreen-triage can reply in the feedback message's thread rather
+    # than opening a second top-level message for the same failure.
+    outputs:
+      slack_ts: ${{ steps.feedback.outputs.slack_ts }}
+      slack_channel: ${{ steps.feedback.outputs.slack_channel }}
     steps:
       - run: |
           # shellcheck disable=SC2242
@@ -711,6 +716,7 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
       - name: Post AlwaysGreen failure feedback
+        id: feedback
         if: failure()
         continue-on-error: true
         uses: ./.github/actions/post-failure-feedback
@@ -1226,3 +1232,35 @@ jobs:
           path: ${{ runner.temp }}/alwaysgreen-context-${{ github.job }}.json
           retention-days: 5
 
+  # Final job: hand a failed run to the triage agent. github.run_id here is this run,
+  # so the classifier reads this run's own artifacts. The triage workflow and the fix
+  # agent live only on main; base_ref carries the branch so the fix targets stable/8.9.
+  #
+  # `continue-on-error` is not available on a job that calls a reusable workflow, so
+  # alwaysgreen-triage.yml keeps its own fallible steps continue-on-error instead.
+  alwaysgreen-triage:
+    name: AlwaysGreen triage and fix dispatch
+    needs:
+      - should-run
+      - preflight
+      - build-operate-frontend
+      - build-tasklist-frontend
+      - build-identity-frontend
+      - build-and-push
+      - format-identifier
+      - helm-deploy-status
+      - trigger-saas-e2e
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    uses: camunda/camunda/.github/workflows/alwaysgreen-triage.yml@main
+    secrets: inherit
+    with:
+      # On a merge_group run this is gh-readonly-queue/<base>/pr-<n>-<sha> rather than the
+      # target branch. Triage normalises it (classify.normalise_base_ref) before anything
+      # derives from it, because the ref is part of every fingerprint and a per-PR value
+      # would defeat dedupe.
+      base_ref: ${{ github.ref_name }}
+      chart_version: ${{ inputs.helmRepositoryDirName || 'camunda-platform-8.9' }}
+      # Empty when the helm stage did not fail, or Slack was unavailable; triage then
+      # posts its own parent message instead of threading.
+      parent_slack_ts: ${{ needs.helm-deploy-status.outputs.slack_ts }}
+      parent_slack_channel: ${{ needs.helm-deploy-status.outputs.slack_channel }}

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -1250,7 +1250,12 @@ jobs:
       - format-identifier
       - helm-deploy-status
       - trigger-saas-e2e
-    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    # Unfinished work is expected to fail: dispatching a fix agent at a draft PR wastes
+    # an agent run and can open a PR against a moving target. No-op until a
+    # pull_request trigger is added — merge_group is never a draft and push carries no
+    # PR. Mirrors the gate on main (#59386).
+    if: ${{ always() && contains(needs.*.result, 'failure')
+            && !github.event.pull_request.draft }}
     uses: camunda/camunda/.github/workflows/alwaysgreen-triage.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
## Description

A failing AlwaysGreen run on `stable/8.9` is never classified and never reaches the
fix agent. The triage caller job was added to `docker-build-helm-integration.yml` on
`main` only (#59043), so a stable-branch failure gets a Slack alert and nothing else.

This adds the caller to `stable/8.9`. **The triage workflow, the fix agent, and the
classifier scripts are not copied here** — they stay on `main` and are reached through
`uses: camunda/camunda/.github/workflows/alwaysgreen-triage.yml@main`, which is the
existing design (`FIX_AGENT_REF: main`, with `base_ref` travelling as an input so a
stable failure is still fixed against its own branch). The only difference from main's
caller is the chart version default, `camunda-platform-8.9`.

Threading needed one extra piece. Triage replies in the post-failure-feedback message's
thread, which requires that message's ts and channel; this branch's action never
published them. Ported just that: `feedback.mjs` writes `slack_ts`/`slack_channel` as
step outputs, the composite action exposes them, and `helm-deploy-status` surfaces them
for the triage job. Without it triage would open a second top-level Slack message for a
failure that already has one.

`main`'s copy of `feedback.mjs` has also diverged for unrelated reasons (medic-mention
fallback, PR-comment lookup). Those are **deliberately not** taken — only the threading
change is ported.

## Verification

- Job graph parses; the triage job's nine `needs` all resolve against this branch's job
  names, which are identical to main's apart from the job being added.
- `actionlint -shellcheck=shellcheck` reports only the pre-existing
  `gcp-perf-core-8-default` unknown-runner-label warning, which is present on the
  unmodified file too (CI supplies the custom-label config).
- `node --check` passes on `feedback.mjs`.
- Behaviour is exercised on main: triage replays produced correct classification and
  dispatch for both surfaces (see #59360).

The triage job carries the same draft gate as `main` (#59386), so a draft PR's failure never
reaches the fix agent. The gate lives in the caller, so each branch needs its own copy — it
is not inherited through `alwaysgreen-triage.yml@main`. Like on `main` it is a no-op today:
this workflow triggers on `push`, `merge_group` and `workflow_dispatch`, a draft cannot enter
a merge queue, and a push carries no PR.

Note this branch's copy of `post-failure-feedback` predates #59386, so the **Slack alert** is
not draft-gated here yet — the triage gate reads `github.event.pull_request.draft` directly
and needs no action inputs, so it stands alone. Porting the alert side is a separate change.

Not verified end to end on this branch — that needs a real `stable/8.9` failure, or a
manual `alwaysgreen-triage.yml` dispatch with `run_id` of a past 8.9 failure and
`base_ref: stable/8.9`. Happy to run the latter before this merges.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Enables #59043 for `stable/8.9`. Slack-summary fixes for the shared triage workflow are in #59360.

**Merge after #59389.** That PR fixes three cross-branch bugs in the shared workflow that
would bite on the first `stable/8.9` dispatch: fix PRs opened against `main` instead of the
failing branch, the fix-agent manual being unreadable on any non-`main` branch, and the
version directories the agent edits being left to inference.

