### PR TITLE
feat: add cross-partition message-start ask round-trip latency timer

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetrics.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Instruments the Business-ID message-start correlation feature: the cross-partition uniqueness
@@ -45,6 +46,22 @@ import java.util.Set;
  * P_K}), never from the scheduler actors that touch the counters, so a plain {@link HashMap} is
  * safe. They are dropped on recovery ({@link #onRecovered}): samples from a previous leadership
  * term would otherwise record meaningless durations.
+ *
+ * <p>The cross-partition ask round-trip timer (M17) isolates the pure technical {@code P_K → P_B →
+ * P_K} latency of the latest attempt: it starts on every ask send and stops the instant {@code P_K}
+ * receives the matching reply, tagged by reply outcome. Where M7 measures the whole ask lifetime
+ * (blending the round-trip with the retry/back-off and business-id contention waits), subtracting
+ * M17 from M7 leaves that retry-plus-contention component. Its samples use the same {@code
+ * messageKey → processDefinitionKey} shape as the M7 map, but — unlike M7 — the map is written from
+ * two actors: the initial dispatch and every reply run on the processing actor, while each retry
+ * restarts the sample from the scheduler actor. It is therefore a {@link ConcurrentHashMap} keyed
+ * by message key whose per-message inner map is only ever mutated inside an atomic {@code compute}
+ * on the outer key, so the two actors cannot corrupt it and the last-send-wins semantics tolerate a
+ * retry racing a reply. A local expiry (the buffered message hits its TTL on {@code P_K} with no
+ * reply) drops that message's whole inner group unmeasured in one O(1) removal — keyed off the
+ * message alone, not the M7 group, so a sample a scheduler retry recreated with no matching M7
+ * entry (e.g. after a leader change repopulated only the pending-ask state) is still discarded;
+ * samples are likewise dropped on recovery.
  *
  * <p>The release-to-start timer (M16) measures, purely on {@code P_B}, the wait between a business
  * id being released by a completing holder and a cross-partition ask that was <em>blocked on that
@@ -80,6 +97,7 @@ public final class MessageCorrelationMetrics implements StreamProcessorLifecycle
       new EnumMap<>(ReleaseResult.class);
   private final Map<BlockReason, Counter> blockedCounters = new EnumMap<>(BlockReason.class);
   private final Map<AskOutcome, Timer> askDurationTimers = new EnumMap<>(AskOutcome.class);
+  private final Map<ReplyOutcome, Timer> askRoundTripTimers = new EnumMap<>(ReplyOutcome.class);
 
   /**
    * Outstanding ask-duration samples keyed by {@code messageKey → processDefinitionKey}. A single
@@ -87,6 +105,18 @@ public final class MessageCorrelationMetrics implements StreamProcessorLifecycle
    * messageKey alone, hence the nested map.
    */
   private final Map<Long, Map<Long, Timer.Sample>> pendingAskSamples = new HashMap<>();
+
+  /**
+   * Outstanding round-trip samples (M17) keyed by {@code messageKey → processDefinitionKey}, the
+   * same shape as {@link #pendingAskSamples}. Unlike the M7 map it is written from two actors — the
+   * initial dispatch and every reply run on the processing actor, but each retry restarts the
+   * sample from the scheduler actor — so it is a {@link ConcurrentHashMap} and every mutation of a
+   * message's inner map goes through an atomic {@code compute} on the outer key (the inner map may
+   * therefore stay a plain {@link HashMap}). A local expiry removes the whole inner group for the
+   * message in one O(1) call, independent of the M7 map, so a sample recreated by a post-recovery
+   * retry with no M7 entry is still discarded; all samples are dropped on recovery.
+   */
+  private final Map<Long, Map<Long, Timer.Sample>> askRoundTripSamples = new ConcurrentHashMap<>();
 
   /**
    * Contended uniqueness domains on {@code P_B}: each entry tracks the cross-partition asks
@@ -258,6 +288,13 @@ public final class MessageCorrelationMetrics implements StreamProcessorLifecycle
    *     was stopped, {@code false} for the common uncontended case
    */
   public boolean expireCrossPartitionAsks(final long messageKey) {
+    // M17: drop this message's in-flight round-trip samples unmeasured — its asks will now get no
+    // reply. Keyed by messageKey alone, not via the M7 group, so a sample a scheduler retry
+    // recreated with no matching M7 entry (e.g. after a leader change repopulated only the
+    // pending-ask state) is still discarded. One O(1) removal, a no-op for the common
+    // non-cross-partition expiry.
+    askRoundTripSamples.remove(messageKey);
+
     final var byProcessDefinition = pendingAskSamples.remove(messageKey);
     if (byProcessDefinition == null) {
       return false;
@@ -265,6 +302,46 @@ public final class MessageCorrelationMetrics implements StreamProcessorLifecycle
     final var timer = askDurationTimer(AskOutcome.EXPIRED);
     byProcessDefinition.values().forEach(sample -> sample.stop(timer));
     return true;
+  }
+
+  /**
+   * M17: (re)starts the round-trip timer for a cross-partition ask send from {@code P_K} — the
+   * initial dispatch or a scheduler retry. Overwrites any previous sample (last-send-wins): a
+   * superseded retry never received a reply, so the delivered reply is measured against the last
+   * send. Safe to call from the scheduler actor because the outer map is concurrent and the
+   * message's inner map is only touched inside this atomic {@code compute}.
+   */
+  public void startRoundTrip(final long messageKey, final long processDefinitionKey) {
+    askRoundTripSamples.compute(
+        messageKey,
+        (key, samples) -> {
+          final var byProcessDefinition =
+              samples != null ? samples : new HashMap<Long, Timer.Sample>();
+          byProcessDefinition.put(processDefinitionKey, Timer.start(registry));
+          return byProcessDefinition;
+        });
+  }
+
+  /**
+   * M17: stops the round-trip timer for a cross-partition ask when {@code P_K} processes its reply,
+   * tagged by {@code outcome}, recording the technical latency of the last send for this {@code
+   * (messageKey, processDefinitionKey)}. No-op if no sample is tracked — the reply raced a leader
+   * change that cleared it, or a retry that would re-arm it has not run yet. The whole update runs
+   * inside the atomic {@code computeIfPresent}, mirroring {@link #startRoundTrip}: recording the
+   * sample there only reads/updates the meter registry (never this map), so it is safe under the
+   * per-key lock, and pruning the emptied inner map keeps fully-replied messages from lingering.
+   */
+  public void stopRoundTrip(
+      final long messageKey, final long processDefinitionKey, final ReplyOutcome outcome) {
+    askRoundTripSamples.computeIfPresent(
+        messageKey,
+        (key, byProcessDefinition) -> {
+          final var sample = byProcessDefinition.remove(processDefinitionKey);
+          if (sample != null) {
+            sample.stop(askRoundTripTimer(outcome));
+          }
+          return byProcessDefinition.isEmpty() ? null : byProcessDefinition;
+        });
   }
 
   /**
@@ -386,6 +463,7 @@ public final class MessageCorrelationMetrics implements StreamProcessorLifecycle
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
     // Samples belong to the previous leadership term; recording them would produce bogus durations.
     pendingAskSamples.clear();
+    askRoundTripSamples.clear();
     contendedByDomain.clear();
   }
 
@@ -394,6 +472,16 @@ public final class MessageCorrelationMetrics implements StreamProcessorLifecycle
         outcome,
         o ->
             MicrometerUtil.buildTimer(MessageCorrelationMetricsDoc.CROSS_PARTITION_ASK_DURATION)
+                .tag(MessageCorrelationKeyNames.OUTCOME.asString(), o.getLabel())
+                .minimumExpectedValue(Duration.ofMillis(10))
+                .register(registry));
+  }
+
+  private Timer askRoundTripTimer(final ReplyOutcome outcome) {
+    return askRoundTripTimers.computeIfAbsent(
+        outcome,
+        o ->
+            MicrometerUtil.buildTimer(MessageCorrelationMetricsDoc.CROSS_PARTITION_ASK_ROUND_TRIP)
                 .tag(MessageCorrelationKeyNames.OUTCOME.asString(), o.getLabel())
                 .minimumExpectedValue(Duration.ofMillis(10))
                 .register(registry));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsDoc.java
@@ -496,6 +496,70 @@ public enum MessageCorrelationMetricsDoc implements ExtendedMeterDocumentation {
   },
 
   /**
+   * Round-trip latency of a single cross-partition message-start ask on {@code P_K}: the time from
+   * the most recent ask <em>send</em> (the initial dispatch or any scheduler retry) until the
+   * matching reply is processed here, tagged by that reply outcome. Where {@link
+   * #CROSS_PARTITION_ASK_DURATION} (M7) measures the whole ask lifetime — first dispatch to a
+   * terminal, blending the technical round-trip with the retry/back-off waits and the business-id
+   * contention wait — this isolates just the technical {@code P_K → P_B → P_K} leg of the latest
+   * attempt (last-send-wins: a superseded retry never received a reply, so the delivered reply is
+   * measured against the last send). Subtracting this from M7 leaves the retry/back-off plus
+   * contention component, making the blocked-start latency decomposable. Each send/reply attempt is
+   * measured, so a repeatedly-rejected ask contributes one sample per reply. Samples are in-memory
+   * and best-effort: a local expiry (the buffered message hits its TTL on {@code P_K} with no
+   * reply) discards the in-flight sample unmeasured, and all samples are dropped on leader change
+   * (see {@link MessageCorrelationMetrics}).
+   */
+  CROSS_PARTITION_ASK_ROUND_TRIP {
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(10),
+      Duration.ofMillis(100),
+      Duration.ofMillis(500),
+      Duration.ofSeconds(1),
+      Duration.ofSeconds(5),
+      Duration.ofSeconds(10),
+      Duration.ofSeconds(30),
+      Duration.ofMinutes(1),
+      Duration.ofMinutes(5),
+      Duration.ofMinutes(10),
+      Duration.ofMinutes(30),
+      Duration.ofHours(1),
+      Duration.ofHours(5),
+      Duration.ofHours(10),
+    };
+
+    @Override
+    public String getName() {
+      return "zeebe.message.start.cross.partition.asks.round.trip.duration";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Round-trip latency of a cross-partition message-start ask on the correlation-key partition (P_K), from the last send to the matching reply, tagged by reply outcome.";
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {MessageCorrelationKeyNames.OUTCOME};
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /**
    * Release-to-start latency on {@code P_B = hash(businessId)}: the time between a business id
    * being freed by a completing/terminating holder and a cross-partition message-start that was
    * blocked on that business id (uniqueness-rejected and retrying) actually starting here. It

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -477,6 +477,7 @@ public final class MessageCorrelateBehavior {
     metrics.crossPartitionAskSent();
     metrics.startCrossPartitionAsk(
         messageData.messageKey(), subscriptionRecord.getProcessDefinitionKey());
+    metrics.startRoundTrip(messageData.messageKey(), subscriptionRecord.getProcessDefinitionKey());
 
     final int targetPartition = routingInfo.partitionForCorrelationKey(messageData.businessId());
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectExpiredProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectExpiredProcessor.java
@@ -51,6 +51,8 @@ public final class MessageStartProcessInstanceRequestRejectExpiredProcessor
   @Override
   public void processRecord(final TypedRecord<MessageStartProcessInstanceRequestRecord> record) {
     final var reply = record.getValue();
+    metrics.stopRoundTrip(
+        reply.getMessageKey(), reply.getProcessDefinitionKey(), ReplyOutcome.REJECTED_EXPIRED);
     stateWriter.appendFollowUpEvent(
         record.getKey(), MessageStartProcessInstanceRequestIntent.EXPIRED_REJECTED, reply);
     metrics.crossPartitionReply(ReplyOutcome.REJECTED_EXPIRED);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor.java
@@ -72,6 +72,10 @@ public final class MessageStartProcessInstanceRequestRejectNoSubscriptionProcess
   @Override
   public void processRecord(final TypedRecord<MessageStartProcessInstanceRequestRecord> record) {
     final var reply = record.getValue();
+    metrics.stopRoundTrip(
+        reply.getMessageKey(),
+        reply.getProcessDefinitionKey(),
+        ReplyOutcome.REJECTED_NO_SUBSCRIPTION);
     stateWriter.appendFollowUpEvent(
         record.getKey(), MessageStartProcessInstanceRequestIntent.NO_SUBSCRIPTION_REJECTED, reply);
     metrics.crossPartitionReply(ReplyOutcome.REJECTED_NO_SUBSCRIPTION);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectUniquenessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectUniquenessProcessor.java
@@ -74,6 +74,8 @@ public final class MessageStartProcessInstanceRequestRejectUniquenessProcessor
   @Override
   public void processRecord(final TypedRecord<MessageStartProcessInstanceRequestRecord> record) {
     final var reply = record.getValue();
+    metrics.stopRoundTrip(
+        reply.getMessageKey(), reply.getProcessDefinitionKey(), ReplyOutcome.REJECTED_UNIQUENESS);
     stateWriter.appendFollowUpEvent(
         record.getKey(), MessageStartProcessInstanceRequestIntent.UNIQUENESS_REJECTED, reply);
     metrics.crossPartitionReply(ReplyOutcome.REJECTED_UNIQUENESS);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestStartProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestStartProcessor.java
@@ -104,16 +104,8 @@ public final class MessageStartProcessInstanceRequestStartProcessor
   public void processRecord(final TypedRecord<MessageStartProcessInstanceRequestRecord> record) {
     final var reply = record.getValue();
 
-    metrics.crossPartitionReply(ReplyOutcome.STARTED);
-    metrics.completeCrossPartitionAskStarted(
-        reply.getMessageKey(), reply.getProcessDefinitionKey());
-
-    LOG.atDebug()
-        .addKeyValue("messageKey", reply.getMessageKey())
-        .addKeyValue("processDefinitionKey", reply.getProcessDefinitionKey())
-        .addKeyValue("outcome", ReplyOutcome.STARTED.getLabel())
-        .addKeyValue("processInstanceKey", reply.getProcessInstanceKey())
-        .log("Applied cross-partition message-start reply");
+    metrics.stopRoundTrip(
+        reply.getMessageKey(), reply.getProcessDefinitionKey(), ReplyOutcome.STARTED);
 
     // Look up the buffered message once: both the CORRELATED applier and the EXPIRED applier need
     // it (CORRELATED writes a foreign-key reference into MESSAGE_KEY; EXPIRED removes the buffered
@@ -165,8 +157,21 @@ public final class MessageStartProcessInstanceRequestStartProcessor
       expiredMessageRecord.wrap(storedMessage.getMessage());
       stateWriter.appendFollowUpEvent(
           reply.getMessageKey(), MessageIntent.EXPIRED, expiredMessageRecord);
+    }
+
+    metrics.crossPartitionReply(ReplyOutcome.STARTED);
+    metrics.completeCrossPartitionAskStarted(
+        reply.getMessageKey(), reply.getProcessDefinitionKey());
+    if (storedMessage != null) {
       metrics.expireCrossPartitionAsks(reply.getMessageKey());
     }
+
+    LOG.atDebug()
+        .addKeyValue("messageKey", reply.getMessageKey())
+        .addKeyValue("processDefinitionKey", reply.getProcessDefinitionKey())
+        .addKeyValue("outcome", ReplyOutcome.STARTED.getLabel())
+        .addKeyValue("processInstanceKey", reply.getProcessInstanceKey())
+        .log("Applied cross-partition message-start reply");
 
     // (iv) If the cross-partition start was triggered by a synchronous correlate command (rather
     // than an asynchronous publish), flush the deferred CORRELATED response to the waiting client.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageStartAskCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageStartAskCheckScheduler.java
@@ -149,6 +149,9 @@ public final class PendingMessageStartAskCheckScheduler
     // Update the sent time to prevent it from being re-sent too soon
     state.updateLastSentTime(ask.getMessageKey(), ask.getProcessDefinitionKey(), now);
     metrics.crossPartitionAskRetried();
+    // M17: this retry is a fresh send; restart the round-trip clock so the eventual reply measures
+    // the last send (last-send-wins). Runs on the scheduler actor — the sample map is concurrent.
+    metrics.startRoundTrip(ask.getMessageKey(), ask.getProcessDefinitionKey());
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/MessageCorrelationMetricsTest.java
@@ -29,6 +29,8 @@ final class MessageCorrelationMetricsTest {
 
   private static final String ASK_DURATION_METRIC =
       "zeebe.message.start.cross.partition.asks.duration";
+  private static final String ROUND_TRIP_METRIC =
+      "zeebe.message.start.cross.partition.asks.round.trip.duration";
   private static final String RELEASE_TO_START_METRIC =
       "zeebe.message.start.cross.partition.release.to.start.duration";
 
@@ -224,6 +226,147 @@ final class MessageCorrelationMetricsTest {
     // then a subsequent terminal is a no-op — the stale sample is gone (M7)
     metrics.completeCrossPartitionAskStarted(1L, 100L);
     assertThat(registry.find(ASK_DURATION_METRIC).timers()).isEmpty();
+  }
+
+  @Test
+  void shouldRecordRoundTripTaggedByReplyOutcome() {
+    // given an ask has been sent
+    metrics.startRoundTrip(1L, 100L);
+
+    // when its reply lands on P_K
+    metrics.stopRoundTrip(1L, 100L, ReplyOutcome.STARTED);
+
+    // then the round trip is recorded under the reply outcome tag (M17)
+    final var timer = registry.find(ROUND_TRIP_METRIC).tag("outcome", "started").timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+  }
+
+  @Test
+  void shouldRecordEachSendReplyAttemptOfARepeatedlyRejectedAsk() {
+    // given an ask that is rejected on uniqueness, retried, and finally started
+    metrics.startRoundTrip(1L, 100L);
+    metrics.stopRoundTrip(1L, 100L, ReplyOutcome.REJECTED_UNIQUENESS);
+    metrics.startRoundTrip(1L, 100L);
+    metrics.stopRoundTrip(1L, 100L, ReplyOutcome.STARTED);
+
+    // then every send/reply attempt contributes one sample under its own outcome (M17)
+    assertThat(
+            registry.get(ROUND_TRIP_METRIC).tag("outcome", "rejected_uniqueness").timer().count())
+        .isEqualTo(1L);
+    assertThat(registry.get(ROUND_TRIP_METRIC).tag("outcome", "started").timer().count())
+        .isEqualTo(1L);
+  }
+
+  @Test
+  void shouldMeasureRoundTripAgainstTheLastSendWhenRetriedBeforeAReply() {
+    // given an ask is (re)sent twice — a retry supersedes the first send — before any reply
+    metrics.startRoundTrip(1L, 100L);
+    metrics.startRoundTrip(1L, 100L);
+
+    // when a single reply lands
+    metrics.stopRoundTrip(1L, 100L, ReplyOutcome.STARTED);
+
+    // then exactly one sample is recorded (last-send-wins) and nothing is left to record (M17)
+    assertThat(registry.get(ROUND_TRIP_METRIC).tag("outcome", "started").timer().count())
+        .isEqualTo(1L);
+    metrics.stopRoundTrip(1L, 100L, ReplyOutcome.STARTED);
+    assertThat(registry.get(ROUND_TRIP_METRIC).tag("outcome", "started").timer().count())
+        .isEqualTo(1L);
+  }
+
+  @Test
+  void shouldNotRecordRoundTripWhenNoSampleIsTracked() {
+    // when a reply is processed for an ask whose send was never tracked (e.g. after a leader
+    // change)
+    metrics.stopRoundTrip(1L, 100L, ReplyOutcome.STARTED);
+
+    // then no round-trip timer is ever registered (M17)
+    assertThat(registry.find(ROUND_TRIP_METRIC).timers()).isEmpty();
+  }
+
+  @Test
+  void shouldDiscardRoundTripOnLocalExpiryWithoutRecording() {
+    // given a message fanned out to two process definitions, each dispatched — at dispatch an ask
+    // holds both an ask-duration (M7) and a round-trip (M17) sample
+    metrics.startCrossPartitionAsk(1L, 100L);
+    metrics.startRoundTrip(1L, 100L);
+    metrics.startCrossPartitionAsk(1L, 200L);
+    metrics.startRoundTrip(1L, 200L);
+
+    // when the buffered message expires locally with no reply
+    metrics.expireCrossPartitionAsks(1L);
+
+    // then no round trip is recorded — an incomplete round trip is not a latency (M17)
+    assertThat(registry.find(ROUND_TRIP_METRIC).timers()).isEmpty();
+    // and the samples are gone: a late reply after expiry is a no-op
+    metrics.stopRoundTrip(1L, 100L, ReplyOutcome.STARTED);
+    metrics.stopRoundTrip(1L, 200L, ReplyOutcome.STARTED);
+    assertThat(registry.find(ROUND_TRIP_METRIC).timers()).isEmpty();
+  }
+
+  @Test
+  void shouldDiscardOnlyTheExpiredMessageRoundTrips() {
+    // given dispatched asks for two different messages (each with paired M7 + M17 samples)
+    metrics.startCrossPartitionAsk(1L, 100L);
+    metrics.startRoundTrip(1L, 100L);
+    metrics.startCrossPartitionAsk(2L, 100L);
+    metrics.startRoundTrip(2L, 100L);
+
+    // when only the first message expires locally
+    metrics.expireCrossPartitionAsks(1L);
+
+    // then the other message's reply is still measured (M17)
+    metrics.stopRoundTrip(2L, 100L, ReplyOutcome.STARTED);
+    assertThat(registry.get(ROUND_TRIP_METRIC).tag("outcome", "started").timer().count())
+        .isEqualTo(1L);
+  }
+
+  @Test
+  void shouldDiscardRoundTripOnExpiryEvenWithoutAPairedAskDurationSample() {
+    // given a round-trip sample re-armed by a scheduler retry that has no matching ask-duration
+    // (M7) sample — the ask-duration sample is only ever created at the original dispatch, so after
+    // a leader change replays the pending-ask state the retry recreates only the round-trip (M17)
+    metrics.startRoundTrip(1L, 100L);
+
+    // when the buffered message expires locally with no reply
+    metrics.expireCrossPartitionAsks(1L);
+
+    // then the orphaned round-trip sample is still discarded — the discard is keyed off the message
+    // alone, independent of the M7 map (M17)
+    metrics.stopRoundTrip(1L, 100L, ReplyOutcome.STARTED);
+    assertThat(registry.find(ROUND_TRIP_METRIC).timers()).isEmpty();
+  }
+
+  @Test
+  void shouldRecordRoundTripPerProcessDefinitionOfTheSameMessage() {
+    // given a single message fanned out to two process definitions, each sent
+    metrics.startRoundTrip(1L, 100L);
+    metrics.startRoundTrip(1L, 200L);
+
+    // when each receives its own reply
+    metrics.stopRoundTrip(1L, 100L, ReplyOutcome.STARTED);
+    metrics.stopRoundTrip(1L, 200L, ReplyOutcome.REJECTED_UNIQUENESS);
+
+    // then both are measured independently under their own outcomes (M17)
+    assertThat(registry.get(ROUND_TRIP_METRIC).tag("outcome", "started").timer().count())
+        .isEqualTo(1L);
+    assertThat(
+            registry.get(ROUND_TRIP_METRIC).tag("outcome", "rejected_uniqueness").timer().count())
+        .isEqualTo(1L);
+  }
+
+  @Test
+  void shouldClearRoundTripSamplesOnRecovery() {
+    // given an outstanding send
+    metrics.startRoundTrip(1L, 100L);
+
+    // when recovery drops the in-memory samples of the previous leadership term
+    metrics.onRecovered(null);
+
+    // then a subsequent reply is a no-op — the stale sample is gone (M17)
+    metrics.stopRoundTrip(1L, 100L, ReplyOutcome.STARTED);
+    assertThat(registry.find(ROUND_TRIP_METRIC).timers()).isEmpty();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionMetricsTest.java
@@ -56,6 +56,8 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
   private static final String ASKS_METRIC = "zeebe.message.start.cross.partition.asks.total";
   private static final String ASK_DURATION_METRIC =
       "zeebe.message.start.cross.partition.asks.duration";
+  private static final String ROUND_TRIP_METRIC =
+      "zeebe.message.start.cross.partition.asks.round.trip.duration";
   private static final String RELEASE_TO_START_METRIC =
       "zeebe.message.start.cross.partition.release.to.start.duration";
 
@@ -234,6 +236,11 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
     assertThat(timerCount(pK, ASK_DURATION_METRIC, "outcome", "expired"))
         .as("M7: a clean start records no expired sample")
         .isZero();
+
+    // and the round-trip latency of the send/reply is recorded once on P_K, tagged started (M17)
+    assertThat(timerCount(pK, ROUND_TRIP_METRIC, "outcome", "started"))
+        .as("M17: the cross-partition ask round-trip is recorded as started on P_K")
+        .isEqualTo(1L);
   }
 
   @Test
@@ -278,6 +285,15 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
         .isGreaterThanOrEqualTo(1L);
     assertThat(timerCount(pK, ASK_DURATION_METRIC, "outcome", "started"))
         .as("M7: a message that never starts records no started sample")
+        .isZero();
+
+    // and each uniqueness-rejected reply recorded a round trip, while the final local expiry
+    // discarded the last in-flight send unmeasured, so no round trip is tagged started (M17)
+    assertThat(timerCount(pK, ROUND_TRIP_METRIC, "outcome", "rejected_uniqueness"))
+        .as("M17: every uniqueness-rejected reply records a round trip on P_K")
+        .isGreaterThanOrEqualTo(1L);
+    assertThat(timerCount(pK, ROUND_TRIP_METRIC, "outcome", "started"))
+        .as("M17: a message that never starts records no started round trip")
         .isZero();
   }
 


### PR DESCRIPTION
## Description

Adds a new Micrometer timer, `zeebe.message.start.cross.partition.asks.round.trip.duration` (M17), that isolates the pure technical `P_K → P_B → P_K` latency of a single cross-partition message-start ask attempt.

### Motivation

The existing ask-duration timer (M7, `zeebe.message.start.cross.partition.asks.duration`) measures the full ask lifetime from first dispatch to a terminal outcome. This conflates three components:

- **Technical round-trip** — the `P_K → P_B → P_K` network/processing leg
- **Retry/back-off waits** — time between scheduler retry attempts
- **Business-id contention wait** — time a business ID is held by an active instance

Without isolating the round-trip, an operator cannot tell whether a high blocked-start latency is caused by infrastructure/network overhead or genuine business back-pressure. M17 fills that gap. Subtracting M17 from M7 yields the retry-plus-contention component, making the blocked-start latency fully decomposable.

### Design

- **Start**: on every ask **send** — initial dispatch in `MessageCorrelateBehavior` and every scheduler retry in `PendingMessageStartAskCheckScheduler`. Last-send-wins: a retry overwrites the previous sample, so the delivered reply is always measured against the last send.
- **Stop**: on any reply processed on `P_K` — `STARTED`, `UNIQUENESS_REJECTED`, `NO_SUBSCRIPTION_REJECTED`, `EXPIRED_REJECTED` — tagged by `outcome`. Each send/reply attempt produces one sample, so a repeatedly-rejected ask contributes one sample per reply.
- **Expiry**: a local expiry (buffered message hits its TTL on `P_K` with no reply) removes the in-flight sample unmeasured in one O(1) `ConcurrentHashMap` removal keyed by message alone, independent of the M7 map.
- **Recovery**: all samples are dropped on `onRecovered`, consistent with M7/M16, preventing stale leadership-term durations.
- **Concurrency**: unlike M7's plain `HashMap`, the sample map is a `ConcurrentHashMap` because it is written from both the processing actor (initial dispatch and replies) and the scheduler actor (retries). Each message's inner map is only ever mutated inside an atomic `compute` on the outer key.
- **SLO buckets**: 10 ms → 10 h, consistent with M7/M16.

## Related issues

Closes #59368