### PR TITLE
refactor: move coordinated leadership transfer code into its own package

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/CatchUpWait.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/CatchUpWait.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.raft.roles;
+package io.atomix.raft.rebalance;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.LeadershipTransferResult;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/LeadershipTransferAdmission.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/LeadershipTransferAdmission.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.raft.roles;
+package io.atomix.raft.rebalance;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.LeadershipTransferResult;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/LeadershipTransferAttempt.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/LeadershipTransferAttempt.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.raft.roles;
+package io.atomix.raft.rebalance;
 
 import com.google.common.base.Throwables;
 import io.atomix.cluster.MemberId;
@@ -21,6 +21,7 @@ import io.atomix.raft.LeadershipTransferResult;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
 import io.atomix.raft.protocol.LeadershipTransferResultRequest;
+import io.atomix.raft.roles.LeaderRole;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import org.jspecify.annotations.NullMarked;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/LeadershipTransferRunner.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/LeadershipTransferRunner.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.raft.roles;
+package io.atomix.raft.rebalance;
 
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
 import io.atomix.raft.protocol.LeadershipTransferInitiateResponse;
 import io.atomix.raft.protocol.RaftResponse.Status;
+import io.atomix.raft.roles.LeaderRole;
 import java.util.function.BooleanSupplier;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -31,7 +32,7 @@ import org.jspecify.annotations.Nullable;
  * survives from one transfer into the next.
  */
 @NullMarked
-final class LeadershipTransferRunner {
+public final class LeadershipTransferRunner {
   private final RaftContext raft;
   private final LeaderRole leader;
   private final LeadershipTransferAdmission admission;
@@ -39,7 +40,7 @@ final class LeadershipTransferRunner {
   // finishes.
   private volatile @Nullable LeadershipTransferAttempt currentAttempt;
 
-  LeadershipTransferRunner(
+  public LeadershipTransferRunner(
       final RaftContext raft,
       final LeaderRole leader,
       final BooleanSupplier pausedForTransfer,
@@ -65,7 +66,7 @@ final class LeadershipTransferRunner {
    * accepted request starts a one-shot attempt, whose outcome reaches the coordinator separately
    * once the transfer finishes.
    */
-  LeadershipTransferInitiateResponse handleInitiate(
+  public LeadershipTransferInitiateResponse handleInitiate(
       final LeadershipTransferInitiateRequest request) {
     raft.checkThread();
     final var rejectionReason =
@@ -84,7 +85,7 @@ final class LeadershipTransferRunner {
     return LeadershipTransferInitiateResponse.builder().withStatus(Status.OK).build();
   }
 
-  void onLeaderStopped() {
+  public void onLeaderStopped() {
     final var attempt = currentAttempt;
     if (attempt != null) {
       attempt.onLeaderStopped();
@@ -92,7 +93,7 @@ final class LeadershipTransferRunner {
   }
 
   /** The freeze ended. */
-  void onPauseCleared() {
+  public void onPauseCleared() {
     final var attempt = currentAttempt;
     if (attempt != null) {
       attempt.onPauseCleared();
@@ -100,7 +101,7 @@ final class LeadershipTransferRunner {
   }
 
   /** The leader's freeze watchdog fired: the pause outlived its resume deadline. */
-  void onPauseDeadlineExpired() {
+  public void onPauseDeadlineExpired() {
     final var attempt = currentAttempt;
     if (attempt != null) {
       attempt.onPauseDeadlineExpired();

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/LeadershipTransferRunner.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/LeadershipTransferRunner.java
@@ -86,6 +86,7 @@ public final class LeadershipTransferRunner {
   }
 
   public void onLeaderStopped() {
+    raft.checkThread();
     final var attempt = currentAttempt;
     if (attempt != null) {
       attempt.onLeaderStopped();
@@ -94,6 +95,7 @@ public final class LeadershipTransferRunner {
 
   /** The freeze ended. */
   public void onPauseCleared() {
+    raft.checkThread();
     final var attempt = currentAttempt;
     if (attempt != null) {
       attempt.onPauseCleared();
@@ -102,6 +104,7 @@ public final class LeadershipTransferRunner {
 
   /** The leader's freeze watchdog fired: the pause outlived its resume deadline. */
   public void onPauseDeadlineExpired() {
+    raft.checkThread();
     final var attempt = currentAttempt;
     if (attempt != null) {
       attempt.onPauseDeadlineExpired();

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/TimeoutNowPromotion.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/TimeoutNowPromotion.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.raft.roles;
+package io.atomix.raft.rebalance;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.LeadershipTransferResult;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/TransferPhase.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/TransferPhase.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.raft.roles;
+package io.atomix.raft.rebalance;
 
 /**
  * One step of a coordinated leadership transfer. A phase owns its timers and listeners, completes

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/package-info.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides the leader-side machinery for a single coordinated leadership transfer, run as part of a
+ * cluster rebalance.
+ */
+package io.atomix.raft.rebalance;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -50,6 +50,7 @@ import io.atomix.raft.protocol.TransferRequest;
 import io.atomix.raft.protocol.TransferResponse;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
+import io.atomix.raft.rebalance.LeadershipTransferRunner;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLogReader;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferPauseGuard.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeadershipTransferPauseGuard.java
@@ -17,6 +17,7 @@ package io.atomix.raft.roles;
 
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.impl.RaftContext;
+import io.atomix.raft.rebalance.LeadershipTransferRunner;
 import io.atomix.raft.roles.LeaderRole.ConfigurationChangeInProgressException;
 import io.atomix.utils.concurrent.Scheduled;
 import java.time.Duration;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/rebalance/CatchUpWaitTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/rebalance/CatchUpWaitTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.raft.roles;
+package io.atomix.raft.rebalance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,6 +21,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.LeadershipTransferResult;
 import io.atomix.raft.RaftRule;
 import io.atomix.raft.RaftServer;
+import io.atomix.raft.roles.LeaderRole;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/rebalance/LeadershipTransferAttemptTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/rebalance/LeadershipTransferAttemptTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.raft.roles;
+package io.atomix.raft.rebalance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,6 +27,7 @@ import io.atomix.raft.protocol.LeadershipTransferResultRequest;
 import io.atomix.raft.protocol.LeadershipTransferResultResponse;
 import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.raft.protocol.TestRaftServerProtocol;
+import io.atomix.raft.roles.LeaderRole;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
Moves the bulk of the leader-side CLT code from `io.atomix.raft.role` into `io.atomix.raft.rebalance`, now that it's no longer so closely tied into `LeaderRole`.

`LeadershipTransferRunner` is the entry point for `LeaderRole` (and `LeadershipTransferPauseGuard`, which stays owned by the role) to call in to the new package.

(depends on https://github.com/camunda/camunda/pull/59194 - will retarget to main once that's merged)