### PR TITLE
ci: stop the evidence listing from killing the fix agent

### DIFF
--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -316,7 +316,12 @@ jobs:
           if [ -n "${FAILING_RUN_URL}" ]; then
             dl "${GITHUB_REPOSITORY}" "${FAILING_RUN_URL##*/}" 'diagnostics-e2e*'
           fi
-          find /tmp/alwaysgreen-artifacts -type f | head -40
+          # Deliberately pipe-free. `find | head -40` makes head close the pipe once
+          # the cap is reached, find then dies on SIGPIPE, and pipefail turns this
+          # informational listing into a step failure that skips the agent.
+          find /tmp/alwaysgreen-artifacts -type f > /tmp/evidence-files.txt
+          echo "evidence files: $(wc -l < /tmp/evidence-files.txt) (first 40 shown)"
+          head -40 /tmp/evidence-files.txt
 
       - name: Run Claude Code fix agent
         env:

--- a/.github/workflows/alwaysgreen-triage.yml
+++ b/.github/workflows/alwaysgreen-triage.yml
@@ -178,7 +178,7 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           exportEnv: false
           secrets: |
-            secret/data/products/camunda/ci/github-actions SLACK_CORE_DOMAIN_BOT_TOKEN;
+            secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
 
       - name: Discover and plan
         id: plan
@@ -251,7 +251,7 @@ jobs:
         if: ${{ steps.mode.outputs.active == 'true' && steps.slack-secrets.outcome == 'success' && (steps.plan.outputs.count != '0' || inputs.parent_slack_ts != '') }}
         continue-on-error: true
         env:
-          SLACK_TOKEN: ${{ steps.slack-secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
+          SLACK_TOKEN: ${{ steps.slack-secrets.outputs.SLACK_BOT_USER_OAUTH_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PARENT_TS: ${{ inputs.parent_slack_ts }}
           PARENT_CHANNEL: ${{ inputs.parent_slack_channel }}
@@ -392,7 +392,7 @@ jobs:
         if: ${{ always() && steps.slack.outputs.self_ts != '' }}
         continue-on-error: true
         env:
-          SLACK_TOKEN: ${{ steps.slack-secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
+          SLACK_TOKEN: ${{ steps.slack-secrets.outputs.SLACK_BOT_USER_OAUTH_TOKEN }}
           SLACK_TS: ${{ steps.slack.outputs.self_ts }}
           SLACK_CHANNEL: ${{ steps.slack.outputs.channel }}
         run: |


### PR DESCRIPTION
## Description

Found by replaying triage against a real `stable/8.9` SaaS failure. **Every SaaS fix-agent
dispatch is currently dead on arrival**, and the cause is an informational log line.

`Download evidence artifacts` ends with:

```bash
find /tmp/alwaysgreen-artifacts -type f | head -40
```

Once the evidence exceeds 40 files *and* enough output to fill the pipe buffer, `head` closes
the pipe, `find` dies on `SIGPIPE` (141), and the step's `set -o pipefail` promotes that to a
step failure. `Run Claude Code fix agent` then **skips** and the dispatch yields nothing — even
though the download itself succeeded.

From [run 31009165514](https://github.com/camunda/camunda/actions/runs/31009165514)
(`stable/8.9:saas-smoke-e2e`):

```
  got json-report* from camunda/c8-cross-component-e2e-tests#30511186073
  got Playwright Report* from camunda/c8-cross-component-e2e-tests#30511186073
  (absent) diagnostics-e2e* from camunda/camunda#30510801170
<exactly 40 paths listed>
##[error]Process completed with exit code 1.
```

## Why it survived the earlier tests

It is size-dependent, and reproduces only at realistic scale:

| listing | result |
|---|---|
| 60 short paths | exit 0 — `find` finishes before `head` exits, output fits the pipe buffer |
| 4000 long paths | **exit 141** — bug reproduced |

An `sm-smoke-e2e` dispatch downloads few files, so the live main-branch test
([run 30996309030](https://github.com/camunda/camunda/actions/runs/30996309030)) passed. A SaaS
dispatch pulls two generations of Playwright reports — hundreds of `data/<sha>.png` paths — and
trips it every time. So this blocks SaaS on `main` too, not just stable branches.

## Fix

Write the list to a file and read it back, so there is no pipe to break, and report the true
count instead of implying 40 was all of it:

```bash
find /tmp/alwaysgreen-artifacts -type f > /tmp/evidence-files.txt
echo "evidence files: $(wc -l < /tmp/evidence-files.txt) (first 40 shown)"
head -40 /tmp/evidence-files.txt
```

This is the only `| head` in either AlwaysGreen workflow, so it is the only site affected.

## Also in this PR: triage posts as the QA bot

Triage authenticated with `SLACK_CORE_DOMAIN_BOT_TOKEN` from
`products/camunda/ci/github-actions`, while the fix agent uses
`SLACK_BOT_USER_OAUTH_TOKEN` from `products/qa/ci/common`. A single thread therefore carried two
identities — the dispatch notice from **Core Domain E2E Test Results**, the outcome reply from
**QA Team Assistant** (visible in the live test thread).

Triage now reads the same `qa/ci/common` token. That is also where `ALWAYSGREEN_FIX_AGENT` lives,
so the whole feature depends on one QA-owned secret path instead of two.

Checked before switching: the QA bot (`U04C2SLKVD3`) is already a member of
#alwaysgreen-reliability, so the production alert channel keeps working — a bot that is not in the
channel would have failed with `not_in_channel`, and since the Slack step is `continue-on-error`
that would have silently dropped every alert.

## Verification

- Mechanism reproduced and the fix confirmed locally at both scales (table above).
- `actionlint -shellcheck=shellcheck` passes on `alwaysgreen-fix.yml` and `alwaysgreen-triage.yml`.
- The bot switch is config only; the first triage message after merge confirms it (it should read
  "QA Team Assistant").
- Not yet verified by a live dispatch — the next SaaS dispatch after this merges is the real
  check. Happy to re-run the `stable/8.9` replay to confirm.

Worth noting the reporting behaved correctly throughout: the run went red and the Slack thread
said "agent failed, no fix applied" rather than claiming no fix was determined.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Follow-up to #59389. No backport labels: the fix agent lives only on `main`.

