### PR TITLE
test: assert Operate version-sort tie rows in a single poll

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
@@ -142,6 +142,22 @@ test.describe('Process Instances Table', () => {
         .toContain(instanceIds[2].toString());
     });
 
+    const versionOneKeys = [
+      instanceIds[0].toString(),
+      instanceIds[1].toString(),
+    ];
+    // Reads both version-1 rows in one pass and returns the expected keys
+    // found in them, so the pair is matched against a single table state.
+    const versionOneKeysInRows =
+      (first: number, second: number) => async () => {
+        const rowsText = `${await operateProcessesPage.processInstancesTable
+          .nth(first)
+          .innerText()}\n${await operateProcessesPage.processInstancesTable
+          .nth(second)
+          .innerText()}`;
+        return versionOneKeys.filter((key) => rowsText.includes(key));
+      };
+
     await test.step('Check sorting of processes by process version DESC', async () => {
       await operateProcessesPage.clickVersionSortButton();
       // Version 2 sorts to the top. The two version-1 rows follow, but their
@@ -155,36 +171,14 @@ test.describe('Process Instances Table', () => {
           operateProcessesPage.processInstancesTable.nth(0).innerText(),
         )
         .toContain(instanceIds[2].toString());
-      const versionOneRowsText = async () =>
-        `${await operateProcessesPage.processInstancesTable
-          .nth(1)
-          .innerText()}\n${await operateProcessesPage.processInstancesTable
-          .nth(2)
-          .innerText()}`;
-      await expect
-        .poll(versionOneRowsText)
-        .toContain(instanceIds[0].toString());
-      await expect
-        .poll(versionOneRowsText)
-        .toContain(instanceIds[1].toString());
+      await expect.poll(versionOneKeysInRows(1, 2)).toEqual(versionOneKeys);
     });
 
     await test.step('Check sorting of processes by process version ASC', async () => {
       await operateProcessesPage.clickVersionSortButton();
       // The two version-1 rows come first (tie broken by instance key, order
       // not guaranteed on a multi-partition cluster), then version 2 last.
-      const versionOneRowsText = async () =>
-        `${await operateProcessesPage.processInstancesTable
-          .nth(0)
-          .innerText()}\n${await operateProcessesPage.processInstancesTable
-          .nth(1)
-          .innerText()}`;
-      await expect
-        .poll(versionOneRowsText)
-        .toContain(instanceIds[0].toString());
-      await expect
-        .poll(versionOneRowsText)
-        .toContain(instanceIds[1].toString());
+      await expect.poll(versionOneKeysInRows(0, 1)).toEqual(versionOneKeys);
       await expect
         .poll(() =>
           operateProcessesPage.processInstancesTable.nth(2).innerText(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
@@ -146,15 +146,15 @@ test.describe('Process Instances Table', () => {
       instanceIds[0].toString(),
       instanceIds[1].toString(),
     ];
-    // Reads both version-1 rows in one pass and returns the expected keys
-    // found in them, so the pair is matched against a single table state.
+    // allInnerTexts() reads every row in one DOM evaluation, so the two rows
+    // are sampled from a single table state. It also returns whatever rows
+    // exist instead of throwing while one is still detached — a throwing
+    // generator aborts expect.poll instead of being retried.
     const versionOneKeysInRows =
       (first: number, second: number) => async () => {
-        const rowsText = `${await operateProcessesPage.processInstancesTable
-          .nth(first)
-          .innerText()}\n${await operateProcessesPage.processInstancesTable
-          .nth(second)
-          .innerText()}`;
+        const rows =
+          await operateProcessesPage.processInstancesTable.allInnerTexts();
+        const rowsText = `${rows[first] ?? ''}\n${rows[second] ?? ''}`;
         return versionOneKeys.filter((key) => rowsText.includes(key));
       };
 
@@ -171,14 +171,18 @@ test.describe('Process Instances Table', () => {
           operateProcessesPage.processInstancesTable.nth(0).innerText(),
         )
         .toContain(instanceIds[2].toString());
-      await expect.poll(versionOneKeysInRows(1, 2)).toEqual(versionOneKeys);
+      await expect
+        .poll(versionOneKeysInRows(1, 2), defaultAssertionOptions)
+        .toEqual(versionOneKeys);
     });
 
     await test.step('Check sorting of processes by process version ASC', async () => {
       await operateProcessesPage.clickVersionSortButton();
       // The two version-1 rows come first (tie broken by instance key, order
       // not guaranteed on a multi-partition cluster), then version 2 last.
-      await expect.poll(versionOneKeysInRows(0, 1)).toEqual(versionOneKeys);
+      await expect
+        .poll(versionOneKeysInRows(0, 1), defaultAssertionOptions)
+        .toEqual(versionOneKeys);
       await expect
         .poll(() =>
           operateProcessesPage.processInstancesTable.nth(2).innerText(),


### PR DESCRIPTION
## Description

[Successful run](https://github.com/camunda/camunda/actions/runs/30984910644) ✅ 
Follow-up to review feedback on #59431 ([comment](https://github.com/camunda/camunda/pull/59431#discussion_r3718478304)).

#59431 made the version-sort assertions independent of the version-1 tie order by checking the combined text of the two version-1 rows. It did so with **two separate `expect.poll(...)` calls** over that same row pair. Each `expect.poll` samples the page independently, so nothing guarantees both keys are present in those rows *at the same moment* — a transient table state can satisfy one poll and a later state the other.

This is not only theoretical for the **version ASC** step: it runs right after version DESC, where the table is `[v2, v1, v1]`. The first poll (`rows 0-1 contain instanceIds[0]`) can therefore be satisfied by the **pre-sort** table, whose rows 0-1 are the version-2 row plus one version-1 row. Only the subsequent assertions observe the sorted state.

### Change

Sample the rows in a single poll and compare the *set* of expected keys found against the expected pair:

```ts
const versionOneKeysInRows = (first: number, second: number) => async () => {
  const rows = await operateProcessesPage.processInstancesTable.allInnerTexts();
  const rowsText = `${rows[first] ?? ''}\n${rows[second] ?? ''}`;
  return versionOneKeys.filter((key) => rowsText.includes(key));
};

await expect
  .poll(versionOneKeysInRows(1, 2), defaultAssertionOptions)
  .toEqual(versionOneKeys);
```

`filter` preserves the order of the *expected* array, not the table order, so the assertion stays tie-order independent — the property #59431 introduced — while now being evaluated atomically. A failure also reports which key was missing instead of a bare "did not contain".

Two details, both raised in review on this PR:

- **`allInnerTexts()` rather than two `nth().innerText()` calls.** Two `innerText()` calls are two round-trips and the table can re-render between them; `allInnerTexts()` is a single `$$eval` over all rows, so both rows come from one DOM evaluation. It also returns the rows that currently exist instead of waiting and throwing on a detached row — which matters because `expect.poll` invokes its generator *outside* the retry `try/catch` ([`pollMatcher`](https://github.com/microsoft/playwright/blob/main/packages/playwright/src/matchers/expect.ts)), so a throwing generator aborts the poll rather than being retried.
- **Explicit polling budget.** Collapsing two polls into one halves the worst-case wait for this condition (2 × the 10s configured `expect.timeout`, now 1×), so the combined polls pass `defaultAssertionOptions` to keep the budget at least as large as before. The surrounding assertions are unchanged.

The unique version-2 row is still pinned to its expected position.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Follow-up to #59431

## Verification

- `npx prettier --check` clean
- `npx eslint` clean (0 errors; only the pre-existing `no-wait-for-timeout` warning elsewhere in the file)
- `npx tsc --noEmit -p tsconfig.json` reports no error in this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)