### PR TITLE
ci: make the fix agent decide regression vs intended change before picking a repo

### DIFF
--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -352,6 +352,11 @@ jobs:
           Failing AlwaysGreen run: ${FAILING_RUN_URL}
           Triage run: ${TRIAGE_RUN_URL}
           Breaking change: PR #${BLAME_PR} by ${BLAME_AUTHOR}
+          Read what that PR changed before choosing a repo. If it also updated the
+          product's own tests to the new value, the change is intended and the
+          cross-component test is behind; if those tests still assert the old value,
+          the product contradicts itself and it is a regression. The manual's
+          "Regression, or an intended change" section is the full rule.
 
           /tmp/test_specs.json  — the failing specs, with retry history per attempt.
           /tmp/fingerprints.json — the fingerprints your PR body MUST claim in its

--- a/docs/alwaysgreen/FIX-AGENT.md
+++ b/docs/alwaysgreen/FIX-AGENT.md
@@ -95,6 +95,44 @@ Read PNG screenshots directly. For a trace: `unzip -l trace.zip`, then extract w
    `camunda-docs/versioned_docs/version-<X.Y>/` and cite it in the PR body. Match the
    version tree exactly. Skip this for pure selector drift.
 
+## Regression, or an intended change the test has not caught up with?
+
+A changed locator has two possible causes, and they land in different repositories. Decide
+this **before** picking a repo, because guessing wrong is expensive in both directions:
+reverting an intentional change destroys someone's work, and adapting the test to a real
+regression masks the defect the test exists to catch.
+
+The discriminator is whether the product still agrees with itself. The breaking PR number
+is in your prompt — read what it changed:
+
+```bash
+gh pr view <blame_pr> --repo camunda/camunda --json title,body,files \
+  --jq '{title, files: [.files[].path]}'
+```
+
+- **It also updated the product's own tests** to the new value — `operate/client/**/tests/**`,
+  `tasklist/client/**/tests/**`, `identity/client/**/tests/**`, or
+  `qa/c8-orchestration-cluster-e2e-test-suite/**` — then the change is **intended** and the
+  cross-component suite is simply behind. Fix `c8-cross-component-e2e-tests`.
+- **The product's own tests still assert the old value**, so the product now contradicts
+  itself: that is a **regression**. Fix `camunda`.
+
+Two weaker signals, for when the first is inconclusive. A Conventional-Commit `feat:` that
+renames user-visible copy is usually deliberate, while `refactor:`/`fix:` that changes copy
+usually is not. And `camunda-docs` describing the new copy or behaviour for this version
+settles it as intended — cite it in the PR body.
+
+If it is still genuinely ambiguous, do **not** pick one. Write `category: "not-determined"`
+to `/tmp/fix-meta.json` with the evidence, name both candidate fixes, and leave the
+fingerprint unclaimed so a recurrence is re-triaged. A human deciding in ten minutes beats
+either wrong PR.
+
+**A test-side fix does not turn the run green by itself.** The helm e2e job runs the
+published `@camunda/e2e-test-suite` package, not the repo source, so a locator fix takes
+effect only once that package is published. Say so in the PR body: until then the pipeline
+stays red and the same failure will be re-dispatched unless your PR carries the coverage
+block.
+
 ## Where fixes go
 
 |                       Diagnosis                       |           Repository           |                  Path                   |

--- a/docs/alwaysgreen/FIX-AGENT.md
+++ b/docs/alwaysgreen/FIX-AGENT.md
@@ -110,12 +110,19 @@ gh pr view <blame_pr> --repo camunda/camunda --json title,body,files \
   --jq '{title, files: [.files[].path]}'
 ```
 
-- **It also updated the product's own tests** to the new value — `operate/client/**/tests/**`,
-  `tasklist/client/**/tests/**`, `identity/client/**/tests/**`, or
-  `qa/c8-orchestration-cluster-e2e-test-suite/**` — then the change is **intended** and the
-  cross-component suite is simply behind. Fix `c8-cross-component-e2e-tests`.
-- **The product's own tests still assert the old value**, so the product now contradicts
-  itself: that is a **regression**. Fix `camunda`.
+- **It also updated the product's own tests** to the new value → the change is **intended**
+  and the cross-component suite is simply behind. Fix `c8-cross-component-e2e-tests`.
+- **Those tests still assert the old value**, so the product now contradicts itself → that
+  is a **regression**. Fix `camunda`.
+
+Product tests are not in one place, so grep the PR's file list rather than matching a fixed
+glob: colocated `*.test.tsx` next to the component, a `tests/` directory beside it,
+`e2e-playwright/` or `e2e/` specs, and `qa/c8-orchestration-cluster-e2e-test-suite/`. In
+`operate/client` most are colocated and only a minority sit under `tests/`.
+
+**Absence of a test change only means something if such tests exist.** `identity/client` has
+no frontend tests at all, so for an Identity UI failure "the tests were not updated" proves
+nothing — skip to the weaker signals below rather than reading it as a regression.
 
 Two weaker signals, for when the first is inconclusive. A Conventional-Commit `feat:` that
 renames user-visible copy is usually deliberate, while `refactor:`/`fix:` that changes copy


### PR DESCRIPTION
## Description

Follow-up to #59389, from what the live end-to-end test of the triage chain revealed.

A deliberately renamed Operate nav label (`Processes` → `Process list`) produced a real
`sm-smoke-e2e` failure, and the fix agent opened its PR in **camunda/camunda**, restoring the
label. That is the correct call for a regression — and the agent's reasoning was sound, because
the product had become self-inconsistent: `operate/client`'s own header tests still asserted
`Processes`.

But it is the wrong repo when a **feature deliberately changes the UI**. Then the cross-component
locator is what needs updating, in `c8-cross-component-e2e-tests`. The manual documented *where*
each fix goes and never *how to tell the two apart*, so the choice rested on the agent's judgement
with no stated rule.

## The rule

Whether the product still agrees with itself. The breaking PR is already in the prompt, so reading
what it changed is one call:

- it **also updated the product's own tests** (`operate/client/**/tests/**`,
  `tasklist/client/**/tests/**`, `identity/client/**/tests/**`,
  `qa/c8-orchestration-cluster-e2e-test-suite/**`) → **intended**, the test is behind → fix the e2e repo
- those tests **still assert the old value** → the product contradicts itself → **regression** → fix `camunda`

Weaker tie-breakers: a `feat:` renaming user-visible copy is usually deliberate, `refactor:`/`fix:`
usually is not; and `camunda-docs` describing the new copy for that version settles it.

## Ambiguity is not a coin flip

Guessing wrong is costly in both directions — reverting an intentional change destroys work,
adapting the test to a real regression masks the defect the test exists to catch. So an ambiguous
case is `category: "not-determined"` with both candidate fixes named and the fingerprint left
unclaimed, which is what the real `main` agent already did today on an auth0 429
([run](https://github.com/camunda/camunda/actions/runs/30995019037)).

**This is the one judgement call to review:** if you would rather the agent lean toward the
test-side fix to keep the pipeline moving, that is a one-line change in the manual.

## Also recorded: a test-side fix does not turn the run green

The helm e2e job runs the published `@camunda/e2e-test-suite` package, not the repo source, so a
locator fix only takes effect once that package is published. Until then the pipeline stays red and
the failure is re-dispatched unless the PR carries the coverage block. Worth knowing before anyone
expects an e2e-side fix to close the loop by itself.

## Verification

Documentation and prompt text, so there is nothing to unit-test. `actionlint -shellcheck=shellcheck`
passes on `alwaysgreen-fix.yml`; the manual is prose and a fenced block rather than a table, since
spotless re-aligns markdown tables and a hand-written one fails `Java checks` (it did on #59389).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Follow-up to #59389 and #59043. No backport labels: the fix agent and its manual live only on `main`.
