### PR TITLE
feat: accept and finalize draining

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DeleteResourceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DeleteResourceIT.java
@@ -14,10 +14,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
-import io.camunda.client.api.response.CreateBatchOperationResponse;
 import io.camunda.client.api.response.DeleteResourceResponse;
 import io.camunda.client.api.response.Process;
-import io.camunda.client.api.search.enums.BatchOperationType;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.configuration.HistoryDeletion;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -115,15 +113,10 @@ public class DeleteResourceIT {
             .send()
             .join();
 
-    // then
+    // then - no batch is returned; draining finalizes the deletion asynchronously
     assertThat(response).isNotNull();
     assertThat(response.getResourceKey()).isEqualTo(String.valueOf(processDefinitionKey));
-    final CreateBatchOperationResponse batchOperation = response.getCreateBatchOperationResponse();
-    assertThat(batchOperation).isNotNull();
-    assertThat(batchOperation.getBatchOperationKey()).isNotNull();
-    assertThat(Long.valueOf(batchOperation.getBatchOperationKey())).isGreaterThan(0);
-    assertThat(batchOperation.getBatchOperationType())
-        .isEqualTo(BatchOperationType.DELETE_PROCESS_INSTANCE);
+    assertThat(response.getCreateBatchOperationResponse()).isNull();
 
     waitForProcessInstances(camundaClient, f -> f.processDefinitionKey(processDefinitionKey), 0);
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessDefinitionHistoryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessDefinitionHistoryIT.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.DeleteResourceResponse;
+import io.camunda.client.api.search.enums.BatchOperationType;
 import io.camunda.client.api.search.enums.MessageSubscriptionType;
 import io.camunda.client.api.search.enums.ProcessDefinitionState;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
@@ -83,10 +84,8 @@ public class DeleteProcessDefinitionHistoryIT {
             .send()
             .join();
 
-    // then
-    final var batchOperationKey = result.getCreateBatchOperationResponse().getBatchOperationKey();
-    waitForBatchOperationWithCorrectTotalCount(camundaClient, batchOperationKey, 1);
-    waitForBatchOperationCompleted(camundaClient, batchOperationKey, 1, 0);
+    // then - no batch is returned; draining finalizes the deletion asynchronously
+    assertThat(result.getCreateBatchOperationResponse()).isNull();
     assertAllProcessInstanceDependantDataDeleted(camundaClient, piKey);
     assertProcessDefinitionDeleted(camundaClient, processDefinitionKey);
   }
@@ -117,10 +116,8 @@ public class DeleteProcessDefinitionHistoryIT {
             .send()
             .join();
 
-    // then - deletion should be successful
-    final var batchOperationKey = result.getCreateBatchOperationResponse().getBatchOperationKey();
-    waitForBatchOperationWithCorrectTotalCount(camundaClient, batchOperationKey, 3);
-    waitForBatchOperationCompleted(camundaClient, batchOperationKey, 3, 0);
+    // then - no batch is returned; draining finalizes the deletion asynchronously
+    assertThat(result.getCreateBatchOperationResponse()).isNull();
     assertAllProcessInstanceDependantDataDeleted(camundaClient, piKey1);
     assertAllProcessInstanceDependantDataDeleted(camundaClient, piKey2);
     assertAllProcessInstanceDependantDataDeleted(camundaClient, piKey3);
@@ -213,6 +210,65 @@ public class DeleteProcessDefinitionHistoryIT {
   }
 
   @Test
+  void shouldMarkProcessDefinitionAsDrainingWhileInstanceStillRunning() {
+    // given - a definition kept alive by a still-running instance (a user task never completes on
+    // its own, so the instance stays active and prevents the deletion from finalizing)
+    final var processId = Strings.newRandomValidBpmnId();
+    final var process =
+        deployProcessAndWaitForIt(
+            camundaClient,
+            Bpmn.createExecutableProcess(processId).startEvent().userTask("wait").endEvent().done(),
+            processId + ".bpmn");
+    final var processDefinitionKey = process.getProcessDefinitionKey();
+    startProcessInstance(camundaClient, processId);
+    waitForProcessInstances(
+        camundaClient, f -> f.processDefinitionId(processId).state(ProcessInstanceState.ACTIVE), 1);
+
+    // when - delete: the running instance blocks finalization, so the definition drains rather than
+    // being deleted outright
+    final DeleteResourceResponse result =
+        camundaClient
+            .newDeleteResourceCommand(processDefinitionKey)
+            .deleteHistory(false)
+            .send()
+            .join();
+    assertThat(result.getCreateBatchOperationResponse()).isNull();
+
+    // then - the DRAINING state is propagated into secondary storage
+    Awaitility.await("Process definition should be marked as draining")
+        .atMost(DELETION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var draining =
+                  camundaClient
+                      .newProcessDefinitionSearchRequest()
+                      .filter(
+                          f ->
+                              f.processDefinitionKey(processDefinitionKey)
+                                  .state(ProcessDefinitionState.DRAINING))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(draining).hasSize(1);
+              assertThat(draining.getFirst().getState()).isEqualTo(ProcessDefinitionState.DRAINING);
+            });
+
+    // and - a draining definition is no longer returned as ACTIVE
+    final var active =
+        camundaClient
+            .newProcessDefinitionSearchRequest()
+            .filter(
+                f ->
+                    f.processDefinitionKey(processDefinitionKey)
+                        .state(ProcessDefinitionState.ACTIVE))
+            .send()
+            .join()
+            .items();
+    assertThat(active).isEmpty();
+  }
+
+  @Test
   void shouldDeleteProcessDefinitionHistoryAfterDeletingWithoutHistory() {
     // given - a deployed process definition with completed process instances
     final var processId = Strings.newRandomValidBpmnId();
@@ -247,9 +303,16 @@ public class DeleteProcessDefinitionHistoryIT {
             .send()
             .join();
 
-    // then - the batch operation should be created and complete successfully
-    final var batchOperationKey =
-        resultWithHistory.getCreateBatchOperationResponse().getBatchOperationKey();
+    // then - the definition is already gone from primary storage, so this delete purges the
+    // leftover history directly and returns the batch operation details
+    final var batchOperation = resultWithHistory.getCreateBatchOperationResponse();
+    assertThat(batchOperation).isNotNull();
+    assertThat(batchOperation.getBatchOperationKey()).isNotNull();
+    assertThat(Long.valueOf(batchOperation.getBatchOperationKey())).isGreaterThan(0);
+    assertThat(batchOperation.getBatchOperationType())
+        .isEqualTo(BatchOperationType.DELETE_PROCESS_INSTANCE);
+
+    final var batchOperationKey = batchOperation.getBatchOperationKey();
     waitForBatchOperationWithCorrectTotalCount(camundaClient, batchOperationKey, 2);
     waitForBatchOperationCompleted(camundaClient, batchOperationKey, 2, 0);
     assertAllProcessInstanceDependantDataDeleted(camundaClient, piKey1);
@@ -279,9 +342,7 @@ public class DeleteProcessDefinitionHistoryIT {
             .deleteHistory(true)
             .send()
             .join();
-    final var batchOperationKey =
-        firstResult.getCreateBatchOperationResponse().getBatchOperationKey();
-    waitForBatchOperationCompleted(camundaClient, batchOperationKey, 1, 0);
+    assertThat(firstResult.getCreateBatchOperationResponse()).isNull();
     assertAllProcessInstanceDependantDataDeleted(camundaClient, piKey);
     assertProcessDefinitionDeleted(camundaClient, processDefinitionKey);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
@@ -378,6 +378,29 @@ public enum EngineMetricsDoc implements ExtendedMeterDocumentation {
     public KeyName[] getAdditionalKeyNames() {
       return PartitionKeyNames.values();
     }
+  },
+
+  /** Number of process definitions currently draining (deleted, awaiting last instance) */
+  DRAINING_PROCESS_DEFINITIONS {
+    @Override
+    public String getDescription() {
+      return "Number of process definitions currently draining (deleted, awaiting last instance)";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.process.definitions.draining.count";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
   };
 
   /** Tags/label values possibly used by the engine metrics. */

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessDefinitionMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessDefinitionMetrics.java
@@ -102,6 +102,14 @@ public final class ProcessDefinitionMetrics {
     drainingProcessDefinitions.decrementAndGet();
   }
 
+  /**
+   * Removes a definition deleted outright from the deployed count, without ever entering the
+   * draining count (its last instance was already gone). Live processing only.
+   */
+  public void processDefinitionDeleted(final long processDefinitionKey) {
+    removeDeployedDefinition(processDefinitionKey);
+  }
+
   private void removeDeployedDefinition(final long processDefinitionKey) {
     final var entry = entriesByKey.remove(processDefinitionKey);
     if (entry == null) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessDefinitionMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessDefinitionMetrics.java
@@ -29,6 +29,7 @@ public final class ProcessDefinitionMetrics {
 
   private final MeterRegistry registry;
   private final AtomicLong totalUniqueProcessIds = new AtomicLong(0);
+  private final AtomicLong drainingProcessDefinitions = new AtomicLong(0);
 
   // processDefinitionKey -> (bpmnProcessId, sizeBytes) — to know what to subtract on deletion
   private final Map<Long, KeyEntry> entriesByKey = new HashMap<>();
@@ -43,12 +44,15 @@ public final class ProcessDefinitionMetrics {
     this.registry = Objects.requireNonNull(registry);
 
     final long startNanos = System.nanoTime();
+    final var drainingCount = new AtomicLong(0);
     processState.forEachProcess(
         null,
         process -> {
           if (process.getState() == PersistedProcessState.ACTIVE) {
             final String bpmnProcessId = BufferUtil.bufferAsString(process.getBpmnProcessId());
             addEntry(process.getKey(), bpmnProcessId, process.getResource().capacity());
+          } else if (process.getState() == PersistedProcessState.DRAINING) {
+            drainingCount.incrementAndGet();
           }
           return true;
         });
@@ -58,10 +62,16 @@ public final class ProcessDefinitionMetrics {
         Duration.ofNanos(System.nanoTime() - startNanos));
 
     totalUniqueProcessIds.set(keysByProcessId.size());
+    drainingProcessDefinitions.set(drainingCount.get());
 
     final var definitionsDoc = EngineMetricsDoc.DEPLOYED_PROCESS_DEFINITIONS;
     Gauge.builder(definitionsDoc.getName(), totalUniqueProcessIds, AtomicLong::get)
         .description(definitionsDoc.getDescription())
+        .register(registry);
+
+    final var drainingDoc = EngineMetricsDoc.DRAINING_PROCESS_DEFINITIONS;
+    Gauge.builder(drainingDoc.getName(), drainingProcessDefinitions, AtomicLong::get)
+        .description(drainingDoc.getDescription())
         .register(registry);
   }
 
@@ -78,11 +88,21 @@ public final class ProcessDefinitionMetrics {
     }
   }
 
+  /** Moves a definition from the deployed count into the draining count. Live processing only. */
+  public void processDefinitionDraining(final long processDefinitionKey) {
+    removeDeployedDefinition(processDefinitionKey);
+    drainingProcessDefinitions.incrementAndGet();
+  }
+
   /**
-   * Records the deletion of a deployed process definition version. Must be called from live event
-   * processing only (not during replay).
+   * Records that a draining process definition finalized its deletion. Must be called from live
+   * event processing only (not during replay).
    */
-  public void processDefinitionDeleted(final long processDefinitionKey) {
+  public void processDefinitionDrainFinalized() {
+    drainingProcessDefinitions.decrementAndGet();
+  }
+
+  private void removeDeployedDefinition(final long processDefinitionKey) {
     final var entry = entriesByKey.remove(processDefinitionKey);
     if (entry == null) {
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -268,6 +268,7 @@ public final class EngineProcessors {
             config,
             incidentMetrics,
             messageCorrelationMetrics,
+            processDefinitionMetrics,
             featureFlags.evaluateBoundaryEventCorrelationKeyInActivityScope(),
             featureFlags.evaluateDuplicateOutputMappingTargetsInOrder(),
             cslCheck,
@@ -382,7 +383,8 @@ public final class EngineProcessors {
         bpmnBehaviors,
         permissionsBehavior,
         tenantCheck,
-        processDefinitionMetrics);
+        processDefinitionMetrics,
+        routingInfo);
     addSignalBroadcastProcessors(
         typedRecordProcessors,
         bpmnBehaviors,
@@ -618,6 +620,7 @@ public final class EngineProcessors {
       final EngineConfiguration config,
       final IncidentMetrics incidentMetrics,
       final MessageCorrelationMetrics messageCorrelationMetrics,
+      final ProcessDefinitionMetrics processDefinitionMetrics,
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
       final boolean evaluateDuplicateOutputMappingTargetsInOrder,
       final CslAuthorizationCheck cslCheck,
@@ -637,6 +640,7 @@ public final class EngineProcessors {
         config,
         incidentMetrics,
         messageCorrelationMetrics,
+        processDefinitionMetrics,
         evaluateBoundaryEventCorrelationKeyInActivityScope,
         evaluateDuplicateOutputMappingTargetsInOrder,
         cslCheck,
@@ -821,7 +825,8 @@ public final class EngineProcessors {
       final BpmnBehaviors bpmnBehaviors,
       final PermissionsBehavior permissionsBehavior,
       final CslTenantCheck tenantCheck,
-      final ProcessDefinitionMetrics processDefinitionMetrics) {
+      final ProcessDefinitionMetrics processDefinitionMetrics,
+      final RoutingInfo routingInfo) {
     final var resourceDeletionProcessor =
         new ResourceDeletionDeleteProcessor(
             writers,
@@ -831,7 +836,8 @@ public final class EngineProcessors {
             bpmnBehaviors,
             permissionsBehavior,
             tenantCheck,
-            processDefinitionMetrics);
+            processDefinitionMetrics,
+            routingInfo);
     typedRecordProcessors.onCommand(
         ValueType.RESOURCE_DELETION, ResourceDeletionIntent.DELETE, resourceDeletionProcessor);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
+import io.camunda.zeebe.engine.metrics.ProcessDefinitionMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.ProcessInstanceStateTransitionGuard;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
@@ -87,6 +88,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final EngineConfiguration config,
       final IncidentMetrics incidentMetrics,
       final MessageCorrelationMetrics messageCorrelationMetrics,
+      final ProcessDefinitionMetrics processDefinitionMetrics,
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
       final boolean evaluateDuplicateOutputMappingTargetsInOrder,
       final CslAuthorizationCheck cslCheck,
@@ -317,7 +319,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             processingState.getBannedInstanceState(),
             writers.command(),
             writers.state(),
-            processingState.getKeyGenerator());
+            processingState.getKeyGenerator(),
+            processDefinitionMetrics);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
+import io.camunda.zeebe.engine.metrics.ProcessDefinitionMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.ProcessInstanceStateTransitionGuard;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
@@ -87,6 +88,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final EngineConfiguration config,
       final IncidentMetrics incidentMetrics,
       final MessageCorrelationMetrics messageCorrelationMetrics,
+      final ProcessDefinitionMetrics processDefinitionMetrics,
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
       final boolean evaluateDuplicateOutputMappingTargetsInOrder,
       final CslAuthorizationCheck cslCheck,
@@ -318,7 +320,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             processingState.getBannedInstanceState(),
             writers.command(),
             writers.state(),
-            processingState.getKeyGenerator());
+            processingState.getKeyGenerator(),
+            processDefinitionMetrics);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessDeletionBehavior.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
+import io.camunda.zeebe.engine.metrics.ProcessDefinitionMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -21,15 +22,8 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 /**
  * Finalizes local deletion of a {@link PersistedProcessState#DRAINING} definition once its last
- * active instance completes or terminates. On this partition it appends the ordinary {@link
- * ProcessIntent#DELETING}/{@link ProcessIntent#DELETED} follow-up events (physically removing the
- * definition locally, reusing the existing appliers), then emits a {@link
- * ProcessIntent#DELETE_COMPLETE} command so {@code ProcessDeleteCompleteProcessor} can aggregate
- * the per-partition reports cluster-wide.
- *
- * <p>Known limitation: {@link ElementInstanceState#hasActiveProcessInstances} excludes banned
- * instances, which never complete/terminate, so a definition whose last instance is banned stays
- * {@code DRAINING} until that instance is resolved.
+ * active instance completes or terminates. Banned instances are excluded from the active-instance
+ * check, as they never complete or terminate.
  */
 public final class BpmnProcessDeletionBehavior {
 
@@ -39,6 +33,7 @@ public final class BpmnProcessDeletionBehavior {
   private final TypedCommandWriter commandWriter;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
+  private final ProcessDefinitionMetrics processDefinitionMetrics;
 
   public BpmnProcessDeletionBehavior(
       final ProcessState processState,
@@ -46,13 +41,15 @@ public final class BpmnProcessDeletionBehavior {
       final BannedInstanceState bannedInstanceState,
       final TypedCommandWriter commandWriter,
       final StateWriter stateWriter,
-      final KeyGenerator keyGenerator) {
+      final KeyGenerator keyGenerator,
+      final ProcessDefinitionMetrics processDefinitionMetrics) {
     this.processState = processState;
     this.elementInstanceState = elementInstanceState;
     this.bannedInstanceState = bannedInstanceState;
     this.commandWriter = commandWriter;
     this.stateWriter = stateWriter;
     this.keyGenerator = keyGenerator;
+    this.processDefinitionMetrics = processDefinitionMetrics;
   }
 
   /**
@@ -95,5 +92,6 @@ public final class BpmnProcessDeletionBehavior {
     stateWriter.appendFollowUpEvent(key, ProcessIntent.DELETING, processRecord);
     stateWriter.appendFollowUpEvent(key, ProcessIntent.DELETED, processRecord);
     commandWriter.appendFollowUpCommand(key, ProcessIntent.DELETE_COMPLETE, processRecord);
+    processDefinitionMetrics.processDefinitionDrainFinalized();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.validation.StraightTh
 import io.camunda.zeebe.engine.processing.deployment.model.validation.UnsupportedMultiTenantFeaturesValidator;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -324,6 +325,10 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
       final DirectBuffer lastVersionDigest) {
     return lastVersionDigest != null
         && lastProcess != null
+        // A DRAINING/PENDING_DELETION latest version is on its way out: reusing its key would make
+        // the redeploy vanish once the drain completes. Only an ACTIVE version can be a duplicate;
+        // otherwise mint a fresh version.
+        && lastProcess.getState() == PersistedProcessState.ACTIVE
         && lastVersionDigest.equals(resourceDigest)
         && lastProcess.getResourceName().equals(deploymentResource.getResourceNameBuffer());
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.validation.StraightTh
 import io.camunda.zeebe.engine.processing.deployment.model.validation.UnsupportedMultiTenantFeaturesValidator;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -291,6 +292,10 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
       final DirectBuffer lastVersionDigest) {
     return lastVersionDigest != null
         && lastProcess != null
+        // A DRAINING/PENDING_DELETION latest version is on its way out: reusing its key would make
+        // the redeploy vanish once the drain completes. Only an ACTIVE version can be a duplicate;
+        // otherwise mint a fresh version.
+        && lastProcess.getState() == PersistedProcessState.ACTIVE
         && lastVersionDigest.equals(resourceDigest)
         && lastProcess.getResourceName().equals(deploymentResource.getResourceNameBuffer());
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionBehavior.java
@@ -47,11 +47,10 @@ public final class HistoryDeletionBehavior {
    *
    * @return the key of the created batch operation
    */
-  public long deleteProcessInstanceHistory(final long eventKey, final long processDefinitionKey) {
+  public long deleteProcessInstanceHistory(final long processDefinitionKey) {
     final var filter =
         new ProcessInstanceFilter.Builder().processDefinitionKeys(processDefinitionKey).build();
     return createBatchOperation(
-        eventKey,
         BatchOperationType.DELETE_PROCESS_INSTANCE,
         MsgPackConverter.convertToMsgPack(filter),
         new HistoryDeletionRecord()
@@ -65,14 +64,12 @@ public final class HistoryDeletionBehavior {
    *
    * @return the key of the created batch operation
    */
-  public long deleteDecisionInstanceHistory(
-      final long eventKey, final long decisionRequirementsKey) {
+  public long deleteDecisionInstanceHistory(final long decisionRequirementsKey) {
     final var filter =
         new DecisionInstanceFilter.Builder()
             .decisionRequirementsKeys(decisionRequirementsKey)
             .build();
     return createBatchOperation(
-        eventKey,
         BatchOperationType.DELETE_DECISION_INSTANCE,
         MsgPackConverter.convertToMsgPack(filter),
         new HistoryDeletionRecord()
@@ -81,7 +78,6 @@ public final class HistoryDeletionBehavior {
   }
 
   private long createBatchOperation(
-      final long eventKey,
       final BatchOperationType batchOperationType,
       final byte[] entityFilter,
       final HistoryDeletionRecord followUpCommand) {
@@ -97,7 +93,7 @@ public final class HistoryDeletionBehavior {
             .setFollowUpCommand(
                 ValueType.HISTORY_DELETION, HistoryDeletionIntent.DELETE, followUpCommand);
     commandWriter.appendFollowUpCommand(
-        eventKey, BatchOperationIntent.CREATE, batchOperationRecord);
+        batchOperationKey, BatchOperationIntent.CREATE, batchOperationRecord);
     return batchOperationKey;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ProcessDeleteCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ProcessDeleteCompleteProcessor.java
@@ -102,8 +102,7 @@ public final class ProcessDeleteCompleteProcessor
       final TypedRecord<ProcessRecord> command, final ProcessRecord process) {
     // delete the history first, then emit FULLY_DELETED as the terminal marker of the deletion
     if (process.isDeleteHistory()) {
-      historyDeletionBehavior.deleteProcessInstanceHistory(
-          command.getKey(), process.getProcessDefinitionKey());
+      historyDeletionBehavior.deleteProcessInstanceHistory(process.getProcessDefinitionKey());
     }
 
     stateWriter.appendFollowUpEvent(command.getKey(), ProcessIntent.FULLY_DELETED, process);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.processing.resource;
 
 import static io.camunda.zeebe.engine.state.instance.TimerInstance.NO_ELEMENT_INSTANCE;
-import static io.camunda.zeebe.protocol.ZbColumnFamilies.PROCESS_CACHE_BY_ID_AND_VERSION;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import io.camunda.security.core.authz.TenantAccess;
@@ -23,6 +22,7 @@ import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.identity.authorization.exception.ForbiddenException;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -30,6 +30,7 @@ import io.camunda.zeebe.engine.state.deployment.DeployedDrg;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
 import io.camunda.zeebe.engine.state.deployment.PersistedForm;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
 import io.camunda.zeebe.engine.state.deployment.PersistedResource;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
@@ -41,6 +42,7 @@ import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.ResourceState;
 import io.camunda.zeebe.engine.state.immutable.TenantState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
+import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
@@ -66,17 +68,15 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ResourceDeletionDeleteProcessor
     implements DistributedTypedRecordProcessor<ResourceDeletionRecord> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(ResourceDeletionDeleteProcessor.class);
   private static final List<ResourceType> SUPPORTED_HISTORY_DELETION_TYPES =
       List.of(ResourceType.PROCESS_DEFINITION, ResourceType.DECISION_REQUIREMENTS);
 
   private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final KeyGenerator keyGenerator;
@@ -96,6 +96,7 @@ public class ResourceDeletionDeleteProcessor
   private final TenantState tenantState;
   private final ProcessDefinitionMetrics processDefinitionMetrics;
   private final HistoryDeletionBehavior historyDeletionBehavior;
+  private final RoutingInfo routingInfo;
 
   public ResourceDeletionDeleteProcessor(
       final Writers writers,
@@ -105,8 +106,10 @@ public class ResourceDeletionDeleteProcessor
       final BpmnBehaviors bpmnBehaviors,
       final PermissionsBehavior permissionsBehavior,
       final CslTenantCheck tenantCheck,
-      final ProcessDefinitionMetrics processDefinitionMetrics) {
+      final ProcessDefinitionMetrics processDefinitionMetrics,
+      final RoutingInfo routingInfo) {
     stateWriter = writers.state();
+    commandWriter = writers.command();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     this.keyGenerator = keyGenerator;
@@ -129,6 +132,7 @@ public class ResourceDeletionDeleteProcessor
     tenantState = processingState.getTenantState();
     this.processDefinitionMetrics = processDefinitionMetrics;
     historyDeletionBehavior = new HistoryDeletionBehavior(keyGenerator, writers.command());
+    this.routingInfo = routingInfo;
   }
 
   @Override
@@ -165,37 +169,49 @@ public class ResourceDeletionDeleteProcessor
           command, exception.getRejectionType(), exception.getMessage());
       responseWriter.writeRejectedResponseOnCommand(
           command, exception.getRejectionType(), exception.getMessage());
+      acknowledgeIfDistributed(command);
       return ProcessingError.EXPECTED_ERROR;
     } else if (error instanceof final NoSuchResourceException exception) {
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, exception.getMessage());
       responseWriter.writeRejectedResponseOnCommand(
           command, RejectionType.NOT_FOUND, exception.getMessage());
-
-      if (command.isCommandDistributed()) {
-        // If the command is distributed, and it cannot be found upon processing, we can acknowledge
-        // the distribution.
-        commandDistributionBehavior.acknowledgeCommand(command);
-      }
-
+      acknowledgeIfDistributed(command);
       return ProcessingError.EXPECTED_ERROR;
-    } else if (error instanceof final ActiveProcessInstancesException exception) {
+    } else if (error instanceof final ResourceDeletionInProgressException exception) {
       rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, exception.getMessage());
       responseWriter.writeRejectedResponseOnCommand(
           command, RejectionType.INVALID_STATE, exception.getMessage());
+      acknowledgeIfDistributed(command);
       return ProcessingError.EXPECTED_ERROR;
     }
 
     return ProcessingError.UNEXPECTED_ERROR;
   }
 
+  // Ack even on rejection, otherwise the distribution never finishes and head-of-line blocks every
+  // command queued behind it.
+  private void acknowledgeIfDistributed(final TypedRecord<ResourceDeletionRecord> command) {
+    if (command.isCommandDistributed()) {
+      commandDistributionBehavior.acknowledgeCommand(command);
+    }
+  }
+
   private void tryDeleteResources(
       final TypedRecord<ResourceDeletionRecord> command, final long eventKey) {
     final var value = command.getValue();
 
+    final var drainingDeletionInFlight = new AtomicBoolean(false);
     final var resourceDeleted =
-        untilResourceDeleted(command, tenantId -> tryDeleteResource(command, tenantId, eventKey));
+        untilResourceDeleted(
+            command,
+            tenantId -> tryDeleteResource(command, tenantId, eventKey, drainingDeletionInFlight));
 
     if (!resourceDeleted) {
+      if (drainingDeletionInFlight.get()
+          || processState.hasPendingDeletion(value.getResourceKey())) {
+        throw new ResourceDeletionInProgressException(value.getResourceKey());
+      }
+      // Delete-time history purge is only for a resource already fully gone from primary storage.
       if (value.isDeleteHistory()
           && SUPPORTED_HISTORY_DELETION_TYPES.contains(value.getResourceType())) {
         deleteHistory(eventKey, command);
@@ -208,23 +224,18 @@ public class ResourceDeletionDeleteProcessor
   private boolean tryDeleteResource(
       final TypedRecord<ResourceDeletionRecord> command,
       final String tenantId,
-      final long eventKey) {
+      final long eventKey,
+      final AtomicBoolean drainingDeletionInFlight) {
     final var value = command.getValue();
 
     final var process = processState.getProcessByKeyAndTenant(value.getResourceKey(), tenantId);
     if (process != null) {
-      command
-          .getValue()
-          .setResourceType(ResourceType.PROCESS_DEFINITION)
-          .setResourceId(process.getBpmnProcessId())
-          .setTenantId(process.getTenantId());
-      return authorizeAndDelete(
-          command,
-          eventKey,
-          PermissionType.DELETE_PROCESS,
-          bufferAsString(process.getBpmnProcessId()),
-          process.getTenantId(),
-          () -> deleteProcess(process, command, eventKey));
+      final var handled = tryDeleteProcessDefinition(command, eventKey, process);
+      if (handled.isPresent()) {
+        return handled.get();
+      }
+      // found but not ACTIVE: deletion already in flight, so the caller rejects as INVALID_STATE
+      drainingDeletionInFlight.set(true);
     }
 
     final var drgOptional =
@@ -343,61 +354,88 @@ public class ResourceDeletionDeleteProcessor
     stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), DecisionIntent.DELETED, decisionRecord);
   }
 
-  private void deleteProcess(
-      final DeployedProcess process,
+  // Empty when the definition is not ACTIVE, so the caller rejects a repeated delete as
+  // already-being-deleted (INVALID_STATE).
+  private Optional<Boolean> tryDeleteProcessDefinition(
       final TypedRecord<ResourceDeletionRecord> command,
-      final long eventKey) {
+      final long eventKey,
+      final DeployedProcess process) {
+    if (process.getState() != PersistedProcessState.ACTIVE) {
+      return Optional.empty();
+    }
+    command
+        .getValue()
+        .setResourceType(ResourceType.PROCESS_DEFINITION)
+        .setResourceId(process.getBpmnProcessId())
+        .setTenantId(process.getTenantId());
+    return Optional.of(
+        authorizeAndDelete(
+            command,
+            eventKey,
+            PermissionType.DELETE_PROCESS,
+            bufferAsString(process.getBpmnProcessId()),
+            process.getTenantId(),
+            () -> deleteProcess(process, command)));
+  }
+
+  private void deleteProcess(
+      final DeployedProcess process, final TypedRecord<ResourceDeletionRecord> command) {
     // We don't add the checksum or resource in this event. The checksum is not easily available
     // and the resources are left out to prevent exceeding the maximum batch size.
     final var processIdBuffer = process.getBpmnProcessId();
     final var tenantId = process.getTenantId();
-    final var processRecord =
-        new ProcessRecord()
-            .setBpmnProcessId(processIdBuffer)
-            .setVersion(process.getVersion())
-            .setVersionTag(process.getVersionTag())
-            .setKey(process.getKey())
-            .setResourceName(process.getResourceName())
-            .setTenantId(tenantId)
-            .setDeploymentKey(process.getDeploymentKey());
-    stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), ProcessIntent.DELETING, processRecord);
-
+    final var processRecord = toProcessRecord(process);
     final String processId = processRecord.getBpmnProcessId();
     final var latestVersion = processState.getLatestProcessVersion(processId, tenantId);
+
+    processRecord.setDrainPartitions(routingInfo.desiredPartitions());
+    processRecord.setDeleteHistory(command.getValue().isDeleteHistory());
+    stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), ProcessIntent.DRAINING, processRecord);
 
     // If we are deleting the latest version we must unsubscribe the start events
     if (latestVersion == process.getVersion()) {
       unsubscribeStartEvents(process);
 
-      final var previousVersion =
-          processState.findProcessVersionBefore(processId, latestVersion, tenantId);
-      // If there is a previous version we must resubscribe to the previous version's start events.
-      if (previousVersion.isPresent()) {
-        final var previousProcess =
-            processState.getProcessByProcessIdAndVersion(
-                processIdBuffer, previousVersion.get(), tenantId);
-        if (previousProcess == null) {
-          warnPreviousProcessNotFound(
-              processIdBuffer, previousVersion.get(), tenantId, processId, latestVersion);
-        } else {
-          startEventSubscriptions.resubscribeToStartEvents(previousProcess);
-        }
+      // Hand the start subscription down to the latest ACTIVE version; DRAINING/deleted versions
+      // reject new instances so must stay unsubscribed.
+      final var previousProcess =
+          findLatestActiveVersionBelow(processIdBuffer, processId, latestVersion, tenantId);
+      if (previousProcess != null) {
+        startEventSubscriptions.resubscribeToStartEvents(previousProcess);
       }
     }
 
     final var bannedInstances = bannedInstanceState.getBannedProcessInstanceKeys();
-    final var hasRunningInstances =
-        elementInstanceState.hasActiveProcessInstances(process.getKey(), bannedInstances);
-
-    if (!hasRunningInstances) {
-      if (!command.isCommandDistributed() && command.getValue().isDeleteHistory()) {
-        deleteProcessInstanceHistory(process.getKey(), eventKey, command.getValue());
-      }
-      stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), ProcessIntent.DELETED, processRecord);
-      processDefinitionMetrics.processDefinitionDeleted(process.getKey());
-    } else {
-      throw new ActiveProcessInstancesException(process.getKey());
+    final boolean finalizedImmediately =
+        !elementInstanceState.hasActiveProcessInstances(process.getKey(), bannedInstances);
+    if (finalizedImmediately) {
+      finalizeDeletion(processRecord);
     }
+
+    // Non-transactional side effects: run only after all state writes that could roll back, and in
+    // increment-then-decrement order so the draining gauge never dips transiently negative.
+    processDefinitionMetrics.processDefinitionDraining(process.getKey());
+    if (finalizedImmediately) {
+      processDefinitionMetrics.processDefinitionDrainFinalized();
+    }
+  }
+
+  private void finalizeDeletion(final ProcessRecord processRecord) {
+    final long key = keyGenerator.nextKey();
+    stateWriter.appendFollowUpEvent(key, ProcessIntent.DELETING, processRecord);
+    stateWriter.appendFollowUpEvent(key, ProcessIntent.DELETED, processRecord);
+    commandWriter.appendFollowUpCommand(key, ProcessIntent.DELETE_COMPLETE, processRecord);
+  }
+
+  private ProcessRecord toProcessRecord(final DeployedProcess process) {
+    return new ProcessRecord()
+        .setBpmnProcessId(process.getBpmnProcessId())
+        .setVersion(process.getVersion())
+        .setVersionTag(process.getVersionTag())
+        .setKey(process.getKey())
+        .setResourceName(process.getResourceName())
+        .setTenantId(process.getTenantId())
+        .setDeploymentKey(process.getDeploymentKey());
   }
 
   private void deleteHistory(
@@ -458,22 +496,23 @@ public class ResourceDeletionDeleteProcessor
     resourceDeletionRecord.setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE);
   }
 
-  private void warnPreviousProcessNotFound(
+  // Skip DRAINING/deleted versions — they must not hold start-event subscriptions.
+  private DeployedProcess findLatestActiveVersionBelow(
       final DirectBuffer processIdBuffer,
-      final int previousVersion,
-      final String tenantId,
       final String processId,
-      final int latestVersion) {
-    LOG.warn(
-        "Expected to find previous process: {} with version: {} and tenant: '{}' to "
-            + "resubscribe start events, but no row exists in {}. "
-            + "knownVersions: {}, current latest version: {}.",
-        bufferAsString(processIdBuffer),
-        previousVersion,
-        tenantId,
-        PROCESS_CACHE_BY_ID_AND_VERSION.name(),
-        processState.getKnownProcessVersions(processId, tenantId),
-        latestVersion);
+      final int version,
+      final String tenantId) {
+    var candidate = processState.findProcessVersionBefore(processId, version, tenantId);
+    while (candidate.isPresent()) {
+      final int candidateVersion = candidate.get();
+      final var process =
+          processState.getProcessByProcessIdAndVersion(processIdBuffer, candidateVersion, tenantId);
+      if (process != null && process.getState() == PersistedProcessState.ACTIVE) {
+        return process;
+      }
+      candidate = processState.findProcessVersionBefore(processId, candidateVersion, tenantId);
+    }
+    return null;
   }
 
   private void unsubscribeStartEvents(final DeployedProcess deployedProcess) {
@@ -605,12 +644,12 @@ public class ResourceDeletionDeleteProcessor
     }
   }
 
-  private static final class ActiveProcessInstancesException extends IllegalStateException {
-    private static final String ERROR_MESSAGE_RUNNING_INSTANCES =
-        "Expected to delete resource with key `%d` but there are still running instances";
+  private static final class ResourceDeletionInProgressException extends IllegalStateException {
+    private static final String ERROR_MESSAGE_DELETION_IN_PROGRESS =
+        "Expected to delete process definition with key `%d`, but it is already being deleted.";
 
-    private ActiveProcessInstancesException(final long processDefinitionKey) {
-      super(String.format(ERROR_MESSAGE_RUNNING_INSTANCES, processDefinitionKey));
+    private ResourceDeletionInProgressException(final long resourceKey) {
+      super(String.format(ERROR_MESSAGE_DELETION_IN_PROGRESS, resourceKey));
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -214,7 +214,7 @@ public class ResourceDeletionDeleteProcessor
       // Delete-time history purge is only for a resource already fully gone from primary storage.
       if (value.isDeleteHistory()
           && SUPPORTED_HISTORY_DELETION_TYPES.contains(value.getResourceType())) {
-        deleteHistory(eventKey, command);
+        deleteHistory(command);
       } else {
         throw new NoSuchResourceException(value.getResourceKey());
       }
@@ -253,7 +253,7 @@ public class ResourceDeletionDeleteProcessor
           PermissionType.DELETE_DRD,
           bufferAsString(drg.getDecisionRequirementsId()),
           drg.getTenantId(),
-          () -> deleteDecisionRequirements(drg, command, eventKey));
+          () -> deleteDecisionRequirements(drg, command));
     }
 
     final var formOptional = formState.findFormByKey(value.getResourceKey(), tenantId);
@@ -309,16 +309,14 @@ public class ResourceDeletionDeleteProcessor
   }
 
   private void deleteDecisionRequirements(
-      final DeployedDrg drg,
-      final TypedRecord<ResourceDeletionRecord> command,
-      final long eventKey) {
+      final DeployedDrg drg, final TypedRecord<ResourceDeletionRecord> command) {
     decisionState
         .findDecisionsByTenantAndDecisionRequirementsKey(
             drg.getTenantId(), drg.getDecisionRequirementsKey())
         .forEach(this::deleteDecision);
 
     if (!command.isCommandDistributed() && command.getValue().isDeleteHistory()) {
-      deleteDecisionInstanceHistory(drg.getDecisionRequirementsKey(), eventKey, command.getValue());
+      deleteDecisionInstanceHistory(drg.getDecisionRequirementsKey(), command.getValue());
     }
 
     final var drgRecord =
@@ -438,8 +436,7 @@ public class ResourceDeletionDeleteProcessor
         .setDeploymentKey(process.getDeploymentKey());
   }
 
-  private void deleteHistory(
-      final long eventKey, final TypedRecord<ResourceDeletionRecord> command) {
+  private void deleteHistory(final TypedRecord<ResourceDeletionRecord> command) {
     if (command.isCommandDistributed()) {
       // We should not create batch operations for distributed commands. This gets handled by the
       // batch operation creator itself.
@@ -464,9 +461,9 @@ public class ResourceDeletionDeleteProcessor
 
     switch (resourceType) {
       case PROCESS_DEFINITION ->
-          deleteProcessInstanceHistory(commandValue.getResourceKey(), eventKey, commandValue);
+          deleteProcessInstanceHistory(commandValue.getResourceKey(), commandValue);
       case DECISION_REQUIREMENTS ->
-          deleteDecisionInstanceHistory(commandValue.getResourceKey(), eventKey, commandValue);
+          deleteDecisionInstanceHistory(commandValue.getResourceKey(), commandValue);
       default -> {
         // No history to delete for forms and unknown resources
         // This should not be reached as SUPPORTED_HISTORY_DELETION_TYPES filters these out
@@ -475,22 +472,18 @@ public class ResourceDeletionDeleteProcessor
   }
 
   private void deleteProcessInstanceHistory(
-      final long processDefinitionKey,
-      final long eventKey,
-      final ResourceDeletionRecord resourceDeletionRecord) {
+      final long processDefinitionKey, final ResourceDeletionRecord resourceDeletionRecord) {
     final long batchOperationKey =
-        historyDeletionBehavior.deleteProcessInstanceHistory(eventKey, processDefinitionKey);
+        historyDeletionBehavior.deleteProcessInstanceHistory(processDefinitionKey);
 
     resourceDeletionRecord.setBatchOperationKey(batchOperationKey);
     resourceDeletionRecord.setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE);
   }
 
   private void deleteDecisionInstanceHistory(
-      final long decisionRequirementsKey,
-      final long eventKey,
-      final ResourceDeletionRecord resourceDeletionRecord) {
+      final long decisionRequirementsKey, final ResourceDeletionRecord resourceDeletionRecord) {
     final long batchOperationKey =
-        historyDeletionBehavior.deleteDecisionInstanceHistory(eventKey, decisionRequirementsKey);
+        historyDeletionBehavior.deleteDecisionInstanceHistory(decisionRequirementsKey);
 
     resourceDeletionRecord.setBatchOperationKey(batchOperationKey);
     resourceDeletionRecord.setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -358,14 +358,16 @@ public class ResourceDeletionDeleteProcessor
       final TypedRecord<ResourceDeletionRecord> command,
       final long eventKey,
       final DeployedProcess process) {
-    if (process.getState() != PersistedProcessState.ACTIVE) {
-      return Optional.empty();
-    }
+    // Stamp metadata before the not-ACTIVE bail-out so a repeat-delete rejection carries the
+    // resolved type/id/tenant, not whatever the client sent.
     command
         .getValue()
         .setResourceType(ResourceType.PROCESS_DEFINITION)
         .setResourceId(process.getBpmnProcessId())
         .setTenantId(process.getTenantId());
+    if (process.getState() != PersistedProcessState.ACTIVE) {
+      return Optional.empty();
+    }
     return Optional.of(
         authorizeAndDelete(
             command,
@@ -396,25 +398,19 @@ public class ResourceDeletionDeleteProcessor
 
       // Hand the start subscription down to the latest ACTIVE version; DRAINING/deleted versions
       // reject new instances so must stay unsubscribed.
-      final var previousProcess =
-          findLatestActiveVersionBelow(processIdBuffer, processId, latestVersion, tenantId);
-      if (previousProcess != null) {
-        startEventSubscriptions.resubscribeToStartEvents(previousProcess);
-      }
+      findLatestActiveVersionBelow(processIdBuffer, processId, latestVersion, tenantId)
+          .ifPresent(startEventSubscriptions::resubscribeToStartEvents);
     }
 
     final var bannedInstances = bannedInstanceState.getBannedProcessInstanceKeys();
     final boolean finalizedImmediately =
         !elementInstanceState.hasActiveProcessInstances(process.getKey(), bannedInstances);
+
     if (finalizedImmediately) {
       finalizeDeletion(processRecord);
-    }
-
-    // Non-transactional side effects: run only after all state writes that could roll back, and in
-    // increment-then-decrement order so the draining gauge never dips transiently negative.
-    processDefinitionMetrics.processDefinitionDraining(process.getKey());
-    if (finalizedImmediately) {
-      processDefinitionMetrics.processDefinitionDrainFinalized();
+      processDefinitionMetrics.processDefinitionDeleted(process.getKey());
+    } else {
+      processDefinitionMetrics.processDefinitionDraining(process.getKey());
     }
   }
 
@@ -490,7 +486,7 @@ public class ResourceDeletionDeleteProcessor
   }
 
   // Skip DRAINING/deleted versions — they must not hold start-event subscriptions.
-  private DeployedProcess findLatestActiveVersionBelow(
+  private Optional<DeployedProcess> findLatestActiveVersionBelow(
       final DirectBuffer processIdBuffer,
       final String processId,
       final int version,
@@ -501,11 +497,11 @@ public class ResourceDeletionDeleteProcessor
       final var process =
           processState.getProcessByProcessIdAndVersion(processIdBuffer, candidateVersion, tenantId);
       if (process != null && process.getState() == PersistedProcessState.ACTIVE) {
-        return process;
+        return Optional.of(process);
       }
       candidate = processState.findProcessVersionBefore(processId, candidateVersion, tenantId);
     }
-    return null;
+    return Optional.empty();
   }
 
   private void unsubscribeStartEvents(final DeployedProcess deployedProcess) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessDrainingApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessDrainingApplier.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.state.appliers;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 
@@ -24,5 +25,14 @@ public class ProcessDrainingApplier implements TypedEventApplier<ProcessIntent, 
   @Override
   public void applyState(final long key, final ProcessRecord value) {
     processState.markDraining(value);
+
+    // Only the deployment partition aggregates; the event key is minted locally so it encodes the
+    // applying partition. Seed one pending entry per frozen partition; each DELETE_COMPLETE clears
+    // one, and the definition is fully deleted once none remain.
+    if (Protocol.decodePartitionId(key) == Protocol.DEPLOYMENT_PARTITION) {
+      for (final int partitionId : value.getDrainPartitions()) {
+        processState.addPendingDeletion(value.getProcessDefinitionKey(), partitionId);
+      }
+    }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/ProcessDefinitionMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/ProcessDefinitionMetricsTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.client.DeploymentClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -31,6 +32,7 @@ public class ProcessDefinitionMetricsTest {
   private static final Logger LOG = LoggerFactory.getLogger(ProcessDefinitionMetricsTest.class);
   private static final String PROCESS_ID_A = "processA";
   private static final String PROCESS_ID_B = "processB";
+  private static final String JOB_TYPE = "task";
 
   @Rule public final EngineRule engine = EngineRule.singlePartition();
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
@@ -295,6 +297,132 @@ public class ProcessDefinitionMetricsTest {
     assertThat(definitionsCountGauge())
         .describedAs("definitions count after restart with %d processes", processCount)
         .isEqualTo(processCount);
+  }
+
+  @Test
+  public void shouldIncrementDrainingGaugeWhenDeletingProcessWithRunningInstance() {
+    // given - a deployed process with a single instance stuck on a job
+    final long processDefinitionKey = deployProcessWithJob(PROCESS_ID_A);
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID_A).create();
+    awaitJobCreated(processInstanceKey);
+    assertThat(definitionsCountGauge()).isOne();
+    assertThat(drainingCountGauge()).isZero();
+
+    // when - the definition is deleted while the instance is still running
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+    awaitDraining(processDefinitionKey);
+
+    // then - it moves out of the deployed count and into the draining count
+    assertThat(drainingCountGauge()).describedAs("draining definitions count").isOne();
+    assertThat(definitionsCountGauge())
+        .describedAs("a draining definition is no longer counted as deployed")
+        .isZero();
+  }
+
+  @Test
+  public void shouldDecrementDrainingGaugeWhenLastDrainingInstanceCompletes() {
+    // given - a draining definition kept alive by one running instance
+    final long processDefinitionKey = deployProcessWithJob(PROCESS_ID_A);
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID_A).create();
+    awaitJobCreated(processInstanceKey);
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+    awaitDraining(processDefinitionKey);
+    assertThat(drainingCountGauge()).isOne();
+
+    // when - the last active instance completes and the deletion is finalized
+    engine.job().ofInstance(processInstanceKey).withType(JOB_TYPE).complete();
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DELETED)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .await();
+
+    // then - the draining count returns to zero
+    assertThat(drainingCountGauge())
+        .describedAs("draining count returns to zero once the definition is finalized")
+        .isZero();
+  }
+
+  @Test
+  public void shouldNotLeaveDrainingGaugeElevatedWhenDeletingProcessWithoutRunningInstances() {
+    // given - a deployed process with no running instances
+    final long processDefinitionKey = deploySimpleProcess(PROCESS_ID_A);
+    assertThat(definitionsCountGauge()).isOne();
+    assertThat(drainingCountGauge()).isZero();
+
+    // when - the definition is deleted; with no instances it drains and finalizes in one step
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DELETED)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .await();
+
+    // then - the draining gauge was incremented then decremented within the same finalize, so it
+    // never stays elevated, and the definition leaves the deployed count
+    assertThat(drainingCountGauge())
+        .describedAs("immediate finalize increments then decrements the draining gauge, net zero")
+        .isZero();
+    assertThat(definitionsCountGauge())
+        .describedAs("the deleted definition is no longer counted as deployed")
+        .isZero();
+  }
+
+  @Test
+  public void shouldRecoverDrainingCountAfterBrokerRestart() {
+    // given - a draining definition
+    final long processDefinitionKey = deployProcessWithJob(PROCESS_ID_A);
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID_A).create();
+    awaitJobCreated(processInstanceKey);
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+    awaitDraining(processDefinitionKey);
+    assertThat(drainingCountGauge()).isOne();
+
+    // when - snapshot and restart triggers the metric initialization scan
+    engine.snapshot();
+    engine.stop();
+    engine.start();
+
+    // then - the draining count is recovered from state, not just from live processing
+    assertThat(drainingCountGauge())
+        .describedAs("draining count should be recovered from state after restart")
+        .isOne();
+  }
+
+  private long deployProcessWithJob(final String processId) {
+    return engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+                .endEvent()
+                .done())
+        .deploy()
+        .getValue()
+        .getProcessesMetadata()
+        .get(0)
+        .getProcessDefinitionKey();
+  }
+
+  private void awaitJobCreated(final long processInstanceKey) {
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(JOB_TYPE)
+        .await();
+  }
+
+  private void awaitDraining(final long processDefinitionKey) {
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DRAINING)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .await();
+  }
+
+  private double drainingCountGauge() {
+    return engine
+        .getMeterRegistry()
+        .get("zeebe.process.definitions.draining.count")
+        .gauge()
+        .value();
   }
 
   private long deploySimpleProcess(final String processId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventCorrelateDrainingRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventCorrelateDrainingRejectionTest.java
@@ -79,10 +79,9 @@ public final class MessageStartEventCorrelateDrainingRejectionTest {
   }
 
   /**
-   * Puts the given process definition into the {@code DRAINING} state. Since no processor writes
-   * the {@code DRAINING} event yet, the event is injected onto the log while the engine is stopped
-   * so it is applied to state on the next start (replay). TODO(#56978): drive draining via a real
-   * {@code RESOURCE_DELETION.DELETE} once that change lands, and remove this injection helper.
+   * Injects a {@code DRAINING} event directly (applied on the next start via replay), bypassing the
+   * deletion processor so the message start-event subscription stays intact. A real deletion cannot
+   * produce this state, since it unsubscribes start events as it drains.
    */
   private void drain(final ProcessMetadataValue metadata) {
     engine.stop();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRequestProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRequestProcessorTest.java
@@ -360,10 +360,9 @@ public final class MessageStartProcessInstanceRequestRequestProcessorTest {
   }
 
   /**
-   * Puts the given process definition into the {@code DRAINING} state. Since no processor writes
-   * the {@code DRAINING} event yet, the event is injected onto the log while the engine is stopped
-   * so it is applied to state on the next start (replay). TODO(#56978): drive draining via a real
-   * {@code RESOURCE_DELETION.DELETE} once that change lands, and remove this injection helper.
+   * Injects a {@code DRAINING} event directly (applied on the next start via replay), bypassing the
+   * deletion processor so the message start-event subscription stays intact. A real deletion cannot
+   * produce this state, since it unsubscribes start events as it drains.
    */
   private void drain(final ProcessMetadataValue metadata) {
     engine.stop();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
@@ -46,6 +46,7 @@ import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionRecordValue;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import io.camunda.zeebe.protocol.record.value.NestedRecordValue;
+import io.camunda.zeebe.protocol.record.value.ResourceType;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -54,6 +55,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.Before;
 import org.junit.Rule;
@@ -63,7 +65,7 @@ import org.mockito.Mockito;
 /**
  * Verifies that no new process instances can be created for a process definition that is in the
  * {@link io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState#DRAINING}
- * state.
+ * state, and that a draining definition is finalized once its last instance completes.
  */
 public class DrainingProcessDefinitionTest {
 
@@ -94,10 +96,11 @@ public class DrainingProcessDefinitionTest {
 
   @Test
   public void shouldRejectCreateInstanceByProcessIdWhenDraining() {
-    // given
+    // given - a definition kept draining by a still-running instance
     final var processId = helper.getBpmnProcessId();
-    final var metadata = deploy(processId);
-    drain(metadata);
+    final var metadata = deployWithJob(processId);
+    awaitJobCreated(engine.processInstance().ofBpmnProcessId(processId).create());
+    drainViaDeletion(metadata.getProcessDefinitionKey());
 
     // when
     engine.processInstance().ofBpmnProcessId(processId).expectRejection().create();
@@ -114,10 +117,11 @@ public class DrainingProcessDefinitionTest {
 
   @Test
   public void shouldRejectCreateInstanceByVersionWhenDraining() {
-    // given
+    // given - a definition kept draining by a still-running instance
     final var processId = helper.getBpmnProcessId();
-    final var metadata = deploy(processId);
-    drain(metadata);
+    final var metadata = deployWithJob(processId);
+    awaitJobCreated(engine.processInstance().ofBpmnProcessId(processId).create());
+    drainViaDeletion(metadata.getProcessDefinitionKey());
 
     // when
     engine.processInstance().ofBpmnProcessId(processId).withVersion(1).expectRejection().create();
@@ -134,10 +138,11 @@ public class DrainingProcessDefinitionTest {
 
   @Test
   public void shouldRejectCreateInstanceWithResultWhenDraining() {
-    // given
+    // given - a definition kept draining by a still-running instance
     final var processId = helper.getBpmnProcessId();
-    final var metadata = deploy(processId);
-    drain(metadata);
+    final var metadata = deployWithJob(processId);
+    awaitJobCreated(engine.processInstance().ofBpmnProcessId(processId).create());
+    drainViaDeletion(metadata.getProcessDefinitionKey());
 
     // when
     engine.processInstance().ofBpmnProcessId(processId).withResult().asyncCreate();
@@ -157,10 +162,11 @@ public class DrainingProcessDefinitionTest {
 
   @Test
   public void shouldRejectCreateInstanceWithStartInstructionsWhenDraining() {
-    // given
+    // given - a definition kept draining by a still-running instance
     final var processId = helper.getBpmnProcessId();
-    final var metadata = deploy(processId);
-    drain(metadata);
+    final var metadata = deployWithJob(processId);
+    awaitJobCreated(engine.processInstance().ofBpmnProcessId(processId).create());
+    drainViaDeletion(metadata.getProcessDefinitionKey());
 
     // when - bogus element id: proves the draining guard runs before start-instruction validation
     engine
@@ -182,10 +188,11 @@ public class DrainingProcessDefinitionTest {
 
   @Test
   public void shouldRaiseIncidentWhenCallActivityCallsDrainingProcessWithLatestBinding() {
-    // given
+    // given - a child definition kept draining by a still-running child instance
     final var childId = helper.getBpmnProcessId() + "-child";
     final var parentId = helper.getBpmnProcessId() + "-parent";
-    final var child = deploy(childId);
+    final var child = deployWithJob(childId);
+    awaitJobCreated(engine.processInstance().ofBpmnProcessId(childId).create());
     engine
         .deployment()
         .withXmlResource(
@@ -197,7 +204,7 @@ public class DrainingProcessDefinitionTest {
                 .endEvent()
                 .done())
         .deploy();
-    drain(child);
+    drainViaDeletion(child.getProcessDefinitionKey());
 
     // when
     final long parentInstanceKey = engine.processInstance().ofBpmnProcessId(parentId).create();
@@ -208,15 +215,19 @@ public class DrainingProcessDefinitionTest {
 
   @Test
   public void shouldRaiseIncidentWhenCallActivityCallsDrainingProcessWithDeploymentBinding() {
-    // given
+    // given - deployment binding resolves the called process within the same deployment
     final var childId = helper.getBpmnProcessId() + "-child";
     final var parentId = helper.getBpmnProcessId() + "-parent";
-    // deployment binding resolves the called process within the same deployment
     final var deployment =
         engine
             .deployment()
             .withXmlResource(
-                "child.bpmn", Bpmn.createExecutableProcess(childId).startEvent().endEvent().done())
+                "child.bpmn",
+                Bpmn.createExecutableProcess(childId)
+                    .startEvent()
+                    .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+                    .endEvent()
+                    .done())
             .withXmlResource(
                 "parent.bpmn",
                 Bpmn.createExecutableProcess(parentId)
@@ -233,7 +244,9 @@ public class DrainingProcessDefinitionTest {
             .filter(p -> p.getBpmnProcessId().equals(childId))
             .findFirst()
             .orElseThrow();
-    drain(child);
+    // a running child instance keeps the child definition draining rather than fully deleted
+    awaitJobCreated(engine.processInstance().ofBpmnProcessId(childId).create());
+    drainViaDeletion(child.getProcessDefinitionKey());
 
     // when
     final long parentInstanceKey = engine.processInstance().ofBpmnProcessId(parentId).create();
@@ -254,12 +267,13 @@ public class DrainingProcessDefinitionTest {
                 Bpmn.createExecutableProcess(childId)
                     .versionTag("v1")
                     .startEvent()
+                    .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
                     .endEvent()
                     .done())
             .deploy()
             .getValue()
             .getProcessesMetadata()
-            .get(0);
+            .getFirst();
     engine
         .deployment()
         .withXmlResource(
@@ -274,7 +288,9 @@ public class DrainingProcessDefinitionTest {
                 .endEvent()
                 .done())
         .deploy();
-    drain(child);
+    // a running child instance keeps the child definition draining rather than fully deleted
+    awaitJobCreated(engine.processInstance().ofBpmnProcessId(childId).create());
+    drainViaDeletion(child.getProcessDefinitionKey());
 
     // when
     final long parentInstanceKey = engine.processInstance().ofBpmnProcessId(parentId).create();
@@ -309,12 +325,19 @@ public class DrainingProcessDefinitionTest {
         .deploy();
     final var target = deploy(targetId, "B");
 
+    // a running target instance keeps the target definition draining rather than fully deleted
+    final long targetKeeperKey = engine.processInstance().ofBpmnProcessId(targetId).create();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(targetKeeperKey)
+        .withElementType(BpmnElementType.USER_TASK)
+        .await();
+
     final long processInstanceKey = engine.processInstance().ofBpmnProcessId(sourceId).create();
     RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
         .withProcessInstanceKey(processInstanceKey)
         .withElementType(BpmnElementType.USER_TASK)
         .await();
-    drain(target);
+    drainViaDeletion(target.getProcessDefinitionKey());
     final long targetProcessDefinitionKey = target.getProcessDefinitionKey();
 
     // when
@@ -341,7 +364,7 @@ public class DrainingProcessDefinitionTest {
     // given - a repeating timer start event so the trigger also reschedules
     final var processId = helper.getBpmnProcessId();
     final var metadata = deployWithStartEvent(processId, start -> start.timerWithCycle("R2/PT1S"));
-    drain(metadata);
+    injectDraining(metadata);
 
     // when - the timer start event fires
     engine.increaseTime(Duration.ofHours(1));
@@ -363,7 +386,7 @@ public class DrainingProcessDefinitionTest {
     // given
     final var processId = helper.getBpmnProcessId();
     final var metadata = deployWithStartEvent(processId, start -> start.message("start-message"));
-    drain(metadata);
+    injectDraining(metadata);
 
     // when - a message is published against the (still-subscribed) message start event
     engine.message().withName("start-message").withCorrelationKey("key").publish();
@@ -386,7 +409,7 @@ public class DrainingProcessDefinitionTest {
     // given
     final var processId = helper.getBpmnProcessId();
     final var metadata = deployWithStartEvent(processId, start -> start.signal("start-signal"));
-    drain(metadata);
+    injectDraining(metadata);
 
     // when - a signal is broadcast to the (still-subscribed) signal start event
     engine.signal().withSignalName("start-signal").broadcast();
@@ -404,7 +427,7 @@ public class DrainingProcessDefinitionTest {
     final var processId = helper.getBpmnProcessId();
     final var metadata =
         deployWithStartEvent(processId, start -> start.condition(c -> c.condition("=x > y")));
-    drain(metadata);
+    injectDraining(metadata);
 
     // when - the conditional start event's condition is evaluated to true
     engine.conditionalEvaluation().withVariables(Map.of("x", 100, "y", 1)).evaluate();
@@ -429,7 +452,7 @@ public class DrainingProcessDefinitionTest {
         .deploy()
         .getValue()
         .getProcessesMetadata()
-        .get(0);
+        .getFirst();
   }
 
   private void assertNoInstanceSpawned(final long processDefinitionKey) {
@@ -451,8 +474,8 @@ public class DrainingProcessDefinitionTest {
     // instance, mimicking a follow-up command that outlived the DRAINING mark. This bypasses the
     // EventHandle guard to exercise the defensive ProcessInstanceStateTransitionGuard directly.
     final var processId = helper.getBpmnProcessId();
-    final var metadata = deploy(processId);
-    drain(metadata);
+    final var metadata = deploy(processId, null);
+    injectDraining(metadata);
 
     final long processInstanceKey = 123L;
     final var record =
@@ -493,23 +516,14 @@ public class DrainingProcessDefinitionTest {
     final var metadata = deployWithJob(processId);
     final long processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
     awaitJobCreated(processInstanceKey);
-    drain(metadata);
+    drainViaDeletion(metadata.getProcessDefinitionKey());
 
     // when - the last active instance completes
     engine.job().ofInstance(processInstanceKey).withType(JOB_TYPE).complete();
 
-    // then - this partition physically removes the definition locally (DELETING/DELETED) and then
-    // reports it has finished draining (DELETE_COMPLETE) so ProcessDeleteCompleteProcessor can
-    // aggregate the per-partition reports cluster-wide.
+    // then - the definition is removed locally (DELETED) and this partition reports drained
     assertDeletedLocally(metadata.getProcessDefinitionKey());
-    assertThat(
-            RecordingExporter.processRecords()
-                .withRecordType(RecordType.COMMAND)
-                .withIntent(ProcessIntent.DELETE_COMPLETE)
-                .withProcessDefinitionKey(metadata.getProcessDefinitionKey())
-                .exists())
-        .describedAs("this partition reports drained once its last instance completes")
-        .isTrue();
+    assertReportedDrained(metadata.getProcessDefinitionKey());
   }
 
   @Test
@@ -519,7 +533,7 @@ public class DrainingProcessDefinitionTest {
     final var metadata = deployWithJob(processId);
     final long processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
     awaitJobCreated(processInstanceKey);
-    drain(metadata, true);
+    drainViaDeletion(metadata.getProcessDefinitionKey(), true);
 
     // when - the last active instance completes
     engine.job().ofInstance(processInstanceKey).withType(JOB_TYPE).complete();
@@ -544,7 +558,7 @@ public class DrainingProcessDefinitionTest {
     final var metadata = deployWithJob(processId);
     final long processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
     awaitJobCreated(processInstanceKey);
-    drain(metadata);
+    drainViaDeletion(metadata.getProcessDefinitionKey());
 
     // when - the last active instance completes
     engine.job().ofInstance(processInstanceKey).withType(JOB_TYPE).complete();
@@ -568,21 +582,14 @@ public class DrainingProcessDefinitionTest {
     final var metadata = deployWithJob(processId);
     final long processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
     awaitJobCreated(processInstanceKey);
-    drain(metadata);
+    drainViaDeletion(metadata.getProcessDefinitionKey());
 
     // when - the last active instance is terminated
     engine.processInstance().withInstanceKey(processInstanceKey).cancel();
 
     // then - the definition is removed locally and this partition reports drained
     assertDeletedLocally(metadata.getProcessDefinitionKey());
-    assertThat(
-            RecordingExporter.processRecords()
-                .withRecordType(RecordType.COMMAND)
-                .withIntent(ProcessIntent.DELETE_COMPLETE)
-                .withProcessDefinitionKey(metadata.getProcessDefinitionKey())
-                .exists())
-        .describedAs("this partition reports drained once its last instance terminates")
-        .isTrue();
+    assertReportedDrained(metadata.getProcessDefinitionKey());
   }
 
   @Test
@@ -594,13 +601,12 @@ public class DrainingProcessDefinitionTest {
     final long secondInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
     awaitJobCreated(firstInstanceKey);
     awaitJobCreated(secondInstanceKey);
-    drain(metadata);
+    drainViaDeletion(metadata.getProcessDefinitionKey());
 
     // when - only the first instance completes
     engine.job().ofInstance(firstInstanceKey).withType(JOB_TYPE).complete();
 
-    // then - the definition is still draining, not yet reported drained (a new instance is still
-    // rejected, which proves it has not been reported drained)
+    // then - still draining: a new instance is still rejected, proving it is not yet drained
     engine.processInstance().ofBpmnProcessId(processId).expectRejection().create();
     final var rejection =
         RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
@@ -610,14 +616,7 @@ public class DrainingProcessDefinitionTest {
     engine.job().ofInstance(secondInstanceKey).withType(JOB_TYPE).complete();
 
     // then - this partition reports drained only after the last instance completes
-    assertThat(
-            RecordingExporter.processRecords()
-                .withRecordType(RecordType.COMMAND)
-                .withIntent(ProcessIntent.DELETE_COMPLETE)
-                .withProcessDefinitionKey(metadata.getProcessDefinitionKey())
-                .exists())
-        .describedAs("this partition reports drained only after the last instance completes")
-        .isTrue();
+    assertReportedDrained(metadata.getProcessDefinitionKey());
   }
 
   @Test
@@ -644,35 +643,31 @@ public class DrainingProcessDefinitionTest {
             .getValue()
             .getProcessInstanceKey();
     awaitJobCreated(childInstanceKey);
-    drain(child);
+    drainViaDeletion(child.getProcessDefinitionKey());
 
     // when - the child instance completes
     engine.job().ofInstance(childInstanceKey).withType(JOB_TYPE).complete();
 
     // then - the draining child definition is reported drained (finalize fires for child processes
     // too)
-    assertThat(
-            RecordingExporter.processRecords()
-                .withRecordType(RecordType.COMMAND)
-                .withIntent(ProcessIntent.DELETE_COMPLETE)
-                .withProcessDefinitionKey(child.getProcessDefinitionKey())
-                .exists())
-        .describedAs(
-            "draining child definition is reported drained when its call-activity instance"
-                + " completes")
-        .isTrue();
+    assertReportedDrained(child.getProcessDefinitionKey());
   }
 
   @Test
-  public void shouldFullyDeleteWhenAllPartitionsReportDrained() {
-    // given - a draining definition whose per-partition drain reports are outstanding for three
-    // partitions
+  public void shouldFullyDeleteWhenLastInstanceDrains() {
+    // given - a draining definition on the deployment partition. On this single-partition harness
+    // ProcessDrainingApplier auto-seeds only the local partition (1) at delete time; partitions 2
+    // and 3 are injected to simulate the rest of a three-partition cluster.
     final var processId = helper.getBpmnProcessId();
-    final var metadata = deploy(processId);
-    drain(metadata);
+    final var metadata = deployWithJob(processId);
     final long processDefinitionKey = metadata.getProcessDefinitionKey();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+    awaitJobCreated(processInstanceKey);
+    drainViaDeletion(processDefinitionKey);
+    seedPendingDeletions(processDefinitionKey, 2, 3);
 
-    seedPendingDeletions(processDefinitionKey, 1, 2, 3);
+    // when - the last active instance completes, finalizing locally and reporting drained
+    engine.job().ofInstance(processInstanceKey).withType(JOB_TYPE).complete();
 
     // when - each partition reports it has finished draining (as the deployment partition receives
     // them: a locally-keyed report for partition 1 and forwarded reports for partitions 2 and 3)
@@ -686,7 +681,7 @@ public class DrainingProcessDefinitionTest {
     assertThat(
             RecordingExporter.processRecords()
                 .withIntent(ProcessIntent.FULLY_DELETED)
-                .withProcessDefinitionKey(processDefinitionKey)
+                .withProcessDefinitionKey(metadata.getProcessDefinitionKey())
                 .limit(1)
                 .count())
         .describedAs("the definition is reported fully deleted exactly once")
@@ -702,11 +697,146 @@ public class DrainingProcessDefinitionTest {
   }
 
   @Test
+  public void shouldMintNewVersionWhenRedeployingIdenticalResourceWhileDraining() {
+    // given - a definition kept draining by a still-running instance
+    final var processId = helper.getBpmnProcessId();
+    final var v1 = deployWithJob(processId);
+    awaitJobCreated(engine.processInstance().ofBpmnProcessId(processId).create());
+    drainViaDeletion(v1.getProcessDefinitionKey());
+
+    // when - the identical resource is redeployed while v1 is still draining
+    final var redeployed = deployWithJob(processId);
+
+    // then - it is not deduplicated onto the draining v1 (which would make the redeploy vanish once
+    // the drain finalizes); a fresh version is minted with a new key
+    assertThat(redeployed.isDuplicate())
+        .describedAs("a draining definition must not be reused as a deployment duplicate")
+        .isFalse();
+    assertThat(redeployed.getVersion()).isEqualTo(2);
+    assertThat(redeployed.getProcessDefinitionKey()).isNotEqualTo(v1.getProcessDefinitionKey());
+  }
+
+  @Test
+  public void shouldFinalizeIgnoringBannedInstances() {
+    // given - a draining definition with two active instances
+    final var processId = helper.getBpmnProcessId();
+    final var metadata = deployWithJob(processId);
+    final long bannedInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+    final long completingInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+    awaitJobCreated(bannedInstanceKey);
+    awaitJobCreated(completingInstanceKey);
+    drainViaDeletion(metadata.getProcessDefinitionKey());
+
+    // and - one instance is banned. A banned instance never completes/terminates and is excluded
+    // from the active-instance check, so it must not block finalization.
+    engine.banInstanceInNewTransaction(1, bannedInstanceKey);
+    RecordingExporter.errorRecords().withRecordKey(bannedInstanceKey).await();
+
+    // when - the other (non-banned) instance completes and triggers the finalize hook
+    engine.job().ofInstance(completingInstanceKey).withType(JOB_TYPE).complete();
+
+    // then - the definition is finalized even though a banned instance still references it
+    assertDeletedLocally(metadata.getProcessDefinitionKey());
+  }
+
+  @Test
+  public void shouldResubscribeStartEventsToLatestActiveVersionSkippingDraining() {
+    // given - three versions of the same message-start-event definition. Only the latest holds the
+    // start-event subscription, so on deletion it must be handed down.
+    final var processId = helper.getBpmnProcessId();
+    final long v1Key = deployWithMessageStartAndJob(processId, "task-v1").getProcessDefinitionKey();
+    final long v2Key = deployWithMessageStartAndJob(processId, "task-v2").getProcessDefinitionKey();
+    final long v3Key = deployWithMessageStartAndJob(processId, "task-v3").getProcessDefinitionKey();
+
+    // and - the middle version (v2) is kept DRAINING by a still-running instance, so it cannot take
+    // over the subscription
+    awaitJobCreated(engine.processInstance().ofBpmnProcessId(processId).withVersion(2).create());
+    drainViaDeletion(v2Key);
+
+    // when - the latest ACTIVE version (v3) is deleted
+    engine.resourceDeletion().withResourceKey(v3Key).delete();
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DRAINING)
+        .withProcessDefinitionKey(v3Key)
+        .await();
+
+    // then - the subscription is handed to v1 (the latest ACTIVE version below v3)
+    engine.message().withName("start-message").withCorrelationKey("key").publish();
+    final var spawned =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementType(BpmnElementType.PROCESS)
+            .withBpmnProcessId(processId)
+            .filter(r -> r.getValue().getProcessDefinitionKey() != v2Key)
+            .getFirst();
+    Assertions.assertThat(spawned.getValue().getProcessDefinitionKey())
+        .describedAs("the message start subscription is handed to v1, skipping the DRAINING v2")
+        .isEqualTo(v1Key);
+  }
+
+  @Test
+  public void shouldNotResubscribeStartEventsWhenNoActiveVersionRemainsBelow() {
+    // given - two versions of the same message-start-event definition. Only the latest (v2) holds
+    // the start-event subscription.
+    final var processId = helper.getBpmnProcessId();
+    final long v1Key = deployWithMessageStartAndJob(processId, "task-v1").getProcessDefinitionKey();
+    final long v2Key = deployWithMessageStartAndJob(processId, "task-v2").getProcessDefinitionKey();
+
+    // and - v1 is kept DRAINING by a still-running instance, so it is not an ACTIVE fallback that
+    // could take over the subscription
+    awaitJobCreated(engine.processInstance().ofBpmnProcessId(processId).withVersion(1).create());
+    drainViaDeletion(v1Key);
+
+    // when - the latest ACTIVE version (v2) is deleted, leaving no ACTIVE version below it
+    engine.resourceDeletion().withResourceKey(v2Key).delete();
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DELETED)
+        .withProcessDefinitionKey(v2Key)
+        .await();
+
+    // then - the subscription is handed to nobody (findLatestActiveVersionBelow returns null), so
+    // the start message correlates to no version: v1 is DRAINING and unsubscribed, v2 is gone
+    engine.message().withName("start-message").withCorrelationKey("key").publish();
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    RecordingExporter.messageStartEventSubscriptionRecords(
+                            MessageStartEventSubscriptionIntent.CORRELATED)
+                        .withBpmnProcessId(processId)
+                        .exists()))
+        .describedAs("the start message correlates to no version - none holds the subscription")
+        .isFalse();
+  }
+
+  // A none start event (so instances can be created via the API to keep a version DRAINING) plus a
+  // message start event (so resubscription is observable by publishing a message). Both branches
+  // wait on a job so created instances stay running.
+  private ProcessMetadataValue deployWithMessageStartAndJob(
+      final String processId, final String taskId) {
+    return engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent("none-start")
+                .serviceTask(taskId, t -> t.zeebeJobType(JOB_TYPE))
+                .endEvent()
+                .moveToProcess(processId)
+                .startEvent("message-start")
+                .message("start-message")
+                .serviceTask(taskId + "-msg", t -> t.zeebeJobType(JOB_TYPE))
+                .endEvent()
+                .done())
+        .deploy()
+        .getValue()
+        .getProcessesMetadata()
+        .getFirst();
+  }
+
+  @Test
   public void shouldDeleteHistoryWhenAllPartitionsReportDrained() {
     // given - a draining definition whose deletion also requested its history to be deleted
     final var processId = helper.getBpmnProcessId();
     final var metadata = deploy(processId);
-    drain(metadata, true);
+    injectDraining(metadata, true);
     final long processDefinitionKey = metadata.getProcessDefinitionKey();
     seedPendingDeletions(processDefinitionKey, 1, 2, 3);
 
@@ -747,7 +877,7 @@ public class DrainingProcessDefinitionTest {
     // given - a draining definition whose deletion did not request history deletion
     final var processId = helper.getBpmnProcessId();
     final var metadata = deploy(processId);
-    drain(metadata);
+    injectDraining(metadata);
     final long processDefinitionKey = metadata.getProcessDefinitionKey();
     seedPendingDeletions(processDefinitionKey, 1, 2, 3);
 
@@ -775,7 +905,7 @@ public class DrainingProcessDefinitionTest {
     // given - a draining definition that has already drained cluster-wide
     final var processId = helper.getBpmnProcessId();
     final var metadata = deploy(processId);
-    drain(metadata, true);
+    injectDraining(metadata, true);
     final long processDefinitionKey = metadata.getProcessDefinitionKey();
     seedPendingDeletions(processDefinitionKey, 1, 2);
 
@@ -802,6 +932,81 @@ public class DrainingProcessDefinitionTest {
                 .count())
         .describedAs("the history of the definition's instances is deleted exactly once")
         .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldRejectRepeatedDeletionWhileDrainingWithoutDeletingActiveInstance() {
+    // given - a definition kept DRAINING by a still-running instance, deleted with history deletion
+    // requested (the only path that would otherwise create a batch operation)
+    final var processId = helper.getBpmnProcessId();
+    final var metadata = deployWithJob(processId);
+    final long processDefinitionKey = metadata.getProcessDefinitionKey();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+    awaitJobCreated(processInstanceKey);
+    engine
+        .resourceDeletion()
+        .withResourceKey(processDefinitionKey)
+        .withDeleteHistory(true)
+        .delete();
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DRAINING)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .await();
+
+    // when - called repeatedly while draining, carrying PROCESS_DEFINITION as the service layer
+    // resolves it for a history deletion in production
+    for (int i = 0; i < 3; i++) {
+      final var rejection =
+          engine
+              .resourceDeletion()
+              .withResourceKey(processDefinitionKey)
+              .withResourceType(ResourceType.PROCESS_DEFINITION)
+              .withResourceId(processId)
+              .withDeleteHistory(true)
+              .expectRejection()
+              .delete();
+
+      // then - rejected as already-being-deleted (not accepted with a fresh batch): the definition
+      // is still draining, so the caller is told to wait rather than getting a misleading not-found
+      assertThat(rejection)
+          .hasRejectionType(RejectionType.INVALID_STATE)
+          .hasRejectionReason(
+              "Expected to delete process definition with key `%d`, but it is already being deleted."
+                  .formatted(processDefinitionKey));
+    }
+
+    // then - no history-deletion batch operation was ever spawned by the repeated calls
+    Assertions.assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    RecordingExporter.batchOperationCreationRecords()
+                        .withIntent(BatchOperationIntent.CREATE)
+                        .exists()))
+        .describedAs("a repeated deletion while draining must not spawn a batch operation")
+        .isFalse();
+
+    // and - the still-running instance was not terminated by the repeated deletions
+    Assertions.assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    RecordingExporter.processInstanceRecords(
+                            ProcessInstanceIntent.ELEMENT_TERMINATED)
+                        .withProcessInstanceKey(processInstanceKey)
+                        .withElementType(BpmnElementType.PROCESS)
+                        .exists()))
+        .describedAs("an active instance must never be deleted prematurely by a repeated deletion")
+        .isFalse();
+
+    // and - the definition is not deleted while an instance is still running: it stays draining
+    Assertions.assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    RecordingExporter.processRecords()
+                        .withIntent(ProcessIntent.DELETED)
+                        .withProcessDefinitionKey(processDefinitionKey)
+                        .exists()))
+        .describedAs("the definition must stay draining, not be deleted, while an instance runs")
+        .isFalse();
   }
 
   private RecordToWrite drainReport(
@@ -856,6 +1061,17 @@ public class DrainingProcessDefinitionTest {
         .isTrue();
   }
 
+  private void assertReportedDrained(final long processDefinitionKey) {
+    Assertions.assertThat(
+            RecordingExporter.processRecords()
+                .withRecordType(RecordType.COMMAND)
+                .withIntent(ProcessIntent.DELETE_COMPLETE)
+                .withProcessDefinitionKey(processDefinitionKey)
+                .exists())
+        .describedAs("this partition reports drained (DELETE_COMPLETE) once its last instance ends")
+        .isTrue();
+  }
+
   private void awaitJobCreated(final long processInstanceKey) {
     RecordingExporter.jobRecords(JobIntent.CREATED)
         .withProcessInstanceKey(processInstanceKey)
@@ -875,7 +1091,7 @@ public class DrainingProcessDefinitionTest {
         .deploy()
         .getValue()
         .getProcessesMetadata()
-        .get(0);
+        .getFirst();
   }
 
   private ProcessMetadataValue deploy(final String processId) {
@@ -893,21 +1109,48 @@ public class DrainingProcessDefinitionTest {
         .deploy()
         .getValue()
         .getProcessesMetadata()
-        .get(0);
+        .getFirst();
   }
 
   /**
-   * Puts the given process definition into the {@code DRAINING} state. Since no processor writes
-   * the {@code DRAINING} event yet, the event is injected onto the log while the engine is stopped
-   * so it is applied to state on the next start (replay), rather than being ignored during live
-   * processing. TODO(#56978): drive draining via a real {@code RESOURCE_DELETION.DELETE} once that
-   * change lands, and remove this injection helper.
+   * Deletes the given definition and waits until it is marked {@code DRAINING}. Requires at least
+   * one active instance, otherwise the deletion finalizes right away instead of draining.
    */
-  private void drain(final ProcessMetadataValue metadata) {
-    drain(metadata, false);
+  private void drainViaDeletion(final long processDefinitionKey) {
+    drainViaDeletion(processDefinitionKey, false);
   }
 
-  private void drain(final ProcessMetadataValue metadata, final boolean deleteHistory) {
+  private void drainViaDeletion(final long processDefinitionKey, final boolean deleteHistory) {
+    engine
+        .resourceDeletion()
+        .withResourceKey(processDefinitionKey)
+        .withDeleteHistory(deleteHistory)
+        .delete();
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DRAINING)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .await();
+  }
+
+  /**
+   * Injects a {@code DRAINING} event directly (applied on the next start via replay), bypassing the
+   * deletion processor. Prefer {@link #drainViaDeletion(long)} — this helper is only for states a
+   * real deletion cannot reach on this harness:
+   *
+   * <ul>
+   *   <li>start-event race tests, which need a scheduled start event on an already-draining
+   *       definition — real deletion unsubscribes start events as it drains;
+   *   <li>tests with no active instance to keep the definition draining (e.g. the defensive {@code
+   *       ACTIVATE_ELEMENT} guard), where a real deletion would finalize immediately;
+   *   <li>deployment-partition aggregation tests that pair injection with {@link
+   *       #seedPendingDeletions} to simulate a multi-partition cluster on this single partition.
+   * </ul>
+   */
+  private void injectDraining(final ProcessMetadataValue metadata) {
+    injectDraining(metadata, false);
+  }
+
+  private void injectDraining(final ProcessMetadataValue metadata, final boolean deleteHistory) {
     engine.stop();
     engine.writeRecords(
         RecordToWrite.event()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
@@ -698,14 +698,34 @@ public class DrainingProcessDefinitionTest {
 
   @Test
   public void shouldMintNewVersionWhenRedeployingIdenticalResourceWhileDraining() {
-    // given - a definition kept draining by a still-running instance
+    // given - a definition kept draining by a still-running instance.
     final var processId = helper.getBpmnProcessId();
-    final var v1 = deployWithJob(processId);
+    final var resource =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .endEvent()
+            .done();
+    final var v1 =
+        engine
+            .deployment()
+            .withXmlResource(resource)
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .getFirst();
     awaitJobCreated(engine.processInstance().ofBpmnProcessId(processId).create());
     drainViaDeletion(v1.getProcessDefinitionKey());
 
     // when - the identical resource is redeployed while v1 is still draining
-    final var redeployed = deployWithJob(processId);
+    final var redeployed =
+        engine
+            .deployment()
+            .withXmlResource(resource)
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .getFirst();
 
     // then - it is not deduplicated onto the draining v1 (which would make the redeploy vanish once
     // the drain finalizes); a fresh version is minted with a new key
@@ -714,6 +734,10 @@ public class DrainingProcessDefinitionTest {
         .isFalse();
     assertThat(redeployed.getVersion()).isEqualTo(2);
     assertThat(redeployed.getProcessDefinitionKey()).isNotEqualTo(v1.getProcessDefinitionKey());
+    // and - the resource is byte-identical to v1
+    assertThat(redeployed.getChecksum())
+        .describedAs("the redeployed resource must be byte-identical to the draining v1")
+        .isEqualTo(v1.getChecksum());
   }
 
   @Test
@@ -960,7 +984,6 @@ public class DrainingProcessDefinitionTest {
           engine
               .resourceDeletion()
               .withResourceKey(processDefinitionKey)
-              .withResourceType(ResourceType.PROCESS_DEFINITION)
               .withResourceId(processId)
               .withDeleteHistory(true)
               .expectRejection()
@@ -1007,6 +1030,29 @@ public class DrainingProcessDefinitionTest {
                         .exists()))
         .describedAs("the definition must stay draining, not be deleted, while an instance runs")
         .isFalse();
+  }
+
+  @Test
+  public void shouldPopulateResourceMetadataOnRejectedDeleteWhileDrainingWithoutExplicitType() {
+    // given - a definition kept DRAINING by a still-running instance
+    final var processId = helper.getBpmnProcessId();
+    final var metadata = deployWithJob(processId);
+    final long processDefinitionKey = metadata.getProcessDefinitionKey();
+    engine.processInstance().ofBpmnProcessId(processId).create();
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DRAINING)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .await();
+
+    // when - the repeated delete carries only the resource key, as the default client path does
+    final var rejection =
+        engine.resourceDeletion().withResourceKey(processDefinitionKey).expectRejection().delete();
+
+    // then - the processor stamps the resolved metadata onto the rejection
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+    assertThat(rejection.getValue().getResourceType()).isEqualTo(ResourceType.PROCESS_DEFINITION);
+    assertThat(rejection.getValue().getResourceId()).isEqualTo(processId);
   }
 
   private RecordToWrite drainReport(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionMultiPartitionTest.java
@@ -13,7 +13,6 @@ import static org.assertj.core.api.Assertions.tuple;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -412,18 +411,9 @@ public class ResourceDeletionMultiPartitionTest {
             IntStream.rangeClosed(1, PARTITION_COUNT).boxed().toArray(Integer[]::new));
 
     // when - the last active instance completes on its partition, freeing that partition to drain.
-    // The command must be written on INSTANCE_PARTITION: the test harness routes writes to the
-    // deployment partition by default, but the job only exists on the instance's partition.
-    final var createdJob =
-        RecordingExporter.jobRecords(JobIntent.CREATED)
-            .withProcessInstanceKey(instanceKey)
-            .withType(JOB_TYPE)
-            .getFirst();
-    engine.writeCommandOnPartition(
-        INSTANCE_PARTITION,
-        createdJob.getKey(),
-        JobIntent.COMPLETE,
-        (JobRecord) createdJob.getValue());
+    // The job client routes the command to the job key's partition, so it lands on
+    // INSTANCE_PARTITION.
+    engine.job().ofInstance(instanceKey).withType(JOB_TYPE).complete();
 
     // then - all partitions' drain reports are cleared on the deployment partition and the
     // definition is reported fully deleted cluster-wide exactly once

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionMultiPartitionTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -33,7 +34,7 @@ import io.camunda.zeebe.protocol.record.value.ResourceType;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
-import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -102,7 +103,7 @@ public class ResourceDeletionMultiPartitionTest {
               RecordingExporter.records()
                   .withPartitionId(partitionId)
                   .limit(r -> r.getIntent().equals(ResourceDeletionIntent.DELETED))
-                  .collect(Collectors.toList()))
+                  .toList())
           .extracting(Record::getIntent)
           .endsWith(
               ResourceDeletionIntent.DELETE,
@@ -124,7 +125,7 @@ public class ResourceDeletionMultiPartitionTest {
             .deploy()
             .getValue()
             .getProcessesMetadata()
-            .get(0)
+            .getFirst()
             .getProcessDefinitionKey();
 
     // when
@@ -148,6 +149,7 @@ public class ResourceDeletionMultiPartitionTest {
                     : r.getPartitionId())
         .containsSubsequence(
             tuple(ResourceDeletionIntent.DELETE, RecordType.COMMAND, 1),
+            tuple(ProcessIntent.DRAINING, RecordType.EVENT, 1),
             tuple(ProcessIntent.DELETING, RecordType.EVENT, 1),
             tuple(ProcessIntent.DELETED, RecordType.EVENT, 1),
             tuple(ResourceDeletionIntent.DELETED, RecordType.EVENT, 1),
@@ -167,7 +169,7 @@ public class ResourceDeletionMultiPartitionTest {
               RecordingExporter.records()
                   .withPartitionId(partitionId)
                   .limit(r -> r.getIntent().equals(ResourceDeletionIntent.DELETED))
-                  .collect(Collectors.toList()))
+                  .toList())
           .extracting(Record::getIntent)
           .endsWith(
               ResourceDeletionIntent.DELETE,
@@ -191,7 +193,7 @@ public class ResourceDeletionMultiPartitionTest {
             .deploy()
             .getValue()
             .getProcessesMetadata()
-            .get(0)
+            .getFirst()
             .getProcessDefinitionKey();
 
     // when
@@ -231,7 +233,7 @@ public class ResourceDeletionMultiPartitionTest {
             .deploy()
             .getValue()
             .getProcessesMetadata()
-            .get(0)
+            .getFirst()
             .getProcessDefinitionKey();
 
     engine.processInstance().ofBpmnProcessId(processId).onPartition(2).create();
@@ -397,6 +399,18 @@ public class ResourceDeletionMultiPartitionTest {
         .withPartitionId(INSTANCE_PARTITION)
         .await();
 
+    // and - the deployment partition emitted a DRAINING event
+    final var drainingOnDeploymentPartition =
+        RecordingExporter.processRecords()
+            .withIntent(ProcessIntent.DRAINING)
+            .withProcessDefinitionKey(processDefinitionKey)
+            .withPartitionId(1)
+            .getFirst();
+    assertThat(((ProcessRecord) drainingOnDeploymentPartition.getValue()).getDrainPartitions())
+        .describedAs("the deployment partition's DRAINING event records every partition to drain")
+        .containsExactlyInAnyOrder(
+            IntStream.rangeClosed(1, PARTITION_COUNT).boxed().toArray(Integer[]::new));
+
     // when - the last active instance completes on its partition, freeing that partition to drain.
     // The command must be written on INSTANCE_PARTITION: the test harness routes writes to the
     // deployment partition by default, but the job only exists on the instance's partition.
@@ -443,7 +457,7 @@ public class ResourceDeletionMultiPartitionTest {
             .deploy()
             .getValue()
             .getFormMetadata()
-            .get(0)
+            .getFirst()
             .getFormKey();
 
     // when
@@ -485,7 +499,7 @@ public class ResourceDeletionMultiPartitionTest {
               RecordingExporter.records()
                   .withPartitionId(partitionId)
                   .limit(r -> r.getIntent().equals(ResourceDeletionIntent.DELETED))
-                  .collect(Collectors.toList()))
+                  .toList())
           .extracting(Record::getIntent)
           .endsWith(
               ResourceDeletionIntent.DELETE,
@@ -547,7 +561,7 @@ public class ResourceDeletionMultiPartitionTest {
               RecordingExporter.records()
                   .withPartitionId(partitionId)
                   .limit(r -> r.getIntent().equals(ResourceDeletionIntent.DELETED))
-                  .collect(Collectors.toList()))
+                  .toList())
           .extracting(Record::getIntent)
           .endsWith(
               ResourceDeletionIntent.DELETE,
@@ -569,7 +583,7 @@ public class ResourceDeletionMultiPartitionTest {
         .deploy()
         .getValue()
         .getProcessesMetadata()
-        .get(0)
+        .getFirst()
         .getProcessDefinitionKey();
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionMultiPartitionTest.java
@@ -12,16 +12,24 @@ import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ResourceType;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -36,6 +44,8 @@ public class ResourceDeletionMultiPartitionTest {
   private static final String DMN_RESOURCE = "/dmn/decision-table.dmn";
   private static final String FORM_RESOURCE = "/form/test-form-1.form";
   private static final String RPA_RESOURCE = "/resource/test-rpa-1.rpa";
+  private static final String JOB_TYPE = "task";
+  private static final int INSTANCE_PARTITION = 2;
 
   @Rule public final EngineRule engine = EngineRule.multiplePartition(PARTITION_COUNT);
   @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
@@ -162,10 +172,265 @@ public class ResourceDeletionMultiPartitionTest {
           .endsWith(
               ResourceDeletionIntent.DELETE,
               ResourceDeletionIntent.DELETING,
+              ProcessIntent.DRAINING,
               ProcessIntent.DELETING,
               ProcessIntent.DELETED,
+              ProcessIntent.DELETE_COMPLETE,
               ResourceDeletionIntent.DELETED);
     }
+  }
+
+  @Test
+  public void shouldFullyDeleteAcrossAllPartitionsWhenDeletingProcessWithoutInstances() {
+    // given - a process with no running instances on any partition
+    final var processId = Strings.newRandomValidBpmnId();
+    final long processDefinitionKey =
+        engine
+            .deployment()
+            .withXmlResource(Bpmn.createExecutableProcess(processId).startEvent().endEvent().done())
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .get(0)
+            .getProcessDefinitionKey();
+
+    // when
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+
+    // then - every partition drains (immediately, since there are no instances) and reports; the
+    // deployment partition clears each report and marks the definition fully deleted exactly once
+    assertThat(
+            RecordingExporter.processRecords()
+                .withIntent(ProcessIntent.DELETE_COMPLETED)
+                .withProcessDefinitionKey(processDefinitionKey)
+                .withPartitionId(1)
+                .limit(PARTITION_COUNT)
+                .count())
+        .describedAs("each partition's drain report is cleared on the deployment partition")
+        .isEqualTo(PARTITION_COUNT);
+    assertThat(
+            RecordingExporter.processRecords()
+                .withIntent(ProcessIntent.FULLY_DELETED)
+                .withProcessDefinitionKey(processDefinitionKey)
+                .withPartitionId(1)
+                .limit(1)
+                .count())
+        .describedAs("the definition is reported fully deleted exactly once")
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldNotBlockDeploymentsWhenDeletingProcessWithActiveInstanceOnOtherPartition() {
+    // given - a process with an active instance stopped at a user task on partition 2 (non-source)
+    final var processId = Strings.newRandomValidBpmnId();
+    final long processDefinitionKey =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId).startEvent().userTask().endEvent().done())
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .get(0)
+            .getProcessDefinitionKey();
+
+    engine.processInstance().ofBpmnProcessId(processId).onPartition(2).create();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withPartitionId(2)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // when - the definition is deleted; distribution to partition 2 gets stuck on the active
+    // instance (delete still succeeds on the source partition and returns)
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+
+    // and - a deployment is issued afterwards (deploy() awaits full distribution to all partitions)
+    final var secondProcessId = Strings.newRandomValidBpmnId();
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(secondProcessId).startEvent().endEvent().done())
+        .deploy();
+
+    // then - the later deployment still reaches the affected partition 2 (queue not blocked)
+    assertThat(
+            RecordingExporter.processRecords()
+                .withIntent(ProcessIntent.CREATED)
+                .withPartitionId(2)
+                .withBpmnProcessId(secondProcessId)
+                .exists())
+        .describedAs("a deployment after the deletion should still reach partition 2")
+        .isTrue();
+
+    // and - the resource-deletion distribution itself completes
+    assertThat(
+            RecordingExporter.commandDistributionRecords()
+                .withDistributionValueType(ValueType.RESOURCE_DELETION)
+                .withIntent(CommandDistributionIntent.FINISHED)
+                .exists())
+        .describedAs("RESOURCE_DELETION distribution should finish, not block the DEPLOYMENT queue")
+        .isTrue();
+  }
+
+  @Test
+  public void shouldNotFullyDeleteWhileInstanceStillActiveOnAnotherPartition() {
+    // given - a process whose only active instance lives on a non-deployment partition
+    final var processId = Strings.newRandomValidBpmnId();
+    final long processDefinitionKey = deployServiceTaskProcess(processId);
+    final long instanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .onPartition(INSTANCE_PARTITION)
+            .create();
+    awaitJobCreated(instanceKey);
+
+    // when - the definition is deleted; every partition drains, but partition INSTANCE_PARTITION
+    // keeps draining because its instance is still active
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+
+    // then - the two instance-free partitions report drained and the deployment partition clears
+    // them (PARTITION_COUNT - 1 reports)
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DELETE_COMPLETED)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .withPartitionId(1)
+        .limit(PARTITION_COUNT - 1)
+        .await();
+
+    // and - with one partition still draining its active instance, the definition must NOT be
+    // reported fully deleted (FULLY_DELETED requires every seeded partition to have reported)
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    RecordingExporter.processRecords()
+                        .withIntent(ProcessIntent.FULLY_DELETED)
+                        .withProcessDefinitionKey(processDefinitionKey)
+                        .withPartitionId(1)
+                        .exists()))
+        .describedAs("FULLY_DELETED must not be emitted while a partition is still draining")
+        .isFalse();
+  }
+
+  @Test
+  public void shouldRejectRetroactiveHistoryDeletionWhileDrainingOnAnotherPartition() {
+    // given - a process draining with its only active instance on a non-deployment partition, and
+    // the deployment partition already finalized locally (it has no instance of its own)
+    final var processId = Strings.newRandomValidBpmnId();
+    final long processDefinitionKey = deployServiceTaskProcess(processId);
+    final long instanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .onPartition(INSTANCE_PARTITION)
+            .create();
+    awaitJobCreated(instanceKey);
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+    // wait until only the instance's partition is still draining: the deployment partition has
+    // finalized locally (definition gone from its primary storage) but the cluster drain is not
+    // done
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DELETE_COMPLETED)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .withPartitionId(1)
+        .limit(PARTITION_COUNT - 1)
+        .await();
+
+    // when - a history deletion is requested for the locally-gone definition. The service resolves
+    // the type from secondary storage, so the command carries PROCESS_DEFINITION as in production.
+    final var rejection =
+        engine
+            .resourceDeletion()
+            .withResourceKey(processDefinitionKey)
+            .withResourceType(ResourceType.PROCESS_DEFINITION)
+            .withResourceId(processId)
+            .withDeleteHistory(true)
+            .expectRejection()
+            .delete();
+
+    // then - rejected as already-being-deleted: the definition is still draining cluster-wide, so
+    // the caller is told to wait rather than getting a misleading not-found
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+
+    // and - no history-deletion batch operation was spawned
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    RecordingExporter.batchOperationCreationRecords()
+                        .withIntent(BatchOperationIntent.CREATE)
+                        .exists()))
+        .describedAs("no batch operation while still draining on another partition")
+        .isFalse();
+
+    // and - the still-active instance on the other partition was not terminated
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    RecordingExporter.processInstanceRecords(
+                            ProcessInstanceIntent.ELEMENT_TERMINATED)
+                        .withProcessInstanceKey(instanceKey)
+                        .withElementType(BpmnElementType.PROCESS)
+                        .exists()))
+        .describedAs("an active instance on another partition must not be terminated")
+        .isFalse();
+  }
+
+  @Test
+  public void shouldFullyDeleteAfterActiveInstanceCompletesOnAnotherPartition() {
+    // given - a process draining with an active instance on a non-deployment partition
+    final var processId = Strings.newRandomValidBpmnId();
+    final long processDefinitionKey = deployServiceTaskProcess(processId);
+    final long instanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .onPartition(INSTANCE_PARTITION)
+            .create();
+    awaitJobCreated(instanceKey);
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+    // wait until the affected partition has actually entered DRAINING before completing the
+    // instance
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DRAINING)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .withPartitionId(INSTANCE_PARTITION)
+        .await();
+
+    // when - the last active instance completes on its partition, freeing that partition to drain.
+    // The command must be written on INSTANCE_PARTITION: the test harness routes writes to the
+    // deployment partition by default, but the job only exists on the instance's partition.
+    final var createdJob =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(instanceKey)
+            .withType(JOB_TYPE)
+            .getFirst();
+    engine.writeCommandOnPartition(
+        INSTANCE_PARTITION,
+        createdJob.getKey(),
+        JobIntent.COMPLETE,
+        (JobRecord) createdJob.getValue());
+
+    // then - all partitions' drain reports are cleared on the deployment partition and the
+    // definition is reported fully deleted cluster-wide exactly once
+    assertThat(
+            RecordingExporter.processRecords()
+                .withIntent(ProcessIntent.DELETE_COMPLETED)
+                .withProcessDefinitionKey(processDefinitionKey)
+                .withPartitionId(1)
+                .limit(PARTITION_COUNT)
+                .count())
+        .describedAs("every partition's drain report is cleared on the deployment partition")
+        .isEqualTo(PARTITION_COUNT);
+    assertThat(
+            RecordingExporter.processRecords()
+                .withIntent(ProcessIntent.FULLY_DELETED)
+                .withProcessDefinitionKey(processDefinitionKey)
+                .withPartitionId(1)
+                .limit(1)
+                .count())
+        .describedAs("the definition is reported fully deleted exactly once")
+        .isEqualTo(1);
   }
 
   @Test
@@ -290,5 +555,28 @@ public class ResourceDeletionMultiPartitionTest {
               ResourceIntent.DELETED,
               ResourceDeletionIntent.DELETED);
     }
+  }
+
+  private long deployServiceTaskProcess(final String processId) {
+    return engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+                .endEvent()
+                .done())
+        .deploy()
+        .getValue()
+        .getProcessesMetadata()
+        .get(0)
+        .getProcessDefinitionKey();
+  }
+
+  private void awaitJobCreated(final long processInstanceKey) {
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(JOB_TYPE)
+        .await();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionRejectionTest.java
@@ -8,12 +8,16 @@
 package io.camunda.zeebe.engine.processing.resource;
 
 import static io.camunda.zeebe.protocol.record.RecordAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import org.junit.Rule;
@@ -108,22 +112,53 @@ public class ResourceDeletionRejectionTest {
   }
 
   @Test
-  public void shouldRejectDeletionWhenRunningInstances() {
+  public void shouldDrainInsteadOfRejectingDeletionWhenRunningInstances() {
     // given
     final var processId = helper.getBpmnProcessId();
     final var processDefinitionKey = deployProcess(processId);
     engine.processInstance().ofBpmnProcessId(processId).create();
 
     // when
+    final var deletion = engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+
+    // then - the deletion is accepted, not rejected
+    Assertions.assertThat(deletion).hasIntent(ResourceDeletionIntent.DELETED);
+
+    // and - the definition is marked draining, not physically deleted, while the instance runs
+    final var eventsUpToDraining =
+        RecordingExporter.processRecords()
+            .withProcessDefinitionKey(processDefinitionKey)
+            .limit(r -> r.getIntent() == ProcessIntent.DRAINING)
+            .asList();
+    assertThat(eventsUpToDraining)
+        .extracting(Record::getIntent)
+        .describedAs("the definition is not deleted while an instance is still running")
+        .doesNotContain(ProcessIntent.DELETED)
+        .contains(ProcessIntent.DRAINING);
+  }
+
+  @Test
+  public void shouldRejectSecondDeletionOfDrainingProcess() {
+    // given - a definition that is draining because it still has a running instance
+    final var processId = helper.getBpmnProcessId();
+    final var processDefinitionKey = deployProcess(processId);
+    engine.processInstance().ofBpmnProcessId(processId).create();
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DRAINING)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .await();
+
+    // when - the same definition is deleted a second time while still draining
     final var rejection =
         engine.resourceDeletion().withResourceKey(processDefinitionKey).expectRejection().delete();
 
-    // then
+    // then - the repeated deletion is rejected as already-being-deleted, not re-marked draining
     assertThat(rejection)
-        .describedAs("Expect running instances")
+        .describedAs("a draining definition reports it is already being deleted")
         .hasRejectionType(RejectionType.INVALID_STATE)
         .hasRejectionReason(
-            "Expected to delete resource with key `%d` but there are still running instances"
+            "Expected to delete process definition with key `%d`, but it is already being deleted."
                 .formatted(processDefinitionKey));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
@@ -261,6 +261,7 @@ public class ResourceDeletionTest {
             ProcessIntent.CREATED,
             DeploymentIntent.CREATED,
             ResourceDeletionIntent.DELETING,
+            ProcessIntent.DRAINING,
             ProcessIntent.DELETING,
             ProcessIntent.DELETED,
             ResourceDeletionIntent.DELETED);
@@ -578,6 +579,40 @@ public class ResourceDeletionTest {
     verifyMessageStartEventSubscriptionIsCreated(versionOneProcessDefinitionKey, 4);
     verifyProcessIdWithVersionIsDeleted(processId, 2);
     verifyResourceDeletionRecords(versionTwoProcessDefinitionKey);
+  }
+
+  @Test
+  public void shouldSkipDrainingVersionWhenResubscribingStartEvents() {
+    // given - three versions of the same process, each with a message start event
+    final var processId = helper.getBpmnProcessId();
+    final var versionOneKey = deployProcessWithMessageStartEventAndUserTask(processId);
+    final var versionTwoKey = deployProcessWithMessageStartEventAndUserTask(processId);
+
+    // and - version two has a running instance, so deleting it leaves it DRAINING rather than
+    // physically deleted (its start subscription is inactive because version three is deployed
+    // next)
+    engine.message().withCorrelationKey("key").withName("message").publish();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessDefinitionKey(versionTwoKey)
+        .withElementType(BpmnElementType.USER_TASK)
+        .await();
+    final var versionThreeKey = deployProcessWithMessageStartEventAndUserTask(processId);
+
+    engine.resourceDeletion().withResourceKey(versionTwoKey).delete();
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DRAINING)
+        .withProcessDefinitionKey(versionTwoKey)
+        .await();
+
+    // when - the latest version is deleted, its start subscription must be handed back down
+    engine.resourceDeletion().withResourceKey(versionThreeKey).delete();
+
+    // then - resubscription skips the DRAINING version two and lands on the ACTIVE version one:
+    // version one is subscribed once on its own deployment, then again by the resubscription. Since
+    // there is exactly one resubscription and it targets version one, the draining version two is
+    // never resubscribed to.
+    verifyMessageStartEventSubscriptionIsDeleted(versionThreeKey);
+    verifyMessageStartEventSubscriptionIsCreated(versionOneKey, 2);
   }
 
   @Test
@@ -1147,6 +1182,23 @@ public class ResourceDeletionTest {
             Bpmn.createExecutableProcess(processId)
                 .startEvent()
                 .message("message")
+                .endEvent()
+                .done())
+        .deploy()
+        .getValue()
+        .getProcessesMetadata()
+        .get(0)
+        .getProcessDefinitionKey();
+  }
+
+  private long deployProcessWithMessageStartEventAndUserTask(final String processId) {
+    return engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .message("message")
+                .userTask("wait")
                 .endEvent()
                 .done())
         .deploy()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.util.client;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
@@ -162,127 +163,86 @@ public final class JobClient {
     return jobKey;
   }
 
-  public Record<JobRecordValue> complete() {
+  // Route to the partition encoded in the job key.
+  // Deployment-partition and non-encoded keys keep the default path.
+  private long writeJobCommand(final JobIntent intent) {
     final long jobKey = findJobKey();
-    final long position =
-        writer.writeCommand(
-            jobKey, JobIntent.COMPLETE, jobRecord, authorizedTenantIds.toArray(new String[0]));
-    return expectation.apply(position);
+    final int partitionId = Protocol.decodePartitionId(jobKey);
+    if (partitionId <= Protocol.DEPLOYMENT_PARTITION) {
+      return writer.writeCommand(
+          jobKey, intent, jobRecord, authorizedTenantIds.toArray(new String[0]));
+    }
+    return writer.writeCommandOnPartition(
+        partitionId, jobKey, intent, jobRecord, authorizedTenantIds.toArray(new String[0]));
+  }
+
+  private long writeJobCommand(final JobIntent intent, final String username) {
+    final long jobKey = findJobKey();
+    final int partitionId = Protocol.decodePartitionId(jobKey);
+    if (partitionId <= Protocol.DEPLOYMENT_PARTITION) {
+      return writer.writeCommand(
+          jobKey, intent, username, jobRecord, authorizedTenantIds.toArray(new String[0]));
+    }
+    return writer.writeCommandOnPartition(
+        partitionId,
+        jobKey,
+        intent,
+        username,
+        jobRecord,
+        authorizedTenantIds.toArray(new String[0]));
+  }
+
+  public Record<JobRecordValue> complete() {
+    return expectation.apply(writeJobCommand(JobIntent.COMPLETE));
   }
 
   public Record<JobRecordValue> complete(final String username) {
-    final long jobKey = findJobKey();
-    final long position =
-        writer.writeCommand(
-            jobKey,
-            JobIntent.COMPLETE,
-            username,
-            jobRecord,
-            authorizedTenantIds.toArray(new String[0]));
-    return expectation.apply(position);
+    return expectation.apply(writeJobCommand(JobIntent.COMPLETE, username));
   }
 
   public Record<JobRecordValue> fail() {
-    final long jobKey = findJobKey();
-    final long position =
-        writer.writeCommand(
-            jobKey, JobIntent.FAIL, jobRecord, authorizedTenantIds.toArray(new String[0]));
-
-    return expectation.apply(position);
+    return expectation.apply(writeJobCommand(JobIntent.FAIL));
   }
 
   public Record<JobRecordValue> fail(final String username) {
-    final long jobKey = findJobKey();
-    final long position =
-        writer.writeCommand(
-            jobKey,
-            JobIntent.FAIL,
-            username,
-            jobRecord,
-            authorizedTenantIds.toArray(new String[0]));
-
-    return expectation.apply(position);
+    return expectation.apply(writeJobCommand(JobIntent.FAIL, username));
   }
 
   public Record<JobRecordValue> yield() {
     final long jobKey = findJobKey();
-    final long position = writer.writeCommand(jobKey, JobIntent.YIELD, jobRecord);
-
+    final int partitionId = Protocol.decodePartitionId(jobKey);
+    final long position =
+        partitionId <= Protocol.DEPLOYMENT_PARTITION
+            ? writer.writeCommand(jobKey, JobIntent.YIELD, jobRecord)
+            : writer.writeCommandOnPartition(partitionId, jobKey, JobIntent.YIELD, jobRecord);
     return expectation.apply(position);
   }
 
   public Record<JobRecordValue> updateRetries() {
-    final long jobKey = findJobKey();
-    final long position =
-        writer.writeCommand(
-            jobKey,
-            JobIntent.UPDATE_RETRIES,
-            jobRecord,
-            authorizedTenantIds.toArray(new String[0]));
-    return expectation.apply(position);
+    return expectation.apply(writeJobCommand(JobIntent.UPDATE_RETRIES));
   }
 
   public Record<JobRecordValue> updateRetries(final String username) {
-    final long jobKey = findJobKey();
-    final long position =
-        writer.writeCommand(
-            jobKey,
-            JobIntent.UPDATE_RETRIES,
-            username,
-            jobRecord,
-            authorizedTenantIds.toArray(new String[0]));
-    return expectation.apply(position);
+    return expectation.apply(writeJobCommand(JobIntent.UPDATE_RETRIES, username));
   }
 
   public Record<JobRecordValue> updateTimeout() {
-    final long jobKey = findJobKey();
-    final long position =
-        writer.writeCommand(
-            jobKey,
-            JobIntent.UPDATE_TIMEOUT,
-            jobRecord,
-            authorizedTenantIds.toArray(new String[0]));
-    return expectation.apply(position);
+    return expectation.apply(writeJobCommand(JobIntent.UPDATE_TIMEOUT));
   }
 
   public Record<JobRecordValue> updateTimeout(final String username) {
-    final long jobKey = findJobKey();
-    final long position =
-        writer.writeCommand(
-            jobKey,
-            JobIntent.UPDATE_TIMEOUT,
-            username,
-            jobRecord,
-            authorizedTenantIds.toArray(new String[0]));
-    return expectation.apply(position);
+    return expectation.apply(writeJobCommand(JobIntent.UPDATE_TIMEOUT, username));
   }
 
   public Record<JobRecordValue> update() {
-    final long jobKey = findJobKey();
-    final long position =
-        writer.writeCommand(
-            jobKey, JobIntent.UPDATE, jobRecord, authorizedTenantIds.toArray(new String[0]));
-    return expectation.apply(position);
+    return expectation.apply(writeJobCommand(JobIntent.UPDATE));
   }
 
   public Record<JobRecordValue> throwError() {
-    final long jobKey = findJobKey();
-    final long position =
-        writer.writeCommand(
-            jobKey, JobIntent.THROW_ERROR, jobRecord, authorizedTenantIds.toArray(new String[0]));
-
-    return expectation.apply(position);
+    return expectation.apply(writeJobCommand(JobIntent.THROW_ERROR));
   }
 
   public Record<JobRecordValue> throwError(final String username) {
-    final long jobKey = findJobKey();
-    final long position =
-        writer.writeCommand(
-            jobKey,
-            JobIntent.THROW_ERROR,
-            username,
-            jobRecord,
-            authorizedTenantIds.toArray(new String[0]));
-    return expectation.apply(position);
+    return expectation.apply(writeJobCommand(JobIntent.THROW_ERROR, username));
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/Process_DRAINING_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/Process_DRAINING_v1.golden
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.state.appliers;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 
@@ -24,5 +25,14 @@ public class ProcessDrainingApplier implements TypedEventApplier<ProcessIntent, 
   @Override
   public void applyState(final long key, final ProcessRecord value) {
     processState.markDraining(value);
+
+    // Only the deployment partition aggregates; the event key is minted locally so it encodes the
+    // applying partition. Seed one pending entry per frozen partition; each DELETE_COMPLETE clears
+    // one, and the definition is fully deleted once none remain.
+    if (Protocol.decodePartitionId(key) == Protocol.DEPLOYMENT_PARTITION) {
+      for (final int partitionId : value.getDrainPartitions()) {
+        processState.addPendingDeletion(value.getProcessDefinitionKey(), partitionId);
+      }
+    }
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -255,10 +255,15 @@ paths:
 
         By default, only the resource itself is deleted from the runtime state. To also delete the
         historic data associated with a resource, set the `deleteHistory` flag in the request body
-        to `true`. The historic data is deleted asynchronously via a batch operation. The details of
-        the created batch operation are included in the response. Note that history deletion is only
-        supported for process resources; for other resource types this flag is ignored and no history
-        will be deleted.
+        to `true`. History deletion is supported for process definitions and decision requirements
+        definitions; for other resource types (forms, generic resources) the flag is ignored and no
+        history is deleted.
+
+        The two supported types differ in how the history is removed. For a decision requirements
+        definition the history is deleted asynchronously via a batch operation whose details are
+        returned in the `batchOperation` field of the response. For a process definition the
+        definition first drains its running instances and its history is deleted asynchronously once
+        the definition is fully removed cluster-wide; no batch operation is returned in the response.
       parameters:
         - name: resourceKey
           in: path
@@ -553,13 +558,15 @@ components:
           $ref: 'keys.yaml#/components/schemas/OperationReference'
         deleteHistory:
           description: |
-            Indicates if the historic data of a process resource should be deleted via a
-            batch operation asynchronously.
+            Indicates if the historic data associated with the resource should also be deleted
+            asynchronously.
 
-            This flag is only effective for process resources. For other resource types
-            (decisions, forms, generic resources), this flag is ignored and no history
-            will be deleted. In those cases, the `batchOperation` field in the response
-            will not be populated.
+            This flag is effective for process definitions and decision requirements definitions.
+            For other resource types (forms, generic resources) it is ignored and no history is
+            deleted. For a decision requirements definition the `batchOperation` field in the
+            response carries the created batch operation. For a process definition the history is
+            deleted as part of the definition's draining/deletion lifecycle and no batch operation is
+            returned.
           type: boolean
           default: false
       x-properties-added-in-version:
@@ -583,9 +590,14 @@ components:
           description: |
             The batch operation created for asynchronously deleting the historic data.
 
-            This field is only populated when the request `deleteHistory` is set to `true` and the resource
-            is a process definition. For other resource types (decisions, forms, generic resources),
-            this field will be `null`.
+            Populated when `deleteHistory` is `true` and either the resource is a decision
+            requirements definition, or the resource is a process definition that is already fully
+            deleted from the runtime state (its history is purged directly by a batch operation).
+
+            For a process definition that still exists in the runtime state, deletion first drains
+            the definition and its history is removed asynchronously as part of that lifecycle, so no
+            batch operation is returned and this field is `null`. It is also `null` for forms and
+            generic resources.
       x-properties-added-in-version:
         - propertyName: resourceKey
           addedInVersion: "8.9"

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
@@ -19,10 +19,14 @@ import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.IntegerValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import org.agrona.DirectBuffer;
@@ -42,9 +46,11 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   private final ArrayProperty<TransformerVersion> transformerVersionsProp =
       new ArrayProperty<>("transformerVersions", TransformerVersion::new);
   private final BooleanProperty deleteHistoryProp = new BooleanProperty("deleteHistory", false);
+  private final ArrayProperty<IntegerValue> drainPartitionsProp =
+      new ArrayProperty<>("drainPartitions", IntegerValue::new);
 
   public ProcessRecord() {
-    super(11);
+    super(12);
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(keyProp)
@@ -55,7 +61,8 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
         .declareProperty(deploymentKeyProp)
         .declareProperty(versionTagProp)
         .declareProperty(transformerVersionsProp)
-        .declareProperty(deleteHistoryProp);
+        .declareProperty(deleteHistoryProp)
+        .declareProperty(drainPartitionsProp);
   }
 
   public ProcessRecord wrap(final ProcessMetadata metadata, final byte[] resource) {
@@ -225,6 +232,19 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   }
 
   /**
+   * Returns the stored slot→version pairs sorted by slot ID. Absent entries default to version 1.
+   * Excluded from JSON export — engine-internal state not exposed to external consumers.
+   */
+  @JsonIgnore
+  public Map<Integer, Integer> getTransformerVersions() {
+    final Map<Integer, Integer> result = new TreeMap<>();
+    for (final TransformerVersion entry : transformerVersionsProp) {
+      result.put(entry.getSlotId(), entry.getVersion());
+    }
+    return result;
+  }
+
+  /**
    * Sets the per-slot transformer versions frozen at deploy time. Entries are sorted by slot ID
    * before writing so the msgpack array is always in a deterministic order regardless of the input
    * map's iteration order. Version-1 entries are stored but redundant — {@link
@@ -244,19 +264,6 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   }
 
   /**
-   * Returns the stored slot→version pairs sorted by slot ID. Absent entries default to version 1.
-   * Excluded from JSON export — engine-internal state not exposed to external consumers.
-   */
-  @JsonIgnore
-  public Map<Integer, Integer> getTransformerVersions() {
-    final Map<Integer, Integer> result = new TreeMap<>();
-    for (final TransformerVersion entry : transformerVersionsProp) {
-      result.put(entry.getSlotId(), entry.getVersion());
-    }
-    return result;
-  }
-
-  /**
    * Whether the instances' history must be deleted once the definition is gone cluster-wide.
    * Carried on {@code DRAINING} to be persisted with the draining definition, then back on the
    * {@code DELETE_COMPLETE} drain report so the deployment partition knows whether to delete it.
@@ -269,6 +276,25 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
 
   public ProcessRecord setDeleteHistory(final boolean deleteHistory) {
     deleteHistoryProp.setValue(deleteHistory);
+    return this;
+  }
+
+  /** Partitions frozen at DRAINING time to seed drain-aggregation. Only set on DRAINING events. */
+  @JsonIgnore
+  public List<Integer> getDrainPartitions() {
+    final List<Integer> result = new ArrayList<>();
+    for (final IntegerValue partitionId : drainPartitionsProp) {
+      result.add(partitionId.getValue());
+    }
+    return result;
+  }
+
+  public ProcessRecord setDrainPartitions(final Collection<Integer> partitionIds) {
+    drainPartitionsProp.reset();
+    // Sort to keep the serialized record deterministic across runs.
+    partitionIds.stream()
+        .sorted()
+        .forEach(partitionId -> drainPartitionsProp.add().setValue(partitionId));
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessRecord.golden
@@ -19,6 +19,7 @@ import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.IntegerValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
@@ -42,9 +43,11 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   private final ArrayProperty<TransformerVersion> transformerVersionsProp =
       new ArrayProperty<>("transformerVersions", TransformerVersion::new);
   private final BooleanProperty deleteHistoryProp = new BooleanProperty("deleteHistory", false);
+  private final ArrayProperty<IntegerValue> drainPartitionsProp =
+      new ArrayProperty<>("drainPartitions", IntegerValue::new);
 
   public ProcessRecord() {
-    super(11);
+    super(12);
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(keyProp)
@@ -55,7 +58,8 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
         .declareProperty(deploymentKeyProp)
         .declareProperty(versionTagProp)
         .declareProperty(transformerVersionsProp)
-        .declareProperty(deleteHistoryProp);
+        .declareProperty(deleteHistoryProp)
+        .declareProperty(drainPartitionsProp);
   }
 
   public ProcessRecord wrap(final ProcessMetadata metadata, final byte[] resource) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateDeploymentTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateDeploymentTest.java
@@ -160,7 +160,7 @@ public final class CreateDeploymentTest {
     final var modelThatFitsJustWithinMaxMessageSize =
         Bpmn.createExecutableProcess("PROCESS")
             .startEvent()
-            .documentation("x".repeat((1046900)))
+            .documentation("x".repeat((1046700)))
             .done();
     getCommand(client, false)
         .addProcessModel(modelThatFitsJustWithinMaxMessageSize, "too_large_process.bpmn")


### PR DESCRIPTION
## Description

- Deleting a process definition with running instances now marks it `DRAINING` instead of rejecting; deletion finalizes once the last instance completes (banned instances excluded).
- Definitions with no running instances finalize immediately; a second delete of a draining definition is rejected as `INVALID_STATE `.
- Start-event subscription is handed down to the latest **ACTIVE** version, skipping draining/deleted versions.
- Cross-partition aggregation: `ProcessRecord` carries `drainPartitions` (+`deleteHistory`), seeded into pending-deletions on the deployment partition so `DELETE_COMPLETE` reports converge to `FULLY_DELETED`.
- New draining gauge `zeebe.process.definitions.draining.count`; metrics split into `processDefinitionDraining` / `processDefinitionDrainFinalized`.
- `RoutingInfo` + `ProcessDefinitionMetrics` wired through `EngineProcessors`; tests updated for drain-instead-of-reject and multi-partition finalization.

## Related issues

closes https://github.com/camunda/camunda/issues/56978
