### PR TITLE
test: merge sibling CCSM ITs to cut per-test container-restart overhead

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/auth/JwtDecoderIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/auth/JwtDecoderIT.java
@@ -265,8 +265,6 @@ public class JwtDecoderIT extends AbstractCCSMIT {
 
   static Stream<Arguments> decoderProvider() {
     return Stream.of(
-        Arguments.of("SaaS", "publicApiJwtDecoder"),
-        Arguments.of("CCSM", "publicApiJwtDecoder"),
-        Arguments.of("SaaS", "publicApiJwtDecoder"));
+        Arguments.of("SaaS", "publicApiJwtDecoder"), Arguments.of("CCSM", "publicApiJwtDecoder"));
   }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeIncidentImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeIncidentImportIT.java
@@ -49,150 +49,184 @@ import org.junit.jupiter.api.condition.EnabledIf;
 public class ZeebeIncidentImportIT extends AbstractCCSMIT {
 
   @Test
-  public void importZeebeIncidentData_openFailTaskIncident() {
-    // given
-    final ProcessInstanceEvent deployedInstance =
-        deployAndStartInstanceForProcess(createSimpleServiceTaskProcess("someProcess"));
-    zeebeExtension.failTask(SERVICE_TASK);
+  public void
+      importZeebeIncidentData_openFailTaskIncidentAndThrowErrorIncidentAndMissingVariableIncident() {
+    // Covers three independent incident-creation scenarios: a fail-task incident, a
+    // throw-error incident, and a missing-variable incident. Each scenario deploys its own
+    // process and is reset to a clean Zeebe export index and clean Optimize data before it
+    // runs — this is what makes createIncident()'s helper lookup (which is not scoped by
+    // process instance key, only by element) safe to reuse here: only one instance's records
+    // ever exist in the index at the point it runs.
 
-    // when
-    waitUntilIncidentRecordWithProcessIdExported("someProcess");
-    importAllZeebeEntitiesFromScratch();
+    // given (open fail-task incident)
+    {
+      final ProcessInstanceEvent deployedInstance =
+          deployAndStartInstanceForProcess(createSimpleServiceTaskProcess("someProcess"));
+      zeebeExtension.failTask(SERVICE_TASK);
 
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(deployedInstance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(deployedInstance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(deployedInstance.getBpmnProcessId());
-              assertThat(savedInstance.getProcessDefinitionVersion())
-                  .isEqualTo(String.valueOf(deployedInstance.getVersion()));
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getState()).isEqualTo(ProcessInstanceConstants.ACTIVE_STATE);
-              assertThat(savedInstance.getBusinessKey()).isNull();
-              assertThat(savedInstance.getFlowNodeInstances()).isNotEmpty();
-              assertThat(savedInstance.getVariables()).isEmpty();
-              assertThat(savedInstance.getStartDate()).isNotNull();
-              assertThat(savedInstance.getEndDate()).isNull();
-              assertThat(savedInstance.getDuration()).isNull();
-              assertThat(savedInstance.getIncidents())
-                  .isNotEmpty()
-                  .hasSize(1)
-                  .containsExactly(
-                      createIncident(savedInstance, deployedInstance, SERVICE_TASK, OPEN));
-            });
-  }
+      // when (open fail-task incident)
+      waitUntilIncidentRecordWithProcessIdExported("someProcess");
+      importAllZeebeEntitiesFromScratch();
 
-  @Test
-  public void importZeebeIncidentData_throwErrorIncident() {
-    // given
-    final ProcessInstanceEvent deployedInstance =
-        deployAndStartInstanceForProcess(createSimpleServiceTaskProcess("someProcess"));
-    zeebeExtension.throwErrorIncident(SERVICE_TASK);
-
-    // when
-    waitUntilIncidentRecordWithProcessIdExported("someProcess");
-    importAllZeebeEntitiesFromScratch();
-
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance ->
+      // then (open fail-task incident)
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance -> {
+                assertThat(savedInstance.getProcessInstanceId())
+                    .isEqualTo(String.valueOf(deployedInstance.getProcessInstanceKey()));
+                assertThat(savedInstance.getProcessDefinitionId())
+                    .isEqualTo(String.valueOf(deployedInstance.getProcessDefinitionKey()));
+                assertThat(savedInstance.getProcessDefinitionKey())
+                    .isEqualTo(deployedInstance.getBpmnProcessId());
+                assertThat(savedInstance.getProcessDefinitionVersion())
+                    .isEqualTo(String.valueOf(deployedInstance.getVersion()));
+                assertThat(savedInstance.getDataSource().getName())
+                    .isEqualTo(getConfiguredZeebeName());
+                assertThat(savedInstance.getState())
+                    .isEqualTo(ProcessInstanceConstants.ACTIVE_STATE);
+                assertThat(savedInstance.getBusinessKey()).isNull();
+                assertThat(savedInstance.getFlowNodeInstances()).isNotEmpty();
+                assertThat(savedInstance.getVariables()).isEmpty();
+                assertThat(savedInstance.getStartDate()).isNotNull();
+                assertThat(savedInstance.getEndDate()).isNull();
+                assertThat(savedInstance.getDuration()).isNull();
                 assertThat(savedInstance.getIncidents())
                     .isNotEmpty()
                     .hasSize(1)
                     .containsExactly(
-                        createIncident(savedInstance, deployedInstance, SERVICE_TASK, OPEN)));
+                        createIncident(savedInstance, deployedInstance, SERVICE_TASK, OPEN));
+              });
+    }
+
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // given (throw-error incident)
+    {
+      final ProcessInstanceEvent deployedInstance =
+          deployAndStartInstanceForProcess(createSimpleServiceTaskProcess("someProcess"));
+      zeebeExtension.throwErrorIncident(SERVICE_TASK);
+
+      // when (throw-error incident)
+      waitUntilIncidentRecordWithProcessIdExported("someProcess");
+      importAllZeebeEntitiesFromScratch();
+
+      // then (throw-error incident)
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance ->
+                  assertThat(savedInstance.getIncidents())
+                      .isNotEmpty()
+                      .hasSize(1)
+                      .containsExactly(
+                          createIncident(savedInstance, deployedInstance, SERVICE_TASK, OPEN)));
+    }
+
+    // reset to a clean slate before the third scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // given (missing-variable incident)
+    {
+      final ProcessInstanceEvent deployedInstance =
+          deployAndStartInstanceForProcess(createIncidentProcess("someProcess"));
+
+      // when (missing-variable incident)
+      waitUntilIncidentRecordWithProcessIdExported("someProcess");
+      importAllZeebeEntitiesFromScratch();
+
+      // then (missing-variable incident)
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance ->
+                  assertThat(savedInstance.getIncidents())
+                      .isNotEmpty()
+                      .hasSize(1)
+                      .containsExactly(
+                          createIncident(savedInstance, deployedInstance, CATCH_EVENT, OPEN)));
+    }
   }
 
   @Test
-  public void importZeebeIncidentData_missingVariableIncident() {
-    // given
-    final ProcessInstanceEvent deployedInstance =
-        deployAndStartInstanceForProcess(createIncidentProcess("someProcess"));
+  public void importZeebeIncidentData_importResolvedIncidentInSameBatchAndInDifferentBatches() {
+    // Covers two independent resolved-incident import scenarios: resolving and importing
+    // both the CREATED and RESOLVED records in a single batch, versus importing CREATED
+    // first, then RESOLVED in a later, separate import pass. Each scenario is reset to a
+    // clean Zeebe export index and clean Optimize data before it runs, for the same
+    // unscoped-helper-lookup reason noted on the sibling merged test above.
 
-    // when
-    waitUntilIncidentRecordWithProcessIdExported("someProcess");
-    importAllZeebeEntitiesFromScratch();
+    // given (resolved incident imported in the same batch)
+    {
+      final ProcessInstanceEvent deployedInstance =
+          deployAndStartInstanceForProcess(createSimpleServiceTaskProcess("someProcess"));
+      zeebeExtension.throwErrorIncident(SERVICE_TASK);
+      waitUntilIncidentRecordWithProcessIdExported("someProcess");
+      resolveIncident();
+      waitUntilIncidentRecordsWithProcessIdExported(2, "someProcess");
 
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance ->
-                assertThat(savedInstance.getIncidents())
-                    .isNotEmpty()
-                    .hasSize(1)
-                    .containsExactly(
-                        createIncident(savedInstance, deployedInstance, CATCH_EVENT, OPEN)));
-  }
+      // when (resolved incident imported in the same batch)
+      importAllZeebeEntitiesFromScratch();
 
-  @Test
-  public void importZeebeIncidentData_importResolvedIncidentInSameBatch() {
-    // given
-    final ProcessInstanceEvent deployedInstance =
-        deployAndStartInstanceForProcess(createSimpleServiceTaskProcess("someProcess"));
-    zeebeExtension.throwErrorIncident(SERVICE_TASK);
-    waitUntilIncidentRecordWithProcessIdExported("someProcess");
-    resolveIncident();
-    waitUntilIncidentRecordsWithProcessIdExported(2, "someProcess");
+      // then (resolved incident imported in the same batch)
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance ->
+                  assertThat(savedInstance.getIncidents())
+                      .isNotEmpty()
+                      .containsExactly(
+                          createIncident(savedInstance, deployedInstance, SERVICE_TASK, RESOLVED)));
+    }
 
-    // when
-    importAllZeebeEntitiesFromScratch();
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance ->
-                assertThat(savedInstance.getIncidents())
-                    .isNotEmpty()
-                    .containsExactly(
-                        createIncident(savedInstance, deployedInstance, SERVICE_TASK, RESOLVED)));
-  }
+    // given (resolved incident imported in a different, later batch)
+    {
+      final ProcessInstanceEvent deployedInstance =
+          deployAndStartInstanceForProcess(createSimpleServiceTaskProcess("someProcess"));
+      zeebeExtension.throwErrorIncident(SERVICE_TASK);
+      waitUntilIncidentRecordWithProcessIdExported("someProcess");
 
-  @Test
-  public void importZeebeIncidentData_importResolvedIncidentInDifferentBatches() {
-    // given
-    final ProcessInstanceEvent deployedInstance =
-        deployAndStartInstanceForProcess(createSimpleServiceTaskProcess("someProcess"));
-    zeebeExtension.throwErrorIncident(SERVICE_TASK);
-    waitUntilIncidentRecordWithProcessIdExported("someProcess");
+      // when (first batch: only the CREATED record)
+      importAllZeebeEntitiesFromScratch();
 
-    // when
-    importAllZeebeEntitiesFromScratch();
+      // then (first batch: only the CREATED record)
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance ->
+                  assertThat(savedInstance.getIncidents())
+                      .isNotEmpty()
+                      .containsExactly(
+                          createIncident(savedInstance, deployedInstance, SERVICE_TASK, OPEN)));
 
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance ->
-                assertThat(savedInstance.getIncidents())
-                    .isNotEmpty()
-                    .containsExactly(
-                        createIncident(savedInstance, deployedInstance, SERVICE_TASK, OPEN)));
+      // when (second, later batch: the RESOLVED record)
+      resolveIncident();
+      waitUntilIncidentRecordsWithProcessIdExported(2, "someProcess");
+      importAllZeebeEntitiesFromLastIndex();
 
-    // when
-    resolveIncident();
-    waitUntilIncidentRecordsWithProcessIdExported(2, "someProcess");
-    importAllZeebeEntitiesFromLastIndex();
-
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance ->
-                assertThat(savedInstance.getIncidents())
-                    .isNotEmpty()
-                    .containsExactly(
-                        createIncident(savedInstance, deployedInstance, SERVICE_TASK, RESOLVED)));
+      // then (second, later batch: the RESOLVED record)
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance ->
+                  assertThat(savedInstance.getIncidents())
+                      .isNotEmpty()
+                      .containsExactly(
+                          createIncident(savedInstance, deployedInstance, SERVICE_TASK, RESOLVED)));
+    }
   }
 
   // Test backwards compatibility for default tenantID applied when importing records pre multi

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeIncidentImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeIncidentImportIT.java
@@ -65,6 +65,7 @@ public class ZeebeIncidentImportIT extends AbstractCCSMIT {
       zeebeExtension.failTask(SERVICE_TASK);
 
       // when (open fail-task incident)
+      waitUntilInstanceRecordWithElementIdExported(SERVICE_TASK);
       waitUntilIncidentRecordWithProcessIdExported("someProcess");
       importAllZeebeEntitiesFromScratch();
 
@@ -112,6 +113,7 @@ public class ZeebeIncidentImportIT extends AbstractCCSMIT {
       zeebeExtension.throwErrorIncident(SERVICE_TASK);
 
       // when (throw-error incident)
+      waitUntilInstanceRecordWithElementIdExported(SERVICE_TASK);
       waitUntilIncidentRecordWithProcessIdExported("someProcess");
       importAllZeebeEntitiesFromScratch();
 
@@ -139,6 +141,7 @@ public class ZeebeIncidentImportIT extends AbstractCCSMIT {
           deployAndStartInstanceForProcess(createIncidentProcess("someProcess"));
 
       // when (missing-variable incident)
+      waitUntilInstanceRecordWithElementIdExported(CATCH_EVENT);
       waitUntilIncidentRecordWithProcessIdExported("someProcess");
       importAllZeebeEntitiesFromScratch();
 
@@ -168,6 +171,7 @@ public class ZeebeIncidentImportIT extends AbstractCCSMIT {
       final ProcessInstanceEvent deployedInstance =
           deployAndStartInstanceForProcess(createSimpleServiceTaskProcess("someProcess"));
       zeebeExtension.throwErrorIncident(SERVICE_TASK);
+      waitUntilInstanceRecordWithElementIdExported(SERVICE_TASK);
       waitUntilIncidentRecordWithProcessIdExported("someProcess");
       resolveIncident();
       waitUntilIncidentRecordsWithProcessIdExported(2, "someProcess");
@@ -197,6 +201,7 @@ public class ZeebeIncidentImportIT extends AbstractCCSMIT {
       final ProcessInstanceEvent deployedInstance =
           deployAndStartInstanceForProcess(createSimpleServiceTaskProcess("someProcess"));
       zeebeExtension.throwErrorIncident(SERVICE_TASK);
+      waitUntilInstanceRecordWithElementIdExported(SERVICE_TASK);
       waitUntilIncidentRecordWithProcessIdExported("someProcess");
 
       // when (first batch: only the CREATED record)

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebePositionBasedImportIndexIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebePositionBasedImportIndexIT.java
@@ -55,96 +55,127 @@ public class ZeebePositionBasedImportIndexIT extends AbstractCCSMIT {
           .captureForType(AbstractZeebeRecordFetcherOS.class);
 
   @Test
-  public void importPositionIsZeroIfNothingIsImportedYet() {
-    // when
-    final List<PositionBasedImportIndexHandler> positionBasedHandlers =
-        embeddedOptimizeExtension.getAllPositionBasedImportHandlers();
+  public void
+      importPositionIsZeroIfNothingIsImportedYetAndIndexesAreRestoredAfterRestartAndCanBeReset() {
+    // Covers four independent position/sequence-tracking scenarios: scenario 1 the initial
+    // zero state before anything is imported; scenario 2 position indexes survive an Optimize
+    // restart; scenario 3 sequence indexes survive an Optimize restart; scenario 4 the import
+    // index can be reset back to zero. Order matters: the zero-state check must run first
+    // (nothing deployed yet), and the reset check must run last (it destroys the state the
+    // restart scenarios verify). Each scenario is reset to a clean Zeebe export index and clean
+    // Optimize data before it runs, mirroring what @BeforeEach/@AfterEach would otherwise do
+    // between separate test methods.
 
-    // then
-    assertThat(positionBasedHandlers)
-        .hasSize(10)
-        .allSatisfy(
-            handler -> {
-              assertThat(handler.getPersistedPositionOfLastEntity()).isZero();
-              assertThat(handler.getPendingSequenceOfLastEntity()).isZero();
-              assertThat(handler.getTimestampOfLastPersistedEntity()).isEqualTo(BEGINNING_OF_TIME);
-              assertThat(handler.getLastImportExecutionTimestamp()).isEqualTo(BEGINNING_OF_TIME);
-              assertThat(handler.isHasSeenSequenceField()).isFalse();
-            });
-  }
+    // given (nothing imported yet)
+    {
+      // when (nothing imported yet)
+      final List<PositionBasedImportIndexHandler> positionBasedHandlers =
+          embeddedOptimizeExtension.getAllPositionBasedImportHandlers();
 
-  @Test
-  public void latestPositionImportIndexesAreRestoredAfterRestartOfOptimize() {
-    // given
-    deployZeebeData();
+      // then (nothing imported yet)
+      assertThat(positionBasedHandlers)
+          .hasSize(10)
+          .allSatisfy(
+              handler -> {
+                assertThat(handler.getPersistedPositionOfLastEntity()).isZero();
+                assertThat(handler.getPendingSequenceOfLastEntity()).isZero();
+                assertThat(handler.getTimestampOfLastPersistedEntity())
+                    .isEqualTo(BEGINNING_OF_TIME);
+                assertThat(handler.getLastImportExecutionTimestamp()).isEqualTo(BEGINNING_OF_TIME);
+                assertThat(handler.isHasSeenSequenceField()).isFalse();
+              });
+    }
 
-    importAllZeebeEntitiesFromScratch();
-
-    embeddedOptimizeExtension.storeImportIndexesToElasticsearch();
-    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
-    final List<Long> positionsBeforeRestart = getCurrentHandlerPositions();
-    final List<OffsetDateTime> lastImportedEntityTimestamps = getLastImportedEntityTimestamps();
-
-    // when
-    startAndUseNewOptimizeInstance();
-    setupZeebeImportAndReloadConfiguration();
-    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
-
-    // then
-    assertThat(getCurrentHandlerPositions())
-        .anySatisfy(position -> assertThat(position).isPositive())
-        .isEqualTo(positionsBeforeRestart);
-    assertThat(getLastImportedEntityTimestamps()).isEqualTo(lastImportedEntityTimestamps);
-  }
-
-  @Test
-  public void latestSequenceImportIndexesAreRestoredAfterRestartOfOptimize() {
-    // given
-    deployZeebeData();
-
-    importAllZeebeEntitiesFromScratch();
-
-    embeddedOptimizeExtension.storeImportIndexesToElasticsearch();
-    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
-    final List<Long> sequencesBeforeRestart = getCurrentHandlerSequences();
-    final List<OffsetDateTime> lastImportedEntityTimestamps = getLastImportedEntityTimestamps();
-
-    // when
-    startAndUseNewOptimizeInstance();
-    setupZeebeImportAndReloadConfiguration();
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
-    // then
-    assertThat(getCurrentHandlerSequences())
-        .anySatisfy(sequence -> assertThat(sequence).isPositive())
-        .isEqualTo(sequencesBeforeRestart);
-    assertThat(getLastImportedEntityTimestamps()).isEqualTo(lastImportedEntityTimestamps);
-    assertThat(embeddedOptimizeExtension.getAllPositionBasedImportHandlers())
-        .filteredOn(handler -> handler.getPersistedSequenceOfLastEntity() > 0)
-        .anySatisfy(handler -> assertThat(handler.isHasSeenSequenceField()).isTrue());
-  }
+    // given (position indexes restored after restart)
+    {
+      deployZeebeData();
 
-  @Test
-  public void importIndexCanBeReset() {
-    // given
-    deployZeebeData();
+      importAllZeebeEntitiesFromScratch();
 
-    importAllZeebeEntitiesFromScratch();
-    embeddedOptimizeExtension.storeImportIndexesToElasticsearch();
+      embeddedOptimizeExtension.storeImportIndexesToElasticsearch();
+      databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+      final List<Long> positionsBeforeRestart = getCurrentHandlerPositions();
+      final List<OffsetDateTime> lastImportedEntityTimestamps = getLastImportedEntityTimestamps();
+
+      // when (position indexes restored after restart)
+      startAndUseNewOptimizeInstance();
+      setupZeebeImportAndReloadConfiguration();
+      databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+      // then (position indexes restored after restart)
+      assertThat(getCurrentHandlerPositions())
+          .anySatisfy(position -> assertThat(position).isPositive())
+          .isEqualTo(positionsBeforeRestart);
+      assertThat(getLastImportedEntityTimestamps()).isEqualTo(lastImportedEntityTimestamps);
+    }
+
+    // reset to a clean slate before the third scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
-    // when
-    embeddedOptimizeExtension.resetPositionBasedImportStartIndexes();
-    embeddedOptimizeExtension.storeImportIndexesToElasticsearch();
+    // given (sequence indexes restored after restart)
+    {
+      deployZeebeData();
+
+      importAllZeebeEntitiesFromScratch();
+
+      embeddedOptimizeExtension.storeImportIndexesToElasticsearch();
+      databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+      final List<Long> sequencesBeforeRestart = getCurrentHandlerSequences();
+      final List<OffsetDateTime> lastImportedEntityTimestamps = getLastImportedEntityTimestamps();
+
+      // when (sequence indexes restored after restart)
+      startAndUseNewOptimizeInstance();
+      setupZeebeImportAndReloadConfiguration();
+      databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+      // then (sequence indexes restored after restart)
+      assertThat(getCurrentHandlerSequences())
+          .anySatisfy(sequence -> assertThat(sequence).isPositive())
+          .isEqualTo(sequencesBeforeRestart);
+      assertThat(getLastImportedEntityTimestamps()).isEqualTo(lastImportedEntityTimestamps);
+      assertThat(embeddedOptimizeExtension.getAllPositionBasedImportHandlers())
+          .filteredOn(handler -> handler.getPersistedSequenceOfLastEntity() > 0)
+          .anySatisfy(handler -> assertThat(handler.isHasSeenSequenceField()).isTrue());
+    }
+
+    // reset to a clean slate before the fourth scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
-    // then
-    assertThat(getCurrentHandlerPositions()).allSatisfy(position -> assertThat(position).isZero());
-    assertThat(getCurrentHandlerSequences()).allSatisfy(sequence -> assertThat(sequence).isZero());
-    assertThat(getLastImportedEntityTimestamps())
-        .allSatisfy(timestamp -> assertThat(timestamp).isEqualTo(BEGINNING_OF_TIME));
-    assertThat(embeddedOptimizeExtension.getAllPositionBasedImportHandlers())
-        .allSatisfy(handler -> assertThat(handler.isHasSeenSequenceField()).isFalse());
+    // given (import index can be reset)
+    {
+      deployZeebeData();
+
+      importAllZeebeEntitiesFromScratch();
+      embeddedOptimizeExtension.storeImportIndexesToElasticsearch();
+      databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+      // when (import index can be reset)
+      embeddedOptimizeExtension.resetPositionBasedImportStartIndexes();
+      embeddedOptimizeExtension.storeImportIndexesToElasticsearch();
+      databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+      // then (import index can be reset)
+      assertThat(getCurrentHandlerPositions())
+          .allSatisfy(position -> assertThat(position).isZero());
+      assertThat(getCurrentHandlerSequences())
+          .allSatisfy(sequence -> assertThat(sequence).isZero());
+      assertThat(getLastImportedEntityTimestamps())
+          .allSatisfy(timestamp -> assertThat(timestamp).isEqualTo(BEGINNING_OF_TIME));
+      assertThat(embeddedOptimizeExtension.getAllPositionBasedImportHandlers())
+          .allSatisfy(handler -> assertThat(handler.isHasSeenSequenceField()).isFalse());
+    }
   }
 
   @Test

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeProcessInstanceImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeProcessInstanceImportIT.java
@@ -89,62 +89,141 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
 
   @Test
   public void
-      importCompletedZeebeProcessInstanceDataInOneBatch_allDataSavedToOptimizeProcessInstance() {
-    // given
-    final String processName = "someProcess";
-    final ProcessInstanceEvent deployedInstance =
-        deployAndStartInstanceForProcess(createStartEndProcess(processName));
+      importCompletedAndRunningZeebeProcessInstanceData_allDataSavedToOptimizeProcessInstance() {
+    // Covers two independent terminal-state scenarios for the same "import from scratch, assert
+    // all fields" flow: scenario 1 a completed instance, scenario 2 a still-running instance. Each
+    // scenario is reset to a clean Zeebe export index and clean Optimize data before it runs,
+    // mirroring what @BeforeEach/@AfterEach would otherwise do between separate test methods.
 
-    // when
-    waitUntilMinimumProcessInstanceEventsExportedCount(6);
-    importAllZeebeEntitiesFromScratch();
+    // given (completed)
+    {
+      final String processName = "someProcess";
+      final ProcessInstanceEvent deployedInstance =
+          deployAndStartInstanceForProcess(createStartEndProcess(processName));
 
-    // then
-    final Map<String, List<ZeebeProcessInstanceRecordDto>> exportedEvents =
-        getZeebeExportedProcessInstanceEventsByElementId();
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(deployedInstance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(deployedInstance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(deployedInstance.getBpmnProcessId());
-              assertThat(savedInstance.getProcessDefinitionVersion())
-                  .isEqualTo(String.valueOf(deployedInstance.getVersion()));
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getState())
-                  .isEqualTo(ProcessInstanceConstants.COMPLETED_STATE);
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getBusinessKey()).isNull();
-              assertThat(savedInstance.getIncidents()).isEmpty();
-              assertThat(savedInstance.getVariables()).isEmpty();
-              assertThat(savedInstance.getStartDate())
-                  .isEqualTo(
-                      getExpectedStartDateForEvents(
-                          exportedEvents.get(deployedInstance.getBpmnProcessId())));
-              assertThat(savedInstance.getEndDate())
-                  .isEqualTo(
-                      getExpectedEndDateForEvents(
-                          exportedEvents.get(deployedInstance.getBpmnProcessId())));
-              assertThat(savedInstance.getDuration())
-                  .isEqualTo(
-                      getExpectedDurationForEvents(
-                          exportedEvents.get(deployedInstance.getBpmnProcessId())));
-              assertThat(savedInstance.getFlowNodeInstances())
-                  .hasSize(2)
-                  .containsExactlyInAnyOrder(
-                      createFlowNodeInstance(
-                          deployedInstance,
-                          exportedEvents,
-                          START_EVENT,
-                          BpmnElementType.START_EVENT),
-                      createFlowNodeInstance(
-                          deployedInstance, exportedEvents, END_EVENT, BpmnElementType.END_EVENT));
-            });
+      // when (completed)
+      waitUntilMinimumProcessInstanceEventsExportedCount(6);
+      importAllZeebeEntitiesFromScratch();
+
+      // then (completed)
+      final Map<String, List<ZeebeProcessInstanceRecordDto>> exportedEvents =
+          getZeebeExportedProcessInstanceEventsByElementId();
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance -> {
+                assertThat(savedInstance.getProcessInstanceId())
+                    .isEqualTo(String.valueOf(deployedInstance.getProcessInstanceKey()));
+                assertThat(savedInstance.getProcessDefinitionId())
+                    .isEqualTo(String.valueOf(deployedInstance.getProcessDefinitionKey()));
+                assertThat(savedInstance.getProcessDefinitionKey())
+                    .isEqualTo(deployedInstance.getBpmnProcessId());
+                assertThat(savedInstance.getProcessDefinitionVersion())
+                    .isEqualTo(String.valueOf(deployedInstance.getVersion()));
+                assertThat(savedInstance.getDataSource().getName())
+                    .isEqualTo(getConfiguredZeebeName());
+                assertThat(savedInstance.getState())
+                    .isEqualTo(ProcessInstanceConstants.COMPLETED_STATE);
+                assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+                assertThat(savedInstance.getBusinessKey()).isNull();
+                assertThat(savedInstance.getIncidents()).isEmpty();
+                assertThat(savedInstance.getVariables()).isEmpty();
+                assertThat(savedInstance.getStartDate())
+                    .isEqualTo(
+                        getExpectedStartDateForEvents(
+                            exportedEvents.get(deployedInstance.getBpmnProcessId())));
+                assertThat(savedInstance.getEndDate())
+                    .isEqualTo(
+                        getExpectedEndDateForEvents(
+                            exportedEvents.get(deployedInstance.getBpmnProcessId())));
+                assertThat(savedInstance.getDuration())
+                    .isEqualTo(
+                        getExpectedDurationForEvents(
+                            exportedEvents.get(deployedInstance.getBpmnProcessId())));
+                assertThat(savedInstance.getFlowNodeInstances())
+                    .hasSize(2)
+                    .containsExactlyInAnyOrder(
+                        createFlowNodeInstance(
+                            deployedInstance,
+                            exportedEvents,
+                            START_EVENT,
+                            BpmnElementType.START_EVENT),
+                        createFlowNodeInstance(
+                            deployedInstance,
+                            exportedEvents,
+                            END_EVENT,
+                            BpmnElementType.END_EVENT));
+              });
+    }
+
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // given (running)
+    {
+      final String processName = "someProcess";
+      final ProcessInstanceEvent deployedInstance =
+          deployAndStartInstanceForProcess(createSimpleUserTaskProcess(processName));
+
+      // when (running)
+      waitUntilMinimumProcessInstanceEventsExportedCount(4);
+      importAllZeebeEntitiesFromScratch();
+
+      // then (running)
+      final Map<String, List<ZeebeProcessInstanceRecordDto>> exportedEvents =
+          getZeebeExportedProcessInstanceEventsByElementId();
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance -> {
+                assertThat(savedInstance.getProcessInstanceId())
+                    .isEqualTo(String.valueOf(deployedInstance.getProcessInstanceKey()));
+                assertThat(savedInstance.getProcessDefinitionId())
+                    .isEqualTo(String.valueOf(deployedInstance.getProcessDefinitionKey()));
+                assertThat(savedInstance.getProcessDefinitionKey())
+                    .isEqualTo(deployedInstance.getBpmnProcessId());
+                assertThat(savedInstance.getProcessDefinitionVersion())
+                    .isEqualTo(String.valueOf(deployedInstance.getVersion()));
+                assertThat(savedInstance.getDataSource().getName())
+                    .isEqualTo(getConfiguredZeebeName());
+                assertThat(savedInstance.getState())
+                    .isEqualTo(ProcessInstanceConstants.ACTIVE_STATE);
+                assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+                assertThat(savedInstance.getBusinessKey()).isNull();
+                assertThat(savedInstance.getIncidents()).isEmpty();
+                assertThat(savedInstance.getVariables()).isEmpty();
+                assertThat(savedInstance.getStartDate())
+                    .isEqualTo(
+                        getExpectedStartDateForEvents(
+                            exportedEvents.get(deployedInstance.getBpmnProcessId())));
+                assertThat(savedInstance.getEndDate()).isNull();
+                assertThat(savedInstance.getDuration()).isNull();
+                final FlowNodeInstanceDto flowNodeInstanceDto =
+                    new FlowNodeInstanceDto(
+                        String.valueOf(deployedInstance.getBpmnProcessId()),
+                        String.valueOf(deployedInstance.getVersion()),
+                        ZEEBE_DEFAULT_TENANT_ID,
+                        String.valueOf(deployedInstance.getProcessInstanceKey()),
+                        USER_TASK,
+                        getBpmnElementTypeNameForType(BpmnElementType.USER_TASK),
+                        String.valueOf(exportedEvents.get(USER_TASK).get(0).getKey()));
+                flowNodeInstanceDto.setStartDate(
+                    getExpectedStartDateForEvents(exportedEvents.get(USER_TASK)));
+                flowNodeInstanceDto.setCanceled(false);
+                assertThat(savedInstance.getFlowNodeInstances())
+                    .hasSize(2)
+                    .containsExactlyInAnyOrder(
+                        createFlowNodeInstance(
+                            deployedInstance,
+                            exportedEvents,
+                            START_EVENT,
+                            BpmnElementType.START_EVENT),
+                        flowNodeInstanceDto);
+              });
+    }
   }
 
   @Test
@@ -216,388 +295,388 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
   }
 
   @Test
-  public void importRunningZeebeProcessInstanceData_allDataSavedToOptimizeProcessInstance() {
-    // given
-    final String processName = "someProcess";
-    final ProcessInstanceEvent deployedInstance =
-        deployAndStartInstanceForProcess(createSimpleUserTaskProcess(processName));
+  public void
+      importCanceledAndFromMultipleDaysZeebeProcessInstanceData_allDataSavedToOptimizeProcessInstance() {
+    // Covers two independent scenarios: scenario 1 a canceled (externally terminated) instance;
+    // scenario 2 an instance completed across a pinned clock jump of one day. Scenario 2 must run
+    // last since it pins the Zeebe engine clock with no reset mechanism — the pin would otherwise
+    // stay in effect for scenario 1 too. Each scenario is reset to a clean Zeebe export index and
+    // clean Optimize data before it runs, mirroring what @BeforeEach/@AfterEach would otherwise do
+    // between separate test methods.
 
-    // when
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    importAllZeebeEntitiesFromScratch();
+    // given (canceled)
+    {
+      final String processName = "someProcess";
+      final ProcessInstanceEvent deployedInstance =
+          deployAndStartInstanceForProcess(createSimpleServiceTaskProcess(processName));
 
-    // then
-    final Map<String, List<ZeebeProcessInstanceRecordDto>> exportedEvents =
-        getZeebeExportedProcessInstanceEventsByElementId();
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(deployedInstance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(deployedInstance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(deployedInstance.getBpmnProcessId());
-              assertThat(savedInstance.getProcessDefinitionVersion())
-                  .isEqualTo(String.valueOf(deployedInstance.getVersion()));
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getState()).isEqualTo(ProcessInstanceConstants.ACTIVE_STATE);
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getBusinessKey()).isNull();
-              assertThat(savedInstance.getIncidents()).isEmpty();
-              assertThat(savedInstance.getVariables()).isEmpty();
-              assertThat(savedInstance.getStartDate())
-                  .isEqualTo(
-                      getExpectedStartDateForEvents(
-                          exportedEvents.get(deployedInstance.getBpmnProcessId())));
-              assertThat(savedInstance.getEndDate()).isNull();
-              assertThat(savedInstance.getDuration()).isNull();
-              final FlowNodeInstanceDto flowNodeInstanceDto =
-                  new FlowNodeInstanceDto(
-                      String.valueOf(deployedInstance.getBpmnProcessId()),
-                      String.valueOf(deployedInstance.getVersion()),
-                      ZEEBE_DEFAULT_TENANT_ID,
-                      String.valueOf(deployedInstance.getProcessInstanceKey()),
-                      USER_TASK,
-                      getBpmnElementTypeNameForType(BpmnElementType.USER_TASK),
-                      String.valueOf(exportedEvents.get(USER_TASK).get(0).getKey()));
-              flowNodeInstanceDto.setStartDate(
-                  getExpectedStartDateForEvents(exportedEvents.get(USER_TASK)));
-              flowNodeInstanceDto.setCanceled(false);
-              assertThat(savedInstance.getFlowNodeInstances())
-                  .hasSize(2)
-                  .containsExactlyInAnyOrder(
-                      createFlowNodeInstance(
-                          deployedInstance,
-                          exportedEvents,
-                          START_EVENT,
-                          BpmnElementType.START_EVENT),
-                      flowNodeInstanceDto);
-            });
-  }
+      // We wait for the service task to be exported before cancelling the process
+      // (1 * process event, 2 * "start_event" events). Then again for the import of cancellation
+      // events (2 cancel events)
+      waitUntilMinimumProcessInstanceEventsExportedCount(4);
+      zeebeExtension.cancelProcessInstance(deployedInstance.getProcessInstanceKey());
+      waitUntilMinimumProcessInstanceEventsExportedCount(6);
 
-  @Test
-  public void importCanceledZeebeProcessInstanceData_allDataSavedToOptimizeProcessInstance() {
-    // given
-    final String processName = "someProcess";
-    final ProcessInstanceEvent deployedInstance =
-        deployAndStartInstanceForProcess(createSimpleServiceTaskProcess(processName));
+      // when (canceled)
+      importAllZeebeEntitiesFromScratch();
 
-    // We wait for the service task to be exported before cancelling the process
-    // (1 * process event, 2 * "start_event" events). Then again for the import of cancellation
-    // events (2 cancel events)
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    zeebeExtension.cancelProcessInstance(deployedInstance.getProcessInstanceKey());
-    waitUntilMinimumProcessInstanceEventsExportedCount(6);
+      // then (canceled)
+      final Map<String, List<ZeebeProcessInstanceRecordDto>> exportedEvents =
+          getZeebeExportedProcessInstanceEventsByElementId();
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance -> {
+                assertThat(savedInstance.getProcessInstanceId())
+                    .isEqualTo(String.valueOf(deployedInstance.getProcessInstanceKey()));
+                assertThat(savedInstance.getProcessDefinitionId())
+                    .isEqualTo(String.valueOf(deployedInstance.getProcessDefinitionKey()));
+                assertThat(savedInstance.getProcessDefinitionKey())
+                    .isEqualTo(deployedInstance.getBpmnProcessId());
+                assertThat(savedInstance.getProcessDefinitionVersion())
+                    .isEqualTo(String.valueOf(deployedInstance.getVersion()));
+                assertThat(savedInstance.getDataSource().getName())
+                    .isEqualTo(getConfiguredZeebeName());
+                assertThat(savedInstance.getState())
+                    .isEqualTo(ProcessInstanceConstants.EXTERNALLY_TERMINATED_STATE);
+                assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+                assertThat(savedInstance.getBusinessKey()).isNull();
+                assertThat(savedInstance.getIncidents()).isEmpty();
+                assertThat(savedInstance.getVariables()).isEmpty();
+                assertThat(savedInstance.getStartDate())
+                    .isEqualTo(
+                        getExpectedStartDateForEvents(
+                            exportedEvents.get(deployedInstance.getBpmnProcessId())));
+                assertThat(savedInstance.getEndDate())
+                    .isEqualTo(
+                        getExpectedEndDateForEvents(
+                            exportedEvents.get(deployedInstance.getBpmnProcessId())));
+                assertThat(savedInstance.getDuration())
+                    .isEqualTo(
+                        getExpectedDurationForEvents(
+                            exportedEvents.get(deployedInstance.getBpmnProcessId())));
+                assertThat(savedInstance.getFlowNodeInstances())
+                    .hasSize(2)
+                    .containsExactlyInAnyOrder(
+                        createFlowNodeInstance(
+                            deployedInstance,
+                            exportedEvents,
+                            START_EVENT,
+                            BpmnElementType.START_EVENT),
+                        createFlowNodeInstance(
+                            deployedInstance,
+                            exportedEvents,
+                            SERVICE_TASK,
+                            BpmnElementType.SERVICE_TASK,
+                            true));
+              });
+    }
 
-    // when
-    importAllZeebeEntitiesFromScratch();
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
-    // then
-    final Map<String, List<ZeebeProcessInstanceRecordDto>> exportedEvents =
-        getZeebeExportedProcessInstanceEventsByElementId();
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(deployedInstance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(deployedInstance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(deployedInstance.getBpmnProcessId());
-              assertThat(savedInstance.getProcessDefinitionVersion())
-                  .isEqualTo(String.valueOf(deployedInstance.getVersion()));
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getState())
-                  .isEqualTo(ProcessInstanceConstants.EXTERNALLY_TERMINATED_STATE);
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getBusinessKey()).isNull();
-              assertThat(savedInstance.getIncidents()).isEmpty();
-              assertThat(savedInstance.getVariables()).isEmpty();
-              assertThat(savedInstance.getStartDate())
-                  .isEqualTo(
-                      getExpectedStartDateForEvents(
-                          exportedEvents.get(deployedInstance.getBpmnProcessId())));
-              assertThat(savedInstance.getEndDate())
-                  .isEqualTo(
-                      getExpectedEndDateForEvents(
-                          exportedEvents.get(deployedInstance.getBpmnProcessId())));
-              assertThat(savedInstance.getDuration())
-                  .isEqualTo(
-                      getExpectedDurationForEvents(
-                          exportedEvents.get(deployedInstance.getBpmnProcessId())));
-              assertThat(savedInstance.getFlowNodeInstances())
-                  .hasSize(2)
-                  .containsExactlyInAnyOrder(
-                      createFlowNodeInstance(
-                          deployedInstance,
-                          exportedEvents,
-                          START_EVENT,
-                          BpmnElementType.START_EVENT),
-                      createFlowNodeInstance(
-                          deployedInstance,
-                          exportedEvents,
-                          SERVICE_TASK,
-                          BpmnElementType.SERVICE_TASK,
-                          true));
-            });
+    // given (from multiple days)
+    {
+      final String processName = "someProcess";
+      final ProcessInstanceEvent deployedInstance =
+          deployAndStartInstanceForProcess(createSimpleServiceTaskProcess(processName));
+
+      // when (from multiple days)
+      waitUntilMinimumProcessInstanceEventsExportedCount(4);
+      try {
+        zeebeExtension.setClock(Instant.now().plus(1, ChronoUnit.DAYS));
+      } catch (final IOException | InterruptedException e) {
+        throw new OptimizeRuntimeException(e);
+      }
+      zeebeExtension.completeTaskForInstanceWithJobType(SERVICE_TASK);
+      waitUntilMinimumProcessInstanceEventsExportedCount(8);
+      importAllZeebeEntitiesFromScratch();
+
+      // then (from multiple days)
+      final Map<String, List<ZeebeProcessInstanceRecordDto>> exportedEvents =
+          getZeebeExportedProcessInstanceEventsByElementId();
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance -> {
+                assertThat(savedInstance.getProcessInstanceId())
+                    .isEqualTo(String.valueOf(deployedInstance.getProcessInstanceKey()));
+                assertThat(savedInstance.getProcessDefinitionId())
+                    .isEqualTo(String.valueOf(deployedInstance.getProcessDefinitionKey()));
+                assertThat(savedInstance.getProcessDefinitionKey())
+                    .isEqualTo(deployedInstance.getBpmnProcessId());
+                assertThat(savedInstance.getProcessDefinitionVersion())
+                    .isEqualTo(String.valueOf(deployedInstance.getVersion()));
+                assertThat(savedInstance.getDataSource().getName())
+                    .isEqualTo(getConfiguredZeebeName());
+                assertThat(savedInstance.getState())
+                    .isEqualTo(ProcessInstanceConstants.COMPLETED_STATE);
+                assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+                assertThat(savedInstance.getBusinessKey()).isNull();
+                assertThat(savedInstance.getIncidents()).isEmpty();
+                assertThat(savedInstance.getVariables()).isEmpty();
+                assertThat(savedInstance.getStartDate())
+                    .isEqualTo(
+                        getExpectedStartDateForEvents(
+                            exportedEvents.get(deployedInstance.getBpmnProcessId())));
+                assertThat(savedInstance.getEndDate())
+                    .isEqualTo(
+                        getExpectedEndDateForEvents(
+                            exportedEvents.get(deployedInstance.getBpmnProcessId())));
+                assertThat(savedInstance.getDuration())
+                    .isEqualTo(
+                        getExpectedDurationForEvents(
+                            exportedEvents.get(deployedInstance.getBpmnProcessId())));
+                assertThat(savedInstance.getFlowNodeInstances())
+                    .hasSize(3)
+                    .containsExactlyInAnyOrder(
+                        createFlowNodeInstance(
+                            deployedInstance,
+                            exportedEvents,
+                            START_EVENT,
+                            BpmnElementType.START_EVENT),
+                        createFlowNodeInstance(
+                            deployedInstance,
+                            exportedEvents,
+                            SERVICE_TASK,
+                            BpmnElementType.SERVICE_TASK),
+                        createFlowNodeInstance(
+                            deployedInstance,
+                            exportedEvents,
+                            END_EVENT,
+                            BpmnElementType.END_EVENT));
+              });
+    }
   }
 
   @Test
   public void
-      importZeebeProcessInstanceDataFromMultipleDays_allDataSavedToOptimizeProcessInstance() {
-    // given
-    final String processName = "someProcess";
-    final ProcessInstanceEvent deployedInstance =
-        deployAndStartInstanceForProcess(createSimpleServiceTaskProcess(processName));
+      importZeebeProcessInstanceData_multipleInstancesForSameProcessAndDifferentProcessesAndDifferentVersions() {
+    // Covers three independent multi-instance scenarios: scenario 1 two instances of the same
+    // process; scenario 2 two instances of two different processes; scenario 3 two instances of
+    // two different versions of the same process. Each scenario is reset to a clean Zeebe export
+    // index and clean Optimize data before it runs, mirroring what @BeforeEach/@AfterEach would
+    // otherwise do between separate test methods.
 
-    // when
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    try {
-      zeebeExtension.setClock(Instant.now().plus(1, ChronoUnit.DAYS));
-    } catch (final IOException | InterruptedException e) {
-      throw new OptimizeRuntimeException(e);
+    // given (same process)
+    {
+      final String processName = "someProcess";
+      final Process deployedProcess =
+          zeebeExtension.deployProcess(createStartEndProcess(processName));
+      final ProcessInstanceEvent firstInstance =
+          zeebeExtension.startProcessInstanceForProcess(deployedProcess.getBpmnProcessId());
+      final ProcessInstanceEvent secondInstance =
+          zeebeExtension.startProcessInstanceForProcess(deployedProcess.getBpmnProcessId());
+
+      // when (same process)
+      // Each instance generates 6 events
+      waitUntilMinimumProcessInstanceEventsExportedCount(12);
+      importAllZeebeEntitiesFromScratch();
+
+      // then (same process)
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .hasSize(2)
+          .allSatisfy(instance -> assertThat(instance.getFlowNodeInstances()).hasSize(2))
+          .extracting(ProcessInstanceDto::getProcessInstanceId)
+          .containsExactlyInAnyOrder(
+              String.valueOf(firstInstance.getProcessInstanceKey()),
+              String.valueOf(secondInstance.getProcessInstanceKey()));
     }
-    zeebeExtension.completeTaskForInstanceWithJobType(SERVICE_TASK);
-    waitUntilMinimumProcessInstanceEventsExportedCount(8);
-    importAllZeebeEntitiesFromScratch();
 
-    // then
-    final Map<String, List<ZeebeProcessInstanceRecordDto>> exportedEvents =
-        getZeebeExportedProcessInstanceEventsByElementId();
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(deployedInstance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(deployedInstance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(deployedInstance.getBpmnProcessId());
-              assertThat(savedInstance.getProcessDefinitionVersion())
-                  .isEqualTo(String.valueOf(deployedInstance.getVersion()));
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getState())
-                  .isEqualTo(ProcessInstanceConstants.COMPLETED_STATE);
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getBusinessKey()).isNull();
-              assertThat(savedInstance.getIncidents()).isEmpty();
-              assertThat(savedInstance.getVariables()).isEmpty();
-              assertThat(savedInstance.getStartDate())
-                  .isEqualTo(
-                      getExpectedStartDateForEvents(
-                          exportedEvents.get(deployedInstance.getBpmnProcessId())));
-              assertThat(savedInstance.getEndDate())
-                  .isEqualTo(
-                      getExpectedEndDateForEvents(
-                          exportedEvents.get(deployedInstance.getBpmnProcessId())));
-              assertThat(savedInstance.getDuration())
-                  .isEqualTo(
-                      getExpectedDurationForEvents(
-                          exportedEvents.get(deployedInstance.getBpmnProcessId())));
-              assertThat(savedInstance.getFlowNodeInstances())
-                  .hasSize(3)
-                  .containsExactlyInAnyOrder(
-                      createFlowNodeInstance(
-                          deployedInstance,
-                          exportedEvents,
-                          START_EVENT,
-                          BpmnElementType.START_EVENT),
-                      createFlowNodeInstance(
-                          deployedInstance,
-                          exportedEvents,
-                          SERVICE_TASK,
-                          BpmnElementType.SERVICE_TASK),
-                      createFlowNodeInstance(
-                          deployedInstance, exportedEvents, END_EVENT, BpmnElementType.END_EVENT));
-            });
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // given (different processes)
+    {
+      final ProcessInstanceEvent firstInstance =
+          zeebeExtension.startProcessInstanceForProcess(
+              zeebeExtension
+                  .deployProcess(createStartEndProcess("firstProcess"))
+                  .getBpmnProcessId());
+      final ProcessInstanceEvent secondInstance =
+          zeebeExtension.startProcessInstanceForProcess(
+              zeebeExtension
+                  .deployProcess(createStartEndProcess("secondProcess"))
+                  .getBpmnProcessId());
+
+      // when (different processes)
+      // both processes have 6 importable events, wait until all records for both have been
+      // exported
+      waitUntilMinimumProcessInstanceEventsExportedCount(12);
+      importAllZeebeEntitiesFromScratch();
+
+      // then (different processes)
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .hasSize(2)
+          .allSatisfy(instance -> assertThat(instance.getFlowNodeInstances()).hasSize(2))
+          .extracting(ProcessInstanceDto::getProcessInstanceId)
+          .containsExactlyInAnyOrder(
+              String.valueOf(firstInstance.getProcessInstanceKey()),
+              String.valueOf(secondInstance.getProcessInstanceKey()));
+    }
+
+    // reset to a clean slate before the third scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // given (different versions of the same process)
+    {
+      final String processName = "someProcess";
+      final ProcessInstanceEvent v1Instance =
+          deployAndStartInstanceForProcess(createStartEndProcess(processName, processName));
+      final ProcessInstanceEvent v2Instance =
+          deployAndStartInstanceForProcess(createStartEndProcess(processName, processName));
+
+      // when (different versions of the same process)
+      // The first instance generates 6 events, so the 7th indicates that both processes have been
+      // exported
+      waitUntilMinimumProcessInstanceEventsExportedCount(12);
+      importAllZeebeEntitiesFromScratch();
+
+      // then (different versions of the same process)
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .hasSize(2)
+          .allSatisfy(instance -> assertThat(instance.getFlowNodeInstances()).hasSize(2))
+          .extracting(
+              ProcessInstanceDto::getProcessInstanceId,
+              ProcessInstanceDto::getProcessDefinitionVersion)
+          .containsExactlyInAnyOrder(
+              Tuple.tuple(String.valueOf(v1Instance.getProcessInstanceKey()), "1"),
+              Tuple.tuple(String.valueOf(v2Instance.getProcessInstanceKey()), "2"));
+    }
   }
 
   @Test
-  public void importZeebeProcessInstanceData_multipleInstancesForSameProcess() {
-    // given
-    final String processName = "someProcess";
-    final Process deployedProcess =
-        zeebeExtension.deployProcess(createStartEndProcess(processName));
-    final ProcessInstanceEvent firstInstance =
-        zeebeExtension.startProcessInstanceForProcess(deployedProcess.getBpmnProcessId());
-    final ProcessInstanceEvent secondInstance =
-        zeebeExtension.startProcessInstanceForProcess(deployedProcess.getBpmnProcessId());
+  public void importZeebeProcessInstanceData_processContainsLoopAndProcessStartedDuringProcess() {
+    // Covers two independent structural edge cases: scenario 1 a process containing a looping
+    // service task; scenario 2 a process started partway through (before two end events). Each
+    // scenario is reset to a clean Zeebe export index and clean Optimize data before it runs,
+    // mirroring what @BeforeEach/@AfterEach would otherwise do between separate test methods.
 
-    // when
-    // Each instance generates 6 events
-    waitUntilMinimumProcessInstanceEventsExportedCount(12);
-    importAllZeebeEntitiesFromScratch();
+    // given (contains loop)
+    {
+      final String processName = "someProcess";
+      deployAndStartInstanceForProcess(createLoopingProcess(processName));
 
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .hasSize(2)
-        .allSatisfy(instance -> assertThat(instance.getFlowNodeInstances()).hasSize(2))
-        .extracting(ProcessInstanceDto::getProcessInstanceId)
-        .containsExactlyInAnyOrder(
-            String.valueOf(firstInstance.getProcessInstanceKey()),
-            String.valueOf(secondInstance.getProcessInstanceKey()));
-  }
+      // when (contains loop)
+      waitUntilMinimumProcessInstanceEventsExportedCount(1);
+      zeebeExtension.completeTaskForInstanceWithJobType(SERVICE_TASK, Map.of("loop", true));
+      zeebeExtension.completeTaskForInstanceWithJobType(SERVICE_TASK, Map.of("loop", false));
+      waitUntilMinimumProcessInstanceEventsExportedCount(18);
+      importAllZeebeEntitiesFromScratch();
 
-  @Test
-  public void importZeebeProcessInstanceData_instancesForDifferentProcesses() {
-    // given
-    final ProcessInstanceEvent firstInstance =
-        zeebeExtension.startProcessInstanceForProcess(
-            zeebeExtension.deployProcess(createStartEndProcess("firstProcess")).getBpmnProcessId());
-    final ProcessInstanceEvent secondInstance =
-        zeebeExtension.startProcessInstanceForProcess(
-            zeebeExtension
-                .deployProcess(createStartEndProcess("secondProcess"))
-                .getBpmnProcessId());
+      // then (contains loop)
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              instance ->
+                  assertThat(instance.getFlowNodeInstances())
+                      .filteredOn(
+                          flowNodeInstance -> flowNodeInstance.getFlowNodeId().equals(SERVICE_TASK))
+                      .hasSizeGreaterThan(1));
+    }
 
-    // when
-    // both processes have 6 importable events, wait until all records for both have been exported
-    waitUntilMinimumProcessInstanceEventsExportedCount(12);
-    importAllZeebeEntitiesFromScratch();
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .hasSize(2)
-        .allSatisfy(instance -> assertThat(instance.getFlowNodeInstances()).hasSize(2))
-        .extracting(ProcessInstanceDto::getProcessInstanceId)
-        .containsExactlyInAnyOrder(
-            String.valueOf(firstInstance.getProcessInstanceKey()),
-            String.valueOf(secondInstance.getProcessInstanceKey()));
-  }
+    // given (started during process)
+    {
+      final String processName = "someProcess";
+      final Process process =
+          zeebeExtension.deployProcess(createSingleStartDoubleEndEventProcess(processName));
+      zeebeExtension.startProcessInstanceBeforeElementWithIds(
+          process.getBpmnProcessId(), END_EVENT, END_EVENT_2);
 
-  @Test
-  public void importZeebeProcessInstanceData_instancesWithDifferentVersionsOfSameProcess() {
-    // given
-    final String processName = "someProcess";
-    final ProcessInstanceEvent v1Instance =
-        deployAndStartInstanceForProcess(createStartEndProcess(processName, processName));
-    final ProcessInstanceEvent v2Instance =
-        deployAndStartInstanceForProcess(createStartEndProcess(processName, processName));
+      // when (started during process)
+      waitUntilMinimumProcessInstanceEventsExportedCount(6);
+      importAllZeebeEntitiesFromScratch();
 
-    // when
-    // The first instance generates 6 events, so the 7th indicates that both processes have been
-    // exported
-    waitUntilMinimumProcessInstanceEventsExportedCount(12);
-    importAllZeebeEntitiesFromScratch();
-
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .hasSize(2)
-        .allSatisfy(instance -> assertThat(instance.getFlowNodeInstances()).hasSize(2))
-        .extracting(
-            ProcessInstanceDto::getProcessInstanceId,
-            ProcessInstanceDto::getProcessDefinitionVersion)
-        .containsExactlyInAnyOrder(
-            Tuple.tuple(String.valueOf(v1Instance.getProcessInstanceKey()), "1"),
-            Tuple.tuple(String.valueOf(v2Instance.getProcessInstanceKey()), "2"));
-  }
-
-  @Test
-  public void importZeebeProcessInstanceData_processContainsLoop() {
-    // given
-    final String processName = "someProcess";
-    deployAndStartInstanceForProcess(createLoopingProcess(processName));
-
-    // when
-    waitUntilMinimumProcessInstanceEventsExportedCount(1);
-    zeebeExtension.completeTaskForInstanceWithJobType(SERVICE_TASK, Map.of("loop", true));
-    zeebeExtension.completeTaskForInstanceWithJobType(SERVICE_TASK, Map.of("loop", false));
-    waitUntilMinimumProcessInstanceEventsExportedCount(18);
-    importAllZeebeEntitiesFromScratch();
-
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            instance ->
-                assertThat(instance.getFlowNodeInstances())
-                    .filteredOn(
-                        flowNodeInstance -> flowNodeInstance.getFlowNodeId().equals(SERVICE_TASK))
-                    .hasSizeGreaterThan(1));
-  }
-
-  @Test
-  public void importZeebeProcessInstanceData_processStartedDuringProcess() {
-    // given
-    final String processName = "someProcess";
-    final Process process =
-        zeebeExtension.deployProcess(createSingleStartDoubleEndEventProcess(processName));
-    zeebeExtension.startProcessInstanceBeforeElementWithIds(
-        process.getBpmnProcessId(), END_EVENT, END_EVENT_2);
-
-    // when
-    waitUntilMinimumProcessInstanceEventsExportedCount(6);
-    importAllZeebeEntitiesFromScratch();
-
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            instance -> {
-              assertThat(instance.getEndDate()).isNotNull();
-              assertThat(instance.getState()).isEqualTo(ProcessInstanceConstants.COMPLETED_STATE);
-              assertThat(instance.getFlowNodeInstances())
-                  .extracting(FlowNodeInstanceDto::getFlowNodeType)
-                  .containsExactlyInAnyOrder(
-                      BpmnElementType.END_EVENT.getElementTypeName().get(),
-                      BpmnElementType.END_EVENT.getElementTypeName().get());
-            });
-  }
-
-  @Test
-  public void importZeebeProcessInstanceData_processContainsTerminateEndEvent() {
-    // given
-    final String processName = "someProcess";
-    deployAndStartInstanceForProcess(createTerminateEndEventProcess(processName));
-
-    // when
-    waitUntilMinimumProcessInstanceEventsExportedCount(6);
-    importAllZeebeEntitiesFromScratch();
-
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            instance ->
+      // then (started during process)
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              instance -> {
+                assertThat(instance.getEndDate()).isNotNull();
+                assertThat(instance.getState()).isEqualTo(ProcessInstanceConstants.COMPLETED_STATE);
                 assertThat(instance.getFlowNodeInstances())
                     .extracting(FlowNodeInstanceDto::getFlowNodeType)
                     .containsExactlyInAnyOrder(
-                        BpmnElementType.START_EVENT.getElementTypeName().get(),
-                        BpmnElementType.END_EVENT.getElementTypeName().get()));
-  }
-
-  @Test
-  public void importZeebeProcessInstanceData_processContainsInclusiveGateway() {
-    // given
-    final String processName = "someProcess";
-    final Process process =
-        zeebeExtension.deployProcess(createInclusiveGatewayProcess(processName));
-    zeebeExtension.startProcessInstanceWithVariables(
-        process.getBpmnProcessId(), Map.of("varName", "a,b"));
-
-    // when
-    waitUntilMinimumProcessInstanceEventsExportedCount(8);
-    importAllZeebeEntitiesFromScratch();
-
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            instance ->
-                assertThat(instance.getFlowNodeInstances())
-                    .extracting(FlowNodeInstanceDto::getFlowNodeType)
-                    .containsExactlyInAnyOrder(
-                        BpmnElementType.START_EVENT.getElementTypeName().get(),
-                        BpmnElementType.INCLUSIVE_GATEWAY.getElementTypeName().get(),
                         BpmnElementType.END_EVENT.getElementTypeName().get(),
-                        BpmnElementType.END_EVENT.getElementTypeName().get()));
+                        BpmnElementType.END_EVENT.getElementTypeName().get());
+              });
+    }
+  }
+
+  @Test
+  public void importZeebeProcessInstanceData_processContainsTerminateEndEventAndInclusiveGateway() {
+    // Covers two independent BPMN-construct checks: scenario 1 a process with a terminate end
+    // event; scenario 2 a process with an inclusive gateway. Each scenario is reset to a clean
+    // Zeebe export index and clean Optimize data before it runs, mirroring what
+    // @BeforeEach/@AfterEach would otherwise do between separate test methods.
+
+    // given (terminate end event)
+    {
+      final String processName = "someProcess";
+      deployAndStartInstanceForProcess(createTerminateEndEventProcess(processName));
+
+      // when (terminate end event)
+      waitUntilMinimumProcessInstanceEventsExportedCount(6);
+      importAllZeebeEntitiesFromScratch();
+
+      // then (terminate end event)
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              instance ->
+                  assertThat(instance.getFlowNodeInstances())
+                      .extracting(FlowNodeInstanceDto::getFlowNodeType)
+                      .containsExactlyInAnyOrder(
+                          BpmnElementType.START_EVENT.getElementTypeName().get(),
+                          BpmnElementType.END_EVENT.getElementTypeName().get()));
+    }
+
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // given (inclusive gateway)
+    {
+      final String processName = "someProcess";
+      final Process process =
+          zeebeExtension.deployProcess(createInclusiveGatewayProcess(processName));
+      zeebeExtension.startProcessInstanceWithVariables(
+          process.getBpmnProcessId(), Map.of("varName", "a,b"));
+
+      // when (inclusive gateway)
+      waitUntilMinimumProcessInstanceEventsExportedCount(8);
+      importAllZeebeEntitiesFromScratch();
+
+      // then (inclusive gateway)
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              instance ->
+                  assertThat(instance.getFlowNodeInstances())
+                      .extracting(FlowNodeInstanceDto::getFlowNodeType)
+                      .containsExactlyInAnyOrder(
+                          BpmnElementType.START_EVENT.getElementTypeName().get(),
+                          BpmnElementType.INCLUSIVE_GATEWAY.getElementTypeName().get(),
+                          BpmnElementType.END_EVENT.getElementTypeName().get(),
+                          BpmnElementType.END_EVENT.getElementTypeName().get()));
+    }
   }
 
   @DisabledIf("isZeebeVersionPre86")
@@ -626,74 +705,89 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
   }
 
   @Test
-  public void importSendTaskZeebeProcessInstanceData_flowNodeInstancesCreatedCorrectly() {
-    // given
-    final ProcessInstanceEvent processInstance =
-        deployAndStartInstanceForProcess(createSendTaskProcess("someProcess"));
+  public void
+      importSendTaskAndNewBpmnElementsIntroducedWith820ZeebeProcessInstanceData_flowNodeInstancesCreatedCorrectly() {
+    // Covers two independent BPMN-construct checks: scenario 1 a process with a send task;
+    // scenario 2 a process with the new 8.2.0 elements (data stores, date objects, link events,
+    // escalation events, undefined tasks). Each scenario is reset to a clean Zeebe export index
+    // and clean Optimize data before it runs, mirroring what @BeforeEach/@AfterEach would
+    // otherwise do between separate test methods.
 
-    // when
-    waitUntilMinimumProcessInstanceEventsExportedCount(1);
-    importAllZeebeEntitiesFromScratch();
+    // given (send task)
+    {
+      final ProcessInstanceEvent processInstance =
+          deployAndStartInstanceForProcess(createSendTaskProcess("someProcess"));
 
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance ->
-                assertThat(savedInstance.getFlowNodeInstances())
-                    .hasSize(2)
-                    .allSatisfy(
-                        flowNodeInstanceDto ->
-                            assertThat(flowNodeInstanceDto)
-                                .hasFieldOrPropertyWithValue(
-                                    FlowNodeInstanceDto.Fields.definitionKey,
-                                    processInstance.getBpmnProcessId())
-                                .hasFieldOrPropertyWithValue(
-                                    FlowNodeInstanceDto.Fields.definitionVersion,
-                                    String.valueOf(processInstance.getVersion()))
-                                .hasFieldOrPropertyWithValue(
-                                    FlowNodeInstanceDto.Fields.tenantId, ZEEBE_DEFAULT_TENANT_ID))
-                    .extracting(
-                        FlowNodeInstanceDto::getFlowNodeId, FlowNodeInstanceDto::getFlowNodeType)
-                    .containsExactlyInAnyOrder(
-                        Tuple.tuple(
-                            START_EVENT,
-                            getBpmnElementTypeNameForType(BpmnElementType.START_EVENT)),
-                        Tuple.tuple(
-                            SEND_TASK, getBpmnElementTypeNameForType(BpmnElementType.SEND_TASK))));
-  }
+      // when (send task)
+      waitUntilMinimumProcessInstanceEventsExportedCount(1);
+      importAllZeebeEntitiesFromScratch();
 
-  @Test
-  public void importZeebeProcessInstanceData_processContainsNewBpmnElementsIntroducedWith820() {
-    // given a process that contains the following:
+      // then (send task)
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance ->
+                  assertThat(savedInstance.getFlowNodeInstances())
+                      .hasSize(2)
+                      .allSatisfy(
+                          flowNodeInstanceDto ->
+                              assertThat(flowNodeInstanceDto)
+                                  .hasFieldOrPropertyWithValue(
+                                      FlowNodeInstanceDto.Fields.definitionKey,
+                                      processInstance.getBpmnProcessId())
+                                  .hasFieldOrPropertyWithValue(
+                                      FlowNodeInstanceDto.Fields.definitionVersion,
+                                      String.valueOf(processInstance.getVersion()))
+                                  .hasFieldOrPropertyWithValue(
+                                      FlowNodeInstanceDto.Fields.tenantId, ZEEBE_DEFAULT_TENANT_ID))
+                      .extracting(
+                          FlowNodeInstanceDto::getFlowNodeId, FlowNodeInstanceDto::getFlowNodeType)
+                      .containsExactlyInAnyOrder(
+                          Tuple.tuple(
+                              START_EVENT,
+                              getBpmnElementTypeNameForType(BpmnElementType.START_EVENT)),
+                          Tuple.tuple(
+                              SEND_TASK,
+                              getBpmnElementTypeNameForType(BpmnElementType.SEND_TASK))));
+    }
+
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // given (new 8.2.0 elements) a process that contains the following:
     // data stores, date objects, link events, escalation events, undefined tasks
-    final BpmnModelInstance model =
-        readProcessDiagramAsInstance("/bpmn/compatibility/adventure.bpmn");
-    final String processId = zeebeExtension.deployProcess(model).getBpmnProcessId();
-    zeebeExtension.startProcessInstanceWithVariables(
-        processId, Map.of("space", true, "time", true));
+    {
+      final BpmnModelInstance model =
+          readProcessDiagramAsInstance("/bpmn/compatibility/adventure.bpmn");
+      final String processId = zeebeExtension.deployProcess(model).getBpmnProcessId();
+      zeebeExtension.startProcessInstanceWithVariables(
+          processId, Map.of("space", true, "time", true));
 
-    // when
-    waitUntilInstanceRecordWithElementIdExported("milkAdventureEndEventId");
-    importAllZeebeEntitiesFromScratch();
+      // when (new 8.2.0 elements)
+      waitUntilInstanceRecordWithElementIdExported("milkAdventureEndEventId");
+      importAllZeebeEntitiesFromScratch();
 
-    // then all new events were imported
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            instance ->
-                assertThat(instance.getFlowNodeInstances())
-                    .extracting(FlowNodeInstanceDto::getFlowNodeId)
-                    .contains(
-                        "linkIntermediateThrowEventId",
-                        "linkIntermediateCatchEventId",
-                        "undefinedTaskId",
-                        "escalationIntermediateThrowEventId",
-                        "escalationNonInterruptingBoundaryEventId",
-                        "escalationBoundaryEventId",
-                        "escalationNonInterruptingStartEventId",
-                        "escalationStartEventId",
-                        "escalationEndEventId"));
+      // then (new 8.2.0 elements) all new events were imported
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              instance ->
+                  assertThat(instance.getFlowNodeInstances())
+                      .extracting(FlowNodeInstanceDto::getFlowNodeId)
+                      .contains(
+                          "linkIntermediateThrowEventId",
+                          "linkIntermediateCatchEventId",
+                          "undefinedTaskId",
+                          "escalationIntermediateThrowEventId",
+                          "escalationNonInterruptingBoundaryEventId",
+                          "escalationBoundaryEventId",
+                          "escalationNonInterruptingStartEventId",
+                          "escalationStartEventId",
+                          "escalationEndEventId"));
+    }
   }
 
   @DisabledIf("isZeebeVersionPre83")

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeUserTaskImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeUserTaskImportIT.java
@@ -47,869 +47,963 @@ public class ZeebeUserTaskImportIT extends AbstractCCSMIT {
   private static final String ASSIGNEE_ID = "assigneeId";
 
   @Test
-  public void importRunningZeebeUserTaskData() {
-    // given
-    final ProcessInstanceEvent instance =
-        deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    // remove all zeebe records except userTask ones to test userTask import only
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
+  public void importRunningZeebeUserTaskDataAndOtherDueDateFormat() {
+    // Covers two independent narrow checks on a running user task: scenario 1 the full field set
+    // for the default due-date format; scenario 2 that an alternate due-date string format is
+    // still parsed correctly. Each scenario is reset to a clean Zeebe export index and clean
+    // Optimize data before it runs, mirroring what @BeforeEach/@AfterEach would otherwise do
+    // between separate test methods.
 
-    // when
-    importAllZeebeEntitiesFromScratch();
+    // given (default due-date format)
+    {
+      final ProcessInstanceEvent instance =
+          deployAndStartInstanceForProcess(
+              createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
+      waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+      // remove all zeebe records except userTask ones to test userTask import only
+      removeAllZeebeExportRecordsExceptUserTaskRecords();
 
-    // then
-    final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              final FlowNodeInstanceDto runningUserTaskInstance =
-                  createRunningUserTaskInstance(instance, exportedEvents);
-              runningUserTaskInstance.setDueDate(EXPECTED_DUE_DATE);
-              assertThat(savedInstance.getFlowNodeInstances())
-                  .singleElement() // only userTask was imported because all other records were
-                  // removed
-                  .usingRecursiveComparison()
-                  .isEqualTo(runningUserTaskInstance);
-            });
-  }
+      // when (default due-date format)
+      importAllZeebeEntitiesFromScratch();
 
-  @Test
-  public void importCompletedUnclaimedZeebeUserTaskData_viaWriter() {
-    // import all data for completed usertask (creation and completion) in one batch, hence the
-    // upsert inserts the new instance created with the logic in the writer
-    // given
-    final ProcessInstanceEvent instance =
-        deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    // remove all zeebe records except userTask ones to test userTask import only
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
-    List<ZeebeUserTaskRecordDto> userTaskEvents = getZeebeExportedUserTaskEvents();
-    zeebeExtension.completeZeebeUserTask(getExpectedUserTaskInstanceIdFromRecords(userTaskEvents));
-    waitUntilUserTaskRecordWithIntentExported(COMPLETED);
-
-    // when
-    importAllZeebeEntitiesFromScratch();
-
-    // then
-    userTaskEvents = getZeebeExportedUserTaskEvents();
-    final OffsetDateTime expectedEndDate =
-        getExpectedEndDateForCompletedUserTaskEvents(userTaskEvents);
-    final FlowNodeInstanceDto expectedUserTask =
-        createRunningUserTaskInstance(instance, userTaskEvents);
-    expectedUserTask.setDueDate(EXPECTED_DUE_DATE);
-    expectedUserTask.setEndDate(expectedEndDate);
-    expectedUserTask.setIdleDurationInMs(0L);
-    expectedUserTask.setTotalDurationInMs(
-        getExpectedTotalDurationForCompletedUserTask(userTaskEvents));
-    expectedUserTask.setWorkDurationInMs(
-        getExpectedTotalDurationForCompletedUserTask(userTaskEvents));
-
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getFlowNodeInstances())
-                  .singleElement() // only the userTask was imported because all other records were
-                  // removed
-                  .usingRecursiveComparison()
-                  .isEqualTo(expectedUserTask);
-            });
-  }
-
-  @Test
-  public void importCompletedUnclaimedZeebeUserTaskData_viaUpdateScript() {
-    // import completed userTask data after the first userTask record was already imported, hence
-    // the upsert uses the logic from the update script
-    // given
-    final ProcessInstanceEvent instance =
-        deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
-
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    // remove all zeebe records except userTask ones to test userTask import only
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
-    importAllZeebeEntitiesFromScratch();
-    final List<ZeebeUserTaskRecordDto> runningUserTaskEvents = getZeebeExportedUserTaskEvents();
-    final FlowNodeInstanceDto expectedUserTask =
-        createRunningUserTaskInstance(instance, runningUserTaskEvents);
-    List<ZeebeUserTaskRecordDto> userTaskEvents = getZeebeExportedUserTaskEvents();
-    zeebeExtension.completeZeebeUserTask(getExpectedUserTaskInstanceIdFromRecords(userTaskEvents));
-    waitUntilUserTaskRecordWithIntentExported(COMPLETED);
-
-    // when
-    importAllZeebeEntitiesFromLastIndex();
-
-    // then
-    userTaskEvents = getZeebeExportedUserTaskEvents();
-    final OffsetDateTime expectedEndDate =
-        getExpectedEndDateForCompletedUserTaskEvents(userTaskEvents);
-    expectedUserTask.setDueDate(EXPECTED_DUE_DATE);
-    expectedUserTask.setEndDate(expectedEndDate);
-    expectedUserTask.setIdleDurationInMs(0L);
-    expectedUserTask.setTotalDurationInMs(
-        getExpectedTotalDurationForCompletedUserTask(userTaskEvents));
-    expectedUserTask.setWorkDurationInMs(
-        getExpectedTotalDurationForCompletedUserTask(userTaskEvents));
-
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getFlowNodeInstances())
-                  .singleElement() // only the userTask was imported because all other records were
-                  // removed
-                  .usingRecursiveComparison()
-                  .isEqualTo(expectedUserTask);
-            });
-  }
-
-  @Test
-  public void importCanceledUnclaimedZeebeUserTaskData_viaWriter() {
-    // import all data for canceled usertask (creation and cancellation) in one batch, hence the
-    // upsert inserts the new instance
-    // created with the logic in the writer
-    final ProcessInstanceEvent instance =
-        deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    zeebeExtension.cancelProcessInstance(instance.getProcessInstanceKey());
-    waitUntilUserTaskRecordWithIntentExported(UserTaskIntent.CANCELED);
-    // remove all zeebe records except userTask ones to test userTask import only
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
-
-    // when
-    importAllZeebeEntitiesFromScratch();
-
-    // then the import in one batch correctly set all fields in the new instance document
-    final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
-    final FlowNodeInstanceDto expectedUserTask =
-        createRunningUserTaskInstance(instance, exportedEvents);
-    final OffsetDateTime expectedEndDate =
-        getExpectedEndDateForCanceledUserTaskEvents(exportedEvents);
-    final Long expectedTotalAndIdleDuration =
-        Duration.between(expectedUserTask.getStartDate(), expectedEndDate).toMillis();
-    expectedUserTask.setDueDate(EXPECTED_DUE_DATE);
-    expectedUserTask.setEndDate(expectedEndDate);
-    expectedUserTask.setTotalDurationInMs(expectedTotalAndIdleDuration);
-    expectedUserTask.setIdleDurationInMs(expectedTotalAndIdleDuration);
-    expectedUserTask.setWorkDurationInMs(0L);
-    expectedUserTask.setCanceled(true);
-
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getFlowNodeInstances())
-                  .singleElement() // only userTask was imported because all other records were
-                  // removed
-                  .usingRecursiveComparison()
-                  .isEqualTo(expectedUserTask);
-            });
-  }
-
-  @Test
-  public void importCanceledUnclaimedZeebeUserTaskData_viaUpdateScript() {
-    // import canceled userTask data after the first userTask record was already imported, hence the
-    // upsert uses the logic  from the update script
-    // given
-    final ProcessInstanceEvent instance =
-        deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
-    importAllZeebeEntitiesFromScratch();
-    zeebeExtension.cancelProcessInstance(instance.getProcessInstanceKey());
-    waitUntilUserTaskRecordWithIntentExported(UserTaskIntent.CANCELED);
-    // remove all zeebe records except userTask ones to test userTask import only
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
-
-    // when
-    importAllZeebeEntitiesFromLastIndex();
-
-    // then the import over two batches correctly updates all fields with the update script
-    final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
-    final FlowNodeInstanceDto expectedUserTask =
-        createRunningUserTaskInstance(instance, exportedEvents);
-    final OffsetDateTime expectedEndDate =
-        getExpectedEndDateForCanceledUserTaskEvents(exportedEvents);
-    expectedUserTask.setDueDate(EXPECTED_DUE_DATE);
-    expectedUserTask.setEndDate(expectedEndDate);
-    expectedUserTask.setTotalDurationInMs(
-        Duration.between(expectedUserTask.getStartDate(), expectedEndDate).toMillis());
-    expectedUserTask.setIdleDurationInMs(
-        Duration.between(expectedUserTask.getStartDate(), expectedEndDate).toMillis());
-    expectedUserTask.setWorkDurationInMs(0L);
-    expectedUserTask.setCanceled(true);
-
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getFlowNodeInstances())
-                  // only userTask was imported because all other records were removed
-                  .singleElement()
-                  .usingRecursiveComparison()
-                  .isEqualTo(expectedUserTask);
-            });
-  }
-
-  @Test
-  public void importCanceledClaimedZeebeUserTaskData_viaWriter() {
-    // import all data for canceled usertask in one batch, hence the upsert inserts the new instance
-    // created with the logic in the writer
-    // given
-    final ProcessInstanceEvent instance =
-        deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
-    zeebeExtension.assignUserTask(
-        getExpectedUserTaskInstanceIdFromRecords(exportedEvents), ASSIGNEE_ID);
-    zeebeExtension.cancelProcessInstance(instance.getProcessInstanceKey());
-    waitUntilUserTaskRecordWithIntentExported(CANCELED);
-    // remove all zeebe records except userTask ones to test userTask import only
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
-
-    // when
-    importAllZeebeEntitiesFromScratch();
-
-    // then
-    exportedEvents = getZeebeExportedUserTaskEvents();
-    final FlowNodeInstanceDto expectedUserTask =
-        createRunningUserTaskInstance(instance, exportedEvents);
-    final OffsetDateTime expectedEndDate =
-        getExpectedEndDateForCanceledUserTaskEvents(exportedEvents);
-    final OffsetDateTime assignDate = getTimestampForAssignedUserTaskEvents(exportedEvents);
-    expectedUserTask.setAssignee(ASSIGNEE_ID);
-    expectedUserTask.setDueDate(EXPECTED_DUE_DATE);
-    expectedUserTask.setEndDate(expectedEndDate);
-    expectedUserTask.setTotalDurationInMs(
-        Duration.between(expectedUserTask.getStartDate(), expectedEndDate).toMillis());
-    expectedUserTask.setIdleDurationInMs(
-        Duration.between(expectedUserTask.getStartDate(), assignDate).toMillis());
-    expectedUserTask.setWorkDurationInMs(Duration.between(assignDate, expectedEndDate).toMillis());
-    expectedUserTask.setAssigneeOperations(
-        List.of(
-            createAssigneeOperationDto(
-                getExpectedIdFromRecords(exportedEvents, ASSIGNED),
-                CLAIM_OPERATION_TYPE,
-                ASSIGNEE_ID,
-                getTimestampForAssignedUserTaskEvents(exportedEvents))));
-    expectedUserTask.setCanceled(true);
-
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getFlowNodeInstances())
-                  // only userTask was imported because all other records were removed
-                  .singleElement()
-                  .usingRecursiveComparison()
-                  .isEqualTo(expectedUserTask);
-            });
-  }
-
-  @Test
-  public void importCanceledClaimedZeebeUserTaskData_viaUpdateScript() {
-    // import canceled userTask data after the first userTask records were already imported, hence
-    // the upsert uses the logic from the update script
-    // given
-    final ProcessInstanceEvent instance =
-        deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
-    zeebeExtension.assignUserTask(
-        getExpectedUserTaskInstanceIdFromRecords(exportedEvents), ASSIGNEE_ID);
-    waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
-
-    // remove all zeebe records except userTask ones to test userTask import only
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
-    importAllZeebeEntitiesFromScratch();
-
-    zeebeExtension.cancelProcessInstance(instance.getProcessInstanceKey());
-    waitUntilUserTaskRecordWithIntentExported(UserTaskIntent.CANCELED);
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
-
-    // when
-    importAllZeebeEntitiesFromLastIndex();
-
-    // then
-    exportedEvents = getZeebeExportedUserTaskEvents();
-    final OffsetDateTime expectedEndDate =
-        getExpectedEndDateForCanceledUserTaskEvents(exportedEvents);
-    final OffsetDateTime assignDate = getTimestampForAssignedUserTaskEvents(exportedEvents);
-    final FlowNodeInstanceDto expectedUserTask =
-        createRunningUserTaskInstance(instance, exportedEvents);
-    expectedUserTask.setAssignee(ASSIGNEE_ID);
-    expectedUserTask.setDueDate(EXPECTED_DUE_DATE);
-    expectedUserTask.setEndDate(expectedEndDate);
-    expectedUserTask.setTotalDurationInMs(
-        Duration.between(expectedUserTask.getStartDate(), expectedEndDate).toMillis());
-    expectedUserTask.setIdleDurationInMs(
-        Duration.between(expectedUserTask.getStartDate(), assignDate).toMillis());
-    expectedUserTask.setWorkDurationInMs(Duration.between(assignDate, expectedEndDate).toMillis());
-    expectedUserTask.setAssigneeOperations(
-        List.of(
-            createAssigneeOperationDto(
-                getExpectedIdFromRecords(exportedEvents, ASSIGNED),
-                CLAIM_OPERATION_TYPE,
-                ASSIGNEE_ID,
-                getTimestampForAssignedUserTaskEvents(exportedEvents))));
-    expectedUserTask.setCanceled(true);
-
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getFlowNodeInstances())
-                  // only userTask was imported because all other records were removed
-                  .singleElement()
-                  .usingRecursiveComparison()
-                  .isEqualTo(expectedUserTask);
-            });
-  }
-
-  @Test
-  public void importClaimOperation_viaWriter() {
-    // import assignee usertask operations in one batch, hence the upsert inserts the new instance
-    // created with the logic in the writer
-    // given
-    final ProcessInstanceEvent instance =
-        deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, null));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
-    zeebeExtension.assignUserTask(
-        getExpectedUserTaskInstanceIdFromRecords(exportedEvents), ASSIGNEE_ID);
-    waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
-    // remove all zeebe records except userTask ones to test userTask import only
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
-
-    // when
-    importAllZeebeEntitiesFromScratch();
-
-    // then
-    exportedEvents = getZeebeExportedUserTaskEvents();
-    final FlowNodeInstanceDto expectedUserTask =
-        createRunningUserTaskInstance(instance, exportedEvents);
-    expectedUserTask.setIdleDurationInMs(
-        getDurationInMsBetweenStartAndFirstAssignOperation(exportedEvents));
-    expectedUserTask.setAssignee(ASSIGNEE_ID);
-    expectedUserTask.setAssigneeOperations(
-        List.of(
-            createAssigneeOperationDto(
-                getExpectedIdFromRecords(exportedEvents, ASSIGNED),
-                CLAIM_OPERATION_TYPE,
-                ASSIGNEE_ID,
-                getTimestampForZeebeAssignEvents(exportedEvents, ASSIGNEE_ID))));
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getFlowNodeInstances())
-                  // only userTask was imported because all other records were removed
-                  .singleElement()
-                  .usingRecursiveComparison()
-                  .isEqualTo(expectedUserTask);
-            });
-  }
-
-  @Test
-  public void importClaimOperation_viaUpdateScript() {
-    // import assignee userTask data after the first userTask records were already imported, hence
-    // the upsert uses the logic from the update script
-    // given
-    final ProcessInstanceEvent instance =
-        deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, null));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
-    importAllZeebeEntitiesFromScratch();
-
-    List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
-    zeebeExtension.assignUserTask(
-        getExpectedUserTaskInstanceIdFromRecords(exportedEvents), ASSIGNEE_ID);
-    waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
-
-    // when
-    importAllZeebeEntitiesFromLastIndex();
-
-    // then
-    exportedEvents = getZeebeExportedUserTaskEvents();
-    final FlowNodeInstanceDto expectedUserTask =
-        createRunningUserTaskInstance(instance, exportedEvents);
-    expectedUserTask.setIdleDurationInMs(
-        getDurationInMsBetweenStartAndFirstAssignOperation(exportedEvents));
-    expectedUserTask.setAssignee(ASSIGNEE_ID);
-    expectedUserTask.setAssigneeOperations(
-        List.of(
-            createAssigneeOperationDto(
-                getExpectedIdFromRecords(exportedEvents, ASSIGNED),
-                CLAIM_OPERATION_TYPE,
-                ASSIGNEE_ID,
-                getTimestampForZeebeAssignEvents(exportedEvents, ASSIGNEE_ID))));
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getFlowNodeInstances())
-                  // only userTask was imported because all other records were removed
-                  .singleElement()
-                  .usingRecursiveComparison()
-                  .isEqualTo(expectedUserTask);
-            });
-  }
-
-  @Test
-  public void importUnclaimOperation_viaWriter() {
-    // import assignee usertask operations in one batch, hence the upsert inserts the new instance
-    // created with the logic in the writer
-    // given
-    final ProcessInstanceEvent instance =
-        deployAndStartInstanceForProcess(
-            createSimpleNativeUserTaskProcessWithAssignee(TEST_PROCESS, null, ASSIGNEE_ID));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-
-    if (isZeebeVersion87_OrLater()) {
-      // to wait for `ASSIGNED` event triggered by Zeebe after UT creation with the defined
-      // `assignee`
-      waitUntilUserTaskRecordWithIntentExported(1, ASSIGNED);
-      zeebeExtension.unassignUserTask(
-          getExpectedUserTaskInstanceIdFromRecords(getZeebeExportedUserTaskEvents()));
-      // wait for the 2nd `ASSIGNED` event triggered by UT unassign operation
-      waitUntilUserTaskRecordWithIntentExported(2, ASSIGNED);
-    } else {
-      zeebeExtension.unassignUserTask(
-          getExpectedUserTaskInstanceIdFromRecords(getZeebeExportedUserTaskEvents()));
-      waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
+      // then (default due-date format)
+      final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance -> {
+                assertThat(savedInstance.getProcessInstanceId())
+                    .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
+                assertThat(savedInstance.getProcessDefinitionId())
+                    .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
+                assertThat(savedInstance.getProcessDefinitionKey())
+                    .isEqualTo(instance.getBpmnProcessId());
+                assertThat(savedInstance.getDataSource().getName())
+                    .isEqualTo(getConfiguredZeebeName());
+                assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+                final FlowNodeInstanceDto runningUserTaskInstance =
+                    createRunningUserTaskInstance(instance, exportedEvents);
+                runningUserTaskInstance.setDueDate(EXPECTED_DUE_DATE);
+                assertThat(savedInstance.getFlowNodeInstances())
+                    .singleElement() // only userTask was imported because all other records were
+                    // removed
+                    .usingRecursiveComparison()
+                    .isEqualTo(runningUserTaskInstance);
+              });
     }
 
-    // remove all zeebe records except userTask ones to test userTask import only
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
-    // when
-    importAllZeebeEntitiesFromScratch();
+    // given (other due-date format)
+    {
+      final String dueDateStringInOtherFormat = "2023-03-02T15:35+02:00";
+      deployAndStartInstanceForProcess(
+          createSimpleNativeUserTaskProcess(TEST_PROCESS, dueDateStringInOtherFormat));
+      waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+      // remove all zeebe records except userTask ones to test userTask import only
+      removeAllZeebeExportRecordsExceptUserTaskRecords();
 
-    // then
-    final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              final FlowNodeInstanceDto runningUserTaskInstance =
-                  createRunningUserTaskInstance(instance, exportedEvents);
-              runningUserTaskInstance.setIdleDurationInMs(0L);
-              runningUserTaskInstance.setWorkDurationInMs(
+      // when (other due-date format)
+      importAllZeebeEntitiesFromScratch();
+
+      // then (other due-date format) dueDate is correctly parsed
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance ->
+                  assertThat(savedInstance.getFlowNodeInstances())
+                      .singleElement()
+                      .extracting(FlowNodeInstanceDto::getDueDate)
+                      .isEqualTo(OffsetDateTime.parse(dueDateStringInOtherFormat)));
+    }
+  }
+
+  @Test
+  public void importCompletedUnclaimedZeebeUserTaskData_viaWriterAndViaUpdateScript() {
+    // Covers both import code paths for a completed (unclaimed) user task: scenario 1 imports
+    // creation and completion together in one batch (upsert via the writer); scenario 2 imports
+    // creation and completion as two separate batches (upsert via the update script). Each
+    // scenario is reset to a clean Zeebe export index and clean Optimize data before it runs,
+    // mirroring what @BeforeEach/@AfterEach would otherwise do between separate test methods.
+
+    // given (writer path)
+    {
+      final ProcessInstanceEvent instance =
+          deployAndStartInstanceForProcess(
+              createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
+      waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+      // remove all zeebe records except userTask ones to test userTask import only
+      removeAllZeebeExportRecordsExceptUserTaskRecords();
+      List<ZeebeUserTaskRecordDto> userTaskEvents = getZeebeExportedUserTaskEvents();
+      zeebeExtension.completeZeebeUserTask(
+          getExpectedUserTaskInstanceIdFromRecords(userTaskEvents));
+      waitUntilUserTaskRecordWithIntentExported(COMPLETED);
+
+      // when (writer path)
+      importAllZeebeEntitiesFromScratch();
+
+      // then (writer path)
+      userTaskEvents = getZeebeExportedUserTaskEvents();
+      final OffsetDateTime expectedEndDate =
+          getExpectedEndDateForCompletedUserTaskEvents(userTaskEvents);
+      final FlowNodeInstanceDto expectedUserTask =
+          createRunningUserTaskInstance(instance, userTaskEvents);
+      expectedUserTask.setDueDate(EXPECTED_DUE_DATE);
+      expectedUserTask.setEndDate(expectedEndDate);
+      expectedUserTask.setIdleDurationInMs(0L);
+      expectedUserTask.setTotalDurationInMs(
+          getExpectedTotalDurationForCompletedUserTask(userTaskEvents));
+      expectedUserTask.setWorkDurationInMs(
+          getExpectedTotalDurationForCompletedUserTask(userTaskEvents));
+
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance -> {
+                assertThat(savedInstance.getProcessInstanceId())
+                    .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
+                assertThat(savedInstance.getProcessDefinitionId())
+                    .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
+                assertThat(savedInstance.getProcessDefinitionKey())
+                    .isEqualTo(instance.getBpmnProcessId());
+                assertThat(savedInstance.getDataSource().getName())
+                    .isEqualTo(getConfiguredZeebeName());
+                assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+                assertThat(savedInstance.getFlowNodeInstances())
+                    .singleElement() // only the userTask was imported because all other records
+                    // were removed
+                    .usingRecursiveComparison()
+                    .isEqualTo(expectedUserTask);
+              });
+    }
+
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // given (update-script path)
+    {
+      final ProcessInstanceEvent instance =
+          deployAndStartInstanceForProcess(
+              createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
+
+      waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+      // remove all zeebe records except userTask ones to test userTask import only
+      removeAllZeebeExportRecordsExceptUserTaskRecords();
+      importAllZeebeEntitiesFromScratch();
+      final List<ZeebeUserTaskRecordDto> runningUserTaskEvents = getZeebeExportedUserTaskEvents();
+      final FlowNodeInstanceDto expectedUserTask =
+          createRunningUserTaskInstance(instance, runningUserTaskEvents);
+      List<ZeebeUserTaskRecordDto> userTaskEvents = getZeebeExportedUserTaskEvents();
+      zeebeExtension.completeZeebeUserTask(
+          getExpectedUserTaskInstanceIdFromRecords(userTaskEvents));
+      waitUntilUserTaskRecordWithIntentExported(COMPLETED);
+
+      // when (update-script path)
+      importAllZeebeEntitiesFromLastIndex();
+
+      // then (update-script path)
+      userTaskEvents = getZeebeExportedUserTaskEvents();
+      final OffsetDateTime expectedEndDate =
+          getExpectedEndDateForCompletedUserTaskEvents(userTaskEvents);
+      expectedUserTask.setDueDate(EXPECTED_DUE_DATE);
+      expectedUserTask.setEndDate(expectedEndDate);
+      expectedUserTask.setIdleDurationInMs(0L);
+      expectedUserTask.setTotalDurationInMs(
+          getExpectedTotalDurationForCompletedUserTask(userTaskEvents));
+      expectedUserTask.setWorkDurationInMs(
+          getExpectedTotalDurationForCompletedUserTask(userTaskEvents));
+
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance -> {
+                assertThat(savedInstance.getProcessInstanceId())
+                    .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
+                assertThat(savedInstance.getProcessDefinitionId())
+                    .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
+                assertThat(savedInstance.getProcessDefinitionKey())
+                    .isEqualTo(instance.getBpmnProcessId());
+                assertThat(savedInstance.getDataSource().getName())
+                    .isEqualTo(getConfiguredZeebeName());
+                assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+                assertThat(savedInstance.getFlowNodeInstances())
+                    .singleElement() // only the userTask was imported because all other records
+                    // were removed
+                    .usingRecursiveComparison()
+                    .isEqualTo(expectedUserTask);
+              });
+    }
+  }
+
+  @Test
+  public void importCanceledUnclaimedZeebeUserTaskData_viaWriterAndViaUpdateScript() {
+    // Covers both import code paths for a canceled (unclaimed) user task: scenario 1 imports
+    // creation and cancellation together in one batch (upsert via the writer); scenario 2 imports
+    // creation and cancellation as two separate batches (upsert via the update script). Each
+    // scenario is reset to a clean Zeebe export index and clean Optimize data before it runs,
+    // mirroring what @BeforeEach/@AfterEach would otherwise do between separate test methods.
+
+    // given (writer path)
+    {
+      final ProcessInstanceEvent instance =
+          deployAndStartInstanceForProcess(
+              createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
+      waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+      zeebeExtension.cancelProcessInstance(instance.getProcessInstanceKey());
+      waitUntilUserTaskRecordWithIntentExported(UserTaskIntent.CANCELED);
+      // remove all zeebe records except userTask ones to test userTask import only
+      removeAllZeebeExportRecordsExceptUserTaskRecords();
+
+      // when (writer path)
+      importAllZeebeEntitiesFromScratch();
+
+      // then (writer path) the import in one batch correctly set all fields in the new instance
+      // document
+      final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
+      final FlowNodeInstanceDto expectedUserTask =
+          createRunningUserTaskInstance(instance, exportedEvents);
+      final OffsetDateTime expectedEndDate =
+          getExpectedEndDateForCanceledUserTaskEvents(exportedEvents);
+      final Long expectedTotalAndIdleDuration =
+          Duration.between(expectedUserTask.getStartDate(), expectedEndDate).toMillis();
+      expectedUserTask.setDueDate(EXPECTED_DUE_DATE);
+      expectedUserTask.setEndDate(expectedEndDate);
+      expectedUserTask.setTotalDurationInMs(expectedTotalAndIdleDuration);
+      expectedUserTask.setIdleDurationInMs(expectedTotalAndIdleDuration);
+      expectedUserTask.setWorkDurationInMs(0L);
+      expectedUserTask.setCanceled(true);
+
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance -> {
+                assertThat(savedInstance.getProcessInstanceId())
+                    .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
+                assertThat(savedInstance.getProcessDefinitionId())
+                    .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
+                assertThat(savedInstance.getProcessDefinitionKey())
+                    .isEqualTo(instance.getBpmnProcessId());
+                assertThat(savedInstance.getDataSource().getName())
+                    .isEqualTo(getConfiguredZeebeName());
+                assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+                assertThat(savedInstance.getFlowNodeInstances())
+                    .singleElement() // only userTask was imported because all other records were
+                    // removed
+                    .usingRecursiveComparison()
+                    .isEqualTo(expectedUserTask);
+              });
+    }
+
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // given (update-script path)
+    {
+      final ProcessInstanceEvent instance =
+          deployAndStartInstanceForProcess(
+              createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
+      waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+      removeAllZeebeExportRecordsExceptUserTaskRecords();
+      importAllZeebeEntitiesFromScratch();
+      zeebeExtension.cancelProcessInstance(instance.getProcessInstanceKey());
+      waitUntilUserTaskRecordWithIntentExported(UserTaskIntent.CANCELED);
+      // remove all zeebe records except userTask ones to test userTask import only
+      removeAllZeebeExportRecordsExceptUserTaskRecords();
+
+      // when (update-script path)
+      importAllZeebeEntitiesFromLastIndex();
+
+      // then (update-script path) the import over two batches correctly updates all fields with
+      // the update script
+      final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
+      final FlowNodeInstanceDto expectedUserTask =
+          createRunningUserTaskInstance(instance, exportedEvents);
+      final OffsetDateTime expectedEndDate =
+          getExpectedEndDateForCanceledUserTaskEvents(exportedEvents);
+      expectedUserTask.setDueDate(EXPECTED_DUE_DATE);
+      expectedUserTask.setEndDate(expectedEndDate);
+      expectedUserTask.setTotalDurationInMs(
+          Duration.between(expectedUserTask.getStartDate(), expectedEndDate).toMillis());
+      expectedUserTask.setIdleDurationInMs(
+          Duration.between(expectedUserTask.getStartDate(), expectedEndDate).toMillis());
+      expectedUserTask.setWorkDurationInMs(0L);
+      expectedUserTask.setCanceled(true);
+
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance -> {
+                assertThat(savedInstance.getProcessInstanceId())
+                    .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
+                assertThat(savedInstance.getProcessDefinitionId())
+                    .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
+                assertThat(savedInstance.getProcessDefinitionKey())
+                    .isEqualTo(instance.getBpmnProcessId());
+                assertThat(savedInstance.getDataSource().getName())
+                    .isEqualTo(getConfiguredZeebeName());
+                assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+                assertThat(savedInstance.getFlowNodeInstances())
+                    // only userTask was imported because all other records were removed
+                    .singleElement()
+                    .usingRecursiveComparison()
+                    .isEqualTo(expectedUserTask);
+              });
+    }
+  }
+
+  @Test
+  public void importCanceledClaimedZeebeUserTaskData_viaWriterAndViaUpdateScript() {
+    // Covers both import code paths for a canceled (claimed) user task: scenario 1 imports
+    // creation, claim, and cancellation together in one batch (upsert via the writer); scenario 2
+    // imports them as two separate batches (upsert via the update script). Each scenario is reset
+    // to a clean Zeebe export index and clean Optimize data before it runs, mirroring what
+    // @BeforeEach/@AfterEach would otherwise do between separate test methods.
+
+    // given (writer path)
+    {
+      final ProcessInstanceEvent instance =
+          deployAndStartInstanceForProcess(
+              createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
+      waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+      List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
+      zeebeExtension.assignUserTask(
+          getExpectedUserTaskInstanceIdFromRecords(exportedEvents), ASSIGNEE_ID);
+      zeebeExtension.cancelProcessInstance(instance.getProcessInstanceKey());
+      waitUntilUserTaskRecordWithIntentExported(CANCELED);
+      // remove all zeebe records except userTask ones to test userTask import only
+      removeAllZeebeExportRecordsExceptUserTaskRecords();
+
+      // when (writer path)
+      importAllZeebeEntitiesFromScratch();
+
+      // then (writer path)
+      exportedEvents = getZeebeExportedUserTaskEvents();
+      final FlowNodeInstanceDto expectedUserTask =
+          createRunningUserTaskInstance(instance, exportedEvents);
+      final OffsetDateTime expectedEndDate =
+          getExpectedEndDateForCanceledUserTaskEvents(exportedEvents);
+      final OffsetDateTime assignDate = getTimestampForAssignedUserTaskEvents(exportedEvents);
+      expectedUserTask.setAssignee(ASSIGNEE_ID);
+      expectedUserTask.setDueDate(EXPECTED_DUE_DATE);
+      expectedUserTask.setEndDate(expectedEndDate);
+      expectedUserTask.setTotalDurationInMs(
+          Duration.between(expectedUserTask.getStartDate(), expectedEndDate).toMillis());
+      expectedUserTask.setIdleDurationInMs(
+          Duration.between(expectedUserTask.getStartDate(), assignDate).toMillis());
+      expectedUserTask.setWorkDurationInMs(
+          Duration.between(assignDate, expectedEndDate).toMillis());
+      expectedUserTask.setAssigneeOperations(
+          List.of(
+              createAssigneeOperationDto(
+                  getExpectedIdFromRecords(exportedEvents, ASSIGNED),
+                  CLAIM_OPERATION_TYPE,
+                  ASSIGNEE_ID,
+                  getTimestampForAssignedUserTaskEvents(exportedEvents))));
+      expectedUserTask.setCanceled(true);
+
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance -> {
+                assertThat(savedInstance.getProcessInstanceId())
+                    .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
+                assertThat(savedInstance.getProcessDefinitionId())
+                    .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
+                assertThat(savedInstance.getProcessDefinitionKey())
+                    .isEqualTo(instance.getBpmnProcessId());
+                assertThat(savedInstance.getDataSource().getName())
+                    .isEqualTo(getConfiguredZeebeName());
+                assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+                assertThat(savedInstance.getFlowNodeInstances())
+                    // only userTask was imported because all other records were removed
+                    .singleElement()
+                    .usingRecursiveComparison()
+                    .isEqualTo(expectedUserTask);
+              });
+    }
+
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // given (update-script path)
+    {
+      final ProcessInstanceEvent instance =
+          deployAndStartInstanceForProcess(
+              createSimpleNativeUserTaskProcess(TEST_PROCESS, DUE_DATE));
+      waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+      List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
+      zeebeExtension.assignUserTask(
+          getExpectedUserTaskInstanceIdFromRecords(exportedEvents), ASSIGNEE_ID);
+      waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
+
+      // remove all zeebe records except userTask ones to test userTask import only
+      removeAllZeebeExportRecordsExceptUserTaskRecords();
+      importAllZeebeEntitiesFromScratch();
+
+      zeebeExtension.cancelProcessInstance(instance.getProcessInstanceKey());
+      waitUntilUserTaskRecordWithIntentExported(UserTaskIntent.CANCELED);
+      removeAllZeebeExportRecordsExceptUserTaskRecords();
+
+      // when (update-script path)
+      importAllZeebeEntitiesFromLastIndex();
+
+      // then (update-script path)
+      exportedEvents = getZeebeExportedUserTaskEvents();
+      final OffsetDateTime expectedEndDate =
+          getExpectedEndDateForCanceledUserTaskEvents(exportedEvents);
+      final OffsetDateTime assignDate = getTimestampForAssignedUserTaskEvents(exportedEvents);
+      final FlowNodeInstanceDto expectedUserTask =
+          createRunningUserTaskInstance(instance, exportedEvents);
+      expectedUserTask.setAssignee(ASSIGNEE_ID);
+      expectedUserTask.setDueDate(EXPECTED_DUE_DATE);
+      expectedUserTask.setEndDate(expectedEndDate);
+      expectedUserTask.setTotalDurationInMs(
+          Duration.between(expectedUserTask.getStartDate(), expectedEndDate).toMillis());
+      expectedUserTask.setIdleDurationInMs(
+          Duration.between(expectedUserTask.getStartDate(), assignDate).toMillis());
+      expectedUserTask.setWorkDurationInMs(
+          Duration.between(assignDate, expectedEndDate).toMillis());
+      expectedUserTask.setAssigneeOperations(
+          List.of(
+              createAssigneeOperationDto(
+                  getExpectedIdFromRecords(exportedEvents, ASSIGNED),
+                  CLAIM_OPERATION_TYPE,
+                  ASSIGNEE_ID,
+                  getTimestampForAssignedUserTaskEvents(exportedEvents))));
+      expectedUserTask.setCanceled(true);
+
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance -> {
+                assertThat(savedInstance.getProcessInstanceId())
+                    .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
+                assertThat(savedInstance.getProcessDefinitionId())
+                    .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
+                assertThat(savedInstance.getProcessDefinitionKey())
+                    .isEqualTo(instance.getBpmnProcessId());
+                assertThat(savedInstance.getDataSource().getName())
+                    .isEqualTo(getConfiguredZeebeName());
+                assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+                assertThat(savedInstance.getFlowNodeInstances())
+                    // only userTask was imported because all other records were removed
+                    .singleElement()
+                    .usingRecursiveComparison()
+                    .isEqualTo(expectedUserTask);
+              });
+    }
+  }
+
+  @Test
+  public void importClaimOperation_viaWriterAndViaUpdateScript() {
+    // Covers both import code paths for a claim operation: scenario 1 imports creation and claim
+    // together in one batch (upsert via the writer); scenario 2 imports creation and claim as two
+    // separate batches (upsert via the update script). Each scenario is reset to a clean Zeebe
+    // export index and clean Optimize data before it runs, mirroring what @BeforeEach/@AfterEach
+    // would otherwise do between separate test methods.
+
+    // given (writer path)
+    {
+      final ProcessInstanceEvent instance =
+          deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, null));
+      waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+      List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
+      zeebeExtension.assignUserTask(
+          getExpectedUserTaskInstanceIdFromRecords(exportedEvents), ASSIGNEE_ID);
+      waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
+      // remove all zeebe records except userTask ones to test userTask import only
+      removeAllZeebeExportRecordsExceptUserTaskRecords();
+
+      // when (writer path)
+      importAllZeebeEntitiesFromScratch();
+
+      // then (writer path)
+      exportedEvents = getZeebeExportedUserTaskEvents();
+      final FlowNodeInstanceDto expectedUserTask =
+          createRunningUserTaskInstance(instance, exportedEvents);
+      expectedUserTask.setIdleDurationInMs(
+          getDurationInMsBetweenStartAndFirstAssignOperation(exportedEvents));
+      expectedUserTask.setAssignee(ASSIGNEE_ID);
+      expectedUserTask.setAssigneeOperations(
+          List.of(
+              createAssigneeOperationDto(
+                  getExpectedIdFromRecords(exportedEvents, ASSIGNED),
+                  CLAIM_OPERATION_TYPE,
+                  ASSIGNEE_ID,
+                  getTimestampForZeebeAssignEvents(exportedEvents, ASSIGNEE_ID))));
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance -> {
+                assertThat(savedInstance.getProcessInstanceId())
+                    .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
+                assertThat(savedInstance.getProcessDefinitionId())
+                    .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
+                assertThat(savedInstance.getProcessDefinitionKey())
+                    .isEqualTo(instance.getBpmnProcessId());
+                assertThat(savedInstance.getDataSource().getName())
+                    .isEqualTo(getConfiguredZeebeName());
+                assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+                assertThat(savedInstance.getFlowNodeInstances())
+                    // only userTask was imported because all other records were removed
+                    .singleElement()
+                    .usingRecursiveComparison()
+                    .isEqualTo(expectedUserTask);
+              });
+    }
+
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // given (update-script path)
+    {
+      final ProcessInstanceEvent instance =
+          deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, null));
+      waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+      removeAllZeebeExportRecordsExceptUserTaskRecords();
+      importAllZeebeEntitiesFromScratch();
+
+      List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
+      zeebeExtension.assignUserTask(
+          getExpectedUserTaskInstanceIdFromRecords(exportedEvents), ASSIGNEE_ID);
+      waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
+
+      // when (update-script path)
+      importAllZeebeEntitiesFromLastIndex();
+
+      // then (update-script path)
+      exportedEvents = getZeebeExportedUserTaskEvents();
+      final FlowNodeInstanceDto expectedUserTask =
+          createRunningUserTaskInstance(instance, exportedEvents);
+      expectedUserTask.setIdleDurationInMs(
+          getDurationInMsBetweenStartAndFirstAssignOperation(exportedEvents));
+      expectedUserTask.setAssignee(ASSIGNEE_ID);
+      expectedUserTask.setAssigneeOperations(
+          List.of(
+              createAssigneeOperationDto(
+                  getExpectedIdFromRecords(exportedEvents, ASSIGNED),
+                  CLAIM_OPERATION_TYPE,
+                  ASSIGNEE_ID,
+                  getTimestampForZeebeAssignEvents(exportedEvents, ASSIGNEE_ID))));
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance -> {
+                assertThat(savedInstance.getProcessInstanceId())
+                    .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
+                assertThat(savedInstance.getProcessDefinitionId())
+                    .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
+                assertThat(savedInstance.getProcessDefinitionKey())
+                    .isEqualTo(instance.getBpmnProcessId());
+                assertThat(savedInstance.getDataSource().getName())
+                    .isEqualTo(getConfiguredZeebeName());
+                assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+                assertThat(savedInstance.getFlowNodeInstances())
+                    // only userTask was imported because all other records were removed
+                    .singleElement()
+                    .usingRecursiveComparison()
+                    .isEqualTo(expectedUserTask);
+              });
+    }
+  }
+
+  @Test
+  public void importUnclaimOperation_viaWriterAndViaUpdateScript() {
+    // Covers both import code paths for an unclaim operation: scenario 1 imports creation and
+    // unclaim together in one batch (upsert via the writer); scenario 2 imports them as two
+    // separate batches (upsert via the update script). Each scenario is reset to a clean Zeebe
+    // export index and clean Optimize data before it runs, mirroring what
+    // @BeforeEach/@AfterEach would otherwise do between separate test methods.
+
+    // given (writer path)
+    {
+      final ProcessInstanceEvent instance =
+          deployAndStartInstanceForProcess(
+              createSimpleNativeUserTaskProcessWithAssignee(TEST_PROCESS, null, ASSIGNEE_ID));
+      waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+
+      if (isZeebeVersion87_OrLater()) {
+        // to wait for `ASSIGNED` event triggered by Zeebe after UT creation with the defined
+        // `assignee`
+        waitUntilUserTaskRecordWithIntentExported(1, ASSIGNED);
+        zeebeExtension.unassignUserTask(
+            getExpectedUserTaskInstanceIdFromRecords(getZeebeExportedUserTaskEvents()));
+        // wait for the 2nd `ASSIGNED` event triggered by UT unassign operation
+        waitUntilUserTaskRecordWithIntentExported(2, ASSIGNED);
+      } else {
+        zeebeExtension.unassignUserTask(
+            getExpectedUserTaskInstanceIdFromRecords(getZeebeExportedUserTaskEvents()));
+        waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
+      }
+
+      // remove all zeebe records except userTask ones to test userTask import only
+      removeAllZeebeExportRecordsExceptUserTaskRecords();
+
+      // when (writer path)
+      importAllZeebeEntitiesFromScratch();
+
+      // then (writer path)
+      final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance -> {
+                assertThat(savedInstance.getProcessInstanceId())
+                    .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
+                assertThat(savedInstance.getProcessDefinitionId())
+                    .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
+                assertThat(savedInstance.getProcessDefinitionKey())
+                    .isEqualTo(instance.getBpmnProcessId());
+                assertThat(savedInstance.getDataSource().getName())
+                    .isEqualTo(getConfiguredZeebeName());
+                assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+                final FlowNodeInstanceDto runningUserTaskInstance =
+                    createRunningUserTaskInstance(instance, exportedEvents);
+                runningUserTaskInstance.setIdleDurationInMs(0L);
+                runningUserTaskInstance.setWorkDurationInMs(
+                    isZeebeVersion87_OrLater()
+                        ? getDurationInMsBetweenStartDateAndLastAssignedOperation(exportedEvents)
+                        : getDurationInMsBetweenStartAndFirstAssignOperation(exportedEvents));
+                runningUserTaskInstance.setAssigneeOperations(
+                    List.of(
+                        createAssigneeOperationDto(
+                            getExpectedIdFromRecords(exportedEvents, CREATING),
+                            CLAIM_OPERATION_TYPE,
+                            ASSIGNEE_ID,
+                            getExpectedStartDateForUserTaskEvents(exportedEvents)),
+                        createAssigneeOperationDto(
+                            getExpectedIdFromRecords(exportedEvents, ASSIGNED),
+                            UNCLAIM_OPERATION_TYPE,
+                            null,
+                            getTimestampForLastZeebeEventsWithIntent(exportedEvents, ASSIGNED))));
+                assertThat(savedInstance.getFlowNodeInstances())
+                    // only userTask was imported because all other records were removed
+                    .singleElement()
+                    .usingRecursiveComparison()
+                    .isEqualTo(runningUserTaskInstance);
+              });
+    }
+
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // given (update-script path)
+    {
+      final ProcessInstanceEvent instance =
+          deployAndStartInstanceForProcess(
+              createSimpleNativeUserTaskProcessWithAssignee(TEST_PROCESS, null, ASSIGNEE_ID));
+      waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+      // remove all zeebe records except userTask ones to test userTask import only
+      removeAllZeebeExportRecordsExceptUserTaskRecords();
+      importAllZeebeEntitiesFromScratch();
+
+      List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
+
+      if (isZeebeVersion87_OrLater()) {
+        // to wait for `ASSIGNED` event triggered by Zeebe after UT creation with the defined
+        // `assignee`
+        waitUntilUserTaskRecordWithIntentExported(1, ASSIGNED);
+        zeebeExtension.unassignUserTask(
+            getExpectedUserTaskInstanceIdFromRecords(getZeebeExportedUserTaskEvents()));
+        // wait for the 2nd `ASSIGNED` event triggered by UT unassign operation
+        waitUntilUserTaskRecordWithIntentExported(2, ASSIGNED);
+      } else {
+        zeebeExtension.unassignUserTask(getExpectedUserTaskInstanceIdFromRecords(exportedEvents));
+        waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
+      }
+
+      // when (update-script path)
+      importAllZeebeEntitiesFromLastIndex();
+
+      // then (update-script path)
+      exportedEvents = getZeebeExportedUserTaskEvents();
+      final FlowNodeInstanceDto expectedUserTask =
+          createRunningUserTaskInstance(instance, exportedEvents);
+      expectedUserTask.setIdleDurationInMs(0L);
+      expectedUserTask.setWorkDurationInMs(
+          isZeebeVersion87_OrLater()
+              ? getDurationInMsBetweenStartDateAndLastAssignedOperation(exportedEvents)
+              : getDurationInMsBetweenStartAndFirstAssignOperation(exportedEvents));
+      expectedUserTask.setAssigneeOperations(
+          List.of(
+              createAssigneeOperationDto(
+                  getExpectedIdFromRecords(exportedEvents, CREATING),
+                  CLAIM_OPERATION_TYPE,
+                  ASSIGNEE_ID,
+                  getExpectedStartDateForUserTaskEvents(exportedEvents)),
+              createAssigneeOperationDto(
+                  getExpectedIdFromRecords(exportedEvents, ASSIGNED),
+                  UNCLAIM_OPERATION_TYPE,
+                  null,
                   isZeebeVersion87_OrLater()
-                      ? getDurationInMsBetweenStartDateAndLastAssignedOperation(exportedEvents)
-                      : getDurationInMsBetweenStartAndFirstAssignOperation(exportedEvents));
-              runningUserTaskInstance.setAssigneeOperations(
-                  List.of(
-                      createAssigneeOperationDto(
-                          getExpectedIdFromRecords(exportedEvents, CREATING),
-                          CLAIM_OPERATION_TYPE,
-                          ASSIGNEE_ID,
-                          getExpectedStartDateForUserTaskEvents(exportedEvents)),
-                      createAssigneeOperationDto(
-                          getExpectedIdFromRecords(exportedEvents, ASSIGNED),
-                          UNCLAIM_OPERATION_TYPE,
-                          null,
-                          getTimestampForLastZeebeEventsWithIntent(exportedEvents, ASSIGNED))));
-              assertThat(savedInstance.getFlowNodeInstances())
-                  // only userTask was imported because all other records were removed
-                  .singleElement()
-                  .usingRecursiveComparison()
-                  .isEqualTo(runningUserTaskInstance);
-            });
+                      ? getTimestampForZeebeLastAssignedEvents(exportedEvents, "")
+                      : getTimestampForZeebeUnassignEvent(exportedEvents))));
+
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance -> {
+                assertThat(savedInstance.getProcessInstanceId())
+                    .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
+                assertThat(savedInstance.getProcessDefinitionId())
+                    .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
+                assertThat(savedInstance.getProcessDefinitionKey())
+                    .isEqualTo(instance.getBpmnProcessId());
+                assertThat(savedInstance.getDataSource().getName())
+                    .isEqualTo(getConfiguredZeebeName());
+                assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+                assertThat(savedInstance.getFlowNodeInstances())
+                    // only userTask was imported because all other records were removed
+                    .singleElement()
+                    .usingRecursiveComparison()
+                    .isEqualTo(expectedUserTask);
+              });
+    }
   }
 
   @Test
-  public void importUnclaimOperation_viaUpdateScript() {
-    // import assignee userTask data after the first userTask records were already imported, hence
-    // the upsert uses the logic from the update script
-    // given
-    final ProcessInstanceEvent instance =
-        deployAndStartInstanceForProcess(
-            createSimpleNativeUserTaskProcessWithAssignee(TEST_PROCESS, null, ASSIGNEE_ID));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    // remove all zeebe records except userTask ones to test userTask import only
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
-    importAllZeebeEntitiesFromScratch();
+  public void importAssigneeFromCreationRecordAndDoNotImportCandidateGroupUpdates() {
+    // Covers two independent narrow checks: scenario 1 that an assignee present in the process
+    // model at creation is imported; scenario 2 that candidate-group updates are not imported at
+    // all. Each scenario is reset to a clean Zeebe export index and clean Optimize data before it
+    // runs, mirroring what @BeforeEach/@AfterEach would otherwise do between separate test
+    // methods.
 
-    List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
+    // given (assignee from creation record)
+    {
+      final ProcessInstanceEvent instance =
+          deployAndStartInstanceForProcess(
+              createSimpleNativeUserTaskProcessWithAssignee(TEST_PROCESS, DUE_DATE, ASSIGNEE_ID));
+      waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+      // remove all zeebe records except userTask ones to test userTask import only
+      removeAllZeebeExportRecordsExceptUserTaskRecords();
 
-    if (isZeebeVersion87_OrLater()) {
-      // to wait for `ASSIGNED` event triggered by Zeebe after UT creation with the defined
-      // `assignee`
-      waitUntilUserTaskRecordWithIntentExported(1, ASSIGNED);
-      zeebeExtension.unassignUserTask(
-          getExpectedUserTaskInstanceIdFromRecords(getZeebeExportedUserTaskEvents()));
-      // wait for the 2nd `ASSIGNED` event triggered by UT unassign operation
-      waitUntilUserTaskRecordWithIntentExported(2, ASSIGNED);
-    } else {
-      zeebeExtension.unassignUserTask(getExpectedUserTaskInstanceIdFromRecords(exportedEvents));
-      waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
+      // when (assignee from creation record)
+      importAllZeebeEntitiesFromScratch();
+
+      // then (assignee from creation record)
+      final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance -> {
+                assertThat(savedInstance.getProcessInstanceId())
+                    .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
+                assertThat(savedInstance.getProcessDefinitionId())
+                    .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
+                assertThat(savedInstance.getProcessDefinitionKey())
+                    .isEqualTo(instance.getBpmnProcessId());
+                assertThat(savedInstance.getDataSource().getName())
+                    .isEqualTo(getConfiguredZeebeName());
+                assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+                final FlowNodeInstanceDto runningUserTaskInstance =
+                    createRunningUserTaskInstance(instance, exportedEvents);
+                runningUserTaskInstance.setDueDate(EXPECTED_DUE_DATE);
+                runningUserTaskInstance.setIdleDurationInMs(0L);
+                runningUserTaskInstance.setAssignee(ASSIGNEE_ID);
+                runningUserTaskInstance.setAssigneeOperations(
+                    List.of(
+                        createAssigneeOperationDto(
+                            getExpectedIdFromRecords(exportedEvents, CREATING),
+                            CLAIM_OPERATION_TYPE,
+                            ASSIGNEE_ID,
+                            getExpectedStartDateForUserTaskEvents(exportedEvents))));
+                assertThat(savedInstance.getFlowNodeInstances())
+                    // only userTask was imported because all other records were removed
+                    .singleElement()
+                    .usingRecursiveComparison()
+                    .isEqualTo(runningUserTaskInstance);
+              });
     }
 
-    // when
-    importAllZeebeEntitiesFromLastIndex();
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
-    // then
-    exportedEvents = getZeebeExportedUserTaskEvents();
-    final FlowNodeInstanceDto expectedUserTask =
-        createRunningUserTaskInstance(instance, exportedEvents);
-    expectedUserTask.setIdleDurationInMs(0L);
-    expectedUserTask.setWorkDurationInMs(
-        isZeebeVersion87_OrLater()
-            ? getDurationInMsBetweenStartDateAndLastAssignedOperation(exportedEvents)
-            : getDurationInMsBetweenStartAndFirstAssignOperation(exportedEvents));
-    expectedUserTask.setAssigneeOperations(
-        List.of(
-            createAssigneeOperationDto(
-                getExpectedIdFromRecords(exportedEvents, CREATING),
-                CLAIM_OPERATION_TYPE,
-                ASSIGNEE_ID,
-                getExpectedStartDateForUserTaskEvents(exportedEvents)),
-            createAssigneeOperationDto(
-                getExpectedIdFromRecords(exportedEvents, ASSIGNED),
-                UNCLAIM_OPERATION_TYPE,
-                null,
-                isZeebeVersion87_OrLater()
-                    ? getTimestampForZeebeLastAssignedEvents(exportedEvents, "")
-                    : getTimestampForZeebeUnassignEvent(exportedEvents))));
+    // given (candidate group updates not imported)
+    {
+      deployAndStartInstanceForProcess(
+          createSimpleNativeUserTaskProcessWithCandidateGroup(
+              TEST_PROCESS, DUE_DATE, "aCandidateGroup"));
+      waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+      final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
+      zeebeExtension.updateCandidateGroupForUserTask(
+          getExpectedUserTaskInstanceIdFromRecords(exportedEvents), "anotherCandidateGroup");
 
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(savedInstance.getFlowNodeInstances())
-                  // only userTask was imported because all other records were removed
-                  .singleElement()
-                  .usingRecursiveComparison()
-                  .isEqualTo(expectedUserTask);
-            });
+      // when (candidate group updates not imported)
+      importAllZeebeEntitiesFromScratch();
+
+      // then (candidate group updates not imported) no candidate group data was imported
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .flatExtracting(ProcessInstanceDto::getFlowNodeInstances)
+          .extracting(FlowNodeInstanceDto::getCandidateGroups)
+          .containsOnly(Collections.emptyList());
+    }
   }
 
   @Test
-  public void importAssignee_fromCreationRecord() {
-    // given a process that was started with an assignee already present in the model
-    final ProcessInstanceEvent instance =
-        deployAndStartInstanceForProcess(
-            createSimpleNativeUserTaskProcessWithAssignee(TEST_PROCESS, DUE_DATE, ASSIGNEE_ID));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    // remove all zeebe records except userTask ones to test userTask import only
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
-
-    // when
-    importAllZeebeEntitiesFromScratch();
-
-    // then
-    final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance -> {
-              assertThat(savedInstance.getProcessInstanceId())
-                  .isEqualTo(String.valueOf(instance.getProcessInstanceKey()));
-              assertThat(savedInstance.getProcessDefinitionId())
-                  .isEqualTo(String.valueOf(instance.getProcessDefinitionKey()));
-              assertThat(savedInstance.getProcessDefinitionKey())
-                  .isEqualTo(instance.getBpmnProcessId());
-              assertThat(savedInstance.getDataSource().getName())
-                  .isEqualTo(getConfiguredZeebeName());
-              assertThat(savedInstance.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              final FlowNodeInstanceDto runningUserTaskInstance =
-                  createRunningUserTaskInstance(instance, exportedEvents);
-              runningUserTaskInstance.setDueDate(EXPECTED_DUE_DATE);
-              runningUserTaskInstance.setIdleDurationInMs(0L);
-              runningUserTaskInstance.setAssignee(ASSIGNEE_ID);
-              runningUserTaskInstance.setAssigneeOperations(
-                  List.of(
-                      createAssigneeOperationDto(
-                          getExpectedIdFromRecords(exportedEvents, CREATING),
-                          CLAIM_OPERATION_TYPE,
-                          ASSIGNEE_ID,
-                          getExpectedStartDateForUserTaskEvents(exportedEvents))));
-              assertThat(savedInstance.getFlowNodeInstances())
-                  // only userTask was imported because all other records were removed
-                  .singleElement()
-                  .usingRecursiveComparison()
-                  .isEqualTo(runningUserTaskInstance);
-            });
-  }
-
-  @Test
-  public void importMultipleAssigneeOperations_viaWriter() {
-    // given
+  public void importMultipleAssigneeOperations_viaWriterAndViaUpdateScript() {
+    // Covers both import code paths for a sequence of claim/unclaim/claim operations: scenario 1
+    // imports creation and all assignee operations together in one batch (upsert via the writer);
+    // scenario 2 imports them as two separate batches (upsert via the update script). Each
+    // scenario is reset to a clean Zeebe export index and clean Optimize data before it runs,
+    // mirroring what @BeforeEach/@AfterEach would otherwise do between separate test methods.
     final String assigneeId1 = ASSIGNEE_ID + "1";
     final String assigneeId2 = ASSIGNEE_ID + "2";
-    final ProcessInstanceEvent instance =
-        deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, null));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    final List<ZeebeUserTaskRecordDto> userTaskEvents = getZeebeExportedUserTaskEvents();
-    final long userTaskInstanceId = getExpectedUserTaskInstanceIdFromRecords(userTaskEvents);
-    zeebeExtension.assignUserTask(userTaskInstanceId, assigneeId1);
-    zeebeExtension.unassignUserTask(userTaskInstanceId);
-    zeebeExtension.assignUserTask(userTaskInstanceId, assigneeId2);
-    zeebeExtension.completeZeebeUserTask(userTaskInstanceId);
-    waitUntilUserTaskRecordWithIntentExported(COMPLETED);
 
-    // remove all zeebe records except userTask ones to test userTask import only
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
+    // given (writer path)
+    {
+      final ProcessInstanceEvent instance =
+          deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, null));
+      waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+      final List<ZeebeUserTaskRecordDto> userTaskEvents = getZeebeExportedUserTaskEvents();
+      final long userTaskInstanceId = getExpectedUserTaskInstanceIdFromRecords(userTaskEvents);
+      zeebeExtension.assignUserTask(userTaskInstanceId, assigneeId1);
+      zeebeExtension.unassignUserTask(userTaskInstanceId);
+      zeebeExtension.assignUserTask(userTaskInstanceId, assigneeId2);
+      zeebeExtension.completeZeebeUserTask(userTaskInstanceId);
+      waitUntilUserTaskRecordWithIntentExported(COMPLETED);
 
-    // when
-    importAllZeebeEntitiesFromScratch();
+      // remove all zeebe records except userTask ones to test userTask import only
+      removeAllZeebeExportRecordsExceptUserTaskRecords();
 
-    // then
-    final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
-    final FlowNodeInstanceDto runningUserTaskInstance =
-        createRunningUserTaskInstance(instance, exportedEvents);
-    runningUserTaskInstance.setEndDate(
-        getExpectedEndDateForCompletedUserTaskEvents(exportedEvents));
-    runningUserTaskInstance.setIdleDurationInMs(
-        getDurationInMsBetweenStartAndFirstAssignOperation(exportedEvents)
-            + getDurationInMsBetweenAssignOperations(exportedEvents, "", assigneeId2));
-    runningUserTaskInstance.setWorkDurationInMs(
-        getDurationInMsBetweenAssignOperations(exportedEvents, assigneeId1, "")
-            + getDurationInMsBetweenLastAssignOperationAndEnd(exportedEvents, assigneeId2));
-    runningUserTaskInstance.setTotalDurationInMs(
-        getExpectedTotalDurationForCompletedUserTask(exportedEvents));
-    runningUserTaskInstance.setAssignee(assigneeId2);
-    runningUserTaskInstance.setAssigneeOperations(
-        List.of(
-            createAssigneeOperationDto(
-                getExpectedIdFromAssignRecordsWithAssigneeId(exportedEvents, assigneeId1),
-                CLAIM_OPERATION_TYPE,
-                assigneeId1,
-                getTimestampForZeebeAssignEvents(exportedEvents, assigneeId1)),
-            createAssigneeOperationDto(
-                getExpectedIdFromAssignRecordsWithAssigneeId(exportedEvents, ""),
-                UNCLAIM_OPERATION_TYPE,
-                null,
-                getTimestampForZeebeUnassignEvent(exportedEvents)),
-            createAssigneeOperationDto(
-                getExpectedIdFromAssignRecordsWithAssigneeId(exportedEvents, assigneeId2),
-                CLAIM_OPERATION_TYPE,
-                assigneeId2,
-                getTimestampForZeebeAssignEvents(exportedEvents, assigneeId2))));
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance ->
-                assertThat(savedInstance.getFlowNodeInstances())
-                    .singleElement()
-                    .usingRecursiveComparison()
-                    .isEqualTo(runningUserTaskInstance));
-  }
+      // when (writer path)
+      importAllZeebeEntitiesFromScratch();
 
-  @Test
-  public void importMultipleAssigneeOperations_viaUpdateScript() {
-    // given
-    final String assigneeId1 = ASSIGNEE_ID + "1";
-    final String assigneeId2 = ASSIGNEE_ID + "2";
-    final ProcessInstanceEvent instance =
-        deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, null));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    final List<ZeebeUserTaskRecordDto> userTaskEvents = getZeebeExportedUserTaskEvents();
-    final long userTaskInstanceId = getExpectedUserTaskInstanceIdFromRecords(userTaskEvents);
-    zeebeExtension.assignUserTask(userTaskInstanceId, assigneeId1);
-    waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
-    // remove all zeebe records except userTask ones to test userTask import only
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
-    importAllZeebeEntitiesFromScratch();
+      // then (writer path)
+      final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
+      final FlowNodeInstanceDto runningUserTaskInstance =
+          createRunningUserTaskInstance(instance, exportedEvents);
+      runningUserTaskInstance.setEndDate(
+          getExpectedEndDateForCompletedUserTaskEvents(exportedEvents));
+      runningUserTaskInstance.setIdleDurationInMs(
+          getDurationInMsBetweenStartAndFirstAssignOperation(exportedEvents)
+              + getDurationInMsBetweenAssignOperations(exportedEvents, "", assigneeId2));
+      runningUserTaskInstance.setWorkDurationInMs(
+          getDurationInMsBetweenAssignOperations(exportedEvents, assigneeId1, "")
+              + getDurationInMsBetweenLastAssignOperationAndEnd(exportedEvents, assigneeId2));
+      runningUserTaskInstance.setTotalDurationInMs(
+          getExpectedTotalDurationForCompletedUserTask(exportedEvents));
+      runningUserTaskInstance.setAssignee(assigneeId2);
+      runningUserTaskInstance.setAssigneeOperations(
+          List.of(
+              createAssigneeOperationDto(
+                  getExpectedIdFromAssignRecordsWithAssigneeId(exportedEvents, assigneeId1),
+                  CLAIM_OPERATION_TYPE,
+                  assigneeId1,
+                  getTimestampForZeebeAssignEvents(exportedEvents, assigneeId1)),
+              createAssigneeOperationDto(
+                  getExpectedIdFromAssignRecordsWithAssigneeId(exportedEvents, ""),
+                  UNCLAIM_OPERATION_TYPE,
+                  null,
+                  getTimestampForZeebeUnassignEvent(exportedEvents)),
+              createAssigneeOperationDto(
+                  getExpectedIdFromAssignRecordsWithAssigneeId(exportedEvents, assigneeId2),
+                  CLAIM_OPERATION_TYPE,
+                  assigneeId2,
+                  getTimestampForZeebeAssignEvents(exportedEvents, assigneeId2))));
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance ->
+                  assertThat(savedInstance.getFlowNodeInstances())
+                      .singleElement()
+                      .usingRecursiveComparison()
+                      .isEqualTo(runningUserTaskInstance));
+    }
 
-    zeebeExtension.unassignUserTask(userTaskInstanceId);
-    zeebeExtension.assignUserTask(userTaskInstanceId, assigneeId2);
-    zeebeExtension.completeZeebeUserTask(userTaskInstanceId);
-    waitUntilUserTaskRecordWithIntentExported(COMPLETED);
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
-    // remove all zeebe records except userTask ones to test userTask import only
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
+    // given (update-script path)
+    {
+      final ProcessInstanceEvent instance =
+          deployAndStartInstanceForProcess(createSimpleNativeUserTaskProcess(TEST_PROCESS, null));
+      waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
+      final List<ZeebeUserTaskRecordDto> userTaskEvents = getZeebeExportedUserTaskEvents();
+      final long userTaskInstanceId = getExpectedUserTaskInstanceIdFromRecords(userTaskEvents);
+      zeebeExtension.assignUserTask(userTaskInstanceId, assigneeId1);
+      waitUntilUserTaskRecordWithIntentExported(ASSIGNED);
+      // remove all zeebe records except userTask ones to test userTask import only
+      removeAllZeebeExportRecordsExceptUserTaskRecords();
+      importAllZeebeEntitiesFromScratch();
 
-    // when
-    importAllZeebeEntitiesFromLastIndex();
+      zeebeExtension.unassignUserTask(userTaskInstanceId);
+      zeebeExtension.assignUserTask(userTaskInstanceId, assigneeId2);
+      zeebeExtension.completeZeebeUserTask(userTaskInstanceId);
+      waitUntilUserTaskRecordWithIntentExported(COMPLETED);
 
-    // then
-    final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
-    final FlowNodeInstanceDto runningUserTaskInstance =
-        createRunningUserTaskInstance(instance, exportedEvents);
-    runningUserTaskInstance.setEndDate(
-        getExpectedEndDateForCompletedUserTaskEvents(exportedEvents));
-    runningUserTaskInstance.setIdleDurationInMs(
-        getDurationInMsBetweenStartAndFirstAssignOperation(exportedEvents)
-            + getDurationInMsBetweenAssignOperations(exportedEvents, "", assigneeId2));
-    runningUserTaskInstance.setWorkDurationInMs(
-        getDurationInMsBetweenAssignOperations(exportedEvents, assigneeId1, "")
-            + getDurationInMsBetweenLastAssignOperationAndEnd(exportedEvents, assigneeId2));
-    runningUserTaskInstance.setTotalDurationInMs(
-        getExpectedTotalDurationForCompletedUserTask(exportedEvents));
-    runningUserTaskInstance.setAssignee(assigneeId2);
-    runningUserTaskInstance.setAssigneeOperations(
-        List.of(
-            createAssigneeOperationDto(
-                getExpectedIdFromAssignRecordsWithAssigneeId(exportedEvents, assigneeId1),
-                CLAIM_OPERATION_TYPE,
-                assigneeId1,
-                getTimestampForZeebeAssignEvents(exportedEvents, assigneeId1)),
-            createAssigneeOperationDto(
-                getExpectedIdFromAssignRecordsWithAssigneeId(exportedEvents, ""),
-                UNCLAIM_OPERATION_TYPE,
-                null,
-                getTimestampForZeebeUnassignEvent(exportedEvents)),
-            createAssigneeOperationDto(
-                getExpectedIdFromAssignRecordsWithAssigneeId(exportedEvents, assigneeId2),
-                CLAIM_OPERATION_TYPE,
-                assigneeId2,
-                getTimestampForZeebeAssignEvents(exportedEvents, assigneeId2))));
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance ->
-                assertThat(savedInstance.getFlowNodeInstances())
-                    .singleElement()
-                    .usingRecursiveComparison()
-                    .isEqualTo(runningUserTaskInstance));
-  }
+      // remove all zeebe records except userTask ones to test userTask import only
+      removeAllZeebeExportRecordsExceptUserTaskRecords();
 
-  @Test
-  public void doNotImportCandidateGroupUpdates() {
-    // given
-    deployAndStartInstanceForProcess(
-        createSimpleNativeUserTaskProcessWithCandidateGroup(
-            TEST_PROCESS, DUE_DATE, "aCandidateGroup"));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
-    zeebeExtension.updateCandidateGroupForUserTask(
-        getExpectedUserTaskInstanceIdFromRecords(exportedEvents), "anotherCandidateGroup");
+      // when (update-script path)
+      importAllZeebeEntitiesFromLastIndex();
 
-    // when
-    importAllZeebeEntitiesFromScratch();
-
-    // then no candidate group data was imported
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .flatExtracting(ProcessInstanceDto::getFlowNodeInstances)
-        .extracting(FlowNodeInstanceDto::getCandidateGroups)
-        .containsOnly(Collections.emptyList());
-  }
-
-  @Test
-  public void importOtherDueDateFormat() {
-    // given
-    final String dueDateStringInOtherFormat = "2023-03-02T15:35+02:00";
-    final ProcessInstanceEvent instance =
-        deployAndStartInstanceForProcess(
-            createSimpleNativeUserTaskProcess(TEST_PROCESS, dueDateStringInOtherFormat));
-    waitUntilUserTaskRecordWithElementIdExported(USER_TASK);
-    // remove all zeebe records except userTask ones to test userTask import only
-    removeAllZeebeExportRecordsExceptUserTaskRecords();
-
-    // when
-    importAllZeebeEntitiesFromScratch();
-
-    // then dueDate is correctly parsed
-    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
-        .singleElement()
-        .satisfies(
-            savedInstance ->
-                assertThat(savedInstance.getFlowNodeInstances())
-                    .singleElement()
-                    .extracting(FlowNodeInstanceDto::getDueDate)
-                    .isEqualTo(OffsetDateTime.parse(dueDateStringInOtherFormat)));
+      // then (update-script path)
+      final List<ZeebeUserTaskRecordDto> exportedEvents = getZeebeExportedUserTaskEvents();
+      final FlowNodeInstanceDto runningUserTaskInstance =
+          createRunningUserTaskInstance(instance, exportedEvents);
+      runningUserTaskInstance.setEndDate(
+          getExpectedEndDateForCompletedUserTaskEvents(exportedEvents));
+      runningUserTaskInstance.setIdleDurationInMs(
+          getDurationInMsBetweenStartAndFirstAssignOperation(exportedEvents)
+              + getDurationInMsBetweenAssignOperations(exportedEvents, "", assigneeId2));
+      runningUserTaskInstance.setWorkDurationInMs(
+          getDurationInMsBetweenAssignOperations(exportedEvents, assigneeId1, "")
+              + getDurationInMsBetweenLastAssignOperationAndEnd(exportedEvents, assigneeId2));
+      runningUserTaskInstance.setTotalDurationInMs(
+          getExpectedTotalDurationForCompletedUserTask(exportedEvents));
+      runningUserTaskInstance.setAssignee(assigneeId2);
+      runningUserTaskInstance.setAssigneeOperations(
+          List.of(
+              createAssigneeOperationDto(
+                  getExpectedIdFromAssignRecordsWithAssigneeId(exportedEvents, assigneeId1),
+                  CLAIM_OPERATION_TYPE,
+                  assigneeId1,
+                  getTimestampForZeebeAssignEvents(exportedEvents, assigneeId1)),
+              createAssigneeOperationDto(
+                  getExpectedIdFromAssignRecordsWithAssigneeId(exportedEvents, ""),
+                  UNCLAIM_OPERATION_TYPE,
+                  null,
+                  getTimestampForZeebeUnassignEvent(exportedEvents)),
+              createAssigneeOperationDto(
+                  getExpectedIdFromAssignRecordsWithAssigneeId(exportedEvents, assigneeId2),
+                  CLAIM_OPERATION_TYPE,
+                  assigneeId2,
+                  getTimestampForZeebeAssignEvents(exportedEvents, assigneeId2))));
+      assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+          .singleElement()
+          .satisfies(
+              savedInstance ->
+                  assertThat(savedInstance.getFlowNodeInstances())
+                      .singleElement()
+                      .usingRecursiveComparison()
+                      .isEqualTo(runningUserTaskInstance));
+    }
   }
 
   private FlowNodeInstanceDto createRunningUserTaskInstance(

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableCreationImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableCreationImportIT.java
@@ -81,30 +81,69 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
   }
 
   @Test
-  public void zeebeVariableImport_processStartedWithVariables() {
-    // given
-    final Long processInstanceKey = deployProcessAndStartProcessInstanceWithVariables();
+  public void
+      zeebeVariableImport_processStartedWithVariablesAndVariablesAddedAfterProcessStarted() {
+    // Covers two independent scenarios exercising different code paths: scenario 1 variables
+    // present at process start; scenario 2 variables added to scope after the process already
+    // started. Each scenario is reset to a clean Zeebe export index and clean Optimize data
+    // before it runs, mirroring what @BeforeEach/@AfterEach would otherwise do between separate
+    // test methods.
 
-    // when
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(1);
-    importAllZeebeEntitiesFromScratch();
+    // given (started with variables)
+    {
+      final Long processInstanceKey = deployProcessAndStartProcessInstanceWithVariables();
 
-    // then
-    final ProcessInstanceDto savedProcessInstance =
-        getProcessInstanceForId(String.valueOf(processInstanceKey));
-    assertThatVariablesHaveBeenImportedForProcessInstance(savedProcessInstance);
+      // when (started with variables)
+      waitUntilMinimumProcessInstanceEventsExportedCount(4);
+      waitUntilMinimumVariableDocumentsExportedCount(1);
+      importAllZeebeEntitiesFromScratch();
+
+      // then (started with variables)
+      final ProcessInstanceDto savedProcessInstance =
+          getProcessInstanceForId(String.valueOf(processInstanceKey));
+      assertThatVariablesHaveBeenImportedForProcessInstance(savedProcessInstance);
+    }
+
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // given (variables added after process started)
+    {
+      final ProcessInstanceEvent processInstanceEvent = deployProcessAndStartProcessInstance();
+      waitUntilMinimumProcessInstanceEventsExportedCount(4);
+      zeebeExtension.addVariablesToScope(
+          processInstanceEvent.getProcessInstanceKey(), BASIC_VARIABLES, false);
+      waitUntilMinimumVariableDocumentsExportedCount(5);
+
+      // when (variables added after process started)
+      importAllZeebeEntitiesFromScratch();
+
+      // then (variables added after process started)
+      final ProcessInstanceDto savedProcessInstance =
+          getProcessInstanceForId(String.valueOf(processInstanceEvent.getProcessInstanceKey()));
+      assertThatVariablesHaveBeenImportedForProcessInstance(savedProcessInstance);
+    }
   }
 
   @Test
-  public void variableImportWorksForLongStrings() {
+  public void variableImportWorksForLongStringsAndDateStrings() {
+    // Covers two independent variable-content edge cases on the same instance: a too-long string
+    // value, and a date-formatted string value.
+
     // given
     final Process deployedProcess = zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
     // see https://www.elastic.co/guide/en/elasticsearch/reference/7.15/ignore-above.html
-    final String variableName = "longStringVar";
+    final String longStringVariableName = "longStringVar";
     // use a too long value of a length > 32766
     final String largeValue = RandomStringUtils.randomAlphabetic(32767);
-    final Map<String, Object> variables = Map.of(variableName, largeValue);
+    final String dateVariableName = "date";
+    final String dateVariableValue = "2025-10-10";
+    final String parsedDateValue = "2025-10-10T00:00:00.000+0000";
+    final Map<String, Object> variables =
+        Map.of(longStringVariableName, largeValue, dateVariableName, dateVariableValue);
     final Long processInstanceKey =
         zeebeExtension.startProcessInstanceWithVariables(
             deployedProcess.getBpmnProcessId(), variables);
@@ -112,80 +151,64 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
     // when
     waitUntilNumberOfDefinitionsExported(1);
     waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(1);
+    waitUntilMinimumVariableDocumentsExportedCount(2);
     importAllZeebeEntitiesFromScratch();
-
-    // when
     final ProcessInstanceDto importedProcessInstance =
         getProcessInstanceForId(String.valueOf(processInstanceKey));
+
+    // then (long string)
     assertThat(importedProcessInstance.getVariables())
+        .filteredOn(variable -> variable.getName().equals(longStringVariableName))
         .singleElement()
         .satisfies(
             variable -> {
-              assertThat(variable.getName()).isEqualTo(variableName);
+              assertThat(variable.getName()).isEqualTo(longStringVariableName);
               assertThat(variable.getValue().get(0)).isEqualTo(largeValue);
             });
-  }
 
-  @Test
-  public void variableImportWorksForDateStrings() {
-    // given
-    final Process deployedProcess = zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
-    final String variableName = "date";
-    final String variableValue = "2025-10-10";
-    final String parsedDateValue = "2025-10-10T00:00:00.000+0000";
-    final Map<String, Object> variables = Map.of(variableName, variableValue);
-    final Long processInstanceKey =
-        zeebeExtension.startProcessInstanceWithVariables(
-            deployedProcess.getBpmnProcessId(), variables);
-
-    waitUntilNumberOfDefinitionsExported(1);
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(1);
-    importAllZeebeEntitiesFromScratch();
-
-    // when
-    final ProcessInstanceDto importedProcessInstance =
-        getProcessInstanceForId(String.valueOf(processInstanceKey));
-
-    // then
+    // then (date string)
     assertThat(importedProcessInstance.getVariables())
+        .filteredOn(variable -> variable.getName().equals(dateVariableName))
         .singleElement()
         .satisfies(
             variable -> {
-              assertThat(variable.getName()).isEqualTo(variableName);
+              assertThat(variable.getName()).isEqualTo(dateVariableName);
               assertThat(variable.getType()).isEqualTo(DATE.getId());
               assertThat(variable.getValue().getFirst()).isEqualTo(parsedDateValue);
             });
   }
 
   @Test
-  public void variableObjectImportDoesNotParseDigitOnlyStringsAsDates() {
+  public void variableObjectAndListImportDoNotParseDigitOnlyStringsAsDates() {
+    // Covers two independent variable-shape edge cases on the same instance: an object-shaped and
+    // a list-shaped variable, both containing digit-only strings that must not be parsed as dates.
+
     // given
     final Map<String, Object> numericStringMap =
         generateNumericStringsOfLengthXInRange(10, 20).stream()
             .collect(Collectors.toMap(str -> String.valueOf(str.length()), str -> str));
-
-    final Map<String, Object> variables = Map.of("numericStrings", numericStringMap);
+    final var numericStringList = generateNumericStringsOfLengthXInRange(10, 20);
+    final Map<String, Object> variables =
+        Map.of("numericStrings", numericStringMap, "numericStringsList", numericStringList);
 
     final Process deployedProcess = zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
     final long processInstanceKey =
         zeebeExtension.startProcessInstanceWithVariables(
             deployedProcess.getBpmnProcessId(), variables);
     waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(1);
+    waitUntilMinimumVariableDocumentsExportedCount(2);
 
     // when
     importAllZeebeEntitiesFromScratch();
     final ProcessInstanceDto instance = getProcessInstanceForId(String.valueOf(processInstanceKey));
 
-    // then
+    // then (object-shaped)
     assertThat(instance.getVariables())
         .extracting(
             SimpleProcessVariableDto::getName,
             SimpleProcessVariableDto::getType,
             SimpleProcessVariableDto::getValue)
-        .containsExactlyInAnyOrder(
+        .contains(
             Tuple.tuple(
                 "numericStrings",
                 OBJECT.getId(),
@@ -221,53 +244,18 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
                 "numericStrings.20",
                 STRING.getId(),
                 Collections.singletonList("12345678901234567890")));
-  }
 
-  @Test
-  public void variableListImportDoesNotParseDigitOnlyStringsAsDates() {
-    // given
-    final var numericStringList = generateNumericStringsOfLengthXInRange(10, 20);
-
-    final Process deployedProcess = zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
-    final long processInstanceKey =
-        zeebeExtension.startProcessInstanceWithVariables(
-            deployedProcess.getBpmnProcessId(), Map.of("numericStrings", numericStringList));
-
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(1);
-
-    // when
-    importAllZeebeEntitiesFromScratch();
-    final ProcessInstanceDto instance = getProcessInstanceForId(String.valueOf(processInstanceKey));
-
-    // then
+    // then (list-shaped)
     assertThat(instance.getVariables())
         .extracting(
             SimpleProcessVariableDto::getName,
             SimpleProcessVariableDto::getType,
             SimpleProcessVariableDto::getValue)
-        .containsExactlyInAnyOrder(
-            Tuple.tuple("numericStrings", STRING.getId(), numericStringList),
+        .contains(
+            Tuple.tuple("numericStringsList", STRING.getId(), numericStringList),
             // additional _listSize variable for lists
-            Tuple.tuple("numericStrings._listSize", LONG.getId(), Collections.singletonList("11")));
-  }
-
-  @Test
-  public void zeebeVariableImport_variablesAddedAfterProcessStarted() {
-    // given
-    final ProcessInstanceEvent processInstanceEvent = deployProcessAndStartProcessInstance();
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    zeebeExtension.addVariablesToScope(
-        processInstanceEvent.getProcessInstanceKey(), BASIC_VARIABLES, false);
-    waitUntilMinimumVariableDocumentsExportedCount(5);
-
-    // when
-    importAllZeebeEntitiesFromScratch();
-
-    // then
-    final ProcessInstanceDto savedProcessInstance =
-        getProcessInstanceForId(String.valueOf(processInstanceEvent.getProcessInstanceKey()));
-    assertThatVariablesHaveBeenImportedForProcessInstance(savedProcessInstance);
+            Tuple.tuple(
+                "numericStringsList._listSize", LONG.getId(), Collections.singletonList("11")));
   }
 
   @Test
@@ -380,57 +368,110 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
   }
 
   @Test
-  public void zeebeVariableImport_unsupportedTypesGetIgnored() {
-    // given
-    final Map<String, Object> supportedAndUnsupportedVariables = new HashMap<>();
-    supportedAndUnsupportedVariables.put("nullValue", null);
-    supportedAndUnsupportedVariables.put("supportedVariable", "someValue");
+  public void
+      zeebeVariableImport_unsupportedTypesGetIgnoredAndObjectVariablesExcludedInConfiguration() {
+    // Covers two independent scenarios: scenario 1 that unsupported variable types (e.g. null)
+    // are ignored on import; scenario 2 that object variables are excluded from import when
+    // configured. Scenario 2 must run last since it mutates shared configuration, only reset by
+    // the next test method's @BeforeEach. Each scenario is reset to a clean Zeebe export index
+    // and clean Optimize data before it runs, mirroring what @BeforeEach/@AfterEach would
+    // otherwise do between separate test methods.
 
-    final Process deployedProcess = zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
-    final long processInstanceKey =
-        zeebeExtension.startProcessInstanceWithVariables(
-            deployedProcess.getBpmnProcessId(), supportedAndUnsupportedVariables);
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(2);
+    // given (unsupported types ignored)
+    {
+      final Map<String, Object> supportedAndUnsupportedVariables = new HashMap<>();
+      supportedAndUnsupportedVariables.put("nullValue", null);
+      supportedAndUnsupportedVariables.put("supportedVariable", "someValue");
 
-    // when
-    importAllZeebeEntitiesFromScratch();
+      final Process deployedProcess =
+          zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
+      final long processInstanceKey =
+          zeebeExtension.startProcessInstanceWithVariables(
+              deployedProcess.getBpmnProcessId(), supportedAndUnsupportedVariables);
+      waitUntilMinimumProcessInstanceEventsExportedCount(4);
+      waitUntilMinimumVariableDocumentsExportedCount(2);
 
-    // then
-    final ProcessInstanceDto savedProcessInstance =
-        getProcessInstanceForId(String.valueOf(processInstanceKey));
-    assertThat(savedProcessInstance.getVariables())
-        .extracting(
-            SimpleProcessVariableDto::getName,
-            SimpleProcessVariableDto::getValue,
-            SimpleProcessVariableDto::getType)
-        .containsExactly(
-            Tuple.tuple("supportedVariable", Collections.singletonList("someValue"), STRING_TYPE));
+      // when (unsupported types ignored)
+      importAllZeebeEntitiesFromScratch();
+
+      // then (unsupported types ignored)
+      final ProcessInstanceDto savedProcessInstance =
+          getProcessInstanceForId(String.valueOf(processInstanceKey));
+      assertThat(savedProcessInstance.getVariables())
+          .extracting(
+              SimpleProcessVariableDto::getName,
+              SimpleProcessVariableDto::getValue,
+              SimpleProcessVariableDto::getType)
+          .containsExactly(
+              Tuple.tuple(
+                  "supportedVariable", Collections.singletonList("someValue"), STRING_TYPE));
+    }
+
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // given (object variables excluded in configuration)
+    {
+      embeddedOptimizeExtension
+          .getConfigurationService()
+          .getConfiguredZeebe()
+          .setIncludeObjectVariableValue(false);
+      final Map<String, Object> variables = Map.of("objectVar", PERSON_VARIABLES, "boolVar", true);
+
+      final Process deployedProcess =
+          zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
+      final long processInstanceKey =
+          zeebeExtension.startProcessInstanceWithVariables(
+              deployedProcess.getBpmnProcessId(), variables);
+      waitUntilMinimumProcessInstanceEventsExportedCount(4);
+      waitUntilMinimumVariableDocumentsExportedCount(1);
+
+      // when (object variables excluded in configuration)
+      importAllZeebeEntitiesFromScratch();
+      final ProcessInstanceDto instance =
+          getProcessInstanceForId(String.valueOf(processInstanceKey));
+
+      // then (object variables excluded in configuration)
+      assertThat(instance.getVariables())
+          .extracting(
+              SimpleProcessVariableDto::getName,
+              SimpleProcessVariableDto::getType,
+              SimpleProcessVariableDto::getValue)
+          .containsExactlyInAnyOrder(
+              Tuple.tuple("boolVar", BOOLEAN.getId(), Collections.singletonList("true")));
+    }
   }
 
   @Test
-  public void zeebeVariableImport_importObjectVariables() {
+  public void zeebeVariableImport_importObjectAndListVariables() {
+    // Covers two independent variable-shape checks on the same instance: an object-shaped
+    // variable and a list-shaped variable, using distinct names so both coexist on one instance.
+
     // given
-    final Map<String, Object> variables = Map.of("objectVar", PERSON_VARIABLES);
+    final Map<String, Object> variables =
+        Map.of("objectVar", PERSON_VARIABLES, "listVar", List.of("value1", "value2"));
 
     final Process deployedProcess = zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
     final long processInstanceKey =
         zeebeExtension.startProcessInstanceWithVariables(
             deployedProcess.getBpmnProcessId(), variables);
     waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(1);
+    waitUntilMinimumVariableDocumentsExportedCount(2);
 
     // when
     importAllZeebeEntitiesFromScratch();
     final ProcessInstanceDto instance = getProcessInstanceForId(String.valueOf(processInstanceKey));
 
-    // then
+    // then (object-shaped)
     assertThat(instance.getVariables())
         .extracting(
             SimpleProcessVariableDto::getName,
             SimpleProcessVariableDto::getType,
             SimpleProcessVariableDto::getValue)
-        .containsExactlyInAnyOrder(
+        .contains(
             Tuple.tuple(
                 "objectVar",
                 OBJECT.getId(),
@@ -455,60 +496,14 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
             Tuple.tuple("objectVar.likes", STRING.getId(), List.of("optimize", "garlic")),
             // additional _listSize variable for lists
             Tuple.tuple("objectVar.likes._listSize", LONG.getId(), Collections.singletonList("2")));
-  }
 
-  @Test
-  public void
-      zeebeVariableImport_importObjectVariablesWhenObjectVariablesAreExcludedInConfiguration() {
-    // given
-    embeddedOptimizeExtension
-        .getConfigurationService()
-        .getConfiguredZeebe()
-        .setIncludeObjectVariableValue(false);
-    final Map<String, Object> variables = Map.of("objectVar", PERSON_VARIABLES, "boolVar", true);
-
-    final Process deployedProcess = zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
-    final long processInstanceKey =
-        zeebeExtension.startProcessInstanceWithVariables(
-            deployedProcess.getBpmnProcessId(), variables);
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(1);
-
-    // when
-    importAllZeebeEntitiesFromScratch();
-    final ProcessInstanceDto instance = getProcessInstanceForId(String.valueOf(processInstanceKey));
-
-    // then
+    // then (list-shaped)
     assertThat(instance.getVariables())
         .extracting(
             SimpleProcessVariableDto::getName,
             SimpleProcessVariableDto::getType,
             SimpleProcessVariableDto::getValue)
-        .containsExactlyInAnyOrder(
-            Tuple.tuple("boolVar", BOOLEAN.getId(), Collections.singletonList("true")));
-  }
-
-  @Test
-  public void zeebeVariableImport_importListVariables() {
-    // given
-    final Process deployedProcess = zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
-    final long processInstanceKey =
-        zeebeExtension.startProcessInstanceWithVariables(
-            deployedProcess.getBpmnProcessId(), Map.of("listVar", List.of("value1", "value2")));
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(1);
-
-    // when
-    importAllZeebeEntitiesFromScratch();
-    final ProcessInstanceDto instance = getProcessInstanceForId(String.valueOf(processInstanceKey));
-
-    // then
-    assertThat(instance.getVariables())
-        .extracting(
-            SimpleProcessVariableDto::getName,
-            SimpleProcessVariableDto::getType,
-            SimpleProcessVariableDto::getValue)
-        .containsExactlyInAnyOrder(
+        .contains(
             Tuple.tuple("listVar", STRING.getId(), List.of("value1", "value2")),
             // additional _listSize variable for lists
             Tuple.tuple("listVar._listSize", LONG.getId(), Collections.singletonList("2")));

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableCreationImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableCreationImportIT.java
@@ -202,13 +202,14 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
     importAllZeebeEntitiesFromScratch();
     final ProcessInstanceDto instance = getProcessInstanceForId(String.valueOf(processInstanceKey));
 
-    // then (object-shaped)
+    // then (object-shaped and list-shaped) — asserted exhaustively in one call since both
+    // variables coexist on this single instance and no other variables are present
     assertThat(instance.getVariables())
         .extracting(
             SimpleProcessVariableDto::getName,
             SimpleProcessVariableDto::getType,
             SimpleProcessVariableDto::getValue)
-        .contains(
+        .containsExactlyInAnyOrder(
             Tuple.tuple(
                 "numericStrings",
                 OBJECT.getId(),
@@ -243,15 +244,7 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
             Tuple.tuple(
                 "numericStrings.20",
                 STRING.getId(),
-                Collections.singletonList("12345678901234567890")));
-
-    // then (list-shaped)
-    assertThat(instance.getVariables())
-        .extracting(
-            SimpleProcessVariableDto::getName,
-            SimpleProcessVariableDto::getType,
-            SimpleProcessVariableDto::getValue)
-        .contains(
+                Collections.singletonList("12345678901234567890")),
             Tuple.tuple("numericStringsList", STRING.getId(), numericStringList),
             // additional _listSize variable for lists
             Tuple.tuple(
@@ -465,13 +458,14 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
     importAllZeebeEntitiesFromScratch();
     final ProcessInstanceDto instance = getProcessInstanceForId(String.valueOf(processInstanceKey));
 
-    // then (object-shaped)
+    // then (object-shaped and list-shaped) — asserted exhaustively in one call since both
+    // variables coexist on this single instance and no other variables are present
     assertThat(instance.getVariables())
         .extracting(
             SimpleProcessVariableDto::getName,
             SimpleProcessVariableDto::getType,
             SimpleProcessVariableDto::getValue)
-        .contains(
+        .containsExactlyInAnyOrder(
             Tuple.tuple(
                 "objectVar",
                 OBJECT.getId(),
@@ -495,15 +489,7 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
                 "objectVar.skills.write", BOOLEAN.getId(), Collections.singletonList("false")),
             Tuple.tuple("objectVar.likes", STRING.getId(), List.of("optimize", "garlic")),
             // additional _listSize variable for lists
-            Tuple.tuple("objectVar.likes._listSize", LONG.getId(), Collections.singletonList("2")));
-
-    // then (list-shaped)
-    assertThat(instance.getVariables())
-        .extracting(
-            SimpleProcessVariableDto::getName,
-            SimpleProcessVariableDto::getType,
-            SimpleProcessVariableDto::getValue)
-        .contains(
+            Tuple.tuple("objectVar.likes._listSize", LONG.getId(), Collections.singletonList("2")),
             Tuple.tuple("listVar", STRING.getId(), List.of("value1", "value2")),
             // additional _listSize variable for lists
             Tuple.tuple("listVar._listSize", LONG.getId(), Collections.singletonList("2")));

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableUpdateImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableUpdateImportIT.java
@@ -44,39 +44,50 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
 
   @Test
   public void
-      zeebeVariableImport_importRecordsForTheCreationAndTheUpdateOfProcessVariablesOnSameBatch() {
-    // given
-    final long processInstanceKey = deployProcessAndStartProcessInstanceWithVariables(VARIABLES);
-    zeebeExtension.addVariablesToScope(processInstanceKey, UPDATED_VARIABLES, true);
-    waitUntilNumberOfDefinitionsExported(1);
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(5);
+      zeebeVariableImport_importRecordsForTheCreationAndTheUpdateOfProcessVariablesOnSameAndOnDifferentBatch() {
+    // Covers two independent variable-update batching scenarios: scenario 1 imports creation and
+    // update together in one batch; scenario 2 imports them as two separate batches. Each
+    // scenario is reset to a clean Zeebe export index and clean Optimize data before it runs,
+    // mirroring what @BeforeEach/@AfterEach would otherwise do between separate test methods.
 
-    // when
-    importAllZeebeEntitiesFromScratch();
+    // given (same batch)
+    {
+      final long processInstanceKey = deployProcessAndStartProcessInstanceWithVariables(VARIABLES);
+      zeebeExtension.addVariablesToScope(processInstanceKey, UPDATED_VARIABLES, true);
+      waitUntilNumberOfDefinitionsExported(1);
+      waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(5);
 
-    // then
-    final ProcessInstanceDto savedProcessInstance =
-        getProcessInstanceForId(String.valueOf(processInstanceKey));
-    assertThatVariablesHaveBeenImportedForProcessInstance(savedProcessInstance);
-  }
+      // when (same batch)
+      importAllZeebeEntitiesFromScratch();
 
-  @Test
-  public void
-      zeebeVariableImport_importRecordsForTheCreationAndTheUpdateOfProcessVariablesOnDifferentBatch() {
-    // given
-    final long processInstanceKey = deployProcessAndStartProcessInstanceWithVariables(VARIABLES);
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(5);
-    importAllZeebeEntitiesFromScratch();
-    zeebeExtension.addVariablesToScope(processInstanceKey, UPDATED_VARIABLES, true);
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(5);
+      // then (same batch)
+      final ProcessInstanceDto savedProcessInstance =
+          getProcessInstanceForId(String.valueOf(processInstanceKey));
+      assertThatVariablesHaveBeenImportedForProcessInstance(savedProcessInstance);
+    }
 
-    // when
-    importAllZeebeEntitiesFromLastIndex();
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
-    // then
-    final ProcessInstanceDto savedProcessInstance =
-        getProcessInstanceForId(String.valueOf(processInstanceKey));
-    assertThatVariablesHaveBeenImportedForProcessInstance(savedProcessInstance);
+    // given (different batch)
+    {
+      final long processInstanceKey = deployProcessAndStartProcessInstanceWithVariables(VARIABLES);
+      waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(5);
+      importAllZeebeEntitiesFromScratch();
+      zeebeExtension.addVariablesToScope(processInstanceKey, UPDATED_VARIABLES, true);
+      waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(5);
+
+      // when (different batch)
+      importAllZeebeEntitiesFromLastIndex();
+
+      // then (different batch)
+      final ProcessInstanceDto savedProcessInstance =
+          getProcessInstanceForId(String.valueOf(processInstanceKey));
+      assertThatVariablesHaveBeenImportedForProcessInstance(savedProcessInstance);
+    }
   }
 
   @Test
@@ -146,111 +157,181 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
   }
 
   @Test
-  public void zeebeVariableImport_variableNameOnSeveralScopesOnlyProcessLevelGetsUpdated() {
-    // given
-    final long processInstanceKey =
-        deployProcessAndStartProcessInstanceWithVariables(Map.of("var1", "someValue"));
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(1);
-    importAllZeebeEntitiesFromScratch();
-    ProcessInstanceDto savedProcessInstance =
-        getProcessInstanceForId(String.valueOf(processInstanceKey));
-    final String flowNodeId =
-        getFlowNodeInstanceIdFromProcessInstanceForActivity(savedProcessInstance, SERVICE_TASK);
-    zeebeExtension.addVariablesToScope(
-        Long.parseLong(flowNodeId), Map.of("var1", "flowNodeInstanceScopeValue"), true);
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(2);
-    importAllZeebeEntitiesFromLastIndex();
-    zeebeExtension.addVariablesToScope(
-        processInstanceKey, Map.of("var1", "processInstanceScopeUpdatedValue"), true);
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(1);
+  public void
+      zeebeVariableImport_variableNameOnSeveralScopesOnlyProcessLevelGetsUpdatedAndOnlyFlowNodeLevelGetsUpdated() {
+    // Covers two independent scoped-update scenarios for a variable name that exists at both
+    // process and flow-node scope: scenario 1 only the process-level value is updated; scenario
+    // 2 only the flow-node-level value is updated. Each scenario is reset to a clean Zeebe export
+    // index and clean Optimize data before it runs, mirroring what @BeforeEach/@AfterEach would
+    // otherwise do between separate test methods.
 
-    // when
-    importAllZeebeEntitiesFromLastIndex();
+    // given (only process level gets updated)
+    {
+      final long processInstanceKey =
+          deployProcessAndStartProcessInstanceWithVariables(Map.of("var1", "someValue"));
+      waitUntilMinimumProcessInstanceEventsExportedCount(4);
+      waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(1);
+      importAllZeebeEntitiesFromScratch();
+      ProcessInstanceDto savedProcessInstance =
+          getProcessInstanceForId(String.valueOf(processInstanceKey));
+      final String flowNodeId =
+          getFlowNodeInstanceIdFromProcessInstanceForActivity(savedProcessInstance, SERVICE_TASK);
+      zeebeExtension.addVariablesToScope(
+          Long.parseLong(flowNodeId), Map.of("var1", "flowNodeInstanceScopeValue"), true);
+      waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(2);
+      importAllZeebeEntitiesFromLastIndex();
+      zeebeExtension.addVariablesToScope(
+          processInstanceKey, Map.of("var1", "processInstanceScopeUpdatedValue"), true);
+      waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(1);
 
-    // then
-    savedProcessInstance = getProcessInstanceForId(String.valueOf(processInstanceKey));
-    assertThat(savedProcessInstance.getVariables())
-        .extracting(
-            SimpleProcessVariableDto::getName,
-            SimpleProcessVariableDto::getValue,
-            SimpleProcessVariableDto::getType)
-        .containsExactlyInAnyOrder(
-            Tuple.tuple(
-                "var1", Collections.singletonList("processInstanceScopeUpdatedValue"), STRING_TYPE),
-            Tuple.tuple(
-                "var1", Collections.singletonList("flowNodeInstanceScopeValue"), STRING_TYPE));
+      // when (only process level gets updated)
+      importAllZeebeEntitiesFromLastIndex();
+
+      // then (only process level gets updated)
+      savedProcessInstance = getProcessInstanceForId(String.valueOf(processInstanceKey));
+      assertThat(savedProcessInstance.getVariables())
+          .extracting(
+              SimpleProcessVariableDto::getName,
+              SimpleProcessVariableDto::getValue,
+              SimpleProcessVariableDto::getType)
+          .containsExactlyInAnyOrder(
+              Tuple.tuple(
+                  "var1",
+                  Collections.singletonList("processInstanceScopeUpdatedValue"),
+                  STRING_TYPE),
+              Tuple.tuple(
+                  "var1", Collections.singletonList("flowNodeInstanceScopeValue"), STRING_TYPE));
+    }
+
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // given (only flow node level gets updated)
+    {
+      final long processInstanceKey =
+          deployProcessAndStartProcessInstanceWithVariables(
+              Map.of("var1", "processInstanceScopeValue"));
+      waitUntilMinimumProcessInstanceEventsExportedCount(1);
+      waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(1);
+      importAllZeebeEntitiesFromScratch();
+      ProcessInstanceDto savedProcessInstance =
+          getProcessInstanceForId(String.valueOf(processInstanceKey));
+      final String flowNodeId =
+          getFlowNodeInstanceIdFromProcessInstanceForActivity(savedProcessInstance, SERVICE_TASK);
+      zeebeExtension.addVariablesToScope(
+          Long.parseLong(flowNodeId), Map.of("var1", "flowNodeInstanceScopeValue"), true);
+      waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(2);
+      importAllZeebeEntitiesFromLastIndex();
+      zeebeExtension.addVariablesToScope(
+          Long.parseLong(flowNodeId), Map.of("var1", "flowNodeInstanceScopeUpdatedValue"), true);
+      waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(1);
+
+      // when (only flow node level gets updated)
+      importAllZeebeEntitiesFromLastIndex();
+
+      // then (only flow node level gets updated)
+      savedProcessInstance = getProcessInstanceForId(String.valueOf(processInstanceKey));
+      assertThat(savedProcessInstance.getVariables())
+          .extracting(
+              SimpleProcessVariableDto::getName,
+              SimpleProcessVariableDto::getValue,
+              SimpleProcessVariableDto::getType)
+          .containsExactlyInAnyOrder(
+              Tuple.tuple(
+                  "var1", Collections.singletonList("processInstanceScopeValue"), STRING_TYPE),
+              Tuple.tuple(
+                  "var1",
+                  Collections.singletonList("flowNodeInstanceScopeUpdatedValue"),
+                  STRING_TYPE));
+    }
   }
 
   @Test
-  public void zeebeVariableImport_variableNameOnSeveralScopesOnlyFlowNodeLevelGetsUpdated() {
-    // given
-    final long processInstanceKey =
-        deployProcessAndStartProcessInstanceWithVariables(
-            Map.of("var1", "processInstanceScopeValue"));
-    waitUntilMinimumProcessInstanceEventsExportedCount(1);
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(1);
-    importAllZeebeEntitiesFromScratch();
-    ProcessInstanceDto savedProcessInstance =
-        getProcessInstanceForId(String.valueOf(processInstanceKey));
-    final String flowNodeId =
-        getFlowNodeInstanceIdFromProcessInstanceForActivity(savedProcessInstance, SERVICE_TASK);
-    zeebeExtension.addVariablesToScope(
-        Long.parseLong(flowNodeId), Map.of("var1", "flowNodeInstanceScopeValue"), true);
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(2);
-    importAllZeebeEntitiesFromLastIndex();
-    zeebeExtension.addVariablesToScope(
-        Long.parseLong(flowNodeId), Map.of("var1", "flowNodeInstanceScopeUpdatedValue"), true);
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(1);
+  public void zeebeVariableImport_updateTheTypeOfVariablesAndUpdateObjectVariable() {
+    // Covers two independent variable-update scenarios: scenario 1 updating primitive variables
+    // to different types; scenario 2 updating a nested object variable's fields. Each scenario is
+    // reset to a clean Zeebe export index and clean Optimize data before it runs, mirroring what
+    // @BeforeEach/@AfterEach would otherwise do between separate test methods.
 
-    // when
-    importAllZeebeEntitiesFromLastIndex();
+    // given (update the type of variables)
+    {
+      final long processInstanceKey = deployProcessAndStartProcessInstanceWithVariables(VARIABLES);
+      waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(5);
+      importAllZeebeEntitiesFromScratch();
+      zeebeExtension.addVariablesToScope(
+          processInstanceKey,
+          Map.of("var1", false, "var2", "someValue", "var3", "", "var4", true, "var5", 123.0),
+          true);
+      waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(5);
 
-    // then
-    savedProcessInstance = getProcessInstanceForId(String.valueOf(processInstanceKey));
-    assertThat(savedProcessInstance.getVariables())
-        .extracting(
-            SimpleProcessVariableDto::getName,
-            SimpleProcessVariableDto::getValue,
-            SimpleProcessVariableDto::getType)
-        .containsExactlyInAnyOrder(
-            Tuple.tuple(
-                "var1", Collections.singletonList("processInstanceScopeValue"), STRING_TYPE),
-            Tuple.tuple(
-                "var1",
-                Collections.singletonList("flowNodeInstanceScopeUpdatedValue"),
-                STRING_TYPE));
-  }
+      // when (update the type of variables)
+      importAllZeebeEntitiesFromLastIndex();
 
-  @Test
-  public void zeebeVariableImport_updateTheTypeOfVariables() {
-    // given
-    final long processInstanceKey = deployProcessAndStartProcessInstanceWithVariables(VARIABLES);
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(5);
-    importAllZeebeEntitiesFromScratch();
-    zeebeExtension.addVariablesToScope(
-        processInstanceKey,
-        Map.of("var1", false, "var2", "someValue", "var3", "", "var4", true, "var5", 123.0),
-        true);
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(5);
+      // then (update the type of variables)
+      final ProcessInstanceDto savedProcessInstance =
+          getProcessInstanceForId(String.valueOf(processInstanceKey));
+      assertThat(savedProcessInstance.getVariables())
+          .extracting(
+              SimpleProcessVariableDto::getName,
+              SimpleProcessVariableDto::getValue,
+              SimpleProcessVariableDto::getType)
+          .containsExactlyInAnyOrder(
+              Tuple.tuple("var1", Collections.singletonList("false"), BOOLEAN_TYPE),
+              Tuple.tuple("var2", Collections.singletonList("someValue"), STRING_TYPE),
+              Tuple.tuple("var3", Collections.singletonList(""), STRING_TYPE),
+              Tuple.tuple("var4", Collections.singletonList("true"), BOOLEAN_TYPE),
+              Tuple.tuple("var5", Collections.singletonList("123.0"), DOUBLE_TYPE));
+    }
 
-    // when
-    importAllZeebeEntitiesFromLastIndex();
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
-    // then
-    final ProcessInstanceDto savedProcessInstance =
-        getProcessInstanceForId(String.valueOf(processInstanceKey));
-    assertThat(savedProcessInstance.getVariables())
-        .extracting(
-            SimpleProcessVariableDto::getName,
-            SimpleProcessVariableDto::getValue,
-            SimpleProcessVariableDto::getType)
-        .containsExactlyInAnyOrder(
-            Tuple.tuple("var1", Collections.singletonList("false"), BOOLEAN_TYPE),
-            Tuple.tuple("var2", Collections.singletonList("someValue"), STRING_TYPE),
-            Tuple.tuple("var3", Collections.singletonList(""), STRING_TYPE),
-            Tuple.tuple("var4", Collections.singletonList("true"), BOOLEAN_TYPE),
-            Tuple.tuple("var5", Collections.singletonList("123.0"), DOUBLE_TYPE));
+    // given (update object variable)
+    {
+      final Map<String, Object> objectVar = new HashMap<>();
+      objectVar.put("name", "Pond");
+      objectVar.put("age", 28);
+      objectVar.put("likes", List.of("optimize", "garlic"));
+      final Map<String, Object> variables = new HashMap<>();
+      variables.put("objectVar", objectVar);
+      final long processInstanceKey = deployProcessAndStartProcessInstanceWithVariables(variables);
+      waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(1);
+      importAllZeebeEntitiesFromScratch();
+
+      objectVar.put("age", 29);
+      objectVar.put("likes", List.of("optimize", "garlic", "tofu"));
+      zeebeExtension.addVariablesToScope(processInstanceKey, variables, true);
+      waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(1);
+
+      // when (update object variable)
+      importAllZeebeEntitiesFromLastIndex();
+
+      // then (update object variable)
+      final ProcessInstanceDto instance =
+          getProcessInstanceForId(String.valueOf(processInstanceKey));
+      assertThat(instance.getVariables())
+          .extracting(
+              SimpleProcessVariableDto::getName,
+              SimpleProcessVariableDto::getType,
+              SimpleProcessVariableDto::getValue)
+          .containsExactlyInAnyOrder(
+              Tuple.tuple(
+                  "objectVar",
+                  OBJECT.getId(),
+                  Collections.singletonList(
+                      variablesClient.createMapJsonObjectVariableDto(objectVar).getValue())),
+              Tuple.tuple("objectVar.name", STRING.getId(), Collections.singletonList("Pond")),
+              Tuple.tuple("objectVar.age", DOUBLE.getId(), Collections.singletonList("29.0")),
+              Tuple.tuple("objectVar.likes", STRING.getId(), List.of("optimize", "garlic", "tofu")),
+              Tuple.tuple(
+                  "objectVar.likes._listSize", LONG.getId(), Collections.singletonList("3")));
+    }
   }
 
   @Test
@@ -294,104 +375,77 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
   }
 
   @Test
-  public void zeebeVariableImport_updateVariableSeveralTimesInSameBatch() {
-    // given
-    final long processInstanceKey =
-        deployProcessAndStartProcessInstanceWithVariables(Map.of("var1", "someValue"));
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(1);
-    importAllZeebeEntitiesFromScratch();
-    zeebeExtension.addVariablesToScope(processInstanceKey, Map.of("var1", "firstUpdate"), true);
-    zeebeExtension.addVariablesToScope(processInstanceKey, Map.of("var1", "secondUpdate"), true);
-    importAllZeebeEntitiesFromLastIndex();
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(2);
+  public void zeebeVariableImport_updateVariableSeveralTimesInSameAndInSeveralBatches() {
+    // Covers two independent variable-update batching scenarios: scenario 1 updates the variable
+    // twice, importing both updates in one batch; scenario 2 updates it twice again on a fresh
+    // instance, importing each update as its own batch (forced via maxImportPageSize=1). Scenario
+    // 2 must run last since it mutates shared configuration, only reset by the next test method's
+    // @BeforeEach.
 
-    // when
-    importAllZeebeEntitiesFromLastIndex();
+    // given (same batch)
+    {
+      final long processInstanceKey =
+          deployProcessAndStartProcessInstanceWithVariables(Map.of("var1", "someValue"));
+      waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(1);
+      importAllZeebeEntitiesFromScratch();
+      zeebeExtension.addVariablesToScope(processInstanceKey, Map.of("var1", "firstUpdate"), true);
+      zeebeExtension.addVariablesToScope(processInstanceKey, Map.of("var1", "secondUpdate"), true);
+      importAllZeebeEntitiesFromLastIndex();
+      waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(2);
 
-    // then
-    final ProcessInstanceDto savedProcessInstance =
-        getProcessInstanceForId(String.valueOf(processInstanceKey));
-    assertThat(savedProcessInstance.getVariables())
-        .extracting(
-            SimpleProcessVariableDto::getName,
-            SimpleProcessVariableDto::getValue,
-            SimpleProcessVariableDto::getType)
-        .containsExactlyInAnyOrder(
-            Tuple.tuple("var1", Collections.singletonList("secondUpdate"), STRING_TYPE));
-  }
+      // when (same batch)
+      importAllZeebeEntitiesFromLastIndex();
 
-  @Test
-  public void zeebeVariableImport_updateVariableSeveralTimesInSeveralBatches() {
-    // given
-    embeddedOptimizeExtension
-        .getConfigurationService()
-        .getConfiguredZeebe()
-        .setMaxImportPageSize(1);
-    embeddedOptimizeExtension.reloadConfiguration();
-    final long processInstanceKey =
-        deployProcessAndStartProcessInstanceWithVariables(Map.of("var1", "someValue"));
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(1);
-    importAllZeebeEntitiesFromScratch();
-    zeebeExtension.addVariablesToScope(processInstanceKey, Map.of("var1", "firstUpdate"), true);
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(1);
-    importAllZeebeEntitiesFromLastIndex();
-    zeebeExtension.addVariablesToScope(processInstanceKey, Map.of("var1", "secondUpdate"), true);
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(2);
+      // then (same batch)
+      final ProcessInstanceDto savedProcessInstance =
+          getProcessInstanceForId(String.valueOf(processInstanceKey));
+      assertThat(savedProcessInstance.getVariables())
+          .extracting(
+              SimpleProcessVariableDto::getName,
+              SimpleProcessVariableDto::getValue,
+              SimpleProcessVariableDto::getType)
+          .containsExactlyInAnyOrder(
+              Tuple.tuple("var1", Collections.singletonList("secondUpdate"), STRING_TYPE));
+    }
 
-    // when
-    importAllZeebeEntitiesFromLastIndex();
-    importAllZeebeEntitiesFromLastIndex();
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
-    // then
-    final ProcessInstanceDto savedProcessInstance =
-        getProcessInstanceForId(String.valueOf(processInstanceKey));
-    assertThat(savedProcessInstance.getVariables())
-        .extracting(
-            SimpleProcessVariableDto::getName,
-            SimpleProcessVariableDto::getValue,
-            SimpleProcessVariableDto::getType)
-        .containsExactlyInAnyOrder(
-            Tuple.tuple("var1", Collections.singletonList("secondUpdate"), STRING_TYPE));
-  }
+    // given (several batches)
+    {
+      embeddedOptimizeExtension
+          .getConfigurationService()
+          .getConfiguredZeebe()
+          .setMaxImportPageSize(1);
+      embeddedOptimizeExtension.reloadConfiguration();
+      final long processInstanceKey =
+          deployProcessAndStartProcessInstanceWithVariables(Map.of("var1", "someValue"));
+      waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(1);
+      importAllZeebeEntitiesFromScratch();
+      zeebeExtension.addVariablesToScope(processInstanceKey, Map.of("var1", "firstUpdate"), true);
+      waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(1);
+      importAllZeebeEntitiesFromLastIndex();
+      zeebeExtension.addVariablesToScope(processInstanceKey, Map.of("var1", "secondUpdate"), true);
+      waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(2);
 
-  @Test
-  public void zeebeVariableImport_updateObjectVariable() {
-    // given
-    final Map<String, Object> objectVar = new HashMap<>();
-    objectVar.put("name", "Pond");
-    objectVar.put("age", 28);
-    objectVar.put("likes", List.of("optimize", "garlic"));
-    final Map<String, Object> variables = new HashMap<>();
-    variables.put("objectVar", objectVar);
-    final long processInstanceKey = deployProcessAndStartProcessInstanceWithVariables(variables);
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(1);
-    importAllZeebeEntitiesFromScratch();
+      // when (several batches)
+      importAllZeebeEntitiesFromLastIndex();
+      importAllZeebeEntitiesFromLastIndex();
 
-    objectVar.put("age", 29);
-    objectVar.put("likes", List.of("optimize", "garlic", "tofu"));
-    zeebeExtension.addVariablesToScope(processInstanceKey, variables, true);
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(1);
-
-    // when
-    importAllZeebeEntitiesFromLastIndex();
-
-    // then
-    final ProcessInstanceDto instance = getProcessInstanceForId(String.valueOf(processInstanceKey));
-    assertThat(instance.getVariables())
-        .extracting(
-            SimpleProcessVariableDto::getName,
-            SimpleProcessVariableDto::getType,
-            SimpleProcessVariableDto::getValue)
-        .containsExactlyInAnyOrder(
-            Tuple.tuple(
-                "objectVar",
-                OBJECT.getId(),
-                Collections.singletonList(
-                    variablesClient.createMapJsonObjectVariableDto(objectVar).getValue())),
-            Tuple.tuple("objectVar.name", STRING.getId(), Collections.singletonList("Pond")),
-            Tuple.tuple("objectVar.age", DOUBLE.getId(), Collections.singletonList("29.0")),
-            Tuple.tuple("objectVar.likes", STRING.getId(), List.of("optimize", "garlic", "tofu")),
-            Tuple.tuple("objectVar.likes._listSize", LONG.getId(), Collections.singletonList("3")));
+      // then (several batches)
+      final ProcessInstanceDto savedProcessInstance =
+          getProcessInstanceForId(String.valueOf(processInstanceKey));
+      assertThat(savedProcessInstance.getVariables())
+          .extracting(
+              SimpleProcessVariableDto::getName,
+              SimpleProcessVariableDto::getValue,
+              SimpleProcessVariableDto::getType)
+          .containsExactlyInAnyOrder(
+              Tuple.tuple("var1", Collections.singletonList("secondUpdate"), STRING_TYPE));
+    }
   }
 
   private Map<String, Object> generateVariables() {

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/processdefinition/ZeebeProcessDefinitionImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/processdefinition/ZeebeProcessDefinitionImportIT.java
@@ -53,132 +53,160 @@ import org.junit.jupiter.api.condition.EnabledIf;
 public class ZeebeProcessDefinitionImportIT extends AbstractCCSMIT {
 
   @Test
-  public void importZeebeProcess_allDataSavedToDefinition() {
-    // given
-    final String processName = "someProcess";
-    final BpmnModelInstance simpleProcess = createSimpleUserTaskProcess(processName);
-    final Process deployedProcess = deployProcessAndStartInstance(simpleProcess);
-    waitUntilNumberOfDefinitionsExported(1);
+  public void importZeebeProcess_allDataSavedToDefinitionAndUnnamedProcessUsesProcessIdAsName() {
+    // Covers two independent scenarios: scenario 1 the full field set for a named process;
+    // scenario 2 that an unnamed process defaults its name to the bpmnProcessId. Each scenario is
+    // reset to a clean Zeebe export index and clean Optimize data before it runs, mirroring what
+    // @BeforeEach/@AfterEach would otherwise do between separate test methods.
 
-    // when
-    importAllZeebeEntitiesFromScratch();
+    // given (named process)
+    {
+      final String processName = "someProcess";
+      final BpmnModelInstance simpleProcess = createSimpleUserTaskProcess(processName);
+      final Process deployedProcess = deployProcessAndStartInstance(simpleProcess);
+      waitUntilNumberOfDefinitionsExported(1);
 
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessDefinitions())
-        .singleElement()
-        .satisfies(
-            importedDef -> {
-              assertThat(importedDef.getId())
-                  .isEqualTo(String.valueOf(deployedProcess.getProcessDefinitionKey()));
-              assertThat(importedDef.getKey()).isEqualTo(deployedProcess.getBpmnProcessId());
-              assertThat(importedDef.getVersion())
-                  .isEqualTo(String.valueOf(deployedProcess.getVersion()));
-              if (isZeebeVersionPre86()) {
-                assertThat(importedDef.getVersionTag()).isNull();
-              } else {
-                assertThat(importedDef.getVersionTag()).isEqualTo(ZeebeBpmnModels.VERSION_TAG);
-              }
-              assertThat(importedDef.getType()).isEqualTo(DefinitionType.PROCESS);
+      // when (named process)
+      importAllZeebeEntitiesFromScratch();
 
-              assertThat(importedDef.getBpmn20Xml()).isEqualTo(Bpmn.convertToString(simpleProcess));
-              assertThat(importedDef.getName()).isEqualTo(processName);
-              assertThat(importedDef.getDataSource().getType())
-                  .isEqualTo(DataImportSourceType.ZEEBE);
+      // then (named process)
+      assertThat(databaseIntegrationTestExtension.getAllProcessDefinitions())
+          .singleElement()
+          .satisfies(
+              importedDef -> {
+                assertThat(importedDef.getId())
+                    .isEqualTo(String.valueOf(deployedProcess.getProcessDefinitionKey()));
+                assertThat(importedDef.getKey()).isEqualTo(deployedProcess.getBpmnProcessId());
+                assertThat(importedDef.getVersion())
+                    .isEqualTo(String.valueOf(deployedProcess.getVersion()));
+                if (isZeebeVersionPre86()) {
+                  assertThat(importedDef.getVersionTag()).isNull();
+                } else {
+                  assertThat(importedDef.getVersionTag()).isEqualTo(ZeebeBpmnModels.VERSION_TAG);
+                }
+                assertThat(importedDef.getType()).isEqualTo(DefinitionType.PROCESS);
 
-              assertThat(importedDef.getDataSource().getName()).isEqualTo(getConfiguredZeebeName());
-              assertThat(importedDef.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(importedDef.isDeleted()).isFalse();
-              assertThat(importedDef.getUserTaskNames()).containsEntry(USER_TASK, USER_TASK);
-              assertThat(importedDef.getFlowNodeData())
-                  .containsExactlyInAnyOrder(
-                      new FlowNodeDataDto(START_EVENT, START_EVENT, "startEvent"),
-                      new FlowNodeDataDto(USER_TASK, USER_TASK, "userTask"),
-                      new FlowNodeDataDto(END_EVENT, null, "endEvent"));
-            });
-  }
+                assertThat(importedDef.getBpmn20Xml())
+                    .isEqualTo(Bpmn.convertToString(simpleProcess));
+                assertThat(importedDef.getName()).isEqualTo(processName);
+                assertThat(importedDef.getDataSource().getType())
+                    .isEqualTo(DataImportSourceType.ZEEBE);
 
-  @Test
-  public void importZeebeProcess_unnamedProcessUsesProcessIdAsName() {
-    // given
-    final BpmnModelInstance noNameStartEventProcess =
-        Bpmn.createExecutableProcess().startEvent(START_EVENT).name(START_EVENT).done();
-    final Process deployedProcess = deployProcessAndStartInstance(noNameStartEventProcess);
-    waitUntilNumberOfDefinitionsExported(1);
-
-    // when
-    importAllZeebeEntitiesFromScratch();
-
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessDefinitions())
-        .singleElement()
-        .satisfies(
-            importedDef -> {
-              assertThat(importedDef.getId())
-                  .isEqualTo(String.valueOf(deployedProcess.getProcessDefinitionKey()));
-              assertThat(importedDef.getKey()).isEqualTo(deployedProcess.getBpmnProcessId());
-              assertThat(importedDef.getVersion())
-                  .isEqualTo(String.valueOf(deployedProcess.getVersion()));
-              assertThat(importedDef.getVersionTag()).isNull();
-              assertThat(importedDef.getType()).isEqualTo(DefinitionType.PROCESS);
-              assertThat(importedDef.getBpmn20Xml())
-                  .isEqualTo(Bpmn.convertToString(noNameStartEventProcess));
-              assertThat(importedDef.getName()).isEqualTo(deployedProcess.getBpmnProcessId());
-              assertThat(importedDef.getDataSource().getType())
-                  .isEqualTo(DataImportSourceType.ZEEBE);
-
-              assertThat(importedDef.getDataSource().getName()).isEqualTo(getConfiguredZeebeName());
-              assertThat(importedDef.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
-              assertThat(importedDef.isDeleted()).isFalse();
-              assertThat(importedDef.getUserTaskNames()).isEmpty();
-              assertThat(importedDef.getFlowNodeData())
-                  .containsExactlyInAnyOrder(
-                      new FlowNodeDataDto(START_EVENT, START_EVENT, "startEvent"));
-            });
-  }
-
-  @Test
-  public void importZeebeProcess_multipleProcessesDeployed() {
-    // given
-    final String firstProcessName = "firstProcess";
-    deployProcessAndStartInstance(createSimpleServiceTaskProcess(firstProcessName));
-    final String secondProcessName = "secondProcess";
-    deployProcessAndStartInstance(createSimpleServiceTaskProcess(secondProcessName));
-    waitUntilNumberOfDefinitionsExported(2);
-
-    // when
-    importAllZeebeEntitiesFromScratch();
-
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessDefinitions())
-        .hasSize(2)
-        .extracting(DefinitionOptimizeResponseDto::getName)
-        .containsExactlyInAnyOrder(firstProcessName, secondProcessName);
-  }
-
-  @Test
-  public void importZeebeProcess_multipleProcessesDeployedOnDifferentDays() {
-    // given
-    final String firstProcessName = "firstProcess";
-    deployProcessAndStartInstance(createSimpleServiceTaskProcess(firstProcessName));
-
-    try {
-      zeebeExtension.setClock(Instant.now().plus(1, ChronoUnit.DAYS));
-    } catch (final IOException | InterruptedException e) {
-      throw new OptimizeRuntimeException(e);
+                assertThat(importedDef.getDataSource().getName())
+                    .isEqualTo(getConfiguredZeebeName());
+                assertThat(importedDef.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+                assertThat(importedDef.isDeleted()).isFalse();
+                assertThat(importedDef.getUserTaskNames()).containsEntry(USER_TASK, USER_TASK);
+                assertThat(importedDef.getFlowNodeData())
+                    .containsExactlyInAnyOrder(
+                        new FlowNodeDataDto(START_EVENT, START_EVENT, "startEvent"),
+                        new FlowNodeDataDto(USER_TASK, USER_TASK, "userTask"),
+                        new FlowNodeDataDto(END_EVENT, null, "endEvent"));
+              });
     }
-    final String secondProcessName = "secondProcess";
-    deployProcessAndStartInstance(createSimpleServiceTaskProcess(secondProcessName));
-    waitUntilDefinitionWithIdExported(firstProcessName);
-    waitUntilDefinitionWithIdExported(secondProcessName);
 
-    // when
-    importAllZeebeEntitiesFromScratch();
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
-    // then
-    assertThat(databaseIntegrationTestExtension.getAllProcessDefinitions())
-        .hasSize(2)
-        .extracting(DefinitionOptimizeResponseDto::getName)
-        .containsExactlyInAnyOrder(firstProcessName, secondProcessName);
+    // given (unnamed process)
+    {
+      final BpmnModelInstance noNameStartEventProcess =
+          Bpmn.createExecutableProcess().startEvent(START_EVENT).name(START_EVENT).done();
+      final Process deployedProcess = deployProcessAndStartInstance(noNameStartEventProcess);
+      waitUntilNumberOfDefinitionsExported(1);
+
+      // when (unnamed process)
+      importAllZeebeEntitiesFromScratch();
+
+      // then (unnamed process)
+      assertThat(databaseIntegrationTestExtension.getAllProcessDefinitions())
+          .singleElement()
+          .satisfies(
+              importedDef -> {
+                assertThat(importedDef.getId())
+                    .isEqualTo(String.valueOf(deployedProcess.getProcessDefinitionKey()));
+                assertThat(importedDef.getKey()).isEqualTo(deployedProcess.getBpmnProcessId());
+                assertThat(importedDef.getVersion())
+                    .isEqualTo(String.valueOf(deployedProcess.getVersion()));
+                assertThat(importedDef.getVersionTag()).isNull();
+                assertThat(importedDef.getType()).isEqualTo(DefinitionType.PROCESS);
+                assertThat(importedDef.getBpmn20Xml())
+                    .isEqualTo(Bpmn.convertToString(noNameStartEventProcess));
+                assertThat(importedDef.getName()).isEqualTo(deployedProcess.getBpmnProcessId());
+                assertThat(importedDef.getDataSource().getType())
+                    .isEqualTo(DataImportSourceType.ZEEBE);
+
+                assertThat(importedDef.getDataSource().getName())
+                    .isEqualTo(getConfiguredZeebeName());
+                assertThat(importedDef.getTenantId()).isEqualTo(ZEEBE_DEFAULT_TENANT_ID);
+                assertThat(importedDef.isDeleted()).isFalse();
+                assertThat(importedDef.getUserTaskNames()).isEmpty();
+                assertThat(importedDef.getFlowNodeData())
+                    .containsExactlyInAnyOrder(
+                        new FlowNodeDataDto(START_EVENT, START_EVENT, "startEvent"));
+              });
+    }
+  }
+
+  @Test
+  public void importZeebeProcess_multipleProcessesDeployedAndOnDifferentDays() {
+    // Covers two independent scenarios: scenario 1 two processes deployed on the same day;
+    // scenario 2 two processes deployed on different days. Scenario 2 must run last since it pins
+    // the Zeebe engine clock with no reset mechanism. Each scenario is reset to a clean Zeebe
+    // export index and clean Optimize data before it runs, mirroring what
+    // @BeforeEach/@AfterEach would otherwise do between separate test methods.
+
+    // given (same day)
+    {
+      final String firstProcessName = "firstProcess";
+      deployProcessAndStartInstance(createSimpleServiceTaskProcess(firstProcessName));
+      final String secondProcessName = "secondProcess";
+      deployProcessAndStartInstance(createSimpleServiceTaskProcess(secondProcessName));
+      waitUntilNumberOfDefinitionsExported(2);
+
+      // when (same day)
+      importAllZeebeEntitiesFromScratch();
+
+      // then (same day)
+      assertThat(databaseIntegrationTestExtension.getAllProcessDefinitions())
+          .hasSize(2)
+          .extracting(DefinitionOptimizeResponseDto::getName)
+          .containsExactlyInAnyOrder(firstProcessName, secondProcessName);
+    }
+
+    // reset to a clean slate before the second scenario, mirroring @AfterEach/@BeforeEach
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+        zeebeExtension.getZeebeRecordPrefix());
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // given (different days)
+    {
+      final String firstProcessName = "firstProcess";
+      deployProcessAndStartInstance(createSimpleServiceTaskProcess(firstProcessName));
+
+      try {
+        zeebeExtension.setClock(Instant.now().plus(1, ChronoUnit.DAYS));
+      } catch (final IOException | InterruptedException e) {
+        throw new OptimizeRuntimeException(e);
+      }
+      final String secondProcessName = "secondProcess";
+      deployProcessAndStartInstance(createSimpleServiceTaskProcess(secondProcessName));
+      waitUntilDefinitionWithIdExported(firstProcessName);
+      waitUntilDefinitionWithIdExported(secondProcessName);
+
+      // when (different days)
+      importAllZeebeEntitiesFromScratch();
+
+      // then (different days)
+      assertThat(databaseIntegrationTestExtension.getAllProcessDefinitions())
+          .hasSize(2)
+          .extracting(DefinitionOptimizeResponseDto::getName)
+          .containsExactlyInAnyOrder(firstProcessName, secondProcessName);
+    }
   }
 
   @Test

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/security/UserIdMigrationIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/security/UserIdMigrationIT.java
@@ -44,18 +44,29 @@ public class UserIdMigrationIT extends AbstractCCSMIT {
   private static final String NEW_USER_ID = "new-sso-user-id";
 
   /**
-   * Happy path: collection owner and embedded role are rewritten; old ID disappears from all
-   * indices.
+   * Covers three sequential synchronous migration scenarios sharing the OLD_USER_ID/NEW_USER_ID
+   * constants: (1) collection owner and embedded role are rewritten and the old ID disappears from
+   * all indices; (2) report owner/lastModifier fields are migrated on entity indices that have no
+   * nested roles; (3) re-running {@link UserIdMigrationRepository#migrateUserId} after the old ID
+   * is already gone is a no-op, since every script is guarded by an {@code == params.oldId} check
+   * on the current document state — safe to chain because each scenario only ever migrates
+   * documents that are, at that point in time, still tagged with OLD_USER_ID. The count-guard that
+   * skips the repository call entirely lives in {@link UserIdMigrationService} and is covered
+   * separately by {@link
+   * #asyncMigrationViaServiceCompletesBeforeNextLoginCheckAndConcurrentLoginsMigrateOnlyOnce}.
    */
   @Test
-  void migratesCollectionOwnershipAndRolesOnUserIdChange() {
+  void migratesCollectionOwnershipAndReportOwnerOnUserIdChangeAndRepeatedMigrationIsANoOp() {
     final CollectionWriter collectionWriter =
         embeddedOptimizeExtension.getBean(CollectionWriter.class);
     final CollectionReader collectionReader =
         embeddedOptimizeExtension.getBean(CollectionReader.class);
+    final ReportWriter reportWriter = embeddedOptimizeExtension.getBean(ReportWriter.class);
+    final EntitiesReader entitiesReader = embeddedOptimizeExtension.getBean(EntitiesReader.class);
     final UserIdMigrationRepository repository =
         embeddedOptimizeExtension.getBean(UserIdMigrationRepository.class);
 
+    // given (collection ownership and roles)
     // the creator is automatically added as a MANAGER role on the collection, so no explicit
     // addRoleToCollection call is needed to have a role entry referencing OLD_USER_ID
     final String collectionId =
@@ -73,9 +84,11 @@ public class UserIdMigrationIT extends AbstractCCSMIT {
         .contains(OLD_USER_ID);
     assertThat(repository.hasDocumentsWithUserId(OLD_USER_ID)).isTrue();
 
+    // when (collection ownership and roles)
     repository.migrateUserId(OLD_USER_ID, NEW_USER_ID);
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
+    // then (collection ownership and roles)
     assertThat(repository.hasDocumentsWithUserId(OLD_USER_ID)).isFalse();
     collection = collectionReader.getCollection(collectionId).orElseThrow();
     assertThat(collection.getOwner()).isEqualTo(NEW_USER_ID);
@@ -83,18 +96,8 @@ public class UserIdMigrationIT extends AbstractCCSMIT {
         .extracting(role -> role.getIdentity().getId())
         .contains(NEW_USER_ID)
         .doesNotContain(OLD_USER_ID);
-  }
 
-  /**
-   * Report owner and lastModifier fields are migrated on entity indices that have no nested roles.
-   */
-  @Test
-  void migratesReportOwnerOnUserIdChange() {
-    final ReportWriter reportWriter = embeddedOptimizeExtension.getBean(ReportWriter.class);
-    final EntitiesReader entitiesReader = embeddedOptimizeExtension.getBean(EntitiesReader.class);
-    final UserIdMigrationRepository repository =
-        embeddedOptimizeExtension.getBean(UserIdMigrationRepository.class);
-
+    // given (report owner, no nested roles) — old ID is reintroduced via a fresh entity
     final String reportId =
         reportWriter
             .createNewSingleProcessReport(
@@ -108,39 +111,26 @@ public class UserIdMigrationIT extends AbstractCCSMIT {
         .containsExactly(reportId);
     assertThat(repository.hasDocumentsWithUserId(OLD_USER_ID)).isTrue();
 
+    // when (report owner, no nested roles)
     repository.migrateUserId(OLD_USER_ID, NEW_USER_ID);
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
+    // then (report owner, no nested roles)
     assertThat(repository.hasDocumentsWithUserId(OLD_USER_ID)).isFalse();
     assertThat(entitiesReader.getAllPrivateEntitiesForOwnerId(NEW_USER_ID))
         .extracting(CollectionEntity::getId)
         .containsExactly(reportId);
     assertThat(entitiesReader.getAllPrivateEntitiesForOwnerId(OLD_USER_ID)).isEmpty();
-  }
 
-  /**
-   * The Painless scripts themselves are safe to reapply: re-running {@link
-   * UserIdMigrationRepository#migrateUserId} after the old ID is already gone is a no-op, since
-   * every script is guarded by an {@code == params.oldId} check on the current document state. The
-   * count-guard that skips the repository call entirely lives in {@link UserIdMigrationService} and
-   * is covered separately by {@link #asyncMigrationViaServiceCompletesBeforeNextLoginCheck}.
-   */
-  @Test
-  void repeatedMigrationOfSameUserIdIsANoOp() {
-    final CollectionWriter collectionWriter =
-        embeddedOptimizeExtension.getBean(CollectionWriter.class);
-    final CollectionReader collectionReader =
-        embeddedOptimizeExtension.getBean(CollectionReader.class);
-    final UserIdMigrationRepository repository =
-        embeddedOptimizeExtension.getBean(UserIdMigrationRepository.class);
-
-    final String collectionId =
+    // given (repeated migration of the same user ID is a no-op) — old ID reintroduced again
+    final String idempotencyCollectionId =
         collectionWriter
             .createNewCollectionAndReturnId(
                 OLD_USER_ID, new PartialCollectionDefinitionRequestDto("Idempotency Test"))
             .getId();
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
+    // when (repeated migration of the same user ID is a no-op)
     repository.migrateUserId(OLD_USER_ID, NEW_USER_ID);
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
     assertThat(repository.hasDocumentsWithUserId(OLD_USER_ID)).isFalse();
@@ -149,18 +139,25 @@ public class UserIdMigrationIT extends AbstractCCSMIT {
     repository.migrateUserId(OLD_USER_ID, NEW_USER_ID);
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
-    assertThat(collectionReader.getCollection(collectionId).orElseThrow().getOwner())
+    // then (repeated migration of the same user ID is a no-op)
+    assertThat(collectionReader.getCollection(idempotencyCollectionId).orElseThrow().getOwner())
         .isEqualTo(NEW_USER_ID);
   }
 
   /**
-   * The async path via {@link UserIdMigrationService}: fire-and-forget resolves before the next
-   * login's {@link UserIdMigrationRepository#hasDocumentsWithUserId} check would see the old ID.
-   * {@code UserIdMigrationService} is {@code @Conditional(CCSaaSCondition.class)} and therefore not
-   * in the Spring context during IT runs; it is instantiated directly here.
+   * Covers two independent scenarios of the async path via {@link UserIdMigrationService}: (1)
+   * fire-and-forget resolves before the next login's {@link
+   * UserIdMigrationRepository#hasDocumentsWithUserId} check would see the old ID; (2) simulates a
+   * logout/login while a migration is still running for the same old user ID — the second {@link
+   * UserIdMigrationService#migrateUserIdIfNeeded} call must be a no-op rather than firing a second,
+   * redundant {@code _update_by_query} pass. The in-progress flag is set synchronously on the
+   * caller's thread before the async task is scheduled, so calling twice back-to-back
+   * deterministically exercises the dedup path regardless of execution speed. {@code
+   * UserIdMigrationService} is {@code @Conditional(CCSaaSCondition.class)} and therefore not in the
+   * Spring context during IT runs; it is instantiated directly in each scenario.
    */
   @Test
-  void asyncMigrationViaServiceCompletesBeforeNextLoginCheck() {
+  void asyncMigrationViaServiceCompletesBeforeNextLoginCheckAndConcurrentLoginsMigrateOnlyOnce() {
     final CollectionWriter collectionWriter =
         embeddedOptimizeExtension.getBean(CollectionWriter.class);
     final CollectionReader collectionReader =
@@ -168,6 +165,7 @@ public class UserIdMigrationIT extends AbstractCCSMIT {
     final UserIdMigrationRepository repository =
         embeddedOptimizeExtension.getBean(UserIdMigrationRepository.class);
 
+    // given (async migration completes before next login check)
     final String collectionId =
         collectionWriter
             .createNewCollectionAndReturnId(
@@ -176,9 +174,11 @@ public class UserIdMigrationIT extends AbstractCCSMIT {
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
     assertThat(repository.hasDocumentsWithUserId(OLD_USER_ID)).isTrue();
 
+    // when (async migration completes before next login check)
     final UserIdMigrationService service = new UserIdMigrationService(repository);
     service.migrateUserIdIfNeeded(NEW_USER_ID, OLD_USER_ID);
 
+    // then (async migration completes before next login check)
     given()
         .timeout(30, SECONDS)
         .pollInterval(200, MILLISECONDS)
@@ -189,25 +189,10 @@ public class UserIdMigrationIT extends AbstractCCSMIT {
               assertThat(collectionReader.getCollection(collectionId).orElseThrow().getOwner())
                   .isEqualTo(NEW_USER_ID);
             });
-  }
 
-  /**
-   * Simulates a logout/login while a migration is still running for the same old user ID: the
-   * second {@link UserIdMigrationService#migrateUserIdIfNeeded} call must be a no-op rather than
-   * firing a second, redundant {@code _update_by_query} pass. The in-progress flag is set
-   * synchronously on the caller's thread before the async task is scheduled, so calling twice
-   * back-to-back deterministically exercises the dedup path regardless of execution speed.
-   */
-  @Test
-  void concurrentLoginsForSameOldUserIdMigrateOnlyOnce() {
-    final CollectionWriter collectionWriter =
-        embeddedOptimizeExtension.getBean(CollectionWriter.class);
-    final CollectionReader collectionReader =
-        embeddedOptimizeExtension.getBean(CollectionReader.class);
-    final UserIdMigrationRepository repository =
-        embeddedOptimizeExtension.getBean(UserIdMigrationRepository.class);
-
-    final String collectionId =
+    // given (concurrent logins for the same old user ID migrate only once) — old ID
+    // reintroduced via a fresh entity
+    final String dedupCollectionId =
         collectionWriter
             .createNewCollectionAndReturnId(
                 OLD_USER_ID, new PartialCollectionDefinitionRequestDto("Dedup Test"))
@@ -229,10 +214,12 @@ public class UserIdMigrationIT extends AbstractCCSMIT {
           }
         };
 
-    final UserIdMigrationService service = new UserIdMigrationService(countingRepository);
-    service.migrateUserIdIfNeeded(NEW_USER_ID, OLD_USER_ID);
-    service.migrateUserIdIfNeeded(NEW_USER_ID, OLD_USER_ID);
+    // when (concurrent logins for the same old user ID migrate only once)
+    final UserIdMigrationService dedupService = new UserIdMigrationService(countingRepository);
+    dedupService.migrateUserIdIfNeeded(NEW_USER_ID, OLD_USER_ID);
+    dedupService.migrateUserIdIfNeeded(NEW_USER_ID, OLD_USER_ID);
 
+    // then (concurrent logins for the same old user ID migrate only once)
     given()
         .timeout(30, SECONDS)
         .pollInterval(200, MILLISECONDS)
@@ -240,7 +227,7 @@ public class UserIdMigrationIT extends AbstractCCSMIT {
             () -> {
               databaseIntegrationTestExtension.refreshAllOptimizeIndices();
               assertThat(repository.hasDocumentsWithUserId(OLD_USER_ID)).isFalse();
-              assertThat(collectionReader.getCollection(collectionId).orElseThrow().getOwner())
+              assertThat(collectionReader.getCollection(dedupCollectionId).orElseThrow().getOwner())
                   .isEqualTo(NEW_USER_ID);
             });
 

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/variable/PublicApiVariableLabelsIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/variable/PublicApiVariableLabelsIT.java
@@ -37,95 +37,101 @@ public class PublicApiVariableLabelsIT extends AbstractCCSMIT {
   }
 
   @Test
-  public void shouldReturn400WithFieldNameWhenDefinitionKeyIsNull() {
-    // given
-    final DefinitionVariableLabelsDto request = new DefinitionVariableLabelsDto(null, List.of());
+  public void shouldReturn400And404ForInvalidDefinitionKeysAnd200ForValidRequestAndDefinition() {
+    // Covers four independent validation/lookup scenarios: null definitionKey rejected with
+    // 400, blank definitionKey rejected with 400, a valid request against an existing
+    // definition succeeds with 200, and a well-formed but non-existent definitionKey is
+    // rejected with 404. Each scenario is fully independent (distinct definitionKey/request),
+    // so no reset is needed between them.
 
-    // when
-    final Response response =
-        embeddedOptimizeExtension
-            .getRequestExecutor()
-            .buildModifyVariableLabelsRequest(request)
-            .withBearerToken(TEST_ACCESS_TOKEN)
-            .execute();
+    // given (null definitionKey)
+    {
+      final DefinitionVariableLabelsDto request = new DefinitionVariableLabelsDto(null, List.of());
 
-    // then
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-    final ErrorResponseDto errorResponse = response.readEntity(ErrorResponseDto.class);
-    assertThat(errorResponse.getErrorCode()).isEqualTo(BAD_REQUEST_ERROR_CODE);
-    assertThat(errorResponse.getDetailedMessage()).contains("definitionKey");
-  }
+      // when (null definitionKey)
+      final Response response =
+          embeddedOptimizeExtension
+              .getRequestExecutor()
+              .buildModifyVariableLabelsRequest(request)
+              .withBearerToken(TEST_ACCESS_TOKEN)
+              .execute();
 
-  @Test
-  public void shouldReturn400WithFieldNameWhenDefinitionKeyIsBlank() {
-    // given
-    final DefinitionVariableLabelsDto request = new DefinitionVariableLabelsDto("  ", List.of());
+      // then (null definitionKey)
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+      final ErrorResponseDto errorResponse = response.readEntity(ErrorResponseDto.class);
+      assertThat(errorResponse.getErrorCode()).isEqualTo(BAD_REQUEST_ERROR_CODE);
+      assertThat(errorResponse.getDetailedMessage()).contains("definitionKey");
+    }
 
-    // when
-    final Response response =
-        embeddedOptimizeExtension
-            .getRequestExecutor()
-            .buildModifyVariableLabelsRequest(request)
-            .withBearerToken(TEST_ACCESS_TOKEN)
-            .execute();
+    // given (blank definitionKey)
+    {
+      final DefinitionVariableLabelsDto request = new DefinitionVariableLabelsDto("  ", List.of());
 
-    // then
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-    final ErrorResponseDto errorResponse = response.readEntity(ErrorResponseDto.class);
-    assertThat(errorResponse.getErrorCode()).isEqualTo(BAD_REQUEST_ERROR_CODE);
-    assertThat(errorResponse.getDetailedMessage()).contains("definitionKey");
-  }
+      // when (blank definitionKey)
+      final Response response =
+          embeddedOptimizeExtension
+              .getRequestExecutor()
+              .buildModifyVariableLabelsRequest(request)
+              .withBearerToken(TEST_ACCESS_TOKEN)
+              .execute();
 
-  @Test
-  public void shouldReturn200WhenRequestIsValid() {
-    // given
-    final String definitionKey = "my-process";
-    embeddedOptimizeExtension
-        .getBean(ProcessDefinitionWriter.class)
-        .importProcessDefinitions(
-            List.of(
-                ProcessDefinitionOptimizeDto.builder()
-                    .id("my-process:1")
-                    .key(definitionKey)
-                    .version("1")
-                    .name(definitionKey)
-                    .bpmn20Xml("<definitions/>")
-                    .build()));
-    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+      // then (blank definitionKey)
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+      final ErrorResponseDto errorResponse = response.readEntity(ErrorResponseDto.class);
+      assertThat(errorResponse.getErrorCode()).isEqualTo(BAD_REQUEST_ERROR_CODE);
+      assertThat(errorResponse.getDetailedMessage()).contains("definitionKey");
+    }
 
-    final LabelDto label = new LabelDto("book availability", "bookAvailable", VariableType.BOOLEAN);
-    final DefinitionVariableLabelsDto request =
-        new DefinitionVariableLabelsDto(definitionKey, List.of(label));
+    // given (valid request against an existing definition)
+    {
+      final String definitionKey = "my-process";
+      embeddedOptimizeExtension
+          .getBean(ProcessDefinitionWriter.class)
+          .importProcessDefinitions(
+              List.of(
+                  ProcessDefinitionOptimizeDto.builder()
+                      .id("my-process:1")
+                      .key(definitionKey)
+                      .version("1")
+                      .name(definitionKey)
+                      .bpmn20Xml("<definitions/>")
+                      .build()));
+      databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
-    // when
-    final Response response =
-        embeddedOptimizeExtension
-            .getRequestExecutor()
-            .buildModifyVariableLabelsRequest(request)
-            .withBearerToken(TEST_ACCESS_TOKEN)
-            .execute();
+      final LabelDto label =
+          new LabelDto("book availability", "bookAvailable", VariableType.BOOLEAN);
+      final DefinitionVariableLabelsDto request =
+          new DefinitionVariableLabelsDto(definitionKey, List.of(label));
 
-    // then
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
-  }
+      // when (valid request against an existing definition)
+      final Response response =
+          embeddedOptimizeExtension
+              .getRequestExecutor()
+              .buildModifyVariableLabelsRequest(request)
+              .withBearerToken(TEST_ACCESS_TOKEN)
+              .execute();
 
-  @Test
-  public void shouldReturn404WhenDefinitionKeyIsValidButDefinitionDoesNotExist() {
-    // given
-    final DefinitionVariableLabelsDto request =
-        new DefinitionVariableLabelsDto("nonexistent-process", List.of());
+      // then (valid request against an existing definition)
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+    }
 
-    // when — validation passes, service throws NotFoundException
-    final Response response =
-        embeddedOptimizeExtension
-            .getRequestExecutor()
-            .buildModifyVariableLabelsRequest(request)
-            .withBearerToken(TEST_ACCESS_TOKEN)
-            .execute();
+    // given (definitionKey valid but definition does not exist)
+    {
+      final DefinitionVariableLabelsDto request =
+          new DefinitionVariableLabelsDto("nonexistent-process", List.of());
 
-    // then
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
-    final ErrorResponseDto errorResponse = response.readEntity(ErrorResponseDto.class);
-    assertThat(errorResponse.getErrorCode()).isEqualTo(NOT_FOUND_ERROR_CODE);
+      // when — validation passes, service throws NotFoundException
+      final Response response =
+          embeddedOptimizeExtension
+              .getRequestExecutor()
+              .buildModifyVariableLabelsRequest(request)
+              .withBearerToken(TEST_ACCESS_TOKEN)
+              .execute();
+
+      // then (definitionKey valid but definition does not exist)
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+      final ErrorResponseDto errorResponse = response.readEntity(ErrorResponseDto.class);
+      assertThat(errorResponse.getErrorCode()).isEqualTo(NOT_FOUND_ERROR_CODE);
+    }
   }
 }


### PR DESCRIPTION
## Summary

CCSM (self-managed Zeebe) integration tests each restart a real Docker Zeebe broker container and wipe all Zeebe export/Optimize data per `@Test` method, via `AbstractCCSMIT`/`ZeebeExtension`. That per-method restart is the dominant cost of the CCSM CI job (currently 45-55 minutes), measured at roughly 10.4s of overhead per test method (CI-vs-CI comparison across recent runs).

This merges sibling `@Test` methods that assert independent things within the same test class into single methods, cutting one container-restart/data-wipe cycle per merge with no change in what's covered. Each merged scenario keeps its own given/when/then block; a manual reset (delete Zeebe records, delete Optimize data, refresh indices) between blocks stands in for the `@BeforeEach`/`@AfterEach` cycle that used to run between separate test methods. Scenarios that mutate shared `ConfigurationService` state are placed last in their merged method, since nothing resets that state within one method.

One `ZeebeIncidentImportIT` file has a helper (`createIncident`/`resolveIncident`) that looks up exported incident records without filtering by process instance key — merging is only safe there because of the reset between blocks, called out in that commit specifically.

`JwtDecoderIT` gets a small unrelated fix: `decoderProvider()` had an exact duplicate `Arguments.of("SaaS", "publicApiJwtDecoder")` entry, running one parameterized case twice for no added coverage.

- 65 test methods reduced to 27 across `ZeebeUserTaskImportIT`, `ZeebeProcessInstanceImportIT`, `ZeebeVariableCreationImportIT`, `ZeebeVariableUpdateImportIT`, `ZeebeProcessDefinitionImportIT`, `ZeebePositionBasedImportIndexIT`, `UserIdMigrationIT`, `PublicApiVariableLabelsIT`, `ZeebeIncidentImportIT` (38 fewer methods, 38 fewer setup/teardown cycles)
- Estimated CI savings: ~38 × 10.4s ≈ 6.6 minutes off the CCSM job
- `stable/8.9` and `main` already use an embedded, class-scoped Zeebe broker (no per-method container restart), so this same merge only yields noise-level savings there — this PR targets `stable/8.8` only. `stable/8.7` shares the same per-method container-restart architecture and is a plausible follow-up backport target.

## Test plan

- [x] Each modified file individually verified against a real Docker Zeebe broker (`./mvnw verify -pl optimize/backend -Dit.test=<Class> -Pccsm-it -Dskip.docker`) — all passing, pre-existing version-gated skips unchanged
- [x] Full `ccsm-test` group run locally against real Docker: 84 tests, 0 failures, 0 errors, 7 skipped (pre-existing), ~10 min wall clock
- [x] Adversarial review pass (fresh subagent, no prior context, instructed to refute the change) — no surviving findings after verification
- [ ] CI run on this PR to confirm the measured wall-clock reduction on the actual CCSM job