### PR TITLE
feat: add metrics for secret resolution

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetrics.java
@@ -22,9 +22,12 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 /**
- * Records how long resolving secrets from a store takes, and what resolving each secret reference
- * ended up as. Without these, a store that fails, throttles, or denies access is visible only in
- * the broker log, so there is nothing to alert on.
+ * Records how long resolving secrets from a store takes, what resolving each secret reference ended
+ * up as, and the cycles a store failed unexpectedly in. Without these, a store that fails,
+ * throttles, or denies access is visible only in the broker log, so there is nothing to alert on.
+ *
+ * <p>The per-reference outcomes and the per-cycle errors are separate meters rather than values on
+ * one counter, so that neither can be added to the other by a query that aggregates across a tag.
  *
  * <p>Every meter is tagged by store ID, which is not known up front: it comes from the pending
  * secret references in state, not from configuration, and the engine resolves references for store
@@ -42,6 +45,7 @@ public final class SecretResolutionMetrics {
       new EnumMap<>(SecretResolutionCallResult.class);
   private final Map<SecretResolutionOutcome, BoundedMeterCache<Counter>> outcomeCounters =
       new EnumMap<>(SecretResolutionOutcome.class);
+  private final BoundedMeterCache<Counter> cycleErrors;
 
   public SecretResolutionMetrics(final MeterRegistry registry) {
     this.registry = registry;
@@ -51,6 +55,7 @@ public final class SecretResolutionMetrics {
     for (final var outcome : SecretResolutionOutcome.values()) {
       outcomeCounters.put(outcome, counterCache(registry, outcome));
     }
+    cycleErrors = cycleErrorCache(registry);
   }
 
   /**
@@ -104,9 +109,13 @@ public final class SecretResolutionMetrics {
    * references it left pending are retried, so this counts cycles rather than references — counting
    * the references instead would scale the series with the pending backlog and with how often the
    * cycle runs, and neither is a quantity anyone can alert on.
+   *
+   * <p>That unit is why this is its own meter rather than another value on the outcome counter: a
+   * counter mixing cycles and references cannot be summed or divided across its {@code result} tag,
+   * so every rate and failure ratio built on it would quietly add the two together.
    */
   public void error(final String storeId) {
-    outcomeCounter(storeId, SecretResolutionOutcome.ERROR).increment();
+    cycleErrors.get(storeTag(storeId)).increment();
   }
 
   private Counter outcomeCounter(final String storeId, final SecretResolutionOutcome outcome) {
@@ -129,6 +138,15 @@ public final class SecretResolutionMetrics {
         Counter.builder(meterDoc.getName())
             .description(meterDoc.getDescription())
             .tag(SecretResolutionKeyNames.RESULT.asString(), outcome.name())
+            .withRegistry(registry);
+    return BoundedMeterCache.of(registry, provider, SecretResolutionKeyNames.STORE);
+  }
+
+  private static BoundedMeterCache<Counter> cycleErrorCache(final MeterRegistry registry) {
+    final var meterDoc = SecretResolutionMetricsDoc.RESOLUTION_CYCLE_ERROR;
+    final var provider =
+        Counter.builder(meterDoc.getName())
+            .description(meterDoc.getDescription())
             .withRegistry(registry);
     return BoundedMeterCache.of(registry, provider, SecretResolutionKeyNames.STORE);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetrics.java
@@ -55,19 +55,22 @@ public final class SecretResolutionMetrics {
 
   /**
    * Runs one batch resolution call against the given store and records how long it took, split by
-   * how the call itself ended. Only the call is measured, so the cache writes and the command
-   * appends that follow a successful one stay out of the latency.
+   * how the call itself ended. Only the call is measured, so the command appends that follow a
+   * successful one stay out of the latency.
    */
   public <T> T recordResolution(final String storeId, final Supplier<T> storeCall) {
     final var sample = Timer.start(registry);
-    var callResult = SecretResolutionCallResult.RETURNED;
+    // anything that leaves this method other than a value or a SecretStoreUnavailableException is
+    // an unmodelled failure, an Error included. Defaulting to ERROR and setting RETURNED only on
+    // the path that returns a value covers those without catching Throwable, which would otherwise
+    // time a failed call under the success bucket.
+    var callResult = SecretResolutionCallResult.ERROR;
     try {
-      return storeCall.get();
+      final T result = storeCall.get();
+      callResult = SecretResolutionCallResult.RETURNED;
+      return result;
     } catch (final SecretStoreUnavailableException e) {
       callResult = SecretResolutionCallResult.STORE_UNAVAILABLE;
-      throw e;
-    } catch (final RuntimeException e) {
-      callResult = SecretResolutionCallResult.ERROR;
       throw e;
     } finally {
       sample.stop(resolutionTimers.get(callResult).get(storeTag(storeId)));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetrics.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import io.camunda.secretstore.SecretErrorCode;
+import io.camunda.secretstore.SecretStoreUnavailableException;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionCallResult;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionKeyNames;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionOutcome;
+import io.camunda.zeebe.util.micrometer.BoundedMeterCache;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Records how long resolving secrets from a store takes, and what resolving each secret reference
+ * ended up as. Without these, a store that fails, throttles, or denies access is visible only in
+ * the broker log, so there is nothing to alert on.
+ *
+ * <p>Every meter is tagged by store ID, which is not known up front: it comes from the pending
+ * secret references in state, not from configuration, and the engine resolves references for store
+ * IDs it has no configured store for. The meters are therefore held in {@link BoundedMeterCache}s
+ * keyed by store ID. The domain is small today — the default store ID every {@code
+ * camunda.secrets.<name>} reference carries, plus {@link SecretResolutionKeyNames#NO_STORE} for a
+ * reference written before that ID existed — but once store selection is wired to the engine (<a
+ * href="https://github.com/camunda/camunda/issues/56563">#56563</a>) a store ID becomes
+ * process-author input, and the bound is what keeps that from growing the registry without limit.
+ */
+public final class SecretResolutionMetrics {
+
+  private final MeterRegistry registry;
+  private final Map<SecretResolutionCallResult, BoundedMeterCache<Timer>> resolutionTimers =
+      new EnumMap<>(SecretResolutionCallResult.class);
+  private final Map<SecretResolutionOutcome, BoundedMeterCache<Counter>> outcomeCounters =
+      new EnumMap<>(SecretResolutionOutcome.class);
+
+  public SecretResolutionMetrics(final MeterRegistry registry) {
+    this.registry = registry;
+    for (final var callResult : SecretResolutionCallResult.values()) {
+      resolutionTimers.put(callResult, timerCache(registry, callResult));
+    }
+    for (final var outcome : SecretResolutionOutcome.values()) {
+      outcomeCounters.put(outcome, counterCache(registry, outcome));
+    }
+  }
+
+  /**
+   * Runs one batch resolution call against the given store and records how long it took, split by
+   * how the call itself ended. Only the call is measured, so the cache writes and the command
+   * appends that follow a successful one stay out of the latency.
+   */
+  public <T> T recordResolution(final String storeId, final Supplier<T> storeCall) {
+    final var sample = Timer.start(registry);
+    var callResult = SecretResolutionCallResult.RETURNED;
+    try {
+      return storeCall.get();
+    } catch (final SecretStoreUnavailableException e) {
+      callResult = SecretResolutionCallResult.STORE_UNAVAILABLE;
+      throw e;
+    } catch (final RuntimeException e) {
+      callResult = SecretResolutionCallResult.ERROR;
+      throw e;
+    } finally {
+      sample.stop(resolutionTimers.get(callResult).get(storeTag(storeId)));
+    }
+  }
+
+  /** Records that one secret reference was resolved to a value. */
+  public void resolved(final String storeId) {
+    outcomeCounter(storeId, SecretResolutionOutcome.RESOLVED).increment();
+  }
+
+  /** Records that one secret reference failed permanently with the store's own error code. */
+  public void failed(final String storeId, final SecretErrorCode code) {
+    outcomeCounter(storeId, SecretResolutionOutcome.from(code)).increment();
+  }
+
+  /**
+   * Records that {@code referenceCount} references failed because their store is not configured, or
+   * could not be reached with no retry attempt left.
+   */
+  public void storeUnavailable(final String storeId, final int referenceCount) {
+    if (referenceCount <= 0) {
+      // nothing happened, so registering the series would only add an always-zero line
+      return;
+    }
+    outcomeCounter(storeId, SecretResolutionOutcome.STORE_UNAVAILABLE).increment(referenceCount);
+  }
+
+  /**
+   * Records one resolution cycle in which a store failed in a way the engine does not model. The
+   * references it left pending are retried, so this counts cycles rather than references — counting
+   * the references instead would scale the series with the pending backlog and with how often the
+   * cycle runs, and neither is a quantity anyone can alert on.
+   */
+  public void error(final String storeId) {
+    outcomeCounter(storeId, SecretResolutionOutcome.ERROR).increment();
+  }
+
+  private Counter outcomeCounter(final String storeId, final SecretResolutionOutcome outcome) {
+    return outcomeCounters.get(outcome).get(storeTag(storeId));
+  }
+
+  private static BoundedMeterCache<Timer> timerCache(
+      final MeterRegistry registry, final SecretResolutionCallResult callResult) {
+    final var provider =
+        MicrometerUtil.buildTimer(SecretResolutionMetricsDoc.RESOLUTION_DURATION)
+            .tag(SecretResolutionKeyNames.RESULT.asString(), callResult.name())
+            .withRegistry(registry);
+    return BoundedMeterCache.of(registry, provider, SecretResolutionKeyNames.STORE);
+  }
+
+  private static BoundedMeterCache<Counter> counterCache(
+      final MeterRegistry registry, final SecretResolutionOutcome outcome) {
+    final var meterDoc = SecretResolutionMetricsDoc.RESOLUTION_OUTCOME;
+    final var provider =
+        Counter.builder(meterDoc.getName())
+            .description(meterDoc.getDescription())
+            .tag(SecretResolutionKeyNames.RESULT.asString(), outcome.name())
+            .withRegistry(registry);
+    return BoundedMeterCache.of(registry, provider, SecretResolutionKeyNames.STORE);
+  }
+
+  /**
+   * A secret reference written before #59432 carries no store ID, so the raw value is the empty
+   * string. An empty tag value is indistinguishable from an absent one on a dashboard, so it gets a
+   * sentinel the same way {@code PartitionKeyNames.noPartition()} does.
+   */
+  private static String storeTag(final String storeId) {
+    return storeId.isBlank() ? SecretResolutionKeyNames.NO_STORE : storeId;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetricsDoc.java
@@ -26,9 +26,10 @@ public enum SecretResolutionMetricsDoc implements ExtendedMeterDocumentation {
   RESOLUTION_DURATION {
     @Override
     public String getDescription() {
-      return "Latency of one batch resolution call against a secret store, covering the store IO "
-          + "only and not the cache write or the follow-up command. Split by how the call ended, so "
-          + "a store timing out does not distort the latency of the calls that came back.";
+      return "Latency of one batch resolution call against a secret store, covering the call "
+          + "itself and not the follow-up commands the engine writes for its results. Split by how "
+          + "the call ended, so a store timing out does not distort the latency of the calls that "
+          + "came back.";
     }
 
     @Override
@@ -74,7 +75,7 @@ public enum SecretResolutionMetricsDoc implements ExtendedMeterDocumentation {
     }
   },
 
-  /** Number of secret references that reached a terminal resolution outcome */
+  /** Outcomes the engine produced while resolving secret references */
   RESOLUTION_OUTCOME {
     @Override
     public String getDescription() {
@@ -84,7 +85,11 @@ public enum SecretResolutionMetricsDoc implements ExtendedMeterDocumentation {
           + "unavailable but still has retry attempts left is not counted at all, because it has "
           + "not reached a terminal outcome yet. ERROR is the one non-terminal value: it counts one "
           + "per resolution cycle a store failed unexpectedly in, not one per reference, since "
-          + "those references stay pending and are retried.";
+          + "those references stay pending and are retried. A terminal value can slightly "
+          + "over-count: a reference stops being pending only once the follow-up command has been "
+          + "processed, so a cycle running before that resolves it a second time and counts it "
+          + "again, even though the duplicate command is then rejected. Read the counter as a rate "
+          + "signal per outcome rather than as an exact number of references.";
     }
 
     @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetricsDoc.java
@@ -79,17 +79,16 @@ public enum SecretResolutionMetricsDoc implements ExtendedMeterDocumentation {
   RESOLUTION_OUTCOME {
     @Override
     public String getDescription() {
-      return "Number of secret reference resolutions that produced an outcome, per store. Every "
-          + "result value except ERROR is terminal for the reference and is only counted once the "
-          + "engine has written the follow-up command for it. A reference whose store is "
-          + "unavailable but still has retry attempts left is not counted at all, because it has "
-          + "not reached a terminal outcome yet. ERROR is the one non-terminal value: it counts one "
-          + "per resolution cycle a store failed unexpectedly in, not one per reference, since "
-          + "those references stay pending and are retried. A terminal value can slightly "
-          + "over-count: a reference stops being pending only once the follow-up command has been "
-          + "processed, so a cycle running before that resolves it a second time and counts it "
-          + "again, even though the duplicate command is then rejected. Read the counter as a rate "
-          + "signal per outcome rather than as an exact number of references.";
+      return "Number of secret reference resolutions that produced an outcome, per store. Counts "
+          + "references throughout: every result value is terminal for the reference it counts, and "
+          + "is only counted once the engine has written the follow-up command for it, so the "
+          + "values can be summed or divided by one another. A reference whose store is unavailable "
+          + "but still has retry attempts left is not counted at all, because it has not reached a "
+          + "terminal outcome yet. A value can slightly over-count: a reference stops being pending "
+          + "only once the follow-up command has been processed, so a cycle running before that "
+          + "resolves it a second time and counts it again, even though the duplicate command is "
+          + "then rejected. Read the counter as a rate signal per outcome rather than as an exact "
+          + "number of references.";
     }
 
     @Override
@@ -105,6 +104,45 @@ public enum SecretResolutionMetricsDoc implements ExtendedMeterDocumentation {
     @Override
     public KeyName[] getKeyNames() {
       return new KeyName[] {SecretResolutionKeyNames.STORE, SecretResolutionKeyNames.RESULT};
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /** Resolution cycles a store failed unexpectedly in */
+  RESOLUTION_CYCLE_ERROR {
+    @Override
+    public String getDescription() {
+      return "Number of resolution cycles in which a store failed in a way the engine does not "
+          + "model — an unexpected exception rather than a per-secret failure or an unreachable "
+          + "store — per store. Always a bug, either in the store implementation or in the engine. "
+          + "Counts cycles rather than references, and is a separate meter from "
+          + "camunda.secret.resolution.outcome for that reason: the references such a cycle leaves "
+          + "pending are retried, so counting them would scale the series with the pending backlog "
+          + "and with how often the cycle runs, and neither is a quantity anyone can alert on. Does "
+          + "not cover an Error thrown by a store: the engine recovers from a RuntimeException "
+          + "only, and an Error instead fails the resolution task and shows up on "
+          + "camunda.secret.resolution.duration with result=ERROR.";
+    }
+
+    @Override
+    public String getName() {
+      return "camunda.secret.resolution.cycle.error";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      // deliberately no `result`: the meter has a single meaning, so there is no value domain to
+      // aggregate across and no way to add a cycle count to a reference count by accident
+      return new KeyName[] {SecretResolutionKeyNames.STORE};
     }
 
     @Override
@@ -160,6 +198,10 @@ public enum SecretResolutionMetricsDoc implements ExtendedMeterDocumentation {
    * here because the engine collapses all of them to a single {@code ResolutionState.NOT_FOUND}
    * when it writes to the stream, so this counter is the only place the distinction between a
    * missing secret and a denied one survives.
+   *
+   * <p>Every value counts one secret reference that reached a terminal outcome. Nothing measured
+   * per cycle belongs here: a counter whose values carry two different units cannot be summed or
+   * divided across the tag, which is what {@link #RESOLUTION_CYCLE_ERROR} is a separate meter for.
    */
   public enum SecretResolutionOutcome {
     /** The store returned a value for the reference */
@@ -177,15 +219,7 @@ public enum SecretResolutionMetricsDoc implements ExtendedMeterDocumentation {
      * be reached and no retry attempt is left. Mirrors {@code ResolutionState.STORE_UNAVAILABLE},
      * which the engine writes for both cases.
      */
-    STORE_UNAVAILABLE,
-    /**
-     * The store failed in a way the engine does not model: an unexpected exception rather than a
-     * {@code Failed} result or a {@code SecretStoreUnavailableException}. Always a bug, either in
-     * the store implementation or in the engine, and the only value here that is not terminal — the
-     * references stay pending and are retried, so this value counts one per failed resolution cycle
-     * rather than one per reference.
-     */
-    ERROR;
+    STORE_UNAVAILABLE;
 
     /**
      * Maps a store's typed error code onto the tag value.
@@ -213,10 +247,11 @@ public enum SecretResolutionMetricsDoc implements ExtendedMeterDocumentation {
    * timer can only say how the call itself ended. That distinction is what keeps a store timing out
    * after 60s out of the same histogram as the calls that returned.
    *
-   * <p>Every value naming a failure means the same thing as the {@link SecretResolutionOutcome}
-   * constant of the same name, so a {@code result} value reads identically on both meters. Only
-   * {@link #RETURNED} is exclusive to this domain, because a returning batch call has no single
-   * per-reference outcome to report.
+   * <p>{@link #STORE_UNAVAILABLE} is the one value shared with {@link SecretResolutionOutcome}, and
+   * means the same failure on both, so that {@code result} value reads identically wherever it
+   * appears. The other two are exclusive to this domain: a returning batch call has no single
+   * per-reference outcome to report, and a call that threw leaves its references pending rather
+   * than resolving any of them.
    */
   public enum SecretResolutionCallResult {
     /** The store returned, whatever the per-reference results were */
@@ -226,7 +261,12 @@ public enum SecretResolutionMetricsDoc implements ExtendedMeterDocumentation {
      * says nothing about retries: it covers every unreachable call, not only the last one.
      */
     STORE_UNAVAILABLE,
-    /** The store threw something the engine does not model. Always a bug */
+    /**
+     * The store threw something the engine does not model. Always a bug. Covers an {@code Error}
+     * too, which the engine does not recover from and which therefore reaches no other meter —
+     * {@link SecretResolutionMetricsDoc#RESOLUTION_CYCLE_ERROR} counts only the cycles the engine
+     * carried on from.
+     */
     ERROR
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetricsDoc.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import io.camunda.secretstore.SecretErrorCode;
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+import java.time.Duration;
+
+/**
+ * Meters for resolving secret references against a secret store.
+ *
+ * <p>No meter here is tagged by secret name: the cardinality is unbounded and secret names are
+ * customer data.
+ */
+@SuppressWarnings("NullableProblems")
+public enum SecretResolutionMetricsDoc implements ExtendedMeterDocumentation {
+  /** Latency of resolving one batch of secret references from a secret store */
+  RESOLUTION_DURATION {
+    @Override
+    public String getDescription() {
+      return "Latency of one batch resolution call against a secret store, covering the store IO "
+          + "only and not the cache write or the follow-up command. Split by how the call ended, so "
+          + "a store timing out does not distort the latency of the calls that came back.";
+    }
+
+    @Override
+    public String getName() {
+      return "camunda.secret.resolution.duration";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public String getBaseUnit() {
+      return "seconds";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {SecretResolutionKeyNames.STORE, SecretResolutionKeyNames.RESULT};
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      // a secret store is typically remote (AWS Secrets Manager, GCP Secret Manager), so the
+      // interesting range runs from a local file read up to a request timing out — further than
+      // MicrometerUtil.defaultPrometheusBuckets(), which stops at 10s
+      return new Duration[] {
+        Duration.ofMillis(10),
+        Duration.ofMillis(100),
+        Duration.ofMillis(500),
+        Duration.ofSeconds(1),
+        Duration.ofSeconds(5),
+        Duration.ofSeconds(10),
+        Duration.ofSeconds(30),
+        Duration.ofSeconds(60)
+      };
+    }
+  },
+
+  /** Number of secret references that reached a terminal resolution outcome */
+  RESOLUTION_OUTCOME {
+    @Override
+    public String getDescription() {
+      return "Number of secret reference resolutions that produced an outcome, per store. Every "
+          + "result value except ERROR is terminal for the reference and is only counted once the "
+          + "engine has written the follow-up command for it. A reference whose store is "
+          + "unavailable but still has retry attempts left is not counted at all, because it has "
+          + "not reached a terminal outcome yet. ERROR is the one non-terminal value: it counts one "
+          + "per resolution cycle a store failed unexpectedly in, not one per reference, since "
+          + "those references stay pending and are retried.";
+    }
+
+    @Override
+    public String getName() {
+      return "camunda.secret.resolution.outcome";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {SecretResolutionKeyNames.STORE, SecretResolutionKeyNames.RESULT};
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  };
+
+  @SuppressWarnings("NullableProblems")
+  public enum SecretResolutionKeyNames implements KeyName {
+    /**
+     * The ID of the secret store the references belong to, or {@link #NO_STORE} for a reference
+     * that carries no store ID. The {@code camunda.secrets.<name>} syntax has no store dimension
+     * yet (<a href="https://github.com/camunda/camunda/issues/56563">#56563</a>), so every
+     * reference names the default store and that is the value this tag mostly carries.
+     */
+    STORE("store"),
+    /**
+     * What the measured operation resulted in: a {@link SecretResolutionOutcome} on {@link
+     * SecretResolutionMetricsDoc#RESOLUTION_OUTCOME}, and the coarser {@link
+     * SecretResolutionCallResult} on {@link SecretResolutionMetricsDoc#RESOLUTION_DURATION}, which
+     * measures a whole batch call and so cannot attribute a per-reference outcome to it.
+     */
+    RESULT("result");
+
+    /**
+     * The {@link #STORE} value used when a secret reference carries no store ID.
+     *
+     * <p>Deliberately not spellable as a store ID: those are property-path segments under {@code
+     * camunda.secrets.stores.<type>.<id>} (e.g. {@code main}, {@code store-a}, {@code aws-main}),
+     * so a bare word like {@code none} would silently merge a configured store's series with the
+     * no-store one. The brackets keep the two apart.
+     */
+    public static final String NO_STORE = "<none>";
+
+    private final String key;
+
+    SecretResolutionKeyNames(final String key) {
+      this.key = key;
+    }
+
+    @Override
+    public String asString() {
+      return key;
+    }
+  }
+
+  /**
+   * The value domain of the {@link SecretResolutionKeyNames#RESULT} tag on {@link
+   * #RESOLUTION_OUTCOME}.
+   *
+   * <p>The four per-secret failure values mirror {@link SecretErrorCode}. They are worth carrying
+   * here because the engine collapses all of them to a single {@code ResolutionState.NOT_FOUND}
+   * when it writes to the stream, so this counter is the only place the distinction between a
+   * missing secret and a denied one survives.
+   */
+  public enum SecretResolutionOutcome {
+    /** The store returned a value for the reference */
+    RESOLVED,
+    /** The store does not hold the reference */
+    NOT_FOUND,
+    /** The store refused to read the reference */
+    ACCESS_DENIED,
+    /** The reference is not valid for the store */
+    INVALID_REF,
+    /** The store holds the reference but could not read a value from it */
+    UNREADABLE,
+    /**
+     * The store could not serve the reference at all: either it is not configured, or it could not
+     * be reached and no retry attempt is left. Mirrors {@code ResolutionState.STORE_UNAVAILABLE},
+     * which the engine writes for both cases.
+     */
+    STORE_UNAVAILABLE,
+    /**
+     * The store failed in a way the engine does not model: an unexpected exception rather than a
+     * {@code Failed} result or a {@code SecretStoreUnavailableException}. Always a bug, either in
+     * the store implementation or in the engine, and the only value here that is not terminal — the
+     * references stay pending and are retried, so this value counts one per failed resolution cycle
+     * rather than one per reference.
+     */
+    ERROR;
+
+    /**
+     * Maps a store's typed error code onto the tag value.
+     *
+     * <p>Exhaustive and without a {@code default} branch on purpose: {@link SecretErrorCode}
+     * documents that every caller maps new codes in the same change, and this is what makes the
+     * compiler enforce that here instead of silently bucketing a new code under an existing tag
+     * value.
+     */
+    public static SecretResolutionOutcome from(final SecretErrorCode code) {
+      return switch (code) {
+        case NOT_FOUND -> NOT_FOUND;
+        case ACCESS_DENIED -> ACCESS_DENIED;
+        case INVALID_REF -> INVALID_REF;
+        case UNREADABLE -> UNREADABLE;
+      };
+    }
+  }
+
+  /**
+   * The value domain of the {@link SecretResolutionKeyNames#RESULT} tag on {@link
+   * #RESOLUTION_DURATION}.
+   *
+   * <p>A batch call resolves many references at once and each of them can end differently, so the
+   * timer can only say how the call itself ended. That distinction is what keeps a store timing out
+   * after 60s out of the same histogram as the calls that returned.
+   *
+   * <p>Every value naming a failure means the same thing as the {@link SecretResolutionOutcome}
+   * constant of the same name, so a {@code result} value reads identically on both meters. Only
+   * {@link #RETURNED} is exclusive to this domain, because a returning batch call has no single
+   * per-reference outcome to report.
+   */
+  public enum SecretResolutionCallResult {
+    /** The store returned, whatever the per-reference results were */
+    RETURNED,
+    /**
+     * The store could not be reached. Unlike {@link SecretResolutionOutcome#STORE_UNAVAILABLE} this
+     * says nothing about retries: it covers every unreachable call, not only the last one.
+     */
+    STORE_UNAVAILABLE,
+    /** The store threw something the engine does not model. Always a bug */
+    ERROR
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessDefinitionMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetrics;
 import io.camunda.zeebe.engine.metrics.TenantMetrics;
 import io.camunda.zeebe.engine.processing.agenthistory.AgentHistoryProcessors;
 import io.camunda.zeebe.engine.processing.agentinstance.AgentInstanceProcessors;
@@ -170,6 +171,8 @@ public final class EngineProcessors {
     final var tenantMetrics = new TenantMetrics(typedRecordProcessorContext.getMeterRegistry());
     final var messageCorrelationMetrics =
         new MessageCorrelationMetrics(typedRecordProcessorContext.getMeterRegistry());
+    final var secretResolutionMetrics =
+        new SecretResolutionMetrics(typedRecordProcessorContext.getMeterRegistry());
 
     subscriptionCommandSender.setWriters(writers);
 
@@ -526,7 +529,8 @@ public final class EngineProcessors {
         incidentMetrics,
         scheduledTaskStateFactory,
         secretStoreRegistry,
-        config);
+        config,
+        secretResolutionMetrics);
 
     return typedRecordProcessors;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceProcessors.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.secretreference;
 import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.IncidentMetrics;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -31,7 +32,8 @@ public final class SecretReferenceProcessors {
       final IncidentMetrics incidentMetrics,
       final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
       final SecretStoreRegistry secretStoreRegistry,
-      final EngineConfiguration config) {
+      final EngineConfiguration config,
+      final SecretResolutionMetrics secretResolutionMetrics) {
     typedRecordProcessors.onCommand(
         ValueType.SECRET_REFERENCE,
         SecretReferenceIntent.RESOLUTION_COMPLETE,
@@ -54,7 +56,8 @@ public final class SecretReferenceProcessors {
             writers, keyGenerator, processingState, incidentMetrics));
 
     final var scheduler =
-        new SecretResolutionScheduler(scheduledTaskStateFactory, secretStoreRegistry, config);
+        new SecretResolutionScheduler(
+            scheduledTaskStateFactory, secretStoreRegistry, config, secretResolutionMetrics);
     typedRecordProcessors.withListener(scheduler);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
@@ -11,6 +11,7 @@ import io.camunda.secretstore.SecretResolutionResult;
 import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.secretstore.SecretStoreUnavailableException;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetrics;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.immutable.SecretReferenceState;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
@@ -76,6 +77,7 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
 
   private final SecretReferenceState secretReferenceState;
   private final SecretStoreRegistry secretStoreRegistry;
+  private final SecretResolutionMetrics metrics;
   private final Duration schedulingInterval;
   private final Duration retryInitialDelay;
   private final Duration retryMaxDelay;
@@ -107,9 +109,11 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
   public SecretResolutionScheduler(
       final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
       final SecretStoreRegistry secretStoreRegistry,
-      final EngineConfiguration config) {
+      final EngineConfiguration config,
+      final SecretResolutionMetrics metrics) {
     secretReferenceState = scheduledTaskStateFactory.get().getSecretReferenceState();
     this.secretStoreRegistry = secretStoreRegistry;
+    this.metrics = metrics;
     schedulingInterval = config.getSecretResolutionInterval();
     retryInitialDelay = config.getSecretResolutionRetryInitialDelay();
     retryMaxDelay = config.getSecretResolutionRetryMaxDelay();
@@ -184,6 +188,10 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
                 entry.getKey(),
                 entry.getValue().size(),
                 e);
+            // a store failing this way is a bug rather than one of the modelled outcomes, and it
+            // would otherwise be log-only: no outcome is counted for these references, so every
+            // rate built on the counter would read as "nothing is happening"
+            metrics.error(entry.getKey());
           }
         }
       }
@@ -270,28 +278,36 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
           "Secret store '{}' is not configured — failing {} pending secret refs",
           storeId,
           refs.size());
-      for (final String ref : refs) {
-        if (!appendResolutionFail(resultBuilder, storeId, ref, ResolutionState.STORE_UNAVAILABLE)) {
-          // batch full; refs not yet appended remain pending and will be retried next cycle —
-          // leave retry state untouched instead of resetting it out from under them
-          return false;
-        }
-        progressMade.set(true);
+      if (appendStoreUnavailableFails(resultBuilder, storeId, refs, progressMade) < refs.size()) {
+        // batch full; refs not yet appended remain pending and will be retried next cycle —
+        // leave retry state untouched instead of resetting it out from under them
+        return false;
       }
       storeRetryStates.remove(storeId);
       return true;
     }
 
     try {
-      final var results = store.resolveFromStore(refs);
+      final var results = metrics.recordResolution(storeId, () -> store.resolveFromStore(refs));
       for (final var entry : results.entrySet()) {
         final String ref = entry.getKey();
         final boolean appended;
+        // only a reference whose command was appended has reached a terminal outcome; one that did
+        // not fit stays pending and is counted when a later cycle appends it. Appending is the
+        // earliest point the outcome is known, but not the point the reference stops being pending
+        // — that is the RESOLUTION_COMPLETED event — so a cycle running before the command is
+        // processed resolves the reference again and counts it again, even though the duplicate
+        // command is then rejected. The over-count is documented on the meter; counting on the
+        // applied event instead would lose the store error code, which the record does not carry.
         switch (entry.getValue()) {
           // the value stays in the store and is never touched here, so the resolution record
           // carries no secret
-          case final SecretResolutionResult.Resolved ignored ->
-              appended = appendResolutionComplete(resultBuilder, storeId, ref);
+          case final SecretResolutionResult.Resolved ignored -> {
+            appended = appendResolutionComplete(resultBuilder, storeId, ref);
+            if (appended) {
+              metrics.resolved(storeId);
+            }
+          }
           case SecretResolutionResult.Failed(
                   final var code,
                   final var message,
@@ -307,6 +323,10 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
             // NOT_FOUND for now; ResolutionState has no finer per-secret states yet (#57855
             // will refine).
             appended = appendResolutionFail(resultBuilder, storeId, ref, ResolutionState.NOT_FOUND);
+            if (appended) {
+              // the metric keeps the code the stream record loses
+              metrics.failed(storeId, code);
+            }
           }
         }
         if (!appended) {
@@ -328,15 +348,11 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
             retryMaxAttempts,
             refs.size(),
             e.getMessage());
-        for (final String ref : refs) {
-          if (!appendResolutionFail(
-              resultBuilder, storeId, ref, ResolutionState.STORE_UNAVAILABLE)) {
-            // batch full; refs not yet appended remain pending. Leave retry state untouched so
-            // the next cycle still sees attempts >= retryMaxAttempts and continues failing them,
-            // instead of resetting to 0 and re-entering the backoff branch below.
-            return false;
-          }
-          progressMade.set(true);
+        if (appendStoreUnavailableFails(resultBuilder, storeId, refs, progressMade) < refs.size()) {
+          // batch full; refs not yet appended remain pending. Leave retry state untouched so
+          // the next cycle still sees attempts >= retryMaxAttempts and continues failing them,
+          // instead of resetting to 0 and re-entering the backoff branch below.
+          return false;
         }
         storeRetryStates.remove(storeId);
       } else {
@@ -352,6 +368,32 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
       }
       return true;
     }
+  }
+
+  /**
+   * Fails as many references of an unusable store as the result still has room for, counting the
+   * outcome for each one it appended. The refs it did not reach stay pending and are failed by the
+   * next cycle: the caller leaves the retry state alone in that case, so neither a store that is
+   * not configured nor one whose retries ran out re-enters the backoff ladder on their account.
+   *
+   * @return how many references the result took, which is fewer than {@code refs} only when the
+   *     batch filled up
+   */
+  private int appendStoreUnavailableFails(
+      final TaskResultBuilder resultBuilder,
+      final String storeId,
+      final Set<String> refs,
+      final MutableBoolean progressMade) {
+    int appended = 0;
+    for (final String ref : refs) {
+      if (!appendResolutionFail(resultBuilder, storeId, ref, ResolutionState.STORE_UNAVAILABLE)) {
+        break;
+      }
+      appended++;
+      progressMade.set(true);
+    }
+    metrics.storeUnavailable(storeId, appended);
+    return appended;
   }
 
   private boolean appendResolutionComplete(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
@@ -190,7 +190,11 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
                 e);
             // a store failing this way is a bug rather than one of the modelled outcomes, and it
             // would otherwise be log-only: no outcome is counted for these references, so every
-            // rate built on the counter would read as "nothing is happening"
+            // rate built on the outcome counter would read as "nothing is happening". Counted on
+            // its own meter, per cycle, because these references stay pending — see
+            // SecretResolutionMetrics#error. Deliberately only what this catch covers: an Error is
+            // not a cycle the scheduler carried on from, and is visible on the duration timer
+            // (result=ERROR) and in the task failing instead.
             metrics.error(entry.getKey());
           }
         }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetricsDocTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetricsDocTest.java
@@ -81,20 +81,40 @@ final class SecretResolutionMetricsDocTest {
             "ACCESS_DENIED",
             "INVALID_REF",
             "UNREADABLE",
-            "STORE_UNAVAILABLE",
-            "ERROR");
+            "STORE_UNAVAILABLE");
+  }
+
+  @Test
+  void shouldCountOnlySecretReferencesOnTheOutcomeCounter() {
+    // given — the two values that describe a whole call rather than a single reference
+    final var callLevelValues =
+        Stream.of(SecretResolutionCallResult.RETURNED, SecretResolutionCallResult.ERROR)
+            .map(Enum::name)
+            .toList();
+
+    // when/then — neither may become an outcome value. A counter whose values carry two units
+    // cannot be summed or divided across its `result` tag, so `sum by(store)(rate(..._total[5m]))`
+    // and every failure ratio would silently add references and calls together. A quantity measured
+    // per call or per cycle belongs on its own meter, as RESOLUTION_CYCLE_ERROR is
+    assertThat(SecretResolutionOutcome.values())
+        .extracting(Enum::name)
+        .doesNotContainAnyElementsOf(callLevelValues);
   }
 
   @Test
   void shouldGiveTheSameResultValueTheSameMeaningOnBothMeters() {
-    // given — the timer's own value for a call that came back, which has no per-reference meaning
-    final var timerOnlyValue = SecretResolutionCallResult.RETURNED.name();
+    // given — the timer's own values: RETURNED because a call that came back has no single
+    // per-reference outcome, ERROR because a call that threw resolved no reference at all
+    final var timerOnlyValues =
+        Stream.of(SecretResolutionCallResult.RETURNED, SecretResolutionCallResult.ERROR)
+            .map(Enum::name)
+            .toList();
 
     // when
     final var sharedValues =
         Stream.of(SecretResolutionCallResult.values())
             .map(Enum::name)
-            .filter(name -> !name.equals(timerOnlyValue))
+            .filter(name -> !timerOnlyValues.contains(name))
             .toList();
 
     // then — a `result` value that appears on both meters must mean the same failure on both,
@@ -118,12 +138,12 @@ final class SecretResolutionMetricsDocTest {
   }
 
   @Test
-  void shouldNotProduceTheNonTerminalOutcomesFromAStoreErrorCode() {
-    // given/when/then — STORE_UNAVAILABLE and ERROR are engine-level, not per-secret, so a store
-    // error code must never map onto them
+  void shouldNotProduceTheStoreLevelOutcomeFromAStoreErrorCode() {
+    // given/when/then — STORE_UNAVAILABLE says the store served no reference at all, so a code the
+    // store returned for one specific reference must never map onto it
     assertThat(SecretErrorCode.values())
         .extracting(SecretResolutionOutcome::from)
-        .doesNotContain(SecretResolutionOutcome.STORE_UNAVAILABLE, SecretResolutionOutcome.ERROR);
+        .doesNotContain(SecretResolutionOutcome.STORE_UNAVAILABLE);
   }
 
   @Test
@@ -143,10 +163,32 @@ final class SecretResolutionMetricsDocTest {
     // given
     final var description = SecretResolutionMetricsDoc.RESOLUTION_OUTCOME.getDescription();
 
-    // when/then — the counter is neither one-per-reference nor exact, and both caveats have to
-    // reach whoever builds an alert on it: ERROR counts per cycle, and a terminal outcome can be
-    // counted twice when a reference is resolved again before its command has been processed
-    assertThat(description).contains("ERROR").contains("over-count");
+    // when/then — the counter is per reference but not exact, and both caveats have to reach
+    // whoever builds an alert on it: a reference with retry attempts left is not counted at all,
+    // and one that is resolved again before its command has been processed is counted twice
+    assertThat(description).contains("retry attempts left").contains("over-count");
+  }
+
+  @Test
+  void shouldDocumentTheCycleErrorAsACounterTaggedByStoreOnly() {
+    // given
+    final var meter = SecretResolutionMetricsDoc.RESOLUTION_CYCLE_ERROR;
+
+    // when/then — no `result` tag: the meter has a single meaning, so there is no value domain to
+    // aggregate across and no way to add a cycle count to a reference count by accident
+    assertThat(meter.getName()).isEqualTo("camunda.secret.resolution.cycle.error");
+    assertThat(meter.getType()).isEqualTo(Type.COUNTER);
+    assertThat(meter.getKeyNames()).containsExactly(SecretResolutionKeyNames.STORE);
+  }
+
+  @Test
+  void shouldDocumentThatTheCycleErrorCountsCyclesRatherThanReferences() {
+    // given
+    final var description = SecretResolutionMetricsDoc.RESOLUTION_CYCLE_ERROR.getDescription();
+
+    // when/then — the unit is the whole point of the separate meter, and reading it as a reference
+    // count would make it look like a backlog rather than a bug rate
+    assertThat(description).contains("cycles rather than references");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetricsDocTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetricsDocTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.secretstore.SecretErrorCode;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionCallResult;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionKeyNames;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionOutcome;
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The doc enum is the documentation for these meters, so it is worth asserting on. Renaming a meter
+ * or a tag key silently breaks every dashboard and alert built on it, and there is no repo-wide
+ * check for that.
+ */
+final class SecretResolutionMetricsDocTest {
+
+  @Test
+  void shouldBeNamedAndDocumentedConsistently() {
+    // given
+    final var meters = (ExtendedMeterDocumentation[]) SecretResolutionMetricsDoc.values();
+
+    // when/then
+    assertThat(meters)
+        .isNotEmpty()
+        .allSatisfy(
+            meter -> {
+              assertThat(meter.getName())
+                  .startsWith("camunda.secret.resolution.")
+                  .doesNotContain("..")
+                  .doesNotContain("-")
+                  .doesNotContain("_");
+              assertThat(meter.getDescription()).isNotBlank();
+              assertThat(meter.getKeyNames()).contains(SecretResolutionKeyNames.STORE);
+              // the partition transition registry stamps these on every meter it forwards
+              assertThat(meter.getAdditionalKeyNames()).contains(PartitionKeyNames.values());
+            });
+  }
+
+  @Test
+  void shouldDocumentTheDurationAsATimerInSeconds() {
+    // given
+    final var meter = SecretResolutionMetricsDoc.RESOLUTION_DURATION;
+
+    // when/then
+    assertThat(meter.getName()).isEqualTo("camunda.secret.resolution.duration");
+    assertThat(meter.getType()).isEqualTo(Type.TIMER);
+    assertThat(meter.getBaseUnit()).isEqualTo("seconds");
+    // a batch call cannot carry a per-reference outcome, so the timer splits on the call itself —
+    // without that, a store timing out lands in the same histogram as the calls that came back
+    assertThat(meter.getKeyNames())
+        .containsExactly((KeyName) SecretResolutionKeyNames.STORE, SecretResolutionKeyNames.RESULT);
+    // a remote store call can take orders of magnitude longer than a local one, so the buckets have
+    // to span that range rather than stopping at the default upper bound
+    assertThat(meter.getTimerSLOs()).isNotEmpty();
+  }
+
+  @Test
+  void shouldDocumentACoarserResultDomainForTheTimerThanForTheCounter() {
+    // given/when/then — both meters tag `result`, but a batch call has no per-reference outcome
+    assertThat(SecretResolutionCallResult.values())
+        .extracting(Enum::name)
+        .containsExactlyInAnyOrder("RETURNED", "STORE_UNAVAILABLE", "ERROR");
+    assertThat(SecretResolutionOutcome.values())
+        .extracting(Enum::name)
+        .containsExactlyInAnyOrder(
+            "RESOLVED",
+            "NOT_FOUND",
+            "ACCESS_DENIED",
+            "INVALID_REF",
+            "UNREADABLE",
+            "STORE_UNAVAILABLE",
+            "ERROR");
+  }
+
+  @Test
+  void shouldGiveTheSameResultValueTheSameMeaningOnBothMeters() {
+    // given — the timer's own value for a call that came back, which has no per-reference meaning
+    final var timerOnlyValue = SecretResolutionCallResult.RETURNED.name();
+
+    // when
+    final var sharedValues =
+        Stream.of(SecretResolutionCallResult.values())
+            .map(Enum::name)
+            .filter(name -> !name.equals(timerOnlyValue))
+            .toList();
+
+    // then — a `result` value that appears on both meters must mean the same failure on both,
+    // otherwise the same legend on a dashboard reads as two different things
+    assertThat(sharedValues)
+        .isNotEmpty()
+        .allSatisfy(
+            name ->
+                assertThat(SecretResolutionOutcome.values()).extracting(Enum::name).contains(name));
+  }
+
+  @Test
+  void shouldGiveTheNoStoreSentinelAValueNoStoreIdCanTake() {
+    // given — a store ID is a property-path segment under camunda.secrets.stores.<type>.<id>, so
+    // it looks like `main`, `store-a` or `aws-main`
+    final var plainPropertySegment = "[A-Za-z0-9._-]+";
+
+    // when/then — a sentinel spelled like one of those would silently merge a configured store's
+    // series with the no-store one, and BoundedMeterCache would hand both the same meter
+    assertThat(SecretResolutionKeyNames.NO_STORE).doesNotMatch(plainPropertySegment).isNotBlank();
+  }
+
+  @Test
+  void shouldNotProduceTheNonTerminalOutcomesFromAStoreErrorCode() {
+    // given/when/then — STORE_UNAVAILABLE and ERROR are engine-level, not per-secret, so a store
+    // error code must never map onto them
+    assertThat(SecretErrorCode.values())
+        .extracting(SecretResolutionOutcome::from)
+        .doesNotContain(SecretResolutionOutcome.STORE_UNAVAILABLE, SecretResolutionOutcome.ERROR);
+  }
+
+  @Test
+  void shouldDocumentTheOutcomeAsACounterTaggedByStoreAndResult() {
+    // given
+    final var meter = SecretResolutionMetricsDoc.RESOLUTION_OUTCOME;
+
+    // when/then
+    assertThat(meter.getName()).isEqualTo("camunda.secret.resolution.outcome");
+    assertThat(meter.getType()).isEqualTo(Type.COUNTER);
+    assertThat(meter.getKeyNames())
+        .containsExactly(SecretResolutionKeyNames.STORE, SecretResolutionKeyNames.RESULT);
+  }
+
+  @Test
+  void shouldMapEveryStoreErrorCodeToItsOwnOutcome() {
+    // given/when
+    final var outcomes =
+        Stream.of(SecretErrorCode.values()).map(SecretResolutionOutcome::from).toList();
+
+    // then — a new error code must not be folded onto a tag value another code already uses, which
+    // would make two different failures indistinguishable on a dashboard. Matching names are not
+    // asserted: the outcome domain is a copy of SecretErrorCode precisely so that renaming a store
+    // API constant does not silently rename a metric tag value.
+    assertThat(outcomes).doesNotHaveDuplicates().hasSameSizeAs(SecretErrorCode.values());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetricsDocTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetricsDocTest.java
@@ -139,6 +139,17 @@ final class SecretResolutionMetricsDocTest {
   }
 
   @Test
+  void shouldDocumentHowFarTheOutcomeCounterCanBeTrusted() {
+    // given
+    final var description = SecretResolutionMetricsDoc.RESOLUTION_OUTCOME.getDescription();
+
+    // when/then — the counter is neither one-per-reference nor exact, and both caveats have to
+    // reach whoever builds an alert on it: ERROR counts per cycle, and a terminal outcome can be
+    // counted twice when a reference is resolved again before its command has been processed
+    assertThat(description).contains("ERROR").contains("over-count");
+  }
+
+  @Test
   void shouldMapEveryStoreErrorCodeToItsOwnOutcome() {
     // given/when
     final var outcomes =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -28,6 +28,11 @@ import io.camunda.secretstore.SecretStore;
 import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.secretstore.SecretStoreUnavailableException;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetrics;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionCallResult;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionKeyNames;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionOutcome;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.immutable.SecretReferenceState;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
@@ -37,6 +42,9 @@ import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -47,6 +55,8 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -71,6 +81,8 @@ final class SecretResolutionSchedulerTest {
   @Mock private StreamClock clock;
 
   private SecretResolutionScheduler scheduler;
+  private SimpleMeterRegistry meterRegistry;
+  private SecretResolutionMetrics metrics;
 
   @BeforeEach
   void setUp() {
@@ -78,13 +90,17 @@ final class SecretResolutionSchedulerTest {
     when(context.getScheduleService()).thenReturn(scheduleService);
     when(context.getClock()).thenReturn(clock);
     lenient().when(clock.millis()).thenReturn(0L);
+    // the real builder returns false once a record no longer fits the batch; the metric assertions
+    // depend on that return value, so the default `false` of the mock would be misleading here
     lenient().when(resultBuilder.appendCommandRecord(any(), any())).thenReturn(true);
 
+    meterRegistry = new SimpleMeterRegistry();
+    metrics = new SecretResolutionMetrics(meterRegistry);
     final Supplier<ScheduledTaskState> stateFactory = () -> scheduledTaskState;
     final var registry =
         new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, secretCache));
     final var config = new EngineConfiguration();
-    scheduler = new SecretResolutionScheduler(stateFactory, registry, config);
+    scheduler = new SecretResolutionScheduler(stateFactory, registry, config, metrics);
     scheduler.onRecovered(context);
   }
 
@@ -186,7 +202,7 @@ final class SecretResolutionSchedulerTest {
             .setSecretResolutionRetryMaxDelay(Duration.ofSeconds(2));
     final var localScheduler =
         new SecretResolutionScheduler(
-            () -> scheduledTaskState, new SecretStoreRegistry(Map.of()), config);
+            () -> scheduledTaskState, new SecretStoreRegistry(Map.of()), config, metrics);
 
     // when/then
     assertThat(localScheduler.calculateBackoff(1)).isEqualTo(Duration.ofSeconds(1));
@@ -226,7 +242,7 @@ final class SecretResolutionSchedulerTest {
     final var registry = new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of());
     final var localScheduler =
         new SecretResolutionScheduler(
-            () -> scheduledTaskState, registry, new EngineConfiguration());
+            () -> scheduledTaskState, registry, new EngineConfiguration(), metrics);
     localScheduler.onRecovered(context);
     stubPending(STORE_ID, "db-password");
     when(secretStore.resolve(Set.of("db-password")))
@@ -251,7 +267,7 @@ final class SecretResolutionSchedulerTest {
         new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, cache));
     final var localScheduler =
         new SecretResolutionScheduler(
-            () -> scheduledTaskState, registry, new EngineConfiguration());
+            () -> scheduledTaskState, registry, new EngineConfiguration(), metrics);
     localScheduler.onRecovered(context);
     stubPending(STORE_ID, "db-password");
     when(secretStore.resolve(Set.of("db-password")))
@@ -401,7 +417,7 @@ final class SecretResolutionSchedulerTest {
         new SecretStoreRegistry(Map.of("store-a", storeA, "store-b", storeB), Map.of());
     final var config = new EngineConfiguration().setSecretResolutionBatchLimit(2);
     final var localScheduler =
-        new SecretResolutionScheduler(() -> scheduledTaskState, registry, config);
+        new SecretResolutionScheduler(() -> scheduledTaskState, registry, config, metrics);
     localScheduler.onRecovered(context);
 
     when(storeA.resolve(Set.of("ref-a1"))).thenThrow(new SecretStoreUnavailableException("down"));
@@ -494,7 +510,7 @@ final class SecretResolutionSchedulerTest {
             Map.of("store-a", storeA, "store-b", storeB), Map.of("store-b", cacheB));
     final var localScheduler =
         new SecretResolutionScheduler(
-            () -> scheduledTaskState, registry, new EngineConfiguration());
+            () -> scheduledTaskState, registry, new EngineConfiguration(), metrics);
     localScheduler.onRecovered(context);
     reset(scheduleService);
 
@@ -548,7 +564,7 @@ final class SecretResolutionSchedulerTest {
             Map.of("store-a", storeA, "store-b", storeB), Map.of("store-b", cacheB));
     final var localScheduler =
         new SecretResolutionScheduler(
-            () -> scheduledTaskState, registry, new EngineConfiguration());
+            () -> scheduledTaskState, registry, new EngineConfiguration(), metrics);
     localScheduler.onRecovered(context);
 
     stubPending(Map.of("store-a", "ref-a", "store-b", "ref-b"));
@@ -596,7 +612,8 @@ final class SecretResolutionSchedulerTest {
         new SecretResolutionScheduler(
             () -> scheduledTaskState,
             new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, secretCache)),
-            config);
+            config,
+            metrics);
     localScheduler.onRecovered(context);
     stubPending(STORE_ID, "ref-1", "ref-2", "ref-3");
     when(secretStore.resolve(Set.of("ref-1", "ref-2")))
@@ -628,7 +645,7 @@ final class SecretResolutionSchedulerTest {
             Map.of("store-a", cacheA, "store-b", cacheB));
     final var config = new EngineConfiguration().setSecretResolutionBatchLimit(3);
     final var localScheduler =
-        new SecretResolutionScheduler(() -> scheduledTaskState, registry, config);
+        new SecretResolutionScheduler(() -> scheduledTaskState, registry, config, metrics);
     localScheduler.onRecovered(context);
 
     doAnswer(
@@ -677,7 +694,8 @@ final class SecretResolutionSchedulerTest {
         new SecretResolutionScheduler(
             () -> scheduledTaskState,
             new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, secretCache)),
-            config);
+            config,
+            metrics);
     localScheduler.onRecovered(context);
     reset(scheduleService);
     stubPending(STORE_ID, "ref-1", "ref-2", "ref-3");
@@ -704,7 +722,8 @@ final class SecretResolutionSchedulerTest {
         new SecretResolutionScheduler(
             () -> scheduledTaskState,
             new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, secretCache)),
-            config);
+            config,
+            metrics);
     localScheduler.onRecovered(context);
     reset(scheduleService);
     stubPending(STORE_ID, "ref-1", "ref-2");
@@ -735,7 +754,8 @@ final class SecretResolutionSchedulerTest {
         new SecretResolutionScheduler(
             () -> scheduledTaskState,
             new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, secretCache)),
-            config);
+            config,
+            metrics);
     localScheduler.onRecovered(context);
     reset(scheduleService);
     when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
@@ -805,7 +825,7 @@ final class SecretResolutionSchedulerTest {
             Map.of("store-a", storeA, "store-b", storeB), Map.of("store-b", cacheB));
     final var config = new EngineConfiguration().setSecretResolutionBatchLimit(2);
     final var localScheduler =
-        new SecretResolutionScheduler(() -> scheduledTaskState, registry, config);
+        new SecretResolutionScheduler(() -> scheduledTaskState, registry, config, metrics);
     localScheduler.onRecovered(context);
 
     // cycle 1 (t=0): drive store-a into retry cooldown
@@ -863,7 +883,7 @@ final class SecretResolutionSchedulerTest {
             Map.of("store-a", storeA, "store-b", storeB), Map.of("store-a", cacheA));
     final var localScheduler =
         new SecretResolutionScheduler(
-            () -> scheduledTaskState, registry, new EngineConfiguration());
+            () -> scheduledTaskState, registry, new EngineConfiguration(), metrics);
     localScheduler.onRecovered(context);
 
     final var refsByStore = new LinkedHashMap<String, String>();
@@ -945,6 +965,240 @@ final class SecretResolutionSchedulerTest {
 
     // then — second attempt happened because the cooldown expired
     verify(secretStore, times(2)).resolve(any());
+  }
+
+  @Test
+  void shouldCountResolvedOutcomeOncePerSecretReference() throws Exception {
+    // given
+    stubPending(STORE_ID, "ref-1", "ref-2");
+    when(secretStore.resolve(Set.of("ref-1", "ref-2")))
+        .thenReturn(
+            Map.of(
+                "ref-1", new SecretResolutionResult.Resolved("value-1"),
+                "ref-2", new SecretResolutionResult.Resolved("value-2")));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — the outcome is per reference, while the duration is per batch call
+    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.RESOLVED)).isEqualTo(2);
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.RETURNED).count()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldNotCountAnOutcomeForAReferenceWhoseCommandDoesNotFit() throws Exception {
+    // given — the result builder is full, so the follow-up command is dropped
+    stubPending(STORE_ID, "db-password");
+    when(secretStore.resolve(Set.of("db-password")))
+        .thenReturn(Map.of("db-password", new SecretResolutionResult.Resolved("s3cr3t")));
+    when(resultBuilder.appendCommandRecord(any(), any())).thenReturn(false);
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — the reference stays pending and is counted by whichever later cycle appends it, so
+    // counting it here would push the counter above the number of references that ever completed
+    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.RESOLVED)).isZero();
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.RETURNED).count()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldCountOnlyTheStoreUnavailableRefsWhoseCommandFits() throws Exception {
+    // given — a store that is not configured, with only room for the first of its two refs
+    stubPending("unknown-store", "a", "b");
+    when(resultBuilder.appendCommandRecord(any(), any())).thenReturn(true, false);
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then
+    assertThat(outcomeCount("unknown-store", SecretResolutionOutcome.STORE_UNAVAILABLE))
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldTagTheOutcomeWithASentinelWhenTheReferenceCarriesNoStoreId() throws Exception {
+    // given — a reference written before #59432, when a reference carried no store ID at all;
+    // those are still in state after an upgrade and are resolved by this scheduler
+    stubPending("", "db-password");
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — an empty tag value is indistinguishable from an absent one on a dashboard
+    assertThat(
+            outcomeCount(
+                SecretResolutionKeyNames.NO_STORE, SecretResolutionOutcome.STORE_UNAVAILABLE))
+        .isEqualTo(1);
+    assertThat(meterRegistry.getMeters())
+        .isNotEmpty()
+        .allSatisfy(
+            meter ->
+                assertThat(meter.getId().getTags()).extracting(Tag::getValue).doesNotContain(""));
+  }
+
+  @Test
+  void shouldCountErrorOncePerCycleWhenTheStoreFailsInAWayTheEngineDoesNotModel() throws Exception {
+    // given — two refs, so a per-reference count would read 2
+    stubPending(STORE_ID, "a", "b");
+    when(secretStore.resolve(any())).thenThrow(new IllegalStateException("boom"));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — the refs stay pending and are retried, so counting them would scale the series with
+    // the backlog and the cycle rate; without counting anything a store failing this way every
+    // cycle leaves every series flat and there is nothing to alert on
+    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.ERROR)).isEqualTo(1);
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.ERROR).count()).isEqualTo(1);
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.RETURNED)).isNull();
+  }
+
+  @Test
+  void shouldNotTimeAnUnreachableStoreAsAnUnexpectedError() throws Exception {
+    // given
+    stubPending(STORE_ID, "db-password");
+    when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("down"));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — an unreachable store is routine, so it must not land in the same series as a bug:
+    // `result` means the same thing on the timer as it does on the outcome counter
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.STORE_UNAVAILABLE).count())
+        .isEqualTo(1);
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.ERROR)).isNull();
+    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.ERROR)).isZero();
+  }
+
+  @ParameterizedTest
+  @EnumSource(SecretErrorCode.class)
+  void shouldCountPermanentFailureUnderItsOwnStoreErrorCode(final SecretErrorCode code)
+      throws Exception {
+    // given
+    stubPending(STORE_ID, "some-ref");
+    when(secretStore.resolve(Set.of("some-ref")))
+        .thenReturn(
+            Map.of("some-ref", new SecretResolutionResult.Failed(code, "failed: " + code, null)));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — the record collapses every code to NOT_FOUND, the counter must not
+    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.from(code))).isEqualTo(1);
+    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.RESOLVED)).isZero();
+  }
+
+  @Test
+  void shouldCountStoreUnavailableForEveryRefOnceRetriesAreExhausted() throws Exception {
+    // given — a monotonic clock (1 day per call) always clears the retry cooldown
+    when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("down"));
+    final var nowMs = new AtomicLong(0);
+    when(clock.millis()).thenAnswer(inv -> nowMs.getAndAdd(Duration.ofDays(1).toMillis()));
+    final int maxAttempts = EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_MAX_ATTEMPTS;
+
+    // when
+    for (int i = 0; i < maxAttempts; i++) {
+      stubPending(STORE_ID, "a", "b");
+      scheduler.resolveSecrets(resultBuilder);
+    }
+
+    // then — both refs counted once, and every attempt was timed even though only the last one
+    // reached a terminal outcome
+    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.STORE_UNAVAILABLE)).isEqualTo(2);
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.STORE_UNAVAILABLE).count())
+        .isEqualTo(maxAttempts);
+  }
+
+  @Test
+  void shouldCountStoreUnavailableWithoutTimingWhenStoreIsNotConfigured() throws Exception {
+    // given — pending refs for a store that has no configured SecretStore
+    stubPending("unknown-store", "db-password");
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — no store call was made, so nothing was timed
+    assertThat(outcomeCount("unknown-store", SecretResolutionOutcome.STORE_UNAVAILABLE))
+        .isEqualTo(1);
+    assertThat(
+            meterRegistry
+                .find(SecretResolutionMetricsDoc.RESOLUTION_DURATION.getName())
+                .tag(SecretResolutionKeyNames.STORE.asString(), "unknown-store")
+                .timers())
+        .isEmpty();
+  }
+
+  @Test
+  void shouldRecordResolutionDurationButNoOutcomeWhileRetriesRemain() throws Exception {
+    // given
+    stubPending(STORE_ID, "db-password");
+    when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — the failed call is timed, but the reference is not terminal yet so nothing is counted
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.STORE_UNAVAILABLE).count())
+        .isEqualTo(1);
+    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.STORE_UNAVAILABLE)).isZero();
+  }
+
+  @Test
+  void shouldRecordNothingWhileStoreIsInCooldown() throws Exception {
+    // given — the first cycle fails and starts the cooldown at t=0
+    stubPending(STORE_ID, "db-password");
+    when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
+    when(clock.millis()).thenReturn(0L);
+    scheduler.resolveSecrets(resultBuilder);
+
+    // when — a second cycle runs while still in cooldown
+    stubPending(STORE_ID, "db-password");
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — the skipped cycle neither times nor counts anything
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.STORE_UNAVAILABLE).count())
+        .isEqualTo(1);
+    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.STORE_UNAVAILABLE)).isZero();
+  }
+
+  @Test
+  void shouldNotTagAnyMeterWithASecretNameOrValue() throws Exception {
+    // given
+    stubPending(STORE_ID, "db-password");
+    when(secretStore.resolve(Set.of("db-password")))
+        .thenReturn(Map.of("db-password", new SecretResolutionResult.Resolved("s3cr3t")));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — secret names have unbounded cardinality and are customer data, and a secret value must
+    // never leave the cache at all
+    assertThat(meterRegistry.getMeters())
+        .isNotEmpty()
+        .allSatisfy(
+            meter ->
+                assertThat(meter.getId().getTags())
+                    .extracting(Tag::getValue)
+                    .doesNotContain("db-password", "s3cr3t"));
+  }
+
+  private double outcomeCount(final String storeId, final SecretResolutionOutcome outcome) {
+    final var counter =
+        meterRegistry
+            .find(SecretResolutionMetricsDoc.RESOLUTION_OUTCOME.getName())
+            .tag(SecretResolutionKeyNames.STORE.asString(), storeId)
+            .tag(SecretResolutionKeyNames.RESULT.asString(), outcome.name())
+            .counter();
+    return counter == null ? 0 : counter.count();
+  }
+
+  private Timer resolutionTimer(final String storeId, final SecretResolutionCallResult callResult) {
+    return meterRegistry
+        .find(SecretResolutionMetricsDoc.RESOLUTION_DURATION.getName())
+        .tag(SecretResolutionKeyNames.STORE.asString(), storeId)
+        .tag(SecretResolutionKeyNames.RESULT.asString(), callResult.name())
+        .timer();
   }
 
   private void stubPending(final String storeId, final String secretRef) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -28,6 +28,11 @@ import io.camunda.secretstore.SecretStore;
 import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.secretstore.SecretStoreUnavailableException;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetrics;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionCallResult;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionKeyNames;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionOutcome;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.immutable.SecretReferenceState;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
@@ -37,6 +42,9 @@ import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -47,6 +55,8 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -71,6 +81,8 @@ final class SecretResolutionSchedulerTest {
   @Mock private StreamClock clock;
 
   private SecretResolutionScheduler scheduler;
+  private SimpleMeterRegistry meterRegistry;
+  private SecretResolutionMetrics metrics;
 
   @BeforeEach
   void setUp() {
@@ -78,13 +90,17 @@ final class SecretResolutionSchedulerTest {
     when(context.getScheduleService()).thenReturn(scheduleService);
     when(context.getClock()).thenReturn(clock);
     lenient().when(clock.millis()).thenReturn(0L);
+    // the real builder returns false once a record no longer fits the batch; the metric assertions
+    // depend on that return value, so the default `false` of the mock would be misleading here
     lenient().when(resultBuilder.appendCommandRecord(any(), any())).thenReturn(true);
 
+    meterRegistry = new SimpleMeterRegistry();
+    metrics = new SecretResolutionMetrics(meterRegistry);
     final Supplier<ScheduledTaskState> stateFactory = () -> scheduledTaskState;
     final var registry =
         new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, secretCache));
     final var config = new EngineConfiguration();
-    scheduler = new SecretResolutionScheduler(stateFactory, registry, config);
+    scheduler = new SecretResolutionScheduler(stateFactory, registry, config, metrics);
     scheduler.onRecovered(context);
   }
 
@@ -186,7 +202,7 @@ final class SecretResolutionSchedulerTest {
             .setSecretResolutionRetryMaxDelay(Duration.ofSeconds(2));
     final var localScheduler =
         new SecretResolutionScheduler(
-            () -> scheduledTaskState, new SecretStoreRegistry(Map.of()), config);
+            () -> scheduledTaskState, new SecretStoreRegistry(Map.of()), config, metrics);
 
     // when/then
     assertThat(localScheduler.calculateBackoff(1)).isEqualTo(Duration.ofSeconds(1));
@@ -226,7 +242,7 @@ final class SecretResolutionSchedulerTest {
     final var registry = new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of());
     final var localScheduler =
         new SecretResolutionScheduler(
-            () -> scheduledTaskState, registry, new EngineConfiguration());
+            () -> scheduledTaskState, registry, new EngineConfiguration(), metrics);
     localScheduler.onRecovered(context);
     stubPending(STORE_ID, "db-password");
     when(secretStore.resolve(Set.of("db-password")))
@@ -251,7 +267,7 @@ final class SecretResolutionSchedulerTest {
         new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, cache));
     final var localScheduler =
         new SecretResolutionScheduler(
-            () -> scheduledTaskState, registry, new EngineConfiguration());
+            () -> scheduledTaskState, registry, new EngineConfiguration(), metrics);
     localScheduler.onRecovered(context);
     stubPending(STORE_ID, "db-password");
     when(secretStore.resolve(Set.of("db-password")))
@@ -365,7 +381,7 @@ final class SecretResolutionSchedulerTest {
         new SecretStoreRegistry(Map.of("store-a", storeA, "store-b", storeB), Map.of());
     final var config = new EngineConfiguration().setSecretResolutionBatchLimit(2);
     final var localScheduler =
-        new SecretResolutionScheduler(() -> scheduledTaskState, registry, config);
+        new SecretResolutionScheduler(() -> scheduledTaskState, registry, config, metrics);
     localScheduler.onRecovered(context);
 
     when(storeA.resolve(Set.of("ref-a1"))).thenThrow(new SecretStoreUnavailableException("down"));
@@ -458,7 +474,7 @@ final class SecretResolutionSchedulerTest {
             Map.of("store-a", storeA, "store-b", storeB), Map.of("store-b", cacheB));
     final var localScheduler =
         new SecretResolutionScheduler(
-            () -> scheduledTaskState, registry, new EngineConfiguration());
+            () -> scheduledTaskState, registry, new EngineConfiguration(), metrics);
     localScheduler.onRecovered(context);
     reset(scheduleService);
 
@@ -512,7 +528,7 @@ final class SecretResolutionSchedulerTest {
             Map.of("store-a", storeA, "store-b", storeB), Map.of("store-b", cacheB));
     final var localScheduler =
         new SecretResolutionScheduler(
-            () -> scheduledTaskState, registry, new EngineConfiguration());
+            () -> scheduledTaskState, registry, new EngineConfiguration(), metrics);
     localScheduler.onRecovered(context);
 
     stubPending(Map.of("store-a", "ref-a", "store-b", "ref-b"));
@@ -560,7 +576,8 @@ final class SecretResolutionSchedulerTest {
         new SecretResolutionScheduler(
             () -> scheduledTaskState,
             new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, secretCache)),
-            config);
+            config,
+            metrics);
     localScheduler.onRecovered(context);
     stubPending(STORE_ID, "ref-1", "ref-2", "ref-3");
     when(secretStore.resolve(Set.of("ref-1", "ref-2")))
@@ -592,7 +609,7 @@ final class SecretResolutionSchedulerTest {
             Map.of("store-a", cacheA, "store-b", cacheB));
     final var config = new EngineConfiguration().setSecretResolutionBatchLimit(3);
     final var localScheduler =
-        new SecretResolutionScheduler(() -> scheduledTaskState, registry, config);
+        new SecretResolutionScheduler(() -> scheduledTaskState, registry, config, metrics);
     localScheduler.onRecovered(context);
 
     doAnswer(
@@ -641,7 +658,8 @@ final class SecretResolutionSchedulerTest {
         new SecretResolutionScheduler(
             () -> scheduledTaskState,
             new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, secretCache)),
-            config);
+            config,
+            metrics);
     localScheduler.onRecovered(context);
     reset(scheduleService);
     stubPending(STORE_ID, "ref-1", "ref-2", "ref-3");
@@ -668,7 +686,8 @@ final class SecretResolutionSchedulerTest {
         new SecretResolutionScheduler(
             () -> scheduledTaskState,
             new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, secretCache)),
-            config);
+            config,
+            metrics);
     localScheduler.onRecovered(context);
     reset(scheduleService);
     stubPending(STORE_ID, "ref-1", "ref-2");
@@ -699,7 +718,8 @@ final class SecretResolutionSchedulerTest {
         new SecretResolutionScheduler(
             () -> scheduledTaskState,
             new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, secretCache)),
-            config);
+            config,
+            metrics);
     localScheduler.onRecovered(context);
     reset(scheduleService);
     when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
@@ -769,7 +789,7 @@ final class SecretResolutionSchedulerTest {
             Map.of("store-a", storeA, "store-b", storeB), Map.of("store-b", cacheB));
     final var config = new EngineConfiguration().setSecretResolutionBatchLimit(2);
     final var localScheduler =
-        new SecretResolutionScheduler(() -> scheduledTaskState, registry, config);
+        new SecretResolutionScheduler(() -> scheduledTaskState, registry, config, metrics);
     localScheduler.onRecovered(context);
 
     // cycle 1 (t=0): drive store-a into retry cooldown
@@ -827,7 +847,7 @@ final class SecretResolutionSchedulerTest {
             Map.of("store-a", storeA, "store-b", storeB), Map.of("store-a", cacheA));
     final var localScheduler =
         new SecretResolutionScheduler(
-            () -> scheduledTaskState, registry, new EngineConfiguration());
+            () -> scheduledTaskState, registry, new EngineConfiguration(), metrics);
     localScheduler.onRecovered(context);
 
     final var refsByStore = new LinkedHashMap<String, String>();
@@ -909,6 +929,240 @@ final class SecretResolutionSchedulerTest {
 
     // then — second attempt happened because the cooldown expired
     verify(secretStore, times(2)).resolve(any());
+  }
+
+  @Test
+  void shouldCountResolvedOutcomeOncePerSecretReference() throws Exception {
+    // given
+    stubPending(STORE_ID, "ref-1", "ref-2");
+    when(secretStore.resolve(Set.of("ref-1", "ref-2")))
+        .thenReturn(
+            Map.of(
+                "ref-1", new SecretResolutionResult.Resolved("value-1"),
+                "ref-2", new SecretResolutionResult.Resolved("value-2")));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — the outcome is per reference, while the duration is per batch call
+    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.RESOLVED)).isEqualTo(2);
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.RETURNED).count()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldNotCountAnOutcomeForAReferenceWhoseCommandDoesNotFit() throws Exception {
+    // given — the result builder is full, so the follow-up command is dropped
+    stubPending(STORE_ID, "db-password");
+    when(secretStore.resolve(Set.of("db-password")))
+        .thenReturn(Map.of("db-password", new SecretResolutionResult.Resolved("s3cr3t")));
+    when(resultBuilder.appendCommandRecord(any(), any())).thenReturn(false);
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — the reference stays pending and is counted by whichever later cycle appends it, so
+    // counting it here would push the counter above the number of references that ever completed
+    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.RESOLVED)).isZero();
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.RETURNED).count()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldCountOnlyTheStoreUnavailableRefsWhoseCommandFits() throws Exception {
+    // given — a store that is not configured, with only room for the first of its two refs
+    stubPending("unknown-store", "a", "b");
+    when(resultBuilder.appendCommandRecord(any(), any())).thenReturn(true, false);
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then
+    assertThat(outcomeCount("unknown-store", SecretResolutionOutcome.STORE_UNAVAILABLE))
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldTagTheOutcomeWithASentinelWhenTheReferenceCarriesNoStoreId() throws Exception {
+    // given — a reference written before #59432, when a reference carried no store ID at all;
+    // those are still in state after an upgrade and are resolved by this scheduler
+    stubPending("", "db-password");
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — an empty tag value is indistinguishable from an absent one on a dashboard
+    assertThat(
+            outcomeCount(
+                SecretResolutionKeyNames.NO_STORE, SecretResolutionOutcome.STORE_UNAVAILABLE))
+        .isEqualTo(1);
+    assertThat(meterRegistry.getMeters())
+        .isNotEmpty()
+        .allSatisfy(
+            meter ->
+                assertThat(meter.getId().getTags()).extracting(Tag::getValue).doesNotContain(""));
+  }
+
+  @Test
+  void shouldCountErrorOncePerCycleWhenTheStoreFailsInAWayTheEngineDoesNotModel() throws Exception {
+    // given — two refs, so a per-reference count would read 2
+    stubPending(STORE_ID, "a", "b");
+    when(secretStore.resolve(any())).thenThrow(new IllegalStateException("boom"));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — the refs stay pending and are retried, so counting them would scale the series with
+    // the backlog and the cycle rate; without counting anything a store failing this way every
+    // cycle leaves every series flat and there is nothing to alert on
+    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.ERROR)).isEqualTo(1);
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.ERROR).count()).isEqualTo(1);
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.RETURNED)).isNull();
+  }
+
+  @Test
+  void shouldNotTimeAnUnreachableStoreAsAnUnexpectedError() throws Exception {
+    // given
+    stubPending(STORE_ID, "db-password");
+    when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("down"));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — an unreachable store is routine, so it must not land in the same series as a bug:
+    // `result` means the same thing on the timer as it does on the outcome counter
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.STORE_UNAVAILABLE).count())
+        .isEqualTo(1);
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.ERROR)).isNull();
+    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.ERROR)).isZero();
+  }
+
+  @ParameterizedTest
+  @EnumSource(SecretErrorCode.class)
+  void shouldCountPermanentFailureUnderItsOwnStoreErrorCode(final SecretErrorCode code)
+      throws Exception {
+    // given
+    stubPending(STORE_ID, "some-ref");
+    when(secretStore.resolve(Set.of("some-ref")))
+        .thenReturn(
+            Map.of("some-ref", new SecretResolutionResult.Failed(code, "failed: " + code, null)));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — the record collapses every code to NOT_FOUND, the counter must not
+    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.from(code))).isEqualTo(1);
+    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.RESOLVED)).isZero();
+  }
+
+  @Test
+  void shouldCountStoreUnavailableForEveryRefOnceRetriesAreExhausted() throws Exception {
+    // given — a monotonic clock (1 day per call) always clears the retry cooldown
+    when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("down"));
+    final var nowMs = new AtomicLong(0);
+    when(clock.millis()).thenAnswer(inv -> nowMs.getAndAdd(Duration.ofDays(1).toMillis()));
+    final int maxAttempts = EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_MAX_ATTEMPTS;
+
+    // when
+    for (int i = 0; i < maxAttempts; i++) {
+      stubPending(STORE_ID, "a", "b");
+      scheduler.resolveSecrets(resultBuilder);
+    }
+
+    // then — both refs counted once, and every attempt was timed even though only the last one
+    // reached a terminal outcome
+    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.STORE_UNAVAILABLE)).isEqualTo(2);
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.STORE_UNAVAILABLE).count())
+        .isEqualTo(maxAttempts);
+  }
+
+  @Test
+  void shouldCountStoreUnavailableWithoutTimingWhenStoreIsNotConfigured() throws Exception {
+    // given — pending refs for a store that has no configured SecretStore
+    stubPending("unknown-store", "db-password");
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — no store call was made, so nothing was timed
+    assertThat(outcomeCount("unknown-store", SecretResolutionOutcome.STORE_UNAVAILABLE))
+        .isEqualTo(1);
+    assertThat(
+            meterRegistry
+                .find(SecretResolutionMetricsDoc.RESOLUTION_DURATION.getName())
+                .tag(SecretResolutionKeyNames.STORE.asString(), "unknown-store")
+                .timers())
+        .isEmpty();
+  }
+
+  @Test
+  void shouldRecordResolutionDurationButNoOutcomeWhileRetriesRemain() throws Exception {
+    // given
+    stubPending(STORE_ID, "db-password");
+    when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — the failed call is timed, but the reference is not terminal yet so nothing is counted
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.STORE_UNAVAILABLE).count())
+        .isEqualTo(1);
+    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.STORE_UNAVAILABLE)).isZero();
+  }
+
+  @Test
+  void shouldRecordNothingWhileStoreIsInCooldown() throws Exception {
+    // given — the first cycle fails and starts the cooldown at t=0
+    stubPending(STORE_ID, "db-password");
+    when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
+    when(clock.millis()).thenReturn(0L);
+    scheduler.resolveSecrets(resultBuilder);
+
+    // when — a second cycle runs while still in cooldown
+    stubPending(STORE_ID, "db-password");
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — the skipped cycle neither times nor counts anything
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.STORE_UNAVAILABLE).count())
+        .isEqualTo(1);
+    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.STORE_UNAVAILABLE)).isZero();
+  }
+
+  @Test
+  void shouldNotTagAnyMeterWithASecretNameOrValue() throws Exception {
+    // given
+    stubPending(STORE_ID, "db-password");
+    when(secretStore.resolve(Set.of("db-password")))
+        .thenReturn(Map.of("db-password", new SecretResolutionResult.Resolved("s3cr3t")));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — secret names have unbounded cardinality and are customer data, and a secret value must
+    // never leave the cache at all
+    assertThat(meterRegistry.getMeters())
+        .isNotEmpty()
+        .allSatisfy(
+            meter ->
+                assertThat(meter.getId().getTags())
+                    .extracting(Tag::getValue)
+                    .doesNotContain("db-password", "s3cr3t"));
+  }
+
+  private double outcomeCount(final String storeId, final SecretResolutionOutcome outcome) {
+    final var counter =
+        meterRegistry
+            .find(SecretResolutionMetricsDoc.RESOLUTION_OUTCOME.getName())
+            .tag(SecretResolutionKeyNames.STORE.asString(), storeId)
+            .tag(SecretResolutionKeyNames.RESULT.asString(), outcome.name())
+            .counter();
+    return counter == null ? 0 : counter.count();
+  }
+
+  private Timer resolutionTimer(final String storeId, final SecretResolutionCallResult callResult) {
+    return meterRegistry
+        .find(SecretResolutionMetricsDoc.RESOLUTION_DURATION.getName())
+        .tag(SecretResolutionKeyNames.STORE.asString(), storeId)
+        .tag(SecretResolutionKeyNames.RESULT.asString(), callResult.name())
+        .timer();
   }
 
   private void stubPending(final String storeId, final String secretRef) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -300,7 +300,7 @@ final class SecretResolutionSchedulerTest {
         new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, cache));
     final var localScheduler =
         new SecretResolutionScheduler(
-            () -> scheduledTaskState, registry, new EngineConfiguration());
+            () -> scheduledTaskState, registry, new EngineConfiguration(), metrics);
     localScheduler.onRecovered(context);
     stubPending(STORE_ID, "db-password", "api-key");
     when(secretStore.resolve(Set.of("db-password", "api-key")))
@@ -1069,9 +1069,49 @@ final class SecretResolutionSchedulerTest {
     // then — the refs stay pending and are retried, so counting them would scale the series with
     // the backlog and the cycle rate; without counting anything a store failing this way every
     // cycle leaves every series flat and there is nothing to alert on
-    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.ERROR)).isEqualTo(1);
+    assertThat(cycleErrorCount(STORE_ID)).isEqualTo(1);
     assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.ERROR).count()).isEqualTo(1);
     assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.RETURNED)).isNull();
+  }
+
+  @Test
+  void shouldNotPutTheCycleErrorOnTheOutcomeCounter() throws Exception {
+    // given
+    stubPending(STORE_ID, "a", "b");
+    when(secretStore.resolve(any())).thenThrow(new IllegalStateException("boom"));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — the outcome counter registers no series at all for this cycle. Every value on it
+    // counts one secret reference, and a cycle count sharing the meter would be added to those by
+    // `sum by(store)(rate(..._total[5m]))` and by any failure ratio built on the same counter
+    assertThat(
+            meterRegistry
+                .find(SecretResolutionMetricsDoc.RESOLUTION_OUTCOME.getName())
+                .tag(SecretResolutionKeyNames.STORE.asString(), STORE_ID)
+                .counters())
+        .isEmpty();
+  }
+
+  @Test
+  void shouldCountACycleErrorWhenTheEngineFailsAfterTheStoreCallCameBack() throws Exception {
+    // given — the store itself is fine; the engine blows up while writing the follow-up command
+    stubPending(STORE_ID, "db-password");
+    when(secretStore.resolve(Set.of("db-password")))
+        .thenReturn(Map.of("db-password", new SecretResolutionResult.Resolved("s3cr3t")));
+    when(resultBuilder.appendCommandRecord(any(), any()))
+        .thenThrow(new IllegalStateException("boom"));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — the duration timer saw a call that came back and so reports nothing wrong; this is
+    // the class of failure only the cycle counter can surface, and the reason it is a meter of its
+    // own rather than something the timer's ERROR bucket already covers
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.RETURNED).count()).isEqualTo(1);
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.ERROR)).isNull();
+    assertThat(cycleErrorCount(STORE_ID)).isEqualTo(1);
   }
 
   @Test
@@ -1088,7 +1128,7 @@ final class SecretResolutionSchedulerTest {
     assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.STORE_UNAVAILABLE).count())
         .isEqualTo(1);
     assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.ERROR)).isNull();
-    assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.ERROR)).isZero();
+    assertThat(cycleErrorCount(STORE_ID)).isZero();
   }
 
   @Test
@@ -1106,6 +1146,13 @@ final class SecretResolutionSchedulerTest {
     // is what its latency would otherwise be read as
     assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.ERROR).count()).isEqualTo(1);
     assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.RETURNED)).isNull();
+
+    // and — the cycle counter stays at zero on purpose. It counts cycles the scheduler carried on
+    // from, and this one it did not: the Error escaped the `catch (RuntimeException)` and failed
+    // the resolution task. Catching it to keep the two meters in step would mean swallowing an
+    // Error in an actor task, which is worse than the asymmetry; the duration timer above and the
+    // failing task are what make this visible instead
+    assertThat(cycleErrorCount(STORE_ID)).isZero();
   }
 
   @ParameterizedTest
@@ -1226,6 +1273,15 @@ final class SecretResolutionSchedulerTest {
             .find(SecretResolutionMetricsDoc.RESOLUTION_OUTCOME.getName())
             .tag(SecretResolutionKeyNames.STORE.asString(), storeId)
             .tag(SecretResolutionKeyNames.RESULT.asString(), outcome.name())
+            .counter();
+    return counter == null ? 0 : counter.count();
+  }
+
+  private double cycleErrorCount(final String storeId) {
+    final var counter =
+        meterRegistry
+            .find(SecretResolutionMetricsDoc.RESOLUTION_CYCLE_ERROR.getName())
+            .tag(SecretResolutionKeyNames.STORE.asString(), storeId)
             .counter();
     return counter == null ? 0 : counter.count();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.secretreference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -981,6 +982,25 @@ final class SecretResolutionSchedulerTest {
   }
 
   @Test
+  void shouldNotRegisterAStoreUnavailableSeriesWhenNoFailCommandFits() throws Exception {
+    // given — a store that is not configured, and a result with no room left for any of its refs
+    stubPending("unknown-store", "a", "b");
+    when(resultBuilder.appendCommandRecord(any(), any())).thenReturn(false);
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — both refs stay pending, so the series must not exist at all: an always-zero line
+    // reads as "this store is healthy" rather than "nothing has been decided for it yet"
+    assertThat(
+            meterRegistry
+                .find(SecretResolutionMetricsDoc.RESOLUTION_OUTCOME.getName())
+                .tag(SecretResolutionKeyNames.STORE.asString(), "unknown-store")
+                .counters())
+        .isEmpty();
+  }
+
+  @Test
   void shouldTagTheOutcomeWithASentinelWhenTheReferenceCarriesNoStoreId() throws Exception {
     // given — a reference written before #59432, when a reference carried no store ID at all;
     // those are still in state after an upgrade and are resolved by this scheduler
@@ -1033,6 +1053,23 @@ final class SecretResolutionSchedulerTest {
         .isEqualTo(1);
     assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.ERROR)).isNull();
     assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.ERROR)).isZero();
+  }
+
+  @Test
+  void shouldNotTimeAStoreThrowingAnErrorAsACallThatCameBack() throws Exception {
+    // given — an Error rather than an exception, e.g. a store blowing the stack or running the
+    // broker out of memory
+    stubPending(STORE_ID, "db-password");
+    when(secretStore.resolve(any())).thenThrow(new StackOverflowError("boom"));
+
+    // when — the scheduler only guards against RuntimeException, so an Error leaves the cycle
+    assertThatThrownBy(() -> scheduler.resolveSecrets(resultBuilder))
+        .isInstanceOf(StackOverflowError.class);
+
+    // then — a call that failed must not land in the histogram of the calls that returned, which
+    // is what its latency would otherwise be read as
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.ERROR).count()).isEqualTo(1);
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.RETURNED)).isNull();
   }
 
   @ParameterizedTest

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.secretreference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -1017,6 +1018,25 @@ final class SecretResolutionSchedulerTest {
   }
 
   @Test
+  void shouldNotRegisterAStoreUnavailableSeriesWhenNoFailCommandFits() throws Exception {
+    // given — a store that is not configured, and a result with no room left for any of its refs
+    stubPending("unknown-store", "a", "b");
+    when(resultBuilder.appendCommandRecord(any(), any())).thenReturn(false);
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — both refs stay pending, so the series must not exist at all: an always-zero line
+    // reads as "this store is healthy" rather than "nothing has been decided for it yet"
+    assertThat(
+            meterRegistry
+                .find(SecretResolutionMetricsDoc.RESOLUTION_OUTCOME.getName())
+                .tag(SecretResolutionKeyNames.STORE.asString(), "unknown-store")
+                .counters())
+        .isEmpty();
+  }
+
+  @Test
   void shouldTagTheOutcomeWithASentinelWhenTheReferenceCarriesNoStoreId() throws Exception {
     // given — a reference written before #59432, when a reference carried no store ID at all;
     // those are still in state after an upgrade and are resolved by this scheduler
@@ -1069,6 +1089,23 @@ final class SecretResolutionSchedulerTest {
         .isEqualTo(1);
     assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.ERROR)).isNull();
     assertThat(outcomeCount(STORE_ID, SecretResolutionOutcome.ERROR)).isZero();
+  }
+
+  @Test
+  void shouldNotTimeAStoreThrowingAnErrorAsACallThatCameBack() throws Exception {
+    // given — an Error rather than an exception, e.g. a store blowing the stack or running the
+    // broker out of memory
+    stubPending(STORE_ID, "db-password");
+    when(secretStore.resolve(any())).thenThrow(new StackOverflowError("boom"));
+
+    // when — the scheduler only guards against RuntimeException, so an Error leaves the cycle
+    assertThatThrownBy(() -> scheduler.resolveSecrets(resultBuilder))
+        .isInstanceOf(StackOverflowError.class);
+
+    // then — a call that failed must not land in the histogram of the calls that returned, which
+    // is what its latency would otherwise be read as
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.ERROR).count()).isEqualTo(1);
+    assertThat(resolutionTimer(STORE_ID, SecretResolutionCallResult.RETURNED)).isNull();
   }
 
   @ParameterizedTest


### PR DESCRIPTION
related to #59315

## Description

part 1 of 2

Part 1 adds metrics for resolution. Part 2 will add cache related metrics (currently blocked by #59314.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to #59315
