### PR TITLE
ci: retry xmllint install to survive Ubuntu mirror flakes

### DIFF
--- a/.github/actions/validate-pom-metadata/action.yml
+++ b/.github/actions/validate-pom-metadata/action.yml
@@ -12,8 +12,13 @@ runs:
   using: composite
   steps:
     - name: Install xmllint
-      shell: bash
-      run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      with:
+        max_attempts: 3
+        retry_wait_seconds: 10
+        timeout_minutes: 2
+        shell: bash
+        command: sudo apt-get update && sudo apt-get install -y --no-install-recommends libxml2-utils
 
     - name: Validate flattened POM metadata
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2439,7 +2439,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1
       - name: Install bats and xmllint
-        run: sudo apt-get install -y bats libxml2-utils
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 10
+          timeout_seconds: 60
+          shell: bash
+          command: sudo apt-get install -y --no-install-recommends bats libxml2-utils
       - name: Run ci-relevance tests
         run: bats .github/scripts/ci-relevance/check.bats
       - name: Run flattened-pom validation tests


### PR DESCRIPTION
## Description

Two CI jobs `apt-get install` packages on `ubuntu-latest` with no retry or timeout:

- "Lint / Flattened POM Metadata" (via the `validate-pom-metadata` composite action) installs `libxml2-utils`. Run 30027026071 timed out at the 10-minute ceiling when the Ubuntu mirror stalled mid-download, cancelling the whole run — a mirror-side flake, not a code issue.
- "Shell / Script Tests" (in `ci.yml`) installs `bats` and `libxml2-utils` with the same exposure (and is missing an `apt-get update`, so a stale package index could also fail it).

`libxml2-utils` and `bats` are not pre-installed on the current `ubuntu-latest` image (checked against the `actions/runner-images` Ubuntu 24.04 readme), so the install steps themselves are unavoidable. This PR makes them tolerant of transient mirror failures.

### Changes

Both installs are now wrapped in `nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0` (the pinned SHA already used across the repo), each with `--no-install-recommends`:

- `.github/actions/validate-pom-metadata/action.yml` — 3 attempts, 2-minute per-attempt timeout, 10s wait. Worst case ~7 min, inside the job's `timeout-minutes: 10`.
- `.github/workflows/ci.yml` (`shell-script-tests` job) — 3 attempts, 60s per-attempt timeout, 10s wait. Worst case ~2.5 min, inside the job's `timeout-minutes: 5`.

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Related to INC-6639
