### PR TITLE
refactor: migrate engine call sites onto CslTenantCheck directly

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -65,6 +65,7 @@ import io.camunda.zeebe.engine.processing.identity.RoleProcessors;
 import io.camunda.zeebe.engine.processing.identity.adapter.AuthorizationScopeStateAdapter;
 import io.camunda.zeebe.engine.processing.identity.adapter.MembershipStateAdapter;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.incident.IncidentEventProcessors;
 import io.camunda.zeebe.engine.processing.job.JobEventProcessors;
 import io.camunda.zeebe.engine.processing.message.MessageEventProcessors;
@@ -247,6 +248,7 @@ public final class EngineProcessors {
     final LazyTokenClaimsConverter claimsConverter =
         (LazyTokenClaimsConverter) ports.claimsResolver();
     final var cslCheck = new CslAuthorizationCheck(authzService, claimsConverter, securityConfig);
+    final var tenantCheck = new CslTenantCheck(claimsConverter, securityConfig);
 
     final var permissionsBehavior = new PermissionsBehavior(processingState, cslCheck);
 
@@ -268,7 +270,8 @@ public final class EngineProcessors {
             messageCorrelationMetrics,
             featureFlags.evaluateBoundaryEventCorrelationKeyInActivityScope(),
             featureFlags.evaluateDuplicateOutputMappingTargetsInOrder(),
-            cslCheck);
+            cslCheck,
+            tenantCheck);
 
     typedRecordProcessors.withListener(bpmnBehaviors.incidentBehavior());
 
@@ -351,12 +354,13 @@ public final class EngineProcessors {
         config,
         clock,
         cslCheck,
+        tenantCheck,
         incidentMetrics,
         secretStoreRegistry);
 
     final var userTaskProcessor =
         createUserTaskProcessor(
-            processingState, bpmnBehaviors, writers, asyncRequestBehavior, cslCheck);
+            processingState, bpmnBehaviors, writers, asyncRequestBehavior, cslCheck, tenantCheck);
     addUserTaskProcessors(typedRecordProcessors, userTaskProcessor);
 
     addIncidentProcessors(
@@ -367,6 +371,7 @@ public final class EngineProcessors {
         writers,
         bpmnBehaviors.jobActivationBehavior(),
         cslCheck,
+        tenantCheck,
         incidentMetrics);
     addResourceDeletionProcessors(
         partitionId,
@@ -376,7 +381,7 @@ public final class EngineProcessors {
         commandDistributionBehavior,
         bpmnBehaviors,
         permissionsBehavior,
-        cslCheck,
+        tenantCheck,
         processDefinitionMetrics);
     addSignalBroadcastProcessors(
         typedRecordProcessors,
@@ -384,9 +389,10 @@ public final class EngineProcessors {
         writers,
         processingState,
         commandDistributionBehavior,
-        cslCheck);
+        cslCheck,
+        tenantCheck);
     addConditionalEvaluationProcessors(
-        typedRecordProcessors, bpmnBehaviors, writers, processingState, cslCheck);
+        typedRecordProcessors, bpmnBehaviors, writers, processingState, cslCheck, tenantCheck);
     addCommandDistributionProcessors(
         commandDistributionBehavior,
         scheduledTaskStateFactory,
@@ -501,7 +507,8 @@ public final class EngineProcessors {
         bpmnBehaviors.expressionBehavior(),
         bpmnBehaviors.expressionLanguage(),
         processingState.getElementInstanceState(),
-        cslCheck);
+        cslCheck,
+        tenantCheck);
 
     JobMetricsProcessors.addJobMetricsProcessors(
         typedRecordProcessors,
@@ -589,7 +596,8 @@ public final class EngineProcessors {
       final BpmnBehaviorsImpl bpmnBehaviors,
       final Writers writers,
       final AsyncRequestBehavior asyncRequestBehavior,
-      final CslAuthorizationCheck cslCheck) {
+      final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck) {
     return new UserTaskProcessor(
         processingState,
         processingState.getUserTaskState(),
@@ -597,7 +605,8 @@ public final class EngineProcessors {
         bpmnBehaviors,
         writers,
         asyncRequestBehavior,
-        cslCheck);
+        cslCheck,
+        tenantCheck);
   }
 
   private static BpmnBehaviorsImpl createBehaviors(
@@ -617,7 +626,8 @@ public final class EngineProcessors {
       final MessageCorrelationMetrics messageCorrelationMetrics,
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
       final boolean evaluateDuplicateOutputMappingTargetsInOrder,
-      final CslAuthorizationCheck cslCheck) {
+      final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck) {
     return new BpmnBehaviorsImpl(
         processingState,
         writers,
@@ -635,7 +645,8 @@ public final class EngineProcessors {
         messageCorrelationMetrics,
         evaluateBoundaryEventCorrelationKeyInActivityScope,
         evaluateDuplicateOutputMappingTargetsInOrder,
-        cslCheck);
+        cslCheck,
+        tenantCheck);
   }
 
   private static TypedRecordProcessor<ProcessInstanceRecord> addProcessProcessors(
@@ -741,6 +752,7 @@ public final class EngineProcessors {
       final Writers writers,
       final BpmnJobActivationBehavior jobActivationBehavior,
       final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
       final IncidentMetrics incidentMetrics) {
     IncidentEventProcessors.addProcessors(
         typedRecordProcessors,
@@ -750,6 +762,7 @@ public final class EngineProcessors {
         writers,
         jobActivationBehavior,
         cslCheck,
+        tenantCheck,
         incidentMetrics);
   }
 
@@ -813,7 +826,7 @@ public final class EngineProcessors {
       final CommandDistributionBehavior commandDistributionBehavior,
       final BpmnBehaviors bpmnBehaviors,
       final PermissionsBehavior permissionsBehavior,
-      final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
       final ProcessDefinitionMetrics processDefinitionMetrics) {
     final var resourceDeletionProcessor =
         new ResourceDeletionDeleteProcessor(
@@ -823,7 +836,7 @@ public final class EngineProcessors {
             commandDistributionBehavior,
             bpmnBehaviors,
             permissionsBehavior,
-            cslCheck,
+            tenantCheck,
             processDefinitionMetrics);
     typedRecordProcessors.onCommand(
         ValueType.RESOURCE_DELETION, ResourceDeletionIntent.DELETE, resourceDeletionProcessor);
@@ -868,7 +881,8 @@ public final class EngineProcessors {
       final Writers writers,
       final MutableProcessingState processingState,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final CslAuthorizationCheck cslCheck) {
+      final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck) {
     final var signalBroadcastProcessor =
         new SignalBroadcastProcessor(
             writers,
@@ -878,6 +892,7 @@ public final class EngineProcessors {
             bpmnBehaviors.eventTriggerBehavior(),
             commandDistributionBehavior,
             cslCheck,
+            tenantCheck,
             bpmnBehaviors.variableBehavior());
     typedRecordProcessors.onCommand(
         ValueType.SIGNAL, SignalIntent.BROADCAST, signalBroadcastProcessor);
@@ -888,7 +903,8 @@ public final class EngineProcessors {
       final BpmnBehaviors bpmnBehaviors,
       final Writers writers,
       final MutableProcessingState processingState,
-      final CslAuthorizationCheck cslCheck) {
+      final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck) {
     final var conditionalEvaluationProcessor =
         new ConditionalEvaluationEvaluateProcessor(
             writers,
@@ -897,6 +913,7 @@ public final class EngineProcessors {
             bpmnBehaviors.stateBehavior(),
             bpmnBehaviors.eventTriggerBehavior(),
             cslCheck,
+            tenantCheck,
             bpmnBehaviors.expressionProcessor());
     typedRecordProcessors.onCommand(
         ValueType.CONDITIONAL_EVALUATION,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.engine.processing.expression.ProcessInstanceContextEvalu
 import io.camunda.zeebe.engine.processing.expression.TenantScopeClusterVariableEvaluationContext;
 import io.camunda.zeebe.engine.processing.expression.VariableEvaluationContext;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
@@ -88,7 +89,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final MessageCorrelationMetrics messageCorrelationMetrics,
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
       final boolean evaluateDuplicateOutputMappingTargetsInOrder,
-      final CslAuthorizationCheck cslCheck) {
+      final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck) {
 
     final var tenantClusterScope =
         new TenantScopeClusterVariableEvaluationContext(processingState.getClusterVariableState());
@@ -237,7 +239,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             processingState.getKeyGenerator(),
             jobMetrics,
             clock,
-            cslCheck);
+            cslCheck,
+            tenantCheck);
 
     multiInstanceInputCollectionBehavior =
         new MultiInstanceInputCollectionBehavior(
@@ -294,7 +297,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
         new BpmnCompensationSubscriptionBehaviour(
             processingState.getKeyGenerator(), processingState, writers, stateBehavior);
 
-    jobUpdateBehaviour = new JobUpdateBehaviour(processingState, clock, cslCheck, writers);
+    jobUpdateBehaviour =
+        new JobUpdateBehaviour(processingState, clock, cslCheck, tenantCheck, writers);
 
     adHocSubProcessBehavior =
         new BpmnAdHocSubProcessBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.job.JobVariablesCollector;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer.JobStream;
@@ -56,6 +57,7 @@ public class BpmnJobActivationBehavior {
   private final JobProcessingMetrics jobMetrics;
   private final InstantSource clock;
   private final CslAuthorizationCheck cslCheck;
+  private final CslTenantCheck tenantCheck;
   private final JobAuthorizationLogger jobAuthorizationLogger;
 
   public BpmnJobActivationBehavior(
@@ -65,7 +67,8 @@ public class BpmnJobActivationBehavior {
       final KeyGenerator keyGenerator,
       final JobProcessingMetrics jobMetrics,
       final InstantSource clock,
-      final CslAuthorizationCheck cslCheck) {
+      final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck) {
     this.jobStreamer = jobStreamer;
     this.keyGenerator = keyGenerator;
     this.jobMetrics = jobMetrics;
@@ -74,6 +77,7 @@ public class BpmnJobActivationBehavior {
     sideEffectWriter = writers.sideEffect();
     this.clock = clock;
     this.cslCheck = cslCheck;
+    this.tenantCheck = tenantCheck;
     this.jobAuthorizationLogger = JobAuthorizationLogger.createDefault();
   }
 
@@ -172,7 +176,7 @@ public class BpmnJobActivationBehavior {
         switch (jobActivationProperties.tenantFilter()) {
           case ASSIGNED -> {
             final var authorizedTenants =
-                cslCheck.resolveAuthorizedTenants(jobActivationProperties.claims());
+                tenantCheck.resolveAuthorizedTenants(jobActivationProperties.claims());
             yield !authorizedTenants.wildcard()
                 && authorizedTenants.isAuthorizedForTenantId(ownerTenantId);
           }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationEvaluateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationEvaluateProcessor.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.expression.InMemoryVariableEvaluationContext;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.identity.authorization.exception.ForbiddenException;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -60,6 +61,7 @@ public class ConditionalEvaluationEvaluateProcessor
   private final ProcessState processState;
   private final ConditionalSubscriptionState conditionalSubscriptionState;
   private final CslAuthorizationCheck cslCheck;
+  private final CslTenantCheck tenantCheck;
   private final ExpressionProcessor expressionProcessor;
 
   public ConditionalEvaluationEvaluateProcessor(
@@ -69,6 +71,7 @@ public class ConditionalEvaluationEvaluateProcessor
       final BpmnStateBehavior stateBehavior,
       final EventTriggerBehavior eventTriggerBehavior,
       final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
       final ExpressionProcessor expressionProcessor) {
     stateWriter = writers.state();
     responseWriter = writers.response();
@@ -77,6 +80,7 @@ public class ConditionalEvaluationEvaluateProcessor
     conditionalSubscriptionState = processingState.getConditionalSubscriptionState();
     this.keyGenerator = keyGenerator;
     this.cslCheck = cslCheck;
+    this.tenantCheck = tenantCheck;
     this.expressionProcessor = expressionProcessor;
     eventHandle =
         new EventHandle(
@@ -92,9 +96,9 @@ public class ConditionalEvaluationEvaluateProcessor
   public void processRecord(final TypedRecord<ConditionalEvaluationRecord> command) {
     final var record = command.getValue();
 
-    final var authorizedTenants = cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
-    final var tenantCheck =
-        cslCheck.checkTenantsRequiringPrincipal(
+    final var authorizedTenants = tenantCheck.resolveAuthorizedTenants(command.getAuthorizations());
+    final var tenantCheckResult =
+        tenantCheck.checkTenantsRequiringPrincipal(
             List.of(record.getTenantId()),
             authorizedTenants,
             record,
@@ -102,8 +106,8 @@ public class ConditionalEvaluationEvaluateProcessor
                 new Rejection(
                     RejectionType.FORBIDDEN,
                     USER_NOT_ASSIGNED_TO_TENANT_MESSAGE.formatted(record.getTenantId())));
-    if (tenantCheck.isLeft()) {
-      final var rejection = tenantCheck.getLeft();
+    if (tenantCheckResult.isLeft()) {
+      final var rejection = tenantCheckResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
       responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionEvaluateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionEvaluateProcessor.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.processing.expression.ExpressionValidator.Resolve
 import io.camunda.zeebe.engine.processing.expression.ExpressionValidator.ValidatedCommand;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -37,6 +38,7 @@ public final class ExpressionEvaluateProcessor implements TypedRecordProcessor<E
   private final ExpressionBehavior expressionBehavior;
   private final ExpressionValidator validator;
   private final CslAuthorizationCheck cslCheck;
+  private final CslTenantCheck tenantCheck;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
@@ -47,13 +49,15 @@ public final class ExpressionEvaluateProcessor implements TypedRecordProcessor<E
       final Writers writers,
       final ExpressionBehavior expressionBehavior,
       final ExpressionValidator validator,
-      final CslAuthorizationCheck cslCheck) {
+      final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck) {
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     this.expressionBehavior = expressionBehavior;
     this.validator = validator;
     this.cslCheck = cslCheck;
+    this.tenantCheck = tenantCheck;
     this.keyGenerator = keyGenerator;
   }
 
@@ -165,7 +169,7 @@ public final class ExpressionEvaluateProcessor implements TypedRecordProcessor<E
     if (tenantId.isBlank()) {
       return Either.right(value);
     }
-    return cslCheck.checkTenant(
+    return tenantCheck.checkTenant(
         command,
         tenantId,
         value,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionProcessors.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.expression;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
@@ -27,12 +28,13 @@ public final class ExpressionProcessors {
       final ExpressionBehavior expressionBehavior,
       final ExpressionLanguage expressionLanguage,
       final ElementInstanceState elementInstanceState,
-      final CslAuthorizationCheck cslCheck) {
+      final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck) {
     final var validator = new ExpressionValidator(expressionLanguage, elementInstanceState);
     typedRecordProcessors.onCommand(
         ValueType.EXPRESSION,
         ExpressionIntent.EVALUATE,
         new ExpressionEvaluateProcessor(
-            keyGenerator, writers, expressionBehavior, validator, cslCheck));
+            keyGenerator, writers, expressionBehavior, validator, cslCheck, tenantCheck));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
@@ -12,18 +12,15 @@ import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.api.model.authz.AuthorizationRejection;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.core.auth.RequiredAuthorization;
-import io.camunda.security.core.authz.TenantAccess;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,8 +37,8 @@ import org.slf4j.LoggerFactory;
  * {@link #resolveForCheck} for multi-check sites (e.g. UserTask processors) that run several CSL
  * checks after the skip-logic resolves the principal.
  *
- * <p>Tenant-membership checks are delegated to {@link CslTenantCheck}; this class exposes them
- * under their original method names so existing callers are unaffected.
+ * <p>Tenant-membership checks live in {@link CslTenantCheck}; this class only combines them with a
+ * preceding RBAC {@link #check} in {@link #checkAuthorizationAndTenant}.
  */
 @NullMarked
 public final class CslAuthorizationCheck {
@@ -108,57 +105,6 @@ public final class CslAuthorizationCheck {
   }
 
   /**
-   * Resolves the {@link TenantAccess} for a command from its authorization claims. Delegates to
-   * {@link CslTenantCheck#resolveAuthorizedTenants}.
-   */
-  public TenantAccess resolveAuthorizedTenants(final Map<String, Object> authorizations) {
-    return tenantCheck.resolveAuthorizedTenants(authorizations);
-  }
-
-  public boolean isMultiTenancyChecksEnabled() {
-    return tenantCheck.isMultiTenancyChecksEnabled();
-  }
-
-  /**
-   * Tenant-assignment check for command sites that must verify tenant membership independently of a
-   * resource {@link #check} — e.g. a command-level tenant gate, or a site whose RBAC check runs at
-   * a different granularity (one tenant, many resource checks). Delegates to {@link
-   * CslTenantCheck#checkTenant}; see that method's javadoc for the full skip-logic contract.
-   *
-   * @param value the value to return on success (mirrors {@link #check}; enables {@code flatMap}
-   *     composition with it)
-   * @param notAssignedRejection the rejection to return when the principal is not assigned to
-   *     {@code tenantId}
-   */
-  public <T> Either<Rejection, T> checkTenant(
-      final TypedRecord<?> command,
-      final String tenantId,
-      final T value,
-      final Rejection notAssignedRejection) {
-    return tenantCheck.checkTenant(command, tenantId, value, notAssignedRejection);
-  }
-
-  /**
-   * Tenant-assignment check across a list of tenant IDs at once, for command sites that call it
-   * directly with no preceding {@link #check}. Delegates to {@link
-   * CslTenantCheck#checkTenantsRequiringPrincipal}; see that method's javadoc for the full
-   * skip-logic contract, including why it has no no-principal skip (unlike {@link #checkTenant}).
-   *
-   * @param authorizedTenants the tenants the command's principal is authorized for, as resolved by
-   *     {@link #resolveAuthorizedTenants} from the same command's claims
-   * @param notAssignedRejection supplies the rejection to return when the principal is not assigned
-   *     to all of {@code tenantIds}; only invoked on that failure path
-   */
-  public <T> Either<Rejection, T> checkTenantsRequiringPrincipal(
-      final List<String> tenantIds,
-      final TenantAccess authorizedTenants,
-      final T value,
-      final Supplier<Rejection> notAssignedRejection) {
-    return tenantCheck.checkTenantsRequiringPrincipal(
-        tenantIds, authorizedTenants, value, notAssignedRejection);
-  }
-
-  /**
    * Combines {@link #check} and {@link CslTenantCheck#checkTenant} into the single call most
    * command sites need: RBAC permission first, tenant membership second. When both checks would
    * fail on the same command, permission rejection wins — so a principal with no permission at all
@@ -182,7 +128,7 @@ public final class CslAuthorizationCheck {
       final String tenantId,
       final Rejection tenantNotAssignedRejection) {
     return check(command, required, value, noPrincipalRejection)
-        .flatMap(v -> checkTenant(command, tenantId, v, tenantNotAssignedRejection));
+        .flatMap(v -> tenantCheck.checkTenant(command, tenantId, v, tenantNotAssignedRejection));
   }
 
   /**
@@ -199,7 +145,7 @@ public final class CslAuthorizationCheck {
       final String tenantId,
       final Rejection tenantNotAssignedRejection) {
     return check(command, required, value, noPrincipalRejection, denialMapper)
-        .flatMap(v -> checkTenant(command, tenantId, v, tenantNotAssignedRejection));
+        .flatMap(v -> tenantCheck.checkTenant(command, tenantId, v, tenantNotAssignedRejection));
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslTenantCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslTenantCheck.java
@@ -24,11 +24,13 @@ import org.jspecify.annotations.NullMarked;
 /**
  * Encapsulates the tenant-membership checks used across engine command processors.
  *
- * <p>Most callers reach {@link #checkTenant} via {@link
- * CslAuthorizationCheck#checkAuthorizationAndTenant}, which runs {@link
- * CslAuthorizationCheck#check} first. Do not call {@link #checkTenant} directly without a preceding
- * authorization check, and do not remove its no-principal skip without auditing every caller.
- * {@link #checkTenantsRequiringPrincipal} has a different contract — see its own javadoc.
+ * <p>Most callers call {@link #checkTenant} directly, downstream of their own RBAC {@link
+ * CslAuthorizationCheck#check} or {@link CslAuthorizationCheck#checkForDistributedCommand} call on
+ * the same command; a few compose both via {@link
+ * CslAuthorizationCheck#checkAuthorizationAndTenant}. Either way, whoever calls {@link
+ * #checkTenant} is responsible for ensuring that RBAC check has already run and passed — do not
+ * call it directly without one, and do not remove its no-principal skip without auditing every
+ * caller. {@link #checkTenantsRequiringPrincipal} has a different contract — see its own javadoc.
  */
 @NullMarked
 public final class CslTenantCheck {
@@ -89,16 +91,15 @@ public final class CslTenantCheck {
    * command's claims (anonymous access is authorized for every tenant) and {@code tenantId} must be
    * among them.
    *
-   * <p>This no-principal skip is load-bearing: every caller runs {@link
-   * CslAuthorizationCheck#check} first — either directly, composed via {@link
-   * CslAuthorizationCheck#checkAuthorizationAndTenant}, or (for the sole remaining direct caller)
-   * via an equivalent {@code check(...).flatMap(v -> checkTenant(...))} of its own — before this
-   * method is ever reached. When authorizations are enabled, {@code check} itself rejects a
-   * no-principal command before this method runs; when authorizations are disabled, letting a
-   * claims-free command through here (e.g. deployment/process lifecycle commands issued without an
-   * explicit user, common in tests and tooling) is the established, relied-upon behavior. Do not
-   * call this method directly without a preceding {@link CslAuthorizationCheck#check}, and do not
-   * remove this skip without auditing every caller.
+   * <p>This no-principal skip is load-bearing: every caller must ensure a RBAC {@link
+   * CslAuthorizationCheck#check} or {@link CslAuthorizationCheck#checkForDistributedCommand} call
+   * for the same command has already run and passed before reaching this method — either directly,
+   * or composed via {@link CslAuthorizationCheck#checkAuthorizationAndTenant}. When authorizations
+   * are enabled, that RBAC check itself rejects a no-principal command before this method runs;
+   * when authorizations are disabled, letting a claims-free command through here (e.g. deployment/
+   * process lifecycle commands issued without an explicit user, common in tests and tooling) is the
+   * established, relied-upon behavior. Do not call this method directly without a preceding RBAC
+   * check, and do not remove this skip without auditing every caller.
    *
    * <p>Callers own the rejection semantics: {@code notAssignedRejection} carries the {@link
    * io.camunda.zeebe.protocol.record.RejectionType} — {@code FORBIDDEN} to signal "not assigned to

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentEventProcessors.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.incident;
 import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -29,6 +30,7 @@ public final class IncidentEventProcessors {
       final Writers writers,
       final BpmnJobActivationBehavior jobActivationBehavior,
       final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
       final IncidentMetrics incidentMetrics) {
     typedRecordProcessors.onCommand(
         ValueType.INCIDENT,
@@ -40,6 +42,7 @@ public final class IncidentEventProcessors {
             writers,
             jobActivationBehavior,
             cslCheck,
+            tenantCheck,
             incidentMetrics));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavio
 import io.camunda.zeebe.engine.processing.common.BannedInstanceCommandCheck;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -68,6 +69,7 @@ public final class IncidentResolveProcessor
   private final BpmnJobActivationBehavior jobActivationBehavior;
   private final JobState jobState;
   private final CslAuthorizationCheck cslCheck;
+  private final CslTenantCheck tenantCheck;
   private final IncidentMetrics incidentMetrics;
   private final BannedInstanceCommandCheck bannedInstanceCheck;
 
@@ -78,6 +80,7 @@ public final class IncidentResolveProcessor
       final Writers writers,
       final BpmnJobActivationBehavior jobActivationBehavior,
       final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
       final IncidentMetrics incidentMetrics) {
     this.bpmnStreamProcessor = bpmnStreamProcessor;
     this.userTaskProcessor = userTaskProcessor;
@@ -90,6 +93,7 @@ public final class IncidentResolveProcessor
     this.jobActivationBehavior = jobActivationBehavior;
     jobState = processingState.getJobState();
     this.cslCheck = cslCheck;
+    this.tenantCheck = tenantCheck;
     this.incidentMetrics = incidentMetrics;
     this.bannedInstanceCheck =
         new BannedInstanceCommandCheck(processingState.getBannedInstanceState());
@@ -98,7 +102,8 @@ public final class IncidentResolveProcessor
   @Override
   public void processRecord(final TypedRecord<IncidentRecord> command) {
     final long key = command.getKey();
-    final var authorizedTenantIds = cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
+    final var authorizedTenantIds =
+        tenantCheck.resolveAuthorizedTenants(command.getAuthorizations());
     final var incident = incidentState.getIncidentRecord(key, authorizedTenantIds);
     if (incident == null) {
       final var errorMessage = String.format(NO_INCIDENT_FOUND_MSG, key);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
 import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.job.JobSecretInjector.DroppedJob;
 import io.camunda.zeebe.engine.processing.job.JobSecretInjector.FailedInjectionJob;
 import io.camunda.zeebe.engine.processing.job.JobSecretInjector.OversizedJob;
@@ -68,6 +69,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   private final ElementInstanceState elementInstanceState;
   private final ProcessState processState;
   private final CslAuthorizationCheck cslCheck;
+  private final CslTenantCheck tenantCheck;
   private final IncidentMetrics incidentMetrics;
   private final JobSecretInjector jobSecretInjector;
 
@@ -77,6 +79,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
       final KeyGenerator keyGenerator,
       final JobProcessingMetrics jobMetrics,
       final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
       final InstantSource clock,
       final IncidentMetrics incidentMetrics,
       final SecretStoreRegistry secretStoreRegistry) {
@@ -85,6 +88,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     this.cslCheck = cslCheck;
+    this.tenantCheck = tenantCheck;
     jobSecretInjector = new JobSecretInjector(secretStoreRegistry);
     jobBatchCollector =
         new JobBatchCollector(
@@ -104,7 +108,8 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
 
   @Override
   public void processRecord(final TypedRecord<JobBatchRecord> record) {
-    final var authorizedTenantIds = cslCheck.resolveAuthorizedTenants(record.getAuthorizations());
+    final var authorizedTenantIds =
+        tenantCheck.resolveAuthorizedTenants(record.getAuthorizations());
     final var value = record.getValue();
 
     final var validationResult = validateRequest(record, authorizedTenantIds);
@@ -156,7 +161,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   private Either<Rejection, Void> validateTenantAuthorization(
       final JobBatchRecord value, final TenantAccess authorizedTenantIds) {
     final var tenantIds = resolveProvidedTenantIds(value);
-    return cslCheck.checkTenantsRequiringPrincipal(
+    return tenantCheck.checkTenantsRequiringPrincipal(
         tenantIds,
         authorizedTenantIds,
         null,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCommandPreconditionValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCommandPreconditionValidator.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.common.BannedInstanceCommandCheck;
-import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
@@ -30,7 +30,7 @@ public class JobCommandPreconditionValidator {
   private final JobState jobState;
   private final String intent;
   private final List<JobCommandCheck> customChecks;
-  private final CslAuthorizationCheck cslCheck;
+  private final CslTenantCheck tenantCheck;
   private final BannedInstanceCommandCheck bannedInstanceCheck;
 
   public JobCommandPreconditionValidator(
@@ -38,8 +38,8 @@ public class JobCommandPreconditionValidator {
       final BannedInstanceState bannedInstanceState,
       final String intent,
       final List<State> validStates,
-      final CslAuthorizationCheck cslCheck) {
-    this(jobState, bannedInstanceState, intent, validStates, List.of(), cslCheck);
+      final CslTenantCheck tenantCheck) {
+    this(jobState, bannedInstanceState, intent, validStates, List.of(), tenantCheck);
   }
 
   public JobCommandPreconditionValidator(
@@ -48,12 +48,12 @@ public class JobCommandPreconditionValidator {
       final String intent,
       final List<State> validStates,
       final List<JobCommandCheck> customChecks,
-      final CslAuthorizationCheck cslCheck) {
+      final CslTenantCheck tenantCheck) {
     this.jobState = jobState;
     this.intent = intent;
     this.validStates = validStates;
     this.customChecks = customChecks;
-    this.cslCheck = cslCheck;
+    this.tenantCheck = tenantCheck;
     bannedInstanceCheck = new BannedInstanceCommandCheck(bannedInstanceState);
   }
 
@@ -100,7 +100,7 @@ public class JobCommandPreconditionValidator {
 
   private Either<Rejection, JobRecord> checkJobExists(final TypedRecord<JobRecord> command) {
     final long jobKey = command.getKey();
-    final var authorizedTenants = cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
+    final var authorizedTenants = tenantCheck.resolveAuthorizedTenants(command.getAuthorizations());
     final var storedJob =
         authorizedTenants.wildcard()
             ? jobState.getJob(jobKey)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.processing.common.ValidationException;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAdHocSubProcess;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBusinessIdAssignmentBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
@@ -152,6 +153,7 @@ public final class JobCompleteProcessor
       final JobProcessingMetrics jobMetrics,
       final EventHandle eventHandle,
       final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
       final VariableBehavior variableBehavior,
       final boolean includeVariablesInJobCompletedEvent,
       final boolean businessIdUniquenessEnabled) {
@@ -183,7 +185,7 @@ public final class JobCompleteProcessor
                 this::checkCreatingListenerJobForAssigneeCorrection,
                 this::checkTaskListenerJobForUnknownPropertyCorrections,
                 this::checkBusinessIdAssignment),
-            cslCheck);
+            tenantCheck);
     this.cslCheck = cslCheck;
     this.jobMetrics = jobMetrics;
     this.eventHandle = eventHandle;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
@@ -36,6 +37,7 @@ public final class JobEventProcessors {
       final EngineConfiguration config,
       final InstantSource clock,
       final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
       final IncidentMetrics incidentMetrics,
       final SecretStoreRegistry secretStoreRegistry) {
 
@@ -62,6 +64,7 @@ public final class JobEventProcessors {
                 jobMetrics,
                 eventHandle,
                 cslCheck,
+                tenantCheck,
                 bpmnBehaviors.variableBehavior(),
                 config.isIncludeVariablesInJobCompletedEvent(),
                 config.isBusinessIdUniquenessEnabled()))
@@ -76,11 +79,12 @@ public final class JobEventProcessors {
                 jobBackoffChecker,
                 bpmnBehaviors,
                 cslCheck,
+                tenantCheck,
                 incidentMetrics))
         .onCommand(
             ValueType.JOB,
             JobIntent.YIELD,
-            new JobYieldProcessor(processingState, bpmnBehaviors, writers, cslCheck))
+            new JobYieldProcessor(processingState, bpmnBehaviors, writers, tenantCheck))
         .onCommand(
             ValueType.JOB,
             JobIntent.THROW_ERROR,
@@ -90,6 +94,7 @@ public final class JobEventProcessors {
                 keyGenerator,
                 jobMetrics,
                 cslCheck,
+                tenantCheck,
                 writers,
                 incidentMetrics,
                 bpmnBehaviors.variableBehavior()))
@@ -128,6 +133,7 @@ public final class JobEventProcessors {
                 processingState.getKeyGenerator(),
                 jobMetrics,
                 cslCheck,
+                tenantCheck,
                 clock,
                 incidentMetrics,
                 secretStoreRegistry))

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
 import io.camunda.zeebe.engine.processing.common.ValidationException;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -78,6 +79,7 @@ public final class JobFailProcessor
       final JobBackoffCheckScheduler jobBackoffChecker,
       final BpmnBehaviors bpmnBehaviors,
       final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
       final IncidentMetrics incidentMetrics) {
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
@@ -96,7 +98,7 @@ public final class JobFailProcessor
             "fail",
             List.of(State.ACTIVATABLE, State.ACTIVATED),
             List.of(JobLeaseFencingCheck.forLifecycleCommand()),
-            cslCheck);
+            tenantCheck);
     this.keyGenerator = keyGenerator;
     this.jobBackoffChecker = jobBackoffChecker;
     this.jobMetrics = jobMetrics;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -97,6 +98,7 @@ public class JobThrowErrorProcessor
       final KeyGenerator keyGenerator,
       final JobProcessingMetrics jobMetrics,
       final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
       final Writers writers,
       final IncidentMetrics incidentMetrics,
       final VariableBehavior variableBehavior) {
@@ -114,7 +116,7 @@ public class JobThrowErrorProcessor
             "throw an error for",
             List.of(State.ACTIVATABLE, State.ACTIVATED),
             List.of(JobLeaseFencingCheck.forLifecycleCommand()),
-            cslCheck);
+            tenantCheck);
 
     stateAnalyzer = new CatchEventAnalyzer(state.getProcessState(), elementInstanceState);
     stateWriter = writers.state();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobYieldProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobYieldProcessor.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.processing.job;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -38,14 +38,18 @@ public final class JobYieldProcessor
       final ProcessingState state,
       final BpmnBehaviors bpmnBehaviors,
       final Writers writers,
-      final CslAuthorizationCheck cslCheck) {
+      final CslTenantCheck tenantCheck) {
     jobState = state.getJobState();
     jobActivationBehavior = bpmnBehaviors.jobActivationBehavior();
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     preconditionChecker =
         new JobCommandPreconditionValidator(
-            jobState, state.getBannedInstanceState(), "yield", List.of(State.ACTIVATED), cslCheck);
+            jobState,
+            state.getBannedInstanceState(),
+            "yield",
+            List.of(State.ACTIVATED),
+            tenantCheck);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
@@ -11,6 +11,7 @@ import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.job.JobCommandPreconditionValidator;
 import io.camunda.zeebe.engine.processing.job.JobLeaseFencingCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -44,6 +45,7 @@ public class JobUpdateBehaviour {
       final ProcessingState processingStateState,
       final InstantSource clock,
       final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
       final Writers writers) {
     jobState = processingStateState.getJobState();
     this.clock = clock;
@@ -55,7 +57,7 @@ public class JobUpdateBehaviour {
             "update",
             List.of(State.ACTIVATABLE, State.ACTIVATED, State.FAILED, State.ERROR_THROWN),
             List.of(JobLeaseFencingCheck.forUpdateCommand()),
-            cslCheck);
+            tenantCheck);
     this.cslCheck = cslCheck;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.message.MessageCorrelateBehavior.MessageData;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
@@ -68,6 +69,7 @@ public final class MessageCorrelationCorrelateProcessor
   private final MessageCorrelateBehavior correlateBehavior;
   private final KeyGenerator keyGenerator;
   private final CslAuthorizationCheck cslCheck;
+  private final CslTenantCheck tenantCheck;
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
@@ -85,6 +87,7 @@ public final class MessageCorrelationCorrelateProcessor
       final MessageSubscriptionState messageSubscriptionState,
       final SubscriptionCommandSender commandSender,
       final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
       final ElementInstanceState elementInstanceState,
       final BannedInstanceState bannedInstanceState,
       final boolean businessIdUniquenessEnabled,
@@ -97,6 +100,7 @@ public final class MessageCorrelationCorrelateProcessor
     rejectionWriter = writers.rejection();
     this.keyGenerator = keyGenerator;
     this.cslCheck = cslCheck;
+    this.tenantCheck = tenantCheck;
     this.metrics = metrics;
     this.suspensionState = suspensionState;
     final var eventHandle =
@@ -129,9 +133,10 @@ public final class MessageCorrelationCorrelateProcessor
 
     // Check tenant authorization if not an internal command
     if (!command.isInternalCommand()) {
-      final var authorizedTenants = cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
-      final var tenantCheck =
-          cslCheck.checkTenantsRequiringPrincipal(
+      final var authorizedTenants =
+          tenantCheck.resolveAuthorizedTenants(command.getAuthorizations());
+      final var tenantCheckResult =
+          tenantCheck.checkTenantsRequiringPrincipal(
               List.of(messageCorrelationRecord.getTenantId()),
               authorizedTenants,
               messageCorrelationRecord,
@@ -140,8 +145,8 @@ public final class MessageCorrelationCorrelateProcessor
                       RejectionType.FORBIDDEN,
                       "Expected to correlate message for tenant '%s', but user is not assigned to this tenant."
                           .formatted(messageCorrelationRecord.getTenantId())));
-      if (tenantCheck.isLeft()) {
-        final var rejection = tenantCheck.getLeft();
+      if (tenantCheckResult.isLeft()) {
+        final var rejection = tenantCheckResult.getLeft();
         rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
         responseWriter.writeRejectedResponseOnCommand(
             command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -73,6 +74,7 @@ public final class MessageEventProcessors {
     final var bannedInstanceState = processingState.getBannedInstanceState();
     final var businessIdUniquenessEnabled = config.isBusinessIdUniquenessEnabled();
     final var cslCheck = new CslAuthorizationCheck(authCheckPort, claimsConverter, securityConfig);
+    final var tenantCheck = new CslTenantCheck(claimsConverter, securityConfig);
 
     typedRecordProcessors
         .onCommand(
@@ -167,6 +169,7 @@ public final class MessageEventProcessors {
                 subscriptionState,
                 subscriptionCommandSender,
                 cslCheck,
+                tenantCheck,
                 elementInstanceState,
                 bannedInstanceState,
                 businessIdUniquenessEnabled,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -21,7 +21,7 @@ import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.deployment.StartEventSubscriptionManager;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.identity.authorization.exception.ForbiddenException;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -101,7 +101,7 @@ public class ResourceDeletionDeleteProcessor
   private final CatchEventBehavior catchEventBehavior;
   private final StartEventSubscriptions startEventSubscriptions;
   private final PermissionsBehavior permissionsBehavior;
-  private final CslAuthorizationCheck cslCheck;
+  private final CslTenantCheck tenantCheck;
   private final StartEventSubscriptionManager startEventSubscriptionManager;
   private final FormState formState;
   private final ResourceState resourceState;
@@ -115,7 +115,7 @@ public class ResourceDeletionDeleteProcessor
       final CommandDistributionBehavior commandDistributionBehavior,
       final BpmnBehaviors bpmnBehaviors,
       final PermissionsBehavior permissionsBehavior,
-      final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
       final ProcessDefinitionMetrics processDefinitionMetrics) {
     stateWriter = writers.state();
     commandWriter = writers.command();
@@ -130,7 +130,7 @@ public class ResourceDeletionDeleteProcessor
     bannedInstanceState = processingState.getBannedInstanceState();
     catchEventBehavior = bpmnBehaviors.catchEventBehavior();
     this.permissionsBehavior = permissionsBehavior;
-    this.cslCheck = cslCheck;
+    this.tenantCheck = tenantCheck;
     startEventSubscriptionManager =
         new StartEventSubscriptionManager(processingState, keyGenerator, stateWriter);
     startEventSubscriptions =
@@ -570,7 +570,7 @@ public class ResourceDeletionDeleteProcessor
   }
 
   private TenantAccess getAuthorizedTenants(final TypedRecord<ResourceDeletionRecord> command) {
-    final var userTenants = cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
+    final var userTenants = tenantCheck.resolveAuthorizedTenants(command.getAuthorizations());
     final String tenantId = command.getValue().getTenantId();
     if (tenantId.isEmpty()) {
       return userTenants;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCat
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.identity.authorization.exception.ForbiddenException;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor.ProcessingError;
@@ -56,6 +57,7 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
   private final ProcessState processState;
   private final ElementInstanceState elementInstanceState;
   private final CslAuthorizationCheck cslCheck;
+  private final CslTenantCheck tenantCheck;
   private final VariableBehavior variableBehavior;
 
   public SignalBroadcastProcessor(
@@ -66,6 +68,7 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
       final EventTriggerBehavior eventTriggerBehavior,
       final CommandDistributionBehavior commandDistributionBehavior,
       final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
       final VariableBehavior variableBehavior) {
     stateWriter = writers.state();
     responseWriter = writers.response();
@@ -76,6 +79,7 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
     this.commandDistributionBehavior = commandDistributionBehavior;
     elementInstanceState = processingState.getElementInstanceState();
     this.cslCheck = cslCheck;
+    this.tenantCheck = tenantCheck;
     this.variableBehavior = variableBehavior;
     eventHandle =
         new EventHandle(
@@ -96,9 +100,10 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
 
     // Check tenant authorization if not an internal command
     if (isAuthNeeded) {
-      final var authorizedTenants = cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
-      final var tenantCheck =
-          cslCheck.checkTenantsRequiringPrincipal(
+      final var authorizedTenants =
+          tenantCheck.resolveAuthorizedTenants(command.getAuthorizations());
+      final var tenantCheckResult =
+          tenantCheck.checkTenantsRequiringPrincipal(
               List.of(signalRecord.getTenantId()),
               authorizedTenants,
               signalRecord,
@@ -107,8 +112,8 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
                       RejectionType.FORBIDDEN,
                       "Expected to broadcast signal for tenant '%s', but user is not assigned to this tenant."
                           .formatted(signalRecord.getTenantId())));
-      if (tenantCheck.isLeft()) {
-        final var rejection = tenantCheck.getLeft();
+      if (tenantCheckResult.isLeft()) {
+        final var rejection = tenantCheckResult.getLeft();
         rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
         responseWriter.writeRejectedResponseOnCommand(
             command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.processing.AsyncRequestBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAssignProcessor;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAuthorizationCheck;
@@ -38,7 +39,8 @@ public final class UserTaskCommandProcessors {
       final BpmnBehaviors bpmnBehaviors,
       final Writers writers,
       final AsyncRequestBehavior asyncRequestBehavior,
-      final CslAuthorizationCheck cslCheck) {
+      final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck) {
     final EventHandle eventHandle =
         new EventHandle(
             keyGenerator,
@@ -61,17 +63,17 @@ public final class UserTaskCommandProcessors {
                     bpmnBehaviors.jobBehavior()),
                 UserTaskIntent.ASSIGN,
                 new UserTaskAssignProcessor(
-                    processingState, writers, asyncRequestBehavior, cslCheck, userTaskAuth),
+                    processingState, writers, asyncRequestBehavior, tenantCheck, userTaskAuth),
                 UserTaskIntent.CLAIM,
                 new UserTaskClaimProcessor(
-                    processingState, writers, asyncRequestBehavior, cslCheck, userTaskAuth),
+                    processingState, writers, asyncRequestBehavior, tenantCheck, userTaskAuth),
                 UserTaskIntent.UPDATE,
                 new UserTaskUpdateProcessor(
                     processingState,
                     writers,
                     bpmnBehaviors.variableBehavior(),
                     asyncRequestBehavior,
-                    cslCheck,
+                    tenantCheck,
                     userTaskAuth),
                 UserTaskIntent.COMPLETE,
                 new UserTaskCompleteProcessor(
@@ -79,7 +81,7 @@ public final class UserTaskCommandProcessors {
                     eventHandle,
                     writers,
                     asyncRequestBehavior,
-                    cslCheck,
+                    tenantCheck,
                     userTaskAuth),
                 UserTaskIntent.CANCEL,
                 new UserTaskCancelProcessor(processingState, writers)));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnUserTaskBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
 import io.camunda.zeebe.engine.processing.deployment.model.element.TaskListener;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.incident.RetryTypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
@@ -84,10 +85,17 @@ public class UserTaskProcessor
       final BpmnBehaviors bpmnBehaviors,
       final Writers writers,
       final AsyncRequestBehavior asyncRequestBehavior,
-      final CslAuthorizationCheck cslCheck) {
+      final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck) {
     commandProcessors =
         new UserTaskCommandProcessors(
-            state, keyGenerator, bpmnBehaviors, writers, asyncRequestBehavior, cslCheck);
+            state,
+            keyGenerator,
+            bpmnBehaviors,
+            writers,
+            asyncRequestBehavior,
+            cslCheck,
+            tenantCheck);
     processState = state.getProcessState();
     this.userTaskState = userTaskState;
     elementInstanceState = state.getElementInstanceState();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
@@ -15,7 +15,7 @@ import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAut
 import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.processing.AsyncRequestBehavior;
 import io.camunda.zeebe.engine.processing.Rejection;
-import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -47,7 +47,7 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
       final ProcessingState state,
       final Writers writers,
       final AsyncRequestBehavior asyncRequestBehavior,
-      final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
       final UserTaskAuthorizationCheck userTaskAuth) {
     stateWriter = writers.state();
     responseWriter = writers.response();
@@ -59,7 +59,7 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
             List.of(LifecycleState.CREATED),
             "assign",
             state.getUserTaskState(),
-            cslCheck,
+            tenantCheck,
             state.getBannedInstanceState());
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
@@ -14,7 +14,7 @@ import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAut
 import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.processing.AsyncRequestBehavior;
 import io.camunda.zeebe.engine.processing.Rejection;
-import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -54,7 +54,7 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
       final ProcessingState state,
       final Writers writers,
       final AsyncRequestBehavior asyncRequestBehavior,
-      final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
       final UserTaskAuthorizationCheck userTaskAuth) {
     stateWriter = writers.state();
     responseWriter = writers.response();
@@ -66,7 +66,7 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
             List.of(LifecycleState.CREATED),
             "claim",
             state.getUserTaskState(),
-            cslCheck,
+            tenantCheck,
             state.getBannedInstanceState());
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionValidator.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.processing.usertask.processors;
 
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.common.BannedInstanceCommandCheck;
-import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
@@ -29,7 +29,7 @@ public class UserTaskCommandPreconditionValidator {
 
   private final List<LifecycleState> validLifecycleStates;
   private final String intent;
-  private final CslAuthorizationCheck cslCheck;
+  private final CslTenantCheck tenantCheck;
   private final UserTaskState userTaskState;
   private final BannedInstanceCommandCheck bannedInstanceCheck;
 
@@ -37,11 +37,11 @@ public class UserTaskCommandPreconditionValidator {
       final List<LifecycleState> validLifecycleStates,
       final String intent,
       final UserTaskState userTaskState,
-      final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
       final BannedInstanceState bannedInstanceState) {
     this.validLifecycleStates = validLifecycleStates;
     this.intent = intent;
-    this.cslCheck = cslCheck;
+    this.tenantCheck = tenantCheck;
     this.userTaskState = userTaskState;
     bannedInstanceCheck = new BannedInstanceCommandCheck(bannedInstanceState);
   }
@@ -64,7 +64,7 @@ public class UserTaskCommandPreconditionValidator {
   public Either<Rejection, UserTaskRecord> checkUserTaskExists(
       final TypedRecord<UserTaskRecord> command) {
     final long userTaskKey = command.getKey();
-    final var authorizedTenants = cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
+    final var authorizedTenants = tenantCheck.resolveAuthorizedTenants(command.getAuthorizations());
     final var persistedUserTask = userTaskState.getUserTask(userTaskKey, authorizedTenants);
 
     if (persistedUserTask == null) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCompleteProcessor.java
@@ -14,7 +14,7 @@ import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAut
 import io.camunda.zeebe.engine.processing.AsyncRequestBehavior;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
-import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -53,7 +53,7 @@ public final class UserTaskCompleteProcessor implements UserTaskCommandProcessor
       final EventHandle eventHandle,
       final Writers writers,
       final AsyncRequestBehavior asyncRequestBehavior,
-      final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
       final UserTaskAuthorizationCheck userTaskAuth) {
     elementInstanceState = state.getElementInstanceState();
     asyncRequestState = state.getAsyncRequestState();
@@ -66,7 +66,7 @@ public final class UserTaskCompleteProcessor implements UserTaskCommandProcessor
             List.of(LifecycleState.CREATED),
             "complete",
             state.getUserTaskState(),
-            cslCheck,
+            tenantCheck,
             state.getBannedInstanceState());
     this.asyncRequestBehavior = asyncRequestBehavior;
     this.userTaskAuth = userTaskAuth;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -14,7 +14,7 @@ import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAut
 import io.camunda.zeebe.engine.processing.AsyncRequestBehavior;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.common.ValidationException;
-import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -56,7 +56,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
       final Writers writers,
       final VariableBehavior variableBehavior,
       final AsyncRequestBehavior asyncRequestBehavior,
-      final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
       final UserTaskAuthorizationCheck userTaskAuth) {
     stateWriter = writers.state();
     variableState = state.getVariableState();
@@ -70,7 +70,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
             List.of(LifecycleState.CREATED),
             "update",
             state.getUserTaskState(),
-            cslCheck,
+            tenantCheck,
             state.getBannedInstanceState());
   }
 


### PR DESCRIPTION
## Summary
- PR camunda/camunda#59048 extracted `CslTenantCheck` out of `CslAuthorizationCheck`
  but left 4 thin tenant-only delegates on `CslAuthorizationCheck` so existing call
  sites wouldn't need to change. This migrates all 9 affected engine call sites onto
  a directly-injected `CslTenantCheck` and deletes the now-unused delegates.
- Commit 1: thread `CslTenantCheck` alongside `CslAuthorizationCheck` at the two
  wiring roots (`EngineProcessors`, `MessageEventProcessors`) and migrate all 9 call
  sites (3 tenant-only, replacing `cslCheck` outright; 6 mixed, adding `tenantCheck`
  as a sibling param). `BpmnJobActivationBehavior` was threaded through the full
  `BpmnProcessors`/`BpmnBehaviorsImpl` chain rather than excluded, to keep the DI
  pattern consistent with the rest of the migration.
- Commit 2: delete the 4 unused delegates from `CslAuthorizationCheck`, repoint its
  internal `checkAuthorizationAndTenant` at `tenantCheck.checkTenant` directly, and
  update both classes' javadoc to state the new caller contract — anyone calling
  `checkTenant` directly must ensure a preceding RBAC check on the same command has
  already run and passed.

Closes camunda/camunda-security-library#585
(cross-repo issue — GitHub won't auto-close it on merge; closing it manually once
this lands.)

## Notes for reviewers
- `CslTenantCheck#isMultiTenancyChecksEnabled()` now has zero callers repo-wide
  (only the deleted delegate called it). Left in place — noted here as a possible
  follow-up, not removed in this PR.
- No-principal-skip ordering was verified at every mixed call site: the migrated
  `checkTenant`/`checkTenantsRequiringPrincipal` call stays downstream of its
  sibling RBAC check on the same command, unchanged from before the migration.
- `AuthorizationArchTest` (`qa/archunit-tests`) passes unchanged — none of the
  deleted delegates were ever in its whitelist.
- Hit one unrelated flaky test during verification:
  `MultiPartitionDeploymentLifecycleTest.shouldRejectCompleteDeploymentDistributionWhenAlreadyCompleted`,
  passed on retry, unrelated to this diff.

## Test plan
- [x] `./mvnw install -Dquickly -T1C` (baseline + final full-repo compile)
- [x] `./mvnw verify -pl zeebe/engine -DskipTests=false -DskipITs -Dquickly`
- [x] `./mvnw verify -pl qa/archunit-tests -Dtest=AuthorizationArchTest -DskipTests=false -DskipITs -Dquickly` (2/2 passed)
- [x] `./mvnw license:format spotless:apply -T1C` (no changes)
