### PR TITLE
ci: load-test: adjust Renovate configuration for load tests

### DIFF
--- a/.github/renovate/team-reliability-testing.json5
+++ b/.github/renovate/team-reliability-testing.json5
@@ -1,6 +1,13 @@
 {
   // This is the Renovate configuration specific to the Reliability Testing team / load test environment.
 
+  // Find updates from internal registries through the actual upstream registries.
+  registryAliases: {
+    "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub": "docker.io",
+    "europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio": "ghcr.io",
+    "europe-west1-docker.pkg.dev/camunda-benchmark/quayio": "quay.io",
+  },
+
   // Configure Renovate to find what to update in custom locations, not natively managed by Renovate.
   customManagers: [
     {
@@ -20,6 +27,14 @@
   ],
 
   packageRules: [
+    {
+      // Disable automerge for all the load test updates, by default.
+      // Automerge can be turned on, on a case by case basis, as needed, until
+      // the teams are more confident about the updates received.
+      matchFileNames: ["load-tests/**"],
+      automerge: false,
+    },
+
     {
       // Simplify the commit message when updating the Camunda Platform Helm Chart for load tests
       matchDepNames: [
@@ -70,7 +85,6 @@
       ],
       matchPackageNames: [
         "registry.camunda.cloud/team-zeebe",
-        "europe-west1-docker.pkg.dev/camunda-benchmark/*",
       ],
       enabled: false,
     },
@@ -86,6 +100,9 @@
     // load-tests setup directories.
     managerFilePatterns: [
       "load-tests/setup/*/values/*.y*ml",
+      // May contain references to other Helm Chart using the
+      // registry/repository/tag format understood by Renovate.
+      "load-tests/setup/charts/load-test-setup/values.yaml",
     ],
   },
 }

--- a/load-tests/setup/charts/load-test-setup/values.yaml
+++ b/load-tests/setup/charts/load-test-setup/values.yaml
@@ -259,6 +259,7 @@ opensearch:
   majorVersion: "2.19.0"
 
   image:
+    repository: europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch
     tag: 2.19.0
 
   replicas: 3

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
         resources:
           {}
       - name: configfile
-        image: "opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
         imagePullPolicy: "IfNotPresent"
         command:
         - sh
@@ -147,7 +147,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
 
-        image: "opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
         imagePullPolicy: "IfNotPresent"
         readinessProbe:
           failureThreshold: 3

--- a/load-tests/setup/test/golden/main/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
         resources:
           {}
       - name: configfile
-        image: "opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
         imagePullPolicy: "IfNotPresent"
         command:
         - sh
@@ -147,7 +147,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
 
-        image: "opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
         imagePullPolicy: "IfNotPresent"
         readinessProbe:
           failureThreshold: 3

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
         resources:
           {}
       - name: configfile
-        image: "opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
         imagePullPolicy: "IfNotPresent"
         command:
         - sh
@@ -147,7 +147,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
 
-        image: "opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
         imagePullPolicy: "IfNotPresent"
         readinessProbe:
           failureThreshold: 3

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
         resources:
           {}
       - name: configfile
-        image: "opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
         imagePullPolicy: "IfNotPresent"
         command:
         - sh
@@ -147,7 +147,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
 
-        image: "opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
         imagePullPolicy: "IfNotPresent"
         readinessProbe:
           failureThreshold: 3

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
         resources:
           {}
       - name: configfile
-        image: "opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
         imagePullPolicy: "IfNotPresent"
         command:
         - sh
@@ -147,7 +147,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
 
-        image: "opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
         imagePullPolicy: "IfNotPresent"
         readinessProbe:
           failureThreshold: 3

--- a/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
         resources:
           {}
       - name: configfile
-        image: "opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
         imagePullPolicy: "IfNotPresent"
         command:
         - sh
@@ -147,7 +147,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
 
-        image: "opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
         imagePullPolicy: "IfNotPresent"
         readinessProbe:
           failureThreshold: 3


### PR DESCRIPTION
## Description

1. Disable automerge: until we get a better picture which updates are safe to automerge or not, let's disable automerging and we can check all the updates.
2. Alias the internal mirroring private registries (which Renovate doesn't have access to) to their upstreams.
   This also allows us to get upgrades that were previously disabled to remove the "Failed to look up docker package" Renovate warnings.
3. Reconfigure OpenSearch to be viewable by the Renovate "helm-values" manager and pull images from our internal mirror registry.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/issues/58912
