### PR TITLE
Expose withLease in the Spring Boot SDK's JobWorkerValue and property overrides

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
@@ -279,7 +279,8 @@ public class AnnotationUtil {
                       ? new Empty<>()
                       : new FromAnnotation<>(Duration.ofMillis(annotation.retryBackoff())),
                   fromSingletonArray(
-                      annotation.tenantFilter(), "tenantFilter", methodInfo.getMethodName())))
+                      annotation.tenantFilter(), "tenantFilter", methodInfo.getMethodName()),
+                  new Empty<>()))
           .map(
               v -> {
                 v.setMethodInfo(methodInfo);

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/value/JobWorkerValue.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/value/JobWorkerValue.java
@@ -42,8 +42,9 @@ public class JobWorkerValue {
   private SourceAware<Integer> maxRetries = new Empty<>();
   private SourceAware<Duration> retryBackoff = new Empty<>();
   private SourceAware<TenantFilter> tenantFilter = new Empty<>();
-  // cannot be changed from change set
+  // autoComplete and withLease cannot be changed from change set
   private SourceAware<Boolean> autoComplete = new Empty<>();
+  private SourceAware<Boolean> withLease = new Empty<>();
 
   @Deprecated(forRemoval = true)
   @JsonIgnore
@@ -68,7 +69,8 @@ public class JobWorkerValue {
       final SourceAware<Duration> streamInactivityTimeout,
       final SourceAware<Integer> maxRetries,
       final SourceAware<Duration> retryBackoff,
-      final SourceAware<TenantFilter> tenantFilter) {
+      final SourceAware<TenantFilter> tenantFilter,
+      final SourceAware<Boolean> withLease) {
     this.type = type;
     this.name = name;
     this.timeout = timeout;
@@ -86,6 +88,7 @@ public class JobWorkerValue {
     this.maxRetries = maxRetries;
     this.retryBackoff = retryBackoff;
     this.tenantFilter = tenantFilter;
+    this.withLease = withLease;
   }
 
   public SourceAware<String> getType() {
@@ -208,6 +211,14 @@ public class JobWorkerValue {
     this.autoComplete = autoComplete;
   }
 
+  public SourceAware<Boolean> getWithLease() {
+    return withLease;
+  }
+
+  public void setWithLease(final SourceAware<Boolean> withLease) {
+    this.withLease = withLease;
+  }
+
   public SourceAware<Duration> getRetryBackoff() {
     return retryBackoff;
   }
@@ -253,7 +264,8 @@ public class JobWorkerValue {
         maxRetries,
         retryBackoff,
         tenantFilter,
-        autoComplete);
+        autoComplete,
+        withLease);
   }
 
   @Override
@@ -278,7 +290,8 @@ public class JobWorkerValue {
         && Objects.equals(maxRetries, that.maxRetries)
         && Objects.equals(retryBackoff, that.retryBackoff)
         && Objects.equals(tenantFilter, that.tenantFilter)
-        && Objects.equals(autoComplete, that.autoComplete);
+        && Objects.equals(autoComplete, that.autoComplete)
+        && Objects.equals(withLease, that.withLease);
   }
 
   @Override
@@ -286,6 +299,8 @@ public class JobWorkerValue {
     return "JobWorkerValue{"
         + "autoComplete="
         + autoComplete
+        + ", withLease="
+        + withLease
         + ", tenantFilter="
         + tenantFilter
         + ", retryBackoff="

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/BeanJobExceptionHandler.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/BeanJobExceptionHandler.java
@@ -103,7 +103,8 @@ public class BeanJobExceptionHandler extends JobExceptionHandlerImpl {
         jobClient
             .newThrowErrorCommand(job.getKey())
             .errorCode(bpmnError.getErrorCode())
-            .errorMessage(bpmnError.getErrorMessage());
+            .errorMessage(bpmnError.getErrorMessage())
+            .withLeaseToken(job.getLeaseToken());
     return JobHandlingUtil.applyVariables(bpmnError.getVariables(), command);
   }
 
@@ -121,7 +122,8 @@ public class BeanJobExceptionHandler extends JobExceptionHandlerImpl {
             .newFailCommand(job.getKey())
             .retries(retries)
             .errorMessage(errorMessage)
-            .retryBackoff(backoff);
+            .retryBackoff(backoff)
+            .withLeaseToken(job.getLeaseToken());
     return JobHandlingUtil.applyVariables(jobError.getVariables(), command);
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/JobHandlerInvokingBeans.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/JobHandlerInvokingBeans.java
@@ -104,7 +104,8 @@ public class JobHandlerInvokingBeans implements JobHandler {
 
   private JobCallbackFinalCommandStep<CompleteJobResponse> createCompleteCommand(
       final JobClient jobClient, final ActivatedJob job, final Object result) {
-    final CompleteJobCommandStep1 completeCommand = jobClient.newCompleteCommand(job.getKey());
+    final CompleteJobCommandStep1 completeCommand =
+        jobClient.newCompleteCommand(job.getKey()).withLeaseToken(job.getLeaseToken());
     if (result instanceof final UserTaskResultFunction resultFunction) {
       return completeCommand.withResult(r -> resultFunction.apply(r.forUserTask()));
     } else if (result instanceof final AdHocSubProcessResultFunction resultFunction) {

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/JobWorkerFactory.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/JobWorkerFactory.java
@@ -105,6 +105,9 @@ public class JobWorkerFactory {
     if (canBeSetToBuilder(jobWorkerValue.getStreamEnabled())) {
       builder.streamEnabled(jobWorkerValue.getStreamEnabled().value());
     }
+    if (canBeSetToBuilder(jobWorkerValue.getWithLease())) {
+      builder.withLease(jobWorkerValue.getWithLease().value());
+    }
     if (canBeSetToBuilder(jobWorkerValue.getStreamTimeout(), this::isValidDuration)) {
       builder.streamTimeout(jobWorkerValue.getStreamTimeout().value());
     }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientJobWorkerProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientJobWorkerProperties.java
@@ -117,6 +117,15 @@ public class CamundaClientJobWorkerProperties {
   private Duration retryBackoff;
 
   /**
+   * Activate the jobs polled by this worker with a lease. When enabled, each activated job is
+   * assigned a distinct lease token, fencing the complete, fail, and throw-error commands against a
+   * superseded activation of the same job.
+   *
+   * <p>Only applies to the polling path. If not set, jobs are activated without a lease.
+   */
+  private Boolean withLease;
+
+  /**
    * This instantiates the properties without any defaults. Intended to be used by {@link
    * CamundaClientWorkerProperties#getOverride()}.
    */
@@ -284,5 +293,13 @@ public class CamundaClientJobWorkerProperties {
 
   public void setRetryBackoff(final Duration retryBackoff) {
     this.retryBackoff = retryBackoff;
+  }
+
+  public Boolean getWithLease() {
+    return withLease;
+  }
+
+  public void setWithLease(final Boolean withLease) {
+    this.withLease = withLease;
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizer.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizer.java
@@ -178,6 +178,12 @@ public class PropertyBasedJobWorkerValueCustomizer implements JobWorkerValueCust
         target::setStreamEnabled,
         target.getStreamEnabled());
     copyProperty(
+        "withLease",
+        overrideSource,
+        source::getWithLease,
+        target::setWithLease,
+        target.getWithLease());
+    copyProperty(
         "streamTimeout",
         overrideSource,
         source::getStreamTimeout,

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/jobhandling/BeanJobExceptionHandlerTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/jobhandling/BeanJobExceptionHandlerTest.java
@@ -64,6 +64,7 @@ public class BeanJobExceptionHandlerTest {
     when(failJobCommandStep2.errorMessage(any())).thenReturn(failJobCommandStep2);
     when(failJobCommandStep2.retryBackoff(any())).thenReturn(failJobCommandStep2);
     when(failJobCommandStep2.variables(any(JobResponse.class))).thenReturn(failJobCommandStep2);
+    when(failJobCommandStep2.withLeaseToken(any())).thenReturn(failJobCommandStep2);
     when(failJobCommandStep2.send()).thenReturn(future);
     when(future.thenAccept(any())).thenReturn(mock(CompletionStage.class));
     final ActivatedJob job = mock(ActivatedJob.class);
@@ -89,6 +90,7 @@ public class BeanJobExceptionHandlerTest {
     when(failJobCommandStep2.errorMessage(any())).thenReturn(failJobCommandStep2);
     when(failJobCommandStep2.retryBackoff(any())).thenReturn(failJobCommandStep2);
     when(failJobCommandStep2.variables(any(JobResponse.class))).thenReturn(failJobCommandStep2);
+    when(failJobCommandStep2.withLeaseToken(any())).thenReturn(failJobCommandStep2);
     when(failJobCommandStep2.send()).thenReturn(future);
     when(future.thenAccept(any())).thenReturn(mock(CompletionStage.class));
     final ActivatedJob job = mock(ActivatedJob.class);
@@ -99,6 +101,32 @@ public class BeanJobExceptionHandlerTest {
     verify(jobClient, times(0)).newCompleteCommand(anyLong());
     verify(jobClient, times(1)).newFailCommand(anyLong());
     verify(jobClient, times(0)).newThrowErrorCommand(anyLong());
+    verify(failJobCommandStep2, times(1)).send();
+  }
+
+  @Test
+  void shouldCarryLeaseTokenOnFail() {
+    final BeanJobExceptionHandler handler =
+        new BeanJobExceptionHandler(Duration.ZERO, 0, jobCallbackCommandWrapperFactory());
+    final JobClient jobClient = mock(JobClient.class);
+    final FailJobCommandStep1 failJobCommandStep1 = mock(FailJobCommandStep1.class);
+    final FailJobCommandStep2 failJobCommandStep2 = mock(FailJobCommandStep2.class);
+    final CamundaFuture<FailJobResponse> future = mock(CamundaFuture.class);
+    when(jobClient.newFailCommand(anyLong())).thenReturn(failJobCommandStep1);
+    when(failJobCommandStep1.retries(anyInt())).thenReturn(failJobCommandStep2);
+    when(failJobCommandStep2.errorMessage(any())).thenReturn(failJobCommandStep2);
+    when(failJobCommandStep2.retryBackoff(any())).thenReturn(failJobCommandStep2);
+    when(failJobCommandStep2.variables(any(JobResponse.class))).thenReturn(failJobCommandStep2);
+    when(failJobCommandStep2.withLeaseToken(any())).thenReturn(failJobCommandStep2);
+    when(failJobCommandStep2.send()).thenReturn(future);
+    when(future.thenAccept(any())).thenReturn(mock(CompletionStage.class));
+    final ActivatedJob job = mock(ActivatedJob.class);
+    when(job.getType()).thenReturn("test");
+    when(job.getRetries()).thenReturn(3);
+    when(job.getLeaseToken()).thenReturn("some-lease-token");
+    handler.handleJobException(
+        new JobExceptionHandlerContext(jobClient, job, new JobError("test error")));
+    verify(failJobCommandStep2).withLeaseToken("some-lease-token");
     verify(failJobCommandStep2, times(1)).send();
   }
 
@@ -115,6 +143,7 @@ public class BeanJobExceptionHandlerTest {
     when(throwErrorCommandStep2.errorMessage(any())).thenReturn(throwErrorCommandStep2);
     when(throwErrorCommandStep2.variables(any(JobResponse.class)))
         .thenReturn(throwErrorCommandStep2);
+    when(throwErrorCommandStep2.withLeaseToken(any())).thenReturn(throwErrorCommandStep2);
     when(throwErrorCommandStep2.send()).thenReturn(future);
     when(future.thenAccept(any())).thenReturn(mock(CompletionStage.class));
     final ActivatedJob job = mock(ActivatedJob.class);
@@ -125,6 +154,32 @@ public class BeanJobExceptionHandlerTest {
     verify(jobClient, times(0)).newCompleteCommand(anyLong());
     verify(jobClient, times(0)).newFailCommand(anyLong());
     verify(jobClient, times(1)).newThrowErrorCommand(anyLong());
+    verify(throwErrorCommandStep2, times(1)).send();
+  }
+
+  @Test
+  void shouldCarryLeaseTokenOnThrowError() {
+    final BeanJobExceptionHandler handler =
+        new BeanJobExceptionHandler(Duration.ZERO, 0, jobCallbackCommandWrapperFactory());
+    final JobClient jobClient = mock(JobClient.class);
+    final ThrowErrorCommandStep1 throwErrorCommandStep1 = mock(ThrowErrorCommandStep1.class);
+    final ThrowErrorCommandStep2 throwErrorCommandStep2 = mock(ThrowErrorCommandStep2.class);
+    final CamundaFuture<ThrowErrorResponse> future = mock(CamundaFuture.class);
+    when(jobClient.newThrowErrorCommand(anyLong())).thenReturn(throwErrorCommandStep1);
+    when(throwErrorCommandStep1.errorCode(any())).thenReturn(throwErrorCommandStep2);
+    when(throwErrorCommandStep2.errorMessage(any())).thenReturn(throwErrorCommandStep2);
+    when(throwErrorCommandStep2.variables(any(JobResponse.class)))
+        .thenReturn(throwErrorCommandStep2);
+    when(throwErrorCommandStep2.withLeaseToken(any())).thenReturn(throwErrorCommandStep2);
+    when(throwErrorCommandStep2.send()).thenReturn(future);
+    when(future.thenAccept(any())).thenReturn(mock(CompletionStage.class));
+    final ActivatedJob job = mock(ActivatedJob.class);
+    when(job.getType()).thenReturn("test");
+    when(job.getRetries()).thenReturn(3);
+    when(job.getLeaseToken()).thenReturn("some-lease-token");
+    handler.handleJobException(
+        new JobExceptionHandlerContext(jobClient, job, new BpmnError("errorCode", "test error")));
+    verify(throwErrorCommandStep2).withLeaseToken("some-lease-token");
     verify(throwErrorCommandStep2, times(1)).send();
   }
 }

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/jobhandling/JobHandlerInvokingBeansTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/jobhandling/JobHandlerInvokingBeansTest.java
@@ -84,6 +84,7 @@ public class JobHandlerInvokingBeansTest {
     when(future.thenAccept(any())).thenReturn(mock(CompletionStage.class));
     when(completeJobCommandStep1.variables(any(JobResponse.class)))
         .thenReturn(completeJobCommandStep1);
+    when(completeJobCommandStep1.withLeaseToken(any())).thenReturn(completeJobCommandStep1);
     when(completeJobCommandStep1.send()).thenReturn(future);
     when(jobClient.newCompleteCommand(anyLong())).thenReturn(completeJobCommandStep1);
     final ActivatedJob job = mock(ActivatedJob.class);
@@ -161,6 +162,38 @@ public class JobHandlerInvokingBeansTest {
         .isInstanceOf(BpmnError.class)
         .hasMessage("[testCode] test message")
         .hasFieldOrPropertyWithValue("errorCode", "testCode");
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = Response.class,
+      names = {"VOID", "RESPONSE"})
+  void shouldCarryLeaseTokenOnComplete(final Response response) throws Exception {
+    final TestDimension testDimension = new TestDimension(AutoComplete.YES, response, List.of());
+    final JobWorkerValue jobWorkerValue = jobWorkerValue(testDimension);
+    final JobHandler jobHandler =
+        new BeanJobHandlerFactory(
+                methodInfo(testDimension),
+                parameterResolverStrategy(),
+                resultProcessorStrategy(),
+                metricsRecorder(),
+                jobCallbackCommandWrapperFactory())
+            .getJobHandler(new JobHandlerFactoryContext(jobWorkerValue, mock(CamundaClient.class)));
+    final JobClient jobClient = mock(JobClient.class);
+    final CompleteJobCommandStep1 completeJobCommandStep1 = mock(CompleteJobCommandStep1.class);
+    final CamundaFuture<CompleteJobResponse> future = mock(CamundaFuture.class);
+    when(future.thenAccept(any())).thenReturn(mock(CompletionStage.class));
+    when(completeJobCommandStep1.variables(any(JobResponse.class)))
+        .thenReturn(completeJobCommandStep1);
+    when(completeJobCommandStep1.withLeaseToken(any())).thenReturn(completeJobCommandStep1);
+    when(completeJobCommandStep1.send()).thenReturn(future);
+    when(jobClient.newCompleteCommand(anyLong())).thenReturn(completeJobCommandStep1);
+    final ActivatedJob job = mock(ActivatedJob.class);
+    when(job.getType()).thenReturn("test");
+    when(job.getLeaseToken()).thenReturn("some-lease-token");
+    jobHandler.handle(jobClient, job);
+    verify(completeJobCommandStep1).withLeaseToken("some-lease-token");
+    verify(completeJobCommandStep1, times(1)).send();
   }
 
   private ParameterResolverStrategy parameterResolverStrategy() {

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/jobhandling/JobWorkerFactoryTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/jobhandling/JobWorkerFactoryTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.jobhandling;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.annotation.value.JobWorkerValue;
+import io.camunda.client.annotation.value.SourceAware.FromAnnotation;
+import io.camunda.client.api.worker.BackoffSupplier;
+import io.camunda.client.api.worker.JobExceptionHandler;
+import io.camunda.client.api.worker.JobHandler;
+import io.camunda.client.api.worker.JobWorker;
+import io.camunda.client.api.worker.JobWorkerBuilderStep1;
+import io.camunda.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep2;
+import io.camunda.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep3;
+import io.camunda.client.api.worker.JobWorkerMetrics;
+import io.camunda.client.metrics.JobWorkerMetricsFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers how {@link JobWorkerFactory} resolves the {@code withLease} property onto the worker
+ * builder. Scoped only to {@code withLease}.
+ */
+public class JobWorkerFactoryTest {
+
+  private CamundaClient camundaClient;
+  private JobWorkerBuilderStep3 step3;
+  private JobWorkerValue jobWorkerValue;
+  private JobWorkerFactory jobWorkerFactory;
+  private JobHandlerFactory jobHandlerFactory;
+
+  @BeforeEach
+  void setUp() {
+    camundaClient = mock(CamundaClient.class);
+    final JobWorkerBuilderStep1 step1 = mock(JobWorkerBuilderStep1.class);
+    final JobWorkerBuilderStep2 step2 = mock(JobWorkerBuilderStep2.class);
+    step3 = mock(JobWorkerBuilderStep3.class);
+
+    when(camundaClient.newWorker()).thenReturn(step1);
+    when(step1.jobType(any())).thenReturn(step2);
+    when(step2.handler(any())).thenReturn(step3);
+    when(step3.name(any())).thenReturn(step3);
+    when(step3.backoffSupplier(any())).thenReturn(step3);
+    when(step3.streamNoJobsBackoffSupplier(any())).thenReturn(step3);
+    when(step3.jobExceptionHandler(any())).thenReturn(step3);
+    when(step3.metrics(any())).thenReturn(step3);
+    when(step3.withLease(anyBoolean())).thenReturn(step3);
+    when(step3.open()).thenReturn(mock(JobWorker.class));
+
+    jobHandlerFactory = mock(JobHandlerFactory.class);
+    when(jobHandlerFactory.getJobHandler(any())).thenReturn(mock(JobHandler.class));
+
+    final JobExceptionHandlerSupplier jobExceptionHandlerSupplier =
+        mock(JobExceptionHandlerSupplier.class);
+    when(jobExceptionHandlerSupplier.getJobExceptionHandler(any()))
+        .thenReturn(mock(JobExceptionHandler.class));
+
+    final JobWorkerMetricsFactory jobWorkerMetricsFactory = mock(JobWorkerMetricsFactory.class);
+    when(jobWorkerMetricsFactory.createJobWorkerMetrics(any()))
+        .thenReturn(mock(JobWorkerMetrics.class));
+
+    jobWorkerFactory =
+        new JobWorkerFactory(
+            BackoffSupplier.newBackoffBuilder().build(),
+            BackoffSupplier.newBackoffBuilder().build(),
+            jobExceptionHandlerSupplier,
+            jobWorkerMetricsFactory);
+
+    jobWorkerValue = new JobWorkerValue();
+    jobWorkerValue.setType(new FromAnnotation<>("test"));
+    jobWorkerValue.setName(new FromAnnotation<>("test-worker"));
+    // maxRetries is unboxed to a primitive int when building the JobExceptionHandlerSupplier
+    // context, so it must be set explicitly - the default Empty<>() would NPE on unboxing.
+    jobWorkerValue.setMaxRetries(new FromAnnotation<>(3));
+  }
+
+  @Test
+  void shouldNotRequestLeaseWhenUnset() {
+    // given
+    // jobWorkerValue.getWithLease() is left at its default Empty<>()
+
+    // when
+    jobWorkerFactory.createJobWorker(camundaClient, jobWorkerValue, jobHandlerFactory);
+
+    // then
+    verify(step3, never()).withLease(anyBoolean());
+  }
+
+  @Test
+  void shouldRequestLeaseWhenExplicitlyTrue() {
+    // given
+    jobWorkerValue.setWithLease(new FromAnnotation<>(true));
+
+    // when
+    jobWorkerFactory.createJobWorker(camundaClient, jobWorkerValue, jobHandlerFactory);
+
+    // then
+    verify(step3).withLease(true);
+  }
+
+  @Test
+  void shouldRequestNoLeaseWhenExplicitlyFalse() {
+    // given
+    jobWorkerValue.setWithLease(new FromAnnotation<>(false));
+
+    // when
+    jobWorkerFactory.createJobWorker(camundaClient, jobWorkerValue, jobHandlerFactory);
+
+    // then
+    verify(step3).withLease(false);
+  }
+}

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
@@ -121,6 +121,9 @@ public class AlignmentTest {
               "camunda.client.worker.defaults.auto-complete",
               new Getter(p -> p.getWorker().getDefaults().getAutoComplete())),
           entry(
+              "camunda.client.worker.defaults.with-lease",
+              new Getter(p -> p.getWorker().getDefaults().getWithLease())),
+          entry(
               "camunda.client.worker.defaults.request-timeout",
               new Getter(p -> p.getWorker().getDefaults().getRequestTimeout(), DURATION_MAPPER)),
           entry(

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizerTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizerTest.java
@@ -255,6 +255,25 @@ public class PropertyBasedJobWorkerValueCustomizerTest {
   }
 
   @Test
+  void shouldOverrideWithLeaseFromWorkerOverGlobalDefault() {
+    // given
+    final CamundaClientProperties properties = properties();
+    properties.getWorker().getDefaults().setWithLease(false);
+    final CamundaClientJobWorkerProperties override = new CamundaClientJobWorkerProperties();
+    override.setWithLease(true);
+    properties.getWorker().getOverride().put("sampleWorker", override);
+    final PropertyBasedJobWorkerValueCustomizer customizer =
+        new PropertyBasedJobWorkerValueCustomizer(properties);
+    final JobWorkerValue jobWorkerValue = new JobWorkerValue();
+    jobWorkerValue.setType(new GeneratedFromMethodInfo<>("sampleWorker"));
+    assertThat(jobWorkerValue.getWithLease()).isEqualTo(new Empty<>());
+    // when
+    customizer.customize(jobWorkerValue);
+    // then
+    assertThat(jobWorkerValue.getWithLease()).isEqualTo(new FromOverrideProperty<>(true));
+  }
+
+  @Test
   void shouldNotOverrideTypeAndNameAndFetchVariablesFromGlobalsIfSet() {
     final CamundaClientProperties properties = properties();
     properties.getWorker().getDefaults().setType("globalOverride");
@@ -380,6 +399,12 @@ public class PropertyBasedJobWorkerValueCustomizerTest {
                 "streamEnabled",
                 CamundaClientJobWorkerProperties::setStreamEnabled,
                 j -> j.getStreamEnabled().value(),
+                true),
+            //    private Boolean withLease;
+            new Input<>(
+                "withLease",
+                CamundaClientJobWorkerProperties::setWithLease,
+                j -> j.getWithLease().value(),
                 true),
             //    private Duration streamTimeout;
             new Input<>(


### PR DESCRIPTION
## Description

You can now opt a Spring Boot SDK job worker into leasing. You can use this by setting `withLease` on a `JobWorkerValue` you build programmatically, or by setting the `camunda.client.worker.override.<type>.with-lease` property for any worker of that type. Once enabled, your worker's completed/failed/thrown-error commands automatically carry the lease token from the activated job, fencing them against stale retries.

This mirrors the raw Java client's `withLease` (#54840), which explicitly deferred Spring Boot support "until a consumer needs them." The AI Agent connector is that consumer: it builds its own `JobWorkerValue` by hand and already completes/fails/throws-error using the activated-job-based command overloads everywhere, so once `JobWorkerValue` carries `withLease`, an operator can opt it into leasing purely via the property — no code change needed in `camunda/connectors`.

Because that property customizer runs unconditionally on every `JobWorkerValue`, not just hand-built ones, it also applies to plain `@JobWorker` beans. So this PR also fixes lease-token propagation on the `@JobWorker` invocation path (complete/fail/throw-error commands). Shipping the property without that fix would let anyone opt an ordinary `@JobWorker` worker into leasing without the token actually fencing its completions — so the fix ships in this PR rather than as a follow-up.

**Out of scope (tracked separately):**
- `@JobWorker` annotation attribute and `@LeaseToken` parameter injection — split off to #59420; ergonomics only for direct `@JobWorker` users, not needed by the connector.
- Runtime-override/actuator support for `withLease` — like `autoComplete`, this is a wiring-time concern, not something to flip live on a running worker.
- Docs update covering the property and programmatic `JobWorkerValue` opt-in.

## Related issues

Closes #57812