### PR TITLE
ci: skip triage for a surface that already has an open fix PR

### DIFF
--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -34,6 +34,14 @@ REPO = os.environ.get("ALWAYSGREEN_REPO", "camunda/camunda")
 E2E_REPO = os.environ.get("ALWAYSGREEN_E2E_REPO", "camunda/c8-cross-component-e2e-tests")
 FIX_WORKFLOW = os.environ.get("ALWAYSGREEN_FIX_WORKFLOW", "alwaysgreen-fix.yml")
 FIX_LABEL = os.environ.get("ALWAYSGREEN_FIX_LABEL", "alwaysgreen-fix")
+#: Prefix of the per-dispatch-key label the fix workflow stamps on every PR it opens.
+KEY_LABEL_PREFIX = "alwaysgreen-key:"
+#: Repos a fix PR can land in, mirroring the fix workflow's own label list.
+FIX_PR_REPOS = [
+    REPO,
+    E2E_REPO,
+    os.environ.get("ALWAYSGREEN_HELM_REPO", "camunda/camunda-platform-helm"),
+]
 
 
 def log(message: str) -> None:
@@ -230,6 +238,41 @@ def covered_fingerprints() -> set[str]:
     return out
 
 
+def open_fix_pr_keys() -> tuple[set[str], bool]:
+    """Dispatch keys that already have an open fix PR, in any repo a fix can land in.
+
+    Read from the `alwaysgreen-key:<base_ref>:<surface>` label the fix workflow
+    stamps, not from the PR body: the body's coverage block is written by the agent
+    and cannot be relied on to exist.
+
+    Returns (keys, ok). As with `inflight_keys`, a failed lookup makes the caller
+    suppress rather than risk a duplicate PR.
+    """
+    out: set[str] = set()
+    ok = True
+    for repo in FIX_PR_REPOS:
+        prs, err = gh_json_ex(
+            [
+                "pr", "list", "--repo", repo,
+                "--search", f"label:{FIX_LABEL} is:open",
+                "--limit", "100", "--json", "labels",
+            ],
+            None,
+        )
+        if prs is None:
+            log(f"::warning::open fix PR lookup failed for {repo}: {err.strip()[:200]}")
+            ok = False
+            continue
+        for pr in prs if isinstance(prs, list) else []:
+            for label in pr.get("labels") or []:
+                name = (label.get("name") or "").strip()
+                if name.startswith(KEY_LABEL_PREFIX):
+                    key = name[len(KEY_LABEL_PREFIX) :].strip()
+                    if key:
+                        out.add(key)
+    return out, ok
+
+
 def inflight_keys() -> tuple[set[str], bool]:
     """Dispatch keys of in-progress fix-agent runs.
 
@@ -401,10 +444,16 @@ def main() -> int:
             keys = {c.key for c in candidates}
             log("::warning::in-flight lookup failed; suppressing dispatch this run")
 
+        pr_keys, pr_keys_ok = open_fix_pr_keys()
+        if not pr_keys_ok:
+            pr_keys = {c.key for c in candidates}
+            log("::warning::open fix PR lookup failed; suppressing dispatch this run")
+
         result = planning.plan_dispatches(
             candidates,
             covered_fingerprints=covered_fingerprints(),
             inflight_keys=keys,
+            open_pr_keys=pr_keys,
             product_bug_fingerprints=product_bug_fingerprints(),
             max_dispatches=args.max_dispatches,
         )

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -25,6 +25,7 @@ import classify
 SUPPRESSED_NOT_DISPATCHABLE = "surface-not-in-increment"
 SUPPRESSED_IN_FLIGHT = "agent-already-running"
 SUPPRESSED_PR_COVERED = "open-pr-covers-all-specs"
+SUPPRESSED_PR_OPEN = "open-fix-pr-for-surface"
 SUPPRESSED_PRODUCT_BUG = "tracked-by-open-product-bug"
 SUPPRESSED_NO_EVIDENCE = "no-failing-specs-extracted"
 SUPPRESSED_CAP = "per-run-cap-reached"
@@ -92,6 +93,7 @@ def plan_dispatches(
     *,
     covered_fingerprints: set[str],
     inflight_keys: set[str],
+    open_pr_keys: set[str],
     product_bug_fingerprints: set[str],
     max_dispatches: int = 2,
     dispatchable_surfaces: frozenset[str] = classify.DISPATCHABLE_SURFACES,
@@ -112,6 +114,13 @@ def plan_dispatches(
 
         if cand.key in inflight_keys:
             plan.suppressed.append(Suppression(cand, SUPPRESSED_IN_FLIGHT, cand.key))
+            continue
+
+        # An open fix PR for this surface stops a second agent regardless of what the
+        # PR body claims. The coverage block is written by the agent, so a PR that
+        # omitted it would otherwise be invisible here and the failure re-dispatched.
+        if cand.key in open_pr_keys:
+            plan.suppressed.append(Suppression(cand, SUPPRESSED_PR_OPEN, cand.key))
             continue
 
         if not cand.job_level and not cand.specs:

--- a/.github/scripts/alwaysgreen/test_plan.py
+++ b/.github/scripts/alwaysgreen/test_plan.py
@@ -24,6 +24,7 @@ def _cand(surface=classify.SURFACE_SM_E2E, base_ref="main", specs=None, job_leve
 def _plan(cands, **kw):
     kw.setdefault("covered_fingerprints", set())
     kw.setdefault("inflight_keys", set())
+    kw.setdefault("open_pr_keys", set())
     kw.setdefault("product_bug_fingerprints", set())
     return plan.plan_dispatches(cands, **kw)
 
@@ -188,3 +189,24 @@ def test_merge_preserves_text_after_the_block():
 def test_render_is_sorted_for_stable_diffs():
     rendered = plan.render_coverage_block({"cccccccc", "aaaaaaaa", "bbbbbbbb"})
     assert rendered.index("aaaaaaaa") < rendered.index("bbbbbbbb") < rendered.index("cccccccc")
+
+
+def test_open_fix_pr_blocks_the_same_surface():
+    cand = _cand(surface=classify.SURFACE_SM_E2E)
+    result = _plan([cand], open_pr_keys={"main:sm-smoke-e2e"})
+    assert result.dispatches == []
+    assert [s.reason for s in result.suppressed] == [plan.SUPPRESSED_PR_OPEN]
+
+
+def test_open_fix_pr_on_another_surface_does_not_block():
+    cand = _cand(surface=classify.SURFACE_SM_E2E)
+    result = _plan([cand], open_pr_keys={"main:saas-smoke-e2e"})
+    assert len(result.dispatches) == 1
+
+
+def test_open_fix_pr_blocks_even_when_the_body_claims_nothing():
+    # The coverage block is agent-written, so an empty one must not let a second
+    # agent through while the first PR is still open.
+    cand = _cand(surface=classify.SURFACE_SM_E2E)
+    result = _plan([cand], covered_fingerprints=set(), open_pr_keys={"main:sm-smoke-e2e"})
+    assert result.dispatches == []

--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -209,10 +209,15 @@ jobs:
       - name: Ensure labels exist
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          KEY_LABEL: alwaysgreen-key:${{ inputs.base_ref }}:${{ inputs.surface }}
         run: |
           for repo in camunda/camunda camunda/c8-cross-component-e2e-tests camunda/camunda-platform-helm; do
             gh label create "${FIX_LABEL}" --repo "$repo" --color "1D76DB" \
               --description "Bot-opened fix PR for an AlwaysGreen failure" 2>/dev/null || true
+            # Triage suppresses a surface that already has an open fix PR. It reads this
+            # label rather than the PR body, whose coverage block the agent may omit.
+            gh label create "${KEY_LABEL}" --repo "$repo" --color "C5DEF5" \
+              --description "AlwaysGreen fix PR for dispatch key ${KEY_LABEL#alwaysgreen-key:}" 2>/dev/null || true
           done
 
       - name: Set up Go
@@ -360,6 +365,7 @@ jobs:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
           BLAME_REVIEWER: ${{ steps.ctx.outputs.blame_reviewer }}
           DEFAULT_REPO: ${{ github.repository }}
+          KEY_LABEL: alwaysgreen-key:${{ inputs.base_ref }}:${{ inputs.surface }}
         run: |
           set -euo pipefail
           [ -f /tmp/fix-meta.json ] || { echo "no fix-meta.json"; exit 0; }
@@ -371,7 +377,8 @@ jobs:
             repo="${DEFAULT_REPO}"
             [ -n "$owner" ] && [ -n "$name" ] && repo="${owner}/${name}"
 
-            gh pr edit "$num" --repo "$repo" --add-label "${FIX_LABEL}" 2>/dev/null || true
+            gh pr edit "$num" --repo "$repo" \
+              --add-label "${FIX_LABEL}" --add-label "${KEY_LABEL}" 2>/dev/null || true
 
             # Requesting review can legitimately fail: the blamed author may not be a
             # collaborator on the repo the fix landed in. The manual requires the author

--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -408,8 +408,14 @@ jobs:
             repo="${DEFAULT_REPO}"
             [ -n "$owner" ] && [ -n "$name" ] && repo="${owner}/${name}"
 
-            gh pr edit "$num" --repo "$repo" \
-              --add-label "${FIX_LABEL}" --add-label "${KEY_LABEL}" 2>/dev/null || true
+            # The key label is what triage reads to suppress re-dispatch, so a silent
+            # failure here means duplicate fix PRs on the next push. Keep stderr and say
+            # so loudly; still non-fatal, because a labelled-but-unreviewed PR is worth
+            # more than a failed run.
+            if ! gh pr edit "$num" --repo "$repo" \
+                   --add-label "${FIX_LABEL}" --add-label "${KEY_LABEL}"; then
+              echo "::warning::could not label ${repo}#${num} with ${KEY_LABEL} — triage will re-dispatch this key until the label is applied"
+            fi
 
             # Only camunda/camunda PRs are branch-scoped; the e2e and chart repos have
             # no per-version branches. Repair rather than trust: an unset --base

--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -117,9 +117,17 @@ jobs:
             sm-smoke-e2e|saas-smoke-e2e) ;;
             *) echo "::error::unsupported surface '$SURFACE'"; exit 1 ;;
           esac
-          # The e2e suite directory the specs live in.
+          # main carries the next unreleased minor; stable/X.Y carries X.Y. Bump this
+          # when main moves to 8.11.
           if [ "$BASE_REF" = "main" ]; then version=8.10; else version="${BASE_REF#stable/}"; fi
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          # The e2e suite directory. SM specs live under an SM- prefix, SaaS specs under
+          # the bare version, and pages/ mirrors tests/ exactly.
+          if [ "$SURFACE" = "sm-smoke-e2e" ]; then suite="SM-${version}"; else suite="${version}"; fi
+          {
+            echo "version=${version}"
+            echo "suite=${suite}"
+            echo "chart=camunda-platform-${version}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Checkout main for tooling
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -319,6 +327,8 @@ jobs:
           BASE_REF: ${{ inputs.base_ref }}
           SURFACE: ${{ inputs.surface }}
           VERSION: ${{ steps.target.outputs.version }}
+          SUITE: ${{ steps.target.outputs.suite }}
+          CHART: ${{ steps.target.outputs.chart }}
           FAILING_RUN_URL: ${{ inputs.failing_run_url }}
           TRIAGE_RUN_URL: ${{ inputs.triage_run_url }}
           BLAME_AUTHOR: ${{ steps.ctx.outputs.blame_author }}
@@ -335,6 +345,10 @@ jobs:
           contract, and the constraints. Do not skip it.
 
           Failing surface: ${SURFACE}   Branch to fix against: ${BASE_REF}   Version: ${VERSION}
+          Edit only these version directories:
+            c8-cross-component-e2e-tests: tests/${SUITE}/ and pages/${SUITE}/
+            camunda-platform-helm:        charts/${CHART}/
+          A sibling version directory that is passing must not be touched.
           Failing AlwaysGreen run: ${FAILING_RUN_URL}
           Triage run: ${TRIAGE_RUN_URL}
           Breaking change: PR #${BLAME_PR} by ${BLAME_AUTHOR}

--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -269,6 +269,17 @@ jobs:
           git -C "$ws_dir" fetch --depth 1 origin "${TARGET_REF}"
           git -C "$ws_dir" checkout "${TARGET_REF}"
 
+      # The manual documents the agent's contract, not the branch's behaviour, and it
+      # only exists on main. Reading it through the workspace monorepo would miss on
+      # every stable-branch dispatch, since that checkout is pinned to base_ref.
+      - name: Stage the fix-agent manual
+        env:
+          WORKSPACE_NAME: ${{ steps.ws.outputs.name }}
+        run: |
+          set -euo pipefail
+          cp docs/alwaysgreen/FIX-AGENT.md \
+             "$HOME/workspaces/${WORKSPACE_NAME}/FIX-AGENT.md"
+
       - name: Download evidence artifacts
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
@@ -319,7 +330,7 @@ jobs:
           prompt=$(cat <<EOF
           You are the Camunda AlwaysGreen fix agent. Workspace: ${ws_dir}
 
-          STEP 0 — read ${ws_dir}/camunda/docs/alwaysgreen/FIX-AGENT.md in full. That is
+          STEP 0 — read ${ws_dir}/FIX-AGENT.md in full. That is
           your operating manual: evidence map, diagnosis order, the PR coverage-block
           contract, and the constraints. Do not skip it.
 

--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -352,6 +352,11 @@ jobs:
           Branch naming: fix/alwaysgreen-${SURFACE}-<slug>. Commit/PR type: 'test:' for
           test-only changes, 'ci:' for workflow changes, 'fix:' for product or chart code.
 
+          PR base: a camunda/camunda PR MUST be opened with --base ${BASE_REF}.
+          Without it gh targets the default branch, so a stable-branch fix would
+          carry the whole stable-to-main delta. PRs in the other repos take their
+          own default branch.
+
           When done write /tmp/fix-meta.json and stop.
           EOF
           )
@@ -365,6 +370,7 @@ jobs:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
           BLAME_REVIEWER: ${{ steps.ctx.outputs.blame_reviewer }}
           DEFAULT_REPO: ${{ github.repository }}
+          BASE_REF: ${{ inputs.base_ref }}
           KEY_LABEL: alwaysgreen-key:${{ inputs.base_ref }}:${{ inputs.surface }}
         run: |
           set -euo pipefail
@@ -379,6 +385,20 @@ jobs:
 
             gh pr edit "$num" --repo "$repo" \
               --add-label "${FIX_LABEL}" --add-label "${KEY_LABEL}" 2>/dev/null || true
+
+            # Only camunda/camunda PRs are branch-scoped; the e2e and chart repos have
+            # no per-version branches. Repair rather than trust: an unset --base
+            # silently targets the default branch, which makes the diff the whole
+            # stable-to-main delta.
+            if [ "$repo" = "${DEFAULT_REPO}" ]; then
+              base=$(gh pr view "$num" --repo "$repo" --json baseRefName \
+                       --jq '.baseRefName' 2>/dev/null || echo "")
+              if [ -n "$base" ] && [ "$base" != "${BASE_REF}" ]; then
+                echo "::warning::${repo}#${num} opened against '${base}', retargeting to '${BASE_REF}'"
+                gh pr edit "$num" --repo "$repo" --base "${BASE_REF}" \
+                  || echo "::error::could not retarget ${repo}#${num} to ${BASE_REF}"
+              fi
+            fi
 
             # Requesting review can legitimately fail: the blamed author may not be a
             # collaborator on the repo the fix landed in. The manual requires the author

--- a/.github/workspace-templates/alwaysgreen.yaml
+++ b/.github/workspace-templates/alwaysgreen.yaml
@@ -6,8 +6,8 @@ purpose: |
 
   The failing job identifies the surface that broke, not the repository that needs
   the change. A Playwright job failing does not mean the test is wrong: the most
-  frequent SM e2e failure is a Keycloak deploy problem. Read
-  camunda/docs/alwaysgreen/FIX-AGENT.md before doing anything else.
+  frequent SM e2e failure is a Keycloak deploy problem. Read FIX-AGENT.md in the
+  workspace root before doing anything else.
 
 repos:
   - url: https://github.com/camunda/camunda.git

--- a/docs/alwaysgreen/FIX-AGENT.md
+++ b/docs/alwaysgreen/FIX-AGENT.md
@@ -123,12 +123,12 @@ behind them:
   mirrors `tests/` exactly.
 - The Helm chart directory is `charts/camunda-platform-<version>/`.
 
-| Dispatch | e2e specs and pages | Helm chart |
-|---|---|---|
-| `sm-smoke-e2e` on `main` | `tests/SM-8.10/`, `pages/SM-8.10/` | `charts/camunda-platform-8.10/` |
-| `saas-smoke-e2e` on `main` | `tests/8.10/`, `pages/8.10/` | `charts/camunda-platform-8.10/` |
-| `sm-smoke-e2e` on `stable/8.9` | `tests/SM-8.9/`, `pages/SM-8.9/` | `charts/camunda-platform-8.9/` |
-| `saas-smoke-e2e` on `stable/8.9` | `tests/8.9/`, `pages/8.9/` | `charts/camunda-platform-8.9/` |
+|             Dispatch             |        e2e specs and pages         |           Helm chart            |
+|----------------------------------|------------------------------------|---------------------------------|
+| `sm-smoke-e2e` on `main`         | `tests/SM-8.10/`, `pages/SM-8.10/` | `charts/camunda-platform-8.10/` |
+| `saas-smoke-e2e` on `main`       | `tests/8.10/`, `pages/8.10/`       | `charts/camunda-platform-8.10/` |
+| `sm-smoke-e2e` on `stable/8.9`   | `tests/SM-8.9/`, `pages/SM-8.9/`   | `charts/camunda-platform-8.9/`  |
+| `saas-smoke-e2e` on `stable/8.9` | `tests/8.9/`, `pages/8.9/`         | `charts/camunda-platform-8.9/`  |
 
 `stable/8.8` and `stable/8.7` follow the same pattern.
 

--- a/docs/alwaysgreen/FIX-AGENT.md
+++ b/docs/alwaysgreen/FIX-AGENT.md
@@ -113,6 +113,18 @@ The SM smoke suite is **shared** with the SM nightly, which has its own fix agen
 change there must not regress the nightly for the same version, and a competing
 `failing-test-fix` PR may already exist — check before editing.
 
+## Which branch the PR targets
+
+A `camunda/camunda` PR must be opened with `--base <base_ref>` — the branch that failed,
+supplied in the prompt. `gh pr create` with no `--base` targets the repository default
+branch, so a `stable/8.9` fix opened that way carries the entire stable-to-main delta, and
+merging it would push stable-only code onto `main`. The workflow re-checks the base
+afterwards and retargets a wrong one, but it warns when it has to.
+
+This applies to `camunda/camunda` only. `c8-cross-component-e2e-tests` and
+`camunda-platform-helm` have no per-version branches — their PRs take their own default
+branch, and the version lives in the path (`tests/SM-8.9/`, `charts/camunda-platform-8.9/`).
+
 ## The PR coverage block — mandatory
 
 Every PR you open must carry, in its body:

--- a/docs/alwaysgreen/FIX-AGENT.md
+++ b/docs/alwaysgreen/FIX-AGENT.md
@@ -113,6 +113,30 @@ The SM smoke suite is **shared** with the SM nightly, which has its own fix agen
 change there must not regress the nightly for the same version, and a competing
 `failing-test-fix` PR may already exist — check before editing.
 
+## Which version directory to edit
+
+The prompt gives you the resolved directories — use them rather than inferring. The rules
+behind them:
+
+- **`main` is the next unreleased minor, currently 8.10.** `stable/X.Y` is X.Y.
+- **SM specs live under an `SM-` prefix, SaaS specs under the bare version.** `pages/`
+  mirrors `tests/` exactly.
+- The Helm chart directory is `charts/camunda-platform-<version>/`.
+
+| Dispatch | e2e specs and pages | Helm chart |
+|---|---|---|
+| `sm-smoke-e2e` on `main` | `tests/SM-8.10/`, `pages/SM-8.10/` | `charts/camunda-platform-8.10/` |
+| `saas-smoke-e2e` on `main` | `tests/8.10/`, `pages/8.10/` | `charts/camunda-platform-8.10/` |
+| `sm-smoke-e2e` on `stable/8.9` | `tests/SM-8.9/`, `pages/SM-8.9/` | `charts/camunda-platform-8.9/` |
+| `saas-smoke-e2e` on `stable/8.9` | `tests/8.9/`, `pages/8.9/` | `charts/camunda-platform-8.9/` |
+
+`stable/8.8` and `stable/8.7` follow the same pattern.
+
+**Do not fan a fix out across version directories.** Only the dispatched version failed;
+the differences between version directories often encode real product differences that
+should stay encoded, and editing a passing sibling risks breaking it. If the same bug
+plausibly affects another version, say so in the PR body instead of changing it.
+
 ## Which branch the PR targets
 
 A `camunda/camunda` PR must be opened with `--base <base_ref>` — the branch that failed,


### PR DESCRIPTION
## Description

Follow-up to #59360. A surface that already has an open fix PR can still get a second
fix agent, which then opens a competing PR for the same failure.

Suppression currently relies on `parse_coverage_block`, which reads `fp=` markers from
the fix PR's body. That block is written by the **agent**, not by the workflow, so a PR
where the agent omitted it claims nothing — `covered_fingerprints()` returns an empty
set and the next failing run dispatches again. Drafts are already included by the
`is:open` search, so the gap is not about draft state as such; it is about a PR whose
body happens to carry no markers.

Key off something the workflow controls instead. `alwaysgreen-fix.yml` now stamps
`alwaysgreen-key:<base_ref>:<surface>` alongside the existing fix label, in all three
repos a fix can land in, and triage suppresses any surface holding an open PR with that
label — draft or not. An open draft is precisely the case where a second agent must not
start.

Fingerprint coverage still runs after this check, so a merged PR's claims keep
suppressing the individual specs it fixed. The new check is deliberately coarser and
earlier: surface-level, before any body parsing.

Failure handling matches `inflight_keys()` — if the PR lookup fails, the run suppresses
rather than dispatching. A duplicate PR is worse than a delay, and the next failing run
retries in 30–40 minutes.

## Also in this PR: cross-branch dispatch correctness

Found while preparing #59388 (stable/8.9), and it blocks that rollout.

**A stable-branch fix PR would have been opened against `main`.** The workspace checks the
monorepo out at `base_ref`, so the edits and the branch point were already correct — but
nothing told the agent what to pass to `gh pr create`, which defaults to the repository's
default branch. A `stable/8.9` fix would therefore appear as a PR against `main` whose diff
is the fix plus the whole stable-to-main delta, and merging it would push stable-only code
onto `main`. The prompt, `FIX-AGENT.md` and `alwaysgreen.guidance.md` were all silent on it.

Now stated in the prompt and the manual, and enforced afterwards rather than trusted: the
label step re-reads `baseRefName` and retargets a wrong base with a warning. Scoped to
`camunda/camunda` — `c8-cross-component-e2e-tests` and `camunda-platform-helm` have no
per-version branches, so their PRs keep their own default branch.

**The agent would have started with no operating manual on a stable branch.** STEP 0 read
`${ws_dir}/camunda/docs/alwaysgreen/FIX-AGENT.md` — inside the workspace monorepo, which is
checked out at `base_ref`. The manual exists only on `main` (verified: missing on 8.7, 8.8
and 8.9), so every stable-branch dispatch would have missed it and run without the evidence
map, the diagnosis order, the constraints, or the PR coverage-block contract. A PR with no
`fp=` block does not suppress re-dispatch, so the same failure would be handed to a fresh
agent on every push — which also defeats the open-fix-PR suppression this PR adds.

The manual describes the agent's contract, not the branch's behaviour, so it is now staged
as tooling: copied out of the `main` checkout next to the workspace, exactly how
`alwaysgreen.yaml` and `alwaysgreen.guidance.md` already are. STEP 0 and the manifest's
`purpose` both point at that copy.

**The agent had to infer which version directory to edit.** The routing table listed
`tests/SM-8.x/`, `tests/8.x/` and `charts/camunda-platform-8.x/`, but nothing said which
prefix goes with which surface, or what `x` resolves to for a given branch. Two facts were
implicit: SM specs live under an `SM-` prefix while SaaS specs use the bare version, and
`main` carries 8.10 while `stable/X.Y` carries X.Y.

Both are now resolved in `Validate inputs` and handed to the agent as directories rather
than a version to interpret:

| Dispatch | e2e specs and pages | Helm chart |
|---|---|---|
| `sm-smoke-e2e` on `main` | `tests/SM-8.10/`, `pages/SM-8.10/` | `charts/camunda-platform-8.10/` |
| `saas-smoke-e2e` on `main` | `tests/8.10/`, `pages/8.10/` | `charts/camunda-platform-8.10/` |
| `sm-smoke-e2e` on `stable/8.9` | `tests/SM-8.9/`, `pages/SM-8.9/` | `charts/camunda-platform-8.9/` |
| `saas-smoke-e2e` on `stable/8.9` | `tests/8.9/`, `pages/8.9/` | `charts/camunda-platform-8.9/` |

The manual carries the same table plus the rules, and now states that a **passing sibling
version must not be edited** — those differences usually encode real product differences.
The `main` = 8.10 mapping is a maintenance point flagged in the code for when main bumps.

## Verification

- New unit tests: the same surface is blocked, another surface is not, and a PR with an
  empty coverage block still blocks (the regression this fixes).
- Full `.github/scripts/alwaysgreen` suite passes locally: 70 tests, 0 failures.
- `actionlint -shellcheck=shellcheck` passes on `alwaysgreen-fix.yml`.
- The manual-path change is likewise not unit-testable; `actionlint` passes and the copy
  step runs after `workspace create`, from the `main` checkout that already holds `docs/`.
- The PR-base change is not unit-testable — it is a prompt/manual instruction plus a
  `gh pr edit --base` repair. Reviewing the retarget block is worth a moment: it is scoped
  to `camunda/camunda`, skips when `gh pr view` returns nothing, and only acts when the base
  actually differs.

Note the label only appears on PRs opened **after** this merges, so any fix PR already
open is still deduped by fingerprints alone until it is relabelled or closed.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Follow-up to #59360 and #59043.




