### PR TITLE
Port agent-readiness infra (AGENTS.md, skills, ADRs) to stable/8.7

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,58 @@
+# .claude/skills/
+
+Repo-specific Claude Code skills for the Camunda monorepo. Skills are loaded automatically by
+the harness from this directory.
+
+Each skill lives in its own subdirectory and must contain a `SKILL.md` with a
+frontmatter `name` and `description` that the harness uses to load it:
+
+```
+.claude/skills/
+  my-skill/
+    SKILL.md        ← required: frontmatter + instructions
+    reference.md    ← optional: supporting reference material
+```
+
+Minimal `SKILL.md` structure:
+
+```markdown
+---
+name: my-skill
+description: One-line trigger description used by the harness to decide when to load this skill.
+---
+
+# My Skill
+
+Instructions go here.
+```
+
+Skills here extend the org-level skills in the central
+[camunda/.github AGENTS.md](https://github.com/camunda/.github/blob/main/AGENTS.md).
+When a skill exists for a recurring operation, use it rather than improvising steps.
+
+## Available skills
+
+|             Skill              |                                                  Description                                                   |
+|--------------------------------|----------------------------------------------------------------------------------------------------------------|
+| `act-testing`                  | Prepare act-testable GitHub Actions workflow scenarios and assess local act feasibility                        |
+| `babysit-pr`                   | Self-driving loop to shepherd one or more PRs (incl. backports) to merged: rerun flaky CI, enqueue, re-enqueue |
+| `ci-fix-failure`               | Diagnose failing GitHub Actions runs and propose fixes                                                         |
+| `ci-flood-triage`              | Orient fast when a flood of CI incidents opens at once — find the shared pattern, flag outliers                |
+| `ci-incident`                  | Drive CI incident response for a full incident by ID                                                           |
+| `ci-push-workflow-health`      | Analyze CI failure patterns for push-triggered workflow jobs on main and stable/* branches                     |
+| `ci-runner-utilization`        | Detect CI runner underutilization and give downsizing recommendations for cost savings                         |
+| `ci-scheduled-workflow-health` | Generate an HTML health report for all scheduled GitHub Actions workflows                                      |
+| `ci-security-compliance`       | Enforce GitHub Actions security and compliance for third-party actions, secrets, and permissions               |
+| `ci-validation`                | Validate GitHub Actions workflow changes with actionlint, conftest, spotless, and act checks                   |
+| `ci-workflow-authoring`        | Author and refactor GitHub Actions workflows and composite actions with required conventions                   |
+| `create-issue`                 | Create a GitHub issue with the correct template, component label, and parent link                              |
+| `engine-expert`                | Implement or fix capabilities in the Zeebe workflow engine (`zeebe/engine/`)                                   |
+| `grill-me`                     | Interview the user relentlessly about a plan or design until reaching shared understanding                     |
+| `load-test-ops`                | Trigger, monitor, update, profile, and stop Camunda load tests using `gh` CLI and kubectl directly             |
+| `zeebe-flamegraph-diff`        | Parse and compare async-profiler CPU flamegraphs, attributing CPU cost and diffing against a baseline          |
+
+## Adding a new skill
+
+1. Create a new directory under `.claude/skills/` matching the skill name (lowercase, hyphens only).
+2. Add a `SKILL.md` with the required frontmatter (`name`, `description`) and instructions.
+3. Update the table above.

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: babysit-pr
+description: Shepherd one or more camunda/camunda PRs through flaky CI and the merge queue to merged. Accepts a list of PRs (e.g. a merge plus its backports). Use when asked to babysit, shepherd, watch, drive, or "get merged" one or more PRs, or to keep retrying CI until they land.
+---
+
+# Babysit PR(s) to merge
+
+Drive PR(s) open → merged. Handle **transient failures only**: rerun flaky CI, enqueue when green +
+approved, re-enqueue after flaky merge-queue removal. Real failure → hand back to human.
+
+**Starts after review.** Reviews are a human gate — never wait on them. Normal PR must be
+**approved** before entering the loop; unapproved → report not-ready, stop. Backports exempt (bot
+approves them, step 2).
+
+Owns its own loop. Invoke once; tends PR(s) across turns until all merged. No `/loop` wrapper.
+
+Acts (reruns, enqueues) — unlike `ci-fix-failure`, which only diagnoses. Never edits code, addresses
+comments, masks a failure, or lowers the bar to force a merge.
+
+## Inputs
+
+PR numbers in `camunda/camunda` or URLs. Shapes:
+
+- Single: `babysit #12345`.
+- **Merge + backports**: original + `backport stable/X.Y` PRs from the bot. Pass the set, or pass
+  the original and discover backports via `gh pr list --repo camunda/camunda --search "<orig> in:body is:open"`
+  or the bot's linked-PR comment.
+
+No PR → ask; don't infer from context.
+Non-`camunda/camunda` → ask human for confirmation, to assume monorepo conventions (GitHub Merge Queue, backport-action).
+
+## Prerequisites
+
+- `gh auth status` works against `camunda/camunda`; CWD = repo root.
+
+## Hard rules
+
+1. **Rerun/re-enqueue = unblock, not fix.** Transients toward `main`/`stable` aren't acceptable
+   long-term; real fix is hardening (retries-in-timeout, caching, runner sizing). Note every
+   rerun; a check that flakes repeatedly → stop retrying, surface as a flake to fix.
+2. **Never edit code/config/workflows to pass CI.** Code fix = author's call → report, stop that PR.
+3. **Never bump a timeout, disable a test, or bypass the queue.** Timeouts are contracts; bypass is
+   incidents-only.
+4. **A passing rerun does NOT clear a Flaky Test Gate alert** — sticky
+   (`docs/monorepo-docs/flaky-test-gate.md`). Needs a code change or `ci:flaky-test-bypass` label —
+   author's call.
+5. **Cancelled = real until proven otherwise.** Fetch annotations first; usually GHA timeouts.
+6. **Cap the loop.** Rerun any check ≤ **3×**; re-enqueue after flaky removal ≤ **3×**. `main`/
+   `stable` paths: escalate sooner.
+
+## Flaky (rerun) vs real (stop)
+
+Classify before every rerun. Unsure → **real**, stop.
+
+**Rerun (transient):** known flake ([dashboard](https://dashboard.int.camunda.com/d/ae2j69npxh3b4f/flaky-tests-camunda-camunda-monorepo));
+infra noise (network, registry, runner provisioning); failure unrelated to diff AND green on
+target; merge-queue failure on the *temp* branch, not PR head.
+
+**Stop (real):** compile/assertion/lint/spotless/license failure in touched code; same check fails
+again after rerun; `BEHIND`/`CONFLICTING` (author rebase); merge-queue removal from a concurrently
+merged dependency ([ci.md §6](../../../docs/monorepo-docs/ci.md#why-is-my-ci-check-failing)); Flaky Test Gate alert.
+
+Non-obvious failure → delegate diagnosis to `ci-fix-failure`, act on its verdict. Don't reimplement
+log-reading.
+
+## Loop
+
+One row per PR. Repeat passes until every PR terminal, then report and stop.
+
+**Terminal:** `MERGED` ✅ · not-approved normal PR (needs review) 🕓 · needs-author ⛔ (real
+failure, conflict, `BEHIND`, Flaky Test Gate) · cap hit 🔁✋.
+
+### Each pass (per non-terminal PR)
+
+**1. State**
+
+```bash
+gh pr view <pr> --repo camunda/camunda \
+  --json number,title,state,isDraft,mergeable,mergeStateStatus,reviewDecision,autoMergeRequest,headRefName,baseRefName,statusCheckRollup
+```
+
+- `MERGED` → ✅.
+- `isDraft` → bot's conflict-backport (committed conflict markers) or not-ready PR. Don't resolve
+  unless asked → ⛔.
+- `CONFLICTING` / `BEHIND` → author rebase (don't rebase their branch unless asked) → ⛔.
+
+**2. Approval gate** (`reviewDecision`) — check before any CI work
+
+- Normal PR, not `APPROVED` → **not ready to babysit.** Report 🕓 needs-review and mark terminal.
+  Do NOT rerun CI or loop waiting for review — reviews are a human gate.
+- Backport → bot auto-approves + auto-merges once green; no human gate. Proceed.
+- Approved → proceed.
+
+**3. Checks** (`statusCheckRollup` / `gh pr checks <pr>`)
+
+- Running → skip this pass.
+- Failed → classify. Transient & under cap → rerun failed jobs only:
+  ```bash
+  gh run rerun <run-id> --failed --repo camunda/camunda
+  ```
+  Log "rerun N/3 of <check>". Real or cap hit → ⛔ + link.
+
+**4. Enqueue** (normal PR, green + approved)
+
+```bash
+# = "Merge when ready": adds to the branch's merge queue, which applies its own
+# configured merge method. Author squashes commits before enqueueing (CONTRIBUTING.md).
+gh pr merge <pr> --repo camunda/camunda --auto
+```
+
+`autoMergeRequest` non-null = queued. Backports self-merge via the bot — don't enqueue one unless
+automation clearly stalled and the engineer asks.
+
+**5. Merge queue** — re-enqueue on flaky removal
+
+Queue builds temp branch (target + PR) and reruns CI. On removal, inspect:
+
+```bash
+gh run list --repo camunda/camunda --event merge_group --branch <baseRefName> --limit 10
+```
+
+Flaky on temp branch & under cap → re-enqueue (repeat step 4) — sanctioned retry
+([CONTRIBUTING.md](../../../CONTRIBUTING.md)). Real → ⛔.
+
+### Between passes
+
+Don't busy-wait. When every non-terminal PR is just waiting on CI, block until CI moves, then next
+pass. Background poll → re-invoked on change:
+
+```bash
+while :; do
+  for pr in <pr-list>; do
+    gh pr checks "$pr" --repo camunda/camunda 2>/dev/null | grep -q pending || exit 0
+  done
+  sleep 300
+done
+```
+
+Floor of a few minutes. Stop the loop once all PRs terminal.
+
+## Reporting
+
+Live status line per PR:
+
+```
+#12345 (main)        📥 enqueued
+#12346 (stable/8.7)  🔁 reran unit-tests (flake 1/3)
+#12347 (stable/8.6)  ✅ merged
+```
+
+Final summary: what merged, what needs the engineer, any check that flaked repeatedly (hardening
+candidate, rule 1). Link runs by URL; code refs use the repo's stable-permalink convention.

--- a/.claude/skills/ci-flood-triage/SKILL.md
+++ b/.claude/skills/ci-flood-triage/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: ci-flood-triage
+description: Triages a flood of CI incidents in camunda/camunda. Use when multiple CI incidents open in a short window and the medic needs to orient fast — find the shared pattern, identify outliers, and know what to do next. Re-runnable as new incidents arrive.
+user-invocable: true
+argument-hint: "[minutes] — how far back to look, default 30"
+---
+
+# CI Flood Triage
+
+Gives the medic a fast orientation snapshot when a flood of CI incidents opens at once. Finds the
+shared pattern, flags outliers, and drafts a broadcast message. Read-only by default — generating
+the snapshot never writes to incident.io. If the medic explicitly asks to merge incidents
+afterward, this skill can do that too, always with a confirmation step first (see Step 6).
+
+## Prerequisites
+
+- **incident.io MCP** — required. Verify the `mcp__incident-io__incident_show` tool is available.
+  If not, tell the user to [configure the incident.io MCP server](https://docs.incident.io/ai/remote-mcp)
+  and stop.
+
+Throughout this skill, MCP tools are referenced by their short verb (`incident_list`,
+`incident_show`, `incident_update`); the actual tool name is namespaced by whichever MCP server
+is configured (e.g. `mcp__incident-io__incident_list`).
+
+## Scope
+
+Multiple incidents only. If the user passes a single incident ID, redirect them to `/ci-incident`
+for deep-dive investigation of that one incident.
+
+This skill owns the multi-incident merge action when the medic asks for it — it already has the
+correlation context (which incidents share a cause) needed to do that safely. `/ci-incident` is
+scoped to driving a single incident's investigation and status updates once assigned; it does not
+handle cross-incident merging.
+
+## Procedure
+
+### Step 1 — Parse the time window
+
+Read `$ARGUMENTS`. Supported forms:
+
+| Argument | Meaning |
+|---|---|
+| *(empty)* | last 30 minutes |
+| `60` | last N minutes |
+| `--since 2026-07-06T15:00Z` | from that UTC timestamp to now |
+| `--since 2026-07-06T15:00Z --until 2026-07-06T17:30Z` | specific historical range |
+
+Timestamps must be RFC 3339 / ISO 8601 UTC (append `Z` if no timezone given).
+When `--until` is provided, this is a **historical replay** — adjust Step 2 accordingly.
+
+### Step 2 — Fetch CI incidents
+
+Call `incident_list` with:
+- `created_after`: derived from Step 1
+- `created_before`: `--until` value if provided, otherwise omit
+- `include: ["summary"]`
+- `status_category: ["triage", "active"]` — **omit this filter for historical replays** (closed
+  incidents won't appear otherwise)
+- Page through all results until no more pages
+
+If the MCP server exposes a `config://organisation` resource (or equivalent), you may read it to
+find the CI incident type ID and filter to it. This is optional, not a required step — if the
+resource isn't available, or you can't determine the type ID from it, proceed without the filter
+(results may include non-CI incidents) and note this in the output.
+
+Record: total count, the list of (reference, name, summary, reported_at) for each.
+
+### Step 3 — Reason about the pattern
+
+Look at all incident names and summaries together. Ask: do these incidents point to a shared root
+cause, or are they independent failures?
+
+Read `references/flood-patterns.md` for known archetypes — use them to inform your reasoning, not
+to gate it. Real floods may not match either pattern cleanly.
+
+Signals to look for:
+- Common job name fragments across incident names
+- Shared failure description in summaries (same error, same upstream, same timing)
+- Tight timing cluster vs spread over many hours
+- Whether summaries mention the same GHA run URLs
+
+Form a working hypothesis: "probably one cause" vs "probably independent" vs "unclear, need more
+data."
+
+### Step 4 — Dig where uncertain
+
+If the hypothesis is unclear, or summaries are thin, call `incident_show` on the incidents that
+need it — not the whole flood. That's normally:
+1. A handful representative of the dominant group (enough to confirm the shared cause — usually
+   3–5, more only if the group is large and heterogeneous)
+2. Every incident that looks like an outlier (there are usually few)
+
+Call these in parallel. From each response, extract:
+- Alert payload run URLs / run IDs — **and** the specific job name / workflow step within that run
+  (e.g. `integration-tests/zeebe-opensearch-exporter` vs `integration-tests/camunda-exporter`).
+  Two incidents can share a run URL while testing entirely different components — a shared run ID
+  is a much weaker signal than a shared job/test name. See the run-ID caveat in
+  `references/flood-patterns.md` before treating a shared run as enough to group on.
+- Any existing investigation content — but scope a stated root cause to the incident that stated
+  it. Do not extend one incident's "already tracked under issue #X" claim to a sibling that shares
+  only a run ID or name prefix with it; confirm the sibling's own failure independently.
+
+If a specific incident's alert payload is thin (e.g. "unsuccessful test cases: none captured") and
+you're relying on it to justify grouping, that's a blocker, not a detail to skip past — a sibling's
+confidence is not a substitute for this incident's own evidence. Before deciding where it belongs:
+pull the actual GHA job log (`gh run view <run_id> --log-failed`) if you have shell access, or
+invoke `/ci-incident <ID>` for that one incident to pull its full investigation context (Slack
+thread, matched runbook). Scope this to the incidents that actually need it; don't run it broadly
+across the flood.
+
+Use all of this to confirm or refute the grouping hypothesis.
+
+### Step 5 — Output the triage snapshot
+
+Print to terminal (never post to Slack, never call any write MCP tool):
+
+```
+CI Flood Triage — [timestamp] — [N] incidents in last [M] min
+
+PATTERN: [one sentence describing what you see]
+
+GROUPS:
+  Group 1 ([N] incidents): [pattern — e.g. "all reference runs 28799271420, 28798845890"]
+    → INC-6435, INC-6436, INC-6437 … (list all)
+    → Likely cause: [hypothesis]
+    → Recommended action: [e.g. "merge into one, assign to @zeebe-medic, pull PR #XXXXX"]
+
+  Outliers ([N] incidents): [why they don't fit]
+    → INC-6440: [reason — e.g. "different failure signature, predates the flood window"]
+    → Recommended action: [e.g. "investigate separately via /ci-incident INC-6440"]
+
+DRAFT SLACK BROADCAST (copy-paste to #top-monorepo-ci):
+---
+:alert: Merge queue blocked — [N] incidents, single root cause identified.
+[One sentence: what failed, why, which team owns it.]
+Tracking in [main incident ref]. ICs assigned. Updates to follow.
+---
+```
+
+If the pattern is genuinely unclear after steps 3–4, say so explicitly rather than guessing. List
+what's known and what still needs checking.
+
+### Step 6 — Wait for medic direction
+
+After the snapshot, stop and wait. Do not act on anything — no merging, no status updates, no
+Slack posts — until the medic explicitly asks.
+
+If asked to merge incidents: list the exact IDs you'll merge and the target, then wait for
+explicit confirmation before calling `incident_update` (or the equivalent merge write tool).
+
+If asked to post the draft broadcast: remind the medic that this skill does not post to Slack
+directly — they should copy-paste from the output above.
+
+## Guardrails
+
+- Never post to Slack.
+- Never merge, update severity, or change status without explicit medic instruction — the snapshot
+  in Step 5 is a recommendation, not an action.
+- Always show draft wording and get confirmation before any `incident_update` call.
+- Never assume an incident has been investigated — ask or check.
+- Never group an incident into a shared-cause bucket on a shared run ID or name prefix alone, and
+  never let one incident's stated root cause/dedup claim cover a sibling that hasn't been checked
+  independently — especially when that sibling's own alert payload is thin. See "Correlation
+  Pitfalls" in `references/flood-patterns.md`.
+- If the snapshot is a partial picture (flood still growing), say so and suggest re-running in
+  5–10 minutes.

--- a/.claude/skills/ci-flood-triage/references/flood-patterns.md
+++ b/.claude/skills/ci-flood-triage/references/flood-patterns.md
@@ -1,0 +1,119 @@
+---
+title: Flood Patterns
+status: current
+---
+
+# Known CI Flood Patterns
+
+These are observed archetypes from real incidents. Use them to inform reasoning — not as rigid
+rules. Real floods may not match either pattern cleanly, or may combine elements of both.
+
+## Pattern A: Merge Queue Flood
+
+**What it looks like:**
+- Many incidents open within a tight window (minutes, not hours)
+- Incident names all contain `high-failure-rate-in-merge-queue`
+- Summaries reference the same 3–5 GHA run URLs
+- Jobs span multiple teams but share a compile failure or infra blip
+
+**Why it happens:**
+A single broken PR or infra issue enters the merge queue. Every job in every batch run fails.
+The alerting fires one incident per job — so one root cause becomes 30 incidents.
+
+**Key correlation signal:** shared GHA run IDs in alert payloads. If 25 of 30 incidents reference
+the same 3 runs, it's almost certainly one cause.
+
+**Caveat — run ID alone is not proof:** a shared run ID means the incidents came from the same CI
+*invocation*, not that they share a cause. This heuristic is strongest here, in a merge-queue batch,
+because a single broken commit really does poison every job in that batch. It is much weaker for a
+scheduled/nightly workflow (see Pattern B) — one nightly run fans out into many independent
+per-component jobs that all legitimately carry the same run URL by construction, whether or not
+their failures are related. Before grouping on run-ID alone, compare the job name segment (e.g.
+`integration-tests/zeebe-opensearch-exporter` vs `integration-tests/camunda-exporter`) — different
+job names sharing one run are a stronger signal of *different* causes than the shared run ID is a
+signal of the same cause. Confirm with the actual failing test/class name when it's available.
+
+**Right response:**
+1. Identify the dominant run IDs
+2. Find the common failure in those runs (compile error → look at Java Checks / Maven; infra →
+   look at Nexus, GitHub Actions, external upstreams)
+3. If it's a PR conflict: pull the offending PR from the merge queue, fix, re-enqueue
+4. Merge all related incidents into one, assign IC to the owning team
+5. Broadcast to #top-monorepo-ci: "merge queue blocked, cause identified, IC assigned"
+
+**Outlier signal:** an incident that doesn't reference the dominant runs, or has a different
+failure message — investigate separately via `/ci-incident`.
+
+---
+
+## Pattern B: Nightly / Scheduled Flood
+
+**What it looks like:**
+- Incidents open spread over hours (e.g. 21:00 → 03:00), not a burst
+- Incident names contain `nightly`, `scheduled`, `manualscheduled`, or `unsuccessful-job`
+- Different workflows, different teams, no obvious shared run IDs
+- Some jobs may have been failing for days
+- A single nightly/scheduled run can trigger several incidents at once — one per failing job in
+  its matrix — that all share the same run URL. That's normal fan-out, not evidence those jobs
+  share a root cause (see the run-ID caveat under Pattern A)
+
+**Why it happens (two sub-cases):**
+
+*Sub-case B1 — Expired silence:*
+A Grafana silence that was suppressing alerts expires. Pre-existing failures suddenly surface as
+new incidents all at once. The jobs were already broken; the silence expiring is the trigger, not
+a new failure.
+
+Signal: summaries say jobs were failing before the flood window. Check whether a silence was
+recently active on `merge-queue-high-failure-rate` or `unsuccessful-job` alert rules.
+
+Response: re-create the silence if appropriate; route real failures to owning teams.
+
+*Sub-case B2 — Shared infra problem:*
+An upstream goes down (e.g. JBoss Maven repo, AWS, Snyk), affecting many independent nightly
+jobs over hours as they happen to run.
+
+Signal: summaries mention the same external URL or service; failures cluster around the same
+error type (timeouts, 503s, auth failures).
+
+Response: identify the shared upstream, open one incident for it, route nightly job incidents to
+their owning teams.
+
+**Right response (general):**
+- Do NOT merge unrelated incidents just because they opened in the same window
+- Route each to its owning team (check `TEST_OWNER` in the workflow or CODEOWNERS)
+- Only merge if you can confirm they share a root cause
+- If it's a silence expiration, the fix is the silence — not investigating each job
+
+---
+
+## When the Pattern Isn't Clear
+
+If incidents span both merge-queue and nightly names, or if timing and summaries don't fit either
+archetype cleanly, pull `incident_show` on a representative sample and look for:
+
+- Common error strings across summaries
+- Shared external dependencies (Maven repos, AWS regions, third-party APIs)
+- Whether the flood started at an unusual hour (silence expiry tends to happen at fixed times)
+
+State your uncertainty explicitly in the triage output rather than forcing a pattern.
+
+---
+
+## Correlation Pitfalls
+
+Two failure modes have actually caused mis-grouping in practice — check for both before finalizing
+any group of more than one incident:
+
+- **Don't let one incident's narrative anchor its siblings.** If incident A's summary says
+  "already tracked under issue #X," that claim covers incident A's own failure. It does not
+  automatically extend to incident B just because B shares a run ID, workflow-name prefix, or
+  timing with A. Confirm each incident's own failing job/test independently before folding it into
+  A's group — a confident sibling is not evidence about an unrelated one.
+- **A thin alert payload blocks grouping, not just outlier status.** If an alert's "unsuccessful
+  test cases" came back empty or uncaptured, you don't know what actually failed. Don't assume it
+  matches the group's dominant cause just because the surrounding metadata (run ID, name prefix)
+  looks similar — that's exactly the situation where superficial signals get mistaken for a shared
+  cause. Pull the real failing test/job (the GHA job log, e.g. `gh run view <run_id> --log-failed`)
+  or escalate via `/ci-incident` before including it.
+

--- a/.claude/skills/ci-push-workflow-health/SKILL.md
+++ b/.claude/skills/ci-push-workflow-health/SKILL.md
@@ -1,0 +1,291 @@
+---
+
+name: ci-push-workflow-health
+description: Analyze CI failure patterns for push-triggered workflow jobs on main and stable/* branches. Use when asked about CI health, broken jobs, flaky workflows, failure rates, or push-trigger problems.
+
+---
+
+# CI Push Workflow Health Analysis
+
+Analyzes failure patterns for `push`-triggered GitHub Actions workflow runs on `main` and `stable/*` branches using BigQuery CI Analytics data.
+
+## Prerequisites
+
+- `bq` CLI available and authenticated (`bq show ci-30-162810:prod_ci_analytics.build_status_v2` should work)
+- BigQuery table: `ci-30-162810.prod_ci_analytics.build_status_v2`
+
+## Analysis approach
+
+Run the following queries in sequence. Each builds on the previous to drill from broad summary down to specific broken jobs. Adjust `INTERVAL 14 DAY` if a shorter or longer window is needed. Longer windows are costlier (maximum 90 days) and less impacted by recent trends/changes.
+
+---
+
+### Step 1 — Overview: total runs and failure counts per branch
+
+Establishes the scope and identifies which branches have significant failure volume.
+
+```sql
+SELECT
+  build_ref,
+  COUNT(*) AS total,
+  COUNTIF(build_status != 'success') AS failures,
+  MIN(report_time) AS earliest,
+  MAX(report_time) AS latest
+FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
+WHERE
+  ci_url = 'https://github.com/camunda/camunda'
+  AND build_trigger = 'push'
+  AND (
+    build_ref = 'refs/heads/main'
+    OR build_ref LIKE 'refs/heads/stable/%'
+  )
+  AND report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
+GROUP BY build_ref
+ORDER BY build_ref
+```
+
+---
+
+### Step 2 — Workflow breakdown: failure rate per workflow per branch
+
+Identifies which workflows are the problem areas. Key signals:
+- `failure_pct` > 10% on a high-volume workflow = high impact
+- `failure_pct` = 100% = completely broken
+- High `cancellations` relative to `failures` = concurrency issue (not real test failures) or timeouts (they are a problem)
+
+```sql
+SELECT
+  build_ref,
+  workflow_name,
+  COUNT(*) AS total_runs,
+  COUNTIF(build_status != 'success') AS failures,
+  ROUND(100.0 * COUNTIF(build_status != 'success') / COUNT(*), 1) AS failure_pct,
+  COUNTIF(build_status = 'failure') AS hard_failures,
+  COUNTIF(build_status = 'cancelled') AS cancellations,
+  COUNTIF(build_status = 'aborted') AS aborts
+FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
+WHERE
+  ci_url = 'https://github.com/camunda/camunda'
+  AND build_trigger = 'push'
+  AND (
+    build_ref = 'refs/heads/main'
+    OR build_ref LIKE 'refs/heads/stable/%'
+  )
+  AND report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
+GROUP BY build_ref, workflow_name
+HAVING failures > 5
+ORDER BY build_ref, failures DESC
+```
+
+---
+
+### Step 3 — Job-level failures in high-failure-rate workflows (excluding Unified CI)
+
+Drills into specific jobs that are broken. Focus on workflows identified as problematic in step 2. A job at 100% failure rate over many runs is permanently broken (not flaky).
+
+```sql
+SELECT
+  build_ref,
+  workflow_name,
+  job_name,
+  COUNT(*) AS total_runs,
+  COUNTIF(build_status != 'success') AS failures,
+  ROUND(100.0 * COUNTIF(build_status != 'success') / COUNT(*), 1) AS failure_pct,
+  COUNTIF(build_status = 'failure') AS hard_failures,
+  COUNTIF(build_status = 'cancelled') AS cancellations
+FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
+WHERE
+  ci_url = 'https://github.com/camunda/camunda'
+  AND build_trigger = 'push'
+  AND (
+    build_ref = 'refs/heads/main'
+    OR build_ref LIKE 'refs/heads/stable/%'
+  )
+  AND report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
+  AND build_status != 'success'
+  AND workflow_name NOT IN ('CI', 'Check Licenses')
+GROUP BY build_ref, workflow_name, job_name
+HAVING failures >= 5
+ORDER BY build_ref, failures DESC
+LIMIT 80
+```
+
+---
+
+### Step 4 — Job-level failures within the Unified CI workflow
+
+The `CI` workflow runs on nearly every push so its absolute failure count is high even at low failure rates. It is the required status check so impact is high. Look for jobs at with high failure rate — those are specific test areas that are broken, not representative of the overall CI health.
+
+```sql
+SELECT
+  build_ref,
+  job_name,
+  COUNT(*) AS total_runs,
+  COUNTIF(build_status != 'success') AS failures,
+  ROUND(100.0 * COUNTIF(build_status != 'success') / COUNT(*), 1) AS failure_pct,
+  COUNTIF(build_status = 'failure') AS hard_failures,
+  COUNTIF(build_status = 'cancelled') AS cancellations,
+  ROUND(AVG(build_duration_milliseconds) / 60000, 1) AS avg_duration_min
+FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
+WHERE
+  ci_url = 'https://github.com/camunda/camunda'
+  AND build_trigger = 'push'
+  AND (
+    build_ref = 'refs/heads/main'
+    OR build_ref LIKE 'refs/heads/stable/%'
+  )
+  AND report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
+  AND workflow_name = 'CI'
+  AND build_status != 'success'
+GROUP BY build_ref, job_name
+HAVING failures >= 3
+ORDER BY build_ref, failures DESC
+LIMIT 60
+```
+
+---
+
+### Step 5 — Weekly trend on main
+
+Shows whether the overall failure rate is improving or degrading. A spike in one week can be traced back to a bad commit window.
+
+```sql
+SELECT
+  DATE_TRUNC(DATE(report_time), WEEK) AS week,
+  COUNT(*) AS total_runs,
+  COUNTIF(build_status != 'success') AS failures,
+  ROUND(100.0 * COUNTIF(build_status != 'success') / COUNT(*), 2) AS failure_pct
+FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
+WHERE
+  ci_url = 'https://github.com/camunda/camunda'
+  AND build_trigger = 'push'
+  AND build_ref = 'refs/heads/main'
+  AND report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
+GROUP BY week
+ORDER BY week
+```
+
+---
+
+### Step 6 — Daily trend for specific suspect workflows
+
+Use this to check whether a workflow's failures are chronic (broken since day 1) or a recent regression. Replace the `workflow_name` list with the workflows identified as problematic in step 2.
+
+```sql
+SELECT
+  build_ref,
+  workflow_name,
+  DATE(report_time) AS day,
+  COUNT(*) AS total_runs,
+  COUNTIF(build_status != 'success') AS failures,
+  ROUND(100.0 * COUNTIF(build_status != 'success') / COUNT(*), 0) AS failure_pct
+FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
+WHERE
+  ci_url = 'https://github.com/camunda/camunda'
+  AND build_trigger = 'push'
+  AND build_ref IN ('refs/heads/main', 'refs/heads/stable/8.7', 'refs/heads/stable/8.8', 'refs/heads/stable/8.9')
+  AND report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
+  AND workflow_name IN (
+    '[Legacy] Operate / E2E Tests',
+    '[Legacy] Tasklist / E2E Tests',
+    '[Legacy] Tasklist',
+    '[Legacy] Operate'
+    -- add other suspect workflows here
+  )
+GROUP BY build_ref, workflow_name, day
+HAVING total_runs > 0
+ORDER BY build_ref, workflow_name, day
+```
+
+---
+
+### Step 7 — Per-commit check status via GitHub Checks API (optional, high GitHub API quota cost)
+
+> **WARNING — High GitHub API quota usage.** This step uses the GitHub Checks API to fetch check suites and check runs for every commit in the window. Each commit can consume 10–50+ API requests depending on the number of check suites. A 3-hour window on `main` can easily use 500–2000+ requests against a PAT's 5000/hour limit. **Always ask the user for confirmation before running this step**, and keep the `--hours` window as small as possible (3–6 hours recommended, never more than 24).
+
+This step uses the `main_branch_health.py` script (bundled in this scripts subfolder) to query the GitHub Checks API directly. Unlike the BigQuery-based steps above, this provides the **exact same check status view as GitHub's UI** on each commit — including check suite names, individual check run conclusions, and per-commit pass/fail summaries. Use this when you need to:
+
+- Verify exactly which checks failed on specific recent commits (matching what the user sees on GitHub)
+- Cross-reference BigQuery aggregate data with actual commit-level check results
+- Debug check runs that may not appear in BigQuery (e.g., third-party checks, non-workflow checks)
+
+#### Prerequisites
+
+- Python 3.9+ with `requests` installed (`pip install requests`)
+- `GITHUB_TOKEN` or `GH_TOKEN` environment variable set with a PAT or fine-grained token that has repo read access
+
+#### Before running — confirm with the user
+
+**You MUST ask the user for confirmation before executing this script.** Present them with:
+1. The branch and time window you plan to query
+2. A warning that this will consume significant GitHub API quota
+3. Ask if they want to proceed
+
+Example prompt: _"I'd like to run the commit-level checks script for `main` over the last 6 hours. This will use the GitHub Checks API which consumes significant API quota (potentially hundreds of requests). Should I proceed?"_
+
+#### Usage
+
+```bash
+# Table output (default) — last 6 hours on main
+python .claude/skills/ci-push-workflow-health/scripts/main_branch_health.py \
+  --branch main --hours 6 --output table --fallback-to-statuses
+
+# JSON output for programmatic analysis
+python .claude/skills/ci-push-workflow-health/scripts/main_branch_health.py \
+  --branch main --hours 6 --output json --fallback-to-statuses
+
+# Stable branch, minimal window
+python .claude/skills/ci-push-workflow-health/scripts/main_branch_health.py \
+  --branch stable/8.8 --hours 3 --output table --fallback-to-statuses
+```
+
+#### Key flags
+
+|           Flag           |                         Description                         |
+|--------------------------|-------------------------------------------------------------|
+| `--hours N`              | Look back N hours (default 3). **Keep this small** (1–3).   |
+| `--branch NAME`          | Branch to scan (default `main`). Use `stable/8.8` etc.      |
+| `--output table\|json`   | Output format. Use `json` when you need to process results. |
+| `--fallback-to-statuses` | Fall back to commit status API if no check runs found.      |
+| `--workers N`            | Parallel workers (default 8).                               |
+
+#### Output
+
+The table output shows per-commit health:
+
+```
+sha      committed_at              summary  overall  source  failed_jobs
+-------  ------------------------  -------  -------  ------  -----------
+abc1234  2025-05-26T10:30:00+00:00  45/47   failure  checks  CI / java-checks (failure), ...
+def5678  2025-05-26T10:15:00+00:00  47/47   success  checks  -
+```
+
+Followed by aggregated failed job totals across all commits in the window.
+
+---
+
+## How to run queries
+
+```bash
+bq query --use_legacy_sql=false --format=pretty '<SQL>'
+```
+
+## How to interpret results
+
+|                  Signal                   |                                         Interpretation                                         |
+|-------------------------------------------|------------------------------------------------------------------------------------------------|
+| `failure_pct` = 100% over many runs       | Permanently broken — needs immediate fix or disable                                            |
+| `failure_pct` = 100% over few runs        | Could be flaky or a recent commit broke it — check trend                                       |
+| High `cancellations`, low `hard_failures` | Concurrency problem ( workflow triggered too often, cancels in-flight runs) or timeout problem |
+| `failure_pct` improving in recent weeks   | Fix landed on main but may not be backported to stable                                         |
+
+## Report structure
+
+Summarize findings in this order:
+
+1. **Overview table** — failure % per branch
+2. **Critical: permanently broken jobs** — 100% failure rate, high run count
+3. **High-impact problems by area** — grouped by root cause pattern
+4. **Trend** — improving, degrading, or stable
+5. **Recommendations** — concrete next steps (backport, disable, add concurrency guard, etc.)
+

--- a/.claude/skills/ci-push-workflow-health/scripts/main_branch_health.py
+++ b/.claude/skills/ci-push-workflow-health/scripts/main_branch_health.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, asdict
+from datetime import datetime, timedelta, timezone
+from functools import partial
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+GITHUB_API = "https://api.github.com"
+DEFAULT_ACCEPT = "application/vnd.github+json"
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def parse_github_datetime(s: str) -> datetime:
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    return datetime.fromisoformat(s)
+
+
+class GitHubAPIError(RuntimeError):
+    pass
+
+
+class GitHubClient:
+    def __init__(self, token: Optional[str], base_url: str = GITHUB_API, timeout: int = 30):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Accept": DEFAULT_ACCEPT, "User-Agent": "main-branch-health-script"}
+        )
+        if token:
+            self.session.headers["Authorization"] = f"Bearer {token}"
+
+    def get(self, path: str, params: Optional[dict] = None) -> requests.Response:
+        url = f"{self.base_url}{path}"
+        resp = self.session.get(url, params=params, timeout=self.timeout)
+        if resp.status_code >= 400:
+            try:
+                body = resp.json()
+            except Exception:
+                body = resp.text[:500]
+            raise GitHubAPIError(f"GitHub API error {resp.status_code} for {url}: {body}")
+        return resp
+
+    def get_json(self, path: str, params: Optional[dict] = None) -> Any:
+        return self.get(path, params=params).json()
+
+
+@dataclass(frozen=True)
+class CommitRef:
+    sha: str
+    committed_at: datetime
+    html_url: str
+
+
+@dataclass
+class CommitHealth:
+    sha: str
+    short_sha: str
+    committed_at: str
+    commit_url: str
+    success: int
+    total: int
+    overall: str  # success|failure|nodata
+    conclusions: Dict[str, int]
+    failed_jobs: List[str]
+    source: str  # checks|statuses|none
+
+
+def past_hours_window_utc(hours: int) -> Tuple[datetime, datetime]:
+    """Returns [start,end) in UTC for the past N hours."""
+    end_utc = utc_now()
+    start_utc = end_utc - timedelta(hours=hours)
+    return start_utc, end_utc
+
+
+def list_commits_page(
+    gh: GitHubClient, owner: str, repo: str, branch: str, page: int, per_page: int
+) -> List[CommitRef]:
+    data = gh.get_json(
+        f"/repos/{owner}/{repo}/commits",
+        params={"sha": branch, "page": page, "per_page": per_page},
+    )
+    if not isinstance(data, list):
+        raise GitHubAPIError(f"Expected list response for commits page, got: {type(data)}")
+
+    out: List[CommitRef] = []
+    for c in data:
+        sha = c["sha"]
+        html_url = c.get("html_url", f"https://github.com/{owner}/{repo}/commit/{sha}")
+
+        commit = c["commit"]
+        dt_str = (commit.get("committer") or {}).get("date") or (commit.get("author") or {}).get("date")
+        if not dt_str:
+            continue
+        committed_at = parse_github_datetime(dt_str)
+
+        out.append(CommitRef(sha=sha, committed_at=committed_at, html_url=html_url))
+    return out
+
+
+def list_commits_from_window(
+    gh: GitHubClient,
+    owner: str,
+    repo: str,
+    branch: str,
+    start_utc: datetime,
+    end_utc: datetime,
+    per_page: int,
+    max_pages: int,
+) -> Tuple[List[CommitRef], int]:
+    """
+    Pages through commits newest->older, collects all commits in [start_utc,end_utc),
+    and stops once we are older than start_utc (i.e., once the window is fully covered).
+    Returns (commits, pages_scanned).
+    """
+    results: List[CommitRef] = []
+    pages_scanned = 0
+
+    for page in range(1, max_pages + 1):
+        commits = list_commits_page(gh, owner, repo, branch, page=page, per_page=per_page)
+        pages_scanned = page
+
+        if not commits:
+            break
+
+        stop = False
+        for c in commits:
+            if c.committed_at >= end_utc:
+                # today (or later) in the chosen tz -> ignore
+                continue
+            if start_utc <= c.committed_at < end_utc:
+                results.append(c)
+                continue
+            if c.committed_at < start_utc:
+                # we've gone older than yesterday -> we can stop scanning
+                stop = True
+                break
+
+        if stop:
+            break
+
+    # Keep newest->oldest ordering in output (same as scan order already)
+    return results, pages_scanned
+
+
+def list_completed_check_runs_for_commit(
+    gh: GitHubClient, owner: str, repo: str, sha: str
+) -> List[Dict[str, Any]]:
+    suites = gh.get_json(
+        f"/repos/{owner}/{repo}/commits/{sha}/check-suites",
+        params={"per_page": 100},
+    )
+    check_suites = suites.get("check_suites", []) or []
+
+    all_runs: List[Dict[str, Any]] = []
+    for suite in check_suites:
+        suite_id = suite["id"]
+        workflow_name = suite.get("workflow_name")
+        suite_runs = list_check_runs_for_suite(gh, owner, repo, suite_id)
+        if workflow_name:
+            for run in suite_runs:
+                run.setdefault("workflow_name", workflow_name)
+        all_runs.extend(suite_runs)
+
+    return [r for r in all_runs if r.get("status") == "completed"]
+
+
+def list_check_runs_for_suite(
+    gh: GitHubClient, owner: str, repo: str, suite_id: int, per_page: int = 100
+) -> List[Dict[str, Any]]:
+    runs: List[Dict[str, Any]] = []
+    for page in range(1, 51):
+        payload = gh.get_json(
+            f"/repos/{owner}/{repo}/check-suites/{suite_id}/check-runs",
+            params={"per_page": per_page, "page": page},
+        )
+        page_runs = payload.get("check_runs", []) or []
+        runs.extend(page_runs)
+        if len(page_runs) < per_page:
+            break
+    return runs
+
+
+def debug_check_metadata(gh: GitHubClient, owner: str, repo: str, sha: str) -> None:
+    suites = gh.get_json(
+        f"/repos/{owner}/{repo}/commits/{sha}/check-suites",
+        params={"per_page": 100},
+    )
+    check_suites = suites.get("check_suites", []) or []
+    if not check_suites:
+        print("No check suites found for debug.")
+        return
+
+    print(f"Check suites found: {len(check_suites)}")
+    suites_with_runs = []
+    total_runs = 0
+    for suite in check_suites:
+        suite_id = suite["id"]
+        suite_runs = list_check_runs_for_suite(gh, owner, repo, suite_id)
+        total_runs += len(suite_runs)
+        suites_with_runs.append((suite, suite_runs))
+
+    print(f"Total check runs found across suites: {total_runs}")
+
+    suite = next((s for s, runs in suites_with_runs if runs), check_suites[0])
+    suite_keys = sorted(suite.keys())
+    print("Sample check suite keys:")
+    print(", ".join(suite_keys))
+    print()
+    print("Sample check suite workflow/app info:")
+    print(
+        json.dumps(
+            {
+                "workflow_name": suite.get("workflow_name"),
+                "workflow_run": (suite.get("workflow_run") or {}),
+                "app": (suite.get("app") or {}),
+            },
+            indent=2,
+        )
+    )
+
+    check_runs = next((runs for _, runs in suites_with_runs if runs), [])
+    if not check_runs:
+        print("No check runs found for debug.")
+        return
+
+    run = check_runs[0]
+    run_keys = sorted(run.keys())
+    print("Sample check run keys:")
+    print(", ".join(run_keys))
+    print()
+    print("Sample check run workflow/app info:")
+    print(
+        json.dumps(
+            {
+                "name": run.get("name"),
+                "workflow_name": run.get("workflow_name"),
+                "workflow_run": (run.get("workflow_run") or {}),
+                "app": (run.get("app") or {}),
+                "check_suite": (run.get("check_suite") or {}),
+            },
+            indent=2,
+        )
+    )
+
+
+def summarize_check_runs(
+    check_runs: List[Dict[str, Any]]
+) -> Tuple[int, int, Dict[str, int], List[str]]:
+    conclusions: Dict[str, int] = {}
+    total = 0
+    success = 0
+    failed_jobs: List[str] = []
+    for r in check_runs:
+        if r.get("status") != "completed":
+            continue
+        conc = r.get("conclusion") or "unknown"
+        conclusions[conc] = conclusions.get(conc, 0) + 1
+        if conc == "skipped":
+            continue
+        total += 1
+        if conc == "success":
+            success += 1
+        else:
+            name = r.get("name") or "unknown"
+            check_suite = r.get("check_suite") or {}
+            run_app_name = (r.get("app") or {}).get("name")
+            suite_app_name = (check_suite.get("app") or {}).get("name")
+            workflow = (
+                r.get("workflow_name")
+                or (r.get("workflow_run") or {}).get("name")
+                or (run_app_name if run_app_name and run_app_name != "GitHub Actions" else None)
+                or check_suite.get("workflow_name")
+                or (check_suite.get("workflow_run") or {}).get("name")
+                or (suite_app_name if suite_app_name and suite_app_name != "GitHub Actions" else None)
+            )
+            if workflow:
+                failed_jobs.append(f"{workflow} / {name} ({conc})")
+            else:
+                failed_jobs.append(f"{name} ({conc})")
+    return success, total, conclusions, failed_jobs
+
+
+def get_combined_status_summary(
+    gh: GitHubClient, owner: str, repo: str, sha: str
+) -> Optional[Tuple[int, int, Dict[str, int], List[str]]]:
+    combined = gh.get_json(f"/repos/{owner}/{repo}/commits/{sha}/status")
+    statuses = combined.get("statuses", []) or []
+    if not statuses:
+        return None
+
+    total = 0
+    success = 0
+    conclusions: Dict[str, int] = {}
+    failed_jobs: List[str] = []
+    for s in statuses:
+        state = s.get("state") or "unknown"
+        total += 1
+        conclusions[state] = conclusions.get(state, 0) + 1
+        if state == "success":
+            success += 1
+        else:
+            context = s.get("context") or "unknown"
+            failed_jobs.append(f"{context} ({state})")
+    return success, total, conclusions, failed_jobs
+
+
+def overall_from_counts(total: int, success: int) -> str:
+    if total == 0:
+        return "nodata"
+    return "success" if success == total else "failure"
+
+
+def compute_health_for_commit(
+    gh: GitHubClient, owner: str, repo: str, commit: CommitRef, fallback_to_statuses: bool
+) -> CommitHealth:
+    sha = commit.sha
+    short_sha = sha[:7]
+
+    try:
+        check_runs = list_completed_check_runs_for_commit(gh, owner, repo, sha)
+        success, total, conclusions, failed_jobs = summarize_check_runs(check_runs)
+
+        if total == 0 and fallback_to_statuses:
+            fb = get_combined_status_summary(gh, owner, repo, sha)
+            if fb is not None:
+                s2, t2, conc2, failed2 = fb
+                return CommitHealth(
+                    sha=sha,
+                    short_sha=short_sha,
+                    committed_at=commit.committed_at.isoformat(),
+                    commit_url=commit.html_url,
+                    success=s2,
+                    total=t2,
+                    overall=overall_from_counts(t2, s2),
+                    conclusions=conc2,
+                    failed_jobs=failed2,
+                    source="statuses",
+                )
+
+        return CommitHealth(
+            sha=sha,
+            short_sha=short_sha,
+            committed_at=commit.committed_at.isoformat(),
+            commit_url=commit.html_url,
+            success=success,
+            total=total,
+            overall=overall_from_counts(total, success),
+            conclusions=conclusions,
+            failed_jobs=failed_jobs,
+            source="checks",
+        )
+    except GitHubAPIError:
+        if fallback_to_statuses:
+            fb = get_combined_status_summary(gh, owner, repo, sha)
+            if fb is not None:
+                s2, t2, conc2, failed2 = fb
+                return CommitHealth(
+                    sha=sha,
+                    short_sha=short_sha,
+                    committed_at=commit.committed_at.isoformat(),
+                    commit_url=commit.html_url,
+                    success=s2,
+                    total=t2,
+                    overall=overall_from_counts(t2, s2),
+                    conclusions=conc2,
+                    failed_jobs=failed2,
+                    source="statuses",
+                )
+        raise
+
+
+def compute_health_for_commit_with_client(
+    token: Optional[str],
+    base_url: str,
+    timeout: int,
+    owner: str,
+    repo: str,
+    commit: CommitRef,
+    fallback_to_statuses: bool,
+) -> CommitHealth:
+    gh = GitHubClient(token=token, base_url=base_url, timeout=timeout)
+    return compute_health_for_commit(
+        gh=gh,
+        owner=owner,
+        repo=repo,
+        commit=commit,
+        fallback_to_statuses=fallback_to_statuses,
+    )
+
+
+def fmt_table(rows: List[CommitHealth]) -> str:
+    headers = ["sha", "committed_at", "summary", "overall", "source", "failed_jobs"]
+    body = [
+        [
+            r.short_sha,
+            r.committed_at,
+            f"{r.success}/{r.total}",
+            r.overall,
+            r.source,
+            ", ".join(r.failed_jobs) if r.failed_jobs else "-",
+        ]
+        for r in rows
+    ]
+    widths = [len(h) for h in headers]
+    for row in body:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(str(cell)))
+
+    def line(cols: List[str]) -> str:
+        return "  ".join(str(c).ljust(widths[i]) for i, c in enumerate(cols))
+
+    out = [line(headers), line(["-" * w for w in widths])]
+    out += [line(r) for r in body]
+    return "\n".join(out)
+
+
+def format_failed_job_totals(rows: List[CommitHealth]) -> str:
+    totals: Dict[str, int] = {}
+    for r in rows:
+        for job in r.failed_jobs:
+            totals[job] = totals.get(job, 0) + 1
+
+    if not totals:
+        return "No failed jobs detected."
+
+    lines = ["Failed jobs totals:"]
+    for job, count in sorted(totals.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"  {job}: {count}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Compute health for all commits from the past N hours.")
+    ap.add_argument("--owner", default="camunda")
+    ap.add_argument("--repo", default="camunda")
+    ap.add_argument("--branch", default="main")
+    ap.add_argument("--hours", type=int, default=3, help="Look back this many hours (default 3).")
+    ap.add_argument("--per-page", type=int, default=100)
+    ap.add_argument("--max-pages", type=int, default=50, help="Safety cap; increase if repo is extremely active.")
+    ap.add_argument("--fallback-to-statuses", action="store_true")
+    ap.add_argument("--output", choices=["json", "table"], default="table")
+    ap.add_argument("--sleep-between", type=float, default=0.0)
+    ap.add_argument(
+        "--debug-checks",
+        nargs="?",
+        const="",
+        help="Print sample check suite/run fields for a commit SHA (or first commit) and exit.",
+    )
+    ap.add_argument(
+        "--workers",
+        type=int,
+        default=8,
+        help="Number of parallel workers for commit checks (default 8).",
+    )
+
+    args = ap.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    gh = GitHubClient(token=token)
+
+    start_utc, end_utc = past_hours_window_utc(args.hours)
+
+    commits, pages_scanned = list_commits_from_window(
+        gh=gh,
+        owner=args.owner,
+        repo=args.repo,
+        branch=args.branch,
+        start_utc=start_utc,
+        end_utc=end_utc,
+        per_page=args.per_page,
+        max_pages=args.max_pages,
+    )
+
+    if not commits:
+        msg = (
+            f"No commits found in past {args.hours} hours for {args.owner}/{args.repo}@{args.branch}.\n"
+            f"Window (UTC): [{start_utc.isoformat()} .. {end_utc.isoformat()})\n"
+            f"Pages scanned: {pages_scanned} (per_page={args.per_page}, max_pages={args.max_pages})."
+        )
+        print(msg)
+        return 0
+
+    if args.debug_checks is not None:
+        debug_sha = args.debug_checks or commits[0].sha
+        debug_check_metadata(gh, args.owner, args.repo, debug_sha)
+        return 0
+
+    results: List[CommitHealth] = []
+    if args.workers <= 1:
+        for c in commits:
+            results.append(
+                compute_health_for_commit(
+                    gh=gh,
+                    owner=args.owner,
+                    repo=args.repo,
+                    commit=c,
+                    fallback_to_statuses=args.fallback_to_statuses,
+                )
+            )
+            if args.sleep_between > 0:
+                time.sleep(args.sleep_between)
+    else:
+        if args.sleep_between > 0:
+            print("--sleep-between ignored when --workers > 1", file=sys.stderr)
+        task = partial(
+            compute_health_for_commit_with_client,
+            token,
+            gh.base_url,
+            gh.timeout,
+            args.owner,
+            args.repo,
+            fallback_to_statuses=args.fallback_to_statuses,
+        )
+        with ThreadPoolExecutor(max_workers=args.workers) as executor:
+            results = list(executor.map(task, commits))
+
+    if args.output == "table":
+        print(fmt_table(results))
+        print()
+        print(format_failed_job_totals(results))
+    else:
+        failed_job_totals: Dict[str, int] = {}
+        for r in results:
+            for job in r.failed_jobs:
+                failed_job_totals[job] = failed_job_totals.get(job, 0) + 1
+        payload = {
+            "repo": f"{args.owner}/{args.repo}",
+            "branch": args.branch,
+            "hours": args.hours,
+            "window_utc": {"start": start_utc.isoformat(), "end": end_utc.isoformat()},
+            "generated_at_utc": utc_now().isoformat(),
+            "pages_scanned": pages_scanned,
+            "commits_found": len(commits),
+            "results": [asdict(r) for r in results],
+            "failed_job_totals": failed_job_totals,
+        }
+        print(json.dumps(payload, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/ci-runner-utilization/SKILL.md
+++ b/.claude/skills/ci-runner-utilization/SKILL.md
@@ -1,0 +1,227 @@
+---
+
+name: ci-runner-utilization
+description: Detect CI runner underutilization and recommend downsizing for cost savings. Use when asked about CI costs, runner sizing, resource waste, underutilization, or right-sizing self-hosted runners.
+
+---
+
+# CI Runner Utilization & Downsizing Analysis
+
+Analyzes CPU and memory utilization of self-hosted CI runners in the `camunda/camunda` repository to find overprovisioned jobs and recommend cheaper runner types.
+
+## What costs money and what doesn't
+
+**Self-hosted runners cost money** — these are Kubernetes pods on GCP or AWS billed by core-hour. Their `runner_type` starts with `gcp-` (e.g., `gcp-perf-core-16-default`) or `aws-`. More cores = higher cost. Downsizing from 16 to 8 cores roughly halves the per-job compute cost.
+
+**GitHub-hosted runners are free for public repos** — jobs on `ubuntu-latest` / `ubuntu-slim` have `runner_type = NULL` in BigQuery. Ignore them entirely for cost optimization.
+
+**CPU is the expensive resource.** Memory is proportional to cores and much cheaper per unit. Focus downsizing decisions on CPU utilization; only check memory to ensure a smaller runner won't OOM.
+
+**Perf runners cost more than standard runners** — `gcp-perf-core-N` uses faster CPUs than `gcp-core-N`. Only suggest downgrading perf→standard if the job doesn't need fast CPUs (e.g., linting, static analysis, artifact uploads).
+
+**Longrunning runners cost more than default** — `-longrunning` has higher durability guarantees and costs more. Only needed for jobs that genuinely run long or are release-critical.
+
+## Runner type naming convention
+
+Format: `{cloud}-{tier?}-core-{cores}-{durability}`
+
+| Component  |                                     Values                                     |
+|------------|--------------------------------------------------------------------------------|
+| cloud      | `gcp`, `aws`                                                                   |
+| tier       | `perf` (fast CPU, more expensive) or absent (standard)                         |
+| cores      | `2`, `4`, `8`, `16` — number of vCPUs                                          |
+| durability | `default` (cheap, preemptible), `release` / `longrunning` (expensive, durable) |
+
+Available self-hosted runner types can be found on https://github.com/camunda/infra-global-github-actions/blob/main/actionlint/actionlint.yaml
+
+Downsizing follows the same family: `gcp-perf-core-16-default` → `gcp-perf-core-8-default`.
+
+## Prerequisites
+
+- `bq` CLI authenticated with access to project `ci-30-162810`
+  - Verify: `bq query --use_legacy_sql=false 'SELECT 1'`
+- Data is in `ci-30-162810.prod_ci_analytics.build_status_v2` (90-day retention)
+- CPU/memory metrics were added on 2026-05-18 — data availability starts from that date
+
+## How to analyze
+
+### Step 1: Identify underutilized self-hosted jobs
+
+This query finds jobs where the peak CPU p95 never exceeds 50% of the runner's capacity, grouped by runner type. Only self-hosted runners (non-NULL `runner_type`) are included.
+
+```bash
+bq query --use_legacy_sql=false --format=prettyjson '
+SELECT
+  job_name,
+  runner_type,
+  COUNT(*) AS samples,
+  ROUND(AVG(cpu_usage_ratio_p95), 3) AS avg_cpu_p95,
+  ROUND(MAX(cpu_usage_ratio_p95), 3) AS max_cpu_p95,
+  ROUND(AVG(memory_usage_ratio_p95), 3) AS avg_mem_p95,
+  ROUND(MAX(memory_usage_ratio_p95), 3) AS max_mem_p95
+FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
+WHERE cpu_usage_ratio_p95 IS NOT NULL
+  AND ci_url LIKE "%camunda/camunda%"
+  AND runner_type IS NOT NULL
+  AND (runner_type LIKE "gcp-%" OR runner_type LIKE "aws-%")
+GROUP BY job_name, runner_type
+HAVING MAX(cpu_usage_ratio_p95) <= 0.5
+ORDER BY max_cpu_p95 ASC
+'
+```
+
+### Step 2: Get full utilization picture (all self-hosted jobs)
+
+This shows all jobs sorted by CPU usage so you can see the full spectrum and identify the boundary between "needs downsizing" and "correctly sized":
+
+```bash
+bq query --use_legacy_sql=false --format=csv --max_rows=200 '
+SELECT
+  job_name,
+  runner_type,
+  COUNT(*) AS samples,
+  ROUND(AVG(cpu_usage_ratio_p95), 3) AS avg_cpu_p95,
+  ROUND(MAX(cpu_usage_ratio_p95), 3) AS max_cpu_p95,
+  ROUND(AVG(memory_usage_ratio_p95), 3) AS avg_mem_p95,
+  ROUND(MAX(memory_usage_ratio_p95), 3) AS max_mem_p95
+FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
+WHERE cpu_usage_ratio_p95 IS NOT NULL
+  AND ci_url LIKE "%camunda/camunda%"
+  AND runner_type IS NOT NULL
+  AND (runner_type LIKE "gcp-%" OR runner_type LIKE "aws-%")
+GROUP BY job_name, runner_type
+ORDER BY max_cpu_p95 ASC
+'
+```
+
+### Step 3: Check runner type distribution
+
+Understand which runner types carry the most jobs and runs:
+
+```bash
+bq query --use_legacy_sql=false --format=prettyjson '
+SELECT
+  runner_type,
+  COUNT(DISTINCT job_name) AS distinct_jobs,
+  COUNT(*) AS total_runs,
+  ROUND(AVG(cpu_usage_ratio_p95), 3) AS overall_avg_cpu_p95
+FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
+WHERE ci_url LIKE "%camunda/camunda%"
+  AND cpu_usage_ratio_p95 IS NOT NULL
+  AND runner_type IS NOT NULL
+GROUP BY runner_type
+ORDER BY total_runs DESC
+'
+```
+
+### Step 4: Deep-dive a specific job (time series)
+
+When you want to see if a job's usage is stable or has spikes over time:
+
+```bash
+bq query --use_legacy_sql=false --format=prettyjson '
+SELECT
+  report_time,
+  job_name,
+  runner_type,
+  ROUND(cpu_usage_ratio_p95, 3) AS cpu_p95,
+  ROUND(memory_usage_ratio_p95, 3) AS mem_p95,
+  build_status
+FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
+WHERE ci_url LIKE "%camunda/camunda%"
+  AND job_name = "REPLACE_WITH_JOB_NAME"
+  AND cpu_usage_ratio_p95 IS NOT NULL
+ORDER BY report_time DESC
+LIMIT 50
+'
+```
+
+## How to interpret results and make recommendations
+
+### Utilization metrics
+
+- `cpu_usage_ratio_p95`: 95th-percentile CPU usage as a fraction of the container's CPU limit (0.0–1.0). A value of 0.25 on a 16-core runner means the job used ~4 cores at p95.
+- `memory_usage_ratio_p95`: Same for memory. Check this to ensure a smaller runner won't OOM.
+- Always use `MAX(cpu_usage_ratio_p95)` across runs, not just the average — you need to handle the worst case, not the typical case.
+
+### Decision framework
+
+| Max CPU p95 |                    Action                    | Confidence |
+|-------------|----------------------------------------------|------------|
+| ≤ 25%       | Downsize by 4x (16→4 cores) or 2x (8→4, 4→2) | High       |
+| 25–50%      | Downsize by 2x (16→8, 8→4)                   | High       |
+| 50–65%      | Borderline — downsize only with ≥50 samples  | Medium     |
+| 65–80%      | Keep current size                            | —          |
+| 80–100%     | Correctly sized or consider upsizing         | —          |
+
+### Memory safety check
+
+Before recommending a downsize, verify `max_mem_p95`:
+- If `max_mem_p95 < 0.5` on the current runner, halving cores (and thus memory) is safe.
+- If `max_mem_p95 > 0.5`, halving would risk OOM. Consider keeping the larger runner or only stepping down one size (16→8 instead of 16→4).
+
+If no suitable runner type can be found, suggest creating new runner types.
+
+### Sample count matters
+
+- **≥ 100 samples**: High confidence — safe to act on.
+- **30–100 samples**: Medium confidence — recommend with a note to monitor.
+- **< 30 samples**: Low confidence — flag for future review, don't act yet.
+
+### Forming the recommendation
+
+For each underutilized job:
+1. Note the current `runner_type` and extract the core count.
+2. Multiply `max_cpu_p95` by the core count to get effective cores used.
+3. Find the smallest available runner type (same family) that provides ≥1.5x the effective cores.
+4. Check memory won't OOM on the smaller runner.
+5. State: job name, current runner, suggested runner, CPU headroom, memory headroom, sample count.
+
+Example: A job with `max_cpu_p95 = 0.25` on `gcp-perf-core-8-default` uses ~2 effective cores.
+A `gcp-perf-core-4-default` (4 cores) gives 2x headroom → recommend it.
+
+If no suitable runner type can be found, suggest creating new runner types.
+
+### Implementing the recommendation
+
+For each underutilized job:
+1. Ask the user for confirmation to apply the recommendation.
+2. Find the GitHub Action workflow YAML file that contains the job, and adjust the `runs-on:` label.
+3. Offer to commit and push the changes to a Pull Request, and observe the CI runtime behavior on that PR.
+4. Confirm job run times on the PR do not increase meaningfully.
+
+## BigQuery table schema reference
+
+Table: `ci-30-162810.prod_ci_analytics.build_status_v2` (90-day retention)
+
+|            Column             |   Type    |                    Description                    |
+|-------------------------------|-----------|---------------------------------------------------|
+| `report_time`                 | TIMESTAMP | When the row was submitted                        |
+| `ci_url`                      | STRING    | `https://github.com/{owner}/{repo}`               |
+| `workflow_name`               | STRING    | GitHub Actions workflow name                      |
+| `job_name`                    | STRING    | Job identifier                                    |
+| `build_id`                    | STRING    | `{run_id}/{attempt}`                              |
+| `build_trigger`               | STRING    | Event name (push, pull_request, schedule, etc.)   |
+| `build_status`                | STRING    | success, failed, cancelled                        |
+| `build_ref`                   | STRING    | Git ref                                           |
+| `build_base_ref`              | STRING    | Target branch (PRs/merge queue)                   |
+| `build_head_ref`              | STRING    | Source branch (PRs)                               |
+| `build_duration_milliseconds` | INTEGER   | Job duration                                      |
+| `runner_name`                 | STRING    | Runner hostname                                   |
+| `runner_arch`                 | STRING    | CPU architecture (x86_64, aarch64)                |
+| `runner_os`                   | STRING    | OS (linux, windows)                               |
+| `runner_type`                 | STRING    | Self-hosted runner label (NULL for GitHub-hosted) |
+| `cpu_usage_ratio_avg`         | FLOAT64   | Average CPU utilization (0.0–1.0)                 |
+| `cpu_usage_ratio_p95`         | FLOAT64   | 95th percentile CPU utilization                   |
+| `memory_usage_ratio_avg`      | FLOAT64   | Average memory utilization (0.0–1.0)              |
+| `memory_usage_ratio_p95`      | FLOAT64   | 95th percentile memory utilization                |
+| `user_reason`                 | STRING    | User-provided failure reason                      |
+| `user_description`            | STRING    | User-provided details                             |
+
+## Data collection pipeline
+
+1. `start-build-monitor` action starts a background monitor (5s polling) collecting CPU/memory from cgroups v2/v1 or `/proc/`
+2. `submit-build-status` action stops the monitor, aggregates stats (avg, p95) via AWK, reads `runner_type` from `/home/runner/.camunda-arc-runner-info/runs-on`, and POSTs to BigQuery
+3. Metrics are normalized ratios relative to the container's CPU/memory limits
+
+Source: `camunda/infra-global-github-actions/start-build-monitor/` and `camunda/infra-global-github-actions/submit-build-status/`

--- a/.claude/skills/ci-scheduled-workflow-health/SKILL.md
+++ b/.claude/skills/ci-scheduled-workflow-health/SKILL.md
@@ -1,0 +1,57 @@
+---
+
+name: ci-scheduled-workflow-health
+description: Generate a health report for scheduled GitHub Actions workflows in this monorepo. Use when asked about scheduled workflow health, nightly build failures, flaky CI, or workflow ownership.
+
+---
+
+# Scheduled Workflow Health Report
+
+Generates an HTML report showing the health status of all scheduled GitHub Actions workflows in the `camunda/camunda` repository.
+
+Then summarizes the concerning failing and flaky workflows by owner.
+
+## What it does
+
+1. Lists all workflow files from `git show main:.github/workflows/`
+2. Filters to those containing a `schedule:` trigger
+3. Extracts the `# owner:` comment from the first 20 lines of each YAML file
+4. Queries the GitHub API (via `gh`) for the last 5 scheduled runs on `main`
+5. Classifies each workflow:
+   - **failing** — most recent run failed AND all checked runs failed
+   - **flaky** — most recent run failed BUT some checked runs passed
+   - **ok** — most recent run passed
+   - **no_runs** / **in_progress** — no completed scheduled runs found
+6. Outputs `scheduled-workflow-report.html` with collapsible sections, owner info, and a legend
+
+## Prerequisites
+
+- `git` with access to the `main` branch (fetched)
+- `gh` CLI authenticated (`gh auth status`)
+- `python3`
+
+## How to run
+
+```bash
+python3 .claude/skills/ci-scheduled-workflow-health/scripts/scheduled-workflow-report.py
+```
+
+The script is at: `.claude/skills/ci-scheduled-workflow-health/scripts/scheduled-workflow-report.py`.
+
+Output: `scheduled-workflow-report.html` in the current directory. Open with a browser.
+
+stderr shows progress and a summary of failing/flaky workflows with their owners.
+
+## Customization
+
+- `RUNS_TO_CHECK` constant (default 5) controls how many recent runs to inspect per workflow
+- `OWNER` / `REPO` constants control the target repository
+- Owner extraction looks for `# owner: <team>` in the first 20 lines of each workflow YAML
+
+## Key design decisions
+
+- Uses `git show main:` instead of filesystem reads to always reflect the `main` branch state
+- Uses `gh api` (no pagination) since we only need ≤5 runs per workflow
+- Filters API calls to `event=schedule&branch=main` to only see scheduled runs
+- HTML report uses `<details>` for collapsible sections — failing/flaky are open by default
+

--- a/.claude/skills/ci-scheduled-workflow-health/scripts/scheduled-workflow-report.py
+++ b/.claude/skills/ci-scheduled-workflow-health/scripts/scheduled-workflow-report.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""
+Generate an HTML report of failing scheduled GitHub Actions workflows.
+
+Extracts scheduled workflow filenames from git main branch, queries the
+GitHub API for recent runs, and outputs an HTML report of failures.
+"""
+
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+OWNER = "camunda"
+REPO = "camunda"
+# How many recent runs per workflow to check
+RUNS_TO_CHECK = 5
+
+
+def git_list_workflow_files():
+    """List workflow files from the main branch via git ls-tree (plumbing)."""
+    result = subprocess.run(
+        ["git", "ls-tree", "--name-only", "main", ".github/workflows/"],
+        capture_output=True, text=True, check=True,
+    )
+    # Each line is ".github/workflows/<filename>"; extract just the filename
+    return [
+        line.rsplit("/", 1)[-1]
+        for line in result.stdout.splitlines()
+        if line.strip()
+    ]
+
+
+def git_read_workflow(filename):
+    """Read a workflow file from the main branch."""
+    result = subprocess.run(
+        ["git", "show", f"main:.github/workflows/{filename}"],
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout
+
+
+def git_file_has_schedule(content):
+    """Check if workflow content contains a schedule trigger."""
+    return "schedule:" in content
+
+
+def extract_owner(content):
+    """Extract owner from '# owner: ...' comment in the first 20 lines."""
+    for line in content.splitlines()[:20]:
+        m = re.match(r'^\s*#\s*owner:?\s*(.+)', line, re.IGNORECASE)
+        if m:
+            owner = m.group(1).strip()
+            # Some lines have "# owner @team" (without colon after owner)
+            owner = re.sub(r'^#\s*owner\s*', '', owner, flags=re.IGNORECASE).strip()
+            if owner:
+                return owner
+    return None
+
+
+def gh_api(endpoint):
+    """Call GitHub API via gh CLI."""
+    result = subprocess.run(
+        ["gh", "api", endpoint],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"  WARNING: API call failed for {endpoint}: {result.stderr.strip()}", file=sys.stderr)
+        return None
+    return json.loads(result.stdout)
+
+
+def get_recent_runs(workflow_filename):
+    """Get recent workflow runs for a given workflow file."""
+    endpoint = (
+        f"/repos/{OWNER}/{REPO}/actions/workflows/{workflow_filename}/runs"
+        f"?per_page={RUNS_TO_CHECK}&branch=main&event=schedule"
+    )
+    data = gh_api(endpoint)
+    if data is None:
+        return []
+    return data.get("workflow_runs", [])
+
+
+def classify_workflow(runs):
+    """Classify workflow status based on recent runs.
+    Returns (status, details) where status is 'failing', 'flaky', 'ok', or 'no_runs'.
+    """
+    if not runs:
+        return "no_runs", []
+
+    details = []
+    for run in runs:
+        details.append({
+            "id": run["id"],
+            "conclusion": run.get("conclusion"),
+            "status": run["status"],
+            "created_at": run["created_at"],
+            "html_url": run["html_url"],
+            "run_number": run["run_number"],
+        })
+
+    conclusions = [r["conclusion"] for r in details if r["conclusion"] is not None]
+    if not conclusions:
+        return "in_progress", details
+
+    if conclusions[0] == "failure":
+        if all(c == "failure" for c in conclusions):
+            return "failing", details
+        return "flaky", details
+
+    return "ok", details
+
+
+def generate_html(workflows):
+    """Generate an HTML report from classified workflow data."""
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    # Separate into categories
+    failing = [(w, o, s, d) for w, o, s, d in workflows if s == "failing"]
+    flaky = [(w, o, s, d) for w, o, s, d in workflows if s == "flaky"]
+    ok = [(w, o, s, d) for w, o, s, d in workflows if s == "ok"]
+    no_runs = [(w, o, s, d) for w, o, s, d in workflows if s in ("no_runs", "in_progress")]
+
+    def status_badge(status):
+        colors = {
+            "failing": "#d73a49",
+            "flaky": "#e36209",
+            "ok": "#28a745",
+            "no_runs": "#6a737d",
+            "in_progress": "#0366d6",
+        }
+        color = colors.get(status, "#6a737d")
+        return f'<span style="background:{color};color:#fff;padding:2px 8px;border-radius:4px;font-size:0.85em;">{status}</span>'
+
+    def conclusion_icon(conclusion):
+        icons = {
+            "success": "&#x2705;",
+            "failure": "&#x274C;",
+            "cancelled": "&#x23F9;",
+            "skipped": "&#x23ED;",
+            "timed_out": "&#x23F0;",
+            None: "&#x23F3;",
+        }
+        return icons.get(conclusion, f"&#x2753; {conclusion}")
+
+    def render_section(title, items, open_by_default=False):
+        if not items:
+            return ""
+        open_attr = " open" if open_by_default else ""
+        rows = []
+        for wf_name, wf_owner, status, details in items:
+            run_cells = ""
+            for d in details[:RUNS_TO_CHECK]:
+                created = d["created_at"][:10]
+                url = d["html_url"]
+                icon = conclusion_icon(d["conclusion"])
+                run_cells += f'<a href="{url}" title="{d["conclusion"] or "in_progress"} on {created}" style="text-decoration:none;margin-right:4px;">{icon}</a>'
+            wf_url = f"https://github.com/{OWNER}/{REPO}/actions/workflows/{wf_name}?query=event%3Aschedule"
+            owner_cell = wf_owner or '<span style="color:#6a737d;">unknown</span>'
+            rows.append(
+                f"<tr>"
+                f'<td><a href="{wf_url}">{wf_name}</a></td>'
+                f"<td>{owner_cell}</td>"
+                f"<td>{status_badge(status)}</td>"
+                f"<td>{run_cells or 'N/A'}</td>"
+                f"</tr>"
+            )
+        return f"""
+        <details{open_attr}>
+          <summary><strong>{title}</strong> ({len(items)})</summary>
+          <table>
+            <thead><tr><th>Workflow</th><th>Owner</th><th>Status</th><th>Recent Runs (newest first)</th></tr></thead>
+            <tbody>{"".join(rows)}</tbody>
+          </table>
+        </details>
+        """
+
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Scheduled Workflow Report — {OWNER}/{REPO}</title>
+<style>
+  body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; margin: 2em; color: #24292e; }}
+  h1 {{ border-bottom: 1px solid #e1e4e8; padding-bottom: 0.3em; }}
+  table {{ border-collapse: collapse; width: 100%; margin: 0.5em 0 1.5em; }}
+  th, td {{ border: 1px solid #e1e4e8; padding: 6px 12px; text-align: left; }}
+  th {{ background: #f6f8fa; }}
+  tr:hover {{ background: #f6f8fa; }}
+  details {{ margin: 1em 0; }}
+  summary {{ cursor: pointer; font-size: 1.1em; padding: 0.3em 0; }}
+  a {{ color: #0366d6; text-decoration: none; }}
+  a:hover {{ text-decoration: underline; }}
+  .stats {{ display: flex; gap: 1.5em; margin: 1em 0; }}
+  .stat {{ padding: 0.8em 1.2em; border-radius: 6px; }}
+  .stat-failing {{ background: #ffeef0; border: 1px solid #d73a49; }}
+  .stat-flaky {{ background: #fff8e1; border: 1px solid #e36209; }}
+  .stat-ok {{ background: #e6ffed; border: 1px solid #28a745; }}
+  .stat-other {{ background: #f1f8ff; border: 1px solid #0366d6; }}
+  .legend {{ border-collapse: collapse; width: auto; margin: 0.3em 0; }}
+  .legend th, .legend td {{ border: 1px solid #e1e4e8; padding: 4px 12px; }}
+  .legend th {{ background: #f6f8fa; }}
+</style>
+</head>
+<body>
+<h1>Scheduled Workflow Report</h1>
+<p>Repository: <a href="https://github.com/{OWNER}/{REPO}">{OWNER}/{REPO}</a> &mdash; Generated: {now}</p>
+<p>Checked last {RUNS_TO_CHECK} scheduled runs on <code>main</code> for each workflow.</p>
+<div class="stats">
+  <div class="stat stat-failing"><strong>{len(failing)}</strong> Failing</div>
+  <div class="stat stat-flaky"><strong>{len(flaky)}</strong> Flaky</div>
+  <div class="stat stat-ok"><strong>{len(ok)}</strong> OK</div>
+  <div class="stat stat-other"><strong>{len(no_runs)}</strong> No runs (yet, could be new) / In progress</div>
+</div>
+<details>
+<summary><strong>Legend</strong></summary>
+<table class="legend">
+  <tr><th>Symbol</th><th>Meaning</th></tr>
+  <tr><td>&#x2705;</td><td>Run succeeded</td></tr>
+  <tr><td>&#x274C;</td><td>Run failed</td></tr>
+  <tr><td>&#x23F9;</td><td>Run was cancelled</td></tr>
+  <tr><td>&#x23ED;</td><td>Run was skipped</td></tr>
+  <tr><td>&#x23F0;</td><td>Run timed out</td></tr>
+  <tr><td>&#x23F3;</td><td>Run is in progress</td></tr>
+  <tr><td>&#x2753;</td><td>Unknown / other conclusion</td></tr>
+</table>
+<table class="legend" style="margin-top:0.5em;">
+  <tr><th>Badge</th><th>Meaning</th></tr>
+  <tr><td><span style="background:#d73a49;color:#fff;padding:2px 8px;border-radius:4px;font-size:0.85em;">failing</span></td><td>Most recent run failed and all checked runs failed</td></tr>
+  <tr><td><span style="background:#e36209;color:#fff;padding:2px 8px;border-radius:4px;font-size:0.85em;">flaky</span></td><td>Most recent run failed but some checked runs passed</td></tr>
+  <tr><td><span style="background:#28a745;color:#fff;padding:2px 8px;border-radius:4px;font-size:0.85em;">ok</span></td><td>Most recent run passed</td></tr>
+  <tr><td><span style="background:#6a737d;color:#fff;padding:2px 8px;border-radius:4px;font-size:0.85em;">no_runs</span></td><td>No scheduled runs found on main</td></tr>
+  <tr><td><span style="background:#0366d6;color:#fff;padding:2px 8px;border-radius:4px;font-size:0.85em;">in_progress</span></td><td>All recent runs still in progress</td></tr>
+</table>
+</details>
+
+{render_section("&#x274C; Failing (most recent run failed, all recent runs failed)", failing, open_by_default=True)}
+{render_section("&#x26A0;&#xFE0F; Flaky (most recent run failed, but some recent runs passed)", flaky, open_by_default=True)}
+{render_section("&#x2705; OK (most recent run passed)", ok, open_by_default=False)}
+{render_section("&#x2754; No Runs / In Progress", no_runs, open_by_default=False)}
+</body>
+</html>"""
+    return html
+
+
+def main():
+    print("Discovering scheduled workflows from git main branch...", file=sys.stderr)
+    all_files = git_list_workflow_files()
+
+    # Read all files and filter for scheduled ones, extracting owners
+    scheduled = []  # list of (filename, owner)
+    for f in all_files:
+        content = git_read_workflow(f)
+        if git_file_has_schedule(content):
+            owner = extract_owner(content)
+            scheduled.append((f, owner))
+    print(f"Found {len(scheduled)} scheduled workflows.", file=sys.stderr)
+
+    results = []
+    for i, (wf, owner) in enumerate(scheduled, 1):
+        print(f"  [{i}/{len(scheduled)}] Checking {wf}...", file=sys.stderr)
+        runs = get_recent_runs(wf)
+        status, details = classify_workflow(runs)
+        results.append((wf, owner, status, details))
+
+    # Sort: failing first, then flaky, then the rest
+    order = {"failing": 0, "flaky": 1, "in_progress": 2, "no_runs": 3, "ok": 4}
+    results.sort(key=lambda x: (order.get(x[2], 99), x[0]))
+
+    html = generate_html(results)
+
+    outfile = "scheduled-workflow-report.html"
+    with open(outfile, "w") as f:
+        f.write(html)
+    print(f"\nReport written to {outfile}", file=sys.stderr)
+
+    # Also print summary to stderr
+    failing = [(w, o) for w, o, s, _ in results if s == "failing"]
+    flaky = [(w, o) for w, o, s, _ in results if s == "flaky"]
+    if failing:
+        print(f"\nFAILING ({len(failing)}):", file=sys.stderr)
+        for w, o in failing:
+            print(f"  - {w}  [{o or 'unknown'}]", file=sys.stderr)
+    if flaky:
+        print(f"\nFLAKY ({len(flaky)}):", file=sys.stderr)
+        for w, o in flaky:
+            print(f"  - {w}  [{o or 'unknown'}]", file=sys.stderr)
+    if not failing and not flaky:
+        print("\nAll scheduled workflows are passing!", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: create-issue
+description: Create a GitHub issue in camunda/camunda with the correct template, component label, and parent link. Use when asked to create, file, or open an issue — for bugs, features, tasks, tech debt, or CVEs.
+---
+
+# Create Issue
+
+Creates a well-formed GitHub issue in `camunda/camunda` following the official templates. Prevents
+missing parent links, wrong component labels, and skipped required fields.
+
+## Prerequisites
+
+```bash
+gh auth status  # must succeed
+```
+
+## Procedure
+
+### Step 1 — Read available templates
+
+This branch (`stable/8.7`) predates the unified YAML issue templates — its local
+`.github/ISSUE_TEMPLATE/` only has old per-team `.md` files. GitHub issues are not branch-scoped:
+templates always render from the repository's default branch (`main`) regardless of which branch
+is checked out locally, so read the authoritative templates from `origin/main` directly instead of
+the local filesystem (the same reasoning the `ci-scheduled-workflow-health` skill uses to read
+workflow files from `main` rather than the local checkout):
+
+```bash
+git ls-tree --name-only origin/main .github/ISSUE_TEMPLATE/ | grep '\.yml$'
+```
+
+The output from above is the authoritative list of available templates. The table below is a
+default mapping for the common cases — if a template appears in the listing but not here, read
+its `labels:` field to infer the `kind/` label.
+
+| User intent                    | Template file              | `kind/` label          |
+|--------------------------------|----------------------------|------------------------|
+| Bug, defect, crash, regression | `1. bug_report.yml`        | `kind/bug`             |
+| Feature, improvement           | `2. feature_request.yml`   | `kind/feature-request` |
+| Task, activity, chore          | `3. task.yml`              | `kind/task`            |
+| Epic breakdown                 | `4. epic breakdown.yml`    | `kind/epic`            |
+| CVE, security vulnerability    | `5. CVE.yml`               | `kind/cve`             |
+| Tech debt, cleanup             | `6. tech debt.yml`         | `kind/tech-debt`       |
+
+If the issue type is ambiguous, ask the user to pick one before proceeding.
+
+### Step 2 — Read the template and collect field values
+
+Read the chosen template from `origin/main` (it does not exist locally on this branch):
+
+```bash
+git show "origin/main:.github/ISSUE_TEMPLATE/<chosen>.yml"
+```
+
+For bug reports (`1. bug_report.yml`), invoke the `grill-me` skill before inferring fields — it
+builds shared understanding of impact, root cause, and reproduction path, making field inference
+much more accurate.
+
+Ask the user for a free-form description of the issue. Use that description to infer values for
+every field in the template's `body:` list. For each item:
+- Skip `type: markdown` items (they are display-only).
+- Infer a value from the description where possible — including title, dropdown selections, and
+  prose sections.
+- Only ask the user a follow-up question when the description does not provide enough signal to
+  fill a field confidently. Batch all uncertain fields into a single follow-up rather than asking
+  one at a time.
+- If `validations.required: true` and a value cannot be inferred, the user must provide one before
+  proceeding.
+- If `validations.required: false` or absent and nothing can be inferred, leave the field empty.
+
+### Step 3 — Infer the component label
+
+Detect which module the issue relates to from the current working directory and modified files:
+
+```bash
+git diff --name-only HEAD
+```
+
+Map path prefixes to component labels:
+
+| Path prefix              | Component label                  |
+|--------------------------|----------------------------------|
+| `zeebe/` — see below     | `component/zeebe-engine` or `component/zeebe-platform` (fallback: `component/zeebe`) |
+| `operate/`               | `component/operate`              |
+| `tasklist/`              | `component/tasklist`             |
+| `identity/`              | `component/identity`             |
+| `optimize/`              | `component/optimize`             |
+| `clients/`               | `component/clients`              |
+| `webapp/`                | `component/c8-api`               |
+| `gateways/gateway-mcp/`  | `component/mcp`                  |
+| `gateways/`              | `component/gateway`              |
+| `db/` or `search/`       | `component/data-layer`           |
+| `document/`              | `component/document-handling`    |
+| `testing/`               | `component/camunda-process-test` |
+| `qa/`                    | `component/qa`                   |
+| `.github/` or `.claude/` | `component/build-pipeline`       |
+
+**Zeebe label split — use the conceptual layer, not the path:**
+
+- `component/zeebe-engine` — application/engine layer: BPMN/DMN execution, process state, variable
+  handling, FEEL evaluation, gRPC/REST API surface, `zeebe/gateway`, `zeebe/engine`
+- `component/zeebe-platform` — platform/infrastructure layer: broker internals, clustering, Raft,
+  replication, storage (RocksDB), job streaming, `zeebe/broker` (infra aspects)
+- Grey areas (e.g. `zeebe/broker` engine logic, job streaming in `zeebe/gateway`): prefer the
+  layer that is more affected; use `component/zeebe` as fallback when genuinely unclear
+
+When multiple modules are touched, pick the label for the most-affected one. If uncertain, ask the
+user. If no files are modified, ask the user which component applies.
+
+### Step 4 — Ask for the parent issue
+
+Ask the user:
+
+> "Does this issue have a parent issue or epic? If so, please provide the issue number or URL."
+
+If they provide one, verify it exists and fetch its title for display in the summary:
+
+```bash
+gh issue view <number> --repo camunda/camunda --json number,title,url
+```
+
+If the user says there is no parent, omit the parent link from the body.
+
+### Step 5 — Compose the issue body
+
+Build the Markdown body directly from the template read in Step 2, mirroring exactly what the
+GitHub form UI produces. For each item in the template's `body:` list:
+
+- Skip `type: markdown` items (display-only).
+- For `type: textarea` items: render `attributes.label` as a `### Heading` and the user's value as
+  the content.
+- For `type: dropdown` items: render `attributes.label` as a `### Heading` and the selected
+  option's text verbatim as the content (e.g. `<!-- Zeebe- -->`). These HTML comment markers are
+  what `.github/opened_issue_labeler.yml` scans on issue open to auto-apply labels.
+
+Append a **Links** section at the end with the parent issue URL if one was provided.
+
+When the body points at specific lines of repository code, use a **stable GitHub permalink** rather
+than a bare `path:line` (see "Referencing code in issues, PRs, and comments" in `AGENTS.md`).
+
+Do not invent sections or use any structure other than what the template defines.
+
+### Step 6 — Propose summary and ask for approval
+
+Before printing the summary, scan the body for sensitive data and redact it: replace UUIDs,
+customer/user IDs, internal hostnames, and email addresses found in any copied log output with
+`<redacted>`.
+
+Print a clear summary and wait for explicit confirmation. Do NOT call `gh issue create` yet.
+
+```
+📋 Issue summary
+────────────────────────────────────────────
+Title:   <proposed title>
+Type:    <bug | feature | task | tech-debt | CVE>
+Labels:  kind/<type>  (component/*, severity/*, likelihood/* applied automatically via labeler)
+Parent:  https://github.com/camunda/camunda/issues/<N>  (or "none")
+
+Body:
+<full proposed body>
+────────────────────────────────────────────
+Create this issue? (y/N)
+```
+
+If the user requests changes, revise the summary and ask again before proceeding.
+
+### Step 7 — Create the issue and register the parent relationship
+
+After the user confirms, create the issue. Pass only the `kind/<type>` label explicitly — all
+other labels (`component/*`, `severity/*`, `likelihood/*`, `affects/*`) are applied automatically
+by `.github/opened_issue_labeler.yml`, which scans the body for the HTML comment markers rendered
+in Step 5.
+
+```bash
+body_file=$(mktemp)
+printf '%s' "<body>" > "$body_file"
+
+gh issue create \
+  --repo camunda/camunda \
+  --title "<title>" \
+  --body-file "$body_file" \
+  --label "kind/<type>"
+
+rm -f "$body_file"
+```
+
+Capture the new issue number from the returned URL. Then fetch its database ID and node ID (both
+needed below — the database ID for the sub-issues API, the node ID for setting the Issue Type):
+
+```bash
+gh api repos/camunda/camunda/issues/<new-issue-number> --jq '{id: .id, node_id: .node_id}'
+```
+
+Set the native GitHub Issue Type (bypassed by `gh issue create`) by resolving the type name from
+the template's `type:` field against the repo's configured issue types:
+
+```bash
+type_id=$(gh api graphql -f query='{
+  repository(owner: "camunda", name: "camunda") {
+    issueTypes(first: 20) { nodes { id name } }
+  }
+}' --jq --arg t "<type from template>" \
+  '.data.repository.issueTypes.nodes[]
+   | select(.name | ascii_downcase == ($t | ascii_downcase)) | .id')
+
+gh api graphql -f query="mutation {
+  updateIssue(input: {id: \"<node_id>\", issueTypeId: \"$type_id\"}) {
+    issue { id }
+  }
+}"
+```
+
+If a parent was provided, register the native GitHub sub-issue relationship so the new issue
+appears as a child of the parent in the GitHub UI:
+
+```bash
+gh api \
+  --method POST \
+  repos/camunda/camunda/issues/<parent-number>/sub_issues \
+  --input - <<< "{\"sub_issue_id\": <new-issue-database-id>}"
+```
+
+Print the URL of the created issue.

--- a/.claude/skills/load-test-ops
+++ b/.claude/skills/load-test-ops
@@ -1,0 +1,1 @@
+../../load-tests/skills/load-test-ops

--- a/.claude/skills/zeebe-flamegraph-diff/SKILL.md
+++ b/.claude/skills/zeebe-flamegraph-diff/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: zeebe-flamegraph-diff
+description: Parse and compare async-profiler CPU flamegraphs from Camunda/Zeebe brokers — benchmark nodes or production. Use when investigating a CPU regression or outlier with .html flamegraphs (e.g. from dashboard.benchmark.camunda.cloud daily runs, or pulled from a live cluster/customer incident) — attribute a node's CPU to Zeebe subsystems and diff a suspect run against a healthy baseline.
+---
+
+# Zeebe flamegraph diff
+
+Tooling to read async-profiler HTML flamegraphs from Camunda 8 / Zeebe brokers
+and answer: **"where is this node burning CPU, and what changed vs a healthy
+run?"** Works on any pair of comparable flamegraphs — daily load-test captures
+(per-node, per-protocol) from `dashboard.benchmark.camunda.cloud`, or ad-hoc
+captures pulled from a production/customer cluster during an incident.
+
+## When to use
+
+- A benchmark/load-test run, or a production node/pod, is flagged problematic
+  (backpressure, dropped requests, low throughput, high CPU) and you have
+  per-node `.html` flamegraphs.
+- One node/broker is a CPU outlier vs its peers.
+- Confirming whether a CPU/throughput regression is a code change, a config/
+  sizing change, or just load — on a benchmark run or in production.
+
+If you don't have a profile yet: benchmark nodes emit one automatically per
+daily run; on production you need `async-profiler` attached to the JVM (or an
+equivalent continuous-profiling agent) and must capture one yourself — this
+skill only covers reading and diffing `.html` output, not attaching/capturing.
+
+Pair with Grafana (`prometheus` datasource) for the metrics half of the story —
+the flamegraph tells you *where* CPU goes; metrics tell you *whether it
+matters* (see step 4). For benchmark runs, also pair with the `load-test-ops`
+skill (triggering/monitoring runs).
+
+## Critical gotchas (read first)
+
+1. **Never diff a gRPC profile against a REST profile.** Each daily run emits
+   TWO flamegraphs per node — one while the gateway serves gRPC, one for REST.
+   Their request-handling stacks are completely different (REST = Tomcat/coyote +
+   Spring Security filter chain + `BearerTokenAuthenticationFilter`; gRPC = Netty
+   event loop, no Tomcat). Diffing across protocols produces garbage. Filenames
+   do NOT say which is which — detect it (step 1).
+2. **Sample counts are not comparable across files.** Different capture windows →
+   different totals. Only compare **percentages** (all scripts output %).
+3. **Lambda/proxy names and native `.so` files carry per-run random ids**
+   (`$$Lambda.0x…7b91000.run`, `librocksdbjni<random>.so`). Raw they look like
+   huge diffs for identical code. `fg_diff.py` normalizes these; `grep` over the
+   raw HTML will also miss compressed names — always parse, don't grep.
+
+## Workflow
+
+All scripts live in `scripts/` and share `fg_common.py`. Run them from that dir
+(or `cd` there) so the import resolves.
+
+### 1. Identify each file's protocol (gRPC vs REST)
+
+```bash
+cd scripts
+python3 fg_top.py <file.html> 40 | grep -iE "coyote|tomcat|BearerToken|SingleThreadIoEventLoop|FrameworkServlet"
+```
+
+Tomcat/coyote/`FrameworkServlet`/`BearerToken` present → **REST**. Only Netty
+(`SingleThreadIoEventLoop`) with no Tomcat → **gRPC**. Pick matching protocols on
+both sides of a diff.
+
+### 2. Attribute one node's CPU to subsystems
+
+```bash
+python3 fg_subsystems.py <file.html>
+```
+
+Leaf-based split across Zeebe subsystems (exporter, replay, processing,
+rocksdb-state, journal-flush, raft-netty, grpc, gc). ~70-75% coverage is normal
+(native/syscall scatter → `other`). See
+[`references/zeebe-contributors.md`](references/zeebe-contributors.md) for what
+each subsystem is and which frames feed it.
+
+### 3. Diff suspect vs healthy baseline
+
+```bash
+python3 fg_diff.py <baseline.html> <candidate.html> [min_delta_pct]
+```
+
+Inclusive-% diff, volatile ids normalized. "Grew in candidate" = where the
+regressed run spends more; "Shrank" = where the healthy run spent more. Ignore
+generic roots that move together (`thread_native_entry`, `start_thread`,
+`Thread::call_run`, `Executors$RunnableAdapter.call`, the renamed `.so`) — they
+are attribution shuffles, not signal. Focus on named Camunda/RocksDB/journal
+frames.
+
+### 4. Confirm with metrics — the efficiency lens (don't stop at the flamegraph)
+
+A flamegraph shows CPU *distribution*, not efficiency. Two runs can have an almost
+identical profile shape yet very different throughput. Pull the metrics half from
+Grafana (`prometheus` datasource). Namespace/datasource depends on where the
+profile came from: daily benchmarks live under
+`c8-medic-daily-<date>-<hash>-test`; a production or customer cluster will be on
+a different namespace/datasource — confirm you can actually reach it (customer
+envs are often not scrapeable from the same Grafana) before assuming the
+metric half is available at all.
+
+Metric cheat-sheet (all rate/histogram over the steady window):
+
+| question | metric |
+|---|---|
+| CPU per pod / saturated? / outlier? | `container_cpu_usage_seconds_total` |
+| backpressure / shed load | `zeebe_dropped_request_count_total`, `zeebe_backpressure_*` |
+| processing throughput | `zeebe_stream_processor_records_total{action="processed"}` |
+| bytes persisted / append rate | `atomix_journal_append_data_rate_total`, `atomix_journal_append_rate_total` |
+| flush count + latency | `atomix_journal_flush_time_seconds_{count,sum,bucket}` |
+| per-record cost by type | `zeebe_stream_processor_processing_duration_seconds_bucket` (group by `valueType,intent`) |
+| state size (rule out data growth) | `zeebe_rocksdb_live_estimate_live_data_size`, `_num_keys`, `zeebe_rocksdb_sst_total_sst_files_size` |
+| GC | `jvm_gc_pause_seconds_*` (STW) vs the `gc` flamegraph bucket (concurrent, off-pause) |
+
+**The key derived signal is work-per-core.** Compute CPU/record and CPU/MB-persisted
+on both runs. Interpreting the combination:
+
+- **CPU pinned at the request/limit** → node is *saturated*; a regression then shows
+  up as **lower throughput at flat CPU**, NOT higher CPU. Don't expect the CPU line
+  to move — divide it by throughput.
+- **Flat CPU + throughput down + a subsystem grew in the diff** → *efficiency*
+  regression (more CPU per unit work), not more load.
+- **Processing-duration median flat but p99 tail up** → usually a *saturation
+  queueing* symptom, not a per-record slowdown; and the extra CPU lives *outside*
+  `processCommand` (replay/commit/flush/state access, which that metric excludes).
+  Break the histogram down by `valueType,intent` to see if one record type
+  regressed vs a uniform shift.
+
+### 5. Decide: is it even a hot-path *code* regression?
+
+Before blaming a commit, separate "code got slower" from "code runs more often" from
+"config/infra changed":
+
+- `git log -1 --format=%ad -- <path/to/hot/file>` for the top grown frames. **If the
+  hot file hasn't changed in the regression window, the code didn't get slower — it's
+  being *called more per record*, or a config/flag/sizing changed.** Chase the caller
+  or the config, not the frame.
+- Rule out data growth: compare RocksDB state size / num_keys. Flat state + more
+  state-access CPU = more ops per record, not more data.
+- Narrow the window cheaply: for daily benchmarks, one build/day means you can
+  **binary-search across days** (is the run between healthy and broken already
+  broken?) to shrink the commit range before diffing 100s of commits. For
+  production, narrow by deploy history instead — which version/config was live
+  at each past-good vs first-bad capture.
+
+## CPU-mode profiling gotchas (async-profiler `-e cpu`)
+
+These bite every flamegraph read, not just regressions:
+
+- **On-CPU only.** CPU-mode samples running threads; **off-CPU time is invisible**
+  (blocked on disk, lock, socket, park). So a slower disk / slower ES backend does
+  **not** raise CPU samples — it shows as lower throughput with threads parked. Never
+  infer "X got slower" from more CPU in X; infer "X did more on-CPU work".
+- **Syscall CPU folds onto a userland stub.** Without kernel stacks (needs
+  perf_events + `perf_event_paranoid<=1` + kernel symbols), kernel time (e.g.
+  `msync`/`fsync` dirty-page scan, socket writes) is attributed to the glibc syscall
+  trampoline (`__syscall_cancel_arch`) or the JNI leaf. You then can't split user vs
+  kernel from that file — re-profile with kernel stacks, or add a wall-clock/off-CPU
+  profile, to see the real split.
+- **Concurrent GC ≠ pause.** The `gc` bucket (G1 concurrent marking) burns CPU on GC
+  threads without showing as STW pause; cross-check `jvm_gc_pause_seconds`.
+
+## Reading the diff → hypothesis (generic patterns)
+
+| Diff signature | Likely direction |
+|---|---|
+| `rocksdb-state` / `TransactionalColumnFamily` up, state size flat | more state ops per record (caller change / config), not bigger data |
+| `journal-flush` / `msync` up, flush-rate flat or down, p99 flat | heavier work per flush (larger scanned region / segment sizing), not disk stalls |
+| `exporter-es-client` up, ES health degraded | exporter blocked/retrying on a slow backend |
+| `gc` up, allocation metrics up | allocation-pressure regression |
+| whole profile shape ~unchanged, throughput down at flat CPU | efficiency regression — find it by ratio, not by eye |
+| one `valueType,intent` tail explodes, others flat | a specific processor/path, not a global slowdown |

--- a/.claude/skills/zeebe-flamegraph-diff/references/zeebe-contributors.md
+++ b/.claude/skills/zeebe-flamegraph-diff/references/zeebe-contributors.md
@@ -1,0 +1,104 @@
+# Biggest CPU contributors in a Zeebe broker flamegraph
+
+Reference for interpreting `fg_subsystems.py` output and `fg_diff.py` frame names.
+These are the subsystems that dominate a Camunda 8 broker CPU profile under load,
+what they mean, the marker frames that identify them, and what a *rise* usually
+implies. Percentages are rough steady-state shares seen on the daily ES-exporter
+benchmark (gRPC profile, single broker node) — treat as ballpark, not SLO.
+
+All engine work runs on the Zeebe **actor scheduler**, so nearly everything sits
+under `io/camunda/zeebe/scheduler/ActorJob.invoke` /
+`AtomixThreadFactory.lambda$newThread$0`. Those two are near the root of almost
+every stack — high % there is expected and not itself a finding; look deeper.
+
+## Subsystems (as split by `fg_subsystems.py`)
+
+### exporter-es-client  (~15-16%)
+Marker frames: `org/apache/http/impl/nio/*` (`produceOutput`, `outputReady`),
+`co/elastic/clients/json/ObjectDeserializer.deserialize`,
+`io/camunda/zeebe/broker/exporter/stream/*` (`ExporterContainer`,
+`ExporterDirector`, `RecordExporter.export`), `sun/nio/ch/SocketChannel*.write`.
+- The Elasticsearch/Camunda exporter serializing records and driving the async
+  HTTP client to bulk-index into ES. Absent entirely with `exporter: none`.
+- **Rises** if ES is slow (client blocks/retries), bulk size/rate grew, or record
+  volume per flush increased. Cross-check with ES cluster health metrics.
+
+### processing  (~12-13%)
+Marker frames: `ProcessingStateMachine` (`batchProcessing`, `processCommand`),
+`TypedRecordProcessor.processRecord`, `processing/bpmn/*`, `EventAppliers.applyState`,
+`ResultBuilderBackedEventApplyingStateWriter`.
+- The actual command→event engine work: executing BPMN, applying state changes.
+  This is the "useful work" bucket — you *want* CPU here.
+- **Falling** processing share while total CPU is flat is a red flag: the node is
+  doing less real work per core (something else crowded it out).
+
+### replay  (~9-12%)
+Marker frames: `ReplayStateMachine` (`tryToReplayBatch`, `lambda$tryToReplayBatch$5`),
+`Engine.replay`.
+- Rebuilding state from the log. Followers replay continuously; leaders replay on
+  transition/restart. High replay on a node = it follows busy partitions or just
+  went through a leader change / restart / snapshot install.
+- A large `Engine.replay` spike (→10%+ from ~0) usually means the capture caught a
+  catch-up burst, not steady state.
+
+### rocksdb-state  (small in `other`/native, but watch the named frames)
+Marker frames: `TransactionalColumnFamily` (`.get`, `.forEach`, `.ensureInOpen`,
+its `$$Lambda.run`), `ColumnFamilyContext.withPrefixKey`, `ZeebeTransaction`,
+native `rocksdb::*` / `librocksdbjni.so`.
+- Reading/iterating/writing engine state in RocksDB. Note much RocksDB time is in
+  native code and lands in `other` in the subsystem split — the *named* Java
+  frames in the diff are the reliable signal.
+- **Rises** with larger state (more/longer prefix scans, bigger LSM → more read
+  amplification), more key lookups per record, or compaction pressure. A big jump
+  in `TransactionalColumnFamily$$Lambda.run` / `forEach` / `withPrefixKey` points
+  at state-access cost per record going up.
+
+### journal-flush  (~3-6%)
+Marker frames: `io/camunda/zeebe/journal/file/*` (`SegmentedJournal.flush`,
+`SegmentedJournalWriter.flush`), `RaftLogFlusher`, `PassiveRole.flush`,
+`java/nio/MappedMemoryUtils.force` (msync), `Sequencer.tryWrite`.
+- Appending to and fsync-ing the Raft log (durability). `MappedMemoryUtils.force`
+  is the mmap msync; its on-CPU cost is kernel dirty-page scan + writeback setup
+  (proportional to region scanned and dirty-page count), NOT the disk transfer.
+- **CPU-mode caveat:** a *slower disk* does NOT raise this bucket — disk wait is
+  off-CPU and invisible to CPU sampling. More flush CPU means more flush *work*:
+  more frequent flushes, or a larger mapped region scanned per `msync` (e.g. bigger
+  journal segments), or more append contention (`Sequencer.tryWrite` climbing).
+  Confirm with `atomix_journal_flush_time_seconds_{count,sum}`: distinguish "more
+  flushes" (count up) from "heavier flushes" (avg latency up, p99 flat) from "disk
+  stalls" (p99 up) — only the first two show as CPU.
+
+### raft-netty  (~14-15%)
+Marker frames: `io/atomix/raft/*` (`ActiveRole.onAppend`, `PassiveRole.appendEntries`,
+`RaftContext`, `RaftServerCommunicator.sendAndReceive`), `io/netty/*`
+(`SingleThreadIoEventLoop`, `epoll`), `sun/nio/ch/SocketChannel`.
+- Raft replication: leaders send AppendEntries, followers receive/ack, all over
+  Netty. Scales with write throughput and cluster chatter.
+
+### grpc  (~2%)
+Marker frames: `io/grpc/*` (`ServerInterceptors`, `SerializingExecutor`),
+`MetricCollectingServerInterceptor`, `NimbusJwtDecoder.createJwt` (auth). REST
+equivalent lives under Tomcat/Spring instead.
+
+### gc  (~8-9%)
+Marker frames: `G1CMTask::do_marking_step`, `G1*`, `CMTask`, GC thread roots.
+- G1 concurrent marking runs on dedicated GC threads and burns CPU **without**
+  showing as stop-the-world pause time. So a high `gc` bucket here can coexist with
+  a tiny `jvm_gc_pause_seconds` — it indicates allocation pressure / churn, not
+  necessarily pause problems. Cross-check `jvm_gc_pause_seconds_*` vs
+  `jvm_gc_memory_allocated_bytes_total`.
+
+### scheduler-idle
+`ActorThread.waitOnRunnable`, `Unsafe.park` — idle actor/park time. High idle means
+the node is NOT CPU-bound on that path; treat as headroom, not work.
+
+## Frames to ignore in diffs (attribution noise, not regressions)
+
+- `thread_native_entry`, `start_thread`, `Thread::call_run`,
+  `Executors$RunnableAdapter.call`, `ForkJoinTask*` — generic thread roots; they
+  swing when the profiler attributes native/unknown differently between runs.
+- `librocksdbjni<random>.so`, `libnetty_*<random>.so` — per-run temp filenames;
+  `fg_common.normalize` collapses them but residual +/- on the raw name is noise.
+- `$$Lambda.0x…run` — the address differs every JVM run; only meaningful after
+  normalization (which `fg_diff.py` does) and only when the *owning class* is a
+  real Camunda/engine type.

--- a/.claude/skills/zeebe-flamegraph-diff/scripts/fg_common.py
+++ b/.claude/skills/zeebe-flamegraph-diff/scripts/fg_common.py
@@ -1,0 +1,68 @@
+"""Shared async-profiler HTML flamegraph parser for Zeebe/Camunda benchmark profiles.
+
+async-profiler emits frames as a sequence of f()/u()/n() JS calls over a
+prefix-compressed `cpool` string array. This module unpacks the cpool and walks
+the call sequence into (level, title, width) frames. Width is in sample units;
+the level-0 frame width is the total sample count.
+
+Frame call semantics (from the generated HTML):
+  f(key, level, left, width)  -> frame at absolute `level`, sets width0=width
+  u(key, width)               -> child: level0+1, inherits width0 if width omitted/0
+  n(key, width)               -> sibling: same level0, inherits width0 if omitted/0
+`key >>> 3` indexes into the unpacked cpool to get the frame title.
+"""
+import re
+
+
+def load_frames(path):
+    """Return (total_samples, [(level, title, width), ...]) for a flamegraph HTML."""
+    txt = open(path, encoding="utf-8").read()
+    m = re.search(r"const cpool = \[(.*?)\];", txt, re.S)
+    items = re.findall(r"'((?:[^'\\]|\\.)*)'", m.group(1))
+    # prefix decompression: first char of each entry encodes shared-prefix length
+    cp = [items[0]]
+    for i in range(1, len(items)):
+        s = items[i]
+        cp.append(cp[i - 1][: ord(s[0]) - 32] + s[1:])
+    body = txt[txt.rindex("unpack(cpool);"):]
+    frames = []
+    total = 0
+    width0 = 0
+    lvl = 0
+    for line in body.splitlines():
+        line = line.strip()
+        mm = re.match(r"([fun])\(([\d,\-]+)\)", line)
+        if not mm:
+            continue
+        fn = mm.group(1)
+        a = [int(x) for x in mm.group(2).split(",")]
+        if fn == "f":
+            key = a[0]
+            lvl = a[1]
+            # f(key, level, left, width): a[2] is `left`, a[3] is width.
+            width = a[3] if len(a) > 3 and a[3] != 0 else width0
+        elif fn == "u":
+            lvl += 1
+            key = a[0]
+            width = a[1] if len(a) > 1 and a[1] != 0 else width0
+        else:  # n
+            key = a[0]
+            width = a[1] if len(a) > 1 and a[1] != 0 else width0
+        width0 = width
+        title = cp[key >> 3]
+        if lvl == 0:
+            total = width
+        frames.append((lvl, title, width))
+    return total, frames
+
+
+def normalize(title):
+    """Collapse per-JVM-run volatile identifiers so two runs are comparable.
+
+    JIT lambda/proxy class names embed a per-run address (…$$Lambda.0x00000000abc.run)
+    and native .so temp files embed a random suffix (librocksdbjni<random>.so). These
+    differ every run for identical code, so strip them before diffing."""
+    t = re.sub(r"0x[0-9a-f]+", "0xLAMBDA", title)
+    t = re.sub(r"librocksdbjni\d+\.so", "librocksdbjni.so", t)
+    t = re.sub(r"libnetty_[a-z_0-9]+\.so", "libnetty.so", t)
+    return t

--- a/.claude/skills/zeebe-flamegraph-diff/scripts/fg_diff.py
+++ b/.claude/skills/zeebe-flamegraph-diff/scripts/fg_diff.py
@@ -1,0 +1,45 @@
+"""Diff two async-profiler flamegraphs by INCLUSIVE per-function %.
+
+Inclusive % = share of total samples whose stack contains the function anywhere.
+Per-run volatile identifiers (lambda addresses, native .so temp names) are
+normalized (see fg_common.normalize) so the diff reflects real code, not noise.
+
+Prints functions that grew the most in FILE_B (e.g. today / regressed) and those
+that shrank vs FILE_A (e.g. baseline / healthy).
+
+Usage: python3 fg_diff.py <baseline.html> <candidate.html> [min_delta_pct]
+
+IMPORTANT for comparability: only diff like-for-like profiles. In the Camunda
+daily benchmark each run produces BOTH a gRPC and a REST flamegraph for the same
+node — never diff gRPC against REST (the whole request-handling stack differs).
+Identify which is which first (see SKILL.md).
+"""
+import sys
+from fg_common import load_frames, normalize
+
+
+def inclusive_pct(path):
+    total, frames = load_frames(path)
+    incl = {}
+    for _, title, width in frames:
+        k = normalize(title)
+        incl[k] = incl.get(k, 0) + width
+    return {k: 100 * v / total for k, v in incl.items()}
+
+
+if __name__ == "__main__":
+    a = inclusive_pct(sys.argv[1])
+    b = inclusive_pct(sys.argv[2])
+    thr = float(sys.argv[3]) if len(sys.argv) > 3 else 1.5
+    keys = set(a) | set(b)
+    d = sorted(((b.get(k, 0) - a.get(k, 0), k) for k in keys), reverse=True)
+    print(f"### Grew in {sys.argv[2].split('/')[-1][:30]} (candidate):")
+    for v, k in d:
+        if v < thr:
+            break
+        print(f"  +{v:6.2f}  (base {a.get(k, 0):6.2f} -> cand {b.get(k, 0):6.2f})  {k[:76]}")
+    print(f"### Shrank vs {sys.argv[1].split('/')[-1][:30]} (baseline):")
+    for v, k in d[::-1]:
+        if -v < thr:
+            break
+        print(f"  {v:7.2f}  (base {a.get(k, 0):6.2f} -> cand {b.get(k, 0):6.2f})  {k[:76]}")

--- a/.claude/skills/zeebe-flamegraph-diff/scripts/fg_subsystems.py
+++ b/.claude/skills/zeebe-flamegraph-diff/scripts/fg_subsystems.py
@@ -1,0 +1,56 @@
+"""Attribute one Zeebe flamegraph's CPU to Camunda subsystems (leaf-based).
+
+Each leaf sample is assigned to the FIRST matching subsystem found while walking
+its stack from root to leaf, using the ordered SUBSYSTEMS table below. Order
+matters: more-specific / outer-owner categories come first. Leaves matching
+nothing land in 'other'. Native/syscall scatter means coverage is typically
+~70-75%, which is fine for a directional split.
+
+Usage: python3 fg_subsystems.py <flamegraph.html>
+"""
+import re
+import sys
+from fg_common import load_frames
+
+# Ordered (name, regex-over-joined-stack). See references/zeebe-contributors.md
+# for what each subsystem means and why it shows up. Tuned for Zeebe broker
+# profiles with the Elasticsearch/Camunda exporter enabled.
+SUBSYSTEMS = [
+    ("exporter-es-client", r"org/apache/http|broker/exporter|co/elastic/clients|elasticsearch|RestClient"),
+    ("replay",             r"ReplayStateMachine|Engine\.replay"),
+    ("processing",         r"ProcessingStateMachine|TypedRecordProcessor|processing/bpmn|EventAppliers|ResultBuilderBacked"),
+    ("rocksdb-state",      r"rocksdb|TransactionalColumnFamily|ZeebeTransaction|ColumnFamilyContext"),
+    ("journal-flush",      r"journal/file|RaftLogFlusher|MappedMemoryUtils\.force|Sequencer"),
+    ("raft-netty",         r"io/atomix/raft|io/netty|SocketChannel|epoll"),
+    ("grpc",               r"io/grpc"),
+    ("gc",                 r"G1|GCTask|CMTask|CollectedHeap|markOop|ConcurrentGC"),
+    ("scheduler-idle",     r"ActorThread\.waitOnRunnable|Unsafe\.park|park\b"),
+]
+
+
+def attribute(path):
+    total, frames = load_frames(path)
+    pathstack = {}
+    agg = {name: 0 for name, _ in SUBSYSTEMS}
+    agg["other"] = 0
+    n = len(frames)
+    for i, (lvl, title, w) in enumerate(frames):
+        pathstack[lvl] = title
+        is_leaf = (i + 1 >= n) or (frames[i + 1][0] <= lvl)
+        if not is_leaf:
+            continue
+        joined = " ".join(pathstack[l] for l in range(0, lvl + 1) if l in pathstack)
+        for name, pat in SUBSYSTEMS:
+            if re.search(pat, joined):
+                agg[name] += w
+                break
+        else:
+            agg["other"] += w
+    return total, agg
+
+
+if __name__ == "__main__":
+    total, agg = attribute(sys.argv[1])
+    print(f"total samples: {total}")
+    for k, v in sorted(agg.items(), key=lambda x: -x[1]):
+        print(f"  {100 * v / total:6.2f}%  {k}")

--- a/.claude/skills/zeebe-flamegraph-diff/scripts/fg_top.py
+++ b/.claude/skills/zeebe-flamegraph-diff/scripts/fg_top.py
@@ -1,0 +1,31 @@
+"""Per-function SELF-time top list for one async-profiler flamegraph.
+
+Self time = a frame's width minus the width of its direct children, aggregated by
+title across the whole tree. Good first look at "what is this node burning CPU on".
+
+Usage: python3 fg_top.py <flamegraph.html> [topN]
+"""
+import sys
+from fg_common import load_frames
+
+
+def self_times(path):
+    total, frames = load_frames(path)
+    stack = {}
+    self_by = {}
+    for lvl, title, width in frames:
+        stack[lvl] = title
+        self_by[title] = self_by.get(title, 0) + width
+        if lvl > 0 and stack.get(lvl - 1) is not None:
+            self_by[stack[lvl - 1]] = self_by.get(stack[lvl - 1], 0) - width
+    return total, self_by
+
+
+if __name__ == "__main__":
+    top = int(sys.argv[2]) if len(sys.argv) > 2 else 30
+    total, s = self_times(sys.argv[1])
+    print(f"total samples: {total}")
+    for t, v in sorted(s.items(), key=lambda x: -x[1])[:top]:
+        if v <= 0:
+            continue
+        print(f"  {100 * v / total:6.2f}%  {t[:90]}")

--- a/.claude/skills/zeebe-flamegraph-diff/tests/fixture.html
+++ b/.claude/skills/zeebe-flamegraph-diff/tests/fixture.html
@@ -1,0 +1,21 @@
+<!-- Minimal async-profiler flamegraph fixture for parser tests.
+     Mirrors the real f()/u()/n() emission scheme:
+       f(key, level, left, width): absolute level; left0 += left; width0 = width || width0
+       u(key, width): child   -> f(key, level0+1, 0, width)
+       n(key, width): sibling -> f(key, level0, width0, width)
+     title = cpool[key >>> 3]; cpool is prefix-compressed (first char = shared-prefix len + 32). -->
+<script>
+	const cpool = [
+'all',
+' root',
+' aa',
+' bb'
+];
+	function unpack(cpool) {}
+unpack(cpool);
+
+n(0,100)
+u(8,60)
+f(16,1,30,40)
+n(24,10)
+</script>

--- a/.claude/skills/zeebe-flamegraph-diff/tests/test_fg_common.py
+++ b/.claude/skills/zeebe-flamegraph-diff/tests/test_fg_common.py
@@ -1,0 +1,30 @@
+"""Golden test for the async-profiler HTML parser in fg_common.load_frames.
+
+Regression guard for the f()-frame width bug: async-profiler emits
+`f(key, level, left, width)`, so width is the 4th arg. Reading the 3rd (`left`)
+instead silently corrupts every f-frame width (and any u/n frames that inherit
+width0 from it). Runnable standalone: `python3 test_fg_common.py`.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import fg_common  # noqa: E402
+
+FIXTURE = os.path.join(os.path.dirname(__file__), "fixture.html")
+
+
+def test_load_frames():
+    total, frames = fg_common.load_frames(FIXTURE)
+    assert total == 100, total
+    assert frames == [
+        (0, "all", 100),
+        (1, "root", 60),
+        (1, "aa", 40),  # from f(16,1,30,40): width is a[3]=40, NOT left a[2]=30
+        (1, "bb", 10),
+    ], frames
+
+
+if __name__ == "__main__":
+    test_load_frames()
+    print("ok")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,11 @@ Load extra context on demand — only when relevant, only if the files exist.
 - Follow conventions in the
   [Code Style wiki](https://github.com/camunda/camunda/wiki/Code-Style).
 
+### Code comments
+
+Before writing an inline comment, name the reader and what they would do differently for having
+read it. If you can't name both, don't write it.
+
 ### Testing conventions
 
 - Test behavior, not implementation — assert on observable outcomes rather than internal state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,314 @@
+# AGENTS.md
+
+> **Note:** This file delegates to a central AGENTS.md. Read and apply it before proceeding.
+
+**URL:**
+https://raw.githubusercontent.com/camunda/.github/refs/heads/main/AGENTS.md
+
+Treat the central file's contents as if they were written directly in this file.
+Instructions below extend those guidelines and take precedence if there is any conflict.
+
+## Repo-specific instructions
+
+### Role & boundary
+
+Camunda 8 delivers scalable, on-demand process automation as-a-service, with execution engines for
+BPMN processes and DMN decisions. This monorepo contains: Zeebe (process engine), Operate
+(monitoring), Tasklist (user tasks), Identity (auth), and supporting libraries. Java 21 backend,
+React/Carbon frontends. Product documentation: https://docs.camunda.io
+
+You are a contributor to the Camunda 8 monorepo. Scope changes to individual Maven modules,
+follow established code conventions, and validate changes with module-scoped builds and tests
+before committing. Don't overengineer, follow YAGNI and KISS mentality.
+
+This is a large monorepo. Always scope your work to the relevant module(s) rather than building or
+testing the entire project.
+
+Before modifying code in any module:
+
+1. Read the module's `README.md` (if present) and any documentation in its directory.
+2. When unsure about cross-cutting conventions, consult `docs/` before inventing a solution.
+
+Not every module has a README yet — when one exists, treat it as the primary reference for that
+module.
+
+**Path map:**
+
+|      Module       |                                   Description                                   |
+|-------------------|---------------------------------------------------------------------------------|
+| `zeebe/`          | Core process engine (broker, engine, protocol, exporters)                       |
+| `zeebe/gateway`   | gRPC gateway for client access                                                  |
+| `operate/`        | Process monitoring webapp                                                       |
+| `tasklist/`       | User task management webapp                                                     |
+| `identity/`       | Authentication and authorization                                                |
+| `search/`         | Search client abstraction (Elasticsearch, OpenSearch)                           |
+| `service/`        | Domain service layer between REST controllers and engine                        |
+| `clients/`        | Client libraries (Java, Spring Boot starters)                                   |
+| `qa/`             | Cross-component acceptance tests                                                |
+| `testing/`        | Process testing libraries                                                       |
+| `authentication/` | Spring Security integration (basic auth)                                        |
+| `document/`       | Document API and storage                                                        |
+| `monitor/`        | Metrics and monitoring definitions for Camunda components                       |
+| `load-tests/`     | Cluster-level load and reliability tests                                        |
+| `c8run/`          | Packaged Camunda 8 distribution for local spin-up                               |
+| `debug-cli/`      | CLI tool for inspecting and troubleshooting Camunda clusters                    |
+| `webapps-common/` | Shared Java utilities used across Operate, Tasklist, and other web modules      |
+| `webapps-schema/` | Shared Java index descriptors and entity models for Operate/Tasklist ES/OS data |
+
+**Ask first:**
+
+- Modifying shared libraries (`webapps-common/`)
+- Changing public API contracts (REST controllers, gRPC, exported types)
+- Adding new dependencies to `pom.xml` or `package.json`
+
+**Never:**
+
+- Run full-repo builds for single-module work
+- Commit secrets, tokens, or credentials
+- Force-push `main`, `stable/` or `release-` branches
+- Skip formatting checks
+
+### Architecture
+
+Architecture overview: `docs/architecture/overview.md`.
+
+Read `docs/architecture/overview.md` when answering questions about system design, module
+structure, or how to approach any new capability — not only when making a change.
+
+Before making any architectural change, consult the relevant ADR indexes in order (see
+`docs/adr/README.md` for the full tier structure):
+
+1. `docs/adr/` — cross-cutting decisions affecting multiple modules
+2. `<module>/docs/adr/` — decisions scoped to the module you are working in
+3. For sub-modules, walk up each parent module to the repo root
+
+If the decision is not covered by an existing ADR, draft a new one using the
+`create-architecture-decision` skill before proceeding.
+
+### Skills
+
+Repo-specific skills live in `.claude/skills/`. They extend the org-level skills
+described in the central AGENTS.md. When a skill exists for a recurring operation, always use it
+rather than improvising steps.
+
+### Commit message guidelines
+
+Uses [Conventional Commits](https://www.conventionalcommits.org/). Max 120 chars for the header.
+
+```
+<type>: <description>
+```
+
+Types: `build`, `ci`, `deps`, `docs`, `feat`, `fix`, `merge`, `perf`, `refactor`, `revert`, `style`,
+`test`
+
+- Separate behavioral changes from structural/refactoring changes into distinct commits
+- Write for the reader: the reviewer first, then whoever needs to understand/debug this change later
+- Header: name the effect (the bug prevented or behavior enabled), not the mechanism. Prefer
+  `fix: prevent duplicate job activation under concurrent polling` over `fix: add mutex around job activation`.
+- Do not use commit scopes — commitlint enforces `scope-empty`. Use `fix: ...` not `fix(ci): ...`
+- Every commit gets a body — including tests and reverts. A test needs the context for why it's
+  needed and the design rationale behind it; a revert needs the reason. Only a purely mechanical
+  change, like a formatter run, stands on its header alone.
+- Body: inverted-pyramid — the problem and its root cause first, then the approach and why it over
+  the alternatives. Summarize the approach; don't restate the diff. Never compress the why — it's the
+  one thing the diff can't say. Include background if needed. If long, use headings for structure.
+- Hard-wrap the body at ~72 columns as `git log` does not soft-wrap.
+
+### Referencing code in issues, PRs, and comments
+
+When pointing at specific lines of repository code in any GitHub-rendered or shared artifact — issue,
+PR description, PR/review comment, or a linked note — use a **stable GitHub permalink** instead of a
+bare `path:line` reference. GitHub renders the linked lines inline, and pinning a commit SHA keeps the
+reference correct even after the file changes later. A bare `path:line` is only acceptable in local,
+throwaway context (never in something a teammate will read on GitHub).
+
+Derive the link locally — no API calls, no `gh`:
+
+```bash
+slug=$(git remote get-url origin | sed -E 's#^(git@github\.com:|https?://github\.com/)##; s#\.git$##')
+sha=$(git log -1 --format=%H -- "<path>")   # commit that last touched the file
+echo "https://github.com/$slug/blob/$sha/<path>#L<start>-L<end>"   # single line: #L<start>
+```
+
+- **SHA choice:** default to the file's last-touching commit (`git log -1 --format=%H -- <path>`). The
+  file content at that commit equals the current committed content, so the line numbers are valid, and
+  for existing code that commit is already on the remote. Use `git rev-parse HEAD` when linking code
+  from the current PR branch. Always use the full 40-char SHA — a branch name or short SHA is less
+  stable and can 404.
+- **Format:** `https://github.com/<slug>/blob/<sha>/<path>#L<start>` for one line, `#L<start>-L<end>`
+  for a range. `<path>` is repo-root-relative.
+- **The SHA must already be pushed to the remote**, otherwise the link 404s — verify with
+  `git branch -r --contains <sha>` (non-empty). The file's last-touching commit satisfies this once the
+  code is merged. If the file has local edits that are not pushed yet, do not link an unpushed SHA: pick
+  a SHA that is already on `main` (e.g. `git rev-parse origin/main`) and select the line range against
+  that version of the file.
+
+### Build pipeline
+
+All builds use the Maven wrapper (`./mvnw`). Use `-T1C` (one thread per CPU core) for standalone
+builds. Use `-T2` (two threads total) when running builds alongside other resource-intensive
+processes (e.g., an IDE, Docker containers, or other concurrent builds).
+
+#### Always-green policy
+
+Before every AI-assisted session, establish a green baseline in two steps:
+
+**Step 1 — Check that `stable/8.7` CI is healthy** (before pulling or branching):
+
+```bash
+gh run list --branch stable/8.7 --limit 5 --repo camunda/camunda
+```
+
+If `stable/8.7` is red, inform the engineer and continue — CI can fail for infra reasons unrelated to
+the code. Do not block on this, but note any failures so they are not confused with regressions
+introduced during the session.
+
+**Step 2 — Build the full repo locally right after branching** (blocking):
+
+```bash
+./mvnw install -Dquickly -T1C
+```
+
+This installs all module JARs and catches any cross-module compilation errors before work begins
+(e.g. an API change on `main` that breaks a downstream module). Do not proceed until this is
+green — a compilation error here will waste far more time if discovered mid-session.
+
+**Step 3 — Once the target module is known, verify it passes locally:**
+
+```bash
+./mvnw verify -pl <module> -Dquickly -DskipTests=false -T1C
+```
+
+If the module has sub-modules, target the specific sub-module where the code lives rather than the top-level directory, otherwise you may get a false green with no tests run.
+
+Any pre-existing failure here must be noted before the session begins — do not absorb it silently.
+
+Never suppress warnings or failures to force a build to pass.
+
+```bash
+# Fast inner loop (single module / affected tests only) to iterate quickly
+./mvnw verify -pl <module> -Dtest=<TestClassName> -DskipTests=false -DskipITs -Dquickly
+
+# Full pipeline before committing the change
+./mvnw license:format spotless:apply -T1C && ./mvnw verify -pl <module> -DskipTests=false -Dquickly
+```
+
+Do not proceed without a green baseline.
+
+If a test fails during the baseline check, re-run it once to determine whether it is flaky. If it
+passes on retry, treat the baseline as green and proceed. If it fails consistently, it should not
+be on the target branch — stop and inform the engineer.
+
+If it is flaky (non-deterministic):
+
+1. Search for an existing open issue in camunda/camunda. If none exists, raise one using
+   the `create-issue` skill (use the bug template; also add the `kind/flake` label).
+2. Assign the issue to the engineer.
+3. Treat the baseline as passed and proceed — do not disable the test.
+
+#### Module-scoped builds (preferred)
+
+```bash
+# Build a module and its dependencies (recommended for monorepo work)
+./mvnw install -pl <module> -am -Dquickly -T1C
+
+# Build only a single module (requires dependencies to be already installed and unchanged)
+./mvnw install -pl <module> -Dquickly -T1C
+
+# Run a single test class in a module
+./mvnw verify -pl <module> -Dtest=<TestClassName> -DskipTests=false -DskipITs -Dquickly
+
+# Run a single integration test in a module
+./mvnw verify -pl <module> -Dit.test=<IntegrationTestClassName> -DskipTests=false -DskipUTs -Dquickly
+```
+
+Note: `-Dquickly` skips tests and formatting checks — use it for fast iteration only. Add `-DskipTests=false` to run tests while still skipping checks. Before committing, always run the full pipeline in the "Before submitting" section instead.
+
+Note: some modules are split into sub-modules where tests live (e.g. `zeebe/engine`, `zeebe/broker`). If running tests against a top-level module produces no results, target the specific sub-module instead.
+
+Never use `-am` with `verify` — it runs tests in all dependency modules. Use `-am` only with `install -Dquickly` when rebuilding dependencies.
+
+#### Before submitting
+
+Always run these steps before every commit — never skip them, even for "obvious" or single-line
+changes. Skipping formatting reliably breaks the `Java checks` CI job.
+
+1. Format code: `./mvnw license:format spotless:apply -T1C` — **mandatory** before every commit
+   that touches Java sources, markdown or `pom.xml` files. Run it again after any subsequent edit.
+2. Build the changed module (see "Module-scoped builds" above for commands)
+3. Run module tests and verify zero failures
+4. Verify the full repo still compiles: `./mvnw install -Dquickly -T1C`
+
+### Scoped instructions
+
+Load extra context on demand — only when relevant, only if the files exist.
+
+**When editing these areas**, read the corresponding instruction file:
+
+**When working inside a specific module**:
+
+- `<module>/docs/architecture.md` — module ownership, dependencies, and constraints
+- `<module>/docs/adr/` — module-scoped architectural decisions
+- `<module>/AGENTS.md` — module-specific behavioral rules (only exists for complex modules with
+  rules that differ from this file)
+- If working in a sub-module (e.g. `zeebe/engine`), also check each parent module up to the repo
+  root for the same files. Parent context is lower priority; the sub-module's files take precedence
+  on any conflict.
+
+### Code style
+
+- Enforced by the Maven Spotless plugin (Google Java Format).
+- Follow conventions in the
+  [Code Style wiki](https://github.com/camunda/camunda/wiki/Code-Style).
+
+### Testing conventions
+
+- Test behavior, not implementation — assert on observable outcomes rather than internal state.
+- Prefix test methods with `should` (e.g., `shouldRejectInvalidInput`).
+- Structure tests with `// given`, `// when`, `// then` comments.
+- Prefer AssertJ for assertions. Avoid introducing new JUnit or Hamcrest assertions unless the
+  surrounding test already uses them.
+- Use [Awaitility](http://www.awaitility.org/) for async waiting. Never use `Thread.sleep`.
+- Isolate tests with unique data (process/tenant/resource IDs) — never reuse fixed identifiers across
+  tests, as collisions cause flakiness.
+- Fix the root cause of a flaky race rather than masking it with retries or longer waits; if a stopgap
+  is unavoidable, mark it explicitly as temporary and track the root cause in an issue.
+- Always tear down resources you create (indices, containers, clients, clusters), even on failure, to
+  avoid cross-run flakiness.
+- Use JUnit 5. Migrate JUnit 4 tests when modifying them.
+
+### Pull request conventions
+
+- PR title should be clear and descriptive
+- Reference the issue number in the description (e.g., `Closes #1234`)
+- Keep PRs focused on a single concern
+- Describe why the changes are necessary and note alternatives considered
+- Keep descriptions brief and concise
+- For bug fixes: ask the engineer whether the fix needs backporting to stable branches before
+  opening the PR. If yes, add the appropriate `backport stable/X.Y` label(s) when creating it
+  (see "Backporting" below).
+
+### Backporting
+
+Automated by a GitHub Action (`korthout/backport-action`, see `.github/workflows/backport.yml`;
+human docs in `CONTRIBUTING.md`). **Never create backport PRs, branches, or cherry-picks yourself,
+and never offer to.** Trigger a backport only through the automation — a label, or a `/backport`
+comment — never by hand.
+
+- **Start:** add one `backport stable/X.Y` label per target branch (e.g. `backport stable/8.7`).
+  Not-yet-merged PR → runs on merge. Already-merged PR → comment `/backport`. Multiple labels →
+  multiple backport PRs.
+- **Success:** action opens the backport PR; a bot approves and merges it once CI passes.
+- **Conflicts:** action opens a **draft** PR with conflict markers committed as-is plus a comment
+  with resolution steps. You may resolve them (check out the branch, fix conflicts and markers) —
+  but only on a draft PR the action already opened. When asked to backport, first check whether
+  such a draft PR exists.
+
+`stable/8.7` is itself a backport target, not a source — changes flow into it from `main` and newer
+`stable/` branches. There is nothing further to backport into once a fix lands here.
+
+### Git workflow
+
+- Never use `git push --force` on the `main` branch; use `--force-with-lease` on feature branches.
+- Follow the commit and PR guidelines in `CONTRIBUTING.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,17 @@
+# Architecture Decision Records
+
+This directory contains ADRs for decisions that affect multiple modules across the monorepo.
+
+## Tiers
+
+|                            Scope                            |                    Location                     |
+|-------------------------------------------------------------|-------------------------------------------------|
+| Monorepo-wide (affects the whole repo or its core design)   | `docs/adr/` — this directory                    |
+| Domain (spans a few related components, not the whole repo) | `docs/adr/<domain>/` — e.g. `docs/adr/storage/` |
+| Module-scoped                                               | `<module>/docs/adr/`                            |
+
+A **domain** is a logical subsystem that groups a few related components — for example, `storage`
+(covers `search/`, `operate/schema/`, `tasklist/els-schema/`) or `auth` (covers `authentication/`,
+`identity/`). A decision belongs at domain level when it is too broad for a single module but does
+not affect the entire monorepo. Create the domain directory when the first ADR for that domain is
+written.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,167 @@
+# Architecture Overview
+
+## What this repo is
+
+Camunda 8 is a process automation platform that executes BPMN workflows and evaluates DMN decisions
+at scale, for both self-managed and SaaS deployments. The monorepo contains: Zeebe (process engine),
+Operate (process monitoring), Tasklist (human task management), Identity (authentication and
+authorization), plus shared libraries and supporting infrastructure. Java backend built with Maven;
+React/Carbon frontends. `dist/` wires the components into deployable Spring Boot application
+variants (e.g. `StandaloneBroker`, `StandaloneCamunda`); components can also be deployed
+independently.
+
+## Runtime topology
+
+Camunda follows a **CQRS** (Command Query Responsibility Segregation) pattern: writes flow from a
+gateway through the Zeebe broker/engine and land in secondary storage via exporters; reads go
+directly from a gateway (through `service/` and `search/`) to secondary storage, bypassing the
+broker/engine entirely. This keeps reads from affecting process execution performance.
+
+```mermaid
+flowchart TD
+  subgraph gw["Gateways"]
+    REST["REST gateway\nzeebe/gateway-rest\nprimary — all new features"]
+    GRPC["gRPC gateway\nzeebe/gateway-grpc\nbackward compat · streaming"]
+  end
+
+  AUTH(["authentication/ · identity/"])
+
+  subgraph write["Zeebe — write path"]
+    BROKER["broker\nzeebe/broker\nRaft log"]
+    ENGINE["engine\nzeebe/engine\nBPMN / DMN execution"]
+    STATE[("state store\nzeebe/zb-db · RocksDB")]
+    BROKER --> ENGINE
+    ENGINE <-.->|state| STATE
+  end
+
+  subgraph exp["Exporters"]
+    direction LR
+    CE["Camunda exporter\nearly stub — Authorization + User only"]
+    ESE["ES exporter\nself-managed"]
+    OSE["OS exporter\nself-managed"]
+  end
+
+  subgraph storage["Secondary storage"]
+    ESOS[("Elasticsearch / OpenSearch")]
+  end
+
+  SVC["service/"]
+  SEARCH["search/"]
+
+  gw --> AUTH
+  AUTH -->|commands| BROKER
+  ENGINE -->|records| exp
+  CE & ESE & OSE --> ESOS
+
+  REST -.->|read queries| SVC
+  SVC --> SEARCH
+  SEARCH --> ESOS
+```
+
+### Write path
+
+Clients submit commands (deploy a process, start an instance, complete a job) through one of two
+entry points:
+
+- **REST gateway** (`zeebe/gateway-rest`): exposes the Camunda REST API and is the primary entry
+  point for new features. Commands flow through `service/`, which translates them into calls to the
+  internal Zeebe gateway. All new core features must be exposed here first.
+- **gRPC gateway** (`zeebe/gateway`, `zeebe/gateway-grpc`): exposes the Zeebe gRPC API defined in
+  `zeebe/gateway-protocol`. Used by the Java client (`clients/java`) and the Spring Boot starter
+  (`clients/spring-boot-starter-camunda-sdk`). Kept for backward compatibility and performance (gRPC
+  is more efficient at scale; job streaming is gRPC-only).
+
+All entry points authenticate via `authentication/` (Spring Security). Authorization is enforced
+against the resource/permission model defined directly in `zeebe/protocol`
+(`AuthorizationResourceType`, `PermissionType`) and managed by `identity/` — there is no unified
+`security/` module on this branch yet.
+
+The **Zeebe broker** (`zeebe/broker`) receives commands, appends them to a partitioned append-only
+log (Raft consensus via `zeebe/atomix`). The **Zeebe engine** (`zeebe/engine`) executes them
+against its primary state store (RocksDB via `zeebe/zb-db`).
+
+### Export path
+
+After processing, the broker emits records to configured exporters:
+
+|        Exporter        |                  Module                  |               Target                |
+|------------------------|------------------------------------------|-------------------------------------|
+| Elasticsearch exporter | `zeebe/exporters/elasticsearch-exporter` | Elasticsearch indices               |
+| OpenSearch exporter    | `zeebe/exporters/opensearch-exporter`    | OpenSearch indices                  |
+| Camunda exporter       | `zeebe/exporters/camunda-exporter`       | Elasticsearch only — see note below |
+
+On this branch, the Camunda Exporter is an early stub: it exports only two record types
+(`AuthorizationRecordValueExportHandler`, `UserRecordValueExportHandler`), only against an
+Elasticsearch client — there is no OpenSearch support and no archiver code yet. It is not the
+target for all new features here; the dedicated Elasticsearch and OpenSearch exporters remain the
+primary path for most record types on this branch.
+
+For the dedicated exporters, ES/OS index templates are owned and applied directly by
+`zeebe/exporters/elasticsearch-exporter/src/main/resources` and
+`zeebe/exporters/opensearch-exporter/src/main/resources` respectively — there is no centralized
+`schema-manager/` on this branch.
+
+### Read path
+
+Operate and Tasklist query secondary storage (Elasticsearch/OpenSearch) through the `search/`
+abstraction layer. The REST API also serves read queries: `zeebe/gateway-rest` calls `service/`,
+which delegates to `search/`.
+
+## Architectural decisions
+
+Cross-cutting architectural decisions are recorded as ADRs in `docs/adr/`. Before making any
+architectural change, check the index there first. If the decision is not covered by an existing
+ADR, draft a new one using the `create-architecture-decision` skill before proceeding.
+
+## Architectural boundaries
+
+Contracts that must not be bypassed:
+
+**Zeebe gRPC protocol** (`zeebe/gateway-protocol/src/main/proto/gateway.proto`)\
+The interface between external clients and the gRPC gateway. Java stubs are generated at build time
+in `zeebe/gateway-protocol-impl/`; never edit them manually. Changing the `.proto` requires
+regenerating stubs in `gateway-protocol-impl/`, updating every caller in `service/`, and bumping
+`clients/java` and the Spring Boot starter — a cascade that touches every layer of the write path.
+
+**Zeebe record/exporter contract** (`zeebe/exporter-api`, `zeebe/protocol`)\
+The SBE-encoded record format emitted by the broker and consumed by exporters. Access broker state
+only through this contract; never read from RocksDB directly.
+
+**ES/OS index schema**\
+All templates use `"dynamic": "strict"` — new fields must be explicitly added to the template
+definitions before the exporter writes them (see e.g.
+`operate/schema/src/main/resources/schema/elasticsearch/` and
+`tasklist/els-schema/src/main/resources/schema/es/`; there is no centralized `webapps-schema/`
+template directory on this branch — each webapp owns its own). Fields are additive-only; never
+change or remove a field once deployed — strict mapping will reject mistyped documents from the
+exporter, and any query in `search/` referencing the field breaks, surfacing in `operate/` and
+`tasklist/`. Never query ES/OS indices directly from application code; always go through `search/`.
+
+**ES/OS exporter index templates** (`zeebe/exporters/elasticsearch-exporter/src/main/resources`,
+`zeebe/exporters/opensearch-exporter/src/main/resources`)\
+Index templates owned by the dedicated ES/OS exporters. Do not modify them without understanding
+the impact on existing index mappings.
+
+**`service/` as the REST-to-engine bridge**\
+All REST commands must flow through `service/` before reaching Zeebe. REST controllers in
+`zeebe/gateway-rest` must not call the Zeebe gRPC gateway directly. An interface change here breaks
+`zeebe/gateway-rest` at compile time; `operate/` and `tasklist/` are indirect consumers via the
+REST API and will break at runtime.
+
+## Path rules
+
+- `zeebe/gateway-protocol-impl/target/generated-sources/` — gRPC Java stubs generated from
+  `gateway.proto`; never edit. Modify the `.proto` source in
+  `zeebe/gateway-protocol/src/main/proto/` instead.
+- `zeebe/protocol/src/main/resources/` (`protocol.xml`, `common-types.xml`,
+  `cluster-management-protocol.xml`) — SBE protocol definitions; generated Java lives in `target/`.
+- `target/` everywhere — Maven build output; never edit or commit.
+- `dist/` — distribution assembly only; no application logic lives here.
+
+## Further detail
+
+- Cross-cutting ADRs: `docs/adr/`
+- Module-specific ADRs: `<module>/docs/adr/`
+- Zeebe internals: `zeebe/docs/`
+- Module-specific architecture: `<module>/docs/architecture.md` (where present)
+- Module-specific behavioral rules: `<module>/AGENTS.md`

--- a/load-tests/skills/load-test-ops/SKILL.md
+++ b/load-tests/skills/load-test-ops/SKILL.md
@@ -1,0 +1,525 @@
+---
+name: load-test-ops
+description: Trigger, monitor, update, profile, and stop Camunda load tests using gh CLI and kubectl directly — no MCP server required
+---
+
+# Camunda Load Test Operations
+
+For the full operational reference (architecture, scenarios, scheduling, secondary storage,
+Helm value typing pitfalls), see [`load-tests/README.md`](https://github.com/camunda/camunda/blob/main/load-tests/README.md). This
+branch does not have `load-tests/docs/metrics.md` yet — for metric names, SLO targets, and PromQL
+queries, use the headline queries in [`load-tests/docs/scripts/queries.yaml`](https://github.com/camunda/camunda/blob/main/load-tests/docs/scripts/queries.yaml)
+plus the Grafana dashboards under [Analyze metrics](#analyze-metrics). For the canonical schema of every
+available chart value (beyond what `load-tests/setup/default/values/camunda-platform-values-defaults.yaml` overrides), see
+the upstream chart at [`camunda/camunda-platform-helm`](https://github.com/camunda/camunda-platform-helm/tree/main/charts/camunda-platform).
+For known load-test and incident tribal knowledge (recurring gotchas, prior incidents, tooling patterns), see
+[`knowledge base`](https://github.com/camunda/team-reliability-testing/blob/main/knowledge/)
+in `camunda/team-reliability-testing` — check it before an investigation, and add durable findings
+back to it afterward.
+
+## Prerequisites check
+
+`gh` CLI must always be authenticated (`gh auth status`).
+
+> **Note for Claude:**
+>
+> - Run `gh` and `kubectl` commands directly via the Bash tool. The user's `gh` CLI is
+>   authenticated on the host. If a command isn't pre-approved, you'll get a one-time
+>   permission prompt — accept it and proceed.
+> - **Don't leave the user waiting.** Whenever you start anything that takes time (workflow
+>   dispatch, helm install, kubectl rollout, log capture, build), follow it through to
+>   completion automatically: watch progress, pull the final output, and render it inline.
+>   Stream interim status updates so the user can interrupt if something looks wrong. Don't
+>   ask "should I wait?" or "want me to fetch the result?" — that's friction; chaining is
+>   the default.
+> - For GHA dispatches specifically: capture the run ID via
+>   `gh run list --workflow=<file> --repo camunda/camunda --limit 1 --json databaseId --jq '.[0].databaseId'`,
+>   watch it with `gh run watch <id> --repo camunda/camunda --exit-status`, then pull the
+>   result with `gh run view <id> --repo camunda/camunda` (job summary) or `gh run download <id>`
+>   (artifacts).
+
+### Default path: GHA workflow
+
+Use GHA for everything by default. It is the only path that builds a Docker image from a branch
+(initial test of a feature branch, or after pushing new commits) and it works for any user with
+`gh` access — no kubectl, no Helm, no Teleport login required. Prefer it unless the user explicitly
+wants the kubectl path or the situation below applies.
+
+### Optional: direct kubectl/Makefile
+
+Only fall back to kubectl when **all** of the following are true:
+
+1. The user has kubectl access to the benchmark cluster (Teleport login active)
+2. There is already a usable Docker image — either a pre-built branch image (`reuse-tag`) or a
+   released image (`orchestration-tag`)
+3. The change is config-only (Helm values, replica counts, resource limits, starter rate) — no
+   code changes that would require a new image build
+
+**Caveat:** the kubectl path cannot build Docker images. If the image you need does not yet exist,
+dispatch a GHA build first, then switch to kubectl for further config iteration on the same image.
+
+Check kubectl access before taking the direct path:
+
+```bash
+kubectl get nodes 2>/dev/null && echo "kubectl available" || echo "use GHA"
+```
+
+---
+
+## Typical workflow
+
+Most runs follow the same arc — each step links to its own section for full options:
+
+1. **[Start a load test](#start-a-load-test)** — dispatch the GHA workflow with a branch ref.
+   Cluster is up in ~5–10 min.
+2. **[Check status](#check-status)** — verify pods and starter reach steady state (~5 min
+   warm-up).
+3. **Wait for the run window** — 10–60 min, depending on what you're measuring. Most signals
+   stabilise within 20 min.
+4. *(optional)* **[Profile a running cluster](#profile-a-running-cluster)** — flamegraph capture
+   (~5 min per pod).
+5. **[Analyze metrics](#analyze-metrics)** — snapshot the run window into a JSON / job-summary
+   report.
+6. **[Compare against a baseline](#compare-against-a-baseline)** — diff against daily tests or a
+   parallel `main` run; absolute numbers are rarely conclusive on their own.
+7. **[Stop / clean up](#stop--clean-up)** — delete the namespace to free benchmark resources
+   (also auto-cleaned at `deadline-date`).
+
+For automation, the metrics workflow's `results-json` output can feed directly into the delete
+workflow.
+
+---
+
+## Namespace conventions
+
+- Format: `c8-<initials>-<slug>-<YYYYMMDD>` — always prefixed with `c8-`
+- Example: `c8-ck-my-feature-20260427` (ck = ChrisKujawa)
+- `camunda-load-test.yml` input `name` may be passed with or without `c8-` (it will add the prefix if missing)
+- Metrics/profile/delete workflows take the full namespace and require it to start with `c8-`
+**Use a unique name for each new run.** Reusing a namespace mixes the new run's metrics with the
+prior run's data and makes comparisons ambiguous; for intentional in-place iteration (config
+tweak, image bump on the same cluster), use [Update / redeploy](#update--redeploy) instead. The
+date alone is not enough — it collides within a single day or across parallel investigations
+from different sessions. Add a disambiguator:
+
+- short Git SHA — `ck-feature-abc1234` — best when validating a specific commit
+- HHMM time — `ck-feature-20260508-1430` — best for ad-hoc iteration loops
+- role suffix — `ck-feature-20260508-baseline` / `-branch` — best for paired comparison runs
+  (see [Compare against a baseline](#compare-against-a-baseline))
+
+Namespaces carry these labels (set by `newLoadTest.sh`):
+
+|        Label         |           Value           |
+|----------------------|---------------------------|
+| `camunda.io/purpose` | `load-test`               |
+| `camunda.io/created-by` | GitHub actor (sanitized)  |
+| `deadline-date`      | `YYYY-MM-DD` (TTL expiry) |
+
+---
+
+## Start a load test
+
+### Via GHA (builds image from branch)
+
+```bash
+gh workflow run camunda-load-test.yml --repo camunda/camunda \
+  --field ref=<branch> \
+  --field name=ck-<slug>-<YYYYMMDD>
+```
+
+Most useful inputs:
+
+|          Input           |                              Use                              |
+|--------------------------|---------------------------------------------------------------|
+| `name` (required)        | Namespace suffix; full namespace becomes `c8-<name>`          |
+| `ref`                    | Git ref to build the image from (defaults to `main`)          |
+| `scenario`               | `latency` / `realistic` / `typical` / `max` / `archiver`      |
+| `secondary-storage-type` | `elasticsearch` (default) / `opensearch` / `postgresql` / ... |
+| `reuse-tag`              | Skip the build and reuse a previously built tag               |
+| `orchestration-tag`      | Use a released Docker Hub image instead of building           |
+| `platform-helm-values`   | Extra `--set` flags for the Camunda platform chart            |
+| `load-test-load`         | Extra `--set` flags for the workload chart                    |
+| `enable-optimize`        | Toggle Optimize (defaults to `true`)                          |
+| `ttl`                    | Days before auto-cleanup (defaults to `1`)                    |
+
+The full input list lives in the `inputs:` block of `.github/workflows/camunda-load-test.yml`.
+
+> **Pick the right tag input — `reuse-tag` and `orchestration-tag` hit different registries:**
+> - `reuse-tag` pulls from the **internal Camunda registry**. Only works for tags built by a
+>   prior GHA load-test run on this repo. Passing a public tag (`8.4.3`, `SNAPSHOT`, `latest`)
+>   fails because the internal registry can't resolve them.
+> - `orchestration-tag` pulls from the **public Docker Hub registry**. Required for released
+>   versions (e.g. `8.4.3`), nightly `SNAPSHOT`, or any tag you didn't build via GHA yourself.
+
+> **Helm value typing — common gotchas:**
+> - Use `--set-string` for chart fields whose schema declares them as strings (e.g.
+>   `orchestration.cpuThreadCount`, `orchestration.ioThreadCount`). Plain `--set` will pass an
+>   integer and the chart's JSON-schema validation will reject the install.
+> - Quote boolean-looking string env values: `--set-string 'orchestration.env[0].value=false'`,
+>   not `--set 'orchestration.env[0].value=false'`.
+> - Quote any value that contains `,` `[` `]` `=` so Helm doesn't parse it as a list/key syntax.
+>
+> Full guidance with copy-paste examples in the
+> [Trigger Camunda Load Test GitHub Workflow](https://github.com/camunda/camunda/blob/main/load-tests/README.md#trigger-camunda-load-test-github-workflow-recommended)
+> section of `load-tests/README.md`.
+
+### Via manual setup (kubectl, existing image only)
+
+Only when GHA is not viable for this iteration and you have kubectl access. The kubectl path does
+not build images — provide an already-built tag (`reuse-tag` from a previous GHA run, or a
+released `orchestration-tag`):
+
+The following will create a new folder under `load-tests/setup/<namespace>` with copying the Helm values for the platform and load test charts.
+
+```bash
+cd load-tests/setup
+./newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize]
+```
+
+Configuration is driven by the values files at the setup folder which is created by the `newLoadTest.sh` script which are copied from the defaults.
+
+For example:
+
+- `load-tests/setup/default/values/camunda-platform-values-defaults.yaml` — platform chart overrides (image tag, resources,
+  exporters, secondary storage)
+- `load-tests/setup/default/values/camunda-platform-values-${storage}.yaml` — platform chart overrides for secondary storage-specific configuration (e.g. Elasticsearch JVM settings, OpenSearch auth)
+- `load-tests/setup/default/values/load-test-values.yaml` — load tester chart overrides (rate, scenario, worker)
+
+Override individual keys by passing extra `--set` flags to the `make` calls (see Update / redeploy below). Full reference in
+`load-tests/setup/README.md`.
+
+Depending on the use case (clarify with the user) different scenarios can be started, e.g realistic, max. 
+
+```bash
+make realistic # Installs the camunda platform and load tester with the realistic scenario configuration, which is defined in the values file.
+```
+
+After running the script, check the deployment via kubectl (this path doesn't dispatch a GHA workflow, so `gh run view` won't show anything). Use the kubectl commands in the
+[Check status](#check-status) section below.
+
+---
+
+## Check status
+
+**Via GHA (always works):**
+
+```bash
+gh run view <run-id> --repo camunda/camunda
+```
+
+**Via kubectl (if available — more accurate):**
+
+```bash
+kubectl get pods -n <namespace>
+kubectl get events -n <namespace> --sort-by='.lastTimestamp' | tail -20
+```
+
+**List all your running load tests:**
+
+```bash
+# Via GHA (default — works without kubectl)
+gh run list --workflow=camunda-load-test.yml --repo camunda/camunda \
+  --user $(gh api /user --jq .login) --limit 20
+
+# Via kubectl labels (if you have cluster access)
+kubectl get namespaces -l camunda.io/purpose=load-test,camunda.io/created-by=$(gh api /user --jq .login)
+```
+
+---
+
+## Inspect configuration
+
+```bash
+# Read default Helm values (know what keys to override)
+cat load-tests/setup/default/values/camunda-platform-values-defaults.yaml
+cat load-tests/setup/default/values/load-test-values.yaml
+
+# What inputs were dispatched into a GHA run? The build/install jobs print
+# the resolved values and parameters into the GitHub Actions step summary.
+gh run view <run-id> --repo camunda/camunda -w
+
+# Read what's actually deployed (requires kubectl and Helm)
+helm get values <namespace> -n <namespace>
+helm get values <namespace>-test -n <namespace>
+```
+
+---
+
+## Update / redeploy
+
+Default to GHA. Use kubectl only for config-only iteration on an existing image (see Prerequisites).
+
+### Via GHA (default — handles builds and config changes)
+
+```bash
+gh workflow run camunda-load-test.yml --repo camunda/camunda \
+  --field ref=<branch> \
+  --field name=ck-<slug>-<YYYYMMDD>
+```
+
+Reuse an existing image to skip the Docker build:
+
+```bash
+# Read the previous run's image tag from its GHA step summary
+gh run view <run-id> --repo camunda/camunda
+
+gh workflow run camunda-load-test.yml --repo camunda/camunda \
+  --field ref=<branch> \
+  --field name=<name-without-c8-prefix> \
+  --field reuse-tag=<image-tag> \
+  --field platform-helm-values="--set orchestration.resources.limits.memory=4Gi"
+```
+
+### Via kubectl (config-only iteration on an existing image)
+
+Faster than GHA for tweaking Helm values against an already-running deployments. See `load-tests/setup/README.md` for full manual setup documentation.
+
+**Always pin the image** — `load-tests/setup/default/values/camunda-platform-values-defaults.yaml` defaults to `tag: SNAPSHOT`,
+which floats. For an iterative loop you usually want a specific tag (the one from the previous
+GHA build, or a released `orchestration-tag`):
+
+```bash
+cd load-tests/setup
+
+# Create namespace if it doesn't exist yet
+./newLoadTest.sh <namespace> <secondary-storage> <ttl-days> <enable-optimize>
+
+# Upgrade platform Helm chart — pin the image tag explicitly
+cd <namespace>
+make max additional_platform_configuration="\
+  --set-string orchestration.image.tag=<image-tag> \
+  --set orchestration.resources.limits.memory=4Gi" \
+  additional_load_test_configuration="--set starter.rate=200"
+```
+
+---
+
+## Profile a running cluster
+
+Profiles all 3 broker pods in parallel (cpu / wall / alloc):
+
+```bash
+gh workflow run profile-load-test.yml --repo camunda/camunda \
+  --field name=<full-namespace-with-c8-prefix>
+```
+
+Profile a single pod (cpu only):
+
+```bash
+gh workflow run profile-load-test.yml --repo camunda/camunda \
+  --field name=<full-namespace-with-c8-prefix> \
+  --field pod=camunda-1
+```
+
+After ~5 min, download flamegraph artifacts:
+
+```bash
+gh run download <run-id> --repo camunda/camunda
+```
+
+Artifact names: `flamegraph-cpu-camunda-0`, `flamegraph-wall-camunda-1`, `flamegraph-alloc-camunda-2`
+
+---
+
+## Analyze metrics
+
+Snapshot run metrics into a JSON / job-summary report — useful for post-run analysis before
+tear-down, so you can capture results and then delete the namespace to free resources.
+
+The workflow and `loadTestMetrics.sh` script both run the **headline queries only** — the fixed
+set defined in [`load-tests/docs/scripts/queries.yaml`](https://github.com/camunda/camunda/blob/main/load-tests/docs/scripts/queries.yaml):
+throughput (PI/s), completion ratio, backpressure, data-availability p99, and
+request-response latency p99. This is enough to answer "did the run meet its SLO?".
+
+For deeper investigation (FNI/s, processing/exporting latency, CPU throttling, JVM heap trend,
+processing and exporting backlogs, write IOPS, disk usage, …), this branch has no full metric
+catalogue doc yet — query the Prometheus instance at
+[`monitor.benchmark.camunda.cloud`](https://monitor.benchmark.camunda.cloud) (Okta login) and the
+[Camunda Performance dashboard](https://dashboard.benchmark.camunda.cloud/d/camunda-performance/camunda-performance)
+directly, or use the Grafana MCP metric-name discovery below — start there when the headline
+numbers don't explain what you're seeing.
+
+### Via GHA (default — no kubectl needed)
+
+```bash
+gh workflow run camunda-load-test-metrics.yaml --repo camunda/camunda \
+  --field namespace=<full-namespace-with-c8-prefix> \
+  --field duration-seconds=1200
+
+# Chain dispatch → watch → render: capture the run, wait for it,
+# and pull the rendered job summary inline (no "should I wait?" prompt).
+sleep 3   # let GitHub register the dispatched run
+RUN_ID=$(gh run list --workflow=camunda-load-test-metrics.yaml --repo camunda/camunda \
+  --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run watch "$RUN_ID" --repo camunda/camunda --exit-status
+gh run view "$RUN_ID" --repo camunda/camunda
+```
+
+`duration-seconds` is the PromQL range each query covers (default `600` = 10 min). Pass `1200`
+for a ~20-min window. Results render in the job summary; the workflow is also reusable via
+`workflow_call` and exposes `results-json` for downstream jobs (e.g. analyze → delete).
+
+### Via Grafana MCP (in Claude Code sessions — no port-forward needed)
+
+Use `mcp__grafana__*` tools directly when running inside Claude Code. Confirm tools are active
+with `mcp__grafana__check_datasources_health` at session start.
+
+**Rule: always run `list_prometheus_metric_names` before writing any PromQL query.** Guessed
+metric names return empty results silently — one discovery call eliminates all name-guess failures.
+
+**Session startup:**
+```
+mcp__grafana__check_datasources_health()
+  → datasourceUid: "prometheus" should show status: OK
+
+mcp__grafana__list_prometheus_label_values(
+  datasourceUid="prometheus", labelName="namespace",
+  matches=[{filters: [{name: "__name__", value: "zeebe_.*", type: "=~"}]}],
+  startRfc3339="now-24h")
+  → lists all namespaces with recent Zeebe data
+```
+
+**Metric name discovery:**
+```
+mcp__grafana__list_prometheus_metric_names(datasourceUid="prometheus", regex="optimize.*", limit=50)
+mcp__grafana__list_prometheus_metric_names(datasourceUid="prometheus", regex="zeebe.*process.*", limit=20)
+```
+
+For metric names and PromQL queries, run `list_prometheus_metric_names` above with a broader regex
+— there is no full metric catalogue doc on this branch yet.
+
+**Known benchmark cluster dashboards:**
+- `camunda-performance` — general throughput/latency/resource overview (namespace variable)
+- `zeebe-dashboard` — deep dive into Zeebe internals (backpressure, partitions, exporters)
+
+See `load-tests/README.md` → **Accessing metrics via Claude Code (Grafana MCP)** for setup instructions.
+
+### Via local script (kubectl + port-forward)
+
+Faster when you have cluster access. First port-forward the monitoring Prometheus pod, then run
+the script directly against `http://localhost:9090`:
+
+```bash
+# Port-forward the monitoring Prometheus service (leave running in a separate terminal)
+kubectl port-forward svc/kube-prometheus-stack-prometheus -n monitoring 9090:9090
+
+# Then run the metrics script
+cd load-tests/docs/scripts
+./loadTestMetrics.sh <full-namespace-with-c8-prefix> 1200 > /tmp/results.json
+```
+
+Args: `<namespace> [duration_seconds] [endpoint] [extra_curl_opts]`. 
+
+### Additional metrics via Prometheus (kubectl required)
+
+When the headline metrics aren't enough and Grafana MCP isn't available, query Prometheus directly
+(there is no full metric catalogue doc on this branch yet — use metric-name discovery, e.g.
+`curl -sG 'http://localhost:9090/api/v1/label/__name__/values'`, to find the right series). Open a
+port-forward in one terminal, then run ad-hoc PromQL in another:
+
+```bash
+# Open port-forward (keep this terminal open)
+kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090
+
+# Ad-hoc query — substitute <namespace> and the PromQL from metrics.md
+curl -sG 'http://localhost:9090/api/v1/query_range' \
+  --data-urlencode 'query=<promql>' \
+  --data-urlencode 'start=<unix-timestamp>' \
+  --data-urlencode 'end=<unix-timestamp>' \
+  --data-urlencode 'step=15s' \
+  | jq '.data.result'
+```
+
+---
+
+## Compare against a baseline
+
+Absolute numbers depend on cluster state, neighbour noise, and time of day — a single
+feature-branch run is rarely conclusive on its own. Always compare against a reference under
+matching conditions:
+
+- **Continuous reference runs** — release, weekly, and daily load tests already cover `main` and
+  stable branches with a standard scenario set. See
+  [`load-tests/README.md` → Test Scenarios](https://github.com/camunda/camunda/blob/main/load-tests/README.md#test-scenarios) for what each
+  variant covers (workload, secondary storage, naming pattern, validation dashboard); pick the
+  closest match to your branch's scenario / secondary-storage / rate.
+- **Custom baseline run** — if your branch diverges from any continuous reference (different
+  scenario, exporter, replica count), dispatch a parallel run on `main` (or the merge-base) with
+  identical inputs and the same `duration-seconds`.
+
+Capture both via [Analyze metrics](#analyze-metrics) over the same window, then diff the JSON
+outputs. The metrics workflow's `results-json` makes this scriptable.
+
+---
+
+## Stop / clean up
+
+### Via GHA (default — no kubectl needed)
+
+```bash
+gh workflow run camunda-delete-load-test.yml --repo camunda/camunda \
+  --field namespace=<full-namespace-with-c8-prefix>
+```
+
+The workflow validates the `c8-` prefix and `camunda.io/purpose=load-test` label before deleting,
+and is idempotent if the namespace is already gone.
+
+
+## Logs
+
+### Default: Stackdriver (works without kubectl)
+
+Stackdriver has the full structured logs from every pod in the namespace. Open the
+**GCP Logs Explorer**, pre-scoped to the load test namespace:
+
+Replace `<namespace>` with the full namespace name (e.g. `c8-ck-my-feature-20260427`).
+```
+https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22<namespace>%22?project=camunda-benchmark
+```
+
+For a GHA-dispatched run, the workflow run logs themselves are also available via:
+
+```bash
+gh run view <run-id> --repo camunda/camunda --log
+```
+
+### Optional: kubectl (when you have cluster access and want a live tail)
+
+```bash
+# Broker logs (follow)
+kubectl logs -n <namespace> camunda-0 -f
+
+# All brokers — last 50 lines each
+for pod in camunda-0 camunda-1 camunda-2; do
+  echo "=== $pod ===" && kubectl logs -n <namespace> $pod --tail=50
+done
+
+# Load tester logs
+kubectl logs -n <namespace> -l app=starter --tail=100
+
+# Describe a pod (scheduling / resource issues)
+kubectl describe pod -n <namespace> camunda-0
+```
+
+---
+
+## Metrics & dashboards
+
+Replace `<namespace>` with the full namespace name (e.g. `c8-ck-my-feature-20260427`).
+
+**Performance dashboard** — high-level overview: throughput, latency, and all key metrics (start here):
+
+```
+https://dashboard.benchmark.camunda.cloud/d/camunda-performance/camunda-performance?orgId=1&from=now-24h&to=now&timezone=browser&var-DS_PROMETHEUS=prometheus&var-namespace=<namespace>&var-pod=$__all&var-partition=$__all
+```
+
+**Zeebe dashboard** — deep dive into Zeebe internals (backpressure, partitions, exporters):
+
+```
+https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=<namespace>
+```
+
+**Metrics reference** — this branch has no full metric catalogue doc yet; use the headline queries
+in [`load-tests/docs/scripts/queries.yaml`](https://github.com/camunda/camunda/blob/main/load-tests/docs/scripts/queries.yaml)
+or the dashboards above.
+


### PR DESCRIPTION
## Description

Ports the agent-readiness doc/tooling infrastructure (root `AGENTS.md`/`CLAUDE.md`, `.claude/skills/`, `docs/architecture/`, `docs/adr/`) from `main` to `stable/8.7`, following up on #53649.

This is the largest of three parallel ports (to `stable/8.9`, `stable/8.8`, and this one). `stable/8.7` split from `main` on 2024-10-02 — over a year before any of this infrastructure existed — so it needed the heaviest rewrite of the three, not a straight copy. Whole modules that main's docs reference don't exist here at all: `optimize/`, `gateways/`, `db/`, `security/`, `schema-manager/`, `microbenchmarks/`, `webapp/`, `webapps-backup/`, `zeebe/exporters/analytics-exporter`, `zeebe/dynamic-node-id-provider`. Every file in this PR was checked against the actual `stable/8.7` tree before writing (module existence, class names, package layouts, build config) rather than copied and trimmed by assumption — the commit bodies list what was verified and what had to be reworded or dropped as a result.

**What's ported:**
- Root `AGENTS.md`/`CLAUDE.md` (didn't exist on this branch at all)
- 8 of main's 25 skills, on top of the 8 this branch already carries unmodified — the smallest skill set of the three target branches, since the frontend and newer-module skills don't apply
- `docs/architecture/overview.md` and `docs/adr/README.md`, both new to this branch, with the overview substantially reworked to describe what's actually here rather than main's current architecture

**What's intentionally skipped**, with reasons in the corresponding commit: module-level `AGENTS.md`/`CLAUDE.md` files for every module — including `c8run/` and `testing/`, which do exist here — since those modules belong to other teams and their docs are left for the owning teams to write; `gateways/gateway-mcp/AGENTS.md`, `optimize/AGENTS.md`/`CLAUDE.md`, `zeebe/dynamic-node-id-provider/AGENTS.md`, `zeebe/exporters/analytics-exporter/AGENTS.md`, `zeebe/dynamic-config/AGENTS.md` (these modules don't exist here anyway); the frontend-\* and \*-frontend skills (this branch's `operate/client`/`tasklist/client` are a full generation older — Create React App, no React Query — porting main's version would actively mislead); individual ADR files (all 15 on main document unreleased 8.10 features or modules absent here).

Opening as **draft**, pending maintainer review — flagging a few judgment calls below that weren't fully specified upfront.

**Judgment calls / discrepancies found while executing, not called out in the original audit:**
- Root `AGENTS.md`'s testing-conventions section referenced `docs/testing.md` and `docs/testing/` — neither exists on `stable/8.7` (both are `main`-only additions) — dropped rather than left dangling.
- Root `AGENTS.md`'s "Role & boundary" intro paragraph listed `Optimize (analytics)` as part of "this monorepo" — dropped for consistency with dropping Optimize from the architecture overview for the same reason (the module doesn't exist in this tree at all).
- The always-green policy's CI health check (`gh run list --branch main`) was retargeted to `stable/8.7` — checking `main`'s CI health isn't the relevant baseline when branching from `stable/8.7`.
- `authentication/`'s path-map description and the overview's write-path prose both said "OIDC token processing" — this branch's `authentication/` has zero OIDC-related code (`git grep -i oidc` — no hits), just a basic-auth `WebSecurityConfig`; reworded both.
- **Deliberate coverage gap, not a moot reference**: root `AGENTS.md`'s "Scoped instructions" table dropped the `testing/AGENTS.md`, `.github/instructions/frontend.instructions.md`, and `.github/instructions/load-tests.instructions.md` rows because none of those files exist on `stable/8.7` (module docs are out of scope for this port; the two instruction files are `main`-only additions) — but the directories they'd apply to (`testing/`, `operate/client/`, `tasklist/client/`, `load-tests/`) do exist here. This branch is left without that guidance until the owning teams backfill it.
- **Formatting could not be verified locally**: `mvn license:format spotless:apply -T1C` fails in this environment before touching any file — `parent/pom.xml` imports Spring BOMs from Camunda's private Artifactory mirror (`NEXUS_USR`/`NEXUS_PSW`), which weren't available in this sandbox (confirmed via a 401 on `spring-framework-bom` and friends, and empty `NEXUS_*` env vars). All markdown tables were hand-formatted against the Flexmark column-width algorithm documented in the repo's Spotless config (centered header, left-aligned body, width = max(header, widest body cell) — verified empirically against two already-formatted tables elsewhere in this repo) and reformatted with a small script, but this should still be spot-checked against a real `spotless:apply` run before merge.

## Checklist

- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to #53649 (original agent-readiness infra on `main`)
