### PR TITLE
Cap pending secret references resolved per scheduling cycle

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/EngineSecrets.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineSecrets.java
@@ -20,12 +20,14 @@ public class EngineSecrets {
   public static final Duration DEFAULT_RETRY_INITIAL_DELAY = Duration.ofSeconds(1);
   public static final Duration DEFAULT_RETRY_MAX_DELAY = Duration.ofSeconds(30);
   public static final int DEFAULT_RETRY_BACKOFF_FACTOR = 2;
+  public static final int DEFAULT_BATCH_RESOLUTION_LIMIT = 20;
 
   private Duration interval = DEFAULT_INTERVAL;
   private int retryMaxAttempts = DEFAULT_RETRY_MAX_ATTEMPTS;
   private Duration retryInitialDelay = DEFAULT_RETRY_INITIAL_DELAY;
   private Duration retryMaxDelay = DEFAULT_RETRY_MAX_DELAY;
   private int retryBackoffFactor = DEFAULT_RETRY_BACKOFF_FACTOR;
+  private int batchResolutionLimit = DEFAULT_BATCH_RESOLUTION_LIMIT;
 
   /**
    * Cadence at which the secret resolution scheduler polls for pending secret references. This
@@ -100,5 +102,21 @@ public class EngineSecrets {
 
   public void setRetryBackoffFactor(final int retryBackoffFactor) {
     this.retryBackoffFactor = retryBackoffFactor;
+  }
+
+  /**
+   * Maximum number of pending secret references resolved per scheduling cycle. Remaining refs are
+   * picked up in subsequent cycles. This configuration can be accessed via the environment
+   * variable: <br>
+   * {@code camunda.processing.engine.secrets.batch-resolution-limit}.
+   *
+   * <p>Defaults to {@code 20}.
+   */
+  public int getBatchResolutionLimit() {
+    return batchResolutionLimit;
+  }
+
+  public void setBatchResolutionLimit(final int batchResolutionLimit) {
+    this.batchResolutionLimit = batchResolutionLimit;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -1294,5 +1294,6 @@ public class BrokerBasedPropertiesOverride {
     secretResolutionCfg.setRetryInitialDelay(engineSecrets.getRetryInitialDelay());
     secretResolutionCfg.setRetryMaxDelay(engineSecrets.getRetryMaxDelay());
     secretResolutionCfg.setRetryBackoffFactor(engineSecrets.getRetryBackoffFactor());
+    secretResolutionCfg.setBatchResolutionLimit(engineSecrets.getBatchResolutionLimit());
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/EngineSecretsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineSecretsTest.java
@@ -30,7 +30,8 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
       "camunda.processing.engine.secrets.retry-max-attempts=5",
       "camunda.processing.engine.secrets.retry-initial-delay=2s",
       "camunda.processing.engine.secrets.retry-max-delay=60s",
-      "camunda.processing.engine.secrets.retry-backoff-factor=3"
+      "camunda.processing.engine.secrets.retry-backoff-factor=3",
+      "camunda.processing.engine.secrets.batch-resolution-limit=7"
     })
 public class EngineSecretsTest {
   final BrokerBasedProperties brokerCfg;
@@ -47,5 +48,6 @@ public class EngineSecretsTest {
     assertThat(secretResolution.getRetryInitialDelay()).isEqualTo(Duration.ofSeconds(2));
     assertThat(secretResolution.getRetryMaxDelay()).isEqualTo(Duration.ofSeconds(60));
     assertThat(secretResolution.getRetryBackoffFactor()).isEqualTo(3);
+    assertThat(secretResolution.getBatchResolutionLimit()).isEqualTo(7);
   }
 }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -293,6 +293,7 @@ processing.engine.job.timeout-checker-polling-interval
 processing.engine.max-process-depth
 processing.engine.messages.ttl-checker-batch-limit
 processing.engine.messages.ttl-checker-interval
+processing.engine.secrets.batch-resolution-limit
 processing.engine.secrets.interval
 processing.engine.secrets.retry-backoff-factor
 processing.engine.secrets.retry-initial-delay

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -222,6 +222,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setSecretResolutionRetryInitialDelay(secretResolution.getRetryInitialDelay())
         .setSecretResolutionRetryMaxDelay(secretResolution.getRetryMaxDelay())
         .setSecretResolutionRetryBackoffFactor(secretResolution.getRetryBackoffFactor())
+        .setSecretResolutionBatchLimit(secretResolution.getBatchResolutionLimit())
         .setUsageMetricsExportInterval(usageMetrics.getExportInterval())
         .setJobMetricsExportInterval(jobMetrics.getExportInterval())
         .setJobMetricsExportEnabled(jobMetrics.isEnabled())

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/SecretResolutionCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/SecretResolutionCfg.java
@@ -20,6 +20,7 @@ public class SecretResolutionCfg implements ConfigurationEntry {
   private Duration retryMaxDelay = EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_MAX_DELAY;
   private int retryBackoffFactor =
       EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_BACKOFF_FACTOR;
+  private int batchResolutionLimit = EngineConfiguration.DEFAULT_SECRET_RESOLUTION_BATCH_LIMIT;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -48,6 +49,11 @@ public class SecretResolutionCfg implements ConfigurationEntry {
       throw new IllegalArgumentException(
           "Secret resolution retryBackoffFactor must be at least 1 but was %d"
               .formatted(retryBackoffFactor));
+    }
+    if (batchResolutionLimit < 1) {
+      throw new IllegalArgumentException(
+          "Secret resolution batchResolutionLimit must be at least 1 but was %d"
+              .formatted(batchResolutionLimit));
     }
   }
 
@@ -91,6 +97,14 @@ public class SecretResolutionCfg implements ConfigurationEntry {
     this.retryBackoffFactor = retryBackoffFactor;
   }
 
+  public int getBatchResolutionLimit() {
+    return batchResolutionLimit;
+  }
+
+  public void setBatchResolutionLimit(final int batchResolutionLimit) {
+    this.batchResolutionLimit = batchResolutionLimit;
+  }
+
   @Override
   public String toString() {
     return "SecretResolutionCfg{"
@@ -104,6 +118,8 @@ public class SecretResolutionCfg implements ConfigurationEntry {
         + retryMaxDelay
         + ", retryBackoffFactor="
         + retryBackoffFactor
+        + ", batchResolutionLimit="
+        + batchResolutionLimit
         + '}';
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -83,6 +83,8 @@ final class EngineCfgTest {
         .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_MAX_DELAY);
     assertThat(configuration.getSecretResolutionRetryBackoffFactor())
         .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_BACKOFF_FACTOR);
+    assertThat(configuration.getSecretResolutionBatchLimit())
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_BATCH_LIMIT);
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/engine/SecretResolutionCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/engine/SecretResolutionCfgTest.java
@@ -87,4 +87,16 @@ final class SecretResolutionCfgTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Secret resolution retryBackoffFactor must be at least 1 but was 0");
   }
+
+  @Test
+  void shouldRejectBatchResolutionLimitBelowOne() {
+    // given
+    final var cfg = new SecretResolutionCfg();
+    cfg.setBatchResolutionLimit(0);
+
+    // when - then
+    assertThatThrownBy(() -> cfg.init(new BrokerCfg(), ""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Secret resolution batchResolutionLimit must be at least 1 but was 0");
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -68,6 +68,7 @@ public final class EngineConfiguration {
       Duration.ofSeconds(1);
   public static final Duration DEFAULT_SECRET_RESOLUTION_RETRY_MAX_DELAY = Duration.ofSeconds(30);
   public static final int DEFAULT_SECRET_RESOLUTION_RETRY_BACKOFF_FACTOR = 2;
+  public static final int DEFAULT_SECRET_RESOLUTION_BATCH_LIMIT = 20;
   public static final boolean DEFAULT_COMMAND_DISTRIBUTION_PAUSED = false;
   public static final Duration DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL = Duration.ofSeconds(10);
   public static final Duration DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION =
@@ -145,6 +146,7 @@ public final class EngineConfiguration {
       DEFAULT_SECRET_RESOLUTION_RETRY_INITIAL_DELAY;
   private Duration secretResolutionRetryMaxDelay = DEFAULT_SECRET_RESOLUTION_RETRY_MAX_DELAY;
   private int secretResolutionRetryBackoffFactor = DEFAULT_SECRET_RESOLUTION_RETRY_BACKOFF_FACTOR;
+  private int secretResolutionBatchLimit = DEFAULT_SECRET_RESOLUTION_BATCH_LIMIT;
   private Duration usageMetricsExportInterval = DEFAULT_USAGE_METRICS_EXPORT_INTERVAL;
   private boolean commandDistributionPaused = DEFAULT_COMMAND_DISTRIBUTION_PAUSED;
   private Duration commandRedistributionInterval = DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL;
@@ -443,6 +445,20 @@ public final class EngineConfiguration {
   public EngineConfiguration setSecretResolutionRetryBackoffFactor(
       final int secretResolutionRetryBackoffFactor) {
     this.secretResolutionRetryBackoffFactor = secretResolutionRetryBackoffFactor;
+    return this;
+  }
+
+  public int getSecretResolutionBatchLimit() {
+    return secretResolutionBatchLimit;
+  }
+
+  public EngineConfiguration setSecretResolutionBatchLimit(final int secretResolutionBatchLimit) {
+    if (secretResolutionBatchLimit < 1) {
+      throw new IllegalArgumentException(
+          "secretResolutionBatchLimit must be at least 1 but was %d"
+              .formatted(secretResolutionBatchLimit));
+    }
+    this.secretResolutionBatchLimit = secretResolutionBatchLimit;
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
@@ -30,14 +30,20 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
+import org.agrona.collections.MutableBoolean;
+import org.agrona.collections.MutableInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Periodically reads all pending secret references from state, resolves them in batches (one batch
- * per store) and writes {@link SecretReferenceIntent#RESOLUTION_COMPLETE} or {@link
- * SecretReferenceIntent#RESOLUTION_FAIL} commands. The store holds what it reads, which is what
- * makes a resolved value available to the activation that requested the resolution.
+ * Periodically reads up to {@code batchLimit} pending secret references from state per cycle,
+ * resolves them in batches (one batch per store) and writes {@link
+ * SecretReferenceIntent#RESOLUTION_COMPLETE} or {@link SecretReferenceIntent#RESOLUTION_FAIL}
+ * commands. The store holds what it reads, which is what makes a resolved value available to the
+ * activation that requested the resolution. Any refs beyond the cap stay pending and are retried in
+ * the next cycle — which is scheduled immediately ({@link Duration#ZERO}) instead of waiting the
+ * normal {@code schedulingInterval} (unless a store is currently in retry cooldown, in which case
+ * the cooldown-aware delay is honored instead).
  *
  * <p>Resolution goes through {@link
  * io.camunda.secretstore.LocallyCachedSecretStore#resolveFromStore} rather than the cache-first
@@ -75,8 +81,12 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
   private final Duration retryMaxDelay;
   private final int retryMaxAttempts;
   private final int retryBackoffFactor;
+  private final int batchLimit;
 
   private final Map<String, StoreRetryState> storeRetryStates = new HashMap<>();
+
+  /** Carries the resume point for {@link #collectPendingByStore} fairly across cycles. */
+  private SecretReferenceState.PendingRefCursor collectionCursor;
 
   /**
    * Whether the scheduler may reschedule itself. Controlled by the stream processor's lifecycle
@@ -105,6 +115,7 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
     retryMaxDelay = config.getSecretResolutionRetryMaxDelay();
     retryMaxAttempts = config.getSecretResolutionRetryMaxAttempts();
     retryBackoffFactor = config.getSecretResolutionRetryBackoffFactor();
+    batchLimit = config.getSecretResolutionBatchLimit();
   }
 
   @Override
@@ -142,14 +153,30 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
   TaskResult resolveSecrets(final TaskResultBuilder resultBuilder) {
     taskScheduled.set(false);
     final long now = clock.millis();
+    boolean taskResultBatchFull = false;
+    boolean capped = false;
+    final var progressMade = new MutableBoolean(false);
     try {
-      final Map<String, Set<String>> pendingByStore = collectPendingByStore();
-      // prune retry state for stores that no longer have pending refs
-      storeRetryStates.keySet().retainAll(pendingByStore.keySet());
+      final CollectedPendingRefs pending = collectPendingByStore(now);
+      capped = pending.capped();
+      final Map<String, Set<String>> pendingByStore = pending.refsByStore();
+      // Prune retry state for stores confirmed to have zero pending refs this cycle. Only
+      // trustworthy when the scan was both uncapped AND didn't skip any store for cooldown —
+      // either condition means a store with pending refs can be missing from pendingByStore for a
+      // reason OTHER than "it has no pending refs", and retainAll would wipe its backoff state as
+      // if it had none, resetting its attempt counter and letting it starve indefinitely without
+      // ever reaching retryMaxAttempts.
+      if (!pending.capped() && pending.cooldownSkippedStores().isEmpty()) {
+        storeRetryStates.keySet().retainAll(pendingByStore.keySet());
+      }
       if (!pendingByStore.isEmpty()) {
         for (final var entry : pendingByStore.entrySet()) {
           try {
-            resolveStore(entry.getKey(), entry.getValue(), resultBuilder, now);
+            if (!resolveStore(entry.getKey(), entry.getValue(), resultBuilder, now, progressMade)) {
+              // the task result batch is full; stop appending more commands this cycle
+              taskResultBatchFull = true;
+              break;
+            }
           } catch (final RuntimeException e) {
             LOG.error(
                 "Unexpected error while resolving secrets from store '{}'; "
@@ -161,7 +188,8 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
         }
       }
     } finally {
-      scheduleNext(computeNextDelay(now));
+      final boolean immediateReschedule = taskResultBatchFull || (capped && progressMade.get());
+      scheduleNext(immediateReschedule ? Duration.ZERO : computeNextDelay(now));
     }
     return resultBuilder.build();
   }
@@ -186,30 +214,51 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
     return schedulingInterval;
   }
 
-  private Map<String, Set<String>> collectPendingByStore() {
+  private CollectedPendingRefs collectPendingByStore(final long now) {
     final Map<String, Set<String>> pendingByStore = new LinkedHashMap<>();
-    secretReferenceState.visitPendingSecretReferences(
-        (storeId, secretRef) ->
-            pendingByStore.computeIfAbsent(storeId, k -> new LinkedHashSet<>()).add(secretRef));
-    return pendingByStore;
+    final Set<String> cooldownSkippedStores = new LinkedHashSet<>();
+    final var counter = new MutableInteger(0);
+    final var lastVisited =
+        secretReferenceState.visitPendingSecretReferences(
+            collectionCursor,
+            (storeId, secretRef) -> {
+              final StoreRetryState retryState =
+                  storeRetryStates.getOrDefault(storeId, StoreRetryState.INITIAL);
+              if (now < retryState.nextAttemptAt()) {
+                // store is cooling down: don't let its refs consume cap budget that a healthy
+                // store could use instead — resolveStore would just skip them anyway
+                cooldownSkippedStores.add(storeId);
+                return true;
+              }
+              if (counter.get() >= batchLimit) {
+                return false;
+              }
+              counter.increment();
+              pendingByStore.computeIfAbsent(storeId, k -> new LinkedHashSet<>()).add(secretRef);
+              return true;
+            });
+    collectionCursor = lastVisited; // null once a full scan completes; resume point otherwise
+    return new CollectedPendingRefs(pendingByStore, lastVisited != null, cooldownSkippedStores);
   }
 
-  private void resolveStore(
+  /**
+   * Resolves the pending refs for a single store, appending {@code RESOLUTION_COMPLETE}/{@code
+   * RESOLUTION_FAIL} commands as results become available.
+   *
+   * <p>The caller guarantees {@code storeId} is not currently in retry cooldown — {@link
+   * #collectPendingByStore} filters those out before they ever reach here.
+   *
+   * @return {@code false} if the task result batch filled up and the cycle must stop immediately —
+   *     no further stores should be processed this cycle; {@code true} otherwise
+   */
+  private boolean resolveStore(
       final String storeId,
       final Set<String> refs,
       final TaskResultBuilder resultBuilder,
-      final long now) {
+      final long now,
+      final MutableBoolean progressMade) {
     final StoreRetryState retryState =
         storeRetryStates.getOrDefault(storeId, StoreRetryState.INITIAL);
-
-    if (now < retryState.nextAttemptAt()) {
-      LOG.trace(
-          "Secret store '{}' in cooldown until {}ms, skipping {} pending refs",
-          storeId,
-          retryState.nextAttemptAt(),
-          refs.size());
-      return;
-    }
 
     // a pending reference is keyed by the store ID its record carries, which for a
     // camunda.secrets.<name> reference is empty and addresses no store here (see #59432)
@@ -219,41 +268,54 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
           "Secret store '{}' is not configured — failing {} pending secret refs",
           storeId,
           refs.size());
-      refs.forEach(
-          ref ->
-              appendResolutionFail(resultBuilder, storeId, ref, ResolutionState.STORE_UNAVAILABLE));
+      for (final String ref : refs) {
+        if (!appendResolutionFail(resultBuilder, storeId, ref, ResolutionState.STORE_UNAVAILABLE)) {
+          // batch full; refs not yet appended remain pending and will be retried next cycle —
+          // leave retry state untouched instead of resetting it out from under them
+          return false;
+        }
+        progressMade.set(true);
+      }
       storeRetryStates.remove(storeId);
-      return;
+      return true;
     }
 
     try {
       final var results = store.resolveFromStore(refs);
-      results.forEach(
-          (ref, result) -> {
-            switch (result) {
-              // the value stays in the store and is never touched here, so the resolution record
-              // carries no secret
-              case final SecretResolutionResult.Resolved ignored ->
-                  appendResolutionComplete(resultBuilder, storeId, ref);
-              case SecretResolutionResult.Failed(
-                      final var code,
-                      final var message,
-                      final var cause) -> {
-                LOG.warn(
-                    "Secret '{}' in secret store '{}' failed permanently: {} — {}",
-                    ref,
-                    storeId,
-                    code,
-                    message,
-                    cause);
-                // All permanent per-secret failures (NOT_FOUND/ACCESS_DENIED/INVALID_REF) map
-                // to NOT_FOUND for now; ResolutionState has no finer per-secret states yet
-                // (#57855 will refine).
-                appendResolutionFail(resultBuilder, storeId, ref, ResolutionState.NOT_FOUND);
-              }
-            }
-          });
+      for (final var entry : results.entrySet()) {
+        final String ref = entry.getKey();
+        final boolean appended;
+        switch (entry.getValue()) {
+          // the value stays in the store and is never touched here, so the resolution record
+          // carries no secret
+          case final SecretResolutionResult.Resolved ignored ->
+              appended = appendResolutionComplete(resultBuilder, storeId, ref);
+          case SecretResolutionResult.Failed(
+                  final var code,
+                  final var message,
+                  final var cause) -> {
+            LOG.warn(
+                "Secret '{}' in secret store '{}' failed permanently: {} — {}",
+                ref,
+                storeId,
+                code,
+                message,
+                cause);
+            // All permanent per-secret failures (NOT_FOUND/ACCESS_DENIED/INVALID_REF) map to
+            // NOT_FOUND for now; ResolutionState has no finer per-secret states yet (#57855
+            // will refine).
+            appended = appendResolutionFail(resultBuilder, storeId, ref, ResolutionState.NOT_FOUND);
+          }
+        }
+        if (!appended) {
+          // batch full; refs not yet appended remain pending and will be retried next cycle —
+          // leave retry state untouched instead of resetting it out from under them
+          return false;
+        }
+        progressMade.set(true);
+      }
       storeRetryStates.remove(storeId);
+      return true;
     } catch (final SecretStoreUnavailableException e) {
       final int nextAttempts = retryState.attempts() + 1;
       if (nextAttempts >= retryMaxAttempts) {
@@ -264,10 +326,16 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
             retryMaxAttempts,
             refs.size(),
             e.getMessage());
-        refs.forEach(
-            ref ->
-                appendResolutionFail(
-                    resultBuilder, storeId, ref, ResolutionState.STORE_UNAVAILABLE));
+        for (final String ref : refs) {
+          if (!appendResolutionFail(
+              resultBuilder, storeId, ref, ResolutionState.STORE_UNAVAILABLE)) {
+            // batch full; refs not yet appended remain pending. Leave retry state untouched so
+            // the next cycle still sees attempts >= retryMaxAttempts and continues failing them,
+            // instead of resetting to 0 and re-entering the backoff branch below.
+            return false;
+          }
+          progressMade.set(true);
+        }
         storeRetryStates.remove(storeId);
       } else {
         final Duration backoff = calculateBackoff(nextAttempts);
@@ -280,27 +348,28 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
             e.getMessage());
         storeRetryStates.put(storeId, new StoreRetryState(nextAttempts, now + backoff.toMillis()));
       }
+      return true;
     }
   }
 
-  private void appendResolutionComplete(
+  private boolean appendResolutionComplete(
       final TaskResultBuilder resultBuilder, final String storeId, final String secretRef) {
     final var record = new SecretReferenceRecord();
     record
         .setStoreId(storeId)
         .setSecretReference(secretRef)
         .setResolutionState(ResolutionState.SUCCESS);
-    resultBuilder.appendCommandRecord(SecretReferenceIntent.RESOLUTION_COMPLETE, record);
+    return resultBuilder.appendCommandRecord(SecretReferenceIntent.RESOLUTION_COMPLETE, record);
   }
 
-  private void appendResolutionFail(
+  private boolean appendResolutionFail(
       final TaskResultBuilder resultBuilder,
       final String storeId,
       final String secretRef,
       final ResolutionState resolutionState) {
     final var record = new SecretReferenceRecord();
     record.setStoreId(storeId).setSecretReference(secretRef).setResolutionState(resolutionState);
-    resultBuilder.appendCommandRecord(SecretReferenceIntent.RESOLUTION_FAIL, record);
+    return resultBuilder.appendCommandRecord(SecretReferenceIntent.RESOLUTION_FAIL, record);
   }
 
   Duration calculateBackoff(final int attempts) {
@@ -331,4 +400,14 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
   record StoreRetryState(int attempts, long nextAttemptAt) {
     static final StoreRetryState INITIAL = new StoreRetryState(0, 0L);
   }
+
+  /**
+   * @param capped whether more pending refs exist in state than {@code batchLimit} allowed
+   *     collecting this cycle — the scheduler should reschedule immediately rather than wait the
+   *     normal {@code schedulingInterval}
+   * @param cooldownSkippedStores stores whose pending refs were excluded from {@code refsByStore}
+   *     this cycle because the store is currently in retry cooldown
+   */
+  private record CollectedPendingRefs(
+      Map<String, Set<String>> refsByStore, boolean capped, Set<String> cooldownSkippedStores) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SecretReferenceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SecretReferenceState.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.state.immutable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import java.util.function.LongPredicate;
 
@@ -36,10 +35,16 @@ public interface SecretReferenceState {
   void visitSecretReferencesByJob(long jobKey, BiPredicate<String, String> visitor);
 
   /**
-   * Visits all pending secret references. The visitor receives (storeId, secretReference) for each
-   * entry.
+   * Visits pending (storeId, secretReference) entries starting at {@code startAt} (inclusive, if it
+   * still exists) or from the beginning if {@code startAt} is {@code null}. The visitor returns
+   * {@code true} to continue or {@code false} to stop early.
+   *
+   * @return the cursor identifying where iteration stopped, to pass as {@code startAt} on the next
+   *     call to resume fairly; {@code null} if the visitor was never told to stop (i.e. iteration
+   *     reached the end of the column family)
    */
-  void visitPendingSecretReferences(BiConsumer<String, String> visitor);
+  PendingRefCursor visitPendingSecretReferences(
+      PendingRefCursor startAt, BiPredicate<String, String> visitor);
 
   /**
    * Collects all (storeId, secretReference) pairs that the given job is waiting for, via {@link
@@ -55,4 +60,7 @@ public interface SecretReferenceState {
         });
     return refs;
   }
+
+  /** Resume point for {@link #visitPendingSecretReferences}, identifying the last-visited entry. */
+  record PendingRefCursor(String storeId, String secretReference) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceState.java
@@ -16,10 +16,11 @@ import io.camunda.zeebe.db.impl.DbForeignKey;
 import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbNil;
 import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.engine.state.immutable.SecretReferenceState;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import java.util.Map;
-import java.util.function.BiConsumer;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiPredicate;
 import java.util.function.LongPredicate;
 
@@ -126,9 +127,31 @@ public final class DbSecretReferenceState implements MutableSecretReferenceState
   }
 
   @Override
-  public void visitPendingSecretReferences(final BiConsumer<String, String> visitor) {
-    pendingSecretReferencesColumnFamily.forEach(
-        (key, value) -> visitor.accept(key.first().toString(), key.second().toString()));
+  public SecretReferenceState.PendingRefCursor visitPendingSecretReferences(
+      final SecretReferenceState.PendingRefCursor startAt,
+      final BiPredicate<String, String> visitor) {
+    final DbCompositeKey<DbString, DbString> startAtKey;
+    if (startAt != null) {
+      storeId.wrapString(startAt.storeId());
+      secretReference.wrapString(startAt.secretReference());
+      startAtKey = storeIdAndSecretReference;
+    } else {
+      startAtKey = null;
+    }
+
+    final var lastVisited = new AtomicReference<SecretReferenceState.PendingRefCursor>();
+    final KeyValuePairVisitor<DbCompositeKey<DbString, DbString>, DbNil> kvVisitor =
+        (key, value) -> {
+          final var storeIdStr = key.first().toString();
+          final var secretRefStr = key.second().toString();
+          if (!visitor.test(storeIdStr, secretRefStr)) {
+            lastVisited.set(new SecretReferenceState.PendingRefCursor(storeIdStr, secretRefStr));
+            return false;
+          }
+          return true;
+        };
+    pendingSecretReferencesColumnFamily.whileTrue(startAtKey, kvVisitor);
+    return lastVisited.get();
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -11,10 +11,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -37,6 +38,7 @@ import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import java.time.Duration;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
@@ -69,6 +71,7 @@ final class SecretResolutionSchedulerTest {
     when(context.getScheduleService()).thenReturn(scheduleService);
     when(context.getClock()).thenReturn(clock);
     lenient().when(clock.millis()).thenReturn(0L);
+    lenient().when(resultBuilder.appendCommandRecord(any(), any())).thenReturn(true);
 
     final Supplier<ScheduledTaskState> stateFactory = () -> scheduledTaskState;
     final var registry =
@@ -273,7 +276,8 @@ final class SecretResolutionSchedulerTest {
     stubPending("my-store", "db-password");
     scheduler.resolveSecrets(resultBuilder);
 
-    // then — store called only once; no command or cache write
+    // then — store called only once; the cooldown store's ref is excluded during collection, so
+    // resolveStore is never invoked for it in cycle 2; no command or cache write
     verify(secretStore, times(1)).resolve(any());
     verify(resultBuilder, never()).appendCommandRecord(any(), any());
     verify(secretCache, never()).put(any(), any());
@@ -331,7 +335,7 @@ final class SecretResolutionSchedulerTest {
     scheduler.resolveSecrets(resultBuilder);
 
     // when — store no longer has pending refs
-    doNothing().when(secretReferenceState).visitPendingSecretReferences(any());
+    doReturn(null).when(secretReferenceState).visitPendingSecretReferences(any(), any());
     when(clock.millis()).thenReturn(Long.MAX_VALUE);
     scheduler.resolveSecrets(resultBuilder);
 
@@ -342,6 +346,64 @@ final class SecretResolutionSchedulerTest {
     verify(scheduleService, times(3)).runDelayedAsync(delayCaptor.capture(), any(), any());
     assertThat(delayCaptor.getAllValues().get(2))
         .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_INTERVAL);
+  }
+
+  @Test
+  void shouldNotResetRetryStateForStoreExcludedByCapAcrossCycle() throws Exception {
+    // given — batch limit of 2; store-a and store-b both fail and enter retry cooldown in the
+    // same (uncapped) cycle
+    final var storeA = mock(SecretStore.class);
+    final var storeB = mock(SecretStore.class);
+    final var registry =
+        new SecretStoreRegistry(Map.of("store-a", storeA, "store-b", storeB), Map.of());
+    final var config = new EngineConfiguration().setSecretResolutionBatchLimit(2);
+    final var localScheduler =
+        new SecretResolutionScheduler(() -> scheduledTaskState, registry, config);
+    localScheduler.onRecovered(context);
+
+    when(storeA.resolve(Set.of("ref-a1"))).thenThrow(new SecretStoreUnavailableException("down"));
+    when(storeB.resolve(Set.of("ref-b1"))).thenThrow(new SecretStoreUnavailableException("down"));
+    // cycle 1 (t=0): both stores' single pending ref fit exactly within the cap — nothing capped
+    // — so both fail and enter cooldown (attempts=1, nextAttemptAt=1000)
+    final var cycle1Refs = new LinkedHashMap<String, String>();
+    cycle1Refs.put("store-a", "ref-a1");
+    cycle1Refs.put("store-b", "ref-b1");
+    stubPending(cycle1Refs);
+    when(clock.millis()).thenReturn(0L, 500L, 500L);
+    localScheduler.resolveSecrets(resultBuilder);
+
+    // when — cycle 2 (t=500): both store-a and store-b are still within their cooldown window
+    // (cooldown entered at t=0 with a 1000ms backoff, cycle 2 runs at t=500), so cooldown-aware
+    // collection skips BOTH stores entirely — pendingByStore ends up empty and
+    // cooldownSkippedStores = {store-a, store-b}, not "cap consumed by store-a" as under the old
+    // per-entry-cap-only behavior
+    doAnswer(
+            inv -> {
+              final var visitor = (BiPredicate<String, String>) inv.getArgument(1);
+              if (!visitor.test("store-a", "ref-a1")) {
+                return null;
+              }
+              if (!visitor.test("store-a", "ref-a2")) {
+                return null;
+              }
+              visitor.test("store-b", "ref-b1");
+              return null;
+            })
+        .when(secretReferenceState)
+        .visitPendingSecretReferences(any(), any());
+    localScheduler.resolveSecrets(resultBuilder);
+
+    // then — cycle 3 (t=500, still short of store-b's t=1000 cooldown deadline): store-b's ref is
+    // offered again, but because cycle 2's read left cooldownSkippedStores non-empty, the
+    // retainAll prune did NOT run in cycle 2, so store-b's retry state survived into cycle 3 and
+    // it is still correctly treated as cooling down — collection excludes it again and resolveStore
+    // is never invoked. Had the prune incorrectly run in cycle 2 (wiping store-b's backoff as if it
+    // had no pending refs), store-b would be treated as fresh here and resolved immediately instead
+    // of honoring the cooldown. store-b's only legitimate resolve() call across all three cycles is
+    // the one from cycle 1 (which put it into cooldown in the first place).
+    stubPending("store-b", "ref-b1");
+    localScheduler.resolveSecrets(resultBuilder);
+    verify(storeB, times(1)).resolve(any());
   }
 
   @Test
@@ -391,6 +453,7 @@ final class SecretResolutionSchedulerTest {
         new SecretResolutionScheduler(
             () -> scheduledTaskState, registry, new EngineConfiguration());
     localScheduler.onRecovered(context);
+    reset(scheduleService);
 
     stubPending(Map.of("store-a", "ref-a", "store-b", "ref-b"));
     when(storeA.resolve(Set.of("ref-a"))).thenThrow(new IllegalStateException("boom"));
@@ -408,8 +471,8 @@ final class SecretResolutionSchedulerTest {
     assertThat(intentCaptor.getValue()).isEqualTo(SecretReferenceIntent.RESOLUTION_COMPLETE);
     assertThat(recordCaptor.getValue().getStoreId()).isEqualTo("store-b");
     assertThat(recordCaptor.getValue().getSecretReference()).isEqualTo("ref-b");
-    // scheduler.onRecovered (setUp) + localScheduler.onRecovered + localScheduler's own reschedule
-    verify(scheduleService, times(3)).runDelayedAsync(any(), any(), any());
+    // only this cycle's reschedule remains after the reset above
+    verify(scheduleService).runDelayedAsync(any(), any(), any());
   }
 
   @Test
@@ -483,6 +546,322 @@ final class SecretResolutionSchedulerTest {
   }
 
   @Test
+  void shouldCapRefsCollectedForASingleStoreToBatchLimit() throws Exception {
+    // given — batch limit of 2, but 3 refs pending in one store
+    final var config = new EngineConfiguration().setSecretResolutionBatchLimit(2);
+    final var localScheduler =
+        new SecretResolutionScheduler(
+            () -> scheduledTaskState,
+            new SecretStoreRegistry(
+                Map.of("my-store", secretStore), Map.of("my-store", secretCache)),
+            config);
+    localScheduler.onRecovered(context);
+    stubPending("my-store", "ref-1", "ref-2", "ref-3");
+    when(secretStore.resolve(Set.of("ref-1", "ref-2")))
+        .thenReturn(
+            Map.of(
+                "ref-1", new SecretResolutionResult.Resolved("value-1"),
+                "ref-2", new SecretResolutionResult.Resolved("value-2")));
+
+    // when
+    localScheduler.resolveSecrets(resultBuilder);
+
+    // then — only the first 2 refs (the batch limit) were resolved; the 3rd stays pending
+    final var refsCaptor = ArgumentCaptor.forClass(Set.class);
+    verify(secretStore).resolve(refsCaptor.capture());
+    assertThat(refsCaptor.getAllValues()).containsExactly(Set.of("ref-1", "ref-2"));
+  }
+
+  @Test
+  void shouldCapAcrossMultipleStoresNotPerStore() throws Exception {
+    // given — global batch limit of 3; two stores contribute pending refs, so the cap applies
+    // across both stores combined, not per store individually
+    final var storeA = mock(SecretStore.class);
+    final var storeB = mock(SecretStore.class);
+    final var cacheA = mock(SecretCache.class);
+    final var cacheB = mock(SecretCache.class);
+    final var registry =
+        new SecretStoreRegistry(
+            Map.of("store-a", storeA, "store-b", storeB),
+            Map.of("store-a", cacheA, "store-b", cacheB));
+    final var config = new EngineConfiguration().setSecretResolutionBatchLimit(3);
+    final var localScheduler =
+        new SecretResolutionScheduler(() -> scheduledTaskState, registry, config);
+    localScheduler.onRecovered(context);
+
+    doAnswer(
+            inv -> {
+              final var visitor = (BiPredicate<String, String>) inv.getArgument(1);
+              if (!visitor.test("store-a", "ref-a1")) {
+                return null;
+              }
+              if (!visitor.test("store-a", "ref-a2")) {
+                return null;
+              }
+              if (!visitor.test("store-b", "ref-b1")) {
+                return null;
+              }
+              visitor.test("store-b", "ref-b2");
+              return null;
+            })
+        .when(secretReferenceState)
+        .visitPendingSecretReferences(any(), any());
+    when(storeA.resolve(Set.of("ref-a1", "ref-a2")))
+        .thenReturn(
+            Map.of(
+                "ref-a1", new SecretResolutionResult.Resolved("v1"),
+                "ref-a2", new SecretResolutionResult.Resolved("v2")));
+    when(storeB.resolve(Set.of("ref-b1")))
+        .thenReturn(Map.of("ref-b1", new SecretResolutionResult.Resolved("v3")));
+
+    // when
+    localScheduler.resolveSecrets(resultBuilder);
+
+    // then — store-a's 2 refs plus only the first of store-b's 2 refs (3 total, the cap);
+    // store-b's second ref ("ref-b2") is left pending for the next cycle
+    final var storeARefsCaptor = ArgumentCaptor.forClass(Set.class);
+    final var storeBRefsCaptor = ArgumentCaptor.forClass(Set.class);
+    verify(storeA).resolve(storeARefsCaptor.capture());
+    verify(storeB).resolve(storeBRefsCaptor.capture());
+    assertThat(storeARefsCaptor.getAllValues()).containsExactly(Set.of("ref-a1", "ref-a2"));
+    assertThat(storeBRefsCaptor.getAllValues()).containsExactly(Set.of("ref-b1"));
+  }
+
+  @Test
+  void shouldRescheduleImmediatelyWhenPendingRefsExceedBatchLimit() throws Exception {
+    // given — batch limit of 2, but 3 refs pending
+    final var config = new EngineConfiguration().setSecretResolutionBatchLimit(2);
+    final var localScheduler =
+        new SecretResolutionScheduler(
+            () -> scheduledTaskState,
+            new SecretStoreRegistry(
+                Map.of("my-store", secretStore), Map.of("my-store", secretCache)),
+            config);
+    localScheduler.onRecovered(context);
+    reset(scheduleService);
+    stubPending("my-store", "ref-1", "ref-2", "ref-3");
+    when(secretStore.resolve(any()))
+        .thenReturn(
+            Map.of(
+                "ref-1", new SecretResolutionResult.Resolved("value-1"),
+                "ref-2", new SecretResolutionResult.Resolved("value-2")));
+
+    // when
+    localScheduler.resolveSecrets(resultBuilder);
+
+    // then — rescheduled with zero delay instead of the normal interval
+    final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
+    verify(scheduleService).runDelayedAsync(delayCaptor.capture(), any(), any());
+    assertThat(delayCaptor.getValue()).isEqualTo(Duration.ZERO);
+  }
+
+  @Test
+  void shouldNotRescheduleImmediatelyWhenPendingRefsAreWithinBatchLimit() throws Exception {
+    // given — batch limit of 2, exactly 2 refs pending (nothing left over)
+    final var config = new EngineConfiguration().setSecretResolutionBatchLimit(2);
+    final var localScheduler =
+        new SecretResolutionScheduler(
+            () -> scheduledTaskState,
+            new SecretStoreRegistry(
+                Map.of("my-store", secretStore), Map.of("my-store", secretCache)),
+            config);
+    localScheduler.onRecovered(context);
+    reset(scheduleService);
+    stubPending("my-store", "ref-1", "ref-2");
+    when(secretStore.resolve(Set.of("ref-1", "ref-2")))
+        .thenReturn(
+            Map.of(
+                "ref-1", new SecretResolutionResult.Resolved("value-1"),
+                "ref-2", new SecretResolutionResult.Resolved("value-2")));
+
+    // when
+    localScheduler.resolveSecrets(resultBuilder);
+
+    // then — the normal scheduling interval is used, since nothing was capped
+    final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
+    verify(scheduleService).runDelayedAsync(delayCaptor.capture(), any(), any());
+    assertThat(delayCaptor.getValue())
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_INTERVAL);
+  }
+
+  @Test
+  void shouldNotRescheduleImmediatelyWhenCappedStoreIsInRetryCooldown() throws Exception {
+    // given — batch limit of 1, but 2 refs pending for a store that is also in retry cooldown;
+    // the cooldown-aware collection must exclude the cooldown store's refs entirely rather than
+    // let them consume the cap, otherwise the scheduler could busy-spin re-scanning state at zero
+    // delay until the cooldown expires by wall clock
+    final var config = new EngineConfiguration().setSecretResolutionBatchLimit(1);
+    final var localScheduler =
+        new SecretResolutionScheduler(
+            () -> scheduledTaskState,
+            new SecretStoreRegistry(
+                Map.of("my-store", secretStore), Map.of("my-store", secretCache)),
+            config);
+    localScheduler.onRecovered(context);
+    reset(scheduleService);
+    when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
+
+    // when — first cycle: store fails, enters retry cooldown
+    stubPending("my-store", "ref-1", "ref-2");
+    localScheduler.resolveSecrets(resultBuilder);
+
+    // when — second cycle: still within the cooldown window; the cooldown store's ref is excluded
+    // from collection entirely, so nothing is capped and nothing is resolved
+    stubPending("my-store", "ref-1", "ref-2");
+    localScheduler.resolveSecrets(resultBuilder);
+
+    // then — the store was only attempted once; the second cycle skipped it during collection
+    verify(secretStore, times(1)).resolve(any());
+
+    // then — the reschedule after the second cycle uses the cooldown-aware delay, not Duration.ZERO
+    // (nothing was capped this cycle, so it falls through to computeNextDelay)
+    final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
+    verify(scheduleService, times(2)).runDelayedAsync(delayCaptor.capture(), any(), any());
+    assertThat(delayCaptor.getAllValues().get(1))
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_INITIAL_DELAY)
+        .isNotEqualTo(Duration.ZERO);
+  }
+
+  @Test
+  void shouldResumeCollectionFromCursorOnNextCycle() throws Exception {
+    // given — cycle 1's collection stops early and reports a resume cursor at the last entry the
+    // visitor was offered before being told to stop
+    final var cycle1Cursor = new SecretReferenceState.PendingRefCursor("my-store", "ref-1");
+    doAnswer(
+            inv -> {
+              final var visitor = (BiPredicate<String, String>) inv.getArgument(1);
+              visitor.test("my-store", "ref-1");
+              return cycle1Cursor;
+            })
+        .when(secretReferenceState)
+        .visitPendingSecretReferences(any(), any());
+
+    // when — cycle 1
+    scheduler.resolveSecrets(resultBuilder);
+
+    // and — cycle 2
+    stubPending("my-store", "ref-2");
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — cycle 2 resumed from exactly where cycle 1 left off, not from the beginning; this is
+    // the fairness fix that lets later stores (in key order) eventually get served instead of a
+    // fresh scan always restarting at the start of the column family
+    final var cursorCaptor = ArgumentCaptor.forClass(SecretReferenceState.PendingRefCursor.class);
+    verify(secretReferenceState, times(2))
+        .visitPendingSecretReferences(cursorCaptor.capture(), any());
+    assertThat(cursorCaptor.getAllValues().get(0)).isNull();
+    assertThat(cursorCaptor.getAllValues().get(1)).isEqualTo(cycle1Cursor);
+  }
+
+  @Test
+  void shouldNotLetCooldownStoreConsumeCapBudgetFromHealthyStore() throws Exception {
+    // given — batch limit of 2; store-a is already in retry cooldown with 3 pending refs, store-b
+    // is healthy with 2 pending refs. Under the old (collection-time-cooldown-unaware) behavior,
+    // the batch limit would have been entirely consumed by store-a's refs, starving store-b.
+    final var storeA = mock(SecretStore.class);
+    final var storeB = mock(SecretStore.class);
+    final var cacheB = mock(SecretCache.class);
+    final var registry =
+        new SecretStoreRegistry(
+            Map.of("store-a", storeA, "store-b", storeB), Map.of("store-b", cacheB));
+    final var config = new EngineConfiguration().setSecretResolutionBatchLimit(2);
+    final var localScheduler =
+        new SecretResolutionScheduler(() -> scheduledTaskState, registry, config);
+    localScheduler.onRecovered(context);
+
+    // cycle 1 (t=0): drive store-a into retry cooldown
+    when(storeA.resolve(Set.of("ref-a1"))).thenThrow(new SecretStoreUnavailableException("down"));
+    stubPending("store-a", "ref-a1");
+    localScheduler.resolveSecrets(resultBuilder);
+
+    // when — cycle 2 (t=0, still within store-a's cooldown window): store-a now has 3 pending
+    // refs (offered first, in key order) and store-b has 2 pending refs
+    doAnswer(
+            inv -> {
+              final var visitor = (BiPredicate<String, String>) inv.getArgument(1);
+              if (!visitor.test("store-a", "ref-a1")) {
+                return new SecretReferenceState.PendingRefCursor("store-a", "ref-a1");
+              }
+              if (!visitor.test("store-a", "ref-a2")) {
+                return new SecretReferenceState.PendingRefCursor("store-a", "ref-a2");
+              }
+              if (!visitor.test("store-a", "ref-a3")) {
+                return new SecretReferenceState.PendingRefCursor("store-a", "ref-a3");
+              }
+              if (!visitor.test("store-b", "ref-b1")) {
+                return new SecretReferenceState.PendingRefCursor("store-b", "ref-b1");
+              }
+              if (!visitor.test("store-b", "ref-b2")) {
+                return new SecretReferenceState.PendingRefCursor("store-b", "ref-b2");
+              }
+              return null;
+            })
+        .when(secretReferenceState)
+        .visitPendingSecretReferences(any(), any());
+    when(storeB.resolve(Set.of("ref-b1", "ref-b2")))
+        .thenReturn(
+            Map.of(
+                "ref-b1", new SecretResolutionResult.Resolved("v1"),
+                "ref-b2", new SecretResolutionResult.Resolved("v2")));
+    localScheduler.resolveSecrets(resultBuilder);
+
+    // then — store-b's refs were not starved by store-a's cooldown refs consuming the cap
+    final var storeBRefsCaptor = ArgumentCaptor.forClass(Set.class);
+    verify(storeB).resolve(storeBRefsCaptor.capture());
+    assertThat(storeBRefsCaptor.getValue()).isEqualTo(Set.of("ref-b1", "ref-b2"));
+    // store-a was never retried while cooling down — its only resolve() call is from cycle 1
+    verify(storeA, times(1)).resolve(any());
+  }
+
+  @Test
+  void shouldStopProcessingFurtherStoresWhenTaskResultBatchIsFull() throws Exception {
+    // given — appendCommandRecord reports the task result batch as full
+    final var storeA = mock(SecretStore.class);
+    final var storeB = mock(SecretStore.class);
+    final var cacheA = mock(SecretCache.class);
+    final var registry =
+        new SecretStoreRegistry(
+            Map.of("store-a", storeA, "store-b", storeB), Map.of("store-a", cacheA));
+    final var localScheduler =
+        new SecretResolutionScheduler(
+            () -> scheduledTaskState, registry, new EngineConfiguration());
+    localScheduler.onRecovered(context);
+
+    final var refsByStore = new LinkedHashMap<String, String>();
+    refsByStore.put("store-a", "ref-a");
+    refsByStore.put("store-b", "ref-b");
+    stubPending(refsByStore);
+    when(storeA.resolve(Set.of("ref-a")))
+        .thenReturn(Map.of("ref-a", new SecretResolutionResult.Resolved("value-a")));
+    when(resultBuilder.appendCommandRecord(any(), any())).thenReturn(false);
+
+    // when
+    localScheduler.resolveSecrets(resultBuilder);
+
+    // then — store-a was attempted (its append hit the full batch), store-b never reached
+    verify(storeA).resolve(Set.of("ref-a"));
+    verify(storeB, never()).resolve(any());
+  }
+
+  @Test
+  void shouldRescheduleImmediatelyWhenTaskResultBatchIsFull() throws Exception {
+    // given
+    stubPending("my-store", "db-password");
+    when(secretStore.resolve(Set.of("db-password")))
+        .thenReturn(Map.of("db-password", new SecretResolutionResult.Resolved("s3cr3t")));
+    when(resultBuilder.appendCommandRecord(any(), any())).thenReturn(false);
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — rescheduled with zero delay instead of the normal interval
+    final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
+    // two calls: onRecovered's initial schedule (in setUp), then this cycle's reschedule
+    verify(scheduleService, times(2)).runDelayedAsync(delayCaptor.capture(), any(), any());
+    assertThat(delayCaptor.getAllValues().get(1)).isEqualTo(Duration.ZERO);
+  }
+
+  @Test
   void shouldNotScheduleSecondChainWhenResumedWhileTaskStillPending() throws Exception {
     // given — setUp already scheduled once via onRecovered
 
@@ -532,41 +911,44 @@ final class SecretResolutionSchedulerTest {
   private void stubPending(final String storeId, final String secretRef) {
     doAnswer(
             inv -> {
-              final var visitor = (BiPredicate<String, String>) inv.getArgument(0);
-              visitor.test(storeId, secretRef);
+              final var visitor = (BiPredicate<String, String>) inv.getArgument(1);
+              if (!visitor.test(storeId, secretRef)) {
+                return new SecretReferenceState.PendingRefCursor(storeId, secretRef);
+              }
               return null;
             })
         .when(secretReferenceState)
-        .visitPendingSecretReferences(any());
+        .visitPendingSecretReferences(any(), any());
   }
 
   private void stubPending(final String storeId, final String... secretRefs) {
     doAnswer(
             inv -> {
-              final var visitor = (BiPredicate<String, String>) inv.getArgument(0);
+              final var visitor = (BiPredicate<String, String>) inv.getArgument(1);
               for (final String secretRef : secretRefs) {
                 if (!visitor.test(storeId, secretRef)) {
-                  break;
+                  return new SecretReferenceState.PendingRefCursor(storeId, secretRef);
                 }
               }
               return null;
             })
         .when(secretReferenceState)
-        .visitPendingSecretReferences(any());
+        .visitPendingSecretReferences(any(), any());
   }
 
   private void stubPending(final Map<String, String> refsByStore) {
     doAnswer(
             inv -> {
-              final var visitor = (BiPredicate<String, String>) inv.getArgument(0);
+              final var visitor = (BiPredicate<String, String>) inv.getArgument(1);
               for (final var entry : refsByStore.entrySet()) {
                 if (!visitor.test(entry.getKey(), entry.getValue())) {
-                  break;
+                  return new SecretReferenceState.PendingRefCursor(
+                      entry.getKey(), entry.getValue());
                 }
               }
               return null;
             })
         .when(secretReferenceState)
-        .visitPendingSecretReferences(any());
+        .visitPendingSecretReferences(any(), any());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -40,7 +40,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.BiConsumer;
+import java.util.function.BiPredicate;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -532,8 +532,8 @@ final class SecretResolutionSchedulerTest {
   private void stubPending(final String storeId, final String secretRef) {
     doAnswer(
             inv -> {
-              final var visitor = (BiConsumer<String, String>) inv.getArgument(0);
-              visitor.accept(storeId, secretRef);
+              final var visitor = (BiPredicate<String, String>) inv.getArgument(0);
+              visitor.test(storeId, secretRef);
               return null;
             })
         .when(secretReferenceState)
@@ -543,9 +543,11 @@ final class SecretResolutionSchedulerTest {
   private void stubPending(final String storeId, final String... secretRefs) {
     doAnswer(
             inv -> {
-              final var visitor = (BiConsumer<String, String>) inv.getArgument(0);
+              final var visitor = (BiPredicate<String, String>) inv.getArgument(0);
               for (final String secretRef : secretRefs) {
-                visitor.accept(storeId, secretRef);
+                if (!visitor.test(storeId, secretRef)) {
+                  break;
+                }
               }
               return null;
             })
@@ -556,8 +558,12 @@ final class SecretResolutionSchedulerTest {
   private void stubPending(final Map<String, String> refsByStore) {
     doAnswer(
             inv -> {
-              final var visitor = (BiConsumer<String, String>) inv.getArgument(0);
-              refsByStore.forEach(visitor::accept);
+              final var visitor = (BiPredicate<String, String>) inv.getArgument(0);
+              for (final var entry : refsByStore.entrySet()) {
+                if (!visitor.test(entry.getKey(), entry.getValue())) {
+                  break;
+                }
+              }
               return null;
             })
         .when(secretReferenceState)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceStateTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.db.ZeebeDbInconsistentException;
+import io.camunda.zeebe.engine.state.immutable.SecretReferenceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
@@ -268,7 +269,7 @@ public final class DbSecretReferenceStateTest {
     // when
     final var collected = new ArrayList<String>();
     state.visitPendingSecretReferences(
-        (storeId, secretRef) -> collected.add(storeId + ":" + secretRef));
+        null, (storeId, secretRef) -> collected.add(storeId + ":" + secretRef));
 
     // then
     assertThat(collected)
@@ -285,10 +286,67 @@ public final class DbSecretReferenceStateTest {
     // when
     final var collected = new ArrayList<String>();
     state.visitPendingSecretReferences(
-        (storeId, secretRef) -> collected.add(storeId + ":" + secretRef));
+        null, (storeId, secretRef) -> collected.add(storeId + ":" + secretRef));
 
     // then
     assertThat(collected).containsExactly("store-a:ref-2");
+  }
+
+  @Test
+  void shouldStopVisitingPendingSecretReferencesWhenVisitorReturnsFalse() {
+    // given
+    state.addPendingSecretReference("store-a", "ref-1");
+    state.addPendingSecretReference("store-a", "ref-2");
+    state.addPendingSecretReference("store-a", "ref-3");
+
+    // when
+    final var visited = new ArrayList<String>();
+    state.visitPendingSecretReferences(
+        null,
+        (storeId, secretRef) -> {
+          visited.add(secretRef);
+          return visited.size() < 2;
+        });
+
+    // then — iteration stops after the second entry; the third is never visited
+    assertThat(visited).containsExactly("ref-1", "ref-2");
+  }
+
+  @Test
+  void shouldReturnResumeCursorMatchingEntryWhereVisitorStoppedAndResumeFromIt() {
+    // given — 4 pending refs across 2 stores, so the resume point is unambiguous
+    state.addPendingSecretReference("store-a", "ref-1");
+    state.addPendingSecretReference("store-a", "ref-2");
+    state.addPendingSecretReference("store-b", "ref-3");
+    state.addPendingSecretReference("store-b", "ref-4");
+
+    // when — stop after the second entry
+    final var firstPass = new ArrayList<String>();
+    final var cursor =
+        state.visitPendingSecretReferences(
+            null,
+            (storeId, secretRef) -> {
+              firstPass.add(storeId + ":" + secretRef);
+              return firstPass.size() < 2;
+            });
+
+    // then — the returned cursor identifies the entry the visitor stopped at
+    assertThat(firstPass).containsExactly("store-a:ref-1", "store-a:ref-2");
+    assertThat(cursor).isEqualTo(new SecretReferenceState.PendingRefCursor("store-a", "ref-2"));
+
+    // when — resuming from that cursor
+    final var secondPass = new ArrayList<String>();
+    final var secondCursor =
+        state.visitPendingSecretReferences(
+            cursor,
+            (storeId, secretRef) -> {
+              secondPass.add(storeId + ":" + secretRef);
+              return true;
+            });
+
+    // then — resumption is inclusive of the cursor entry and visits the remainder in order
+    assertThat(secondPass).containsExactly("store-a:ref-2", "store-b:ref-3", "store-b:ref-4");
+    assertThat(secondCursor).isNull();
   }
 
   @Test


### PR DESCRIPTION
## Description

`SecretResolutionScheduler` (introduced in #58221) read *all* pending secret references from state every cycle and resolved them in one `store.resolve(Set)` call per store, with no upper bound. During a store outage (or any backlog buildup while jobs keep parking), that's unbounded memory for the collected refs, an oversized batch handed to the store SPI, and potentially more commands than fit in one `TaskResult` record batch — and the scheduler was silently ignoring `appendCommandRecord`'s return value when that happened, dropping commands (self-healing since the refs stay pending, but it wastes store IO re-resolving the same secrets every cycle).

This caps the scheduler to a configurable maximum number of secret resolutions per cycle (`camunda.processing.engine.secrets.batch-resolution-limit`, default 20, global across all stores combined — not per-store), checks `appendCommandRecord`'s return value and stops the cycle instead of dropping commands when the batch fills up, and reschedules immediately instead of waiting the normal interval whenever either condition leaves work pending. Followed the exact same pattern `JobTimeoutCheckScheduler` already uses for its own batch limit (early-exit visitor + counter + immediate reschedule on early yield).

The trickier part turned out to be the interaction between "reschedule immediately" and the existing store-unavailable retry/backoff logic:
1. If a store is capped *and* in retry cooldown at the same time, naively rescheduling at zero delay busy-spins re-scanning RocksDB until the cooldown elapses by wall clock, instead of honoring the backoff delay. Fixed by only using the zero-delay reschedule when no store is currently in cooldown.
2. A subtler one caught in the final review: `storeRetryStates.keySet().retainAll(pendingByStore.keySet())` assumed the collected set always contained *every* store with pending refs. Once collection can stop early at the cap, a store whose refs just weren't reached yet (an earlier store consumed the cap first) gets dropped from that set even though it still has pending refs — so `retainAll` was wiping its retry/backoff state as if it had none, resetting exponential backoff to attempt-zero every cycle. In a sustained multi-store outage that can mean a starved store never actually reaches `retryMaxAttempts` and never fails out. Fixed by only pruning `storeRetryStates` when the cycle's read wasn't capped, since only then is the collected set known to be complete.

## Checklist
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #58546