### PR TITLE
fix: validate initial admin requests before checking existing users

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/known-failing-tests.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/known-failing-tests.json
@@ -312,26 +312,6 @@
       "reason": "#59378 - getUsageMetrics binds tenantId as a plain String and passes it straight to UsageMetricsFilter, so the TenantId pattern (^(<default>|[\\w\\.\\-]{1,31})$) is never checked and the request succeeds with a 200. Previously masked by #58948: the scenario sent no query string at all, so its 400 came from the missing required startTime/endTime"
     },
     {
-      "describe": "Setup Validation API Tests",
-      "title": "createAdminUser - Missing password (#1)",
-      "reason": "createAdminUser body validation reorder (28d20717880f) is incomplete"
-    },
-    {
-      "describe": "Setup Validation API Tests",
-      "title": "createAdminUser - Missing password (#2)",
-      "reason": "createAdminUser body validation reorder (28d20717880f) is incomplete"
-    },
-    {
-      "describe": "Setup Validation API Tests",
-      "title": "createAdminUser - Missing username",
-      "reason": "createAdminUser body validation reorder (28d20717880f) is incomplete"
-    },
-    {
-      "describe": "Setup Validation API Tests",
-      "title": "createAdminUser - Missing combo username,password",
-      "reason": "createAdminUser body validation reorder (28d20717880f) is incomplete"
-    },
-    {
       "describe": "Tenants Validation API Tests",
       "title": "assignGroupToTenant - Path param groupId length-min violation",
       "reason": "empty trailing path segment never reaches the controller (resolves as a static-resource 404 in Spring MVC before validation runs) - routing-level fix needed, not a validator fix"

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/tests/request-validation/setup-validation-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/tests/request-validation/setup-validation-api-tests.spec.ts
@@ -79,8 +79,7 @@ test.describe('Setup Validation API Tests', () => {
     //   }
     expect(res.status()).toBe(400);
   });
-  // Known failing (see known-failing-tests.json): createAdminUser body validation reorder (28d20717880f) is incomplete
-  test.skip('createAdminUser - Missing password (#1)', async ({request}) => {
+  test('createAdminUser - Missing password (#1)', async ({request}) => {
     const requestBody = {
       username: null,
     };
@@ -94,8 +93,7 @@ test.describe('Setup Validation API Tests', () => {
     //   }
     expect(res.status()).toBe(400);
   });
-  // Known failing (see known-failing-tests.json): createAdminUser body validation reorder (28d20717880f) is incomplete
-  test.skip('createAdminUser - Missing password (#2)', async ({request}) => {
+  test('createAdminUser - Missing password (#2)', async ({request}) => {
     const requestBody = {
       username: 'x',
     };
@@ -109,8 +107,7 @@ test.describe('Setup Validation API Tests', () => {
     //   }
     expect(res.status()).toBe(400);
   });
-  // Known failing (see known-failing-tests.json): createAdminUser body validation reorder (28d20717880f) is incomplete
-  test.skip('createAdminUser - Missing username', async ({request}) => {
+  test('createAdminUser - Missing username', async ({request}) => {
     const requestBody = {
       password: 'x',
     };
@@ -134,8 +131,7 @@ test.describe('Setup Validation API Tests', () => {
     //   }
     expect(res.status()).toBe(400);
   });
-  // Known failing (see known-failing-tests.json): createAdminUser body validation reorder (28d20717880f) is incomplete
-  test.skip('createAdminUser - Missing combo username,password', async ({
+  test('createAdminUser - Missing combo username,password', async ({
     request,
   }) => {
     const requestBody = {};

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupController.java
@@ -19,6 +19,7 @@ import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.security.validation.IdentifierValidator;
 import io.camunda.security.validation.UserValidator;
+import io.camunda.service.UserServices.UserDTO;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.registry.ServiceRegistry;
@@ -70,6 +71,15 @@ public class SetupController {
           GatewayErrorMapper.mapErrorToProblem(exception));
     }
 
+    return userMapper
+        .toUserRequest(request)
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            dto -> createInitialAdminUser(physicalTenantId, dto));
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> createInitialAdminUser(
+      final String physicalTenantId, final UserDTO dto) {
     final var anonymousAuth = authenticationProvider.getAnonymousCamundaAuthentication();
     if (serviceRegistry
         .roleServices(physicalTenantId)
@@ -79,17 +89,12 @@ public class SetupController {
           GatewayErrorMapper.mapErrorToProblem(exception));
     }
 
-    return userMapper
-        .toUserRequest(request)
-        .fold(
-            RestErrorMapper::mapProblemToCompletedResponse,
-            dto ->
-                RequestExecutor.executeServiceMethod(
-                    () ->
-                        serviceRegistry
-                            .userServices(physicalTenantId)
-                            .createInitialAdminUser(dto, anonymousAuth),
-                    ResponseMapper::toUserCreateResponse,
-                    HttpStatus.CREATED));
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            serviceRegistry
+                .userServices(physicalTenantId)
+                .createInitialAdminUser(dto, anonymousAuth),
+        ResponseMapper::toUserCreateResponse,
+        HttpStatus.CREATED);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupControllerTest.java
@@ -172,6 +172,27 @@ class SetupControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldRejectUserCreationWithMissingUsernameWhenAdminUserExists() {
+    // given
+    final var request = Map.of("password", "zabraboof", "name", "Foo Bar", "email", "bar@baz.com");
+    whenAdminUserExists();
+
+    // when then
+    assertRequestRejectedExceptionally(
+        request,
+        """
+            {
+              "type": "about:blank",
+              "status": 400,
+              "title": "INVALID_ARGUMENT",
+              "detail": "No username provided.",
+              "instance": "%s"
+            }"""
+            .formatted(USER_PATH));
+    verifyNoInteractions(userServices);
+  }
+
+  @Test
   void shouldRejectUserCreationWithMissingUsername() {
     // given
     final var request = Map.of("password", "zabraboof", "name", "Foo Bar", "email", "bar@baz.com");


### PR DESCRIPTION
## Description

Malformed `POST /v2/setup/user` requests returned the existing-admin error when an admin user was
already present because role membership was checked before the request body was validated.

This change validates and maps the request first. Invalid bodies now consistently return `400 Bad
Request`; valid requests continue to check for an existing admin before creating the initial user.
A regression test covers the ordering, and the four generated request-validation cases for missing
credentials are enabled again.

The generated setup validation spec was synchronized after removing the four known-failing entries.

TestRail suite: [C8 Orchestration Cluster](https://camunda.testrail.com/index.php?/suites/view/17050)

## Testing

- `npm run generate:raw -- --deep --only-operations=createAdminUser`
- `npm run format && npm run lint:generated`
- `npm run lint`
- `./mvnw license:format spotless:apply -T1C`
- `./mvnw verify -pl zeebe/gateway-rest -DskipTests=false -Dquickly -T1C`
- `./mvnw install -Dquickly -T1C`

## Checklist

- [ ] Maintainer: add `backport stable/8.9` and `backport stable/8.8`.
- [ ] Run the C8 Orchestration Cluster E2E on-demand workflow before requesting review.

## Related issues

Closes #58946
