### PR TITLE
Model zeebe:agentDefinition marker in zeebe/bpmn-model

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
@@ -217,6 +217,7 @@ import io.camunda.zeebe.model.bpmn.impl.instance.di.ShapeImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.di.StyleImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.di.WaypointImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeAdHocImpl;
+import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeAgentDefinitionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeAssignmentDefinitionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeCalledDecisionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeCalledElementImpl;
@@ -682,6 +683,7 @@ public class Bpmn {
     ZeebeLinkedResourceImpl.registerType(bpmnModelBuilder);
     ZeebeLinkedResourcesImpl.registerType(bpmnModelBuilder);
     ZeebeConditionalFilterImpl.registerType(bpmnModelBuilder);
+    ZeebeAgentDefinitionImpl.registerType(bpmnModelBuilder);
   }
 
   /**

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractAdHocSubProcessBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractAdHocSubProcessBuilder.java
@@ -75,6 +75,17 @@ public class AbstractAdHocSubProcessBuilder<B extends AbstractAdHocSubProcessBui
     return myself;
   }
 
+  /**
+   * Sets the zeebe:modelerTemplate attribute of the build ad-hoc sub-process.
+   *
+   * @param modelerTemplate the element template id to set
+   * @return the builder object
+   */
+  public B zeebeModelerTemplate(final String modelerTemplate) {
+    ((AdHocSubProcess) element).setModelerTemplate(modelerTemplate);
+    return myself;
+  }
+
   public B zeebeOutputCollection(final String outputCollection) {
     final ZeebeAdHoc adHoc = getCreateSingleExtensionElement(ZeebeAdHoc.class);
     adHoc.setOutputCollection(outputCollection);

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractAdHocSubProcessBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractAdHocSubProcessBuilder.java
@@ -23,6 +23,8 @@ import io.camunda.zeebe.model.bpmn.instance.FlowNode;
 import io.camunda.zeebe.model.bpmn.instance.bpmndi.BpmnShape;
 import io.camunda.zeebe.model.bpmn.instance.dc.Bounds;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHoc;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAgentDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAgentType;
 
 public class AbstractAdHocSubProcessBuilder<B extends AbstractAdHocSubProcessBuilder<B>>
     extends AbstractSubProcessBuilder<B> implements ZeebeJobWorkerElementBuilder<B> {
@@ -82,6 +84,18 @@ public class AbstractAdHocSubProcessBuilder<B extends AbstractAdHocSubProcessBui
   public B zeebeOutputElementExpression(final String outputElementExpression) {
     final ZeebeAdHoc adHoc = getCreateSingleExtensionElement(ZeebeAdHoc.class);
     adHoc.setOutputElement(asZeebeExpression(outputElementExpression));
+    return myself;
+  }
+
+  /**
+   * Marks this ad-hoc sub-process as a Camunda-native AI agent.
+   *
+   * @return the builder object
+   */
+  public B zeebeAiAgentSubProcessDefinition() {
+    final ZeebeAgentDefinition agentDefinition =
+        getCreateSingleExtensionElement(ZeebeAgentDefinition.class);
+    agentDefinition.setAgentType(ZeebeAgentType.aiAgentSubProcess);
     return myself;
   }
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractServiceTaskBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractServiceTaskBuilder.java
@@ -18,6 +18,8 @@ package io.camunda.zeebe.model.bpmn.builder;
 
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAgentDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAgentType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLinkedResource;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLinkedResources;
@@ -53,6 +55,37 @@ public abstract class AbstractServiceTaskBuilder<B extends AbstractServiceTaskBu
     final LinkedResourceBuilder builder = new LinkedResourceBuilder(linkedResource, myself);
     linkedResourceBuilderConsumer.accept(builder);
     return myself;
+  }
+
+  /**
+   * Marks this service task as an agent definition.
+   *
+   * @param agentType the agent type declared on the marker
+   * @return the builder object
+   */
+  public B zeebeAgentDefinition(final ZeebeAgentType agentType) {
+    final ZeebeAgentDefinition agentDefinition =
+        myself.getCreateSingleExtensionElement(ZeebeAgentDefinition.class);
+    agentDefinition.setAgentType(agentType);
+    return myself;
+  }
+
+  /**
+   * Marks this service task as a Camunda-native AI agent task.
+   *
+   * @return the builder object
+   */
+  public B zeebeAiAgentTaskDefinition() {
+    return zeebeAgentDefinition(ZeebeAgentType.aiAgentTask);
+  }
+
+  /**
+   * Marks this service task as an external agent.
+   *
+   * @return the builder object
+   */
+  public B zeebeExternalAgentDefinition() {
+    return zeebeAgentDefinition(ZeebeAgentType.external);
   }
 
   private ZeebeLinkedResource createLinkedResourceElement() {

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractServiceTaskBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractServiceTaskBuilder.java
@@ -47,6 +47,17 @@ public abstract class AbstractServiceTaskBuilder<B extends AbstractServiceTaskBu
     return myself;
   }
 
+  /**
+   * Sets the zeebe:modelerTemplate attribute of the build service task.
+   *
+   * @param modelerTemplate the element template id to set
+   * @return the builder object
+   */
+  public B zeebeModelerTemplate(final String modelerTemplate) {
+    element.setModelerTemplate(modelerTemplate);
+    return myself;
+  }
+
   public B zeebeLinkedResources(
       final Consumer<LinkedResourceBuilder> linkedResourceBuilderConsumer) {
     final ZeebeLinkedResource linkedResource = createLinkedResourceElement();

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -75,6 +75,7 @@ public class ZeebeConstants {
   public static final String ATTRIBUTE_CONDITION = "condition";
 
   public static final String ATTRIBUTE_AGENT_TYPE = "agentType";
+  public static final String ATTRIBUTE_MODELER_TEMPLATE = "modelerTemplate";
 
   public static final String ELEMENT_HEADER = "header";
   public static final String ELEMENT_INPUT = "input";

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -74,6 +74,8 @@ public class ZeebeConstants {
   public static final String ATTRIBUTE_VARIABLE_EVENTS = "variableEvents";
   public static final String ATTRIBUTE_CONDITION = "condition";
 
+  public static final String ATTRIBUTE_AGENT_TYPE = "agentType";
+
   public static final String ELEMENT_HEADER = "header";
   public static final String ELEMENT_INPUT = "input";
   public static final String ELEMENT_IO_MAPPING = "ioMapping";
@@ -127,6 +129,8 @@ public class ZeebeConstants {
   public static final String ELEMENT_LINKED_RESOURCES = "linkedResources";
 
   public static final String ELEMENT_CONDITIONAL_FILTER = "conditionalFilter";
+
+  public static final String ELEMENT_AGENT_DEFINITION = "agentDefinition";
 
   /** The property used for the example output JSON data. */
   public static final String PROPERTY_EXAMPLE_DATA = "camundaModeler:exampleOutputJson";

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/AdHocSubProcessImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/AdHocSubProcessImpl.java
@@ -18,7 +18,9 @@ package io.camunda.zeebe.model.bpmn.impl.instance;
 import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.BPMN20_NS;
 import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.BPMN_ATTRIBUTE_CANCEL_REMAINING_INSTANCES;
 import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.BPMN_ELEMENT_AD_HOC_SUB_PROCESS;
+import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.ZEEBE_NS;
 
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
 import io.camunda.zeebe.model.bpmn.instance.CompletionCondition;
 import io.camunda.zeebe.model.bpmn.instance.SubProcess;
@@ -34,6 +36,7 @@ public class AdHocSubProcessImpl extends SubProcessImpl implements AdHocSubProce
 
   private static Attribute<Boolean> cancelRemainingInstancesAttribute;
   private static ChildElement<CompletionCondition> completionConditionChild;
+  private static Attribute<String> modelerTemplateAttribute;
 
   public AdHocSubProcessImpl(final ModelTypeInstanceContext context) {
     super(context);
@@ -63,6 +66,12 @@ public class AdHocSubProcessImpl extends SubProcessImpl implements AdHocSubProce
     final SequenceBuilder sequenceBuilder = typeBuilder.sequence();
     completionConditionChild = sequenceBuilder.element(CompletionCondition.class).build();
 
+    modelerTemplateAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_MODELER_TEMPLATE)
+            .namespace(ZEEBE_NS)
+            .build();
+
     typeBuilder.build();
   }
 
@@ -84,5 +93,15 @@ public class AdHocSubProcessImpl extends SubProcessImpl implements AdHocSubProce
   @Override
   public void setCancelRemainingInstances(final boolean cancelRemainingInstances) {
     cancelRemainingInstancesAttribute.setValue(this, cancelRemainingInstances);
+  }
+
+  @Override
+  public String getModelerTemplate() {
+    return modelerTemplateAttribute.getValue(this);
+  }
+
+  @Override
+  public void setModelerTemplate(final String modelerTemplate) {
+    modelerTemplateAttribute.setValue(this, modelerTemplate);
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/ServiceTaskImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/ServiceTaskImpl.java
@@ -20,9 +20,11 @@ import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.BPMN20_NS;
 import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.BPMN_ATTRIBUTE_IMPLEMENTATION;
 import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.BPMN_ATTRIBUTE_OPERATION_REF;
 import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.BPMN_ELEMENT_SERVICE_TASK;
+import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.ZEEBE_NS;
 
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder;
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.camunda.zeebe.model.bpmn.instance.Operation;
 import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
 import io.camunda.zeebe.model.bpmn.instance.Task;
@@ -42,6 +44,7 @@ public class ServiceTaskImpl extends TaskImpl implements ServiceTask {
 
   protected static Attribute<String> implementationAttribute;
   protected static AttributeReference<Operation> operationRefAttribute;
+  protected static Attribute<String> modelerTemplateAttribute;
 
   public ServiceTaskImpl(final ModelTypeInstanceContext context) {
     super(context);
@@ -73,6 +76,12 @@ public class ServiceTaskImpl extends TaskImpl implements ServiceTask {
             .qNameAttributeReference(Operation.class)
             .build();
 
+    modelerTemplateAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_MODELER_TEMPLATE)
+            .namespace(ZEEBE_NS)
+            .build();
+
     typeBuilder.build();
   }
 
@@ -99,5 +108,15 @@ public class ServiceTaskImpl extends TaskImpl implements ServiceTask {
   @Override
   public void setOperation(final Operation operation) {
     operationRefAttribute.setReferenceTargetElement(this, operation);
+  }
+
+  @Override
+  public String getModelerTemplate() {
+    return modelerTemplateAttribute.getValue(this);
+  }
+
+  @Override
+  public void setModelerTemplate(final String modelerTemplate) {
+    modelerTemplateAttribute.setValue(this, modelerTemplate);
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeAgentDefinitionImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeAgentDefinitionImpl.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.impl.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAgentDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAgentType;
+import org.camunda.bpm.model.xml.ModelBuilder;
+import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+import org.camunda.bpm.model.xml.type.attribute.Attribute;
+
+public class ZeebeAgentDefinitionImpl extends BpmnModelElementInstanceImpl
+    implements ZeebeAgentDefinition {
+
+  private static Attribute<ZeebeAgentType> agentTypeAttribute;
+
+  public ZeebeAgentDefinitionImpl(final ModelTypeInstanceContext instanceContext) {
+    super(instanceContext);
+  }
+
+  public static void registerType(final ModelBuilder modelBuilder) {
+    final ModelElementTypeBuilder typeBuilder =
+        modelBuilder
+            .defineType(ZeebeAgentDefinition.class, ZeebeConstants.ELEMENT_AGENT_DEFINITION)
+            .namespaceUri(BpmnModelConstants.ZEEBE_NS)
+            .instanceProvider(ZeebeAgentDefinitionImpl::new);
+
+    agentTypeAttribute =
+        typeBuilder
+            .enumAttribute(ZeebeConstants.ATTRIBUTE_AGENT_TYPE, ZeebeAgentType.class)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .required()
+            .build();
+
+    typeBuilder.build();
+  }
+
+  @Override
+  public ZeebeAgentType getAgentType() {
+    return agentTypeAttribute.getValue(this);
+  }
+
+  @Override
+  public void setAgentType(final ZeebeAgentType agentType) {
+    agentTypeAttribute.setValue(this, agentType);
+  }
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/AdHocSubProcess.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/AdHocSubProcess.java
@@ -42,4 +42,18 @@ public interface AdHocSubProcess extends SubProcess {
    * @param cancelRemainingInstances whether to cancel remaining instances on completion
    */
   void setCancelRemainingInstances(boolean cancelRemainingInstances);
+
+  /**
+   * @return the zeebe:modelerTemplate attribute value, or {@code null} if this ad-hoc sub-process
+   *     was not built from a Camunda Modeler element template. This is a plain pass-through
+   *     attribute; bpmn-model does not interpret what any particular template id means.
+   */
+  String getModelerTemplate();
+
+  /**
+   * Sets the zeebe:modelerTemplate attribute.
+   *
+   * @param modelerTemplate the element template id to set
+   */
+  void setModelerTemplate(String modelerTemplate);
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/ServiceTask.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/ServiceTask.java
@@ -35,4 +35,18 @@ public interface ServiceTask extends Task {
   Operation getOperation();
 
   void setOperation(Operation operation);
+
+  /**
+   * @return the zeebe:modelerTemplate attribute value, or {@code null} if this service task was not
+   *     built from a Camunda Modeler element template. This is a plain pass-through attribute;
+   *     bpmn-model does not interpret what any particular template id means.
+   */
+  String getModelerTemplate();
+
+  /**
+   * Sets the zeebe:modelerTemplate attribute.
+   *
+   * @param modelerTemplate the element template id to set
+   */
+  void setModelerTemplate(String modelerTemplate);
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAgentDefinition.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAgentDefinition.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+
+/**
+ * Marks a {@code serviceTask} or {@code adHocSubProcess} element as an agent definition: the shared
+ * design-time signal that both the agent registry and external-agent features rely on to detect
+ * agents at deploy time.
+ */
+public interface ZeebeAgentDefinition extends BpmnModelElementInstance {
+
+  /**
+   * @return the agent type declared on the marker, identifying both the agent's origin
+   *     (Camunda-native vs. external) and, for Camunda-native agents, the hosting element shape
+   */
+  ZeebeAgentType getAgentType();
+
+  void setAgentType(ZeebeAgentType agentType);
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAgentType.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAgentType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+/**
+ * The kind of agent a {@code zeebe:agentDefinition} marker declares, encoding both its origin
+ * (Camunda-native vs. externally-hosted) and, for Camunda-native agents, the hosting element shape.
+ */
+public enum ZeebeAgentType {
+  aiAgentSubProcess,
+  aiAgentTask,
+  external
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/AgentDefinitionValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/AgentDefinitionValidator.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
+import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
+import io.camunda.zeebe.model.bpmn.instance.FlowElement;
+import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAgentDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAgentType;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+/**
+ * Validates that a {@code zeebe:agentDefinition} marker's {@code agentType} is consistent with the
+ * element it is attached to: {@code aiAgentSubProcess} is only valid on an ad-hoc sub-process,
+ * while {@code aiAgentTask} and {@code external} are only valid on a service task.
+ */
+public final class AgentDefinitionValidator implements ModelElementValidator<FlowElement> {
+
+  @Override
+  public Class<FlowElement> getElementType() {
+    return FlowElement.class;
+  }
+
+  @Override
+  public void validate(
+      final FlowElement element, final ValidationResultCollector validationResultCollector) {
+    final ExtensionElements extensionElements = element.getExtensionElements();
+    if (extensionElements == null) {
+      return;
+    }
+
+    extensionElements.getChildElementsByType(ZeebeAgentDefinition.class).stream()
+        .findFirst()
+        .ifPresent(
+            agentDefinition ->
+                validateAgentType(element, agentDefinition, validationResultCollector));
+  }
+
+  private static void validateAgentType(
+      final FlowElement element,
+      final ZeebeAgentDefinition agentDefinition,
+      final ValidationResultCollector validationResultCollector) {
+    final ZeebeAgentType agentType = agentDefinition.getAgentType();
+    if (agentType == null) {
+      // missing/empty agentType is already reported by the required-attribute check
+      return;
+    }
+
+    switch (agentType) {
+      case aiAgentSubProcess:
+        if (!(element instanceof AdHocSubProcess)) {
+          validationResultCollector.addError(
+              0, "agentType 'aiAgentSubProcess' is only allowed on an ad-hoc sub-process.");
+        }
+        break;
+
+      case aiAgentTask:
+      case external:
+        if (!(element instanceof ServiceTask)) {
+          validationResultCollector.addError(
+              0, String.format("agentType '%s' is only allowed on a service task.", agentType));
+        }
+        break;
+
+      default:
+        break;
+    }
+  }
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExtensionElementDuplicationValidators.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExtensionElementDuplicationValidators.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.model.bpmn.instance.SendTask;
 import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
 import io.camunda.zeebe.model.bpmn.instance.UserTask;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHoc;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAgentDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
@@ -73,6 +74,9 @@ public class ExtensionElementDuplicationValidators {
           ExtensionElementsDuplicationValidator.verifyThat(ServiceTask.class)
               .hasSingleExtensionElement(
                   ZeebeJobPriorityDefinition.class, ZeebeConstants.ELEMENT_JOB_PRIORITY_DEFINITION),
+          ExtensionElementsDuplicationValidator.verifyThat(ServiceTask.class)
+              .hasSingleExtensionElement(
+                  ZeebeAgentDefinition.class, ZeebeConstants.ELEMENT_AGENT_DEFINITION),
           ExtensionElementsDuplicationValidator.verifyThat(SendTask.class)
               .hasSingleExtensionElement(
                   ZeebeTaskHeaders.class, ZeebeConstants.ELEMENT_TASK_HEADERS),
@@ -135,6 +139,9 @@ public class ExtensionElementDuplicationValidators {
           // ad-hoc subprocess
           ExtensionElementsDuplicationValidator.verifyThat(AdHocSubProcess.class)
               .hasSingleExtensionElement(ZeebeAdHoc.class, ZeebeConstants.ELEMENT_AD_HOC),
+          ExtensionElementsDuplicationValidator.verifyThat(AdHocSubProcess.class)
+              .hasSingleExtensionElement(
+                  ZeebeAgentDefinition.class, ZeebeConstants.ELEMENT_AGENT_DEFINITION),
 
           // end event
           ExtensionElementsDuplicationValidator.verifyThat(EndEvent.class)

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.model.bpmn.instance.CallActivity;
 import io.camunda.zeebe.model.bpmn.instance.Condition;
 import io.camunda.zeebe.model.bpmn.instance.MultiInstanceLoopCharacteristics;
 import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAgentDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
@@ -47,6 +48,7 @@ public final class ZeebeDesignTimeValidators {
     final List<ModelElementValidator<?>> validators = new ArrayList<>();
     validators.add(new ActivityValidator());
     validators.add(new AdHocSubProcessValidator());
+    validators.add(new AgentDefinitionValidator());
     validators.add(new BoundaryEventValidator());
     validators.add(new BusinessRuleTaskValidator());
     validators.add(
@@ -82,6 +84,10 @@ public final class ZeebeDesignTimeValidators {
     validators.add(new StartEventValidator());
     validators.add(new SubProcessValidator());
     validators.add(new TimerEventDefinitionValidator());
+    validators.add(
+        ZeebeElementValidator.verifyThat(ZeebeAgentDefinition.class)
+            .hasNonEmptyEnumAttribute(
+                ZeebeAgentDefinition::getAgentType, ZeebeConstants.ATTRIBUTE_AGENT_TYPE));
     validators.add(
         ZeebeElementValidator.verifyThat(ZeebeCalledElement.class)
             .hasNonEmptyAttribute(

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/AdHocSubProcessBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/AdHocSubProcessBuilderTest.java
@@ -341,6 +341,26 @@ class AdHocSubProcessBuilderTest {
         .isEqualTo(ZeebeAgentType.aiAgentSubProcess);
   }
 
+  @Test
+  void shouldSetModelerTemplate() {
+    // given / when
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .adHocSubProcess(
+                "ad-hoc",
+                adHocSubProcess ->
+                    adHocSubProcess
+                        .zeebeModelerTemplate("io.camunda.connectors.MyTemplate")
+                        .task("A"))
+            .endEvent()
+            .done();
+
+    // then
+    final AdHocSubProcess adHocSubProcess = process.getModelElementById("ad-hoc");
+    assertThat(adHocSubProcess.getModelerTemplate()).isEqualTo("io.camunda.connectors.MyTemplate");
+  }
+
   private Collection<ZeebeExecutionListener> getExecutionListeners(
       final ModelElementInstance elementInstance) {
     return elementInstance

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/AdHocSubProcessBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/AdHocSubProcessBuilderTest.java
@@ -25,6 +25,8 @@ import io.camunda.zeebe.model.bpmn.instance.CompletionCondition;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.FlowElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHoc;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAgentDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAgentType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
@@ -312,6 +314,31 @@ class AdHocSubProcessBuilderTest {
         .first()
         .extracting(ZeebeAdHoc::getOutputElement, ZeebeAdHoc::getOutputCollection)
         .containsExactly("=" + outputElementExpression, outputCollection);
+  }
+
+  @Test
+  void shouldSetAiAgentSubProcessDefinition() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .adHocSubProcess(
+                "ad-hoc",
+                adHocSubProcess -> adHocSubProcess.zeebeAiAgentSubProcessDefinition().task("A"))
+            .endEvent()
+            .done();
+
+    // when/then
+    final ModelElementInstance adHocSubProcess = process.getModelElementById("ad-hoc");
+
+    final ExtensionElements extensionElements =
+        (ExtensionElements) adHocSubProcess.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements).isNotNull();
+
+    assertThat(extensionElements.getChildElementsByType(ZeebeAgentDefinition.class))
+        .singleElement()
+        .extracting(ZeebeAgentDefinition::getAgentType)
+        .isEqualTo(ZeebeAgentType.aiAgentSubProcess);
   }
 
   private Collection<ZeebeExecutionListener> getExecutionListeners(

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ServiceTaskBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ServiceTaskBuilderTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
+import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAgentDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAgentType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
@@ -286,5 +287,20 @@ public class ServiceTaskBuilderTest {
         .singleElement()
         .extracting(ZeebeAgentDefinition::getAgentType)
         .isEqualTo(ZeebeAgentType.external);
+  }
+
+  @Test
+  void shouldSetModelerTemplate() {
+    // given / when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeModelerTemplate("io.camunda.connectors.MyTemplate"))
+            .endEvent()
+            .done();
+
+    // then
+    final ServiceTask serviceTask = instance.getModelElementById("task");
+    assertThat(serviceTask.getModelerTemplate()).isEqualTo("io.camunda.connectors.MyTemplate");
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ServiceTaskBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ServiceTaskBuilderTest.java
@@ -24,6 +24,8 @@ import static org.assertj.core.api.Assertions.tuple;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAgentDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAgentType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
@@ -224,5 +226,65 @@ public class ServiceTaskBuilderTest {
         .singleElement()
         .extracting(ZeebeJobPriorityDefinition::getPriority)
         .isEqualTo("=priority");
+  }
+
+  @Test
+  void shouldSetAgentDefinitionOnServiceTask() {
+    // given / when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeAgentDefinition(ZeebeAgentType.aiAgentTask))
+            .endEvent()
+            .done();
+
+    // then
+    final ModelElementInstance serviceTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) serviceTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeAgentDefinition.class))
+        .singleElement()
+        .extracting(ZeebeAgentDefinition::getAgentType)
+        .isEqualTo(ZeebeAgentType.aiAgentTask);
+  }
+
+  @Test
+  void shouldSetAiAgentTaskDefinition() {
+    // given / when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", ServiceTaskBuilder::zeebeAiAgentTaskDefinition)
+            .endEvent()
+            .done();
+
+    // then
+    final ModelElementInstance serviceTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) serviceTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeAgentDefinition.class))
+        .singleElement()
+        .extracting(ZeebeAgentDefinition::getAgentType)
+        .isEqualTo(ZeebeAgentType.aiAgentTask);
+  }
+
+  @Test
+  void shouldSetExternalAgentDefinition() {
+    // given / when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", ServiceTaskBuilder::zeebeExternalAgentDefinition)
+            .endEvent()
+            .done();
+
+    // then
+    final ModelElementInstance serviceTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) serviceTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeAgentDefinition.class))
+        .singleElement()
+        .extracting(ZeebeAgentDefinition::getAgentType)
+        .isEqualTo(ZeebeAgentType.external);
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/ServiceTaskTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/ServiceTaskTest.java
@@ -16,6 +16,7 @@
 
 package io.camunda.zeebe.model.bpmn.instance;
 
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -38,6 +39,7 @@ public class ServiceTaskTest extends BpmnModelElementInstanceTest {
   public Collection<AttributeAssumption> getAttributesAssumptions() {
     return Arrays.asList(
         new AttributeAssumption("implementation", false, false, "##WebService"),
-        new AttributeAssumption("operationRef"));
+        new AttributeAssumption("operationRef"),
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "modelerTemplate", false, false));
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAgentDefinitionTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAgentDefinitionTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstanceTest;
+import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
+import java.io.ByteArrayInputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import org.junit.Test;
+
+public class ZeebeAgentDefinitionTest extends BpmnModelElementInstanceTest {
+
+  @Override
+  public TypeAssumption getTypeAssumption() {
+    return new TypeAssumption(BpmnModelConstants.ZEEBE_NS, false);
+  }
+
+  @Override
+  public Collection<ChildElementAssumption> getChildElementAssumptions() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Collection<AttributeAssumption> getAttributesAssumptions() {
+    return Arrays.asList(
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "agentType", false, true));
+  }
+
+  @Test
+  public void shouldRoundTripAgentDefinitionOnServiceTaskForAllAgentTypes() {
+    for (final ZeebeAgentType agentType : ZeebeAgentType.values()) {
+      // given
+      final BpmnModelInstance modelInstance =
+          Bpmn.createExecutableProcess("process-" + agentType)
+              .startEvent()
+              .serviceTask("task", t -> t.zeebeAgentDefinition(agentType))
+              .endEvent()
+              .done();
+      final String modelXml = Bpmn.convertToString(modelInstance);
+
+      // when
+      final ServiceTask serviceTask =
+          Bpmn.readModelFromStream(new ByteArrayInputStream(modelXml.getBytes()))
+              .getModelElementById("task");
+      final ZeebeAgentDefinition agentDefinition =
+          serviceTask.getSingleExtensionElement(ZeebeAgentDefinition.class);
+
+      // then
+      assertThat(agentDefinition.getAgentType()).isEqualTo(agentType);
+    }
+  }
+
+  @Test
+  public void shouldRoundTripAgentDefinitionOnAdHocSubProcessForAllAgentTypes() {
+    for (final ZeebeAgentType agentType : ZeebeAgentType.values()) {
+      // given
+      final BpmnModelInstance modelInstance =
+          Bpmn.createExecutableProcess("process-" + agentType)
+              .startEvent()
+              .adHocSubProcess(
+                  "ad-hoc",
+                  adHocSubProcess ->
+                      adHocSubProcess.zeebeAiAgentSubProcessDefinition().task("inner"))
+              .endEvent()
+              .done();
+      final AdHocSubProcess builtAdHocSubProcess = modelInstance.getModelElementById("ad-hoc");
+      builtAdHocSubProcess
+          .getSingleExtensionElement(ZeebeAgentDefinition.class)
+          .setAgentType(agentType);
+      final String modelXml = Bpmn.convertToString(modelInstance);
+
+      // when
+      final AdHocSubProcess adHocSubProcess =
+          Bpmn.readModelFromStream(new ByteArrayInputStream(modelXml.getBytes()))
+              .getModelElementById("ad-hoc");
+      final ZeebeAgentDefinition agentDefinition =
+          adHocSubProcess.getSingleExtensionElement(ZeebeAgentDefinition.class);
+
+      // then
+      assertThat(agentDefinition.getAgentType()).isEqualTo(agentType);
+    }
+  }
+}

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/AgentDefinitionValidatorTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/AgentDefinitionValidatorTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation;
+
+import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
+import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAgentDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAgentType;
+import org.camunda.bpm.model.xml.impl.util.ReflectUtil;
+import org.junit.jupiter.api.Test;
+
+class AgentDefinitionValidatorTest {
+
+  @Test
+  void aiAgentSubProcessOnAdHocSubProcessIsValid() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .adHocSubProcess(
+                "ad-hoc",
+                adHocSubProcess -> adHocSubProcess.zeebeAiAgentSubProcessDefinition().task("A"))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  void aiAgentTaskOnServiceTaskIsValid() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("test").zeebeAiAgentTaskDefinition())
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  void externalOnServiceTaskIsValid() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("test").zeebeExternalAgentDefinition())
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  void aiAgentSubProcessOnServiceTaskIsInvalid() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t -> t.zeebeJobType("test").zeebeAgentDefinition(ZeebeAgentType.aiAgentSubProcess))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            ServiceTask.class,
+            "agentType 'aiAgentSubProcess' is only allowed on an ad-hoc sub-process."));
+  }
+
+  @Test
+  void aiAgentTaskOnAdHocSubProcessIsInvalid() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.readModelFromStream(
+            ReflectUtil.getResourceAsStream(
+                "io/camunda/zeebe/model/bpmn/validation/AgentDefinitionValidatorTest.aiAgentTaskOnAdHocSubProcessIsInvalid.bpmn"));
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            AdHocSubProcess.class, "agentType 'aiAgentTask' is only allowed on a service task."));
+  }
+
+  @Test
+  void externalOnAdHocSubProcessIsInvalid() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.readModelFromStream(
+            ReflectUtil.getResourceAsStream(
+                "io/camunda/zeebe/model/bpmn/validation/AgentDefinitionValidatorTest.externalOnAdHocSubProcessIsInvalid.bpmn"));
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(AdHocSubProcess.class, "agentType 'external' is only allowed on a service task."));
+  }
+
+  @Test
+  void missingAgentTypeIsInvalid() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.readModelFromStream(
+            ReflectUtil.getResourceAsStream(
+                "io/camunda/zeebe/model/bpmn/validation/AgentDefinitionValidatorTest.missingAgentTypeIsInvalid.bpmn"));
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(ZeebeAgentDefinition.class, "Attribute 'agentType' must be present and not empty"));
+  }
+}

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/AgentDefinitionValidatorTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/AgentDefinitionValidatorTest.java
@@ -122,6 +122,32 @@ class AgentDefinitionValidatorTest {
   }
 
   @Test
+  void duplicateAgentDefinitionOnAdHocSubProcessIsInvalid() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.readModelFromStream(
+            ReflectUtil.getResourceAsStream(
+                "io/camunda/zeebe/model/bpmn/validation/AgentDefinitionValidatorTest.duplicateAgentDefinitionOnAdHocSubProcess.bpmn"));
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process, expect(AdHocSubProcess.class, "Must have exactly one 'zeebe:agentDefinition'"));
+  }
+
+  @Test
+  void duplicateAgentDefinitionOnServiceTaskIsInvalid() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.readModelFromStream(
+            ReflectUtil.getResourceAsStream(
+                "io/camunda/zeebe/model/bpmn/validation/AgentDefinitionValidatorTest.duplicateAgentDefinitionOnServiceTask.bpmn"));
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process, expect(ServiceTask.class, "Must have exactly one 'zeebe:agentDefinition'"));
+  }
+
+  @Test
   void missingAgentTypeIsInvalid() {
     // given
     final BpmnModelInstance process =

--- a/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/AgentDefinitionValidatorTest.aiAgentTaskOnAdHocSubProcessIsInvalid.bpmn
+++ b/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/AgentDefinitionValidatorTest.aiAgentTaskOnAdHocSubProcessIsInvalid.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1hhbqbg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>Flow_1du2tni</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1du2tni" sourceRef="start_event" targetRef="ad-hoc" />
+    <bpmn:sequenceFlow id="Flow_029v1e2" sourceRef="ad-hoc" targetRef="end_event" />
+    <bpmn:endEvent id="end_event">
+      <bpmn:incoming>Flow_029v1e2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:adHocSubProcess id="ad-hoc">
+      <bpmn:extensionElements>
+        <zeebe:agentDefinition agentType="aiAgentTask" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1du2tni</bpmn:incoming>
+      <bpmn:outgoing>Flow_029v1e2</bpmn:outgoing>
+      <bpmn:task id="A" />
+    </bpmn:adHocSubProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start_event">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05j5qkv_di" bpmnElement="ad-hoc">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_068g3bp_di" bpmnElement="end_event">
+        <dc:Bounds x="472" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1du2tni_di" bpmnElement="Flow_1du2tni">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_029v1e2_di" bpmnElement="Flow_029v1e2">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="472" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/AgentDefinitionValidatorTest.duplicateAgentDefinitionOnAdHocSubProcess.bpmn
+++ b/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/AgentDefinitionValidatorTest.duplicateAgentDefinitionOnAdHocSubProcess.bpmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="start"/>
+    <bpmn:adHocSubProcess id="ad-hoc">
+      <bpmn:extensionElements>
+        <zeebe:agentDefinition agentType="aiAgentSubProcess"/>
+        <zeebe:agentDefinition agentType="aiAgentSubProcess"/>
+      </bpmn:extensionElements>
+      <bpmn:task id="A"/>
+    </bpmn:adHocSubProcess>
+  </bpmn:process>
+</bpmn:definitions>

--- a/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/AgentDefinitionValidatorTest.duplicateAgentDefinitionOnServiceTask.bpmn
+++ b/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/AgentDefinitionValidatorTest.duplicateAgentDefinitionOnServiceTask.bpmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="start"/>
+    <bpmn:serviceTask id="task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="service"/>
+        <zeebe:agentDefinition agentType="aiAgentTask"/>
+        <zeebe:agentDefinition agentType="external"/>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+</bpmn:definitions>

--- a/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/AgentDefinitionValidatorTest.externalOnAdHocSubProcessIsInvalid.bpmn
+++ b/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/AgentDefinitionValidatorTest.externalOnAdHocSubProcessIsInvalid.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1hhbqbg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>Flow_1du2tni</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1du2tni" sourceRef="start_event" targetRef="ad-hoc" />
+    <bpmn:sequenceFlow id="Flow_029v1e2" sourceRef="ad-hoc" targetRef="end_event" />
+    <bpmn:endEvent id="end_event">
+      <bpmn:incoming>Flow_029v1e2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:adHocSubProcess id="ad-hoc">
+      <bpmn:extensionElements>
+        <zeebe:agentDefinition agentType="external" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1du2tni</bpmn:incoming>
+      <bpmn:outgoing>Flow_029v1e2</bpmn:outgoing>
+      <bpmn:task id="A" />
+    </bpmn:adHocSubProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start_event">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05j5qkv_di" bpmnElement="ad-hoc">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_068g3bp_di" bpmnElement="end_event">
+        <dc:Bounds x="472" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1du2tni_di" bpmnElement="Flow_1du2tni">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_029v1e2_di" bpmnElement="Flow_029v1e2">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="472" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/AgentDefinitionValidatorTest.missingAgentTypeIsInvalid.bpmn
+++ b/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/AgentDefinitionValidatorTest.missingAgentTypeIsInvalid.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1hhbqbg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>Flow_1du2tni</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1du2tni" sourceRef="start_event" targetRef="task" />
+    <bpmn:sequenceFlow id="Flow_029v1e2" sourceRef="task" targetRef="end_event" />
+    <bpmn:endEvent id="end_event">
+      <bpmn:incoming>Flow_029v1e2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="task">
+      <bpmn:extensionElements>
+        <zeebe:agentDefinition />
+        <zeebe:taskDefinition type="test" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1du2tni</bpmn:incoming>
+      <bpmn:outgoing>Flow_029v1e2</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start_event">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05j5qkv_di" bpmnElement="task">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_068g3bp_di" bpmnElement="end_event">
+        <dc:Bounds x="472" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1du2tni_di" bpmnElement="Flow_1du2tni">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_029v1e2_di" bpmnElement="Flow_029v1e2">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="472" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

Models the `zeebe:agentDefinition` marker in `zeebe/bpmn-model`, per the locked design (Opt-3) in #58975: a required `agentType` enum attribute (`aiAgentSubProcess` / `aiAgentTask` / `external`) that can be attached to an ad-hoc sub-process or a service task, plus the `agentType` ↔ hosting-element consistency validation that mirrors the existing `AdHocSubProcessValidator` pattern.

**What's included:**
- `ZeebeAgentDefinition` / `ZeebeAgentType` model classes and the `zeebe:agentDefinition` extension element, registered on `AdHocSubProcess` and `ServiceTask`.
- Builder API: `zeebeAgentDefinition(ZeebeAgentType)` on `AbstractServiceTaskBuilder`, plus convenience wrappers `zeebeAiAgentAgentTaskDefinition()`, `zeebeExternalAgentDefinition()` and `zeebeAiAgentSubProcessDefinition()` on `AbstractAdHocSubProcessBuilder`.
- `zeebe:modelerTemplate` exposed as a typed attribute.
- `AgentDefinitionValidator`: rejects `agentType` values that don't match their hosting element — `aiAgentSubProcess` only valid on an ad-hoc sub-process; `aiAgentTask` and `external` only valid on a service task. Registered in `ZeebeDesignTimeValidators` alongside the required-attribute check for `agentType` itself and an `ExtensionElementsDuplicationValidator` rule rejecting more than one `zeebe:agentDefinition` extension element on the same `ServiceTask`/`AdHocSubProcess`.
- Round-trip, builder, and validator test coverage (see `AgentDefinitionValidatorTest`, `ZeebeAgentDefinitionTest`, `AdHocSubProcessBuilderTest`, `ServiceTaskBuilderTest`).

**Out of scope (deliberately):** deploy-time detection/derivation logic, `ExecutableJobWorkerElement`, and BPMN transformers in `zeebe/engine` are **not** touched here — that work is tracked separately in #59028. This PR is limited to `zeebe/bpmn-model` only.

> [!NOTE]
**Open design question:** whether `external` should be valid on an ad-hoc sub-process is currently pending confirmation (this PR keeps it service-task-only, matching camunda/product-hub#3702 issue's current wording); the validator and Bpmn builder API may need adjusting depending on the answer, but no BPMN-model changes are expected either way.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #58975

