### PR TITLE
fix: reconcile exporter state correctly after a restore on the new config model

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -310,7 +310,8 @@ public final class ClusterConfigurationManagerService
         .andThen(
             new PartitionGroupExporterStateInitializer(
                 staticConfiguration.partitionConfig().exporting().exporters().keySet(),
-                staticConfiguration.localMemberId()))
+                staticConfiguration.localMemberId(),
+                false))
         .andThen(
             PartitionDistributorInitializer
                 .currentClusterConfigurationPartitionDistributorInitializer(staticConfiguration))
@@ -343,7 +344,8 @@ public final class ClusterConfigurationManagerService
         .andThen(
             new PartitionGroupExporterStateInitializer(
                 staticConfiguration.partitionConfig().exporting().exporters().keySet(),
-                staticConfiguration.localMemberId()))
+                staticConfiguration.localMemberId(),
+                true))
         .andThen(
             PartitionDistributorInitializer
                 .currentClusterConfigurationPartitionDistributorInitializer(staticConfiguration))

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializer.java
@@ -17,29 +17,46 @@ import java.util.Set;
 
 /**
  * New-model counterpart of {@link ExporterStateInitializer}, applying the same exporter-state
- * reconciliation to the local member's partitions in <em>every</em> partition group, instead of
- * once for the single default group. The per-partition reconciliation logic is shared with {@link
+ * reconciliation to partitions in <em>every</em> partition group, instead of once for the single
+ * default group. The per-partition reconciliation logic is shared with {@link
  * ExporterStateInitializer} via its package-visible static helpers.
  *
- * <p>Unlike {@link ExporterStateInitializer}, this does not have a post-restore branch that updates
- * every member's exporter state: nothing currently produces a restore change plan on {@link
- * CurrentClusterConfiguration}, so that branch would be unreachable and untested. Revisit once
- * restore is migrated to the new model.
+ * <p>Mirrors {@link ExporterStateInitializer}'s post-restore handling: if the migrated
+ * configuration is {@link CurrentClusterConfiguration#isAfterRestore()}, only the coordinator
+ * updates the exporter state, and it does so for every member of every group (not just the local
+ * member) — the coordinator is the only member guaranteed to run this initializer again once the
+ * post-restore {@code UpdateRoutingState} operation is applied, so it must reconcile on behalf of
+ * everyone. Non-coordinators skip initialization entirely in that case.
  */
 public class PartitionGroupExporterStateInitializer
     implements ClusterConfigurationModifier<CurrentClusterConfiguration> {
 
   private final Set<String> configuredExporters;
   private final MemberId localMemberId;
+  private final boolean isCoordinator;
 
   public PartitionGroupExporterStateInitializer(
-      final Set<String> configuredExporters, final MemberId localMemberId) {
+      final Set<String> configuredExporters,
+      final MemberId localMemberId,
+      final boolean isCoordinator) {
     this.configuredExporters = configuredExporters;
     this.localMemberId = localMemberId;
+    this.isCoordinator = isCoordinator;
   }
 
   @Override
   public ActorFuture<CurrentClusterConfiguration> modify(
+      final CurrentClusterConfiguration configuration) {
+    if (configuration.isAfterRestore()) {
+      if (isCoordinator) {
+        return CompletableActorFuture.completed(updateExporterStateForAllMembers(configuration));
+      }
+      return CompletableActorFuture.completed(configuration);
+    }
+    return CompletableActorFuture.completed(updateLocalMemberExporterState(configuration));
+  }
+
+  private CurrentClusterConfiguration updateLocalMemberExporterState(
       final CurrentClusterConfiguration configuration) {
     var updated = configuration;
     for (final var groupId : configuration.partitionGroups().keySet()) {
@@ -49,7 +66,20 @@ public class PartitionGroupExporterStateInitializer
                 groupId, group -> group.updateMember(localMemberId, this::updateExporterState));
       }
     }
-    return CompletableActorFuture.completed(updated);
+    return updated;
+  }
+
+  private CurrentClusterConfiguration updateExporterStateForAllMembers(
+      final CurrentClusterConfiguration configuration) {
+    var updated = configuration;
+    for (final var groupId : configuration.partitionGroups().keySet()) {
+      for (final var memberId : updated.partitionGroup(groupId).members().keySet()) {
+        updated =
+            updated.updatePartitionGroupConfig(
+                groupId, group -> group.updateMember(memberId, this::updateExporterState));
+      }
+    }
+    return updated;
   }
 
   private BrokerPartitionState updateExporterState(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.dynamic.config.state;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.InitializableClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
@@ -505,6 +506,32 @@ public record CurrentClusterConfiguration(
     return partitionGroups.containsKey(groupId);
   }
 
+  /**
+   * Returns true if this configuration was produced by migrating a legacy {@link
+   * ClusterConfiguration} that was itself {@link ClusterConfiguration#isAfterRestore()}: the
+   * pending plan's id is {@link PhasedChangePlan#RESTORED_PLAN_ID} (see {@link
+   * PhasedChangePlan#hasRestorePlanId()}) and it contains exactly one phase with exactly one
+   * operation, an {@link UpdateRoutingState}. Mirrors {@link
+   * ClusterConfiguration#isAfterRestore()}.
+   */
+  public boolean isAfterRestore() {
+    return phasedChangeState
+        .pending()
+        .filter(PhasedChangePlan::hasRestorePlanId)
+        .filter(plan -> plan.phases().size() == 1)
+        .map(plan -> plan.phases().get(0))
+        .filter(
+            phase ->
+                phase instanceof final PartitionGroupParallelPhase parallelPhase
+                    && parallelPhase.groupOperations().size() == 1
+                    && parallelPhase.groupOperations().values().stream()
+                        .allMatch(
+                            operations ->
+                                operations.size() == 1
+                                    && operations.get(0) instanceof UpdateRoutingState))
+        .isPresent();
+  }
+
   public @Nullable PartitionGroupConfiguration partitionGroup(final String groupId) {
     return partitionGroups.get(groupId);
   }
@@ -533,17 +560,40 @@ public record CurrentClusterConfiguration(
 
   /**
    * Builds the pending {@link PhasedChangePlan}, normalizing the plan id. Legacy restore plans use
-   * a negative sentinel id ({@code ClusterChangePlan.RESTORE_CHANGE_ID = -2}), but {@link
-   * PhasedChangePlan} requires a positive id and {@link PhasedChangeState} requires the pending id
-   * to exceed the last completed change id. Any legacy id that is not positive or not greater than
-   * {@code lastChangeId} is replaced with {@code lastChangeId + 1}, keeping ids positive and
-   * monotonic after migration.
+   * a negative sentinel id ({@code ClusterChangePlan.RESTORE_CHANGE_ID = -2}) that cannot be
+   * preserved as-is ({@link PhasedChangePlan} requires a non-negative id); they are instead
+   * assigned {@link PhasedChangePlan#RESTORED_PLAN_ID}, the new model's own sentinel (see {@link
+   * PhasedChangePlan#hasRestorePlanId()} and {@link #isAfterRestore()}). Any other legacy id that
+   * is not positive or not greater than {@code lastChangeId} is replaced with {@code lastChangeId +
+   * 1}, keeping ids positive and monotonic after migration.
+   *
+   * <p>A restore is only ever produced by {@code RestoreManager#restoreTopologyFile}, which always
+   * regenerates a completely fresh legacy configuration (via {@code StaticConfigurationGenerator})
+   * and attaches the restore plan to it — so a legacy restore plan is expected to never carry a
+   * prior completed change ({@code lastChangeId == 0}). This is asserted below rather than assumed
+   * silently: violating it would mean two restore plans could both be assigned {@link
+   * PhasedChangePlan#RESTORED_PLAN_ID}, and the second migration would only fail downstream in
+   * {@link PhasedChangeState}'s id-monotonicity check with no restore-specific context.
+   *
+   * @throws IllegalStateException if a legacy restore plan is migrated alongside a prior completed
+   *     change, which would violate the assumption above
    */
   private static Optional<PhasedChangePlan> toPhasedChangePlan(
       final ClusterChangePlan plan, final long lastChangeId) {
     final var phases = toPhases(plan.pendingOperations());
     if (phases.isEmpty()) {
       return Optional.empty();
+    }
+
+    if (plan.isRestore()) {
+      if (lastChangeId != 0) {
+        throw new IllegalStateException(
+            "Cannot migrate a legacy restore plan: expected no prior completed change "
+                + "(lastChangeId=0) since a restore always regenerates a fresh configuration, but "
+                + "found lastChangeId="
+                + lastChangeId);
+      }
+      return Optional.of(PhasedChangePlan.initForRestore(phases, plan.startedAt()));
     }
     final long id = plan.id() > 0 && plan.id() > lastChangeId ? plan.id() : lastChangeId + 1;
     return Optional.of(new PhasedChangePlan(id, 0, phases, plan.startedAt()));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PhasedChangePlan.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PhasedChangePlan.java
@@ -30,9 +30,12 @@ import org.jspecify.annotations.NullMarked;
 public record PhasedChangePlan(
     long id, int currentPhaseIndex, List<Phase> phases, Instant startedAt) {
 
+  public static final long RESTORED_PLAN_ID = 0;
+  public static final long INITIAL_PLAN_ID = 1;
+
   public PhasedChangePlan {
-    if (id <= 0) {
-      throw new IllegalArgumentException("id must be positive");
+    if (id < 0) {
+      throw new IllegalArgumentException("id must be non-negative");
     }
     Objects.checkIndex(currentPhaseIndex, phases.size());
     phases = List.copyOf(phases);
@@ -41,6 +44,16 @@ public record PhasedChangePlan(
   public static PhasedChangePlan init(
       final long id, final List<Phase> phases, final Instant startedAt) {
     return new PhasedChangePlan(id, 0, phases, startedAt);
+  }
+
+  /**
+   * Creates a plan migrated from a legacy restore change plan, assigning it {@link
+   * #RESTORED_PLAN_ID} — the legacy sentinel id ({@code ClusterChangePlan.RESTORE_CHANGE_ID = -2})
+   * cannot be preserved as-is since this record requires a non-negative id. See {@link
+   * #hasRestorePlanId()} and {@link CurrentClusterConfiguration#isAfterRestore()}.
+   */
+  public static PhasedChangePlan initForRestore(final List<Phase> phases, final Instant startedAt) {
+    return new PhasedChangePlan(RESTORED_PLAN_ID, 0, phases, startedAt);
   }
 
   /** Returns the currently active phase. */
@@ -81,6 +94,15 @@ public record PhasedChangePlan(
       return currentPhaseIndex >= other.currentPhaseIndex ? this : other;
     }
     return id > other.id ? this : other;
+  }
+
+  /**
+   * Returns {@code true} if this plan's id is {@link #RESTORED_PLAN_ID} — i.e. it was migrated from
+   * a legacy restore change plan. Note this is a necessary but not sufficient condition for {@link
+   * CurrentClusterConfiguration#isAfterRestore()}, which additionally checks the plan's shape.
+   */
+  public boolean hasRestorePlanId() {
+    return id == RESTORED_PLAN_ID;
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PhasedChangeState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PhasedChangeState.java
@@ -62,7 +62,7 @@ public record PhasedChangeState(
       throw new IllegalStateException(
           "Cannot init a new plan while one is already pending: " + pending.get());
     }
-    final long nextId = lastChange.map(c -> c.id() + 1).orElse(1L);
+    final long nextId = lastChange.map(c -> c.id() + 1).orElse(PhasedChangePlan.INITIAL_PLAN_ID);
     final var plan = PhasedChangePlan.init(nextId, phases, Instant.now());
     return new PhasedChangeState(Optional.of(plan), lastChange);
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializerTest.java
@@ -19,8 +19,13 @@ import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -45,7 +50,7 @@ final class PartitionGroupExporterStateInitializerTest {
 
     // when
     final var result =
-        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID)
+        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID, false)
             .modify(configuration)
             .join();
 
@@ -74,7 +79,7 @@ final class PartitionGroupExporterStateInitializerTest {
 
     // when
     final var result =
-        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID)
+        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID, false)
             .modify(configuration)
             .join();
 
@@ -114,7 +119,7 @@ final class PartitionGroupExporterStateInitializerTest {
 
     // when
     final var result =
-        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID)
+        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID, false)
             .modify(configuration)
             .join();
 
@@ -139,12 +144,99 @@ final class PartitionGroupExporterStateInitializerTest {
 
     // when
     final var result =
-        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID)
+        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID, false)
             .modify(configuration)
             .join();
 
     // then
     assertThat(result).isEqualTo(configuration);
+  }
+
+  @Test
+  void shouldUpdateAllMembersInEveryGroupWhenCoordinatorAndPostRestore() {
+    // given — two groups, each with the local member and another member; the local member is
+    // the coordinator, and a restore was just migrated (pending post-restore plan)
+    final var config = DynamicPartitionConfig.init();
+    final var otherMember = MemberId.from("1");
+    final var configuration =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of(
+                "tenant-a",
+                groupWithMember(LOCAL_MEMBER_ID, config)
+                    .addMember(otherMember, initialPartitionState(config)),
+                "tenant-b",
+                groupWithMember(LOCAL_MEMBER_ID, config)),
+            postRestorePendingState());
+
+    // when
+    final var result =
+        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID, true)
+            .modify(configuration)
+            .join();
+
+    // then — every member of every group is updated, not just the local member
+    assertThat(
+            result
+                .partitionGroup("tenant-a")
+                .getMember(LOCAL_MEMBER_ID)
+                .getPartition(1)
+                .config()
+                .exporting()
+                .exporters())
+        .containsKey("expA");
+    assertThat(
+            result
+                .partitionGroup("tenant-a")
+                .getMember(otherMember)
+                .getPartition(1)
+                .config()
+                .exporting()
+                .exporters())
+        .containsKey("expA");
+    assertThat(
+            result
+                .partitionGroup("tenant-b")
+                .getMember(LOCAL_MEMBER_ID)
+                .getPartition(1)
+                .config()
+                .exporting()
+                .exporters())
+        .containsKey("expA");
+  }
+
+  @Test
+  void shouldSkipWhenNonCoordinatorAndPostRestore() {
+    // given
+    final var config = DynamicPartitionConfig.init();
+    final var configuration =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of("tenant-a", groupWithMember(LOCAL_MEMBER_ID, config)),
+            postRestorePendingState());
+
+    // when
+    final var result =
+        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID, false)
+            .modify(configuration)
+            .join();
+
+    // then — unchanged; the coordinator will initialize on behalf of everyone
+    assertThat(result).isEqualTo(configuration);
+  }
+
+  private static PhasedChangeState postRestorePendingState() {
+    final var plan =
+        PhasedChangePlan.initForRestore(
+            List.of(
+                new PartitionGroupParallelPhase(
+                    Map.of(
+                        CurrentClusterConfiguration.DEFAULT_GROUP,
+                        List.of(new UpdateRoutingState(LOCAL_MEMBER_ID, Optional.empty()))))),
+            Instant.EPOCH);
+    return new PhasedChangeState(Optional.of(plan), Optional.empty());
   }
 
   private static PartitionGroupConfiguration groupWithMember(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
@@ -348,8 +348,9 @@ class CurrentClusterConfigurationTest {
     }
 
     @Test
-    void shouldNormalizeRestorePendingPlanId() {
-      // given — a legacy restore plan uses the negative sentinel id (RESTORE_CHANGE_ID = -2)
+    void shouldAssignRestoredPlanIdToMigratedRestorePlan() {
+      // given — a legacy restore plan uses the negative sentinel id (RESTORE_CHANGE_ID = -2),
+      // which cannot be preserved as-is (PhasedChangePlan requires a non-negative id)
       final var restore =
           ClusterChangePlan.initForRestore(List.of(new DeleteHistoryOperation(MEMBER_0)));
       final var legacy =
@@ -362,9 +363,80 @@ class CurrentClusterConfigurationTest {
       // when — migration must not fail on the non-positive id
       final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
 
-      // then — the pending plan id is normalized to a positive value
+      // then — the pending plan is assigned the new model's own restore sentinel id
       final var plan = migrated.phasedChangeState().pending().orElseThrow();
-      assertThat(plan.id()).isEqualTo(1);
+      assertThat(plan.id()).isEqualTo(PhasedChangePlan.RESTORED_PLAN_ID);
+      assertThat(plan.hasRestorePlanId()).isTrue();
+    }
+
+    @Test
+    void shouldRejectRestorePlanMigratedAlongsideAPriorCompletedChange() {
+      // given — a restore plan is only ever produced alongside a freshly regenerated legacy
+      // configuration (RestoreManager#restoreTopologyFile), so it should never carry a prior
+      // completed change. Constructing that combination here simulates that assumption breaking.
+      final var restore =
+          ClusterChangePlan.initForRestore(List.of(new DeleteHistoryOperation(MEMBER_0)));
+      final var priorChange =
+          new CompletedChange(3, ClusterChangePlan.Status.COMPLETED, Instant.EPOCH, Instant.EPOCH);
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(5)
+              .members(Map.of(MEMBER_0, activeMember()))
+              .lastChange(Optional.of(priorChange))
+              .pendingChanges(Optional.of(restore))
+              .build();
+
+      // when / then — fails loudly with restore-specific context instead of only surfacing later
+      // as PhasedChangeState's generic id-monotonicity violation
+      assertThatThrownBy(() -> CurrentClusterConfiguration.fromLegacy(legacy))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("restore");
+    }
+
+    @Test
+    void shouldDetectAfterRestoreOnMigratedRestorePlan() {
+      // given — a legacy config that is isAfterRestore(): a restore plan with exactly one
+      // pending UpdateRoutingState operation
+      final var restore =
+          ClusterChangePlan.initForRestore(
+              List.of(new PartitionGroupOperation.UpdateRoutingState(MEMBER_0, Optional.empty())));
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(5)
+              .members(Map.of(MEMBER_0, activeMember()))
+              .pendingChanges(Optional.of(restore))
+              .build();
+      assertThat(legacy.isAfterRestore()).isTrue();
+
+      // when
+      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
+
+      // then — the migrated configuration is detectable as post-restore too
+      assertThat(migrated.isAfterRestore()).isTrue();
+    }
+
+    @Test
+    void shouldNotDetectAfterRestoreForAnOrdinaryPendingUpdateRoutingState() {
+      // given — a plain (non-restore) pending plan with the exact same single-op shape as a
+      // restore plan: an admin-triggered updateRoutingState request produces this too, so
+      // isAfterRestore() must not rely on operation shape alone
+      final var pending =
+          ClusterChangePlan.init(
+              2,
+              List.of(new PartitionGroupOperation.UpdateRoutingState(MEMBER_0, Optional.empty())));
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(5)
+              .members(Map.of(MEMBER_0, activeMember()))
+              .pendingChanges(Optional.of(pending))
+              .build();
+      assertThat(legacy.isAfterRestore()).isFalse();
+
+      // when
+      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
+
+      // then
+      assertThat(migrated.isAfterRestore()).isFalse();
     }
 
     @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PhasedChangePlanTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PhasedChangePlanTest.java
@@ -211,4 +211,62 @@ class PhasedChangePlanTest {
       assertThat(phase.groupOperations().get("g1")).hasSize(1);
     }
   }
+
+  @Nested
+  class Validation {
+    @Test
+    void shouldThrowWhenIdIsNegative() {
+      // when / then
+      assertThatThrownBy(() -> PhasedChangePlan.init(-1, List.of(globalPhase0), Instant.EPOCH))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldAllowRestoredPlanIdOfZero() {
+      // given / when — RESTORED_PLAN_ID (0) must be constructible: it is the sentinel a migrated
+      // legacy restore plan is assigned (see CurrentClusterConfiguration#toPhasedChangePlan)
+      final var plan =
+          PhasedChangePlan.init(
+              PhasedChangePlan.RESTORED_PLAN_ID, List.of(globalPhase0), Instant.EPOCH);
+
+      // then
+      assertThat(plan.id()).isZero();
+    }
+  }
+
+  @Nested
+  class Restore {
+    @Test
+    void shouldReportRestorePlanIdForRestoredPlanId() {
+      // given
+      final var plan =
+          PhasedChangePlan.init(
+              PhasedChangePlan.RESTORED_PLAN_ID, List.of(globalPhase0), Instant.EPOCH);
+
+      // when / then
+      assertThat(plan.hasRestorePlanId()).isTrue();
+    }
+
+    @Test
+    void shouldNotReportRestorePlanIdForAnOrdinaryPlanId() {
+      // given
+      final var plan = planWithThreePhases(PhasedChangePlan.INITIAL_PLAN_ID);
+
+      // when / then
+      assertThat(plan.hasRestorePlanId()).isFalse();
+    }
+
+    @Test
+    void shouldInitForRestoreWithRestoredPlanIdAtPhaseZero() {
+      // when
+      final var plan =
+          PhasedChangePlan.initForRestore(List.of(globalPhase0, groupPhase1), Instant.EPOCH);
+
+      // then
+      assertThat(plan.id()).isEqualTo(PhasedChangePlan.RESTORED_PLAN_ID);
+      assertThat(plan.currentPhaseIndex()).isZero();
+      assertThat(plan.phases()).containsExactly(globalPhase0, groupPhase1);
+      assertThat(plan.hasRestorePlanId()).isTrue();
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- `PartitionGroupExporterStateInitializer` (new multi-partition-group cluster config model) had no post-restore handling, unlike its legacy counterpart `ExporterStateInitializer`: it always reconciled only the local member's exporter state in every partition group, on every broker.
- Fixes this in two parts:
  1. Give `CurrentClusterConfiguration`/`PhasedChangePlan` a way to detect that the current pending plan was migrated from a legacy restore. Legacy's `ClusterConfiguration.isAfterRestore()` relies on `ClusterChangePlan`'s negative sentinel id (`RESTORE_CHANGE_ID = -2`), which cannot be carried across migration as-is since `PhasedChangePlan` requires a non-negative, monotonic id. Introduces `PhasedChangePlan.RESTORED_PLAN_ID` (reusing the existing `id` field, so no proto/serializer changes are needed) plus `CurrentClusterConfiguration.isAfterRestore()` mirroring the legacy check.
  2. Give `PartitionGroupExporterStateInitializer` an `isCoordinator` flag mirroring legacy's constructor: on `isAfterRestore()`, only the coordinator reconciles exporter state for every member of every group; non-coordinators skip entirely.

Fixes the flaky restore acceptance test by adapting the previous [fix](https://github.com/camunda/camunda/pull/52199) to the new dynamic config model.