### PR TITLE
refactor: delegate resource-fetch tenant resolution to CslTenantCheck

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -447,13 +447,7 @@ public final class EngineProcessors {
         keyGenerator, typedRecordProcessors, writers, securityConfig, config);
 
     addResourceFetchProcessors(
-        typedRecordProcessors,
-        writers,
-        processingState,
-        permissionsBehavior,
-        claimsConverter,
-        securityConfig,
-        config);
+        typedRecordProcessors, writers, processingState, permissionsBehavior, tenantCheck, config);
 
     BatchOperationSetupProcessors.addBatchOperationProcessors(
         keyGenerator,
@@ -853,12 +847,10 @@ public final class EngineProcessors {
       final Writers writers,
       final ProcessingState processingState,
       final PermissionsBehavior permissionsBehavior,
-      final LazyTokenClaimsConverter claimsConverter,
-      final EngineSecurityConfig securityConfig,
+      final CslTenantCheck tenantCheck,
       final EngineConfiguration config) {
     final var resourceFetchProcessor =
-        new ResourceFetchProcessor(
-            writers, processingState, permissionsBehavior, claimsConverter, securityConfig);
+        new ResourceFetchProcessor(writers, processingState, permissionsBehavior, tenantCheck);
     typedRecordProcessors.onCommand(
         ValueType.RESOURCE, ResourceIntent.FETCH, resourceFetchProcessor);
     // Migration to reexport resources to secondary storage

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchProcessor.java
@@ -7,11 +7,9 @@
  */
 package io.camunda.zeebe.engine.processing.resource;
 
-import io.camunda.security.configuration.EngineSecurityConfig;
-import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.core.authz.TenantAccess;
-import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.identity.authorization.exception.ForbiddenException;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -30,8 +28,6 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -43,23 +39,20 @@ public class ResourceFetchProcessor implements TypedRecordProcessor<ResourceReco
   private final ResourceState resourceState;
   private final TenantState tenantState;
   private final PermissionsBehavior permissionsBehavior;
-  private final LazyTokenClaimsConverter claimsConverter;
-  private final EngineSecurityConfig securityConfig;
+  private final CslTenantCheck tenantCheck;
 
   public ResourceFetchProcessor(
       final Writers writers,
       final ProcessingState processingState,
       final PermissionsBehavior permissionsBehavior,
-      final LazyTokenClaimsConverter claimsConverter,
-      final EngineSecurityConfig securityConfig) {
+      final CslTenantCheck tenantCheck) {
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     stateWriter = writers.state();
     resourceState = processingState.getResourceState();
     tenantState = processingState.getTenantState();
     this.permissionsBehavior = permissionsBehavior;
-    this.claimsConverter = claimsConverter;
-    this.securityConfig = securityConfig;
+    this.tenantCheck = tenantCheck;
   }
 
   @Override
@@ -106,7 +99,7 @@ public class ResourceFetchProcessor implements TypedRecordProcessor<ResourceReco
 
   private Optional<PersistedResource> findResource(
       final TypedRecord<ResourceRecord> command, final long resourceKey) {
-    final var authorizedTenants = determineAuthorizedTenants(command);
+    final var authorizedTenants = tenantCheck.resolveAuthorizedTenants(command.getAuthorizations());
     return authorizedTenants.wildcard()
         ? findResourceForAnonymouslyAuthorizedTenants(resourceKey)
         : findResourceForAuthenticatedAuthorizedTenants(resourceKey, authorizedTenants);
@@ -142,24 +135,6 @@ public class ResourceFetchProcessor implements TypedRecordProcessor<ResourceReco
           return true;
         });
     return Optional.ofNullable(resource.get());
-  }
-
-  private TenantAccess determineAuthorizedTenants(final TypedRecord<?> command) {
-    final var authorizations = command.getAuthorizations();
-    if (Boolean.TRUE.equals(authorizations.get(Authorization.AUTHORIZED_ANONYMOUS_USER))) {
-      return TenantAccess.wildcard(List.of());
-    }
-    if (!securityConfig.isMultiTenancyChecksEnabled()) {
-      return TenantAccess.allowed(List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
-    }
-    if (authorizations.get(Authorization.AUTHORIZED_USERNAME) == null
-        && authorizations.get(Authorization.AUTHORIZED_CLIENT_ID) == null) {
-      return TenantAccess.allowed(List.of());
-    }
-    final var authentication = claimsConverter.convert(authorizations);
-    final var tenantIds =
-        Objects.requireNonNullElse(authentication.authenticatedTenantIds(), List.<String>of());
-    return TenantAccess.allowed(tenantIds);
   }
 
   private void checkAuthorization(


### PR DESCRIPTION
## Summary
- `ResourceFetchProcessor` reimplemented the exact 4-branch tenant-resolution
  policy (anonymous -> wildcard, multi-tenancy off -> default tenant, no
  principal -> empty allowed, else -> claims-resolved) that `CslTenantCheck`
  already encapsulates, instead of delegating to it.
- Confirmed `claimsConverter.convert(...)` (used by the old inline logic) and
  `claimsConverter.resolve(...)` (used by `CslTenantCheck`) are the same code
  path — `resolve()` is a one-line bytecode delegate to `convert()` — so this
  is a behavior-preserving consolidation, not just a structural refactor.
- Threads the `CslTenantCheck` instance PR #59396 already constructs once in
  `EngineProcessors` into `ResourceFetchProcessor` as well, replacing its
  separate `LazyTokenClaimsConverter` + `EngineSecurityConfig` parameters —
  the same pattern #59396 uses for `ResourceDeletionDeleteProcessor`.
- Based on `refactor/csl-tenant-check-call-sites` (#59396) since this reuses
  the `tenantCheck` wiring that PR introduces; will retarget to `main` once
  #59396 merges.

Relates to https://github.com/camunda/camunda-security-library/issues/592 (cross-repo issue, closing manually
once this and the tenant-provider-relocation follow-up both land — this PR
addresses only the tenant-resolution-duplication half).

## Test plan
- [x] `./mvnw install -Dquickly -T1C` (baseline)
- [x] `./mvnw verify -pl zeebe/engine -DskipTests=false -DskipITs -Dquickly` — no
      dedicated `ResourceFetchProcessorTest` exists; verified via the module's
      existing tenant-aware coverage: `TenantAwareResourceFetchTest`,
      `ResourceFetchAuthorizationTest`, `ResourceFetchTest`, all green
- [x] `./mvnw verify -pl qa/archunit-tests -Dtest=AuthorizationArchTest -DskipTests=false -DskipITs -Dquickly`
      (parity with #59396's test plan — unaffected, `ResourceFetchProcessor`
      still delegates RBAC to `PermissionsBehavior`, unchanged by this diff)
- [x] `./mvnw license:format spotless:apply -T1C`
