### PR TITLE
build: parallelize AWS OpenSearch ITs with version grouping and cluster verification

### DIFF
--- a/.github/scripts/check-aws-opensearch-version.py
+++ b/.github/scripts/check-aws-opensearch-version.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+import os
+import sys
+from urllib.parse import urlparse
+
+import boto3
+from opensearchpy import OpenSearch, RequestsHttpConnection, AWSV4SignerAuth
+
+# Validate and normalize environment variables first.
+opensearch_url = os.environ.get("OPENSEARCH_URL", "").strip()
+if not opensearch_url:
+    print("ERROR: OPENSEARCH_URL is required")
+    sys.exit(1)
+OPENSEARCH_URL = opensearch_url.rstrip("/")
+
+expected_version = os.environ.get("EXPECTED_OS_VERSION", "").strip()
+if not expected_version:
+    print("ERROR: EXPECTED_OS_VERSION is required")
+    sys.exit(1)
+
+REGION = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
+
+raw_creds = boto3.Session().get_credentials()
+if raw_creds is None:
+    print("ERROR: No AWS credentials found. Ensure the runner has a configured IAM role or credentials.")
+    sys.exit(1)
+
+parsed = urlparse(OPENSEARCH_URL)
+if not parsed.hostname:
+    print("ERROR: OPENSEARCH_URL must be a valid URL with hostname")
+    sys.exit(1)
+
+awsauth = AWSV4SignerAuth(raw_creds, REGION, "es")
+client = OpenSearch(
+    hosts=[{"host": parsed.hostname, "port": parsed.port or (443 if parsed.scheme == "https" else 80)}],
+    http_auth=awsauth,
+    use_ssl=parsed.scheme == "https",
+    verify_certs=True,
+    connection_class=RequestsHttpConnection,
+)
+
+try:
+    info = client.info()
+except Exception as exc:
+    print(f"ERROR: Failed to reach OpenSearch cluster at {OPENSEARCH_URL}: {exc}")
+    sys.exit(1)
+
+actual_version = info.get("version", {}).get("number", "").strip()
+if not actual_version:
+    print(f"ERROR: Could not determine cluster version from response: {info}")
+    sys.exit(1)
+
+# Compare major.minor only; the patch version is allowed to differ.
+actual_major_minor = ".".join(actual_version.split(".")[:2])
+if actual_major_minor != expected_version:
+    print(
+        f"ERROR: Cluster at {OPENSEARCH_URL} reports version '{actual_version}' "
+        f"(major.minor '{actual_major_minor}'), which does not match the requested "
+        f"job version '{expected_version}'. Refusing to proceed with cleanup/tests "
+        "against a mismatched cluster."
+    )
+    sys.exit(1)
+
+print(f"OK: Cluster at {OPENSEARCH_URL} reports version '{actual_version}', matches expected '{expected_version}'.")

--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -21,243 +21,31 @@ on:
         options:
           - "2.19"
           - "3.5"
+          - "all"
   schedule:
     - cron: "0 4 * * Mon-Fri"
 
-defaults:
-  run:
-    # use bash shell by default to ensure pipefail behavior is the default
-    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
-    shell: bash
-
-# Prevent concurrent runs of this workflow from stacking additional load on the
-# shared AWS OpenSearch clusters used by the integration-tests matrix below.
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
-
-env:
-  TEST_OWNER: '@camunda/core-features'
-
 jobs:
-  cleanup-opensearch-indices:
-    name: "[PRE] Cleanup old AWS OpenSearch indices. OS ver.${{ matrix.os_version }}"
-    permissions:
-      contents: read
-    timeout-minutes: 30
-    runs-on: aws-core-8-default
-    strategy:
-      fail-fast: false
-      matrix:
-        os_version: ${{ fromJSON(format('[{0}]', github.event.inputs.opensearch-version || '"2.19", "3.5"')) }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ inputs.ref }}
-      - name: Setup AWS OpenSearch
-        uses: ./.github/actions/setup-aws-opensearch-env
-        with:
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-          opensearch-version: ${{ matrix.os_version }}
-      - name: Python setup
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.x"
-      - name: Install Python dependencies
-        run: |
-          python3 -m pip install -q --disable-pip-version-check boto3==1.42.50 opensearch-py==3.1.0
-      - name: Delete old aws opensearch indices
-        env:
-          OPENSEARCH_URL: ${{ env.OPENSEARCH_URL }}
-          DRY_RUN: "false"
-          AGE_HOURS: "2"
-        run: python3 .github/scripts/clean-up-aws-opensearch-indices.py
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          job_name: "cleanup-opensearch-indices/${{ matrix.os_version }}"
-          build_status: ${{ job.status }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-
-  integration-tests:
-    name: "[IT] ${{ matrix.name }}. OS ver.${{ matrix.os_version }}"
-    needs: cleanup-opensearch-indices
+  # Each matrix leg below is a separate call to the reusable workflow, i.e. a fully
+  # independent job graph (check version -> cleanup -> integration tests -> slack
+  # notification, sequential within that call). That's what makes the 2.19 and 3.5
+  # chains run as two parallel, independent boxes instead of one shared job graph
+  # gated on both versions at every step: a `needs:` on a matrixed job waits for ALL
+  # of that job's matrix legs, not just the matching os_version, so keeping os_version
+  # as a matrix dimension on shared jobs (as before) would still serialize 2.19 and 3.5
+  # at each phase boundary even with per-version concurrency groups.
+  run-aws-opensearch-tests:
+    name: "AWS OpenSearch ${{ matrix.os_version }}"
     permissions:
       contents: read
       actions: write
-    timeout-minutes: 360
-    runs-on: ${{ matrix.runs-on }}
-    env:
-      TEST_OWNER: ${{ matrix.owner }}
     strategy:
       fail-fast: false
-      # Cap concurrent matrix jobs: all groups for a given os_version share one
-      # AWS OpenSearch cluster, and running all 5 at once overloads it (cluster
-      # event queue timeouts, search_phase_execution_exception, and jobs hanging
-      # until the job timeout). This is a nightly/manual job, so trading some
-      # wall-clock time for reliability is an acceptable tradeoff.
-      max-parallel: 1
       matrix:
-        os_version: ${{ fromJSON(format('[{0}]', github.event.inputs.opensearch-version || '"2.19", "3.5"')) }}
-        group:
-        - camunda-qa-acceptance-tests-client
-        - camunda-qa-acceptance-tests-non-client
-        - search-client-opensearch
-        - camunda-exporter
-        - zeebe-opensearch-exporter
-        include:
-          - group: camunda-qa-acceptance-tests-client
-            name: "Camunda QA Module Client Tests"
-            maven-modules: "'io.camunda:camunda-qa-acceptance-tests'"
-            maven-build-threads: 2
-            maven-test-fork-count: 1
-            maven-test-profiles: multi-db-test-client
-            runs-on: aws-core-8-default
-            owner: '@camunda/engineering-operations'
-          - group: camunda-qa-acceptance-tests-non-client
-            name: "Camunda QA Module Non-Client Tests"
-            maven-modules: "'io.camunda:camunda-qa-acceptance-tests'"
-            maven-build-threads: 2
-            maven-test-fork-count: 1
-            maven-test-profiles: multi-db-test-non-client
-            runs-on: aws-core-8-default
-            owner: '@camunda/engineering-operations'
-          - group: search-client-opensearch
-            name: "Search Client OpenSearch ITs"
-            maven-modules: "'io.camunda:camunda-search-client-connect,io.camunda:camunda-search-client-opensearch'"
-            maven-build-threads: 2
-            maven-test-fork-count: 1
-            maven-test-profiles: multi-db-test
-            runs-on: aws-core-8-default
-            owner: '@camunda/core-features'
-          - group: camunda-exporter
-            name: "Camunda Exporter ITs"
-            maven-modules: "'io.camunda:camunda-exporter'"
-            maven-build-threads: 2
-            maven-test-fork-count: 1
-            maven-test-profiles: multi-db-test
-            runs-on: aws-core-8-default
-            owner: '@camunda/data-layer'
-          - group: zeebe-opensearch-exporter
-            name: "Zeebe OpenSearch Exporter ITs"
-            maven-modules: "'io.camunda:zeebe-opensearch-exporter'"
-            maven-build-threads: 2
-            maven-test-fork-count: 1
-            maven-test-profiles: multi-db-test
-            runs-on: aws-core-8-default
-            owner: '@camunda/data-layer'
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Setup AWS OpenSearch
-        uses: ./.github/actions/setup-aws-opensearch-env
-        with:
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-          opensearch-version: ${{ matrix.os_version }}
-      - uses: ./.github/actions/setup-build
-        with:
-          maven-cache-key-modifier: it-${{ matrix.group }}
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - uses: ./.github/actions/build-zeebe
-        id: build-zeebe
-        with:
-          maven-extra-args: -T1C -D skip.fe.build -D skip.yarn -D skip.docker
-      - name: Create build output log file
-        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
-      - name: Maven Test Build
-        shell: bash
-        run: >
-          ./mvnw -B -T ${{ matrix.maven-build-threads }} --no-snapshot-updates
-          -D forkCount=${{ matrix.maven-test-fork-count }}
-          -D maven.javadoc.skip=true
-          -D skipUTs -D skipChecks
-          -D flaky.test.reportDir=failsafe-reports
-          -D test.integration.opensearch.aws.url="${{ env.OPENSEARCH_URL }}"
-          -D test.integration.camunda.database.type=AWS_OS
-          -D test.integration.opensearch.aws.timeout.seconds=180
-          -P parallel-tests,extract-flaky-tests,${{ matrix.maven-test-profiles }}
-          -pl ${{ matrix.maven-modules }}
-          verify
-          | tee "${BUILD_OUTPUT_FILE_PATH}"
-      - name: Analyze Test Runs
-        id: analyze-test-run
-        if: always()
-        uses: ./.github/actions/analyze-test-runs
-        with:
-          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
-      - name: Upload test artifacts
-        uses: ./.github/actions/collect-test-artifacts
-        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
-        with:
-          name: "[IT] ${{ matrix.name }}"
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          job_name: "integration-tests/${{ matrix.group }}"
-          build_status: ${{ job.status }}
-          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-
-  send-slack-notificaion:
-    name: "Send slack notification on fail"
-    runs-on: ubuntu-latest
-    needs: integration-tests
-
-    # TODO: Re-enable this once the pipeline is in a healthy and meaningful state
-    # currently tracked in https://github.com/camunda/camunda/issues/52892
-    # if: (failure() || cancelled()) && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))
-    if: ${{ false }}
-
-    permissions:
-      contents: read
-      actions: write
-    steps:
-    - name: Import secrets from Vault
-      id: secrets
-      uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
-      with:
-        url: ${{ secrets.VAULT_ADDR }}
-        method: approle
-        roleId: ${{ secrets.VAULT_ROLE_ID }}
-        secretId: ${{ secrets.VAULT_SECRET_ID }}
-        secrets: |
-          secret/data/products/camunda/ci/github-actions DATA_ENGINE_CI_ALERT_WEBHOOK_URL;
-    - name: Send notification
-      uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
-      with:
-        webhook: ${{ steps.secrets.outputs.DATA_ENGINE_CI_ALERT_WEBHOOK_URL }}
-        webhook-type: webhook-trigger
-        # For posting a rich message using Block Kit
-        payload: |
-          text: "AWS OpenSearch Manual/Scheduled Run Integration Tests failed or were cancelled"
-          blocks:
-            - type: "section"
-              text:
-                type: "mrkdwn"
-                text: "AWS OpenSearch Manual/Scheduled Run Integration Tests FAILED or WERE CANCELLED\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-    - name: Checkout
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        sparse-checkout: .github
-    - name: Observe build status
-      if: always()
-      continue-on-error: true
-      uses: ./.github/actions/observe-build-status
-      with:
-        build_status: ${{ job.status }}
-        secret_vault_address: ${{ secrets.VAULT_ADDR }}
-        secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-        secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+        # "all" and the unset/schedule case both expand to both versions.
+        os_version: ${{ fromJSON(format('[{0}]', (github.event.inputs.opensearch-version == 'all' || !github.event.inputs.opensearch-version) && '"2.19", "3.5"' || format('"{0}"', github.event.inputs.opensearch-version))) }}
+    uses: ./.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      ref: ${{ inputs.ref }}
+      os_version: ${{ matrix.os_version }}

--- a/.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
+++ b/.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
@@ -198,7 +198,7 @@ jobs:
           opensearch-version: ${{ inputs.os_version }}
       - uses: ./.github/actions/setup-build
         with:
-          maven-cache-key-modifier: it-${{ matrix.group }}
+          maven-cache-key-modifier: it-${{ matrix.group }}-${{ inputs.os_version }}
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
+++ b/.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
@@ -1,0 +1,298 @@
+# description: Reusable workflow running the check/cleanup/IT/notify chain for one AWS OS version
+# type: CI
+# owner: @camunda/core-features, @camunda/data-layer
+name: AWS OpenSearch Integration Tests (single version)
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Branch or commit to test against
+        type: string
+        default: "main"
+      os_version:
+        description: Version of AWS OpenSearch to run this chain against
+        type: string
+        required: true
+
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+env:
+  TEST_OWNER: '@camunda/core-features'
+
+jobs:
+  check-opensearch-version:
+    name: "[PRE] Verify AWS OpenSearch cluster version matches OS ver.${{ inputs.os_version }}"
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    runs-on: aws-core-8-default
+    # Shares the per-os_version AWS OpenSearch cluster with cleanup-opensearch-indices
+    # and integration-tests below, so concurrent runs against the same cluster queue
+    # up instead of colliding.
+    concurrency:
+      group: aws-opensearch-${{ inputs.os_version }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Setup AWS OpenSearch
+        uses: ./.github/actions/setup-aws-opensearch-env
+        with:
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          opensearch-version: ${{ inputs.os_version }}
+      - name: Python setup
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.x"
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install -q --disable-pip-version-check boto3==1.42.50 opensearch-py==3.1.0
+      - name: Verify AWS OpenSearch cluster version
+        env:
+          OPENSEARCH_URL: ${{ env.OPENSEARCH_URL }}
+          EXPECTED_OS_VERSION: ${{ inputs.os_version }}
+        run: python3 .github/scripts/check-aws-opensearch-version.py
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "check-opensearch-version/${{ inputs.os_version }}"
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+  cleanup-opensearch-indices:
+    name: "[PRE] Cleanup old AWS OpenSearch indices. OS ver.${{ inputs.os_version }}"
+    needs: check-opensearch-version
+    permissions:
+      contents: read
+    timeout-minutes: 30
+    runs-on: aws-core-8-default
+    # See the concurrency comment on check-opensearch-version above.
+    concurrency:
+      group: aws-opensearch-${{ inputs.os_version }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Setup AWS OpenSearch
+        uses: ./.github/actions/setup-aws-opensearch-env
+        with:
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          opensearch-version: ${{ inputs.os_version }}
+      - name: Python setup
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.x"
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install -q --disable-pip-version-check boto3==1.42.50 opensearch-py==3.1.0
+      - name: Delete old aws opensearch indices
+        env:
+          OPENSEARCH_URL: ${{ env.OPENSEARCH_URL }}
+          DRY_RUN: "false"
+          AGE_HOURS: "2"
+        run: python3 .github/scripts/clean-up-aws-opensearch-indices.py
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "cleanup-opensearch-indices/${{ inputs.os_version }}"
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+  integration-tests:
+    name: "[IT] ${{ matrix.name }}. OS ver.${{ inputs.os_version }}"
+    needs: cleanup-opensearch-indices
+    permissions:
+      contents: read
+      actions: write
+    timeout-minutes: 360
+    runs-on: ${{ matrix.runs-on }}
+    env:
+      TEST_OWNER: ${{ matrix.owner }}
+    # All groups below share the one AWS OpenSearch cluster for this os_version, and
+    # running all 5 at once overloads it (cluster event queue timeouts,
+    # search_phase_execution_exception, and jobs hanging until the job timeout). Queue
+    # matrix legs one at a time via the same per-version concurrency group used by
+    # check-opensearch-version and cleanup-opensearch-indices above.
+    concurrency:
+      group: aws-opensearch-${{ inputs.os_version }}
+      cancel-in-progress: false
+    strategy:
+      fail-fast: false
+      matrix:
+        group:
+        - camunda-qa-acceptance-tests-client
+        - camunda-qa-acceptance-tests-non-client
+        - search-client-opensearch
+        - camunda-exporter
+        - zeebe-opensearch-exporter
+        include:
+          - group: camunda-qa-acceptance-tests-client
+            name: "Camunda QA Module Client Tests"
+            maven-modules: "'io.camunda:camunda-qa-acceptance-tests'"
+            maven-build-threads: 2
+            maven-test-fork-count: 1
+            maven-test-profiles: multi-db-test-client
+            runs-on: aws-core-8-default
+            owner: '@camunda/engineering-operations'
+          - group: camunda-qa-acceptance-tests-non-client
+            name: "Camunda QA Module Non-Client Tests"
+            maven-modules: "'io.camunda:camunda-qa-acceptance-tests'"
+            maven-build-threads: 2
+            maven-test-fork-count: 1
+            maven-test-profiles: multi-db-test-non-client
+            runs-on: aws-core-8-default
+            owner: '@camunda/engineering-operations'
+          - group: search-client-opensearch
+            name: "Search Client OpenSearch ITs"
+            maven-modules: "'io.camunda:camunda-search-client-connect,io.camunda:camunda-search-client-opensearch'"
+            maven-build-threads: 2
+            maven-test-fork-count: 1
+            maven-test-profiles: multi-db-test
+            runs-on: aws-core-8-default
+            owner: '@camunda/core-features'
+          - group: camunda-exporter
+            name: "Camunda Exporter ITs"
+            maven-modules: "'io.camunda:camunda-exporter'"
+            maven-build-threads: 2
+            maven-test-fork-count: 1
+            maven-test-profiles: multi-db-test
+            runs-on: aws-core-8-default
+            owner: '@camunda/data-layer'
+          - group: zeebe-opensearch-exporter
+            name: "Zeebe OpenSearch Exporter ITs"
+            maven-modules: "'io.camunda:zeebe-opensearch-exporter'"
+            maven-build-threads: 2
+            maven-test-fork-count: 1
+            maven-test-profiles: multi-db-test
+            runs-on: aws-core-8-default
+            owner: '@camunda/data-layer'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Setup AWS OpenSearch
+        uses: ./.github/actions/setup-aws-opensearch-env
+        with:
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          opensearch-version: ${{ inputs.os_version }}
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: it-${{ matrix.group }}
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C -D skip.fe.build -D skip.yarn -D skip.docker
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
+      - name: Maven Test Build
+        shell: bash
+        run: >
+          ./mvnw -B -T ${{ matrix.maven-build-threads }} --no-snapshot-updates
+          -D forkCount=${{ matrix.maven-test-fork-count }}
+          -D maven.javadoc.skip=true
+          -D skipUTs -D skipChecks
+          -D flaky.test.reportDir=failsafe-reports
+          -D test.integration.opensearch.aws.url="${{ env.OPENSEARCH_URL }}"
+          -D test.integration.camunda.database.type=AWS_OS
+          -D test.integration.opensearch.aws.timeout.seconds=180
+          -P parallel-tests,extract-flaky-tests,${{ matrix.maven-test-profiles }}
+          -pl ${{ matrix.maven-modules }}
+          verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Analyze Test Runs
+        id: analyze-test-run
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
+        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
+        with:
+          name: "[IT] ${{ matrix.name }}"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "integration-tests/${{ matrix.group }}"
+          build_status: ${{ job.status }}
+          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+  send-slack-notificaion:
+    name: "Send slack notification on fail. OS ver.${{ inputs.os_version }}"
+    runs-on: ubuntu-latest
+    needs: integration-tests
+
+    # TODO: Re-enable this once the pipeline is in a healthy and meaningful state
+    # currently tracked in https://github.com/camunda/camunda/issues/52892
+    # if: (failure() || cancelled()) && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))
+    if: ${{ false }}
+
+    permissions:
+      contents: read
+      actions: write
+    steps:
+    - name: Import secrets from Vault
+      id: secrets
+      uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        secrets: |
+          secret/data/products/camunda/ci/github-actions DATA_ENGINE_CI_ALERT_WEBHOOK_URL;
+    - name: Send notification
+      uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+      with:
+        webhook: ${{ steps.secrets.outputs.DATA_ENGINE_CI_ALERT_WEBHOOK_URL }}
+        webhook-type: webhook-trigger
+        # For posting a rich message using Block Kit
+        payload: |
+          text: "AWS OpenSearch Manual/Scheduled Run Integration Tests failed or were cancelled"
+          blocks:
+            - type: "section"
+              text:
+                type: "mrkdwn"
+                text: "AWS OpenSearch Manual/Scheduled Run Integration Tests (OS ver. ${{ inputs.os_version }}) FAILED or WERE CANCELLED\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+    - name: Checkout
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        sparse-checkout: .github
+    - name: Observe build status
+      if: always()
+      continue-on-error: true
+      uses: ./.github/actions/observe-build-status
+      with:
+        build_status: ${{ job.status }}
+        secret_vault_address: ${{ secrets.VAULT_ADDR }}
+        secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR does the following:
* refactors the pipeline by grouping by OpenSearch version
* the multiple versions can run in parallel
* the jobs within each version set are sequential, as this showed to improve tests reliability and lower failure rates
* added a PRE job that verifies that the actual cluster version corresponds to the version the workflow has been invoked upon

Sample run:

https://github.com/camunda/camunda/actions/runs/30927772700/job/92054450602

The refactoring looks as follows:

<img width="299" height="616" alt="image" src="https://github.com/user-attachments/assets/02298968-6c2b-4486-921c-3a045204e98c" />

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
