### PR TITLE
ci: post AlwaysGreen failure feedback for SaaS E2E failures

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -764,6 +764,12 @@ jobs:
     timeout-minutes: 35
     continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: { }
+    # Surfaced for the same reason as helm-deploy-status: a SaaS-only failure must
+    # still give alwaysgreen-triage a thread parent, otherwise one failure produces
+    # two unrelated top-level Slack messages.
+    outputs:
+      slack_ts: ${{ steps.feedback.outputs.slack_ts }}
+      slack_channel: ${{ steps.feedback.outputs.slack_channel }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1085,7 +1091,95 @@ jobs:
           path: ${{ runner.temp }}/alwaysgreen-saas-category.json
           retention-days: 14
 
+      # Standardised AlwaysGreen feedback, same contract as helm-deploy-status:
+      # Verdict/Evidence/Next-steps to the job summary, the PR (upserted) and Slack.
+      # Until this ran, a SaaS failure reached the author only as a check-run on the
+      # tested commit -- which on a push run is the merge commit, not part of the PR.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: failure()
+        with:
+          node-version: "24"
+      - name: Import Slack token
+        id: slack-secrets
+        if: failure()
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_CORE_DOMAIN_BOT_TOKEN;
+      # downstream-category speaks the ci-failure-categories.md vocabulary
+      # (infrastructure / product / mixed / unknown_artifact_unreachable); the
+      # feedback action speaks the CI Failure Feedback Standard's enum. Translate
+      # rather than passing through, or every message renders as "Needs triage".
+      - name: Map downstream category to feedback category
+        id: map-category
+        if: failure()
+        env:
+          DOWNSTREAM_CATEGORY: ${{ steps.downstream-category.outputs.downstream_category }}
+          DOWNSTREAM_OWNER: ${{ steps.downstream-category.outputs.downstream_owner }}
+          DOWNSTREAM_URL: ${{ steps.wait-downstream.outputs.downstream_run_url }}
+          DOWNSTREAM_CONCLUSION: ${{ steps.wait-downstream.outputs.downstream_conclusion }}
+        run: |
+          set -euo pipefail
+          case "${DOWNSTREAM_CATEGORY:-}" in
+            infrastructure)                 CATEGORY="test-infra" ;;
+            product)                        CATEGORY="product" ;;
+            # At least one deterministic failure alongside the flakes, so route it
+            # as a real failure -- the flaky count goes in the evidence line.
+            mixed)                          CATEGORY="product" ;;
+            unknown_artifact_unreachable)   CATEGORY="external" ;;
+            # Empty when the dispatch or the wait itself failed and no downstream
+            # run was ever resolved: that is this job's own plumbing.
+            ""|none|unknown|*)              CATEGORY="unknown" ;;
+          esac
 
+          # SaaS E2E is owned end-to-end by test-automation-team, including this
+          # job's dispatch/wait mechanism -- same routing as the failure-context
+          # artifact below. The one exception is an unreachable artifact, which is
+          # a parent-side permissions/integration problem owned by Distribution.
+          OWNER="${DOWNSTREAM_OWNER:-}"
+          if [[ -z "$OWNER" || "$OWNER" == "none" ]]; then
+            OWNER="@camunda/test-automation-team"
+          fi
+
+          if [[ -n "${DOWNSTREAM_URL:-}" ]]; then
+            EVIDENCE="Downstream SaaS E2E run ${DOWNSTREAM_CONCLUSION:-failed} (category: ${DOWNSTREAM_CATEGORY:-unresolved}) — ${DOWNSTREAM_URL}"
+          else
+            EVIDENCE="SaaS E2E dispatch or wait failed before a downstream run could be resolved."
+          fi
+
+          {
+            echo "failure_category=$CATEGORY"
+            echo "owner_team=$OWNER"
+            echo "evidence=$EVIDENCE"
+          } >> "$GITHUB_OUTPUT"
+      - name: Post AlwaysGreen failure feedback
+        id: feedback
+        if: failure()
+        continue-on-error: true
+        uses: ./.github/actions/post-failure-feedback
+        with:
+          failure_category: ${{ steps.map-category.outputs.failure_category || 'unknown' }}
+          stage: saas-e2e
+          owner_team: ${{ steps.map-category.outputs.owner_team || '@camunda/test-automation-team' }}
+          run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          status: failure
+          evidence: ${{ steps.map-category.outputs.evidence || 'SaaS E2E tests failed.' }}
+          pr: ${{ github.event.merge_group.head_ref || github.event.pull_request.number }}
+          # merge_group is never a draft (a draft cannot enter the queue), and a
+          # pull_request event carries its own flag — so the draft gate costs no
+          # API call here and needs no extra token scope.
+          pr_is_draft: ${{ github.event.merge_group && 'false' || github.event.pull_request.draft }}
+          # Existing AlwaysGreen alerting channel (#alwaysgreen-reliability), same
+          # as helm-deploy-status and alwaysgreen-streak-detector.yml.
+          slack_channel: "C0AK0AVKRL0"
+          slack_bot_token: ${{ steps.slack-secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
+          # Same app token the dispatch uses; its installation covers camunda, so
+          # no second token step is needed for the PR comment.
+          github_token: ${{ steps.github-token.outputs.token }}
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -1162,7 +1256,9 @@ jobs:
       # would defeat dedupe.
       base_ref: ${{ github.ref_name }}
       chart_version: ${{ inputs.helmRepositoryDirName || 'camunda-platform-8.10' }}
-      # Empty when the helm stage did not fail, or Slack was unavailable; triage then
-      # posts its own parent message instead of threading.
-      parent_slack_ts: ${{ needs.helm-deploy-status.outputs.slack_ts }}
-      parent_slack_channel: ${{ needs.helm-deploy-status.outputs.slack_channel }}
+      # Whichever stage posted feedback owns the thread. Helm wins when both failed:
+      # an install failure is the more likely root cause of a SaaS failure than the
+      # reverse. Empty when neither stage failed, or Slack was unavailable; triage
+      # then posts its own parent message instead of threading.
+      parent_slack_ts: ${{ needs.helm-deploy-status.outputs.slack_ts || needs.trigger-saas-e2e.outputs.slack_ts }}
+      parent_slack_channel: ${{ needs.helm-deploy-status.outputs.slack_channel || needs.trigger-saas-e2e.outputs.slack_channel }}


### PR DESCRIPTION
## Description

`trigger-saas-e2e` never called `./.github/actions/post-failure-feedback`, so a SaaS-only
failure produced **no PR comment and no feedback Slack message**. The only author-facing
signal was the check-run that `c8-cross-component-e2e-tests` PATCHes onto the tested
commit — which on a `push` run is the *merge commit*, so it is not part of the PR at all.

It also left `alwaysgreen-triage` without a thread parent: `helm-deploy-status` only
exposes `slack_ts` when the **helm** stage itself fails, so a SaaS-only failure fell back
to a second top-level Slack message for the same failure.

Worked example — run [30992674680](https://github.com/camunda/camunda/actions/runs/30992674680):
helm passed, `Trigger SaaS E2E tests` failed. `helm-deploy-status` concluded `success`, so
every `if: failure()` step in it (including the feedback call) was skipped; triage logged
`PARENT_TS:` empty and posted a standalone message. The failing commit `a1b5ac3` is the
merge commit of #59396, whose head is `03a8677f` — so the check-run never appeared in that
PR, and the PR has 0 comments.

### What this changes

- `trigger-saas-e2e` calls `post-failure-feedback` with `stage: saas-e2e`, `if: failure()`,
  `continue-on-error: true` — mirroring the `helm-deploy-status` call site (same pinned
  `setup-node`, same Vault `SLACK_CORE_DOMAIN_BOT_TOKEN`, same `#alwaysgreen-reliability`
  channel `C0AK0AVKRL0`).
- The job exposes `slack_ts` / `slack_channel`, and `alwaysgreen-triage` threads onto
  whichever stage posted: `helm-deploy-status.outputs.slack_ts || trigger-saas-e2e.outputs.slack_ts`.
  Helm wins when both failed — an install failure is the likelier root cause of a SaaS
  failure than the reverse.
- New `map-category` step translates the vocabularies. `downstream-category` already
  computed a category and owner but buried them in the `alwaysgreen-saas-category`
  artifact; those values use the `ci-failure-categories.md` names, while the action's
  `CATALOG` in `feedback.mjs` keys on the CI Failure Feedback Standard enum and silently
  falls through to `unknown`. Without translation every SaaS message would render as
  "Needs triage".

| `downstream_category` | → `failure_category` |
|---|---|
| `infrastructure` | `test-infra` |
| `product` | `product` |
| `mixed` | `product` (≥1 deterministic failure; flaky count goes in evidence) |
| `unknown_artifact_unreachable` | `external` |
| empty / `none` / `unknown` | `unknown` (dispatch or wait failed before a downstream run resolved) |

Owner stays `@camunda/test-automation-team`, matching the existing routing comment that
SaaS is owned end-to-end including this job's dispatch/wait, except
`unknown_artifact_unreachable` where `downstream-category` already routes to
`@camunda/distribution`. Both are in the action's `MEDIC` map, so the subteam ping
resolves. No second app-token step — reuses `steps.github-token.outputs.token` from the
dispatch, whose installation already covers `camunda`.

### Known limitation (not addressed here)

`pr` resolves from `merge_group.head_ref || pull_request.number`, so on **`push`** runs it
is empty and the PR comment is still skipped — there is no PR for the action to attach to.
This PR fixes the Slack/threading half unconditionally and the PR-comment half for
merge-queue and `pull_request` triggers. Resolving the PR from the merge commit for push
runs is a separate change.

### Validation

- `yaml.safe_load` parses; `actionlint` (with `shellcheck` available, so the new `run:`
  block was shell-checked) reports **1 finding on this branch and 1 on the baseline** — the
  same pre-existing `gcp-perf-core-8-default` custom-runner-label warning at line 410. No
  new findings.
- Workflow-only change; no Java/markdown/pom touched, so `spotless`/module builds do not apply.
- End-to-end behavior can only be confirmed by a run where `trigger-saas-e2e` actually
  fails — the steps are `if: failure()`.

### Follow-up

`c8-cross-component-e2e-tests` carries its own copy of `post-failure-feedback`
(`.github/actions/post-failure-feedback/`) with **zero callers** — added 2026-07-01, still
unreferenced, and kept in sync with this repo's copy by
camunda/c8-cross-component-e2e-tests#2933. Now that the parent posts, wiring that copy into
`finalize-check-run` would double-post; it should be deleted in a separate PR.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Relates to camunda/camunda#59386 and camunda/c8-cross-component-e2e-tests#2933 (the draft-PR
gate on the same action).
