### PR TITLE
feat: add Operate Decisions decision panel

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/decision-definition-xmls.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/decision-definition-xmls.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+const DMN_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="invoiceBusinessDecisions" name="Invoice Business Decisions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="invoiceClassification" name="invoiceClassification">
+    <decisionTable id="decisionTable">
+      <input id="clause1" label="Invoice Amount">
+        <inputExpression id="inputExpression1" typeRef="double">
+          <text>amount</text>
+        </inputExpression>
+      </input>
+      <output id="clause3" label="Classification" name="invoiceClassification" typeRef="string" />
+      <rule id="DecisionRule_1">
+        <inputEntry id="LiteralExpression_1">
+          <text>&lt; 250</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_2">
+          <text>"day-to-day expense"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="DMNDiagram_1">
+      <dmndi:DMNShape id="DMNShape_1" dmnElementRef="invoiceClassification">
+        <dc:Bounds height="80" width="180" x="160" y="220" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>`;
+
+export {DMN_XML};

--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
@@ -59,6 +59,11 @@ const mockCreateDecisionInstancesDeletionBatchOperationEndpoint = createEndpoint
 	method: endpoints.createDecisionInstancesDeletionBatchOperation.method,
 });
 
+const mockGetDecisionDefinitionXmlEndpoint = createEndpointMock({
+	endpoint: endpoints.getDecisionDefinitionXml.getUrl({decisionDefinitionKey: ':decisionDefinitionKey'}),
+	method: endpoints.getDecisionDefinitionXml.method,
+});
+
 const mockCurrentUserEndpoint = createEndpointMock({
 	endpoint: endpoints.getCurrentUser.getUrl(),
 	method: endpoints.getCurrentUser.method,
@@ -180,5 +185,6 @@ export {
 	mockQueryDecisionDefinitionsEndpoint,
 	mockQueryDecisionInstancesEndpoint,
 	mockCreateDecisionInstancesDeletionBatchOperationEndpoint,
+	mockGetDecisionDefinitionXmlEndpoint,
 	mockQueryAuditLogsEndpoint,
 };

--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
@@ -6,7 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {endpoints} from '@camunda/camunda-api-zod-schemas/8.10';
+import {HttpResponse, http} from 'msw';
+import {endpoints, queryDecisionDefinitionsRequestBodySchema} from '@camunda/camunda-api-zod-schemas/8.10';
 import {createEndpointMock} from './mock-endpoint';
 
 const mockQueryUserTasksEndpoint = createEndpointMock({
@@ -48,6 +49,36 @@ const mockQueryDecisionDefinitionsEndpoint = createEndpointMock({
 	endpoint: endpoints.queryDecisionDefinitions.getUrl(),
 	method: endpoints.queryDecisionDefinitions.method,
 });
+
+function mockQueryDecisionDefinitionsEndpointByFilter({
+	unfilteredResponse,
+	filteredResponse,
+	versionsResponses = [filteredResponse],
+}: {
+	unfilteredResponse: Response;
+	filteredResponse: Response;
+	versionsResponses?: Response[];
+}) {
+	let versionResponseIndex = 0;
+
+	return http.post(endpoints.queryDecisionDefinitions.getUrl(), async ({request}) => {
+		const result = queryDecisionDefinitionsRequestBodySchema.safeParse(await request.json());
+		if (!result.success) {
+			return HttpResponse.json({}, {status: 400});
+		}
+
+		if (result.data.filter?.decisionDefinitionId === undefined) {
+			return unfilteredResponse.clone();
+		}
+		if (result.data.filter.version !== undefined) {
+			return filteredResponse.clone();
+		}
+
+		const response = versionsResponses[Math.min(versionResponseIndex, versionsResponses.length - 1)];
+		versionResponseIndex += 1;
+		return (response ?? filteredResponse).clone();
+	});
+}
 
 const mockQueryDecisionInstancesEndpoint = createEndpointMock({
 	endpoint: endpoints.queryDecisionInstances.getUrl(),
@@ -183,6 +214,7 @@ export {
 	mockQueryBatchOperationsEndpoint,
 	mockGetDecisionInstanceEndpoint,
 	mockQueryDecisionDefinitionsEndpoint,
+	mockQueryDecisionDefinitionsEndpointByFilter,
 	mockQueryDecisionInstancesEndpoint,
 	mockCreateDecisionInstancesDeletionBatchOperationEndpoint,
 	mockGetDecisionDefinitionXmlEndpoint,

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/DecisionHeader.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/DecisionHeader.test.tsx
@@ -24,7 +24,10 @@ describe('<DecisionHeader />', () => {
 			<DecisionHeader
 				decisionDefinitionSelection={{
 					kind: 'single-version',
-					definition: createDecisionDefinition({name: 'Invoice Classification', decisionDefinitionId: 'invoice-classification'}),
+					definition: createDecisionDefinition({
+						name: 'Invoice Classification',
+						decisionDefinitionId: 'invoice-classification',
+					}),
 				}}
 			/>,
 		);

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/DecisionHeader.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/DecisionHeader.test.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, expect} from 'vitest';
+import {render} from 'vitest-browser-react';
+import {it} from '#/vitest-modules/test-extend';
+import {createDecisionDefinition} from '#/shared-test-modules/api-mocks/decision-definitions';
+import {DecisionHeader} from './DecisionHeader';
+
+describe('<DecisionHeader />', () => {
+	it('shows a generic title when there is no matching definition', async () => {
+		const screen = await render(<DecisionHeader decisionDefinitionSelection={{kind: 'no-match'}} />);
+
+		await expect.element(screen.getByText('Decision')).toBeVisible();
+	});
+
+	it('shows the decision name and copiable ID for a single selected version', async () => {
+		const screen = await render(
+			<DecisionHeader
+				decisionDefinitionSelection={{
+					kind: 'single-version',
+					definition: createDecisionDefinition({name: 'Invoice Classification', decisionDefinitionId: 'invoice-classification'}),
+				}}
+			/>,
+		);
+
+		await expect.element(screen.getByText('Invoice Classification')).toBeVisible();
+		await expect.element(screen.getByText('invoice-classification')).toBeVisible();
+	});
+
+	it('shows the decision name and copiable ID for an all-versions selection', async () => {
+		const screen = await render(
+			<DecisionHeader
+				decisionDefinitionSelection={{
+					kind: 'all-versions',
+					definition: {name: 'Invoice Classification', decisionDefinitionId: 'invoice-classification'},
+				}}
+			/>,
+		);
+
+		await expect.element(screen.getByText('Invoice Classification')).toBeVisible();
+		await expect.element(screen.getByText('invoice-classification')).toBeVisible();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/DecisionHeader.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/DecisionHeader.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useTranslation} from 'react-i18next';
+import {PanelHeader, CopiableContent} from './styled';
+import type {DecisionDefinitionSelection} from './DecisionPanel';
+import {getDecisionDefinitionName} from './getDecisionDefinitionName';
+
+type Props = {
+	decisionDefinitionSelection: DecisionDefinitionSelection;
+};
+
+const DecisionHeader: React.FC<Props> = ({decisionDefinitionSelection}) => {
+	const {t} = useTranslation();
+	const title =
+		decisionDefinitionSelection.kind === 'no-match'
+			? t('operate.decisions.diagramHeader.title')
+			: getDecisionDefinitionName(decisionDefinitionSelection.definition);
+
+	return (
+		<PanelHeader title={title}>
+			{decisionDefinitionSelection.kind !== 'no-match' && (
+				<CopiableContent
+					copyButtonDescription={t('operate.decisions.diagramHeader.copyButtonDescription')}
+					content={decisionDefinitionSelection.definition.decisionDefinitionId}
+				/>
+			)}
+		</PanelHeader>
+	);
+};
+
+export {DecisionHeader};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/DecisionPanel.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/DecisionPanel.test.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, expect} from 'vitest';
+import {HttpResponse} from 'msw';
+import {it} from '#/vitest-modules/test-extend';
+import {renderWithRouter} from '#/vitest-modules/render-with-router';
+import {mockGetDecisionDefinitionXmlEndpoint} from '#/shared-test-modules/mock-handlers';
+import {createDecisionDefinition} from '#/shared-test-modules/api-mocks/decision-definitions';
+import {DMN_XML} from '#/shared-test-modules/api-mocks/decision-definition-xmls';
+import {DecisionPanel} from './DecisionPanel';
+
+function renderDecisionPanel(props: React.ComponentProps<typeof DecisionPanel>) {
+	return renderWithRouter(() => <DecisionPanel {...props} />, {path: '/operate/decisions'});
+}
+
+const DEFINITION = createDecisionDefinition({decisionDefinitionKey: '2251799813685280'});
+
+describe('<DecisionPanel />', () => {
+	it('shows an empty message when no decision is selected', async () => {
+		const screen = await renderDecisionPanel({decisionDefinitionSelection: {kind: 'no-match'}});
+
+		await expect.element(screen.getByText('There is no Decision selected')).toBeVisible();
+	});
+
+	it('shows an empty message when multiple versions are selected', async () => {
+		const screen = await renderDecisionPanel({
+			decisionDefinitionSelection: {
+				kind: 'all-versions',
+				definition: {name: 'Invoice Classification', decisionDefinitionId: 'invoice-classification'},
+			},
+		});
+
+		await expect
+			.element(screen.getByText('There is more than one Version selected for Decision "Invoice Classification"'))
+			.toBeVisible();
+	});
+
+	it('renders the decision diagram for a single selected version', async ({worker}) => {
+		worker.use(mockGetDecisionDefinitionXmlEndpoint({successResponse: HttpResponse.text(DMN_XML)}));
+
+		const screen = await renderDecisionPanel({
+			decisionDefinitionSelection: {kind: 'single-version', definition: DEFINITION},
+		});
+
+		await expect.element(screen.getByTestId('decision-viewer')).toBeVisible();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/DecisionPanel.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/DecisionPanel.test.tsx
@@ -41,6 +41,19 @@ describe('<DecisionPanel />', () => {
 			.toBeVisible();
 	});
 
+	it('shows an empty message when the selected version exists in multiple tenants', async () => {
+		const screen = await renderDecisionPanel({
+			decisionDefinitionSelection: {
+				kind: 'multiple-tenants',
+				definition: {name: 'Invoice Classification', decisionDefinitionId: 'invoice-classification'},
+			},
+		});
+
+		await expect
+			.element(screen.getByText('Decision "Invoice Classification" exists in more than one Tenant'))
+			.toBeVisible();
+	});
+
 	it('renders the decision diagram for a single selected version', async ({worker}) => {
 		worker.use(mockGetDecisionDefinitionXmlEndpoint({successResponse: HttpResponse.text(DMN_XML)}));
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/DecisionPanel.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/DecisionPanel.test.tsx
@@ -19,7 +19,10 @@ function renderDecisionPanel(props: React.ComponentProps<typeof DecisionPanel>) 
 	return renderWithRouter(() => <DecisionPanel {...props} />, {path: '/operate/decisions'});
 }
 
-const DEFINITION = createDecisionDefinition({decisionDefinitionKey: '2251799813685280'});
+const DEFINITION = createDecisionDefinition({
+	decisionDefinitionKey: '2251799813685280',
+	decisionDefinitionId: 'invoiceClassification',
+});
 
 describe('<DecisionPanel />', () => {
 	it('shows an empty message when no decision is selected', async () => {
@@ -62,5 +65,6 @@ describe('<DecisionPanel />', () => {
 		});
 
 		await expect.element(screen.getByTestId('decision-viewer')).toBeVisible();
+		await expect.element(screen.getByText('Invoice Amount')).toBeVisible();
 	});
 });

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/DecisionPanel.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/DecisionPanel.tsx
@@ -18,13 +18,20 @@ import {Section} from './styled';
 type DecisionDefinitionSelection =
 	| {kind: 'no-match'}
 	| {kind: 'single-version'; definition: DecisionDefinition}
-	| {kind: 'all-versions'; definition: Pick<DecisionDefinition, 'name' | 'decisionDefinitionId'>};
+	| {kind: 'all-versions'; definition: Pick<DecisionDefinition, 'name' | 'decisionDefinitionId'>}
+	| {kind: 'multiple-tenants'; definition: Pick<DecisionDefinition, 'name' | 'decisionDefinitionId'>};
 
 type Props = {
 	decisionDefinitionSelection: DecisionDefinitionSelection;
+	isDefinitionSelectionLoading?: boolean;
+	isDefinitionSelectionError?: boolean;
 };
 
-const DecisionPanel: React.FC<Props> = ({decisionDefinitionSelection}) => {
+const DecisionPanel: React.FC<Props> = ({
+	decisionDefinitionSelection,
+	isDefinitionSelectionLoading = false,
+	isDefinitionSelectionError = false,
+}) => {
 	const {t} = useTranslation();
 	const selectedDefinitionKey =
 		decisionDefinitionSelection.kind === 'single-version'
@@ -42,10 +49,10 @@ const DecisionPanel: React.FC<Props> = ({decisionDefinitionSelection}) => {
 	const {data: xml, isFetching: isXmlFetching, isError: isXmlError} = useDecisionDefinitionXml(selectedDefinitionKey);
 
 	const getStatus = () => {
-		if (isXmlFetching) {
+		if (isDefinitionSelectionLoading || isXmlFetching) {
 			return 'loading';
 		}
-		if (isXmlError) {
+		if (isDefinitionSelectionError || isXmlError) {
 			return 'error';
 		}
 		if (decisionDefinitionSelection.kind !== 'single-version') {
@@ -54,23 +61,30 @@ const DecisionPanel: React.FC<Props> = ({decisionDefinitionSelection}) => {
 		return 'content';
 	};
 
+	const getEmptyMessage = () => {
+		switch (decisionDefinitionSelection.kind) {
+			case 'all-versions':
+				return {
+					message: t('operate.decisions.diagramPanel.multipleVersionsSelected', {name: selectedDefinitionName}),
+					additionalInfo: t('operate.decisions.diagramPanel.selectSingleVersion'),
+				};
+			case 'multiple-tenants':
+				return {
+					message: t('operate.decisions.diagramPanel.multipleTenantsSelected', {name: selectedDefinitionName}),
+					additionalInfo: t('operate.decisions.diagramPanel.selectSingleTenant'),
+				};
+			default:
+				return {
+					message: t('operate.decisions.diagramPanel.noDecisionSelected'),
+					additionalInfo: t('operate.decisions.diagramPanel.selectDecisionInFilters'),
+				};
+		}
+	};
+
 	return (
 		<Section aria-label="Decision Panel">
 			<DecisionHeader decisionDefinitionSelection={decisionDefinitionSelection} />
-			<DiagramShell
-				status={getStatus()}
-				emptyMessage={
-					decisionDefinitionSelection.kind === 'all-versions'
-						? {
-								message: t('operate.decisions.diagramPanel.multipleVersionsSelected', {name: selectedDefinitionName}),
-								additionalInfo: t('operate.decisions.diagramPanel.selectSingleVersion'),
-							}
-						: {
-								message: t('operate.decisions.diagramPanel.noDecisionSelected'),
-								additionalInfo: t('operate.decisions.diagramPanel.selectDecisionInFilters'),
-							}
-				}
-			>
+			<DiagramShell status={getStatus()} emptyMessage={getEmptyMessage()}>
 				<DecisionViewer xml={xml ?? null} decisionViewId={selectedDefinitionId ?? null} />
 			</DiagramShell>
 		</Section>

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/DecisionPanel.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/DecisionPanel.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useTranslation} from 'react-i18next';
+import type {DecisionDefinition} from '@camunda/camunda-api-zod-schemas/8.10';
+import {DecisionViewer} from '#/operate/shared/DecisionViewer';
+import {DiagramShell} from '#/operate/shared/DiagramShell/DiagramShell';
+import {DecisionHeader} from './DecisionHeader';
+import {useDecisionDefinitionXml} from './useDecisionDefinitionXml';
+import {getDecisionDefinitionName} from './getDecisionDefinitionName';
+import {Section} from './styled';
+
+type DecisionDefinitionSelection =
+	| {kind: 'no-match'}
+	| {kind: 'single-version'; definition: DecisionDefinition}
+	| {kind: 'all-versions'; definition: Pick<DecisionDefinition, 'name' | 'decisionDefinitionId'>};
+
+type Props = {
+	decisionDefinitionSelection: DecisionDefinitionSelection;
+};
+
+const DecisionPanel: React.FC<Props> = ({decisionDefinitionSelection}) => {
+	const {t} = useTranslation();
+	const selectedDefinitionKey =
+		decisionDefinitionSelection.kind === 'single-version'
+			? decisionDefinitionSelection.definition.decisionDefinitionKey
+			: undefined;
+	const selectedDefinitionId =
+		decisionDefinitionSelection.kind === 'single-version'
+			? decisionDefinitionSelection.definition.decisionDefinitionId
+			: undefined;
+	const selectedDefinitionName =
+		decisionDefinitionSelection.kind !== 'no-match'
+			? getDecisionDefinitionName(decisionDefinitionSelection.definition)
+			: t('operate.decisions.diagramHeader.title');
+
+	const {data: xml, isFetching: isXmlFetching, isError: isXmlError} = useDecisionDefinitionXml(selectedDefinitionKey);
+
+	const getStatus = () => {
+		if (isXmlFetching) {
+			return 'loading';
+		}
+		if (isXmlError) {
+			return 'error';
+		}
+		if (decisionDefinitionSelection.kind !== 'single-version') {
+			return 'empty';
+		}
+		return 'content';
+	};
+
+	return (
+		<Section aria-label="Decision Panel">
+			<DecisionHeader decisionDefinitionSelection={decisionDefinitionSelection} />
+			<DiagramShell
+				status={getStatus()}
+				emptyMessage={
+					decisionDefinitionSelection.kind === 'all-versions'
+						? {
+								message: t('operate.decisions.diagramPanel.multipleVersionsSelected', {name: selectedDefinitionName}),
+								additionalInfo: t('operate.decisions.diagramPanel.selectSingleVersion'),
+							}
+						: {
+								message: t('operate.decisions.diagramPanel.noDecisionSelected'),
+								additionalInfo: t('operate.decisions.diagramPanel.selectDecisionInFilters'),
+							}
+				}
+			>
+				<DecisionViewer xml={xml ?? null} decisionViewId={selectedDefinitionId ?? null} />
+			</DiagramShell>
+		</Section>
+	);
+};
+
+export {DecisionPanel};
+export type {DecisionDefinitionSelection};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/Decisions.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/Decisions.test.tsx
@@ -21,6 +21,8 @@ import {
 } from '#/shared-test-modules/api-mocks/decision-definitions';
 import {createQueryDecisionInstancesResponse} from '#/shared-test-modules/api-mocks/decision-instances';
 import {createSystemConfiguration} from '#/shared-test-modules/api-mocks/system-configuration';
+import {Notifications} from '#/shared/notifications/components/Notifications';
+import {notificationsStore} from '#/shared/notifications/notifications.store';
 import {DecisionsHarness} from './DecisionsHarness';
 
 const DECISION_DEFINITIONS = HttpResponse.json(
@@ -50,6 +52,7 @@ describe('<Decisions />', () => {
 
 	afterEach(() => {
 		sessionStorage.clear();
+		notificationsStore.reset();
 	});
 
 	it('should render the filter sections', async ({worker}) => {
@@ -104,6 +107,27 @@ describe('<Decisions />', () => {
 		const getSearch = () => screen.router.state.location.search as Record<string, unknown>;
 		await expect.poll(getSearch).toMatchObject({decisionDefinitionId: 'invoice-approval'});
 		expect(getSearch().decisionDefinitionVersion).toBeUndefined();
+	});
+
+	it('clears the decision filter and shows an error toast when the decision id has no match', async ({worker}) => {
+		worker.use(
+			mockQueryDecisionDefinitionsEndpoint({successResponse: DECISION_DEFINITIONS}),
+			mockQueryDecisionInstancesEndpoint({successResponse: EMPTY_DECISION_INSTANCES}),
+		);
+
+		const screen = await renderWithRouter(
+			() => (
+				<>
+					<DecisionsHarness />
+					<Notifications />
+				</>
+			),
+			{path: '/operate/decisions', initialEntry: '/operate/decisions?decisionDefinitionId=does-not-exist'},
+		);
+		const getSearch = () => screen.router.state.location.search as Record<string, unknown>;
+
+		await expect.element(screen.getByText('Decision could not be found')).toBeVisible();
+		await expect.poll(() => getSearch().decisionDefinitionId).toBeUndefined();
 	});
 
 	describe('instance state checkboxes', () => {

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/Decisions.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/Decisions.test.tsx
@@ -12,13 +12,16 @@ import {HttpResponse} from 'msw';
 import {it} from '#/vitest-modules/test-extend';
 import {renderWithRouter} from '#/vitest-modules/render-with-router';
 import {
+	mockGetDecisionDefinitionXmlEndpoint,
 	mockQueryDecisionDefinitionsEndpoint,
+	mockQueryDecisionDefinitionsEndpointByFilter,
 	mockQueryDecisionInstancesEndpoint,
 } from '#/shared-test-modules/mock-handlers';
 import {
 	createDecisionDefinition,
 	createQueryDecisionDefinitionsResponse,
 } from '#/shared-test-modules/api-mocks/decision-definitions';
+import {DMN_XML} from '#/shared-test-modules/api-mocks/decision-definition-xmls';
 import {createQueryDecisionInstancesResponse} from '#/shared-test-modules/api-mocks/decision-instances';
 import {createSystemConfiguration} from '#/shared-test-modules/api-mocks/system-configuration';
 import {Notifications} from '#/shared/notifications/components/Notifications';
@@ -95,6 +98,7 @@ describe('<Decisions />', () => {
 		worker.use(
 			mockQueryDecisionDefinitionsEndpoint({successResponse: DECISION_DEFINITIONS}),
 			mockQueryDecisionInstancesEndpoint({successResponse: EMPTY_DECISION_INSTANCES}),
+			mockGetDecisionDefinitionXmlEndpoint({successResponse: HttpResponse.text(DMN_XML)}),
 		);
 
 		const screen = await renderDecisionsPage({decisionDefinitionId: 'discount-rate', decisionDefinitionVersion: '1'});
@@ -128,6 +132,133 @@ describe('<Decisions />', () => {
 
 		await expect.element(screen.getByText('Decision could not be found')).toBeVisible();
 		await expect.poll(() => getSearch().decisionDefinitionId).toBeUndefined();
+		expect(screen.router.history.canGoBack()).toBe(false);
+	});
+
+	it('should resolve a selected decision outside the loaded definitions page', async ({worker}) => {
+		const selectedDefinition = createDecisionDefinition({
+			name: 'Later Decision',
+			decisionDefinitionId: 'later-decision',
+			version: 2,
+		});
+		const olderDefinition = createDecisionDefinition({
+			name: 'Later Decision',
+			decisionDefinitionId: 'later-decision',
+			version: 1,
+		});
+		worker.use(
+			mockQueryDecisionDefinitionsEndpointByFilter({
+				unfilteredResponse: HttpResponse.json(
+					createQueryDecisionDefinitionsResponse({
+						items: [],
+						page: {hasMoreTotalItems: true, totalItems: 1001},
+					}),
+				),
+				filteredResponse: HttpResponse.json(createQueryDecisionDefinitionsResponse({items: [selectedDefinition]})),
+				versionsResponses: [
+					HttpResponse.json(
+						createQueryDecisionDefinitionsResponse({
+							items: [selectedDefinition],
+							page: {totalItems: 2, endCursor: 'next-page', hasMoreTotalItems: true},
+						}),
+					),
+					HttpResponse.json(
+						createQueryDecisionDefinitionsResponse({
+							items: [olderDefinition],
+							page: {totalItems: 2},
+						}),
+					),
+				],
+			}),
+			mockQueryDecisionInstancesEndpoint({successResponse: EMPTY_DECISION_INSTANCES}),
+			mockGetDecisionDefinitionXmlEndpoint({successResponse: HttpResponse.text(DMN_XML)}),
+		);
+
+		const screen = await renderDecisionsPage({
+			decisionDefinitionId: 'later-decision',
+			decisionDefinitionVersion: '2',
+		});
+
+		await expect.element(screen.getByRole('heading', {name: 'Later Decision'})).toBeVisible();
+		await expect.element(screen.getByRole('combobox', {name: 'Name'})).toHaveValue('Later Decision');
+		await expect.element(screen.getByRole('combobox', {name: 'Version'})).toHaveTextContent('2');
+		await userEvent.click(screen.getByRole('combobox', {name: 'Version'}));
+		await expect.element(screen.getByRole('option', {name: '1'})).toBeVisible();
+		expect((screen.router.state.location.search as Record<string, unknown>).decisionDefinitionId).toBe(
+			'later-decision',
+		);
+	});
+
+	it('should wait for a stale missing selection to refetch before clearing it', async ({worker}) => {
+		const emptyResponse = HttpResponse.json(createQueryDecisionDefinitionsResponse());
+		worker.use(
+			mockQueryDecisionDefinitionsEndpointByFilter({
+				unfilteredResponse: DECISION_DEFINITIONS,
+				filteredResponse: emptyResponse,
+			}),
+			mockQueryDecisionInstancesEndpoint({successResponse: EMPTY_DECISION_INSTANCES}),
+			mockGetDecisionDefinitionXmlEndpoint({successResponse: HttpResponse.text(DMN_XML)}),
+		);
+
+		const screen = await renderDecisionsPage({
+			decisionDefinitionId: 'new-decision',
+			decisionDefinitionVersion: '1',
+		});
+		const getSearch = () => screen.router.state.location.search as Record<string, unknown>;
+		await expect.poll(() => getSearch().decisionDefinitionId).toBeUndefined();
+
+		const newDefinition = createDecisionDefinition({
+			name: 'New Decision',
+			decisionDefinitionId: 'new-decision',
+			version: 1,
+		});
+		worker.use(
+			mockQueryDecisionDefinitionsEndpointByFilter({
+				unfilteredResponse: DECISION_DEFINITIONS,
+				filteredResponse: HttpResponse.json(createQueryDecisionDefinitionsResponse({items: [newDefinition]})),
+			}),
+		);
+
+		await screen.router.navigate({
+			to: '.',
+			search: {decisionDefinitionId: 'new-decision', decisionDefinitionVersion: 1},
+		});
+
+		await expect.element(screen.getByRole('heading', {name: 'New Decision'})).toBeVisible();
+		expect(getSearch().decisionDefinitionId).toBe('new-decision');
+	});
+
+	it('should ask for a tenant when a decision version exists in multiple tenants', async ({worker}) => {
+		const definitions = HttpResponse.json(
+			createQueryDecisionDefinitionsResponse({
+				items: [
+					createDecisionDefinition({
+						name: 'Invoice Approval',
+						decisionDefinitionId: 'invoice-approval',
+						version: 1,
+						tenantId: '<tenant-A>',
+					}),
+					createDecisionDefinition({
+						name: 'Invoice Approval',
+						decisionDefinitionId: 'invoice-approval',
+						version: 1,
+						tenantId: '<tenant-B>',
+					}),
+				],
+			}),
+		);
+		worker.use(
+			mockQueryDecisionDefinitionsEndpoint({successResponse: definitions}),
+			mockQueryDecisionInstancesEndpoint({successResponse: EMPTY_DECISION_INSTANCES}),
+		);
+
+		const screen = await renderDecisionsPage({
+			decisionDefinitionId: 'invoice-approval',
+			decisionDefinitionVersion: '1',
+			tenantId: 'all',
+		});
+
+		await expect.element(screen.getByText('Decision "Invoice Approval" exists in more than one Tenant')).toBeVisible();
 	});
 
 	describe('instance state checkboxes', () => {

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/Decisions.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/Decisions.tsx
@@ -24,6 +24,7 @@ import {WarningFilled, CheckmarkOutline} from '#/operate/shared/StateIcon/styled
 import {VisuallyHiddenH1} from '#/operate/shared/VisuallyHiddenH1/VisuallyHiddenH1';
 import {InstancesTable} from './InstancesTable';
 import {OptionalFiltersFormGroup, type OptionalFilter, type OptionalFilterValues} from './OptionalFiltersFormGroup';
+import {DecisionPanel, type DecisionDefinitionSelection} from './DecisionPanel';
 import type {DecisionsSearch} from './decisionsFilter';
 
 type FiltersFormValues = OptionalFilterValues & {
@@ -83,6 +84,24 @@ const Decisions: React.FC<Props> = ({
 	}, [data, decisionDefinitionId]);
 
 	const selectedDecision = decisionItems.find((item) => item.id === decisionDefinitionId) ?? null;
+
+	const decisionDefinitionSelection = useMemo<DecisionDefinitionSelection>(() => {
+		if (!decisionDefinitionId) {
+			return {kind: 'no-match'};
+		}
+
+		const matches = data.items.filter((def) => def.decisionDefinitionId === decisionDefinitionId);
+
+		if (decisionDefinitionVersion === undefined) {
+			const first = matches[0];
+			return first === undefined
+				? {kind: 'no-match'}
+				: {kind: 'all-versions', definition: {name: first.name, decisionDefinitionId: first.decisionDefinitionId}};
+		}
+
+		const definition = matches.find((def) => def.version === decisionDefinitionVersion);
+		return definition === undefined ? {kind: 'no-match'} : {kind: 'single-version', definition};
+	}, [data, decisionDefinitionId, decisionDefinitionVersion]);
 
 	const hasOptionalFilters =
 		tenantId !== undefined || Object.values(optionalFilterValues).some((value) => value !== undefined);
@@ -238,7 +257,7 @@ const Decisions: React.FC<Props> = ({
 						)}
 					</Form>
 				}
-				topPanel={<div />}
+				topPanel={<DecisionPanel decisionDefinitionSelection={decisionDefinitionSelection} />}
 				bottomPanel={
 					<InstancesTable
 						search={{

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/Decisions.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/Decisions.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useMemo, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useSuspenseQuery} from '@tanstack/react-query';
 import {useNavigate} from '@tanstack/react-router';
@@ -15,6 +15,7 @@ import {Checkbox, ComboBox, Dropdown, Stack} from '@carbon/react';
 import {decisionDefinitionsOptions} from './decisions.queries';
 import {isSpecificTenant} from '#/operate/shared/utils/isSpecificTenant';
 import {getClientConfig} from '#/shared/config/getClientConfig';
+import {notificationsStore} from '#/shared/notifications/notifications.store';
 import {InstancesList} from '#/operate/shared/InstancesList/InstancesList';
 import {FiltersPanel} from '#/operate/shared/FiltersPanel/FiltersPanel';
 import {Title, Form as StyledForm} from '#/operate/shared/FiltersPanel/styled';
@@ -102,6 +103,22 @@ const Decisions: React.FC<Props> = ({
 		const definition = matches.find((def) => def.version === decisionDefinitionVersion);
 		return definition === undefined ? {kind: 'no-match'} : {kind: 'single-version', definition};
 	}, [data, decisionDefinitionId, decisionDefinitionVersion]);
+
+	useEffect(() => {
+		if (decisionDefinitionId === undefined || decisionDefinitionSelection.kind !== 'no-match') {
+			return;
+		}
+
+		void navigate({
+			to: '.',
+			search: (prev) => ({...prev, decisionDefinitionId: undefined, decisionDefinitionVersion: undefined}),
+		});
+		notificationsStore.displayNotification({
+			kind: 'error',
+			title: t('operate.decisions.diagramPanel.decisionNotFoundTitle'),
+			isDismissable: true,
+		});
+	}, [decisionDefinitionId, decisionDefinitionSelection, navigate, t]);
 
 	const hasOptionalFilters =
 		tenantId !== undefined || Object.values(optionalFilterValues).some((value) => value !== undefined);

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/Decisions.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/Decisions.tsx
@@ -8,11 +8,11 @@
 
 import {useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import {useSuspenseQuery} from '@tanstack/react-query';
+import {useQuery, useSuspenseQuery} from '@tanstack/react-query';
 import {useNavigate} from '@tanstack/react-router';
 import {Form} from 'react-final-form';
 import {Checkbox, ComboBox, Dropdown, Stack} from '@carbon/react';
-import {decisionDefinitionsOptions} from './decisions.queries';
+import {decisionDefinitionSelectionOptions, decisionDefinitionsOptions} from './decisions.queries';
 import {isSpecificTenant} from '#/operate/shared/utils/isSpecificTenant';
 import {getClientConfig} from '#/shared/config/getClientConfig';
 import {notificationsStore} from '#/shared/notifications/notifications.store';
@@ -26,6 +26,7 @@ import {VisuallyHiddenH1} from '#/operate/shared/VisuallyHiddenH1/VisuallyHidden
 import {InstancesTable} from './InstancesTable';
 import {OptionalFiltersFormGroup, type OptionalFilter, type OptionalFilterValues} from './OptionalFiltersFormGroup';
 import {DecisionPanel, type DecisionDefinitionSelection} from './DecisionPanel';
+import {useDecisionDefinitionVersions} from './useDecisionDefinitionVersions';
 import type {DecisionsSearch} from './decisionsFilter';
 
 type FiltersFormValues = OptionalFilterValues & {
@@ -62,36 +63,74 @@ const Decisions: React.FC<Props> = ({
 		[decisionEvaluationInstanceKey, processInstanceKey, businessId, evaluationDateFrom, evaluationDateTo],
 	);
 
+	const decisionDefinitionSelectionQuery = useQuery({
+		...decisionDefinitionSelectionOptions({
+			decisionDefinitionId,
+			decisionDefinitionVersion,
+			tenantId: specificTenantId,
+		}),
+		enabled: decisionDefinitionId !== undefined,
+	});
+	const decisionDefinitionVersionsQuery = useDecisionDefinitionVersions(decisionDefinitionId, specificTenantId);
+
 	const decisionItems = useMemo<DecisionItem[]>(() => {
 		const seen = new Set<string>();
-		return data.items.reduce<DecisionItem[]>((acc, def) => {
+		const definitions = [
+			...data.items,
+			...(decisionDefinitionSelectionQuery.data?.items ?? []),
+			...(decisionDefinitionVersionsQuery.data ?? []),
+		];
+		const items = definitions.reduce<DecisionItem[]>((acc, def) => {
 			if (!seen.has(def.decisionDefinitionId)) {
 				seen.add(def.decisionDefinitionId);
 				acc.push({id: def.decisionDefinitionId, label: def.name ?? def.decisionDefinitionId});
 			}
 			return acc;
 		}, []);
-	}, [data]);
+		if (decisionDefinitionId !== undefined && !seen.has(decisionDefinitionId)) {
+			items.push({id: decisionDefinitionId, label: decisionDefinitionId});
+		}
+		return items;
+	}, [data, decisionDefinitionId, decisionDefinitionSelectionQuery.data, decisionDefinitionVersionsQuery.data]);
 
 	const versionNumbers = useMemo<(number | undefined)[]>(() => {
 		if (!decisionDefinitionId) {
 			return [];
 		}
-		const versions = data.items
-			.filter((def) => def.decisionDefinitionId === decisionDefinitionId)
-			.sort((a, b) => b.version - a.version)
-			.map((def) => def.version);
+		const definitions = [
+			...data.items,
+			...(decisionDefinitionSelectionQuery.data?.items ?? []),
+			...(decisionDefinitionVersionsQuery.data ?? []),
+		];
+		const versionSet = new Set(
+			definitions.filter((def) => def.decisionDefinitionId === decisionDefinitionId).map((def) => def.version),
+		);
+		if (decisionDefinitionVersion !== undefined) {
+			versionSet.add(decisionDefinitionVersion);
+		}
+		const versions = [...versionSet].sort((a, b) => b - a);
 		return [undefined, ...versions];
-	}, [data, decisionDefinitionId]);
+	}, [
+		data,
+		decisionDefinitionId,
+		decisionDefinitionSelectionQuery.data,
+		decisionDefinitionVersion,
+		decisionDefinitionVersionsQuery.data,
+	]);
 
 	const selectedDecision = decisionItems.find((item) => item.id === decisionDefinitionId) ?? null;
 
 	const decisionDefinitionSelection = useMemo<DecisionDefinitionSelection>(() => {
-		if (!decisionDefinitionId) {
+		if (!decisionDefinitionId || decisionDefinitionSelectionQuery.status !== 'success') {
 			return {kind: 'no-match'};
 		}
 
-		const matches = data.items.filter((def) => def.decisionDefinitionId === decisionDefinitionId);
+		const matches = decisionDefinitionSelectionQuery.data.items.filter(
+			(definition) =>
+				definition.decisionDefinitionId === decisionDefinitionId &&
+				(decisionDefinitionVersion === undefined || definition.version === decisionDefinitionVersion) &&
+				(specificTenantId === undefined || definition.tenantId === specificTenantId),
+		);
 
 		if (decisionDefinitionVersion === undefined) {
 			const first = matches[0];
@@ -100,25 +139,53 @@ const Decisions: React.FC<Props> = ({
 				: {kind: 'all-versions', definition: {name: first.name, decisionDefinitionId: first.decisionDefinitionId}};
 		}
 
-		const definition = matches.find((def) => def.version === decisionDefinitionVersion);
-		return definition === undefined ? {kind: 'no-match'} : {kind: 'single-version', definition};
-	}, [data, decisionDefinitionId, decisionDefinitionVersion]);
+		const definition = matches[0];
+		if (definition === undefined) {
+			return {kind: 'no-match'};
+		}
+		if (new Set(matches.map(({tenantId: definitionTenantId}) => definitionTenantId)).size > 1) {
+			return {
+				kind: 'multiple-tenants',
+				definition: {name: definition.name, decisionDefinitionId: definition.decisionDefinitionId},
+			};
+		}
+		return {kind: 'single-version', definition};
+	}, [
+		decisionDefinitionId,
+		decisionDefinitionSelectionQuery.data,
+		decisionDefinitionSelectionQuery.status,
+		decisionDefinitionVersion,
+		specificTenantId,
+	]);
 
 	useEffect(() => {
-		if (decisionDefinitionId === undefined || decisionDefinitionSelection.kind !== 'no-match') {
+		if (
+			decisionDefinitionId === undefined ||
+			decisionDefinitionSelectionQuery.status !== 'success' ||
+			decisionDefinitionSelectionQuery.fetchStatus !== 'idle' ||
+			decisionDefinitionSelection.kind !== 'no-match'
+		) {
 			return;
 		}
 
 		void navigate({
 			to: '.',
 			search: (prev) => ({...prev, decisionDefinitionId: undefined, decisionDefinitionVersion: undefined}),
+			replace: true,
 		});
 		notificationsStore.displayNotification({
 			kind: 'error',
 			title: t('operate.decisions.diagramPanel.decisionNotFoundTitle'),
 			isDismissable: true,
 		});
-	}, [decisionDefinitionId, decisionDefinitionSelection, navigate, t]);
+	}, [
+		decisionDefinitionId,
+		decisionDefinitionSelection,
+		decisionDefinitionSelectionQuery.fetchStatus,
+		decisionDefinitionSelectionQuery.status,
+		navigate,
+		t,
+	]);
 
 	const hasOptionalFilters =
 		tenantId !== undefined || Object.values(optionalFilterValues).some((value) => value !== undefined);
@@ -274,7 +341,16 @@ const Decisions: React.FC<Props> = ({
 						)}
 					</Form>
 				}
-				topPanel={<DecisionPanel decisionDefinitionSelection={decisionDefinitionSelection} />}
+				topPanel={
+					<DecisionPanel
+						decisionDefinitionSelection={decisionDefinitionSelection}
+						isDefinitionSelectionLoading={
+							decisionDefinitionId !== undefined &&
+							(decisionDefinitionSelectionQuery.isPending || decisionDefinitionSelectionQuery.fetchStatus !== 'idle')
+						}
+						isDefinitionSelectionError={decisionDefinitionSelectionQuery.isError}
+					/>
+				}
 				bottomPanel={
 					<InstancesTable
 						search={{

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/decisions.queries.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/decisions.queries.ts
@@ -11,6 +11,13 @@ import type {QueryDecisionDefinitionsResponseBody} from '@camunda/camunda-api-zo
 import {ForbiddenError} from '#/shared/errors';
 import {request} from '#/shared/http/request';
 import {endpoints} from '#/shared/http/endpoints';
+import {queries} from '#/shared/http/queries';
+
+type DecisionDefinitionSelectionOptions = {
+	decisionDefinitionId?: string;
+	decisionDefinitionVersion?: number;
+	tenantId?: string;
+};
 
 function decisionDefinitionsOptions(tenantId?: string) {
 	return queryOptions({
@@ -30,4 +37,20 @@ function decisionDefinitionsOptions(tenantId?: string) {
 	});
 }
 
-export {decisionDefinitionsOptions};
+function decisionDefinitionSelectionOptions({
+	decisionDefinitionId,
+	decisionDefinitionVersion,
+	tenantId,
+}: DecisionDefinitionSelectionOptions) {
+	return queries.queryDecisionDefinitions({
+		filter: {
+			decisionDefinitionId,
+			version: decisionDefinitionVersion,
+			tenantId,
+		},
+		page: {limit: decisionDefinitionVersion === undefined ? 1 : 2},
+		sort: [{field: 'version', order: 'desc'}],
+	});
+}
+
+export {decisionDefinitionsOptions, decisionDefinitionSelectionOptions};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/getDecisionDefinitionName.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/getDecisionDefinitionName.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {DecisionDefinition} from '@camunda/camunda-api-zod-schemas/8.10';
+
+function getDecisionDefinitionName(definition: Pick<DecisionDefinition, 'name' | 'decisionDefinitionId'>) {
+	return definition.name ?? definition.decisionDefinitionId;
+}
+
+export {getDecisionDefinitionName};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/styled.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/styled.ts
@@ -8,6 +8,8 @@
 
 import styled from 'styled-components';
 import {Link} from '@carbon/react';
+import {PanelHeader as BasePanelHeader} from '#/operate/shared/PanelHeader/PanelHeader';
+import {CopiableContent as BaseCopiableContent} from '#/operate/shared/PanelHeader/CopiableContent';
 
 const Container = styled.section`
 	height: 100%;
@@ -27,4 +29,28 @@ const InstanceLink = styled(Link)`
 	}
 `;
 
-export {Container, DecisionName, InstanceLink};
+const Section = styled.section`
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+`;
+
+const PanelHeader = styled(BasePanelHeader)`
+	padding-right: 0;
+`;
+
+const CopiableContent = styled(BaseCopiableContent)`
+	display: inline-flex;
+	margin-left: var(--cds-spacing-09);
+	position: relative;
+	&:before {
+		content: ' ';
+		position: absolute;
+		left: calc(-1 * var(--cds-spacing-05));
+		height: var(--cds-spacing-06);
+		width: 1px;
+		background-color: var(--cds-border-subtle-01);
+	}
+`;
+
+export {Container, DecisionName, InstanceLink, Section, PanelHeader, CopiableContent};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/useDecisionDefinitionVersions.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/useDecisionDefinitionVersions.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {skipToken, useQuery} from '@tanstack/react-query';
+import type {DecisionDefinition} from '@camunda/camunda-api-zod-schemas/8.10';
+import {request} from '#/shared/http/request';
+import {endpoints} from '#/shared/http/endpoints';
+
+const PAGE_LIMIT = 1000;
+
+function useDecisionDefinitionVersions(decisionDefinitionId?: string, tenantId?: string) {
+	return useQuery({
+		queryKey: ['decisionDefinitionVersions', decisionDefinitionId, tenantId] as const,
+		queryFn:
+			decisionDefinitionId === undefined
+				? skipToken
+				: async (): Promise<DecisionDefinition[]> => {
+						const definitions: DecisionDefinition[] = [];
+						let after: string | undefined;
+
+						while (true) {
+							const {response, error} = await request(
+								endpoints.queryDecisionDefinitions({
+									filter: {decisionDefinitionId, tenantId},
+									sort: [{field: 'version', order: 'desc'}],
+									page: {after, limit: PAGE_LIMIT},
+								}),
+							);
+							if (error !== null) {
+								throw error;
+							}
+
+							const result = await response.json();
+							definitions.push(...result.items);
+
+							const nextCursor = result.page.endCursor ?? undefined;
+							if (
+								result.items.length === 0 ||
+								nextCursor === undefined ||
+								nextCursor === after ||
+								(!result.page.hasMoreTotalItems && definitions.length >= result.page.totalItems)
+							) {
+								return definitions;
+							}
+							after = nextCursor;
+						}
+					},
+	});
+}
+
+export {useDecisionDefinitionVersions};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/useDecisionDefinitionVersions.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/useDecisionDefinitionVersions.ts
@@ -50,6 +50,7 @@ function useDecisionDefinitionVersions(decisionDefinitionId?: string, tenantId?:
 							after = nextCursor;
 						}
 					},
+		staleTime: 'static',
 	});
 }
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/useDecisionDefinitionXml.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Decisions/useDecisionDefinitionXml.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {skipToken, useQuery} from '@tanstack/react-query';
+import {request} from '#/shared/http/request';
+import {endpoints} from '#/shared/http/endpoints';
+
+function useDecisionDefinitionXml(decisionDefinitionKey?: string) {
+	return useQuery({
+		queryKey: ['decisionDefinitionXml', decisionDefinitionKey] as const,
+		queryFn:
+			decisionDefinitionKey === undefined
+				? skipToken
+				: async () => {
+						const {response, error} = await request(endpoints.getDecisionDefinitionXml({decisionDefinitionKey}));
+						if (error !== null) {
+							throw error;
+						}
+
+						return response.text();
+					},
+		staleTime: 'static',
+	});
+}
+
+export {useDecisionDefinitionXml};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/PanelHeader/CopiableContent.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/PanelHeader/CopiableContent.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useTranslation} from 'react-i18next';
+import {CodeSnippet, Layer} from '@carbon/react';
+
+type Props = {
+	content: string;
+	copyButtonDescription: string;
+	className?: string;
+};
+
+const CopiableContent: React.FC<Props> = ({content, copyButtonDescription, className}) => {
+	const {t} = useTranslation();
+	return (
+		<Layer className={className}>
+			<CodeSnippet
+				type="inline"
+				// @ts-expect-error - Carbon types are wrong
+				title={copyButtonDescription}
+				aria-label={copyButtonDescription}
+				feedback={t('operate.shared.copyButton.copiedToClipboard')}
+			>
+				{content}
+			</CodeSnippet>
+		</Layer>
+	);
+};
+
+export {CopiableContent};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
@@ -26,6 +26,7 @@ import {
 	type QueryAuditLogsRequestBody,
 	type UserTask,
 	type ProcessDefinition,
+	type DecisionDefinition,
 	type AuditLog,
 	type DecisionInstance,
 	type Variable,
@@ -211,6 +212,13 @@ const endpoints = {
 			...BASE_REQUEST_OPTIONS,
 			method: unifiedAPIEndpoints.createDecisionInstancesDeletionBatchOperation.method,
 			body: JSON.stringify(body),
+			headers: {'Content-Type': 'application/json'},
+		}),
+
+	getDecisionDefinitionXml: ({decisionDefinitionKey}: Pick<DecisionDefinition, 'decisionDefinitionKey'>) =>
+		new Request(getFullURL(unifiedAPIEndpoints.getDecisionDefinitionXml.getUrl({decisionDefinitionKey})), {
+			...BASE_REQUEST_OPTIONS,
+			method: unifiedAPIEndpoints.getDecisionDefinitionXml.method,
 			headers: {'Content-Type': 'application/json'},
 		}),
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
@@ -490,7 +490,8 @@
 					"multipleVersionsSelected": "Für die Entscheidung \"{{name}}\" ist mehr als eine Version ausgewählt",
 					"selectSingleVersion": "Um eine Entscheidungstabelle oder einen literalen Ausdruck zu sehen, wählen Sie eine einzelne Version aus",
 					"noDecisionSelected": "Es ist keine Entscheidung ausgewählt",
-					"selectDecisionInFilters": "Um eine Entscheidungstabelle oder einen literalen Ausdruck zu sehen, wählen Sie eine Entscheidung im Filterbereich aus"
+					"selectDecisionInFilters": "Um eine Entscheidungstabelle oder einen literalen Ausdruck zu sehen, wählen Sie eine Entscheidung im Filterbereich aus",
+					"decisionNotFoundTitle": "Entscheidung konnte nicht gefunden werden"
 				},
 				"filters": {
 					"tenant": "Mandant",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
@@ -489,6 +489,8 @@
 				"diagramPanel": {
 					"multipleVersionsSelected": "Für die Entscheidung \"{{name}}\" ist mehr als eine Version ausgewählt",
 					"selectSingleVersion": "Um eine Entscheidungstabelle oder einen literalen Ausdruck zu sehen, wählen Sie eine einzelne Version aus",
+					"multipleTenantsSelected": "Die Entscheidung \"{{name}}\" ist in mehr als einem Mandanten vorhanden",
+					"selectSingleTenant": "Um eine Entscheidungstabelle oder einen literalen Ausdruck zu sehen, wählen Sie einen einzelnen Mandanten aus",
 					"noDecisionSelected": "Es ist keine Entscheidung ausgewählt",
 					"selectDecisionInFilters": "Um eine Entscheidungstabelle oder einen literalen Ausdruck zu sehen, wählen Sie eine Entscheidung im Filterbereich aus",
 					"decisionNotFoundTitle": "Entscheidung konnte nicht gefunden werden"

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
@@ -482,6 +482,16 @@
 			},
 			"decisions": {
 				"title": "Entscheidungen",
+				"diagramHeader": {
+					"title": "Entscheidung",
+					"copyButtonDescription": "Entscheidungs-ID / Klicken zum Kopieren"
+				},
+				"diagramPanel": {
+					"multipleVersionsSelected": "Für die Entscheidung \"{{name}}\" ist mehr als eine Version ausgewählt",
+					"selectSingleVersion": "Um eine Entscheidungstabelle oder einen literalen Ausdruck zu sehen, wählen Sie eine einzelne Version aus",
+					"noDecisionSelected": "Es ist keine Entscheidung ausgewählt",
+					"selectDecisionInFilters": "Um eine Entscheidungstabelle oder einen literalen Ausdruck zu sehen, wählen Sie eine Entscheidung im Filterbereich aus"
+				},
 				"filters": {
 					"tenant": "Mandant",
 					"decisionSection": "Entscheidung",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
@@ -503,6 +503,8 @@
 				"diagramPanel": {
 					"multipleVersionsSelected": "There is more than one Version selected for Decision \"{{name}}\"",
 					"selectSingleVersion": "To see a Decision Table or a Literal Expression, select a single Version",
+					"multipleTenantsSelected": "Decision \"{{name}}\" exists in more than one Tenant",
+					"selectSingleTenant": "To see a Decision Table or a Literal Expression, select a single Tenant",
 					"noDecisionSelected": "There is no Decision selected",
 					"selectDecisionInFilters": "To see a Decision Table or a Literal Expression, select a Decision in the Filters panel",
 					"decisionNotFoundTitle": "Decision could not be found"

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
@@ -504,7 +504,8 @@
 					"multipleVersionsSelected": "There is more than one Version selected for Decision \"{{name}}\"",
 					"selectSingleVersion": "To see a Decision Table or a Literal Expression, select a single Version",
 					"noDecisionSelected": "There is no Decision selected",
-					"selectDecisionInFilters": "To see a Decision Table or a Literal Expression, select a Decision in the Filters panel"
+					"selectDecisionInFilters": "To see a Decision Table or a Literal Expression, select a Decision in the Filters panel",
+					"decisionNotFoundTitle": "Decision could not be found"
 				},
 				"filters": {
 					"tenant": "Tenant",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
@@ -496,6 +496,16 @@
 			},
 			"decisions": {
 				"title": "Decisions",
+				"diagramHeader": {
+					"title": "Decision",
+					"copyButtonDescription": "Decision ID / Click to copy"
+				},
+				"diagramPanel": {
+					"multipleVersionsSelected": "There is more than one Version selected for Decision \"{{name}}\"",
+					"selectSingleVersion": "To see a Decision Table or a Literal Expression, select a single Version",
+					"noDecisionSelected": "There is no Decision selected",
+					"selectDecisionInFilters": "To see a Decision Table or a Literal Expression, select a Decision in the Filters panel"
+				},
 				"filters": {
 					"tenant": "Tenant",
 					"decisionSection": "Decision",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
@@ -489,6 +489,8 @@
 				"diagramPanel": {
 					"multipleVersionsSelected": "Hay más de una versión seleccionada para la decisión \"{{name}}\"",
 					"selectSingleVersion": "Para ver una tabla de decisión o una expresión literal, seleccione una sola versión",
+					"multipleTenantsSelected": "La decisión \"{{name}}\" existe en más de un inquilino",
+					"selectSingleTenant": "Para ver una tabla de decisión o una expresión literal, seleccione un solo inquilino",
 					"noDecisionSelected": "No hay ninguna decisión seleccionada",
 					"selectDecisionInFilters": "Para ver una tabla de decisión o una expresión literal, seleccione una decisión en el panel de filtros",
 					"decisionNotFoundTitle": "No se pudo encontrar la decisión"

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
@@ -490,7 +490,8 @@
 					"multipleVersionsSelected": "Hay más de una versión seleccionada para la decisión \"{{name}}\"",
 					"selectSingleVersion": "Para ver una tabla de decisión o una expresión literal, seleccione una sola versión",
 					"noDecisionSelected": "No hay ninguna decisión seleccionada",
-					"selectDecisionInFilters": "Para ver una tabla de decisión o una expresión literal, seleccione una decisión en el panel de filtros"
+					"selectDecisionInFilters": "Para ver una tabla de decisión o una expresión literal, seleccione una decisión en el panel de filtros",
+					"decisionNotFoundTitle": "No se pudo encontrar la decisión"
 				},
 				"filters": {
 					"tenant": "Inquilino",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
@@ -482,6 +482,16 @@
 			},
 			"decisions": {
 				"title": "Decisiones",
+				"diagramHeader": {
+					"title": "Decisión",
+					"copyButtonDescription": "ID de decisión / Clic para copiar"
+				},
+				"diagramPanel": {
+					"multipleVersionsSelected": "Hay más de una versión seleccionada para la decisión \"{{name}}\"",
+					"selectSingleVersion": "Para ver una tabla de decisión o una expresión literal, seleccione una sola versión",
+					"noDecisionSelected": "No hay ninguna decisión seleccionada",
+					"selectDecisionInFilters": "Para ver una tabla de decisión o una expresión literal, seleccione una decisión en el panel de filtros"
+				},
 				"filters": {
 					"tenant": "Inquilino",
 					"decisionSection": "Decisión",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
@@ -493,7 +493,8 @@
 					"multipleVersionsSelected": "Plusieurs versions sont sélectionnées pour la décision \"{{name}}\"",
 					"selectSingleVersion": "Pour voir une table de décision ou une expression littérale, sélectionnez une seule version",
 					"noDecisionSelected": "Aucune décision n'est sélectionnée",
-					"selectDecisionInFilters": "Pour voir une table de décision ou une expression littérale, sélectionnez une décision dans le panneau de filtres"
+					"selectDecisionInFilters": "Pour voir une table de décision ou une expression littérale, sélectionnez une décision dans le panneau de filtres",
+					"decisionNotFoundTitle": "La décision n'a pas pu être trouvée"
 				},
 				"filters": {
 					"tenant": "Locataire",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
@@ -485,6 +485,16 @@
 			},
 			"decisions": {
 				"title": "Décisions",
+				"diagramHeader": {
+					"title": "Décision",
+					"copyButtonDescription": "ID de décision / Cliquer pour copier"
+				},
+				"diagramPanel": {
+					"multipleVersionsSelected": "Plusieurs versions sont sélectionnées pour la décision \"{{name}}\"",
+					"selectSingleVersion": "Pour voir une table de décision ou une expression littérale, sélectionnez une seule version",
+					"noDecisionSelected": "Aucune décision n'est sélectionnée",
+					"selectDecisionInFilters": "Pour voir une table de décision ou une expression littérale, sélectionnez une décision dans le panneau de filtres"
+				},
 				"filters": {
 					"tenant": "Locataire",
 					"decisionSection": "Décision",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
@@ -492,6 +492,8 @@
 				"diagramPanel": {
 					"multipleVersionsSelected": "Plusieurs versions sont sélectionnées pour la décision \"{{name}}\"",
 					"selectSingleVersion": "Pour voir une table de décision ou une expression littérale, sélectionnez une seule version",
+					"multipleTenantsSelected": "La décision \"{{name}}\" existe dans plusieurs locataires",
+					"selectSingleTenant": "Pour voir une table de décision ou une expression littérale, sélectionnez un seul locataire",
 					"noDecisionSelected": "Aucune décision n'est sélectionnée",
 					"selectDecisionInFilters": "Pour voir une table de décision ou une expression littérale, sélectionnez une décision dans le panneau de filtres",
 					"decisionNotFoundTitle": "La décision n'a pas pu être trouvée"


### PR DESCRIPTION
## Description

Ports the Decision panel from legacy Operate (`operate/client/src/App/Decisions/Decision/`) to the unified webapp: the `topPanel` on `/operate/decisions` was still a placeholder `<div />`, so selecting a decision in the filters had no visible effect. This PR wires in the panel + DMN diagram; the delete operation is split into a follow-up PR, since it depends on `DangerButton`/`OperationItems`, still unmerged in #59309.

Notable deviations from legacy:
- Selection resolves through an exact filtered query rather than the (1,000-item capped) definitions list, so bookmarked/deep-linked selections outside the loaded page still resolve.
- An ambiguous all-tenants match asks the user to pick a tenant instead of showing an arbitrary one.
- Ports `CopiableContent` (legacy, never migrated) into `operate/shared/PanelHeader/CopiableContent.tsx`.
- A no-match id clears the filter and shows an error toast, but only once the query is confirmed fresh (not mid-refetch).

i18n: de/fr/es are LLM-translated, native speaker review requested.

## Checklist

- [ ] Enable backports when necessary
- [ ] If this PR modifies the C8 Orchestration Cluster E2E Test Suite, the relevant tests have been run

## Related issues

Part of #56025 (the follow-up PR with `DecisionOperations` will close it)
