### PR TITLE
Extend AGENT_INSTANCE record schema for embedded history batch

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.zeebe.agentinstance;
 
 import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
 
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue.AgentInstanceToolValue;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
@@ -29,6 +30,9 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
   private long processDefinitionKey;
   private int processDefinitionVersion;
   private String tenantId;
+  private long jobKey = -1L;
+  private String jobLease;
+  private int loopIteration;
   private AgentInstanceStatus status;
   private AgentDefinitionValueDto definition = new AgentDefinitionValueDto();
   private AgentMetricsValueDto metrics = new AgentMetricsValueDto();
@@ -129,6 +133,40 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
   }
 
   @Override
+  public long getJobKey() {
+    return jobKey;
+  }
+
+  public void setJobKey(final long jobKey) {
+    this.jobKey = jobKey;
+  }
+
+  @Override
+  public String getJobLease() {
+    return jobLease;
+  }
+
+  public void setJobLease(final String jobLease) {
+    this.jobLease = jobLease;
+  }
+
+  @Override
+  public int getLoopIteration() {
+    return loopIteration;
+  }
+
+  public void setLoopIteration(final int loopIteration) {
+    this.loopIteration = loopIteration;
+  }
+
+  // Not tracked — Optimize's import doesn't need the embedded history batch, only the
+  // instance-level fields above.
+  @Override
+  public List<AgentHistoryRecordValue> getHistory() {
+    return null;
+  }
+
+  @Override
   public String getTenantId() {
     return StringUtils.isEmpty(tenantId) ? ZEEBE_DEFAULT_TENANT_ID : tenantId;
   }
@@ -200,6 +238,9 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
         processDefinitionKey,
         processDefinitionVersion,
         tenantId,
+        jobKey,
+        jobLease,
+        loopIteration,
         status,
         definition,
         metrics,
@@ -219,10 +260,13 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
         && rootProcessInstanceKey == that.rootProcessInstanceKey
         && processDefinitionKey == that.processDefinitionKey
         && processDefinitionVersion == that.processDefinitionVersion
+        && jobKey == that.jobKey
+        && loopIteration == that.loopIteration
         && Objects.equals(elementInstanceKeys, that.elementInstanceKeys)
         && Objects.equals(elementId, that.elementId)
         && Objects.equals(bpmnProcessId, that.bpmnProcessId)
         && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(jobLease, that.jobLease)
         && Objects.equals(status, that.status)
         && Objects.equals(definition, that.definition)
         && Objects.equals(metrics, that.metrics)
@@ -248,6 +292,12 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
         + processDefinitionVersion
         + ", tenantId="
         + tenantId
+        + ", jobKey="
+        + jobKey
+        + ", jobLease="
+        + jobLease
+        + ", loopIteration="
+        + loopIteration
         + ", status="
         + status
         + ", definition="
@@ -273,6 +323,9 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
     public static final String processDefinitionKey = "processDefinitionKey";
     public static final String processDefinitionVersion = "processDefinitionVersion";
     public static final String tenantId = "tenantId";
+    public static final String jobKey = "jobKey";
+    public static final String jobLease = "jobLease";
+    public static final String loopIteration = "loopIteration";
     public static final String status = "status";
     public static final String definition = "definition";
     public static final String metrics = "metrics";
@@ -341,6 +394,9 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
 
     private long inputTokens;
     private long outputTokens;
+    private long reasoningTokenCount;
+    private long cacheCreationTokenCount;
+    private long cacheReadTokenCount;
     private int modelCalls;
     private int toolCalls;
 
@@ -365,6 +421,33 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
     }
 
     @Override
+    public long getReasoningTokenCount() {
+      return reasoningTokenCount;
+    }
+
+    public void setReasoningTokenCount(final long reasoningTokenCount) {
+      this.reasoningTokenCount = reasoningTokenCount;
+    }
+
+    @Override
+    public long getCacheCreationTokenCount() {
+      return cacheCreationTokenCount;
+    }
+
+    public void setCacheCreationTokenCount(final long cacheCreationTokenCount) {
+      this.cacheCreationTokenCount = cacheCreationTokenCount;
+    }
+
+    @Override
+    public long getCacheReadTokenCount() {
+      return cacheReadTokenCount;
+    }
+
+    public void setCacheReadTokenCount(final long cacheReadTokenCount) {
+      this.cacheReadTokenCount = cacheReadTokenCount;
+    }
+
+    @Override
     public int getModelCalls() {
       return modelCalls;
     }
@@ -384,7 +467,14 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
 
     @Override
     public int hashCode() {
-      return Objects.hash(inputTokens, outputTokens, modelCalls, toolCalls);
+      return Objects.hash(
+          inputTokens,
+          outputTokens,
+          reasoningTokenCount,
+          cacheCreationTokenCount,
+          cacheReadTokenCount,
+          modelCalls,
+          toolCalls);
     }
 
     @Override
@@ -395,6 +485,9 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
       final AgentMetricsValueDto that = (AgentMetricsValueDto) o;
       return inputTokens == that.inputTokens
           && outputTokens == that.outputTokens
+          && reasoningTokenCount == that.reasoningTokenCount
+          && cacheCreationTokenCount == that.cacheCreationTokenCount
+          && cacheReadTokenCount == that.cacheReadTokenCount
           && modelCalls == that.modelCalls
           && toolCalls == that.toolCalls;
     }
@@ -405,6 +498,12 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
           + inputTokens
           + ", outputTokens="
           + outputTokens
+          + ", reasoningTokenCount="
+          + reasoningTokenCount
+          + ", cacheCreationTokenCount="
+          + cacheCreationTokenCount
+          + ", cacheReadTokenCount="
+          + cacheReadTokenCount
           + ", modelCalls="
           + modelCalls
           + ", toolCalls="

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
@@ -238,12 +238,18 @@ final class AgentInstanceHandlerTest {
 
   @Test
   void shouldPreserveCreationDateAcrossSubsequentIntents() {
-    // given — CREATED sets the creation date on the entity
+    // given — CREATED sets the creation date on the entity. Timestamps are pinned explicitly and
+    // strictly increasing: the factory randomizes record.getTimestamp() independently per call, so
+    // leaving it random makes the "lastUpdatedDate is after creationDate" assertion below flaky —
+    // there's no guarantee an independently-random later record has a larger random timestamp.
     final var entity = new AgentInstanceEntity().setId("1");
     final Record<AgentInstanceRecordValue> createdRecord =
         factory.generateRecord(
             ValueType.AGENT_INSTANCE,
-            r -> r.withIntent(AgentInstanceIntent.CREATED).withValue(buildMinimalRecordValue(1L)));
+            r ->
+                r.withIntent(AgentInstanceIntent.CREATED)
+                    .withValue(buildMinimalRecordValue(1L))
+                    .withTimestamp(1_000L));
     underTest.updateEntity(createdRecord, entity);
     final var creationDate = entity.getCreationDate();
     assertThat(creationDate).isNotNull();
@@ -252,7 +258,10 @@ final class AgentInstanceHandlerTest {
     final Record<AgentInstanceRecordValue> updatedRecord =
         factory.generateRecord(
             ValueType.AGENT_INSTANCE,
-            r -> r.withIntent(AgentInstanceIntent.UPDATED).withValue(buildMinimalRecordValue(1L)));
+            r ->
+                r.withIntent(AgentInstanceIntent.UPDATED)
+                    .withValue(buildMinimalRecordValue(1L))
+                    .withTimestamp(2_000L));
     underTest.updateEntity(updatedRecord, entity);
 
     // then — creation date preserved, last updated advanced, completion still absent
@@ -269,7 +278,10 @@ final class AgentInstanceHandlerTest {
     final Record<AgentInstanceRecordValue> completedRecord =
         factory.generateRecord(
             ValueType.AGENT_INSTANCE,
-            r -> r.withIntent(AgentInstanceIntent.COMPLETED).withValue(completedValue));
+            r ->
+                r.withIntent(AgentInstanceIntent.COMPLETED)
+                    .withValue(completedValue)
+                    .withTimestamp(3_000L));
     underTest.updateEntity(completedRecord, entity);
 
     // then — creation date still untouched, completion date now set

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-history-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-history-template.json
@@ -80,6 +80,9 @@
                 }
               }
             },
+            "historyItemId": {
+              "type": "keyword"
+            },
             "tools": {
               "properties": {
                 "name": {
@@ -114,6 +117,9 @@
             },
             "changedAttributes": {
               "type": "keyword"
+            },
+            "duplicate": {
+              "type": "boolean"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-history-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-history-template.json
@@ -61,6 +61,9 @@
             "content": {
               "enabled": false
             },
+            "systemPrompt": {
+              "enabled": false
+            },
             "toolCalls": {
               "enabled": false
             },
@@ -76,6 +79,41 @@
                   "type": "long"
                 }
               }
+            },
+            "tools": {
+              "properties": {
+                "name": {
+                  "type": "keyword"
+                },
+                "description": {
+                  "type": "text"
+                },
+                "elementId": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "model": {
+              "type": "keyword"
+            },
+            "provider": {
+              "type": "keyword"
+            },
+            "limits": {
+              "properties": {
+                "maxTokens": {
+                  "type": "long"
+                },
+                "maxModelCalls": {
+                  "type": "integer"
+                },
+                "maxToolCalls": {
+                  "type": "integer"
+                }
+              }
+            },
+            "changedAttributes": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-history-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-history-template.json
@@ -75,6 +75,15 @@
                 "outputTokens": {
                   "type": "long"
                 },
+                "reasoningTokenCount": {
+                  "type": "long"
+                },
+                "cacheCreationTokenCount": {
+                  "type": "long"
+                },
+                "cacheReadTokenCount": {
+                  "type": "long"
+                },
                 "durationMs": {
                   "type": "long"
                 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-template.json
@@ -185,6 +185,9 @@
                     }
                   }
                 },
+                "historyItemId": {
+                  "type": "keyword"
+                },
                 "tools": {
                   "properties": {
                     "name": {
@@ -219,6 +222,9 @@
                 },
                 "changedAttributes": {
                   "type": "keyword"
+                },
+                "duplicate": {
+                  "type": "boolean"
                 }
               }
             }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-template.json
@@ -112,6 +112,15 @@
             },
             "changedAttributes": {
               "type": "keyword"
+            },
+            "jobKey": {
+              "type": "long"
+            },
+            "jobLease": {
+              "type": "keyword"
+            },
+            "loopIteration": {
+              "type": "integer"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-template.json
@@ -89,6 +89,15 @@
                 "outputTokens": {
                   "type": "long"
                 },
+                "reasoningTokenCount": {
+                  "type": "long"
+                },
+                "cacheCreationTokenCount": {
+                  "type": "long"
+                },
+                "cacheReadTokenCount": {
+                  "type": "long"
+                },
                 "modelCalls": {
                   "type": "integer"
                 },
@@ -178,6 +187,15 @@
                       "type": "long"
                     },
                     "outputTokens": {
+                      "type": "long"
+                    },
+                    "reasoningTokenCount": {
+                      "type": "long"
+                    },
+                    "cacheCreationTokenCount": {
+                      "type": "long"
+                    },
+                    "cacheReadTokenCount": {
                       "type": "long"
                     },
                     "durationMs": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-template.json
@@ -166,6 +166,9 @@
                 "content": {
                   "enabled": false
                 },
+                "systemPrompt": {
+                  "enabled": false
+                },
                 "toolCalls": {
                   "enabled": false
                 },
@@ -181,6 +184,41 @@
                       "type": "long"
                     }
                   }
+                },
+                "tools": {
+                  "properties": {
+                    "name": {
+                      "type": "keyword"
+                    },
+                    "description": {
+                      "type": "text"
+                    },
+                    "elementId": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "model": {
+                  "type": "keyword"
+                },
+                "provider": {
+                  "type": "keyword"
+                },
+                "limits": {
+                  "properties": {
+                    "maxTokens": {
+                      "type": "long"
+                    },
+                    "maxModelCalls": {
+                      "type": "integer"
+                    },
+                    "maxToolCalls": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "changedAttributes": {
+                  "type": "keyword"
                 }
               }
             }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-template.json
@@ -121,6 +121,68 @@
             },
             "loopIteration": {
               "type": "integer"
+            },
+            "history": {
+              "properties": {
+                "agentHistoryKey": {
+                  "type": "long"
+                },
+                "agentInstanceKey": {
+                  "type": "long"
+                },
+                "elementInstanceKey": {
+                  "type": "long"
+                },
+                "processInstanceKey": {
+                  "type": "long"
+                },
+                "rootProcessInstanceKey": {
+                  "type": "long"
+                },
+                "bpmnProcessId": {
+                  "type": "keyword"
+                },
+                "processDefinitionKey": {
+                  "type": "long"
+                },
+                "tenantId": {
+                  "type": "keyword"
+                },
+                "jobKey": {
+                  "type": "long"
+                },
+                "jobLease": {
+                  "type": "keyword"
+                },
+                "loopIteration": {
+                  "type": "integer"
+                },
+                "role": {
+                  "type": "keyword"
+                },
+                "producedAt": {
+                  "type": "long"
+                },
+                "content": {
+                  "enabled": false
+                },
+                "toolCalls": {
+                  "enabled": false
+                },
+                "metrics": {
+                  "properties": {
+                    "inputTokens": {
+                      "type": "long"
+                    },
+                    "outputTokens": {
+                      "type": "long"
+                    },
+                    "durationMs": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-history-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-history-template.json
@@ -67,6 +67,9 @@
             "content": {
               "enabled": false
             },
+            "systemPrompt": {
+              "enabled": false
+            },
             "toolCalls": {
               "enabled": false
             },
@@ -82,6 +85,41 @@
                   "type": "long"
                 }
               }
+            },
+            "tools": {
+              "properties": {
+                "name": {
+                  "type": "keyword"
+                },
+                "description": {
+                  "type": "text"
+                },
+                "elementId": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "model": {
+              "type": "keyword"
+            },
+            "provider": {
+              "type": "keyword"
+            },
+            "limits": {
+              "properties": {
+                "maxTokens": {
+                  "type": "long"
+                },
+                "maxModelCalls": {
+                  "type": "integer"
+                },
+                "maxToolCalls": {
+                  "type": "integer"
+                }
+              }
+            },
+            "changedAttributes": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-history-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-history-template.json
@@ -86,6 +86,9 @@
                 }
               }
             },
+            "historyItemId": {
+              "type": "keyword"
+            },
             "tools": {
               "properties": {
                 "name": {
@@ -120,6 +123,9 @@
             },
             "changedAttributes": {
               "type": "keyword"
+            },
+            "duplicate": {
+              "type": "boolean"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-history-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-history-template.json
@@ -81,6 +81,15 @@
                 "outputTokens": {
                   "type": "long"
                 },
+                "reasoningTokenCount": {
+                  "type": "long"
+                },
+                "cacheCreationTokenCount": {
+                  "type": "long"
+                },
+                "cacheReadTokenCount": {
+                  "type": "long"
+                },
                 "durationMs": {
                   "type": "long"
                 }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-template.json
@@ -191,6 +191,9 @@
                     }
                   }
                 },
+                "historyItemId": {
+                  "type": "keyword"
+                },
                 "tools": {
                   "properties": {
                     "name": {
@@ -225,6 +228,9 @@
                 },
                 "changedAttributes": {
                   "type": "keyword"
+                },
+                "duplicate": {
+                  "type": "boolean"
                 }
               }
             }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-template.json
@@ -95,6 +95,15 @@
                 "outputTokens": {
                   "type": "long"
                 },
+                "reasoningTokenCount": {
+                  "type": "long"
+                },
+                "cacheCreationTokenCount": {
+                  "type": "long"
+                },
+                "cacheReadTokenCount": {
+                  "type": "long"
+                },
                 "modelCalls": {
                   "type": "integer"
                 },
@@ -184,6 +193,15 @@
                       "type": "long"
                     },
                     "outputTokens": {
+                      "type": "long"
+                    },
+                    "reasoningTokenCount": {
+                      "type": "long"
+                    },
+                    "cacheCreationTokenCount": {
+                      "type": "long"
+                    },
+                    "cacheReadTokenCount": {
                       "type": "long"
                     },
                     "durationMs": {

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-template.json
@@ -127,6 +127,68 @@
             },
             "loopIteration": {
               "type": "integer"
+            },
+            "history": {
+              "properties": {
+                "agentHistoryKey": {
+                  "type": "long"
+                },
+                "agentInstanceKey": {
+                  "type": "long"
+                },
+                "elementInstanceKey": {
+                  "type": "long"
+                },
+                "processInstanceKey": {
+                  "type": "long"
+                },
+                "rootProcessInstanceKey": {
+                  "type": "long"
+                },
+                "bpmnProcessId": {
+                  "type": "keyword"
+                },
+                "processDefinitionKey": {
+                  "type": "long"
+                },
+                "tenantId": {
+                  "type": "keyword"
+                },
+                "jobKey": {
+                  "type": "long"
+                },
+                "jobLease": {
+                  "type": "keyword"
+                },
+                "loopIteration": {
+                  "type": "integer"
+                },
+                "role": {
+                  "type": "keyword"
+                },
+                "producedAt": {
+                  "type": "long"
+                },
+                "content": {
+                  "enabled": false
+                },
+                "toolCalls": {
+                  "enabled": false
+                },
+                "metrics": {
+                  "properties": {
+                    "inputTokens": {
+                      "type": "long"
+                    },
+                    "outputTokens": {
+                      "type": "long"
+                    },
+                    "durationMs": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-template.json
@@ -118,6 +118,15 @@
             },
             "changedAttributes": {
               "type": "keyword"
+            },
+            "jobKey": {
+              "type": "long"
+            },
+            "jobLease": {
+              "type": "keyword"
+            },
+            "loopIteration": {
+              "type": "integer"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-template.json
@@ -172,6 +172,9 @@
                 "content": {
                   "enabled": false
                 },
+                "systemPrompt": {
+                  "enabled": false
+                },
                 "toolCalls": {
                   "enabled": false
                 },
@@ -187,6 +190,41 @@
                       "type": "long"
                     }
                   }
+                },
+                "tools": {
+                  "properties": {
+                    "name": {
+                      "type": "keyword"
+                    },
+                    "description": {
+                      "type": "text"
+                    },
+                    "elementId": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "model": {
+                  "type": "keyword"
+                },
+                "provider": {
+                  "type": "keyword"
+                },
+                "limits": {
+                  "properties": {
+                    "maxTokens": {
+                      "type": "long"
+                    },
+                    "maxModelCalls": {
+                      "type": "integer"
+                    },
+                    "maxToolCalls": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "changedAttributes": {
+                  "type": "keyword"
                 }
               }
             }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryMetrics.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryMetrics.java
@@ -17,12 +17,19 @@ public final class AgentHistoryMetrics extends ObjectValue implements AgentHisto
 
   private final LongProperty inputTokensProp = new LongProperty("inputTokens", -1L);
   private final LongProperty outputTokensProp = new LongProperty("outputTokens", -1L);
+  private final LongProperty reasoningTokenCountProp = new LongProperty("reasoningTokenCount", -1L);
+  private final LongProperty cacheCreationTokenCountProp =
+      new LongProperty("cacheCreationTokenCount", -1L);
+  private final LongProperty cacheReadTokenCountProp = new LongProperty("cacheReadTokenCount", -1L);
   private final LongProperty durationMsProp = new LongProperty("durationMs", -1L);
 
   public AgentHistoryMetrics() {
-    super(3);
+    super(6);
     declareProperty(inputTokensProp)
         .declareProperty(outputTokensProp)
+        .declareProperty(reasoningTokenCountProp)
+        .declareProperty(cacheCreationTokenCountProp)
+        .declareProperty(cacheReadTokenCountProp)
         .declareProperty(durationMsProp);
   }
 
@@ -43,6 +50,36 @@ public final class AgentHistoryMetrics extends ObjectValue implements AgentHisto
 
   public AgentHistoryMetrics setOutputTokens(final long outputTokens) {
     outputTokensProp.setValue(outputTokens);
+    return this;
+  }
+
+  @Override
+  public long getReasoningTokenCount() {
+    return reasoningTokenCountProp.getValue();
+  }
+
+  public AgentHistoryMetrics setReasoningTokenCount(final long reasoningTokenCount) {
+    reasoningTokenCountProp.setValue(reasoningTokenCount);
+    return this;
+  }
+
+  @Override
+  public long getCacheCreationTokenCount() {
+    return cacheCreationTokenCountProp.getValue();
+  }
+
+  public AgentHistoryMetrics setCacheCreationTokenCount(final long cacheCreationTokenCount) {
+    cacheCreationTokenCountProp.setValue(cacheCreationTokenCount);
+    return this;
+  }
+
+  @Override
+  public long getCacheReadTokenCount() {
+    return cacheReadTokenCountProp.getValue();
+  }
+
+  public AgentHistoryMetrics setCacheReadTokenCount(final long cacheReadTokenCount) {
+    cacheReadTokenCountProp.setValue(cacheReadTokenCount);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
@@ -13,10 +13,14 @@ import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceLimits;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceTool;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue.AgentInstanceToolValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
@@ -43,13 +47,23 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   private final LongProperty producedAtProp = new LongProperty("producedAt", -1L);
   private final ArrayProperty<AgentHistoryMessageContent> contentProp =
       new ArrayProperty<>("content", AgentHistoryMessageContent::new);
+  private final ArrayProperty<AgentHistoryMessageContent> systemPromptProp =
+      new ArrayProperty<>("systemPrompt", AgentHistoryMessageContent::new);
   private final ArrayProperty<AgentHistoryEmbeddedToolCall> toolCallsProp =
       new ArrayProperty<>("toolCalls", AgentHistoryEmbeddedToolCall::new);
   private final ObjectProperty<AgentHistoryMetrics> metricsProp =
       new ObjectProperty<>("metrics", new AgentHistoryMetrics());
+  private final ArrayProperty<AgentInstanceTool> toolsProp =
+      new ArrayProperty<>("tools", AgentInstanceTool::new);
+  private final StringProperty modelProp = new StringProperty("model", "");
+  private final StringProperty providerProp = new StringProperty("provider", "");
+  private final ObjectProperty<AgentInstanceLimits> limitsProp =
+      new ObjectProperty<>("limits", new AgentInstanceLimits());
+  private final ArrayProperty<StringValue> changedAttributesProp =
+      new ArrayProperty<>("changedAttributes", StringValue::new);
 
   public AgentHistoryRecord() {
-    super(16);
+    super(22);
     declareProperty(agentHistoryKeyProp)
         .declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -64,8 +78,14 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
         .declareProperty(roleProp)
         .declareProperty(producedAtProp)
         .declareProperty(contentProp)
+        .declareProperty(systemPromptProp)
         .declareProperty(toolCallsProp)
-        .declareProperty(metricsProp);
+        .declareProperty(metricsProp)
+        .declareProperty(toolsProp)
+        .declareProperty(modelProp)
+        .declareProperty(providerProp)
+        .declareProperty(limitsProp)
+        .declareProperty(changedAttributesProp);
   }
 
   @Override
@@ -225,6 +245,34 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   }
 
   @Override
+  public List<AgentHistoryMessageContentValue> getSystemPrompt() {
+    return systemPromptProp.stream()
+        .map(
+            element -> {
+              final var copy = new AgentHistoryMessageContent();
+              copy.copy(element);
+              return (AgentHistoryMessageContentValue) copy;
+            })
+        .toList();
+  }
+
+  public AgentHistoryRecord setSystemPrompt(
+      final List<? extends AgentHistoryMessageContentValue> systemPrompt) {
+    systemPromptProp.reset();
+    if (systemPrompt != null) {
+      for (final var item : systemPrompt) {
+        systemPromptProp.add().copy(item);
+      }
+    }
+    return this;
+  }
+
+  public AgentHistoryRecord addSystemPrompt(final AgentHistoryMessageContent block) {
+    systemPromptProp.add().copy(block);
+    return this;
+  }
+
+  @Override
   public List<AgentHistoryEmbeddedToolCallValue> getToolCalls() {
     return toolCallsProp.stream()
         .map(
@@ -257,5 +305,74 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
 
   public AgentHistoryRecord ignoreLease() {
     return setJobLease(JobRecord.EMPTY_LEASE);
+  }
+
+  @Override
+  public List<AgentInstanceToolValue> getTools() {
+    return toolsProp.stream()
+        .map(
+            element -> {
+              final var copy = new AgentInstanceTool();
+              copy.copy(element);
+              return (AgentInstanceToolValue) copy;
+            })
+        .toList();
+  }
+
+  public AgentHistoryRecord setTools(final List<? extends AgentInstanceToolValue> tools) {
+    toolsProp.reset();
+    if (tools != null) {
+      for (final var tool : tools) {
+        toolsProp.add().copy(tool);
+      }
+    }
+    return this;
+  }
+
+  @Override
+  public String getModel() {
+    return BufferUtil.bufferAsString(modelProp.getValue());
+  }
+
+  public AgentHistoryRecord setModel(final String model) {
+    modelProp.setValue(model);
+    return this;
+  }
+
+  @Override
+  public String getProvider() {
+    return BufferUtil.bufferAsString(providerProp.getValue());
+  }
+
+  public AgentHistoryRecord setProvider(final String provider) {
+    providerProp.setValue(provider);
+    return this;
+  }
+
+  @Override
+  public AgentInstanceLimits getLimits() {
+    return limitsProp.getValue();
+  }
+
+  @Override
+  public List<String> getChangedAttributes() {
+    return changedAttributesProp.stream()
+        .map(StringValue::getValue)
+        .map(BufferUtil::bufferAsString)
+        .toList();
+  }
+
+  public AgentHistoryRecord setChangedAttributes(final List<String> changedAttributes) {
+    changedAttributesProp.reset();
+    if (changedAttributes != null) {
+      changedAttributes.forEach(
+          attr -> changedAttributesProp.add().wrap(BufferUtil.wrapString(attr)));
+    }
+    return this;
+  }
+
+  public AgentHistoryRecord addChangedAttribute(final String attribute) {
+    changedAttributesProp.add().wrap(BufferUtil.wrapString(attribute));
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.record.value.agenthistory;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
@@ -53,6 +54,7 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
       new ArrayProperty<>("toolCalls", AgentHistoryEmbeddedToolCall::new);
   private final ObjectProperty<AgentHistoryMetrics> metricsProp =
       new ObjectProperty<>("metrics", new AgentHistoryMetrics());
+  private final StringProperty historyItemIdProp = new StringProperty("historyItemId", "");
   private final ArrayProperty<AgentInstanceTool> toolsProp =
       new ArrayProperty<>("tools", AgentInstanceTool::new);
   private final StringProperty modelProp = new StringProperty("model", "");
@@ -61,9 +63,10 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
       new ObjectProperty<>("limits", new AgentInstanceLimits());
   private final ArrayProperty<StringValue> changedAttributesProp =
       new ArrayProperty<>("changedAttributes", StringValue::new);
+  private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
 
   public AgentHistoryRecord() {
-    super(22);
+    super(24);
     declareProperty(agentHistoryKeyProp)
         .declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -81,11 +84,13 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
         .declareProperty(systemPromptProp)
         .declareProperty(toolCallsProp)
         .declareProperty(metricsProp)
+        .declareProperty(historyItemIdProp)
         .declareProperty(toolsProp)
         .declareProperty(modelProp)
         .declareProperty(providerProp)
         .declareProperty(limitsProp)
-        .declareProperty(changedAttributesProp);
+        .declareProperty(changedAttributesProp)
+        .declareProperty(isDuplicateProp);
   }
 
   @Override
@@ -308,6 +313,16 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   }
 
   @Override
+  public String getHistoryItemId() {
+    return BufferUtil.bufferAsString(historyItemIdProp.getValue());
+  }
+
+  public AgentHistoryRecord setHistoryItemId(final String historyItemId) {
+    historyItemIdProp.setValue(historyItemId);
+    return this;
+  }
+
+  @Override
   public List<AgentInstanceToolValue> getTools() {
     return toolsProp.stream()
         .map(
@@ -373,6 +388,16 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
 
   public AgentHistoryRecord addChangedAttribute(final String attribute) {
     changedAttributesProp.add().wrap(BufferUtil.wrapString(attribute));
+    return this;
+  }
+
+  @Override
+  public boolean isDuplicate() {
+    return isDuplicateProp.getValue();
+  }
+
+  public AgentHistoryRecord setDuplicate(final boolean duplicate) {
+    isDuplicateProp.setValue(duplicate);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceMetrics.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceMetrics.java
@@ -19,13 +19,20 @@ public final class AgentInstanceMetrics extends ObjectValue
 
   private final LongProperty inputTokensProp = new LongProperty("inputTokens", 0L);
   private final LongProperty outputTokensProp = new LongProperty("outputTokens", 0L);
+  private final LongProperty reasoningTokenCountProp = new LongProperty("reasoningTokenCount", 0L);
+  private final LongProperty cacheCreationTokenCountProp =
+      new LongProperty("cacheCreationTokenCount", 0L);
+  private final LongProperty cacheReadTokenCountProp = new LongProperty("cacheReadTokenCount", 0L);
   private final IntegerProperty modelCallsProp = new IntegerProperty("modelCalls", 0);
   private final IntegerProperty toolCallsProp = new IntegerProperty("toolCalls", 0);
 
   public AgentInstanceMetrics() {
-    super(4);
+    super(7);
     declareProperty(inputTokensProp)
         .declareProperty(outputTokensProp)
+        .declareProperty(reasoningTokenCountProp)
+        .declareProperty(cacheCreationTokenCountProp)
+        .declareProperty(cacheReadTokenCountProp)
         .declareProperty(modelCallsProp)
         .declareProperty(toolCallsProp);
   }
@@ -47,6 +54,36 @@ public final class AgentInstanceMetrics extends ObjectValue
 
   public AgentInstanceMetrics setOutputTokens(final long outputTokens) {
     outputTokensProp.setValue(outputTokens);
+    return this;
+  }
+
+  @Override
+  public long getReasoningTokenCount() {
+    return reasoningTokenCountProp.getValue();
+  }
+
+  public AgentInstanceMetrics setReasoningTokenCount(final long reasoningTokenCount) {
+    reasoningTokenCountProp.setValue(reasoningTokenCount);
+    return this;
+  }
+
+  @Override
+  public long getCacheCreationTokenCount() {
+    return cacheCreationTokenCountProp.getValue();
+  }
+
+  public AgentInstanceMetrics setCacheCreationTokenCount(final long cacheCreationTokenCount) {
+    cacheCreationTokenCountProp.setValue(cacheCreationTokenCount);
+    return this;
+  }
+
+  @Override
+  public long getCacheReadTokenCount() {
+    return cacheReadTokenCountProp.getValue();
+  }
+
+  public AgentInstanceMetrics setCacheReadTokenCount(final long cacheReadTokenCount) {
+    cacheReadTokenCountProp.setValue(cacheReadTokenCount);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
@@ -16,11 +16,14 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public final class AgentInstanceRecord extends UnifiedRecordValue
     implements AgentInstanceRecordValue {
@@ -60,9 +63,11 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   private final LongProperty jobKeyProp = new LongProperty("jobKey", -1L);
   private final StringProperty jobLeaseProp = new StringProperty("jobLease", "");
   private final IntegerProperty loopIterationProp = new IntegerProperty("loopIteration", 0);
+  private final ArrayProperty<AgentHistoryRecord> historyProp =
+      new ArrayProperty<>("history", AgentHistoryRecord::new);
 
   public AgentInstanceRecord() {
-    super(20);
+    super(21);
     declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(elementInstanceKeysProp)
@@ -82,7 +87,8 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
         .declareProperty(changedAttributesProp)
         .declareProperty(jobKeyProp)
         .declareProperty(jobLeaseProp)
-        .declareProperty(loopIterationProp);
+        .declareProperty(loopIterationProp)
+        .declareProperty(historyProp);
   }
 
   @Override
@@ -297,6 +303,26 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord setLoopIteration(final int loopIteration) {
     loopIterationProp.setValue(loopIteration);
+    return this;
+  }
+
+  @Override
+  public List<AgentHistoryRecordValue> getHistory() {
+    return historyProp.stream().collect(Collectors.toList());
+  }
+
+  public AgentInstanceRecord setHistory(final List<? extends AgentHistoryRecord> history) {
+    historyProp.reset();
+    if (history != null) {
+      for (final var item : history) {
+        historyProp.add().copyFrom(item);
+      }
+    }
+    return this;
+  }
+
+  public AgentInstanceRecord addHistoryItem(final AgentHistoryRecord historyItem) {
+    historyProp.add().copyFrom(historyItem);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
@@ -57,9 +57,12 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
       new ArrayProperty<>("tools", AgentInstanceTool::new);
   private final ArrayProperty<StringValue> changedAttributesProp =
       new ArrayProperty<>("changedAttributes", StringValue::new);
+  private final LongProperty jobKeyProp = new LongProperty("jobKey", -1L);
+  private final StringProperty jobLeaseProp = new StringProperty("jobLease", "");
+  private final IntegerProperty loopIterationProp = new IntegerProperty("loopIteration", 0);
 
   public AgentInstanceRecord() {
-    super(17);
+    super(20);
     declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(elementInstanceKeysProp)
@@ -76,7 +79,10 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
         .declareProperty(limitsProp)
         .declareProperty(metricsProp)
         .declareProperty(toolsProp)
-        .declareProperty(changedAttributesProp);
+        .declareProperty(changedAttributesProp)
+        .declareProperty(jobKeyProp)
+        .declareProperty(jobLeaseProp)
+        .declareProperty(loopIterationProp);
   }
 
   @Override
@@ -261,6 +267,36 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord addChangedAttribute(final String attribute) {
     changedAttributesProp.add().wrap(BufferUtil.wrapString(attribute));
+    return this;
+  }
+
+  @Override
+  public long getJobKey() {
+    return jobKeyProp.getValue();
+  }
+
+  public AgentInstanceRecord setJobKey(final long jobKey) {
+    jobKeyProp.setValue(jobKey);
+    return this;
+  }
+
+  @Override
+  public String getJobLease() {
+    return BufferUtil.bufferAsString(jobLeaseProp.getValue());
+  }
+
+  public AgentInstanceRecord setJobLease(final String jobLease) {
+    jobLeaseProp.setValue(jobLease);
+    return this;
+  }
+
+  @Override
+  public int getLoopIteration() {
+    return loopIterationProp.getValue();
+  }
+
+  public AgentInstanceRecord setLoopIteration(final int loopIteration) {
+    loopIterationProp.setValue(loopIteration);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
@@ -32,6 +32,15 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   public static final String ATTR_METRICS = "metrics";
   public static final String ATTR_TOOLS = "tools";
 
+  // Derived from a future configuration-change history entry kind on the output side (see #58794
+  // for that entry kind and #58791 for the engine processing that merges them in), never from a
+  // request-level changedAttributes entry — these are not part of ALLOWED_ATTRIBUTES in
+  // AgentInstanceUpdateProcessor, only of the output-side merge order.
+  public static final String ATTR_SYSTEM_PROMPT = "systemPrompt";
+  public static final String ATTR_MODEL = "model";
+  public static final String ATTR_PROVIDER = "provider";
+  public static final String ATTR_LIMITS = "limits";
+
   private final LongProperty agentInstanceKeyProp = new LongProperty("agentInstanceKey", -1L);
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
   private final ArrayProperty<LongValue> elementInstanceKeysProp =

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -5217,6 +5217,10 @@ final class JsonSerializableToJsonTest {
                   new AgentHistoryMessageContent()
                       .setContentType(AgentHistoryContentType.OBJECT)
                       .setObject(wrapArray(MsgPackConverter.convertToMsgPack(Map.of("page", 1)))));
+              record.addSystemPrompt(
+                  new AgentHistoryMessageContent()
+                      .setContentType(AgentHistoryContentType.TEXT)
+                      .setText("You are an invoice extraction assistant."));
               record.addToolCall(
                   new AgentHistoryEmbeddedToolCall()
                       .setToolCallId("call_abc123")
@@ -5264,6 +5268,14 @@ final class JsonSerializableToJsonTest {
               "object": { "page": 1 }
             }
           ],
+          "systemPrompt": [
+            {
+              "contentType": "TEXT",
+              "text": "You are an invoice extraction assistant.",
+              "documentReference": { "documentId": "", "storeId": "", "contentHash": "", "metadata": { "contentType": "", "fileName": "", "expiresAt": -1, "size": -1, "processDefinitionId": "", "processInstanceKey": -1, "customProperties": {} } },
+              "object": null
+            }
+          ],
           "toolCalls": [
             {
               "toolCallId": "call_abc123",
@@ -5277,7 +5289,12 @@ final class JsonSerializableToJsonTest {
           "processInstanceKey": -1,
           "rootProcessInstanceKey": -1,
           "bpmnProcessId": "process",
-          "processDefinitionKey": -1
+          "processDefinitionKey": -1,
+          "tools": [],
+          "model": "",
+          "provider": "",
+          "limits": { "maxTokens": -1, "maxModelCalls": -1, "maxToolCalls": -1 },
+          "changedAttributes": []
         }
         """
       },
@@ -5354,13 +5371,19 @@ final class JsonSerializableToJsonTest {
               "object": "hello"
             }
           ],
+          "systemPrompt": [],
           "toolCalls": [],
           "metrics": { "inputTokens": -1, "outputTokens": -1, "durationMs": -1 },
           "tenantId": "<default>",
           "processInstanceKey": -1,
           "rootProcessInstanceKey": -1,
           "bpmnProcessId": "",
-          "processDefinitionKey": -1
+          "processDefinitionKey": -1,
+          "tools": [],
+          "model": "",
+          "provider": "",
+          "limits": { "maxTokens": -1, "maxModelCalls": -1, "maxToolCalls": -1 },
+          "changedAttributes": []
         }
         """
       },
@@ -5378,13 +5401,19 @@ final class JsonSerializableToJsonTest {
           "role": "UNSPECIFIED",
           "producedAt": -1,
           "content": [],
+          "systemPrompt": [],
           "toolCalls": [],
           "metrics": { "inputTokens": -1, "outputTokens": -1, "durationMs": -1 },
           "tenantId": "<default>",
           "processInstanceKey": -1,
           "rootProcessInstanceKey": -1,
           "bpmnProcessId": "",
-          "processDefinitionKey": -1
+          "processDefinitionKey": -1,
+          "tools": [],
+          "model": "",
+          "provider": "",
+          "limits": { "maxTokens": -1, "maxModelCalls": -1, "maxToolCalls": -1 },
+          "changedAttributes": []
         }
         """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -5165,6 +5165,102 @@ final class JsonSerializableToJsonTest {
         }
         """
       },
+      {
+        "AgentInstanceRecord with embedded history batch",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final var item =
+                  new AgentHistoryRecord()
+                      .setHistoryItemId("item-config-1")
+                      .setRole(AgentHistoryRole.ASSISTANT)
+                      .setModel("gpt-4o")
+                      .setProvider("openai")
+                      .setProducedAt(1717199999000L)
+                      .setDuplicate(true);
+              item.addSystemPrompt(
+                  new AgentHistoryMessageContent()
+                      .setContentType(AgentHistoryContentType.TEXT)
+                      .setText("You are an invoice extraction assistant."));
+              item.setTools(List.of(new AgentInstanceTool().setName("extract_line_items")));
+              item.getLimits().setMaxTokens(8000L).setMaxModelCalls(10).setMaxToolCalls(20);
+              item.getMetrics()
+                  .setInputTokens(512L)
+                  .setOutputTokens(148L)
+                  .setReasoningTokenCount(64L)
+                  .setCacheCreationTokenCount(32L)
+                  .setCacheReadTokenCount(16L)
+                  .setDurationMs(1200L);
+
+              final AgentInstanceRecord record =
+                  new AgentInstanceRecord()
+                      .setJobKey(2251799813685252L)
+                      .setJobLease("job-lease-abc123")
+                      .setLoopIteration(3)
+                      .setHistory(List.of(item));
+              return record;
+            },
+        """
+        {
+          "agentInstanceKey": -1,
+          "elementInstanceKey": -1,
+          "elementInstanceKeys": [],
+          "elementId": "",
+          "processInstanceKey": -1,
+          "rootProcessInstanceKey": -1,
+          "bpmnProcessId": "",
+          "processDefinitionKey": -1,
+          "processDefinitionVersion": -1,
+          "versionTag": "",
+          "tenantId": "<default>",
+          "status": "UNSPECIFIED",
+          "definition": { "model": "", "provider": "", "systemPrompt": "" },
+          "limits": { "maxTokens": -1, "maxModelCalls": -1, "maxToolCalls": -1 },
+          "metrics": { "inputTokens": 0, "outputTokens": 0, "reasoningTokenCount": 0, "cacheCreationTokenCount": 0, "cacheReadTokenCount": 0, "modelCalls": 0, "toolCalls": 0 },
+          "tools": [],
+          "changedAttributes": [],
+          "jobKey": 2251799813685252,
+          "jobLease": "job-lease-abc123",
+          "loopIteration": 3,
+          "history": [
+            {
+              "agentHistoryKey": -1,
+              "agentInstanceKey": -1,
+              "elementInstanceKey": -1,
+              "jobKey": -1,
+              "jobLease": "",
+              "loopIteration": 0,
+              "role": "ASSISTANT",
+              "producedAt": 1717199999000,
+              "content": [],
+              "systemPrompt": [
+                {
+                  "contentType": "TEXT",
+                  "text": "You are an invoice extraction assistant.",
+                  "documentReference": { "documentId": "", "storeId": "", "contentHash": "", "metadata": { "contentType": "", "fileName": "", "expiresAt": -1, "size": -1, "processDefinitionId": "", "processInstanceKey": -1, "customProperties": {} } },
+                  "object": null
+                }
+              ],
+              "toolCalls": [],
+              "metrics": { "inputTokens": 512, "outputTokens": 148, "reasoningTokenCount": 64, "cacheCreationTokenCount": 32, "cacheReadTokenCount": 16, "durationMs": 1200 },
+              "tenantId": "<default>",
+              "processInstanceKey": -1,
+              "rootProcessInstanceKey": -1,
+              "bpmnProcessId": "",
+              "processDefinitionKey": -1,
+              "historyItemId": "item-config-1",
+              "tools": [
+                { "name": "extract_line_items", "description": "", "elementId": "" }
+              ],
+              "model": "gpt-4o",
+              "provider": "openai",
+              "limits": { "maxTokens": 8000, "maxModelCalls": 10, "maxToolCalls": 20 },
+              "changedAttributes": [],
+              "duplicate": true
+            }
+          ]
+        }
+        """
+      },
       /////////////////////////////////////////////////////////////////////////////////////////////
       ////////////////////////////////// AgentHistoryRecord ///////////////////////////////////////
       /////////////////////////////////////////////////////////////////////////////////////////////

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -5131,7 +5131,8 @@ final class JsonSerializableToJsonTest {
           "changedAttributes": ["status", "metrics"],
           "jobKey": -1,
           "jobLease": "",
-          "loopIteration": 0
+          "loopIteration": 0,
+          "history": []
         }
         """
       },
@@ -5159,7 +5160,8 @@ final class JsonSerializableToJsonTest {
           "changedAttributes": [],
           "jobKey": -1,
           "jobLease": "",
-          "loopIteration": 0
+          "loopIteration": 0,
+          "history": []
         }
         """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -5123,7 +5123,7 @@ final class JsonSerializableToJsonTest {
             "systemPrompt": "Extract vendor, amount, date, and line items from the invoice."
           },
           "limits": { "maxTokens": 8000, "maxModelCalls": 10, "maxToolCalls": 20 },
-          "metrics": { "inputTokens": 512, "outputTokens": 148, "modelCalls": 1, "toolCalls": 1 },
+          "metrics": { "inputTokens": 512, "outputTokens": 148, "reasoningTokenCount": 0, "cacheCreationTokenCount": 0, "cacheReadTokenCount": 0, "modelCalls": 1, "toolCalls": 1 },
           "tools": [
             { "name": "extract_line_items", "description": "", "elementId": "extract-line-items-task" },
             { "name": "MCP_ocr___scan_document", "description": "", "elementId": "MCP_ocr" }
@@ -5155,7 +5155,7 @@ final class JsonSerializableToJsonTest {
           "status": "UNSPECIFIED",
           "definition": { "model": "", "provider": "", "systemPrompt": "" },
           "limits": { "maxTokens": -1, "maxModelCalls": -1, "maxToolCalls": -1 },
-          "metrics": { "inputTokens": 0, "outputTokens": 0, "modelCalls": 0, "toolCalls": 0 },
+          "metrics": { "inputTokens": 0, "outputTokens": 0, "reasoningTokenCount": 0, "cacheCreationTokenCount": 0, "cacheReadTokenCount": 0, "modelCalls": 0, "toolCalls": 0 },
           "tools": [],
           "changedAttributes": [],
           "jobKey": -1,
@@ -5284,7 +5284,7 @@ final class JsonSerializableToJsonTest {
               "arguments": { "documentId": "inv-001" }
             }
           ],
-          "metrics": { "inputTokens": 512, "outputTokens": 148, "durationMs": 1200 },
+          "metrics": { "inputTokens": 512, "outputTokens": 148, "reasoningTokenCount": -1, "cacheCreationTokenCount": -1, "cacheReadTokenCount": -1, "durationMs": 1200 },
           "tenantId": "<default>",
           "processInstanceKey": -1,
           "rootProcessInstanceKey": -1,
@@ -5375,7 +5375,7 @@ final class JsonSerializableToJsonTest {
           ],
           "systemPrompt": [],
           "toolCalls": [],
-          "metrics": { "inputTokens": -1, "outputTokens": -1, "durationMs": -1 },
+          "metrics": { "inputTokens": -1, "outputTokens": -1, "reasoningTokenCount": -1, "cacheCreationTokenCount": -1, "cacheReadTokenCount": -1, "durationMs": -1 },
           "tenantId": "<default>",
           "processInstanceKey": -1,
           "rootProcessInstanceKey": -1,
@@ -5407,7 +5407,7 @@ final class JsonSerializableToJsonTest {
           "content": [],
           "systemPrompt": [],
           "toolCalls": [],
-          "metrics": { "inputTokens": -1, "outputTokens": -1, "durationMs": -1 },
+          "metrics": { "inputTokens": -1, "outputTokens": -1, "reasoningTokenCount": -1, "cacheCreationTokenCount": -1, "cacheReadTokenCount": -1, "durationMs": -1 },
           "tenantId": "<default>",
           "processInstanceKey": -1,
           "rootProcessInstanceKey": -1,

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -5128,7 +5128,10 @@ final class JsonSerializableToJsonTest {
             { "name": "extract_line_items", "description": "", "elementId": "extract-line-items-task" },
             { "name": "MCP_ocr___scan_document", "description": "", "elementId": "MCP_ocr" }
           ],
-          "changedAttributes": ["status", "metrics"]
+          "changedAttributes": ["status", "metrics"],
+          "jobKey": -1,
+          "jobLease": "",
+          "loopIteration": 0
         }
         """
       },
@@ -5153,7 +5156,10 @@ final class JsonSerializableToJsonTest {
           "limits": { "maxTokens": -1, "maxModelCalls": -1, "maxToolCalls": -1 },
           "metrics": { "inputTokens": 0, "outputTokens": 0, "modelCalls": 0, "toolCalls": 0 },
           "tools": [],
-          "changedAttributes": []
+          "changedAttributes": [],
+          "jobKey": -1,
+          "jobLease": "",
+          "loopIteration": 0
         }
         """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -5290,11 +5290,13 @@ final class JsonSerializableToJsonTest {
           "rootProcessInstanceKey": -1,
           "bpmnProcessId": "process",
           "processDefinitionKey": -1,
+          "historyItemId": "",
           "tools": [],
           "model": "",
           "provider": "",
           "limits": { "maxTokens": -1, "maxModelCalls": -1, "maxToolCalls": -1 },
-          "changedAttributes": []
+          "changedAttributes": [],
+          "duplicate": false
         }
         """
       },
@@ -5379,11 +5381,13 @@ final class JsonSerializableToJsonTest {
           "rootProcessInstanceKey": -1,
           "bpmnProcessId": "",
           "processDefinitionKey": -1,
+          "historyItemId": "",
           "tools": [],
           "model": "",
           "provider": "",
           "limits": { "maxTokens": -1, "maxModelCalls": -1, "maxToolCalls": -1 },
-          "changedAttributes": []
+          "changedAttributes": [],
+          "duplicate": false
         }
         """
       },
@@ -5409,11 +5413,13 @@ final class JsonSerializableToJsonTest {
           "rootProcessInstanceKey": -1,
           "bpmnProcessId": "",
           "processDefinitionKey": -1,
+          "historyItemId": "",
           "tools": [],
           "model": "",
           "provider": "",
           "limits": { "maxTokens": -1, "maxModelCalls": -1, "maxToolCalls": -1 },
-          "changedAttributes": []
+          "changedAttributes": [],
+          "duplicate": false
         }
         """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
@@ -402,4 +402,49 @@ final class AgentHistoryRecordTest {
     // then
     assertThat(record.getChangedAttributes()).containsExactly("model", "provider");
   }
+
+  @Test
+  void shouldDefaultHistoryItemIdToEmpty() {
+    // given
+    final AgentHistoryRecord record = new AgentHistoryRecord();
+
+    // then
+    assertThat(record.getHistoryItemId()).isEmpty();
+  }
+
+  @Test
+  void shouldRoundTripHistoryItemIdViaMsgPack() {
+    // given
+    final AgentHistoryRecord original = new AgentHistoryRecord().setHistoryItemId("item-1");
+
+    // when
+    final AgentHistoryRecord copy = new AgentHistoryRecord();
+    copy.copyFrom(original);
+
+    // then
+    assertThat(copy.getHistoryItemId()).isEqualTo("item-1");
+  }
+
+  @Test
+  void shouldDefaultIsDuplicateToFalse() {
+    // given
+    final AgentHistoryRecord record = new AgentHistoryRecord();
+
+    // then
+    assertThat(record.isDuplicate()).isFalse();
+  }
+
+  @Test
+  void shouldRoundTripIsDuplicateViaMsgPack() {
+    // given
+    final AgentHistoryRecord original =
+        new AgentHistoryRecord().setHistoryItemId("item-1").setDuplicate(true);
+
+    // when
+    final AgentHistoryRecord copy = new AgentHistoryRecord();
+    copy.copyFrom(original);
+
+    // then
+    assertThat(copy.isDuplicate()).isTrue();
+  }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
@@ -8,10 +8,13 @@
 package io.camunda.zeebe.protocol.impl.record.value.agenthistory;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceTool;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue.AgentInstanceToolValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
@@ -282,5 +285,121 @@ final class AgentHistoryRecordTest {
     assertThat(copy.getProcessInstanceKey()).isEqualTo(2251799813685260L);
     assertThat(copy.getRootProcessInstanceKey()).isEqualTo(2251799813685262L);
     assertThat(copy.getProcessDefinitionKey()).isEqualTo(2251799813685261L);
+  }
+
+  @Test
+  void shouldDefaultReservedConfigChangeFieldsToUnset() {
+    // given
+    final AgentHistoryRecord record = new AgentHistoryRecord();
+
+    // then
+    assertThat(record.getTools()).isEmpty();
+    assertThat(record.getModel()).isEmpty();
+    assertThat(record.getProvider()).isEmpty();
+    assertThat(record.getLimits().getMaxTokens()).isEqualTo(-1L);
+    assertThat(record.getLimits().getMaxModelCalls()).isEqualTo(-1);
+    assertThat(record.getLimits().getMaxToolCalls()).isEqualTo(-1);
+    assertThat(record.getChangedAttributes()).isEmpty();
+    assertThat(record.getSystemPrompt()).isEmpty();
+  }
+
+  @Test
+  void shouldRoundTripReservedConfigChangeFieldsViaMsgPack() {
+    // given
+    final AgentInstanceTool tool =
+        new AgentInstanceTool().setName("extract_line_items").setElementId("extract-task");
+    final AgentHistoryRecord original =
+        new AgentHistoryRecord()
+            .setTools(List.of(tool))
+            .setModel("gpt-4o")
+            .setProvider("openai")
+            .setChangedAttributes(List.of("model", "tools"));
+    original.getLimits().setMaxTokens(8000L).setMaxModelCalls(10).setMaxToolCalls(20);
+
+    // when
+    final AgentHistoryRecord copy = new AgentHistoryRecord();
+    copy.copyFrom(original);
+
+    // then
+    assertThat(copy.getTools())
+        .extracting(AgentInstanceToolValue::getName, AgentInstanceToolValue::getElementId)
+        .containsExactly(tuple("extract_line_items", "extract-task"));
+    assertThat(copy.getModel()).isEqualTo("gpt-4o");
+    assertThat(copy.getProvider()).isEqualTo("openai");
+    assertThat(copy.getLimits().getMaxTokens()).isEqualTo(8000L);
+    assertThat(copy.getLimits().getMaxModelCalls()).isEqualTo(10);
+    assertThat(copy.getLimits().getMaxToolCalls()).isEqualTo(20);
+    assertThat(copy.getChangedAttributes()).containsExactly("model", "tools");
+  }
+
+  @Test
+  void shouldRoundTripSystemPromptIndependentlyOfContentViaMsgPack() {
+    // given
+    final var annotation =
+        new AgentHistoryMessageContent()
+            .setContentType(AgentHistoryContentType.TEXT)
+            .setText("annotation: rotated system prompt for compliance review");
+    final var systemPromptBlock =
+        new AgentHistoryMessageContent()
+            .setContentType(AgentHistoryContentType.TEXT)
+            .setText("You are a compliance review assistant.");
+
+    final AgentHistoryRecord original =
+        new AgentHistoryRecord()
+            .setContent(List.of(annotation))
+            .setSystemPrompt(List.of(systemPromptBlock));
+
+    // when
+    final AgentHistoryRecord copy = new AgentHistoryRecord();
+    copy.copyFrom(original);
+
+    // then
+    assertThat(copy.getContent()).hasSize(1);
+    assertThat(copy.getContent().get(0).getText())
+        .isEqualTo("annotation: rotated system prompt for compliance review");
+    assertThat(copy.getSystemPrompt()).hasSize(1);
+    assertThat(copy.getSystemPrompt().get(0).getText())
+        .isEqualTo("You are a compliance review assistant.");
+  }
+
+  @Test
+  void shouldReplaceExistingToolsOnSet() {
+    // given
+    final AgentHistoryRecord record =
+        new AgentHistoryRecord().setTools(List.of(new AgentInstanceTool().setName("first")));
+
+    // when
+    record.setTools(List.of(new AgentInstanceTool().setName("second")));
+
+    // then
+    assertThat(record.getTools())
+        .extracting(AgentInstanceToolValue::getName)
+        .containsExactly("second");
+  }
+
+  @Test
+  void shouldReplaceExistingChangedAttributesOnSet() {
+    // given
+    final AgentHistoryRecord record =
+        new AgentHistoryRecord().setChangedAttributes(List.of("model"));
+
+    // when
+    record.setChangedAttributes(List.of("provider", "limits"));
+
+    // then
+    assertThat(record.getChangedAttributes()).containsExactly("provider", "limits");
+  }
+
+  @Test
+  void shouldAppendChangedAttribute() {
+    // given
+    final AgentHistoryRecord record =
+        new AgentHistoryRecord().setChangedAttributes(List.of("model"));
+
+    // when
+    record.addChangedAttribute("provider");
+
+    // then
+    assertThat(record.getChangedAttributes()).containsExactly("model", "provider");
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
@@ -217,6 +217,9 @@ final class AgentHistoryRecordTest {
     // then
     assertThat(record.getMetrics().getInputTokens()).isEqualTo(-1L);
     assertThat(record.getMetrics().getOutputTokens()).isEqualTo(-1L);
+    assertThat(record.getMetrics().getReasoningTokenCount()).isEqualTo(-1L);
+    assertThat(record.getMetrics().getCacheCreationTokenCount()).isEqualTo(-1L);
+    assertThat(record.getMetrics().getCacheReadTokenCount()).isEqualTo(-1L);
     assertThat(record.getMetrics().getDurationMs()).isEqualTo(-1L);
   }
 
@@ -252,7 +255,14 @@ final class AgentHistoryRecordTest {
   void shouldRoundTripMetricsViaMsgPack() {
     // given
     final AgentHistoryRecord original = new AgentHistoryRecord();
-    original.getMetrics().setInputTokens(100L).setOutputTokens(200L).setDurationMs(350L);
+    original
+        .getMetrics()
+        .setInputTokens(100L)
+        .setOutputTokens(200L)
+        .setReasoningTokenCount(40L)
+        .setCacheCreationTokenCount(30L)
+        .setCacheReadTokenCount(20L)
+        .setDurationMs(350L);
 
     // when
     final AgentHistoryRecord copy = new AgentHistoryRecord();
@@ -261,6 +271,9 @@ final class AgentHistoryRecordTest {
     // then
     assertThat(copy.getMetrics().getInputTokens()).isEqualTo(100L);
     assertThat(copy.getMetrics().getOutputTokens()).isEqualTo(200L);
+    assertThat(copy.getMetrics().getReasoningTokenCount()).isEqualTo(40L);
+    assertThat(copy.getMetrics().getCacheCreationTokenCount()).isEqualTo(30L);
+    assertThat(copy.getMetrics().getCacheReadTokenCount()).isEqualTo(20L);
     assertThat(copy.getMetrics().getDurationMs()).isEqualTo(350L);
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
@@ -10,6 +10,12 @@ package io.camunda.zeebe.protocol.impl.record.value.agentinstance;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryEmbeddedToolCall;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue.AgentInstanceToolValue;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -329,5 +335,92 @@ final class AgentInstanceRecordTest {
     assertThat(copy.getJobKey()).isEqualTo(2251799813685300L);
     assertThat(copy.getJobLease()).isEqualTo("job-lease-xyz789");
     assertThat(copy.getLoopIteration()).isEqualTo(4);
+  }
+
+  @Test
+  void shouldDefaultHistoryToEmptyList() {
+    final AgentInstanceRecord record = new AgentInstanceRecord();
+    assertThat(record.getHistory()).isEmpty();
+  }
+
+  @Test
+  void shouldRoundTripHistoryViaMsgPack() {
+    // given
+    final var userItem =
+        new AgentHistoryRecord().setRole(AgentHistoryRole.USER).setProducedAt(1717200000000L);
+    userItem.addContent(
+        new AgentHistoryMessageContent()
+            .setContentType(AgentHistoryContentType.TEXT)
+            .setText("Please extract the invoice data."));
+
+    final var assistantItem =
+        new AgentHistoryRecord().setRole(AgentHistoryRole.ASSISTANT).setProducedAt(1717199999000L);
+    assistantItem.addContent(
+        new AgentHistoryMessageContent()
+            .setContentType(AgentHistoryContentType.TEXT)
+            .setText("Here is the extracted invoice data."));
+    assistantItem.addToolCall(
+        new AgentHistoryEmbeddedToolCall().setToolCallId("call-1").setToolName("noop"));
+    assistantItem.getMetrics().setInputTokens(10L).setOutputTokens(20L).setDurationMs(30L);
+
+    final AgentInstanceRecord original =
+        new AgentInstanceRecord().setHistory(List.of(assistantItem, userItem));
+
+    // when
+    final AgentInstanceRecord copy = new AgentInstanceRecord();
+    copy.copyFrom(original);
+
+    // then
+    final var history = copy.getHistory();
+    assertThat(history).hasSize(2);
+
+    final AgentHistoryRecordValue firstItem = history.get(0);
+    assertThat(firstItem.getRole()).isEqualTo(AgentHistoryRole.ASSISTANT);
+    assertThat(firstItem.getContent()).hasSize(1);
+    assertThat(firstItem.getContent().get(0).getText())
+        .isEqualTo("Here is the extracted invoice data.");
+    assertThat(firstItem.getToolCalls()).hasSize(1);
+    assertThat(firstItem.getToolCalls().get(0).getToolCallId()).isEqualTo("call-1");
+    assertThat(firstItem.getMetrics().getInputTokens()).isEqualTo(10L);
+    assertThat(firstItem.getMetrics().getOutputTokens()).isEqualTo(20L);
+    assertThat(firstItem.getMetrics().getDurationMs()).isEqualTo(30L);
+    assertThat(firstItem.getProducedAt()).isEqualTo(1717199999000L);
+
+    final AgentHistoryRecordValue secondItem = history.get(1);
+    assertThat(secondItem.getRole()).isEqualTo(AgentHistoryRole.USER);
+    assertThat(secondItem.getContent()).hasSize(1);
+    assertThat(secondItem.getContent().get(0).getText())
+        .isEqualTo("Please extract the invoice data.");
+    assertThat(secondItem.getProducedAt()).isEqualTo(1717200000000L);
+  }
+
+  @Test
+  void shouldReplaceExistingHistoryOnSet() {
+    // given
+    final AgentInstanceRecord record =
+        new AgentInstanceRecord().setHistory(List.of(new AgentHistoryRecord().setProducedAt(1L)));
+
+    // when
+    record.setHistory(List.of(new AgentHistoryRecord().setProducedAt(2L)));
+
+    // then
+    assertThat(record.getHistory())
+        .extracting(AgentHistoryRecordValue::getProducedAt)
+        .containsExactly(2L);
+  }
+
+  @Test
+  void shouldAppendHistoryItem() {
+    // given
+    final AgentInstanceRecord record =
+        new AgentInstanceRecord().setHistory(List.of(new AgentHistoryRecord().setProducedAt(1L)));
+
+    // when
+    record.addHistoryItem(new AgentHistoryRecord().setProducedAt(2L));
+
+    // then
+    assertThat(record.getHistory())
+        .extracting(AgentHistoryRecordValue::getProducedAt)
+        .containsExactly(1L, 2L);
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
@@ -153,6 +153,9 @@ final class AgentInstanceRecordTest {
     final AgentInstanceRecord record = new AgentInstanceRecord();
     assertThat(record.getMetrics().getInputTokens()).isZero();
     assertThat(record.getMetrics().getOutputTokens()).isZero();
+    assertThat(record.getMetrics().getReasoningTokenCount()).isZero();
+    assertThat(record.getMetrics().getCacheCreationTokenCount()).isZero();
+    assertThat(record.getMetrics().getCacheReadTokenCount()).isZero();
     assertThat(record.getMetrics().getModelCalls()).isZero();
     assertThat(record.getMetrics().getToolCalls()).isZero();
   }
@@ -165,6 +168,9 @@ final class AgentInstanceRecordTest {
         .getMetrics()
         .setInputTokens(1340L)
         .setOutputTokens(490L)
+        .setReasoningTokenCount(120L)
+        .setCacheCreationTokenCount(80L)
+        .setCacheReadTokenCount(40L)
         .setModelCalls(3)
         .setToolCalls(2);
 
@@ -175,6 +181,9 @@ final class AgentInstanceRecordTest {
     // then
     assertThat(copy.getMetrics().getInputTokens()).isEqualTo(1340L);
     assertThat(copy.getMetrics().getOutputTokens()).isEqualTo(490L);
+    assertThat(copy.getMetrics().getReasoningTokenCount()).isEqualTo(120L);
+    assertThat(copy.getMetrics().getCacheCreationTokenCount()).isEqualTo(80L);
+    assertThat(copy.getMetrics().getCacheReadTokenCount()).isEqualTo(40L);
     assertThat(copy.getMetrics().getModelCalls()).isEqualTo(3);
     assertThat(copy.getMetrics().getToolCalls()).isEqualTo(2);
   }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
@@ -303,4 +303,31 @@ final class AgentInstanceRecordTest {
         .extracting(AgentInstanceToolValue::getName)
         .containsExactly("second");
   }
+
+  @Test
+  void shouldDefaultJobFieldsToUnset() {
+    final AgentInstanceRecord record = new AgentInstanceRecord();
+    assertThat(record.getJobKey()).isEqualTo(-1L);
+    assertThat(record.getJobLease()).isEmpty();
+    assertThat(record.getLoopIteration()).isZero();
+  }
+
+  @Test
+  void shouldRoundTripJobFieldsViaMsgPack() {
+    // given
+    final AgentInstanceRecord original =
+        new AgentInstanceRecord()
+            .setJobKey(2251799813685300L)
+            .setJobLease("job-lease-xyz789")
+            .setLoopIteration(4);
+
+    // when
+    final AgentInstanceRecord copy = new AgentInstanceRecord();
+    copy.copyFrom(original);
+
+    // then
+    assertThat(copy.getJobKey()).isEqualTo(2251799813685300L);
+    assertThat(copy.getJobLease()).isEqualTo("job-lease-xyz789");
+    assertThat(copy.getLoopIteration()).isEqualTo(4);
+  }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryMetrics.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryMetrics.golden
@@ -17,12 +17,19 @@ public final class AgentHistoryMetrics extends ObjectValue implements AgentHisto
 
   private final LongProperty inputTokensProp = new LongProperty("inputTokens", -1L);
   private final LongProperty outputTokensProp = new LongProperty("outputTokens", -1L);
+  private final LongProperty reasoningTokenCountProp = new LongProperty("reasoningTokenCount", -1L);
+  private final LongProperty cacheCreationTokenCountProp =
+      new LongProperty("cacheCreationTokenCount", -1L);
+  private final LongProperty cacheReadTokenCountProp = new LongProperty("cacheReadTokenCount", -1L);
   private final LongProperty durationMsProp = new LongProperty("durationMs", -1L);
 
   public AgentHistoryMetrics() {
-    super(3);
+    super(6);
     declareProperty(inputTokensProp)
         .declareProperty(outputTokensProp)
+        .declareProperty(reasoningTokenCountProp)
+        .declareProperty(cacheCreationTokenCountProp)
+        .declareProperty(cacheReadTokenCountProp)
         .declareProperty(durationMsProp);
   }
 
@@ -43,6 +50,36 @@ public final class AgentHistoryMetrics extends ObjectValue implements AgentHisto
 
   public AgentHistoryMetrics setOutputTokens(final long outputTokens) {
     outputTokensProp.setValue(outputTokens);
+    return this;
+  }
+
+  @Override
+  public long getReasoningTokenCount() {
+    return reasoningTokenCountProp.getValue();
+  }
+
+  public AgentHistoryMetrics setReasoningTokenCount(final long reasoningTokenCount) {
+    reasoningTokenCountProp.setValue(reasoningTokenCount);
+    return this;
+  }
+
+  @Override
+  public long getCacheCreationTokenCount() {
+    return cacheCreationTokenCountProp.getValue();
+  }
+
+  public AgentHistoryMetrics setCacheCreationTokenCount(final long cacheCreationTokenCount) {
+    cacheCreationTokenCountProp.setValue(cacheCreationTokenCount);
+    return this;
+  }
+
+  @Override
+  public long getCacheReadTokenCount() {
+    return cacheReadTokenCountProp.getValue();
+  }
+
+  public AgentHistoryMetrics setCacheReadTokenCount(final long cacheReadTokenCount) {
+    cacheReadTokenCountProp.setValue(cacheReadTokenCount);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryRecord.golden
@@ -13,9 +13,14 @@ import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceLimits;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceTool;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue.AgentInstanceToolValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
@@ -42,13 +47,23 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   private final LongProperty producedAtProp = new LongProperty("producedAt", -1L);
   private final ArrayProperty<AgentHistoryMessageContent> contentProp =
       new ArrayProperty<>("content", AgentHistoryMessageContent::new);
+  private final ArrayProperty<AgentHistoryMessageContent> systemPromptProp =
+      new ArrayProperty<>("systemPrompt", AgentHistoryMessageContent::new);
   private final ArrayProperty<AgentHistoryEmbeddedToolCall> toolCallsProp =
       new ArrayProperty<>("toolCalls", AgentHistoryEmbeddedToolCall::new);
   private final ObjectProperty<AgentHistoryMetrics> metricsProp =
       new ObjectProperty<>("metrics", new AgentHistoryMetrics());
+  private final ArrayProperty<AgentInstanceTool> toolsProp =
+      new ArrayProperty<>("tools", AgentInstanceTool::new);
+  private final StringProperty modelProp = new StringProperty("model", "");
+  private final StringProperty providerProp = new StringProperty("provider", "");
+  private final ObjectProperty<AgentInstanceLimits> limitsProp =
+      new ObjectProperty<>("limits", new AgentInstanceLimits());
+  private final ArrayProperty<StringValue> changedAttributesProp =
+      new ArrayProperty<>("changedAttributes", StringValue::new);
 
   public AgentHistoryRecord() {
-    super(16);
+    super(22);
     declareProperty(agentHistoryKeyProp)
         .declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -63,8 +78,14 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
         .declareProperty(roleProp)
         .declareProperty(producedAtProp)
         .declareProperty(contentProp)
+        .declareProperty(systemPromptProp)
         .declareProperty(toolCallsProp)
-        .declareProperty(metricsProp);
+        .declareProperty(metricsProp)
+        .declareProperty(toolsProp)
+        .declareProperty(modelProp)
+        .declareProperty(providerProp)
+        .declareProperty(limitsProp)
+        .declareProperty(changedAttributesProp);
   }
 
   @Override
@@ -224,6 +245,34 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   }
 
   @Override
+  public List<AgentHistoryMessageContentValue> getSystemPrompt() {
+    return systemPromptProp.stream()
+        .map(
+            element -> {
+              final var copy = new AgentHistoryMessageContent();
+              copy.copy(element);
+              return (AgentHistoryMessageContentValue) copy;
+            })
+        .toList();
+  }
+
+  public AgentHistoryRecord setSystemPrompt(
+      final List<? extends AgentHistoryMessageContentValue> systemPrompt) {
+    systemPromptProp.reset();
+    if (systemPrompt != null) {
+      for (final var item : systemPrompt) {
+        systemPromptProp.add().copy(item);
+      }
+    }
+    return this;
+  }
+
+  public AgentHistoryRecord addSystemPrompt(final AgentHistoryMessageContent block) {
+    systemPromptProp.add().copy(block);
+    return this;
+  }
+
+  @Override
   public List<AgentHistoryEmbeddedToolCallValue> getToolCalls() {
     return toolCallsProp.stream()
         .map(
@@ -252,5 +301,78 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   @Override
   public AgentHistoryMetrics getMetrics() {
     return metricsProp.getValue();
+  }
+
+  public AgentHistoryRecord ignoreLease() {
+    return setJobLease(JobRecord.EMPTY_LEASE);
+  }
+
+  @Override
+  public List<AgentInstanceToolValue> getTools() {
+    return toolsProp.stream()
+        .map(
+            element -> {
+              final var copy = new AgentInstanceTool();
+              copy.copy(element);
+              return (AgentInstanceToolValue) copy;
+            })
+        .toList();
+  }
+
+  public AgentHistoryRecord setTools(final List<? extends AgentInstanceToolValue> tools) {
+    toolsProp.reset();
+    if (tools != null) {
+      for (final var tool : tools) {
+        toolsProp.add().copy(tool);
+      }
+    }
+    return this;
+  }
+
+  @Override
+  public String getModel() {
+    return BufferUtil.bufferAsString(modelProp.getValue());
+  }
+
+  public AgentHistoryRecord setModel(final String model) {
+    modelProp.setValue(model);
+    return this;
+  }
+
+  @Override
+  public String getProvider() {
+    return BufferUtil.bufferAsString(providerProp.getValue());
+  }
+
+  public AgentHistoryRecord setProvider(final String provider) {
+    providerProp.setValue(provider);
+    return this;
+  }
+
+  @Override
+  public AgentInstanceLimits getLimits() {
+    return limitsProp.getValue();
+  }
+
+  @Override
+  public List<String> getChangedAttributes() {
+    return changedAttributesProp.stream()
+        .map(StringValue::getValue)
+        .map(BufferUtil::bufferAsString)
+        .toList();
+  }
+
+  public AgentHistoryRecord setChangedAttributes(final List<String> changedAttributes) {
+    changedAttributesProp.reset();
+    if (changedAttributes != null) {
+      changedAttributes.forEach(
+          attr -> changedAttributesProp.add().wrap(BufferUtil.wrapString(attr)));
+    }
+    return this;
+  }
+
+  public AgentHistoryRecord addChangedAttribute(final String attribute) {
+    changedAttributesProp.add().wrap(BufferUtil.wrapString(attribute));
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryRecord.golden
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.record.value.agenthistory;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
@@ -53,6 +54,7 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
       new ArrayProperty<>("toolCalls", AgentHistoryEmbeddedToolCall::new);
   private final ObjectProperty<AgentHistoryMetrics> metricsProp =
       new ObjectProperty<>("metrics", new AgentHistoryMetrics());
+  private final StringProperty historyItemIdProp = new StringProperty("historyItemId", "");
   private final ArrayProperty<AgentInstanceTool> toolsProp =
       new ArrayProperty<>("tools", AgentInstanceTool::new);
   private final StringProperty modelProp = new StringProperty("model", "");
@@ -61,9 +63,10 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
       new ObjectProperty<>("limits", new AgentInstanceLimits());
   private final ArrayProperty<StringValue> changedAttributesProp =
       new ArrayProperty<>("changedAttributes", StringValue::new);
+  private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
 
   public AgentHistoryRecord() {
-    super(22);
+    super(24);
     declareProperty(agentHistoryKeyProp)
         .declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -81,11 +84,13 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
         .declareProperty(systemPromptProp)
         .declareProperty(toolCallsProp)
         .declareProperty(metricsProp)
+        .declareProperty(historyItemIdProp)
         .declareProperty(toolsProp)
         .declareProperty(modelProp)
         .declareProperty(providerProp)
         .declareProperty(limitsProp)
-        .declareProperty(changedAttributesProp);
+        .declareProperty(changedAttributesProp)
+        .declareProperty(isDuplicateProp);
   }
 
   @Override
@@ -308,6 +313,16 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   }
 
   @Override
+  public String getHistoryItemId() {
+    return BufferUtil.bufferAsString(historyItemIdProp.getValue());
+  }
+
+  public AgentHistoryRecord setHistoryItemId(final String historyItemId) {
+    historyItemIdProp.setValue(historyItemId);
+    return this;
+  }
+
+  @Override
   public List<AgentInstanceToolValue> getTools() {
     return toolsProp.stream()
         .map(
@@ -373,6 +388,16 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
 
   public AgentHistoryRecord addChangedAttribute(final String attribute) {
     changedAttributesProp.add().wrap(BufferUtil.wrapString(attribute));
+    return this;
+  }
+
+  @Override
+  public boolean isDuplicate() {
+    return isDuplicateProp.getValue();
+  }
+
+  public AgentHistoryRecord setDuplicate(final boolean duplicate) {
+    isDuplicateProp.setValue(duplicate);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceMetrics.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceMetrics.golden
@@ -19,13 +19,20 @@ public final class AgentInstanceMetrics extends ObjectValue
 
   private final LongProperty inputTokensProp = new LongProperty("inputTokens", 0L);
   private final LongProperty outputTokensProp = new LongProperty("outputTokens", 0L);
+  private final LongProperty reasoningTokenCountProp = new LongProperty("reasoningTokenCount", 0L);
+  private final LongProperty cacheCreationTokenCountProp =
+      new LongProperty("cacheCreationTokenCount", 0L);
+  private final LongProperty cacheReadTokenCountProp = new LongProperty("cacheReadTokenCount", 0L);
   private final IntegerProperty modelCallsProp = new IntegerProperty("modelCalls", 0);
   private final IntegerProperty toolCallsProp = new IntegerProperty("toolCalls", 0);
 
   public AgentInstanceMetrics() {
-    super(4);
+    super(7);
     declareProperty(inputTokensProp)
         .declareProperty(outputTokensProp)
+        .declareProperty(reasoningTokenCountProp)
+        .declareProperty(cacheCreationTokenCountProp)
+        .declareProperty(cacheReadTokenCountProp)
         .declareProperty(modelCallsProp)
         .declareProperty(toolCallsProp);
   }
@@ -47,6 +54,36 @@ public final class AgentInstanceMetrics extends ObjectValue
 
   public AgentInstanceMetrics setOutputTokens(final long outputTokens) {
     outputTokensProp.setValue(outputTokens);
+    return this;
+  }
+
+  @Override
+  public long getReasoningTokenCount() {
+    return reasoningTokenCountProp.getValue();
+  }
+
+  public AgentInstanceMetrics setReasoningTokenCount(final long reasoningTokenCount) {
+    reasoningTokenCountProp.setValue(reasoningTokenCount);
+    return this;
+  }
+
+  @Override
+  public long getCacheCreationTokenCount() {
+    return cacheCreationTokenCountProp.getValue();
+  }
+
+  public AgentInstanceMetrics setCacheCreationTokenCount(final long cacheCreationTokenCount) {
+    cacheCreationTokenCountProp.setValue(cacheCreationTokenCount);
+    return this;
+  }
+
+  @Override
+  public long getCacheReadTokenCount() {
+    return cacheReadTokenCountProp.getValue();
+  }
+
+  public AgentInstanceMetrics setCacheReadTokenCount(final long cacheReadTokenCount) {
+    cacheReadTokenCountProp.setValue(cacheReadTokenCount);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
@@ -16,11 +16,14 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public final class AgentInstanceRecord extends UnifiedRecordValue
     implements AgentInstanceRecordValue {
@@ -60,9 +63,11 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   private final LongProperty jobKeyProp = new LongProperty("jobKey", -1L);
   private final StringProperty jobLeaseProp = new StringProperty("jobLease", "");
   private final IntegerProperty loopIterationProp = new IntegerProperty("loopIteration", 0);
+  private final ArrayProperty<AgentHistoryRecord> historyProp =
+      new ArrayProperty<>("history", AgentHistoryRecord::new);
 
   public AgentInstanceRecord() {
-    super(20);
+    super(21);
     declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(elementInstanceKeysProp)
@@ -82,7 +87,8 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
         .declareProperty(changedAttributesProp)
         .declareProperty(jobKeyProp)
         .declareProperty(jobLeaseProp)
-        .declareProperty(loopIterationProp);
+        .declareProperty(loopIterationProp)
+        .declareProperty(historyProp);
   }
 
   @Override
@@ -297,6 +303,26 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord setLoopIteration(final int loopIteration) {
     loopIterationProp.setValue(loopIteration);
+    return this;
+  }
+
+  @Override
+  public List<AgentHistoryRecordValue> getHistory() {
+    return historyProp.stream().collect(Collectors.toList());
+  }
+
+  public AgentInstanceRecord setHistory(final List<? extends AgentHistoryRecord> history) {
+    historyProp.reset();
+    if (history != null) {
+      for (final var item : history) {
+        historyProp.add().copyFrom(item);
+      }
+    }
+    return this;
+  }
+
+  public AgentInstanceRecord addHistoryItem(final AgentHistoryRecord historyItem) {
+    historyProp.add().copyFrom(historyItem);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
@@ -25,6 +25,10 @@ import java.util.List;
 public final class AgentInstanceRecord extends UnifiedRecordValue
     implements AgentInstanceRecordValue {
 
+  public static final String ATTR_STATUS = "status";
+  public static final String ATTR_METRICS = "metrics";
+  public static final String ATTR_TOOLS = "tools";
+
   private final LongProperty agentInstanceKeyProp = new LongProperty("agentInstanceKey", -1L);
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
   private final ArrayProperty<LongValue> elementInstanceKeysProp =
@@ -53,9 +57,12 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
       new ArrayProperty<>("tools", AgentInstanceTool::new);
   private final ArrayProperty<StringValue> changedAttributesProp =
       new ArrayProperty<>("changedAttributes", StringValue::new);
+  private final LongProperty jobKeyProp = new LongProperty("jobKey", -1L);
+  private final StringProperty jobLeaseProp = new StringProperty("jobLease", "");
+  private final IntegerProperty loopIterationProp = new IntegerProperty("loopIteration", 0);
 
   public AgentInstanceRecord() {
-    super(17);
+    super(20);
     declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(elementInstanceKeysProp)
@@ -72,7 +79,10 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
         .declareProperty(limitsProp)
         .declareProperty(metricsProp)
         .declareProperty(toolsProp)
-        .declareProperty(changedAttributesProp);
+        .declareProperty(changedAttributesProp)
+        .declareProperty(jobKeyProp)
+        .declareProperty(jobLeaseProp)
+        .declareProperty(loopIterationProp);
   }
 
   @Override
@@ -257,6 +267,36 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord addChangedAttribute(final String attribute) {
     changedAttributesProp.add().wrap(BufferUtil.wrapString(attribute));
+    return this;
+  }
+
+  @Override
+  public long getJobKey() {
+    return jobKeyProp.getValue();
+  }
+
+  public AgentInstanceRecord setJobKey(final long jobKey) {
+    jobKeyProp.setValue(jobKey);
+    return this;
+  }
+
+  @Override
+  public String getJobLease() {
+    return BufferUtil.bufferAsString(jobLeaseProp.getValue());
+  }
+
+  public AgentInstanceRecord setJobLease(final String jobLease) {
+    jobLeaseProp.setValue(jobLease);
+    return this;
+  }
+
+  @Override
+  public int getLoopIteration() {
+    return loopIterationProp.getValue();
+  }
+
+  public AgentInstanceRecord setLoopIteration(final int loopIteration) {
+    loopIterationProp.setValue(loopIteration);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
@@ -32,6 +32,15 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   public static final String ATTR_METRICS = "metrics";
   public static final String ATTR_TOOLS = "tools";
 
+  // Derived from CONFIGURATION-role history items on the output side (see #58791 for the engine
+  // processing that merges them in), never from a request-level changedAttributes entry — these
+  // are not part of ALLOWED_ATTRIBUTES in AgentInstanceUpdateProcessor, only of the output-side
+  // merge order.
+  public static final String ATTR_SYSTEM_PROMPT = "systemPrompt";
+  public static final String ATTR_MODEL = "model";
+  public static final String ATTR_PROVIDER = "provider";
+  public static final String ATTR_LIMITS = "limits";
+
   private final LongProperty agentInstanceKeyProp = new LongProperty("agentInstanceKey", -1L);
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
   private final ArrayProperty<LongValue> elementInstanceKeysProp =

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
@@ -193,6 +193,15 @@ public interface AgentHistoryRecordValue extends RecordValue, TenantOwned, Proce
     /** Returns the number of output tokens produced. */
     long getOutputTokens();
 
+    /** Returns the number of reasoning tokens consumed by this LLM call. */
+    long getReasoningTokenCount();
+
+    /** Returns the number of cache-creation tokens consumed by this LLM call. */
+    long getCacheCreationTokenCount();
+
+    /** Returns the number of cache-read tokens consumed by this LLM call. */
+    long getCacheReadTokenCount();
+
     /** Returns the wall-clock duration of the LLM call in milliseconds. */
     long getDurationMs();
   }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
@@ -85,11 +85,52 @@ public interface AgentHistoryRecordValue extends RecordValue, TenantOwned, Proce
   /** Returns the list of content blocks in this history entry. */
   List<AgentHistoryMessageContentValue> getContent();
 
+  /**
+   * Returns the system prompt, as content blocks, as of this entry. Reserved for a future
+   * configuration-change entry kind (see #58794); unused until that lands. An empty list does not
+   * by itself mean the system prompt wasn't touched — it may also mean the prompt was explicitly
+   * cleared; check {@link #getChangedAttributes()} to tell the two apart.
+   */
+  List<AgentHistoryMessageContentValue> getSystemPrompt();
+
   /** Returns the list of tool calls made during this history entry. */
   List<AgentHistoryEmbeddedToolCallValue> getToolCalls();
 
   /** Returns the metrics captured for this history entry. */
   AgentHistoryMetricsValue getMetrics();
+
+  /**
+   * Returns the complete list of tools available to the agent as of this entry. Reserved for a
+   * future configuration-change entry kind (see #58794); unused until that lands. An empty list
+   * does not by itself mean the tool list wasn't touched — it may also mean the tools were
+   * explicitly cleared; check {@link #getChangedAttributes()} to tell the two apart.
+   */
+  List<AgentInstanceRecordValue.AgentInstanceToolValue> getTools();
+
+  /**
+   * Returns the LLM model identifier as of this entry. Reserved for a future configuration-change
+   * entry kind (see #58794); empty until that lands.
+   */
+  String getModel();
+
+  /**
+   * Returns the LLM provider as of this entry. Reserved for a future configuration-change entry
+   * kind (see #58794); empty until that lands.
+   */
+  String getProvider();
+
+  /**
+   * Returns the operational limits as of this entry. Reserved for a future configuration-change
+   * entry kind (see #58794); unused until that lands.
+   */
+  AgentInstanceRecordValue.AgentInstanceLimitsValue getLimits();
+
+  /**
+   * Returns the names of attributes this entry intends to update, or the names of the attributes
+   * that were actually updated; empty otherwise. Reserved for a future configuration-change entry
+   * kind (see #58794); unused until that lands.
+   */
+  List<String> getChangedAttributes();
 
   /** Represents a single content block in a history entry message. */
   @Value.Immutable

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
@@ -99,6 +99,9 @@ public interface AgentHistoryRecordValue extends RecordValue, TenantOwned, Proce
   /** Returns the metrics captured for this history entry. */
   AgentHistoryMetricsValue getMetrics();
 
+  /** Returns the client-supplied identifier this item was created with. */
+  String getHistoryItemId();
+
   /**
    * Returns the complete list of tools available to the agent as of this entry. Reserved for a
    * future configuration-change entry kind (see #58794); unused until that lands. An empty list
@@ -131,6 +134,15 @@ public interface AgentHistoryRecordValue extends RecordValue, TenantOwned, Proce
    * kind (see #58794); unused until that lands.
    */
   List<String> getChangedAttributes();
+
+  /**
+   * Returns whether this entry was recognized as a duplicate of a previously-processed history item
+   * with the same historyItemId (scoped to the producing agent instance's whole lifetime) or of a
+   * still-pending item under the current job lease — meaningful only when this entry is echoed back
+   * embedded in an AgentInstanceRecord's history[]; if true, no new AGENT_HISTORY event was
+   * actually created for it and agentHistoryKey is the ORIGINAL entry's key, not a new one.
+   */
+  boolean isDuplicate();
 
   /** Represents a single content block in a history entry message. */
   @Value.Immutable

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
@@ -223,6 +223,24 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
     long getOutputTokens();
 
     /**
+     * @return on events, the current number of reasoning tokens consumed; on UPDATE, the delta to
+     *     add ({@code -1} means the field is not provided)
+     */
+    long getReasoningTokenCount();
+
+    /**
+     * @return on events, the current number of tokens used to create a prompt cache entry; on
+     *     UPDATE, the delta to add ({@code -1} means the field is not provided)
+     */
+    long getCacheCreationTokenCount();
+
+    /**
+     * @return on events, the current number of tokens read from a prompt cache entry; on UPDATE,
+     *     the delta to add ({@code -1} means the field is not provided)
+     */
+    long getCacheReadTokenCount();
+
+    /**
      * @return on events, the current number of model calls made by the agent; on UPDATE, the delta
      *     to add ({@code -1} means the field is not provided)
      */

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
@@ -133,6 +133,12 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
    */
   int getLoopIteration();
 
+  /**
+   * @return the batch of history items carried by this command, each reusing the same shape as a
+   *     persisted {@code AgentHistoryRecord} entry
+   */
+  List<AgentHistoryRecordValue> getHistory();
+
   /** Represents a tool available to an agent. */
   @Value.Immutable
   @ImmutableProtocol(builder = ImmutableAgentInstanceToolValue.Builder.class)

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
@@ -116,6 +116,23 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
    */
   List<String> getChangedAttributes();
 
+  /**
+   * @return the key of the job this command was produced for
+   */
+  long getJobKey();
+
+  /**
+   * @return the opaque lease token identifying the job activation during which this command was
+   *     produced
+   */
+  String getJobLease();
+
+  /**
+   * @return the loopIteration this command belongs to; a loopIteration is one pass through the
+   *     agent feedback loop: one LLM call, its tool dispatches, and their results
+   */
+  int getLoopIteration();
+
   /** Represents a tool available to an agent. */
   @Value.Immutable
   @ImmutableProtocol(builder = ImmutableAgentInstanceToolValue.Builder.class)


### PR DESCRIPTION
## Summary

Extends the `AgentInstanceRecord`/`AgentHistoryRecord` protocol schema to support embedding a batch of history items directly in an `AGENT_INSTANCE:CREATE`/`UPDATE` command, instead of requiring a separate `AGENT_HISTORY:CREATE` per item. Today's Agent Instance Command API needs one HTTP call per history item plus separate calls for status/metrics/tools, so a single LLM turn costs 3+ round trips.

Embedded history items reuse `AgentHistoryRecord` directly rather than introducing a separate item type, following the existing precedent set by `GlobalListenerBatchRecord.listeners[]` embedding `GlobalListenerRecord` directly elsewhere in this protocol. `AgentInstanceRecord.getHistory()` returns `List<AgentHistoryRecordValue>` — the same interface a persisted `AGENT_HISTORY` event exposes.

## Commits

1. `feat: add jobKey/jobLease/loopIteration to AgentInstanceRecord` — job-context fields, distinguishing the job vs. the specific activation (`jobLease`).
2. `feat: embed a history[] batch in AgentInstanceRecord` — the `history[]` array itself.
3. `feat: add reserved configuration-change fields to AgentHistoryRecord` — adds systemPrompt/tools/model/provider/limits/changedAttributes, the fields a future configuration-change entry kind will need. Deliberately does **not** add a `CONFIGURATION` role value: doing so breaks the exhaustive role-mapping `switch` in both `camunda-exporter`'s `AgentHistoryHandler` and `rdbms-exporter`'s `AgentHistoryExportHandler` (plus their entity-layer role enums), so introducing the role itself is left to #58794, which already needs to touch those switches.
4. `feat: add historyItemId and isDuplicate to AgentHistoryRecord for embedded-batch dedup reporting` — client-supplied identifier plus the engine's dedup-recognition report; #58792's scope.
5. `feat: add reasoning/cache token metrics to agent history and instance metrics` — `reasoningTokenCount`/`cacheCreationTokenCount`/`cacheReadTokenCount`; #59320's scope.
6. `test: cover the full embedded history batch shape in JsonSerializableToJsonTest` — a fully-populated round-trip fixture exercising every field added across the preceding commits.

Each schema-changing commit also updates the matching raw Elasticsearch *and* OpenSearch index templates (`zeebe-record-agent-instance-template.json` / `zeebe-record-agent-history-template.json`) in the same commit — both search backends keep their own separate copy of these `"dynamic": "strict"` templates, so both need updating and both were verified against real instances via testcontainers.

No `requestId` field is added to the command or record, per this issue's acceptance criteria.

Closes #58790.

## Test plan

- [x] `zeebe-protocol`/`zeebe-protocol-impl` unit tests (`AgentInstanceRecordTest`, `AgentHistoryRecordTest`, `JsonSerializableToJsonTest`, `RecordGoldenFilesTest`) — 308 tests, 0 failures.
- [x] `ElasticsearchExporterIT`/`SchemaManagerIT` against a real Elasticsearch testcontainer.
- [x] `OpensearchExporterIT`/`SchemaManagerIT` against a real OpenSearch testcontainer.
- [x] `camunda-exporter`/`rdbms-exporter` build and test clean with zero modifications (confirms dropping the `CONFIGURATION` role avoided the exhaustive-switch break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)