### PR TITLE
feat: load-test: deploy PostgreSQL (secondary storage) via the CNPG Operator

### DIFF
--- a/load-tests/setup/charts/load-test-setup/README.md
+++ b/load-tests/setup/charts/load-test-setup/README.md
@@ -13,6 +13,10 @@ This Helm Chart sets up the surrounding infrastructure for a Camunda load test n
   that use Elasticsearch as secondary storage.
 * An optional **[OpenSearch](https://opensearch-project.github.io/helm-charts/)** cluster
   (`opensearch.enabled=true`), for load tests that use OpenSearch as secondary storage.
+* An optional **CNPG-managed PostgreSQL cluster** for Camunda's own secondary storage
+  (`postgresql.enabled=true`), for load tests that use PostgreSQL as secondary storage. See the
+  [PostgreSQL (Camunda secondary storage)](#postgresql-camunda-secondary-storage) section below for
+  details.
 * An optional **Keycloak instance**, backed by its own **PostgreSQL cluster** (`keycloak.enabled`,
   default: `true`). See the [Keycloak](#keycloak) section below for details.
 * An optional **metrics-exporter** deployment to query the report internal
@@ -122,7 +126,7 @@ Either use:
 * A load-test `make clean` command: this explicitly deletes the Keycloak CR and Secrets from the
   `keycloak-operator` namespace before tearing down the load test namespace (see the `clean` target
   in `common.mk`).
-* Delete the resources from the `keycloak-operator` namespace by targetting the specific `namespace`
+* Delete the resources from the `keycloak-operator` namespace by targeting the specific `namespace`
   label with:
 
   ```shell
@@ -147,7 +151,7 @@ Keycloak is backed by PostgreSQL (PG). The PG cluster is deployed using the [Clo
 When a CNPG cluster is created, the CNPG Operator creates the underlying Kubernetes resources
 (non-exhaustive list, see [the doc](https://cloudnative-pg.io/docs/1.30/) for the full details):
 
-1. A dedicated Kubernetes service account: the SA exists in the target namespace and represent the
+1. A dedicated Kubernetes service account: the SA exists in the target namespace and represents the
    Kubernetes identity used by the underlying PG cluster
 2. The Kubernetes RBAC to allow the SA to read its secrets, etc.
 3. New pod(s) to represent the actual PostgreSQL node(s)
@@ -155,3 +159,16 @@ When a CNPG cluster is created, the CNPG Operator creates the underlying Kuberne
 The PG cluster is immediately initialized at creation time using the `bootstrap` mechanism, with a
 single database owned by a single user. This ensures that when the PG cluster starts, it's already
 usable by Keycloak without further provisioning to be done.
+
+## PostgreSQL (Camunda secondary storage)
+
+For load tests that run Camunda with PostgreSQL as secondary storage (`secondary_storage=postgresql`),
+this chart can also deploy a second, independent CNPG-managed PostgreSQL cluster
+(`postgresql.enabled=true`) for Camunda itself — separate from the Keycloak PostgreSQL cluster
+described above.
+
+> [!NOTE]
+> Unlike Keycloak's cluster, this one is entirely self-contained in the load
+> test namespace and doesn't deploy or require resources outside of that
+> namespace (except for the CNPG Operator, indirectly).
+

--- a/load-tests/setup/charts/load-test-setup/templates/_constants.tpl
+++ b/load-tests/setup/charts/load-test-setup/templates/_constants.tpl
@@ -24,7 +24,7 @@ same namespace.
 {{- end -}}
 
 {{/*
-The name of the Kubernetse Secret used to store the Keycloak initial "admin" user.
+The name of the Kubernetes Secret used to store the Keycloak initial "admin" user.
 
 This user has full access on Keycloak and is used by Identity to provision it.
 This secret is stored inside the `keycloak-operator` namespace, and is prefixed
@@ -32,6 +32,13 @@ by the current load test name to prevent collision with other load tests.
 */}}
 {{- define "load-test-setup.keycloak.admin-secret-name" -}}
 {{ printf "%s-admin" .Release.Namespace }}
+{{- end -}}
+
+{{/*
+The name of the Kubernetes Secret used by the CNPG Operator to keep the credentials for the Camunda user in PostgreSQL.
+*/}}
+{{- define "load-test-setup.postgresql.cnpg-secret-name" -}}
+postgresql-camunda-user
 {{- end -}}
 
 {{/* vim: set filetype=gotmpl: */}}

--- a/load-tests/setup/charts/load-test-setup/templates/_helpers.tpl
+++ b/load-tests/setup/charts/load-test-setup/templates/_helpers.tpl
@@ -15,11 +15,11 @@ The input is expected to be a dict with:
 
 The "derivePassword" function is not well documented, by conventions, we use:
 
-* The "counter" input is the same for all the password.
+* The "counter" input is the same for all the passwords.
 * The generated passwords will be "long" passwords: 14 characters with a mix of random characters
 * The "password" input is always set to "secret"
-* The "user" input is the key we generate the input for ; it's not the actual username but something unique across all the users with need
-* The "site" is the name of namespace: this is actually the only "random" value seeded into the password generator. It guarantees that:
+* The "user" input is the key we generate the input for ; it's not the actual username but something unique across all the users that need one
+* The "site" is the name of the namespace: this is actually the only "random" value seeded into the password generator. It guarantees that:
   1. Different namespaces will produce different passwords
   2. The same namespace will produce the same passwords (as long as the other inputs don't change).
 */}}

--- a/load-tests/setup/charts/load-test-setup/templates/postgresql-user.yaml
+++ b/load-tests/setup/charts/load-test-setup/templates/postgresql-user.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.postgresql.enabled -}}
+---
+# Configure the PostgreSQL credentials for the Camunda application (secondary storage).
+# The Secret is used by:
+#
+#   1. The CNPG Operator to configure the password for the "camunda" PostgreSQL role
+#   2. Camunda itself, to connect into the PostgreSQL cluster.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "load-test-setup.postgresql.cnpg-secret-name" . }}
+  annotations:
+    description: |
+      Contains the username/password for the Camunda user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster
+      used for Camunda's secondary storage.
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "{{ .Values.postgresql.database.user | b64enc }}"
+  password: "{{ .Values.postgresql.database.password | b64enc }}"
+{{- end -}}

--- a/load-tests/setup/charts/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/charts/load-test-setup/templates/postgresql.yaml
@@ -1,53 +1,52 @@
-{{- if .Values.keycloak.enabled -}}
+{{- if .Values.postgresql.enabled -}}
 ---
-# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
-#
-# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
-# use PostgreSQL as a secondary storage database!
+# Configure a CNPG-managed PostgreSQL cluster for Camunda secondary storage.
 #
 # Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: {{ .Values.keycloak.postgresql.clusterName }}
+  name: {{ .Values.postgresql.clusterName }}
 spec:
-  description: PostgreSQL cluster for Keycloak and Camunda Identity
+  description: PostgreSQL cluster for Camunda secondary storage
 
   instances: 1
-  {{- with .Values.keycloak.postgresql.image }}
+  {{- with .Values.postgresql.image }}
   imageName: {{ .registry }}/{{ .repository }}:{{ .tag }}
   {{- end }}
 
   resources:
-    {{- toYaml .Values.keycloak.postgresql.resources | nindent 4 }}
+    {{- toYaml .Values.postgresql.resources | nindent 4 }}
 
   storage:
-    {{- toYaml .Values.keycloak.postgresql.storage | nindent 4 }}
+    {{- toYaml .Values.postgresql.storage | nindent 4 }}
 
   affinity:
     nodeSelector:
       topology.kubernetes.io/zone: "{{ .Values.topologyZone }}"
-      {{- toYaml .Values.keycloak.postgresql.nodeSelector | nindent 6 }}
+      {{- toYaml .Values.postgresql.nodeSelector | nindent 6 }}
 
     tolerations:
-      {{- toYaml .Values.keycloak.postgresql.tolerations | nindent 6 }}
+      {{- toYaml .Values.postgresql.tolerations | nindent 6 }}
 
   postgresql:
+    shared_preload_libraries:
+      {{- toYaml .Values.postgresql.shared_preload_libraries | nindent 6 }}
+
     # The PostgreSQL configuration flags.
     parameters:
-      lock_timeout: 30s
-      statement_timeout: "0"
-      #log_statement: all
-      #log_connections: "on"
-      #log_disconnections: "on"
+      {{- toYaml .Values.postgresql.parameters | nindent 6 }}
 
-  # Initialize the Keycloak PostgreSQL cluster with:
+  postgresUID: {{ .Values.postgresql.postgresUID }}
+  postgresGID: {{ .Values.postgresql.postgresGID }}
+
+  # Initialize the Camunda PostgreSQL cluster with:
   #
   # 1. A dedicated user
   # 2. A dedicated database, owned by the user created in 1.
   # 3. The password comes from the specified Kubernetes Secret
   #
-  # The dedicated user will also be used by Keycloak to connect into this
+  # The dedicated user will also be used by Camunda to connect into this
   # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
@@ -62,10 +61,10 @@ spec:
   # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
   bootstrap:
     initdb:
-      database: {{ .Values.keycloak.postgresql.databaseName }}
-      owner: {{ .Values.keycloak.postgresql.databaseUser }}
+      database: {{ .Values.postgresql.database.name }}
+      owner: {{ .Values.postgresql.database.user }}
       secret:
-        name: {{ include "load-test-setup.keycloak.postgresql.cnpg-secret-name" . }}
+        name: {{ include "load-test-setup.postgresql.cnpg-secret-name" . }}
 
   managed:
     services:

--- a/load-tests/setup/charts/load-test-setup/values.yaml
+++ b/load-tests/setup/charts/load-test-setup/values.yaml
@@ -195,8 +195,9 @@ keycloak:
   # We deploy Keycloak using the Keycloak Operator, which is currently limited
   # to managed custom resources in a single namespace only.
   # As such, we **have** to deploy Keycloak in the same namespace as the
-  # Keycloak Operator and we can't simply Keycloak in the load test namespace.
-  # This option allows to configure in which namespace Keycloak will be
+  # Keycloak Operator and we can't simply deploy Keycloak in the load test
+  # namespace.
+  # This option allows configuring in which namespace Keycloak will be
   # managed.
   # This probably should not be changed.
   namespace: keycloak-operator
@@ -352,3 +353,111 @@ prometheus-elasticsearch-exporter:
     # Labels used by the service monitor, specific to our prometheus installation
     labels:
       release: monitoring
+
+# -- Configure the PostgreSQL cluster used by Camunda as secondary storage.
+# If you want to use PostgreSQL as secondary storage for Camunda, you must
+# enable this resource and configure it according to your needs.
+#
+# This cluster is **independent** from the PostgreSQL cluster used by Keycloak,
+# configured via `keycloak.postgresql`.
+postgresql:
+  # -- Set to true to deploy this CNPG-managed PostgreSQL cluster.
+  # Only needed when the load test uses PostgreSQL as secondary storage.
+  enabled: false
+
+  # -- The name of the CNPG Cluster resource deployed for Camunda's secondary storage.
+  # Changing this name will also change the Kubernetes Service deployed by the
+  # CNPG operator, and thus will require to adjust the JDBC URL used to connect
+  # Camunda to PostgreSQL.
+  clusterName: postgresql
+
+  # -- The PostgreSQL CNPG image to be used when creating a CNPG-based
+  # PostgreSQL cluster.
+  image:
+    registry: europe-west1-docker.pkg.dev/camunda-benchmark
+    repository: dockerhub/postgres
+    tag: "18.4"
+
+  # -- The UID and GID used by the PostgreSQL container.
+  # This should match the UID/GID in use by the specified Docker image.
+  postgresUID: 999
+  postgresGID: 999
+
+  # -- CPU and memory resource requests and limits for the PostgreSQL cluster.
+  resources:
+    requests:
+      memory: 8Gi
+      cpu: 3000m
+    limits:
+      cpu: 3000m
+      memory: 12Gi
+
+  # -- Persistent storage configuration for the PostgreSQL cluster.
+  storage:
+    size: 512Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  # -- The PostgreSQL database and user used by Camunda to connect to this cluster.
+  database:
+    # -- The name of the PostgreSQL database created for Camunda.
+    name: camunda
+    # -- The name of the PostgreSQL user Camunda uses to connect to its database.
+    user: camunda
+    # -- The password for the PostgreSQL user used by Camunda. Shared verbatim with
+    # `orchestration.data.secondaryStorage.rdbms.secret.inlineSecret` in the
+    # `camunda-platform-values-rdbms.yaml` values files, independently of the
+    # underlying RDBMS database.
+    password: camunda
+
+  # -- PostgreSQL extensions loaded at server startup.
+  shared_preload_libraries:
+    - pg_stat_statements
+
+  # -- PostgreSQL server configuration parameters (`postgresql.conf`), tuned for the
+  # load test's expected write/update volume.
+  parameters:
+    # WAL Performance Tuning
+    wal_buffers: 128MB
+    max_wal_size: 4GB
+    min_wal_size: 1GB
+    checkpoint_timeout: 20min
+    checkpoint_completion_target: "0.9"
+    wal_writer_delay: 200ms
+    wal_writer_flush_after: 1MB
+
+    # Memory Settings
+    shared_buffers: 2GB
+    effective_cache_size: 7GB
+    work_mem: 32MB
+    maintenance_work_mem: 1GB
+
+    # Autovacuum - Aggressive for high UPDATE/DELETE volume
+    autovacuum_max_workers: "6"
+    autovacuum_naptime: 15s
+    autovacuum_vacuum_scale_factor: "0.03"
+    autovacuum_analyze_scale_factor: "0.02"
+    autovacuum_vacuum_cost_limit: "5000"
+
+    # Monitoring
+    pg_stat_statements.track: all
+    pg_stat_statements.max: "10000"
+    track_io_timing: "on"
+    track_functions: all
+
+    # Logging - default to silent, but keep the values to easily turn them on
+    # during investigations.
+    log_statement: none
+    log_connections: "off"
+    log_disconnections: "off"
+
+  # -- Node selector labels for PostgreSQL pod scheduling.
+  # The top-level `topologyZone` value is also applied as `topology.kubernetes.io/zone`.
+  nodeSelector:
+    component: benchmark-n2-standard-4
+
+  # -- Tolerations applied to PostgreSQL pods.
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule

--- a/load-tests/setup/common.mk
+++ b/load-tests/setup/common.mk
@@ -224,13 +224,7 @@ ifneq ($(install_storage_target),)
 # Install secondary storage based on configuration
 .PHONY: install-storage
 install-storage:
-ifeq ($(secondary_storage),postgresql)
-	@echo "Installing PostgreSQL database for namespace $(namespace)..."
-	# Install Postgres database - configuration provided via camunda-platform-values-defaults.yaml, camunda-platform-values-rdbms.yaml and camunda-platform-values-postgresql.yaml
-	helm upgrade --install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql \
-		--namespace $(namespace) \
-		$(platform_values)
-else ifeq ($(secondary_storage),mysql)
+ifeq ($(secondary_storage),mysql)
 	@echo "Installing MySQL database for namespace $(namespace)..."
 	# Install MySQL database - configuration provided via camunda-platform-values-defaults.yaml, camunda-platform-values-rdbms.yaml and camunda-platform-values-mysql.yaml
 	helm upgrade --install mysql oci://registry-1.docker.io/bitnamicharts/mysql \
@@ -250,8 +244,6 @@ else ifeq ($(secondary_storage),oracle)
 	@echo "Installing Oracle database for namespace $(namespace)..."
 	# Deploy Oracle Free 23c via plain Kubernetes manifests (oracle.yaml) since no maintained public chart is available
 	kubectl apply --namespace $(namespace) -f databases/oracle.yaml
-else
-	@echo "Skipping secondary storage installation (secondary_storage=$(secondary_storage))"
 endif
 endif
 

--- a/load-tests/setup/main/values/camunda-platform-values-postgresql.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-postgresql.yaml
@@ -1,93 +1,10 @@
 ########################################################################################
-################################################### Global cluster configuration
-########################################################################################
-global:
-  postgresql:
-    auth:
-      database: camunda
-      username: camunda
-      password: camunda
-      postgresPassword: camunda
-  # needed to allow the pass-through-cache for postgres images
-  security:
-    allowInsecureImages: true
-
-########################################################################################
 ################################################### Orchestration cluster configuration
 ########################################################################################
 orchestration:
   data:
     secondaryStorage:
       rdbms:
-        url: jdbc:postgresql://postgresql:5432/camunda
-
-###########################################################################
-#
-#    ######  #######  #####  #######  #####  ######  #######  #####
-#    #     # #     # #     #    #    #     # #     # #       #     #
-#    #     # #     # #          #    #       #     # #       #
-#    ######  #     #  #####     #    #  #### ######  #####    #####
-#    #       #     #       #    #    #     # #   #   #             #
-#    #       #     # #     #    #    #     # #    #  #       #     #
-#    #       #######  #####     #     #####  #     # #######  #####
-#
-###########################################################################
-# Use the internal registry mirror to avoid Docker Hub rate limiting in the benchmark cluster
-image:
-  registry: europe-west1-docker.pkg.dev
-  repository: camunda-benchmark/dockerhub/bitnami/postgresql
-  tag: latest
-
-postgresqlSharedPreloadLibraries: pg_stat_statements
-
-primary:
-  resources:
-    requests:
-      memory: 8Gi
-      cpu: 3000m
-    limits:
-      cpu: 3000m
-      memory: 12Gi
-
-  nodeSelector:
-    component: benchmark-n2-standard-4
-    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
-
-  tolerations:
-    - key: nodepool
-      operator: Equal
-      value: n2-standard-4
-      effect: NoSchedule
-
-  persistence:
-    size: 512Gi
-    storageClass: "benchmark-ssd-zonal-v1"
-
-  extendedConfiguration: |-
-    # WAL Performance Tuning
-    wal_buffers = 128MB
-    max_wal_size = 4GB
-    min_wal_size = 1GB
-    checkpoint_timeout = 20min
-    checkpoint_completion_target = 0.9
-    wal_writer_delay = 200ms
-    wal_writer_flush_after = 1MB
-
-    # Memory Settings
-    shared_buffers = 2GB
-    effective_cache_size = 7GB
-    work_mem = 32MB
-    maintenance_work_mem = 1GB
-
-    # Autovacuum - Aggressive for high UPDATE/DELETE volume
-    autovacuum_max_workers = 6
-    autovacuum_naptime = 15s
-    autovacuum_vacuum_scale_factor = 0.03
-    autovacuum_analyze_scale_factor = 0.02
-    autovacuum_vacuum_cost_limit = 5000
-
-    # Monitoring
-    pg_stat_statements.track = all
-    pg_stat_statements.max = 10000
-    track_io_timing = on
-    track_functions = all
+        # The hostname depends on the name of the PostgreSQL cluster deployed
+        # by the load-test-setup Helm Chart.
+        url: jdbc:postgresql://postgresql-rw:5432/camunda

--- a/load-tests/setup/main/values/camunda-platform-values-rdbms.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-rdbms.yaml
@@ -11,8 +11,10 @@ orchestration:
     secondaryStorage:
       type: rdbms
       rdbms:
+        # The username is the same for all the underlying RDBMS databases.
         username: camunda
         secret:
+          # The password is the same for all the underlying RDBMS databases.
           inlineSecret: camunda
 
   # Overriding the extraConfiguration for the Platform chart

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -154,6 +154,8 @@ cp -v  "$VERSION_DIR/values/camunda-platform-values-${secondary_storage}.yaml"  
 # or via Optimize)
 elasticsearchEnabled=false
 opensearchEnabled=false
+postgresqlEnabled=false
+
 # The Elasticsearch/OpenSearch URI for the Prometheus exporter for Elasticsearch.
 es_uri=""
 
@@ -170,6 +172,10 @@ case "$secondary_storage" in
     ;;
   postgresql|mysql|mariadb|mssql|oracle)
     cp -v "$VERSION_DIR/values/camunda-platform-values-rdbms.yaml" "$TARGET_DIRECTORY/"
+
+    if [ "$secondary_storage" = "postgresql" ]; then
+      postgresqlEnabled=true
+    fi
 
     physical_tenants_rdbms_config_file="$VERSION_DIR/values/camunda-platform-two-physical-tenants-shared-rdbms.yaml"
     if [[ -f "$physical_tenants_rdbms_config_file" ]]; then
@@ -314,6 +320,11 @@ EOF
     topology.kubernetes.io/zone: "$availability_zone"
 EOF
   fi
+
+  cat <<EOF
+postgresql:
+  enabled: $postgresqlEnabled
+EOF
 } > load-test-setup-values.yaml
 
 # Add/update helm repositories

--- a/load-tests/setup/stable-89/values/camunda-platform-values-postgresql.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-postgresql.yaml
@@ -1,93 +1,10 @@
 ########################################################################################
-################################################### Global cluster configuration
-########################################################################################
-global:
-  postgresql:
-    auth:
-      database: camunda
-      username: camunda
-      password: camunda
-      postgresPassword: camunda
-  # needed to allow the pass-through-cache for postgres images
-  security:
-    allowInsecureImages: true
-
-########################################################################################
 ################################################### Orchestration cluster configuration
 ########################################################################################
 orchestration:
   data:
     secondaryStorage:
       rdbms:
-        url: jdbc:postgresql://postgresql:5432/camunda
-
-###########################################################################
-#
-#    ######  #######  #####  #######  #####  ######  #######  #####
-#    #     # #     # #     #    #    #     # #     # #       #     #
-#    #     # #     # #          #    #       #     # #       #
-#    ######  #     #  #####     #    #  #### ######  #####    #####
-#    #       #     #       #    #    #     # #   #   #             #
-#    #       #     # #     #    #    #     # #    #  #       #     #
-#    #       #######  #####     #     #####  #     # #######  #####
-#
-###########################################################################
-# Use the internal registry mirror to avoid Docker Hub rate limiting in the benchmark cluster
-image:
-  registry: europe-west1-docker.pkg.dev
-  repository: camunda-benchmark/dockerhub/bitnami/postgresql
-  tag: latest
-
-postgresqlSharedPreloadLibraries: pg_stat_statements
-
-primary:
-  resources:
-    requests:
-      memory: 8Gi
-      cpu: 3000m
-    limits:
-      cpu: 3000m
-      memory: 12Gi
-
-  nodeSelector:
-    component: benchmark-n2-standard-4
-    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
-
-  tolerations:
-    - key: nodepool
-      operator: Equal
-      value: n2-standard-4
-      effect: NoSchedule
-
-  persistence:
-    size: 512Gi
-    storageClass: "benchmark-ssd-zonal-v1"
-
-  extendedConfiguration: |-
-    # WAL Performance Tuning
-    wal_buffers = 128MB
-    max_wal_size = 4GB
-    min_wal_size = 1GB
-    checkpoint_timeout = 20min
-    checkpoint_completion_target = 0.9
-    wal_writer_delay = 200ms
-    wal_writer_flush_after = 1MB
-
-    # Memory Settings
-    shared_buffers = 2GB
-    effective_cache_size = 7GB
-    work_mem = 32MB
-    maintenance_work_mem = 1GB
-
-    # Autovacuum - Aggressive for high UPDATE/DELETE volume
-    autovacuum_max_workers = 6
-    autovacuum_naptime = 15s
-    autovacuum_vacuum_scale_factor = 0.03
-    autovacuum_analyze_scale_factor = 0.02
-    autovacuum_vacuum_cost_limit = 5000
-
-    # Monitoring
-    pg_stat_statements.track = all
-    pg_stat_statements.max = 10000
-    track_io_timing = on
-    track_functions = all
+        # The hostname depends on the name of the PostgreSQL cluster deployed
+        # by the load-test-setup Helm Chart.
+        url: jdbc:postgresql://postgresql-rw:5432/camunda

--- a/load-tests/setup/stable-89/values/camunda-platform-values-rdbms.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-rdbms.yaml
@@ -11,10 +11,12 @@ orchestration:
     secondaryStorage:
       type: rdbms
       rdbms:
+        # The username is the same for all the underlying RDBMS databases.
         username: camunda
         secret:
+          # The password is the same for all the underlying RDBMS databases.
           inlineSecret: camunda
-        # set to 2001 and not 2000 o´to directly see when queue is full in metrics dashboard
+
         queueSize: 2001
         history:
           defaultHistoryTTL: PT1H

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/main/max/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/main/max/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/main/none-optimize/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/main/none/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/main/none/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/main/opensearch/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/postgresql-user.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/postgresql-user.yaml
@@ -1,0 +1,22 @@
+---
+# Source: load-test-setup/templates/postgresql-user.yaml
+# Configure the PostgreSQL credentials for the Camunda application (secondary storage).
+# The Secret is used by:
+#
+#   1. The CNPG Operator to configure the password for the "camunda" PostgreSQL role
+#   2. Camunda itself, to connect into the PostgreSQL cluster.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-camunda-user
+  annotations:
+    description: |
+      Contains the username/password for the Camunda user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster
+      used for Camunda's secondary storage.
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "Y2FtdW5kYQ=="
+  password: "Y2FtdW5kYQ=="

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/postgresql.yaml
@@ -1,36 +1,33 @@
 ---
-# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
-# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
-#
-# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
-# use PostgreSQL as a secondary storage database!
+# Source: load-test-setup/templates/postgresql.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Camunda secondary storage.
 #
 # Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: postgresql-keycloak
+  name: postgresql
 spec:
-  description: PostgreSQL cluster for Keycloak and Camunda Identity
+  description: PostgreSQL cluster for Camunda secondary storage
 
   instances: 1
-  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/postgres:18.4
 
   resources:
     limits:
-      cpu: 150m
-      memory: 192Mi
+      cpu: 3000m
+      memory: 12Gi
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 3000m
+      memory: 8Gi
 
   storage:
-    size: 1Gi
+    size: 512Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:
     nodeSelector:
-      topology.kubernetes.io/zone: "europe-west1-d"
+      topology.kubernetes.io/zone: "europe-west1-c"
       component: benchmark-n2-standard-4
 
     tolerations:
@@ -40,21 +37,45 @@ spec:
         value: n2-standard-4
 
   postgresql:
+    shared_preload_libraries:
+      - pg_stat_statements
+
     # The PostgreSQL configuration flags.
     parameters:
-      lock_timeout: 30s
-      statement_timeout: "0"
-      #log_statement: all
-      #log_connections: "on"
-      #log_disconnections: "on"
+      autovacuum_analyze_scale_factor: "0.02"
+      autovacuum_max_workers: "6"
+      autovacuum_naptime: 15s
+      autovacuum_vacuum_cost_limit: "5000"
+      autovacuum_vacuum_scale_factor: "0.03"
+      checkpoint_completion_target: "0.9"
+      checkpoint_timeout: 20min
+      effective_cache_size: 7GB
+      log_connections: "off"
+      log_disconnections: "off"
+      log_statement: none
+      maintenance_work_mem: 1GB
+      max_wal_size: 4GB
+      min_wal_size: 1GB
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: all
+      shared_buffers: 2GB
+      track_functions: all
+      track_io_timing: "on"
+      wal_buffers: 128MB
+      wal_writer_delay: 200ms
+      wal_writer_flush_after: 1MB
+      work_mem: 32MB
 
-  # Initialize the Keycloak PostgreSQL cluster with:
+  postgresUID: 999
+  postgresGID: 999
+
+  # Initialize the Camunda PostgreSQL cluster with:
   #
   # 1. A dedicated user
   # 2. A dedicated database, owned by the user created in 1.
   # 3. The password comes from the specified Kubernetes Secret
   #
-  # The dedicated user will also be used by Keycloak to connect into this
+  # The dedicated user will also be used by Camunda to connect into this
   # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
@@ -69,10 +90,10 @@ spec:
   # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
   bootstrap:
     initdb:
-      database: keycloak
-      owner: keycloak
+      database: camunda
+      owner: camunda
       secret:
-        name: postgresql-keycloak-user
+        name: postgresql-camunda-user
 
   managed:
     services:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/configmap.yaml
@@ -124,7 +124,7 @@ data:
               policy-name: "camunda-retention-policy"
           rdbms:
             aws-enabled: false
-            url: "jdbc:postgresql://postgresql:5432/camunda"
+            url: "jdbc:postgresql://postgresql-rw:5432/camunda"
             username: "camunda"
             password: "${VALUES_ORCHESTRATION_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD:}"
     

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/postgresql-user.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/postgresql-user.yaml
@@ -1,0 +1,22 @@
+---
+# Source: load-test-setup/templates/postgresql-user.yaml
+# Configure the PostgreSQL credentials for the Camunda application (secondary storage).
+# The Secret is used by:
+#
+#   1. The CNPG Operator to configure the password for the "camunda" PostgreSQL role
+#   2. Camunda itself, to connect into the PostgreSQL cluster.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-camunda-user
+  annotations:
+    description: |
+      Contains the username/password for the Camunda user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster
+      used for Camunda's secondary storage.
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "Y2FtdW5kYQ=="
+  password: "Y2FtdW5kYQ=="

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/postgresql.yaml
@@ -1,31 +1,28 @@
 ---
-# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
-# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
-#
-# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
-# use PostgreSQL as a secondary storage database!
+# Source: load-test-setup/templates/postgresql.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Camunda secondary storage.
 #
 # Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: postgresql-keycloak
+  name: postgresql
 spec:
-  description: PostgreSQL cluster for Keycloak and Camunda Identity
+  description: PostgreSQL cluster for Camunda secondary storage
 
   instances: 1
-  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/postgres:18.4
 
   resources:
     limits:
-      cpu: 150m
-      memory: 192Mi
+      cpu: 3000m
+      memory: 12Gi
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 3000m
+      memory: 8Gi
 
   storage:
-    size: 1Gi
+    size: 512Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:
@@ -40,21 +37,45 @@ spec:
         value: n2-standard-4
 
   postgresql:
+    shared_preload_libraries:
+      - pg_stat_statements
+
     # The PostgreSQL configuration flags.
     parameters:
-      lock_timeout: 30s
-      statement_timeout: "0"
-      #log_statement: all
-      #log_connections: "on"
-      #log_disconnections: "on"
+      autovacuum_analyze_scale_factor: "0.02"
+      autovacuum_max_workers: "6"
+      autovacuum_naptime: 15s
+      autovacuum_vacuum_cost_limit: "5000"
+      autovacuum_vacuum_scale_factor: "0.03"
+      checkpoint_completion_target: "0.9"
+      checkpoint_timeout: 20min
+      effective_cache_size: 7GB
+      log_connections: "off"
+      log_disconnections: "off"
+      log_statement: none
+      maintenance_work_mem: 1GB
+      max_wal_size: 4GB
+      min_wal_size: 1GB
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: all
+      shared_buffers: 2GB
+      track_functions: all
+      track_io_timing: "on"
+      wal_buffers: 128MB
+      wal_writer_delay: 200ms
+      wal_writer_flush_after: 1MB
+      work_mem: 32MB
 
-  # Initialize the Keycloak PostgreSQL cluster with:
+  postgresUID: 999
+  postgresGID: 999
+
+  # Initialize the Camunda PostgreSQL cluster with:
   #
   # 1. A dedicated user
   # 2. A dedicated database, owned by the user created in 1.
   # 3. The password comes from the specified Kubernetes Secret
   #
-  # The dedicated user will also be used by Keycloak to connect into this
+  # The dedicated user will also be used by Camunda to connect into this
   # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
@@ -69,10 +90,10 @@ spec:
   # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
   bootstrap:
     initdb:
-      database: keycloak
-      owner: keycloak
+      database: camunda
+      owner: camunda
       secret:
-        name: postgresql-keycloak-user
+        name: postgresql-camunda-user
 
   managed:
     services:

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/orchestration/configmap.yaml
@@ -114,7 +114,7 @@ data:
             minimum-age: "1d"
           rdbms:
             aws-enabled: false
-            url: "jdbc:postgresql://postgresql:5432/camunda"
+            url: "jdbc:postgresql://postgresql-rw:5432/camunda"
             username: "camunda"
             password: "${VALUES_ORCHESTRATION_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD:}"
     

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/postgresql-user.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/postgresql-user.yaml
@@ -1,0 +1,22 @@
+---
+# Source: load-test-setup/templates/postgresql-user.yaml
+# Configure the PostgreSQL credentials for the Camunda application (secondary storage).
+# The Secret is used by:
+#
+#   1. The CNPG Operator to configure the password for the "camunda" PostgreSQL role
+#   2. Camunda itself, to connect into the PostgreSQL cluster.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-camunda-user
+  annotations:
+    description: |
+      Contains the username/password for the Camunda user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster
+      used for Camunda's secondary storage.
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "Y2FtdW5kYQ=="
+  password: "Y2FtdW5kYQ=="

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/postgresql.yaml
@@ -1,36 +1,33 @@
 ---
-# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
-# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
-#
-# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
-# use PostgreSQL as a secondary storage database!
+# Source: load-test-setup/templates/postgresql.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Camunda secondary storage.
 #
 # Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: postgresql-keycloak
+  name: postgresql
 spec:
-  description: PostgreSQL cluster for Keycloak and Camunda Identity
+  description: PostgreSQL cluster for Camunda secondary storage
 
   instances: 1
-  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/postgres:18.4
 
   resources:
     limits:
-      cpu: 150m
-      memory: 192Mi
+      cpu: 3000m
+      memory: 12Gi
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 3000m
+      memory: 8Gi
 
   storage:
-    size: 1Gi
+    size: 512Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:
     nodeSelector:
-      topology.kubernetes.io/zone: "europe-west1-d"
+      topology.kubernetes.io/zone: "europe-west1-c"
       component: benchmark-n2-standard-4
 
     tolerations:
@@ -40,21 +37,45 @@ spec:
         value: n2-standard-4
 
   postgresql:
+    shared_preload_libraries:
+      - pg_stat_statements
+
     # The PostgreSQL configuration flags.
     parameters:
-      lock_timeout: 30s
-      statement_timeout: "0"
-      #log_statement: all
-      #log_connections: "on"
-      #log_disconnections: "on"
+      autovacuum_analyze_scale_factor: "0.02"
+      autovacuum_max_workers: "6"
+      autovacuum_naptime: 15s
+      autovacuum_vacuum_cost_limit: "5000"
+      autovacuum_vacuum_scale_factor: "0.03"
+      checkpoint_completion_target: "0.9"
+      checkpoint_timeout: 20min
+      effective_cache_size: 7GB
+      log_connections: "off"
+      log_disconnections: "off"
+      log_statement: none
+      maintenance_work_mem: 1GB
+      max_wal_size: 4GB
+      min_wal_size: 1GB
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: all
+      shared_buffers: 2GB
+      track_functions: all
+      track_io_timing: "on"
+      wal_buffers: 128MB
+      wal_writer_delay: 200ms
+      wal_writer_flush_after: 1MB
+      work_mem: 32MB
 
-  # Initialize the Keycloak PostgreSQL cluster with:
+  postgresUID: 999
+  postgresGID: 999
+
+  # Initialize the Camunda PostgreSQL cluster with:
   #
   # 1. A dedicated user
   # 2. A dedicated database, owned by the user created in 1.
   # 3. The password comes from the specified Kubernetes Secret
   #
-  # The dedicated user will also be used by Keycloak to connect into this
+  # The dedicated user will also be used by Camunda to connect into this
   # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
@@ -69,10 +90,10 @@ spec:
   # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
   bootstrap:
     initdb:
-      database: keycloak
-      owner: keycloak
+      database: camunda
+      owner: camunda
       secret:
-        name: postgresql-keycloak-user
+        name: postgresql-camunda-user
 
   managed:
     services:

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/orchestration/configmap.yaml
@@ -114,7 +114,7 @@ data:
             minimum-age: "1d"
           rdbms:
             aws-enabled: false
-            url: "jdbc:postgresql://postgresql:5432/camunda"
+            url: "jdbc:postgresql://postgresql-rw:5432/camunda"
             username: "camunda"
             password: "${VALUES_ORCHESTRATION_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD:}"
     

--- a/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/postgresql-user.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/postgresql-user.yaml
@@ -1,0 +1,22 @@
+---
+# Source: load-test-setup/templates/postgresql-user.yaml
+# Configure the PostgreSQL credentials for the Camunda application (secondary storage).
+# The Secret is used by:
+#
+#   1. The CNPG Operator to configure the password for the "camunda" PostgreSQL role
+#   2. Camunda itself, to connect into the PostgreSQL cluster.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-camunda-user
+  annotations:
+    description: |
+      Contains the username/password for the Camunda user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster
+      used for Camunda's secondary storage.
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "Y2FtdW5kYQ=="
+  password: "Y2FtdW5kYQ=="

--- a/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/postgresql.yaml
@@ -1,36 +1,33 @@
 ---
-# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
-# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
-#
-# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
-# use PostgreSQL as a secondary storage database!
+# Source: load-test-setup/templates/postgresql.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Camunda secondary storage.
 #
 # Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: postgresql-keycloak
+  name: postgresql
 spec:
-  description: PostgreSQL cluster for Keycloak and Camunda Identity
+  description: PostgreSQL cluster for Camunda secondary storage
 
   instances: 1
-  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/postgres:18.4
 
   resources:
     limits:
-      cpu: 150m
-      memory: 192Mi
+      cpu: 3000m
+      memory: 12Gi
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 3000m
+      memory: 8Gi
 
   storage:
-    size: 1Gi
+    size: 512Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:
     nodeSelector:
-      topology.kubernetes.io/zone: "europe-west1-d"
+      topology.kubernetes.io/zone: "europe-west1-b"
       component: benchmark-n2-standard-4
 
     tolerations:
@@ -40,21 +37,45 @@ spec:
         value: n2-standard-4
 
   postgresql:
+    shared_preload_libraries:
+      - pg_stat_statements
+
     # The PostgreSQL configuration flags.
     parameters:
-      lock_timeout: 30s
-      statement_timeout: "0"
-      #log_statement: all
-      #log_connections: "on"
-      #log_disconnections: "on"
+      autovacuum_analyze_scale_factor: "0.02"
+      autovacuum_max_workers: "6"
+      autovacuum_naptime: 15s
+      autovacuum_vacuum_cost_limit: "5000"
+      autovacuum_vacuum_scale_factor: "0.03"
+      checkpoint_completion_target: "0.9"
+      checkpoint_timeout: 20min
+      effective_cache_size: 7GB
+      log_connections: "off"
+      log_disconnections: "off"
+      log_statement: none
+      maintenance_work_mem: 1GB
+      max_wal_size: 4GB
+      min_wal_size: 1GB
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: all
+      shared_buffers: 2GB
+      track_functions: all
+      track_io_timing: "on"
+      wal_buffers: 128MB
+      wal_writer_delay: 200ms
+      wal_writer_flush_after: 1MB
+      work_mem: 32MB
 
-  # Initialize the Keycloak PostgreSQL cluster with:
+  postgresUID: 999
+  postgresGID: 999
+
+  # Initialize the Camunda PostgreSQL cluster with:
   #
   # 1. A dedicated user
   # 2. A dedicated database, owned by the user created in 1.
   # 3. The password comes from the specified Kubernetes Secret
   #
-  # The dedicated user will also be used by Keycloak to connect into this
+  # The dedicated user will also be used by Camunda to connect into this
   # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
@@ -69,10 +90,10 @@ spec:
   # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
   bootstrap:
     initdb:
-      database: keycloak
-      owner: keycloak
+      database: camunda
+      owner: camunda
       secret:
-        name: postgresql-keycloak-user
+        name: postgresql-camunda-user
 
   managed:
     services:

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/orchestration/configmap.yaml
@@ -114,7 +114,7 @@ data:
             minimum-age: "1d"
           rdbms:
             aws-enabled: false
-            url: "jdbc:postgresql://postgresql:5432/camunda"
+            url: "jdbc:postgresql://postgresql-rw:5432/camunda"
             username: "camunda"
             password: "${VALUES_ORCHESTRATION_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD:}"
     

--- a/load-tests/setup/test/golden/main/realistic/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/main/realistic/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-87/max/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-87/max/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-87/realistic/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-87/realistic/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-88/max/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/max/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-88/none/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-89/max/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/max/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-89/none/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/postgresql-user.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/postgresql-user.yaml
@@ -1,0 +1,22 @@
+---
+# Source: load-test-setup/templates/postgresql-user.yaml
+# Configure the PostgreSQL credentials for the Camunda application (secondary storage).
+# The Secret is used by:
+#
+#   1. The CNPG Operator to configure the password for the "camunda" PostgreSQL role
+#   2. Camunda itself, to connect into the PostgreSQL cluster.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-camunda-user
+  annotations:
+    description: |
+      Contains the username/password for the Camunda user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster
+      used for Camunda's secondary storage.
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "Y2FtdW5kYQ=="
+  password: "Y2FtdW5kYQ=="

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/postgresql.yaml
@@ -1,36 +1,33 @@
 ---
-# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
-# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
-#
-# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
-# use PostgreSQL as a secondary storage database!
+# Source: load-test-setup/templates/postgresql.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Camunda secondary storage.
 #
 # Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: postgresql-keycloak
+  name: postgresql
 spec:
-  description: PostgreSQL cluster for Keycloak and Camunda Identity
+  description: PostgreSQL cluster for Camunda secondary storage
 
   instances: 1
-  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/postgres:18.4
 
   resources:
     limits:
-      cpu: 150m
-      memory: 192Mi
+      cpu: 3000m
+      memory: 12Gi
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 3000m
+      memory: 8Gi
 
   storage:
-    size: 1Gi
+    size: 512Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:
     nodeSelector:
-      topology.kubernetes.io/zone: "europe-west1-d"
+      topology.kubernetes.io/zone: "europe-west1-c"
       component: benchmark-n2-standard-4
 
     tolerations:
@@ -40,21 +37,45 @@ spec:
         value: n2-standard-4
 
   postgresql:
+    shared_preload_libraries:
+      - pg_stat_statements
+
     # The PostgreSQL configuration flags.
     parameters:
-      lock_timeout: 30s
-      statement_timeout: "0"
-      #log_statement: all
-      #log_connections: "on"
-      #log_disconnections: "on"
+      autovacuum_analyze_scale_factor: "0.02"
+      autovacuum_max_workers: "6"
+      autovacuum_naptime: 15s
+      autovacuum_vacuum_cost_limit: "5000"
+      autovacuum_vacuum_scale_factor: "0.03"
+      checkpoint_completion_target: "0.9"
+      checkpoint_timeout: 20min
+      effective_cache_size: 7GB
+      log_connections: "off"
+      log_disconnections: "off"
+      log_statement: none
+      maintenance_work_mem: 1GB
+      max_wal_size: 4GB
+      min_wal_size: 1GB
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: all
+      shared_buffers: 2GB
+      track_functions: all
+      track_io_timing: "on"
+      wal_buffers: 128MB
+      wal_writer_delay: 200ms
+      wal_writer_flush_after: 1MB
+      work_mem: 32MB
 
-  # Initialize the Keycloak PostgreSQL cluster with:
+  postgresUID: 999
+  postgresGID: 999
+
+  # Initialize the Camunda PostgreSQL cluster with:
   #
   # 1. A dedicated user
   # 2. A dedicated database, owned by the user created in 1.
   # 3. The password comes from the specified Kubernetes Secret
   #
-  # The dedicated user will also be used by Keycloak to connect into this
+  # The dedicated user will also be used by Camunda to connect into this
   # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
@@ -69,10 +90,10 @@ spec:
   # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
   bootstrap:
     initdb:
-      database: keycloak
-      owner: keycloak
+      database: camunda
+      owner: camunda
       secret:
-        name: postgresql-keycloak-user
+        name: postgresql-camunda-user
 
   managed:
     services:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/configmap.yaml
@@ -120,7 +120,7 @@ data:
               policy-name: "camunda-retention-policy"
           rdbms:
             aws-enabled: false
-            url: "jdbc:postgresql://postgresql:5432/camunda"
+            url: "jdbc:postgresql://postgresql-rw:5432/camunda"
             username: "camunda"
             password: "${VALUES_ORCHESTRATION_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD:}"
     

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/postgresql-user.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/postgresql-user.yaml
@@ -1,0 +1,22 @@
+---
+# Source: load-test-setup/templates/postgresql-user.yaml
+# Configure the PostgreSQL credentials for the Camunda application (secondary storage).
+# The Secret is used by:
+#
+#   1. The CNPG Operator to configure the password for the "camunda" PostgreSQL role
+#   2. Camunda itself, to connect into the PostgreSQL cluster.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-camunda-user
+  annotations:
+    description: |
+      Contains the username/password for the Camunda user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster
+      used for Camunda's secondary storage.
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "Y2FtdW5kYQ=="
+  password: "Y2FtdW5kYQ=="

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/postgresql.yaml
@@ -1,31 +1,28 @@
 ---
-# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
-# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
-#
-# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
-# use PostgreSQL as a secondary storage database!
+# Source: load-test-setup/templates/postgresql.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Camunda secondary storage.
 #
 # Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: postgresql-keycloak
+  name: postgresql
 spec:
-  description: PostgreSQL cluster for Keycloak and Camunda Identity
+  description: PostgreSQL cluster for Camunda secondary storage
 
   instances: 1
-  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/postgres:18.4
 
   resources:
     limits:
-      cpu: 150m
-      memory: 192Mi
+      cpu: 3000m
+      memory: 12Gi
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 3000m
+      memory: 8Gi
 
   storage:
-    size: 1Gi
+    size: 512Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:
@@ -40,21 +37,45 @@ spec:
         value: n2-standard-4
 
   postgresql:
+    shared_preload_libraries:
+      - pg_stat_statements
+
     # The PostgreSQL configuration flags.
     parameters:
-      lock_timeout: 30s
-      statement_timeout: "0"
-      #log_statement: all
-      #log_connections: "on"
-      #log_disconnections: "on"
+      autovacuum_analyze_scale_factor: "0.02"
+      autovacuum_max_workers: "6"
+      autovacuum_naptime: 15s
+      autovacuum_vacuum_cost_limit: "5000"
+      autovacuum_vacuum_scale_factor: "0.03"
+      checkpoint_completion_target: "0.9"
+      checkpoint_timeout: 20min
+      effective_cache_size: 7GB
+      log_connections: "off"
+      log_disconnections: "off"
+      log_statement: none
+      maintenance_work_mem: 1GB
+      max_wal_size: 4GB
+      min_wal_size: 1GB
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: all
+      shared_buffers: 2GB
+      track_functions: all
+      track_io_timing: "on"
+      wal_buffers: 128MB
+      wal_writer_delay: 200ms
+      wal_writer_flush_after: 1MB
+      work_mem: 32MB
 
-  # Initialize the Keycloak PostgreSQL cluster with:
+  postgresUID: 999
+  postgresGID: 999
+
+  # Initialize the Camunda PostgreSQL cluster with:
   #
   # 1. A dedicated user
   # 2. A dedicated database, owned by the user created in 1.
   # 3. The password comes from the specified Kubernetes Secret
   #
-  # The dedicated user will also be used by Keycloak to connect into this
+  # The dedicated user will also be used by Camunda to connect into this
   # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
@@ -69,10 +90,10 @@ spec:
   # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
   bootstrap:
     initdb:
-      database: keycloak
-      owner: keycloak
+      database: camunda
+      owner: camunda
       secret:
-        name: postgresql-keycloak-user
+        name: postgresql-camunda-user
 
   managed:
     services:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/orchestration/configmap.yaml
@@ -110,7 +110,7 @@ data:
             minimum-age: "1d"
           rdbms:
             aws-enabled: false
-            url: "jdbc:postgresql://postgresql:5432/camunda"
+            url: "jdbc:postgresql://postgresql-rw:5432/camunda"
             username: "camunda"
             password: "${VALUES_ORCHESTRATION_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD:}"
     

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/postgresql-user.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/postgresql-user.yaml
@@ -1,0 +1,22 @@
+---
+# Source: load-test-setup/templates/postgresql-user.yaml
+# Configure the PostgreSQL credentials for the Camunda application (secondary storage).
+# The Secret is used by:
+#
+#   1. The CNPG Operator to configure the password for the "camunda" PostgreSQL role
+#   2. Camunda itself, to connect into the PostgreSQL cluster.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-camunda-user
+  annotations:
+    description: |
+      Contains the username/password for the Camunda user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster
+      used for Camunda's secondary storage.
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "Y2FtdW5kYQ=="
+  password: "Y2FtdW5kYQ=="

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/postgresql.yaml
@@ -1,36 +1,33 @@
 ---
-# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
-# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
-#
-# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
-# use PostgreSQL as a secondary storage database!
+# Source: load-test-setup/templates/postgresql.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Camunda secondary storage.
 #
 # Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: postgresql-keycloak
+  name: postgresql
 spec:
-  description: PostgreSQL cluster for Keycloak and Camunda Identity
+  description: PostgreSQL cluster for Camunda secondary storage
 
   instances: 1
-  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/postgres:18.4
 
   resources:
     limits:
-      cpu: 150m
-      memory: 192Mi
+      cpu: 3000m
+      memory: 12Gi
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 3000m
+      memory: 8Gi
 
   storage:
-    size: 1Gi
+    size: 512Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:
     nodeSelector:
-      topology.kubernetes.io/zone: "europe-west1-d"
+      topology.kubernetes.io/zone: "europe-west1-c"
       component: benchmark-n2-standard-4
 
     tolerations:
@@ -40,21 +37,45 @@ spec:
         value: n2-standard-4
 
   postgresql:
+    shared_preload_libraries:
+      - pg_stat_statements
+
     # The PostgreSQL configuration flags.
     parameters:
-      lock_timeout: 30s
-      statement_timeout: "0"
-      #log_statement: all
-      #log_connections: "on"
-      #log_disconnections: "on"
+      autovacuum_analyze_scale_factor: "0.02"
+      autovacuum_max_workers: "6"
+      autovacuum_naptime: 15s
+      autovacuum_vacuum_cost_limit: "5000"
+      autovacuum_vacuum_scale_factor: "0.03"
+      checkpoint_completion_target: "0.9"
+      checkpoint_timeout: 20min
+      effective_cache_size: 7GB
+      log_connections: "off"
+      log_disconnections: "off"
+      log_statement: none
+      maintenance_work_mem: 1GB
+      max_wal_size: 4GB
+      min_wal_size: 1GB
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: all
+      shared_buffers: 2GB
+      track_functions: all
+      track_io_timing: "on"
+      wal_buffers: 128MB
+      wal_writer_delay: 200ms
+      wal_writer_flush_after: 1MB
+      work_mem: 32MB
 
-  # Initialize the Keycloak PostgreSQL cluster with:
+  postgresUID: 999
+  postgresGID: 999
+
+  # Initialize the Camunda PostgreSQL cluster with:
   #
   # 1. A dedicated user
   # 2. A dedicated database, owned by the user created in 1.
   # 3. The password comes from the specified Kubernetes Secret
   #
-  # The dedicated user will also be used by Keycloak to connect into this
+  # The dedicated user will also be used by Camunda to connect into this
   # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
@@ -69,10 +90,10 @@ spec:
   # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
   bootstrap:
     initdb:
-      database: keycloak
-      owner: keycloak
+      database: camunda
+      owner: camunda
       secret:
-        name: postgresql-keycloak-user
+        name: postgresql-camunda-user
 
   managed:
     services:

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/orchestration/configmap.yaml
@@ -110,7 +110,7 @@ data:
             minimum-age: "1d"
           rdbms:
             aws-enabled: false
-            url: "jdbc:postgresql://postgresql:5432/camunda"
+            url: "jdbc:postgresql://postgresql-rw:5432/camunda"
             username: "camunda"
             password: "${VALUES_ORCHESTRATION_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD:}"
     

--- a/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -55,14 +55,14 @@ spec:
   # 3. The password comes from the specified Kubernetes Secret
   #
   # The dedicated user will also be used by Keycloak to connect into this
-  # PostgeSQL cluster.
+  # PostgreSQL cluster.
   #
   # In this cluster, this "bootstrap/initdb" method is preferred over the
   # dedicated `Database`/`DatabaseRole` custom resources, as:
   #
   # 1. We only create a single database role + database ; we don't need to
   #    manage multiple databases.
-  # 2. It's faster to provision the PostgeSQL cluster: this bootstrap method is
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
   #    done very early during the cluster creation, whereas the custom resource
   #    requires the CNPG Operator to trigger reconciliations.
   #


### PR DESCRIPTION
## Description

This removes the internal PostgreSQL Bitnami Helm Chart and deploys PostgreSQL, when used as a secondary storage option, via the load-test-setup Helm Chart.

The main difference is that we used to depend on PostgreSQL "latest" and the CNPG requires a specific version (set to 18.4, as described in the latest `europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/bitnami/postgresql:latest` image.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/issues/54151
