### PR TITLE
fix: clean node_modules before retrying npm ci

### DIFF
--- a/.github/actions/npm-ci-with-retry/action.yml
+++ b/.github/actions/npm-ci-with-retry/action.yml
@@ -41,3 +41,8 @@ runs:
         shell: bash
         command: |
           cd "${{ inputs.directory }}" && npm ci
+        # A killed attempt (timeout) can leave node_modules half-extracted,
+        # which makes the next attempt fail deterministically (e.g. ENOTEMPTY)
+        # instead of getting a clean retry.
+        on_retry_command: |
+          rm -rf "${{ inputs.directory }}/node_modules"


### PR DESCRIPTION
## Description

A killed npm ci attempt (hit the per-attempt timeout) can leave node_modules half-extracted. The next retry attempt then fails deterministically with ENOTEMPTY trying to install into that same directory, so a single slow attempt guarantees the whole job fails regardless of max_attempts.

Observed on main: Operate FE TypeScript Type Check job attempt 1 timed out mid-extraction of @ibm/plex/IBM-Plex-Sans-Thai/fonts, attempt 2 failed immediately with ENOTEMPTY on the same path (run https://github.com/camunda/camunda/actions/runs/30642251489/job/91196082495).

Use nick-fields/retry's on_retry_command to remove node_modules before each retry so every attempt starts from a clean state.

## Related issues

closes #
