### PR TITLE
Bound agent instance cleanup at process completion to one command per cycle

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteProcessor.java
@@ -25,26 +25,18 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.util.List;
 
 /**
- * Handles {@code AGENT_INSTANCE:COMPLETE}, which has two meanings depending on whether {@code
- * agentInstanceKey} is set on the command:
- *
- * <ul>
- *   <li>set — completes exactly that agent instance.
- *   <li>unset ({@code -1}, only {@code processInstanceKey} set) — "batch completion": completes one
- *       agent instance still belonging to that process instance, then re-appends the same command
- *       as a follow-up so the next one is picked up on the next cycle. Once none remain, the
- *       command is rejected {@code NOT_FOUND} — the rejection doubles as the signal that the
- *       process instance's agent instances are fully cleaned up. At most two records are written
- *       per cycle (the {@code COMPLETED} event and the re-issued {@code COMPLETE}), so this relies
- *       on the general follow-up-command mechanism rather than a bespoke batch limit or cursor.
- * </ul>
+ * Handles {@code AGENT_INSTANCE:COMPLETE}: completes one agent instance still belonging to the
+ * process instance identified by {@code processInstanceKey}, then re-appends the same command as a
+ * follow-up so the next one is picked up on the next cycle. Once none remain, the command is
+ * rejected {@code NOT_FOUND} — the rejection doubles as the signal that the process instance's
+ * agent instances are fully cleaned up. At most two records are written per cycle (the {@code
+ * COMPLETED} event and the re-issued {@code COMPLETE}), so this relies on the general
+ * follow-up-command mechanism rather than a bespoke batch limit or cursor.
  */
 @ExcludeAuthorizationCheck
 public final class AgentInstanceCompleteProcessor
     implements TypedRecordProcessor<AgentInstanceRecord>, SuspensionAware<AgentInstanceRecord> {
 
-  private static final String ERROR_MSG_NOT_FOUND =
-      "Expected to complete agent instance with key '%d', but no such agent instance was found.";
   private static final String ERROR_MSG_NONE_REMAINING =
       "No remaining agent instances to complete for process instance with key '%d'.";
 
@@ -63,42 +55,24 @@ public final class AgentInstanceCompleteProcessor
 
   @Override
   public void processRecord(final TypedRecord<AgentInstanceRecord> command) {
-    final var value = command.getValue();
-    final boolean isBatchCompletion = value.getAgentInstanceKey() == -1L;
-
-    final Long agentInstanceKey;
-    if (isBatchCompletion) {
-      agentInstanceKey =
-          agentInstanceState.getFirstAgentInstanceKeyByProcessInstanceKey(
-              value.getProcessInstanceKey());
-    } else {
-      agentInstanceKey = value.getAgentInstanceKey();
-    }
-    final var current =
-        agentInstanceKey == null ? null : agentInstanceState.getRecord(agentInstanceKey);
-    if (current == null) {
+    final long processInstanceKey = command.getValue().getProcessInstanceKey();
+    final Long agentInstanceKey =
+        agentInstanceState.getFirstAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
+    if (agentInstanceKey == null) {
       rejectionWriter.appendRejection(
-          command, RejectionType.NOT_FOUND, rejectionReason(isBatchCompletion, value));
+          command, RejectionType.NOT_FOUND, ERROR_MSG_NONE_REMAINING.formatted(processInstanceKey));
       return;
     }
 
+    final var current = agentInstanceState.getRecord(agentInstanceKey);
     current.setStatus(AgentInstanceStatus.COMPLETED);
     current.setChangedAttributes(List.of(AgentInstanceRecord.ATTR_STATUS));
     stateWriter.appendFollowUpEvent(agentInstanceKey, AgentInstanceIntent.COMPLETED, current);
 
-    if (isBatchCompletion) {
-      // re-chain: other agent instances may still be left for this process instance
-      commandWriter.appendNewCommand(
-          AgentInstanceIntent.COMPLETE,
-          new AgentInstanceRecord().setProcessInstanceKey(value.getProcessInstanceKey()));
-    }
-  }
-
-  private static String rejectionReason(
-      final boolean isBatchCompletion, final AgentInstanceRecord value) {
-    return isBatchCompletion
-        ? ERROR_MSG_NONE_REMAINING.formatted(value.getProcessInstanceKey())
-        : ERROR_MSG_NOT_FOUND.formatted(value.getAgentInstanceKey());
+    // re-chain: other agent instances may still be left for this process instance
+    commandWriter.appendNewCommand(
+        AgentInstanceIntent.COMPLETE,
+        new AgentInstanceRecord().setProcessInstanceKey(processInstanceKey));
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteProcessor.java
@@ -63,48 +63,43 @@ public final class AgentInstanceCompleteProcessor
 
   @Override
   public void processRecord(final TypedRecord<AgentInstanceRecord> command) {
-    final long agentInstanceKey = command.getValue().getAgentInstanceKey();
-    if (agentInstanceKey == -1L) {
-      completeNextOfProcessInstance(command);
-    } else {
-      completeSingle(command, agentInstanceKey);
-    }
-  }
+    final var value = command.getValue();
+    final boolean isBatchCompletion = value.getAgentInstanceKey() == -1L;
 
-  private void completeSingle(
-      final TypedRecord<AgentInstanceRecord> command, final long agentInstanceKey) {
-    final var current = agentInstanceState.getRecord(agentInstanceKey);
+    final Long agentInstanceKey;
+    if (isBatchCompletion) {
+      agentInstanceKey =
+          agentInstanceState.findFirstAgentInstanceKeyByProcessInstanceKey(
+              value.getProcessInstanceKey());
+    } else {
+      agentInstanceKey = value.getAgentInstanceKey();
+    }
+    final var current =
+        agentInstanceKey == null ? null : agentInstanceState.getRecord(agentInstanceKey);
     if (current == null) {
       rejectionWriter.appendRejection(
-          command, RejectionType.NOT_FOUND, ERROR_MSG_NOT_FOUND.formatted(agentInstanceKey));
+          command, RejectionType.NOT_FOUND, rejectionReason(isBatchCompletion, value));
       return;
     }
 
-    appendCompleted(agentInstanceKey, current);
-  }
-
-  private void completeNextOfProcessInstance(final TypedRecord<AgentInstanceRecord> command) {
-    final long processInstanceKey = command.getValue().getProcessInstanceKey();
-    final Long agentInstanceKey =
-        agentInstanceState.findFirstAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
-    if (agentInstanceKey == null) {
-      rejectionWriter.appendRejection(
-          command, RejectionType.NOT_FOUND, ERROR_MSG_NONE_REMAINING.formatted(processInstanceKey));
-      return;
-    }
-
-    appendCompleted(agentInstanceKey, agentInstanceState.getRecord(agentInstanceKey));
-    // re-chain: other agent instances may still be left for this process instance
-    commandWriter.appendFollowUpCommand(
-        command.getKey(),
-        AgentInstanceIntent.COMPLETE,
-        new AgentInstanceRecord().setProcessInstanceKey(processInstanceKey));
-  }
-
-  private void appendCompleted(final long agentInstanceKey, final AgentInstanceRecord current) {
     current.setStatus(AgentInstanceStatus.COMPLETED);
     current.setChangedAttributes(List.of(AgentInstanceRecord.ATTR_STATUS));
     stateWriter.appendFollowUpEvent(agentInstanceKey, AgentInstanceIntent.COMPLETED, current);
+
+    if (isBatchCompletion) {
+      // re-chain: other agent instances may still be left for this process instance
+      commandWriter.appendFollowUpCommand(
+          command.getKey(),
+          AgentInstanceIntent.COMPLETE,
+          new AgentInstanceRecord().setProcessInstanceKey(value.getProcessInstanceKey()));
+    }
+  }
+
+  private static String rejectionReason(
+      final boolean isBatchCompletion, final AgentInstanceRecord value) {
+    return isBatchCompletion
+        ? ERROR_MSG_NONE_REMAINING.formatted(value.getProcessInstanceKey())
+        : ERROR_MSG_NOT_FOUND.formatted(value.getAgentInstanceKey());
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteProcessor.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.AgentInstanceState;
@@ -23,27 +24,55 @@ import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.util.List;
 
+/**
+ * Handles {@code AGENT_INSTANCE:COMPLETE}, which has two meanings depending on whether {@code
+ * agentInstanceKey} is set on the command:
+ *
+ * <ul>
+ *   <li>set — completes exactly that agent instance.
+ *   <li>unset ({@code -1}, only {@code processInstanceKey} set) — "batch completion": completes one
+ *       agent instance still belonging to that process instance, then re-appends the same command
+ *       as a follow-up so the next one is picked up on the next cycle. Once none remain, the
+ *       command is rejected {@code NOT_FOUND} — the rejection doubles as the signal that the
+ *       process instance's agent instances are fully cleaned up. At most two records are written
+ *       per cycle (the {@code COMPLETED} event and the re-issued {@code COMPLETE}), so this relies
+ *       on the general follow-up-command mechanism rather than a bespoke batch limit or cursor.
+ * </ul>
+ */
 @ExcludeAuthorizationCheck
 public final class AgentInstanceCompleteProcessor
     implements TypedRecordProcessor<AgentInstanceRecord>, SuspensionAware<AgentInstanceRecord> {
 
   private static final String ERROR_MSG_NOT_FOUND =
       "Expected to complete agent instance with key '%d', but no such agent instance was found.";
+  private static final String ERROR_MSG_NONE_REMAINING =
+      "No remaining agent instances to complete for process instance with key '%d'";
 
   private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final AgentInstanceState agentInstanceState;
 
   public AgentInstanceCompleteProcessor(
       final Writers writers, final ProcessingState processingState) {
     stateWriter = writers.state();
+    commandWriter = writers.command();
     rejectionWriter = writers.rejection();
     agentInstanceState = processingState.getAgentInstanceState();
   }
 
   @Override
   public void processRecord(final TypedRecord<AgentInstanceRecord> command) {
-    final long agentInstanceKey = command.getKey();
+    final long agentInstanceKey = command.getValue().getAgentInstanceKey();
+    if (agentInstanceKey == -1L) {
+      completeNextOfProcessInstance(command);
+    } else {
+      completeSingle(command, agentInstanceKey);
+    }
+  }
+
+  private void completeSingle(
+      final TypedRecord<AgentInstanceRecord> command, final long agentInstanceKey) {
     final var current = agentInstanceState.getRecord(agentInstanceKey);
     if (current == null) {
       rejectionWriter.appendRejection(
@@ -51,6 +80,28 @@ public final class AgentInstanceCompleteProcessor
       return;
     }
 
+    appendCompleted(agentInstanceKey, current);
+  }
+
+  private void completeNextOfProcessInstance(final TypedRecord<AgentInstanceRecord> command) {
+    final long processInstanceKey = command.getValue().getProcessInstanceKey();
+    final Long agentInstanceKey =
+        agentInstanceState.findNextAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
+    if (agentInstanceKey == null) {
+      rejectionWriter.appendRejection(
+          command, RejectionType.NOT_FOUND, ERROR_MSG_NONE_REMAINING.formatted(processInstanceKey));
+      return;
+    }
+
+    appendCompleted(agentInstanceKey, agentInstanceState.getRecord(agentInstanceKey));
+    // re-chain: other agent instances may still be left for this process instance
+    commandWriter.appendFollowUpCommand(
+        command.getKey(),
+        AgentInstanceIntent.COMPLETE,
+        new AgentInstanceRecord().setProcessInstanceKey(processInstanceKey));
+  }
+
+  private void appendCompleted(final long agentInstanceKey, final AgentInstanceRecord current) {
     current.setStatus(AgentInstanceStatus.COMPLETED);
     current.setChangedAttributes(List.of(AgentInstanceRecord.ATTR_STATUS));
     stateWriter.appendFollowUpEvent(agentInstanceKey, AgentInstanceIntent.COMPLETED, current);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteProcessor.java
@@ -69,7 +69,7 @@ public final class AgentInstanceCompleteProcessor
     final Long agentInstanceKey;
     if (isBatchCompletion) {
       agentInstanceKey =
-          agentInstanceState.findFirstAgentInstanceKeyByProcessInstanceKey(
+          agentInstanceState.getFirstAgentInstanceKeyByProcessInstanceKey(
               value.getProcessInstanceKey());
     } else {
       agentInstanceKey = value.getAgentInstanceKey();
@@ -88,8 +88,7 @@ public final class AgentInstanceCompleteProcessor
 
     if (isBatchCompletion) {
       // re-chain: other agent instances may still be left for this process instance
-      commandWriter.appendFollowUpCommand(
-          command.getKey(),
+      commandWriter.appendNewCommand(
           AgentInstanceIntent.COMPLETE,
           new AgentInstanceRecord().setProcessInstanceKey(value.getProcessInstanceKey()));
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteProcessor.java
@@ -46,7 +46,7 @@ public final class AgentInstanceCompleteProcessor
   private static final String ERROR_MSG_NOT_FOUND =
       "Expected to complete agent instance with key '%d', but no such agent instance was found.";
   private static final String ERROR_MSG_NONE_REMAINING =
-      "No remaining agent instances to complete for process instance with key '%d'";
+      "No remaining agent instances to complete for process instance with key '%d'.";
 
   private final StateWriter stateWriter;
   private final TypedCommandWriter commandWriter;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteProcessor.java
@@ -86,7 +86,7 @@ public final class AgentInstanceCompleteProcessor
   private void completeNextOfProcessInstance(final TypedRecord<AgentInstanceRecord> command) {
     final long processInstanceKey = command.getValue().getProcessInstanceKey();
     final Long agentInstanceKey =
-        agentInstanceState.findNextAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
+        agentInstanceState.findFirstAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
     if (agentInstanceKey == null) {
       rejectionWriter.appendRejection(
           command, RejectionType.NOT_FOUND, ERROR_MSG_NONE_REMAINING.formatted(processInstanceKey));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AgentInstanceBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AgentInstanceBehavior.java
@@ -7,35 +7,36 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
+import io.camunda.zeebe.engine.processing.agentinstance.AgentInstanceCompleteProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.immutable.AgentInstanceState;
-import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 
 public final class AgentInstanceBehavior {
 
   private final TypedCommandWriter commandWriter;
-  private final AgentInstanceState agentInstanceState;
 
-  public AgentInstanceBehavior(final ProcessingState processingState, final Writers writers) {
+  public AgentInstanceBehavior(final Writers writers) {
     commandWriter = writers.command();
-    agentInstanceState = processingState.getAgentInstanceState();
   }
 
-  /** Completes every agent instance still associated with the given process instance. */
+  /**
+   * Completes every agent instance still associated with the given process instance.
+   *
+   * <p>Writes a single "batch completion" {@code AGENT_INSTANCE:COMPLETE} command scoped to the
+   * process instance (no {@code agentInstanceKey}), instead of one command per agent instance: the
+   * number of agent instances a process instance has accumulated is unbounded, so writing one
+   * follow-up command per instance here could exceed the record-batch size limit for a single
+   * processing round. {@link AgentInstanceCompleteProcessor} completes them one at a time,
+   * self-chaining until none remain.
+   */
   public void completeAgentInstancesOfProcessInstance(final BpmnElementContext context) {
     final long processInstanceKey = context.getProcessInstanceKey();
-    for (final long agentInstanceKey :
-        agentInstanceState.getAgentInstanceKeysByProcessInstanceKey(processInstanceKey)) {
-      commandWriter.appendFollowUpCommand(
-          agentInstanceKey,
-          AgentInstanceIntent.COMPLETE,
-          new AgentInstanceRecord()
-              .setAgentInstanceKey(agentInstanceKey)
-              .setProcessInstanceKey(processInstanceKey));
-    }
+    commandWriter.appendFollowUpCommand(
+        -1L,
+        AgentInstanceIntent.COMPLETE,
+        new AgentInstanceRecord().setProcessInstanceKey(processInstanceKey));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AgentInstanceBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AgentInstanceBehavior.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
-import io.camunda.zeebe.engine.processing.agentinstance.AgentInstanceCompleteProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -22,20 +21,10 @@ public final class AgentInstanceBehavior {
     commandWriter = writers.command();
   }
 
-  /**
-   * Completes every agent instance still associated with the given process instance.
-   *
-   * <p>Writes a single "batch completion" {@code AGENT_INSTANCE:COMPLETE} command scoped to the
-   * process instance (no {@code agentInstanceKey}), instead of one command per agent instance: the
-   * number of agent instances a process instance has accumulated is unbounded, so writing one
-   * follow-up command per instance here could exceed the record-batch size limit for a single
-   * processing round. {@link AgentInstanceCompleteProcessor} completes them one at a time,
-   * self-chaining until none remain.
-   */
+  /** Completes every agent instance still associated with the given process instance. */
   public void completeAgentInstancesOfProcessInstance(final BpmnElementContext context) {
     final long processInstanceKey = context.getProcessInstanceKey();
-    commandWriter.appendFollowUpCommand(
-        -1L,
+    commandWriter.appendNewCommand(
         AgentInstanceIntent.COMPLETE,
         new AgentInstanceRecord().setProcessInstanceKey(processInstanceKey));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -308,7 +308,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             variableBehavior,
             processingState);
 
-    agentInstanceBehavior = new AgentInstanceBehavior(processingState, writers);
+    agentInstanceBehavior = new AgentInstanceBehavior(writers);
 
     processDeletionBehavior =
         new BpmnProcessDeletionBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agentinstance/DbAgentInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agentinstance/DbAgentInstanceState.java
@@ -69,7 +69,7 @@ public final class DbAgentInstanceState implements MutableAgentInstanceState {
   }
 
   @Override
-  public Long findFirstAgentInstanceKeyByProcessInstanceKey(final long piKey) {
+  public Long getFirstAgentInstanceKeyByProcessInstanceKey(final long piKey) {
     final var found = new AtomicReference<Long>();
     processInstanceKey.wrapLong(piKey);
     byProcessInstanceKeyColumnFamily.whileEqualPrefix(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agentinstance/DbAgentInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agentinstance/DbAgentInstanceState.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 public final class DbAgentInstanceState implements MutableAgentInstanceState {
 
@@ -65,6 +66,19 @@ public final class DbAgentInstanceState implements MutableAgentInstanceState {
           keys.add(key.second().getValue());
         });
     return keys;
+  }
+
+  @Override
+  public Long findNextAgentInstanceKeyByProcessInstanceKey(final long piKey) {
+    final var found = new AtomicReference<Long>();
+    processInstanceKey.wrapLong(piKey);
+    byProcessInstanceKeyColumnFamily.whileEqualPrefix(
+        processInstanceKey,
+        (compositeKey) -> {
+          found.set(compositeKey.second().getValue());
+          return false;
+        });
+    return found.get();
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agentinstance/DbAgentInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agentinstance/DbAgentInstanceState.java
@@ -69,7 +69,7 @@ public final class DbAgentInstanceState implements MutableAgentInstanceState {
   }
 
   @Override
-  public Long findNextAgentInstanceKeyByProcessInstanceKey(final long piKey) {
+  public Long findFirstAgentInstanceKeyByProcessInstanceKey(final long piKey) {
     final var found = new AtomicReference<Long>();
     processInstanceKey.wrapLong(piKey);
     byProcessInstanceKeyColumnFamily.whileEqualPrefix(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentInstanceState.java
@@ -23,11 +23,11 @@ public interface AgentInstanceState {
   List<Long> getAgentInstanceKeysByProcessInstanceKey(long processInstanceKey);
 
   /**
-   * Finds a single agent instance still associated with the given process instance, without loading
-   * the full key list. Used to drive batch completion one instance at a time.
+   * Returns the smallest remaining agent instance key for the given process instance, without
+   * loading the full key list. Used to drive batch completion one instance at a time.
    *
-   * @return the key of an agent instance still associated with the given process instance, or
-   *     {@code null} if none remain
+   * @return the smallest key of an agent instance still associated with the given process instance,
+   *     or {@code null} if none remain
    */
-  Long findFirstAgentInstanceKeyByProcessInstanceKey(long processInstanceKey);
+  Long getFirstAgentInstanceKeyByProcessInstanceKey(long processInstanceKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentInstanceState.java
@@ -21,4 +21,13 @@ public interface AgentInstanceState {
    * @return the keys of all agent instances currently associated with the given process instance
    */
   List<Long> getAgentInstanceKeysByProcessInstanceKey(long processInstanceKey);
+
+  /**
+   * Finds a single agent instance still associated with the given process instance, without loading
+   * the full key list. Used to drive batch completion one instance at a time.
+   *
+   * @return the key of an agent instance still associated with the given process instance, or
+   *     {@code null} if none remain
+   */
+  Long findNextAgentInstanceKeyByProcessInstanceKey(long processInstanceKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentInstanceState.java
@@ -29,5 +29,5 @@ public interface AgentInstanceState {
    * @return the key of an agent instance still associated with the given process instance, or
    *     {@code null} if none remain
    */
-  Long findNextAgentInstanceKeyByProcessInstanceKey(long processInstanceKey);
+  Long findFirstAgentInstanceKeyByProcessInstanceKey(long processInstanceKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteOnProcessInstanceLifecycleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteOnProcessInstanceLifecycleTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
@@ -69,10 +70,11 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
     // when
     ENGINE.job().ofInstance(processInstanceKey).withType(AGENT_JOB_TYPE).complete();
 
-    // then — AGENT_INSTANCE:COMPLETE is emitted as a follow-up to PROCESS:COMPLETE_ELEMENT
+    // then — the batch AGENT_INSTANCE:COMPLETE command is emitted as a follow-up to
+    // PROCESS:COMPLETE_ELEMENT, and the agent instance itself is completed from it
     final var agentInstanceCompleteCommand =
         RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETE)
-            .withRecordKey(agentInstanceKey)
+            .withProcessInstanceKey(processInstanceKey)
             .getFirst();
     final var processCompleteElementCommand =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.COMPLETE_ELEMENT)
@@ -85,6 +87,11 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
             "AGENT_INSTANCE:COMPLETE is a follow-up to PROCESS:COMPLETE_ELEMENT, "
                 + "so it must appear after it in the log")
         .isGreaterThan(processCompleteElementCommand.getPosition());
+    assertThat(
+            RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETED)
+                .withRecordKey(agentInstanceKey)
+                .exists())
+        .isTrue();
   }
 
   @Test
@@ -135,7 +142,7 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
     // completion
     final var agentInstanceCompleteCommand =
         RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETE)
-            .withRecordKey(agentInstanceKey)
+            .withProcessInstanceKey(processInstanceKey)
             .getFirst();
     final var processCompleteElementCommand =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.COMPLETE_ELEMENT)
@@ -148,6 +155,11 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
             "AGENT_INSTANCE:COMPLETE is a follow-up to PROCESS:COMPLETE_ELEMENT, "
                 + "so it must appear after it in the log")
         .isGreaterThan(processCompleteElementCommand.getPosition());
+    assertThat(
+            RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETED)
+                .withRecordKey(agentInstanceKey)
+                .exists())
+        .isTrue();
   }
 
   @Test
@@ -247,7 +259,10 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
 
   @Test
   public void shouldCompleteAllAgentInstancesOfProcessInstance() {
-    // given — two parallel agentic service tasks, each with its own agent instance
+    // given — two parallel agentic service tasks, each with its own agent instance, on the
+    // process instance under test; plus an unrelated process instance with its own agent
+    // instance, whose agentic job is left active so its own cleanup never triggers, to prove the
+    // batch stays scoped to the process instance under test
     final String otherAgentTaskId = "other-agent-task";
     final String otherAgentJobType = "other-agent";
     ENGINE
@@ -282,17 +297,83 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
     awaitAndActivateJob(AGENT_JOB_TYPE);
     awaitAndActivateJob(otherAgentJobType);
 
-    // when
+    final String unrelatedProcessId = "unrelated-process";
+    final String unrelatedAgentJobType = "unrelated-agent";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(unrelatedProcessId)
+                .startEvent()
+                .serviceTask(AGENT_TASK_ID, t -> t.zeebeJobType(unrelatedAgentJobType))
+                .endEvent()
+                .done())
+        .deploy();
+    final var unrelatedProcessInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(unrelatedProcessId).create();
+    final var unrelatedTaskInstance =
+        awaitElementActivated(unrelatedProcessInstanceKey, AGENT_TASK_ID);
+    final var unrelatedAgentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(unrelatedTaskInstance.getKey())
+            .create()
+            .getKey();
+
+    // when — only the process instance under test completes; the unrelated one's agentic job is
+    // left active on purpose
     ENGINE.job().ofInstance(processInstanceKey).withType(AGENT_JOB_TYPE).complete();
     ENGINE.job().ofInstance(processInstanceKey).withType(otherAgentJobType).complete();
 
-    // then
+    // then — a single AGENT_INSTANCE:COMPLETE command is written as a follow-up of the process
+    // instance completing
+    final var firstCompleteCommand =
+        RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETE)
+            .onlyCommands()
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // and — it self-chains until every agent instance is completed, closing with a NOT_FOUND
+    // rejection once none remain; that rejection is the signal the batch is done
+    final var rejectedCompleteCommand =
+        RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETE)
+            .onlyCommandRejections()
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(rejectedCompleteCommand.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
+
+    // and — between that first command and the closing rejection, both (and only both) agent
+    // instances belonging to the process instance are completed; how many self-chained COMPLETE
+    // commands it took to get there is an implementation detail, not asserted here
     assertThat(
             RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .filter(
+                    r ->
+                        r.getPosition() > firstCompleteCommand.getPosition()
+                            && r.getPosition() < rejectedCompleteCommand.getPosition())
                 .limit(2)
                 .map(Record::getKey))
-        .describedAs("Both agent instances belonging to the process instance are completed")
+        .describedAs(
+            "Both agent instances belonging to the process instance are completed between the "
+                + "first COMPLETE command and the closing rejection")
         .containsExactlyInAnyOrder(firstAgentInstanceKey, secondAgentInstanceKey);
+
+    // and — the unrelated process instance's own agent instance was never touched by this batch;
+    // bound the negative check with a clock reset marker, since exists() can't short-circuit on
+    // an absence
+    final long clockResetKey = ENGINE.clock().reset().getKey();
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getKey() == clockResetKey)
+                .withValueType(ValueType.AGENT_INSTANCE)
+                .withIntent(AgentInstanceIntent.COMPLETED)
+                .withRecordKey(unrelatedAgentInstanceKey)
+                .exists())
+        .describedAs(
+            ("Unrelated process instance %d's agent instance is untouched by process instance "
+                    + "%d's batch completion")
+                .formatted(unrelatedProcessInstanceKey, processInstanceKey))
+        .isFalse();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteTest.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -81,6 +82,100 @@ public class AgentInstanceCompleteTest {
     // then
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
     assertThat(rejection.getRejectionReason()).contains(String.valueOf(unknownAgentInstanceKey));
+  }
+
+  @Test
+  public void shouldRejectBatchCompleteWhenNoAgentInstanceForProcessInstance() {
+    // given
+    final long unknownProcessInstanceKey = 9999L;
+
+    // when — no expectRejection() needed: for batch completion, a NOT_FOUND rejection is one of
+    // two equally valid outcomes, not an error
+    final var rejection =
+        ENGINE.agentInstances().withProcessInstanceKey(unknownProcessInstanceKey).complete();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(rejection.getRejectionReason()).contains(String.valueOf(unknownProcessInstanceKey));
+    assertThat(rejection.getValue().getProcessInstanceKey()).isEqualTo(unknownProcessInstanceKey);
+    assertThat(rejection.getValue().getAgentInstanceKey()).isEqualTo(-1L);
+  }
+
+  @Test
+  public void shouldCompleteAgentInstancesOfProcessInstanceAcrossMultipleBatchCycles() {
+    // given — two agent instances belonging to the same process instance, created directly
+    // (mirroring this class's style of driving the processor without a job/process lifecycle)
+    final String secondTaskId = "second-agent-task";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .parallelGateway("fork")
+                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .parallelGateway("join")
+                .endEvent()
+                .moveToNode("fork")
+                .serviceTask(secondTaskId, t -> t.zeebeJobType("other-agent"))
+                .connectTo("join")
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var firstTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst();
+    final var secondTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(secondTaskId)
+            .getFirst();
+    final var firstAgentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(firstTaskInstance.getKey())
+            .create()
+            .getKey();
+    final var secondAgentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(secondTaskInstance.getKey())
+            .create()
+            .getKey();
+
+    // when — a single batch-completion command is issued for the process instance
+    ENGINE.agentInstances().withProcessInstanceKey(processInstanceKey).complete();
+
+    // then — both agent instances are completed, one per self-chained cycle
+    assertThat(
+            RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(2)
+                .map(Record::getKey))
+        .describedAs("Both agent instances are completed across self-chained batch cycles")
+        .containsExactlyInAnyOrder(firstAgentInstanceKey, secondAgentInstanceKey);
+
+    // and — the final self-chained batch command, once no agent instances remain, is rejected;
+    // this rejection is itself the signal that the process instance's cleanup is complete
+    assertThat(
+            RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETE)
+                .onlyCommands()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(3)
+                .toList())
+        .describedAs(
+            "3 COMPLETE commands: the initial one plus 2 self-chained follow-ups, one per "
+                + "completed instance")
+        .hasSize(3);
+    final var rejectedBatchCommand =
+        RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETE)
+            .onlyCommandRejections()
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(rejectedBatchCommand.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
   }
 
   private long deployAndCreateAgentInstance() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteTest.java
@@ -43,54 +43,44 @@ public class AgentInstanceCompleteTest {
   @Test
   public void shouldCompleteAgentInstanceAndSetStatusCompleted() {
     // given
-    final var agentInstanceKey = deployAndCreateAgentInstance();
+    final var fixture = deployAndCreateAgentInstance();
 
-    // when
-    final var completed = ENGINE.agentInstances().withAgentInstanceKey(agentInstanceKey).complete();
+    // when — no expectRejection() needed: complete() always resolves to the closing NOT_FOUND
+    // rejection, the signal that cleanup finished, not an error
+    ENGINE.agentInstances().withProcessInstanceKey(fixture.processInstanceKey()).complete();
 
     // then
-    assertThat(completed.getKey()).isEqualTo(agentInstanceKey);
+    final var completed =
+        RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETED)
+            .withRecordKey(fixture.agentInstanceKey())
+            .getFirst();
     assertThat(completed.getValue().getStatus()).isEqualTo(AgentInstanceStatus.COMPLETED);
   }
 
   @Test
   public void shouldDeleteAgentInstanceFromStateOnCompleted() {
     // given
-    final var agentInstanceKey = deployAndCreateAgentInstance();
+    final var fixture = deployAndCreateAgentInstance();
 
     // when
-    ENGINE.agentInstances().withAgentInstanceKey(agentInstanceKey).complete();
+    ENGINE.agentInstances().withProcessInstanceKey(fixture.processInstanceKey()).complete();
 
     // then
-    assertThat(ENGINE.getProcessingState().getAgentInstanceState().getRecord(agentInstanceKey))
+    assertThat(
+            ENGINE
+                .getProcessingState()
+                .getAgentInstanceState()
+                .getRecord(fixture.agentInstanceKey()))
         .isNull();
   }
 
   @Test
-  public void shouldRejectCompleteWhenAgentInstanceDoesNotExist() {
-    // given
-    final long unknownAgentInstanceKey = 9999L;
-
-    // when
-    final var rejection =
-        ENGINE
-            .agentInstances()
-            .withAgentInstanceKey(unknownAgentInstanceKey)
-            .expectRejection()
-            .complete();
-
-    // then
-    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
-    assertThat(rejection.getRejectionReason()).contains(String.valueOf(unknownAgentInstanceKey));
-  }
-
-  @Test
-  public void shouldRejectBatchCompleteWhenNoAgentInstanceForProcessInstance() {
+  public void shouldRejectCompleteWhenNoAgentInstanceForProcessInstance() {
     // given
     final long unknownProcessInstanceKey = 9999L;
 
-    // when — no expectRejection() needed: for batch completion, a NOT_FOUND rejection is one of
-    // two equally valid outcomes, not an error
+    // when — no expectRejection() needed: a NOT_FOUND rejection is one of two equally valid
+    // outcomes, not an error
     final var rejection =
         ENGINE.agentInstances().withProcessInstanceKey(unknownProcessInstanceKey).complete();
 
@@ -98,7 +88,6 @@ public class AgentInstanceCompleteTest {
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
     assertThat(rejection.getRejectionReason()).contains(String.valueOf(unknownProcessInstanceKey));
     assertThat(rejection.getValue().getProcessInstanceKey()).isEqualTo(unknownProcessInstanceKey);
-    assertThat(rejection.getValue().getAgentInstanceKey()).isEqualTo(-1L);
   }
 
   @Test
@@ -185,7 +174,7 @@ public class AgentInstanceCompleteTest {
     assertThat(rejectedBatchCommand.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
   }
 
-  private long deployAndCreateAgentInstance() {
+  private AgentInstanceFixture deployAndCreateAgentInstance() {
     ENGINE
         .deployment()
         .withXmlResource(
@@ -197,12 +186,14 @@ public class AgentInstanceCompleteTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
-    return ENGINE
-        .agentInstances()
-        .withElementInstanceKey(serviceTaskInstance.getKey())
-        .create()
-        .getValue()
-        .getAgentInstanceKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(serviceTaskInstance.getKey())
+            .create()
+            .getValue()
+            .getAgentInstanceKey();
+    return new AgentInstanceFixture(processInstanceKey, agentInstanceKey);
   }
 
   private static Record<ProcessInstanceRecordValue> awaitServiceTaskActivated(
@@ -213,4 +204,6 @@ public class AgentInstanceCompleteTest {
         .withElementId(SERVICE_TASK_ID)
         .getFirst();
   }
+
+  private record AgentInstanceFixture(long processInstanceKey, long agentInstanceKey) {}
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteTest.java
@@ -103,9 +103,10 @@ public class AgentInstanceCompleteTest {
 
   @Test
   public void shouldCompleteAgentInstancesOfProcessInstanceAcrossMultipleBatchCycles() {
-    // given — two agent instances belonging to the same process instance, created directly
+    // given — three agent instances belonging to the same process instance, created directly
     // (mirroring this class's style of driving the processor without a job/process lifecycle)
     final String secondTaskId = "second-agent-task";
+    final String thirdTaskId = "third-agent-task";
     ENGINE
         .deployment()
         .withXmlResource(
@@ -117,6 +118,9 @@ public class AgentInstanceCompleteTest {
                 .endEvent()
                 .moveToNode("fork")
                 .serviceTask(secondTaskId, t -> t.zeebeJobType("other-agent"))
+                .connectTo("join")
+                .moveToNode("fork")
+                .serviceTask(thirdTaskId, t -> t.zeebeJobType("third-agent"))
                 .connectTo("join")
                 .done())
         .deploy();
@@ -133,6 +137,12 @@ public class AgentInstanceCompleteTest {
             .withElementType(BpmnElementType.SERVICE_TASK)
             .withElementId(secondTaskId)
             .getFirst();
+    final var thirdTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(thirdTaskId)
+            .getFirst();
     final var firstAgentInstanceKey =
         ENGINE
             .agentInstances()
@@ -145,31 +155,28 @@ public class AgentInstanceCompleteTest {
             .withElementInstanceKey(secondTaskInstance.getKey())
             .create()
             .getKey();
+    final var thirdAgentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(thirdTaskInstance.getKey())
+            .create()
+            .getKey();
 
     // when — a single batch-completion command is issued for the process instance
     ENGINE.agentInstances().withProcessInstanceKey(processInstanceKey).complete();
 
-    // then — both agent instances are completed, one per self-chained cycle
+    // then — all three agent instances are completed, one per self-chained cycle
     assertThat(
             RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETED)
                 .withProcessInstanceKey(processInstanceKey)
-                .limit(2)
+                .limit(3)
                 .map(Record::getKey))
-        .describedAs("Both agent instances are completed across self-chained batch cycles")
-        .containsExactlyInAnyOrder(firstAgentInstanceKey, secondAgentInstanceKey);
+        .describedAs("All three agent instances are completed across self-chained batch cycles")
+        .containsExactlyInAnyOrder(
+            firstAgentInstanceKey, secondAgentInstanceKey, thirdAgentInstanceKey);
 
     // and — the final self-chained batch command, once no agent instances remain, is rejected;
     // this rejection is itself the signal that the process instance's cleanup is complete
-    assertThat(
-            RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETE)
-                .onlyCommands()
-                .withProcessInstanceKey(processInstanceKey)
-                .limit(3)
-                .toList())
-        .describedAs(
-            "3 COMPLETE commands: the initial one plus 2 self-chained follow-ups, one per "
-                + "completed instance")
-        .hasSize(3);
     final var rejectedBatchCommand =
         RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETE)
             .onlyCommandRejections()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteWithoutCommandBatchingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteWithoutCommandBatchingTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agentinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Covers batch completion with the engine's general command-batching effectively disabled ({@code
+ * maxCommandsInBatch(1)}, mirroring {@code MigrateProcessInstanceConcurrentNoBatchingTest}), so
+ * each self-chained {@code COMPLETE} command is dequeued in its own processing round instead of
+ * being reprocessed eagerly within the same round as the one before it.
+ */
+public class AgentInstanceCompleteWithoutCommandBatchingTest {
+
+  @ClassRule
+  public static final EngineRule ENGINE = EngineRule.singlePartition().maxCommandsInBatch(1);
+
+  private static final String PROCESS_ID = "process";
+  private static final String FIRST_TASK_ID = "first-agent-task";
+  private static final String SECOND_TASK_ID = "second-agent-task";
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCompleteAgentInstancesOfProcessInstanceAcrossMultipleRounds() {
+    // given — two agent instances belonging to the same process instance; with command batching
+    // disabled, completing both requires the batch command to be dequeued and processed in two
+    // separate rounds, each with its own source record position
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .parallelGateway("fork")
+                .serviceTask(FIRST_TASK_ID, t -> t.zeebeJobType("agent"))
+                .parallelGateway("join")
+                .endEvent()
+                .moveToNode("fork")
+                .serviceTask(SECOND_TASK_ID, t -> t.zeebeJobType("other-agent"))
+                .connectTo("join")
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var firstTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(FIRST_TASK_ID)
+            .getFirst();
+    final var secondTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SECOND_TASK_ID)
+            .getFirst();
+    final var firstAgentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(firstTaskInstance.getKey())
+            .create()
+            .getKey();
+    final var secondAgentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(secondTaskInstance.getKey())
+            .create()
+            .getKey();
+
+    // when — a single batch-completion command is issued for the process instance
+    final var rejection =
+        ENGINE.agentInstances().withProcessInstanceKey(processInstanceKey).complete();
+
+    // then — the client's wait resolves to the closing rejection even though it took multiple
+    // separate rounds to get there, since it isn't tied to the initial command's source position
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
+
+    // and — both agent instances were completed along the way
+    assertThat(
+            RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(2)
+                .map(Record::getKey))
+        .describedAs("Both agent instances are completed across separate processing rounds")
+        .containsExactlyInAnyOrder(firstAgentInstanceKey, secondAgentInstanceKey);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/agentinstance/AgentInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/agentinstance/AgentInstanceStateTest.java
@@ -160,7 +160,7 @@ public final class AgentInstanceStateTest {
 
     // when
     final var found =
-        agentInstanceState.findFirstAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
+        agentInstanceState.getFirstAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
 
     // then
     assertThat(found).isEqualTo(agentInstanceKey);
@@ -187,10 +187,10 @@ public final class AgentInstanceStateTest {
 
     // when
     final var first =
-        agentInstanceState.findFirstAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
+        agentInstanceState.getFirstAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
     agentInstanceState.delete(first);
     final var second =
-        agentInstanceState.findFirstAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
+        agentInstanceState.getFirstAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
 
     // then
     assertThat(first).isNotEqualTo(second);
@@ -201,7 +201,7 @@ public final class AgentInstanceStateTest {
   @Test
   public void shouldReturnNullWhenNoAgentInstanceKeyFoundForProcessInstanceKey() {
     // given / when
-    final var found = agentInstanceState.findFirstAgentInstanceKeyByProcessInstanceKey(9999L);
+    final var found = agentInstanceState.getFirstAgentInstanceKeyByProcessInstanceKey(9999L);
 
     // then
     assertThat(found).isNull();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/agentinstance/AgentInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/agentinstance/AgentInstanceStateTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
+import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Rule;
@@ -143,6 +144,67 @@ public final class AgentInstanceStateTest {
 
     // then
     assertThat(keys).isEmpty();
+  }
+
+  @Test
+  public void shouldFindOneAgentInstanceKeyByProcessInstanceKey() {
+    // given
+    final long processInstanceKey = 100L;
+    final long agentInstanceKey = 1L;
+    agentInstanceState.insert(
+        agentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.INITIALIZING));
+
+    // when
+    final var found =
+        agentInstanceState.findNextAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
+
+    // then
+    assertThat(found).isEqualTo(agentInstanceKey);
+  }
+
+  @Test
+  public void shouldFindNextAgentInstanceKeyAfterOneIsDeleted() {
+    // given
+    final long processInstanceKey = 100L;
+    final long firstAgentInstanceKey = 1L;
+    final long secondAgentInstanceKey = 2L;
+    agentInstanceState.insert(
+        firstAgentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(firstAgentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.INITIALIZING));
+    agentInstanceState.insert(
+        secondAgentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(secondAgentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.INITIALIZING));
+
+    // when
+    final var first =
+        agentInstanceState.findNextAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
+    agentInstanceState.delete(first);
+    final var second =
+        agentInstanceState.findNextAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
+
+    // then
+    assertThat(first).isNotEqualTo(second);
+    assertThat(List.of(first, second))
+        .containsExactlyInAnyOrder(firstAgentInstanceKey, secondAgentInstanceKey);
+  }
+
+  @Test
+  public void shouldReturnNullWhenNoAgentInstanceKeyFoundForProcessInstanceKey() {
+    // given / when
+    final var found = agentInstanceState.findNextAgentInstanceKeyByProcessInstanceKey(9999L);
+
+    // then
+    assertThat(found).isNull();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/agentinstance/AgentInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/agentinstance/AgentInstanceStateTest.java
@@ -160,7 +160,7 @@ public final class AgentInstanceStateTest {
 
     // when
     final var found =
-        agentInstanceState.findNextAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
+        agentInstanceState.findFirstAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
 
     // then
     assertThat(found).isEqualTo(agentInstanceKey);
@@ -187,10 +187,10 @@ public final class AgentInstanceStateTest {
 
     // when
     final var first =
-        agentInstanceState.findNextAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
+        agentInstanceState.findFirstAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
     agentInstanceState.delete(first);
     final var second =
-        agentInstanceState.findNextAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
+        agentInstanceState.findFirstAgentInstanceKeyByProcessInstanceKey(processInstanceKey);
 
     // then
     assertThat(first).isNotEqualTo(second);
@@ -201,7 +201,7 @@ public final class AgentInstanceStateTest {
   @Test
   public void shouldReturnNullWhenNoAgentInstanceKeyFoundForProcessInstanceKey() {
     // given / when
-    final var found = agentInstanceState.findNextAgentInstanceKeyByProcessInstanceKey(9999L);
+    final var found = agentInstanceState.findFirstAgentInstanceKeyByProcessInstanceKey(9999L);
 
     // then
     assertThat(found).isNull();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentInstanceClient.java
@@ -100,6 +100,16 @@ public final class AgentInstanceClient {
     return this;
   }
 
+  /**
+   * Leaves {@code agentInstanceKey} unset, so {@link #complete()} drives the "batch completion"
+   * branch of {@code AGENT_INSTANCE:COMPLETE}: complete one agent instance still belonging to this
+   * process instance, self-chaining until none remain.
+   */
+  public AgentInstanceClient withProcessInstanceKey(final long processInstanceKey) {
+    record.setProcessInstanceKey(processInstanceKey);
+    return this;
+  }
+
   public AgentInstanceClient withDefinition(
       final String model, final String provider, final String systemPrompt) {
     record.getDefinition().setModel(model).setProvider(provider).setSystemPrompt(systemPrompt);
@@ -206,8 +216,12 @@ public final class AgentInstanceClient {
   }
 
   /**
-   * Drives {@code AGENT_INSTANCE:COMPLETE} directly against {@link #withAgentInstanceKey}, without
-   * requiring a ProcessProcessor-driven process instance lifecycle.
+   * Drives {@code AGENT_INSTANCE:COMPLETE} directly, without requiring a ProcessProcessor-driven
+   * process instance lifecycle. Targets {@link #withAgentInstanceKey} when set, otherwise drives
+   * the "batch completion" branch for {@link #withProcessInstanceKey} — which always ends in a
+   * {@code NOT_FOUND} rejection once every agent instance for that process instance has been
+   * completed, so {@link #expectRejection()} is not needed: batch completion always waits for that
+   * rejection, the signal that closes the loop.
    */
   public Record<AgentInstanceRecordValue> complete() {
     final long position =
@@ -216,7 +230,10 @@ public final class AgentInstanceClient {
             AgentInstanceIntent.COMPLETE,
             record,
             authorizedTenantIds.toArray(new String[0]));
-    return (expectRejection ? COMPLETE_REJECTION_EXPECTATION : COMPLETED_EXPECTATION)
+    final boolean isBatchCompletion = record.getAgentInstanceKey() == -1L;
+    return (isBatchCompletion || expectRejection
+            ? COMPLETE_REJECTION_EXPECTATION
+            : COMPLETED_EXPECTATION)
         .apply(position);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentInstanceClient.java
@@ -63,32 +63,15 @@ public final class AgentInstanceClient {
                   .withSourceRecordPosition(position)
                   .getFirst();
 
-  private static final Function<Long, Record<AgentInstanceRecordValue>> COMPLETED_EXPECTATION =
-      (position) ->
-          RecordingExporter.agentInstanceRecords()
-              .withIntent(AgentInstanceIntent.COMPLETED)
-              .withSourceRecordPosition(position)
-              .getFirst();
-
-  private static final Function<Long, Record<AgentInstanceRecordValue>>
-      COMPLETE_REJECTION_EXPECTATION =
-          (position) ->
-              RecordingExporter.agentInstanceRecords()
-                  .onlyCommandRejections()
-                  .withIntent(AgentInstanceIntent.COMPLETE)
-                  .withSourceRecordPosition(position)
-                  .getFirst();
-
   /**
-   * Unlike {@link #COMPLETE_REJECTION_EXPECTATION}, this doesn't filter by {@code
-   * sourceRecordPosition}: with command batching disabled (or too small a limit), each self-chained
-   * follow-up {@code COMPLETE} command is dequeued in its own processing round and gets its own
-   * source position, so the closing rejection's source position isn't the initial command's
-   * position. Filtering by {@code processInstanceKey} instead still identifies the right (and only)
-   * rejection, regardless of how many rounds the batch took.
+   * Self-chained follow-up {@code COMPLETE} commands are each dequeued in their own processing
+   * round (with command batching disabled) or reprocessed eagerly within the initial one (the
+   * default), so the closing rejection's source position isn't reliably the initial command's
+   * position. Filtering by {@code processInstanceKey} instead identifies the right (and only)
+   * rejection regardless of how many rounds completion took.
    */
   private static final Function<Long, Record<AgentInstanceRecordValue>>
-      COMPLETE_BATCH_REJECTION_EXPECTATION =
+      COMPLETE_REJECTION_EXPECTATION =
           (processInstanceKey) ->
               RecordingExporter.agentInstanceRecords()
                   .onlyCommandRejections()
@@ -117,14 +100,8 @@ public final class AgentInstanceClient {
     return this;
   }
 
-  /**
-   * Clears {@code agentInstanceKey} (even if a previous {@link #withAgentInstanceKey} call set it),
-   * so {@link #complete()} drives the "batch completion" branch of {@code AGENT_INSTANCE:COMPLETE}:
-   * complete one agent instance still belonging to this process instance, self-chaining until none
-   * remain.
-   */
+  /** Sets the process instance the agent instance belongs to. */
   public AgentInstanceClient withProcessInstanceKey(final long processInstanceKey) {
-    record.setAgentInstanceKey(-1L);
     record.setProcessInstanceKey(processInstanceKey);
     return this;
   }
@@ -236,25 +213,15 @@ public final class AgentInstanceClient {
 
   /**
    * Drives {@code AGENT_INSTANCE:COMPLETE} directly, without requiring a ProcessProcessor-driven
-   * process instance lifecycle. Targets {@link #withAgentInstanceKey} when set, otherwise drives
-   * the "batch completion" branch for {@link #withProcessInstanceKey} — which always ends in a
-   * {@code NOT_FOUND} rejection once every agent instance for that process instance has been
-   * completed, so {@link #expectRejection()} is not needed: batch completion always waits for that
-   * rejection, the signal that closes the loop.
+   * process instance lifecycle: completes every agent instance belonging to {@link
+   * #withProcessInstanceKey}. Always returns the closing {@code NOT_FOUND} rejection, the signal
+   * that every agent instance for that process instance has been completed, so {@link
+   * #expectRejection()} is not needed.
    */
   public Record<AgentInstanceRecordValue> complete() {
-    final boolean isBatchCompletion = record.getAgentInstanceKey() == -1L;
-    final long position =
-        writer.writeCommand(
-            record.getAgentInstanceKey(),
-            AgentInstanceIntent.COMPLETE,
-            record,
-            authorizedTenantIds.toArray(new String[0]));
-    if (isBatchCompletion) {
-      return COMPLETE_BATCH_REJECTION_EXPECTATION.apply(record.getProcessInstanceKey());
-    }
-    return (expectRejection ? COMPLETE_REJECTION_EXPECTATION : COMPLETED_EXPECTATION)
-        .apply(position);
+    writer.writeCommand(
+        AgentInstanceIntent.COMPLETE, record, authorizedTenantIds.toArray(new String[0]));
+    return COMPLETE_REJECTION_EXPECTATION.apply(record.getProcessInstanceKey());
   }
 
   private void applyChangedAttributes() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentInstanceClient.java
@@ -79,6 +79,23 @@ public final class AgentInstanceClient {
                   .withSourceRecordPosition(position)
                   .getFirst();
 
+  /**
+   * Unlike {@link #COMPLETE_REJECTION_EXPECTATION}, this doesn't filter by {@code
+   * sourceRecordPosition}: with command batching disabled (or too small a limit), each self-chained
+   * follow-up {@code COMPLETE} command is dequeued in its own processing round and gets its own
+   * source position, so the closing rejection's source position isn't the initial command's
+   * position. Filtering by {@code processInstanceKey} instead still identifies the right (and only)
+   * rejection, regardless of how many rounds the batch took.
+   */
+  private static final Function<Long, Record<AgentInstanceRecordValue>>
+      COMPLETE_BATCH_REJECTION_EXPECTATION =
+          (processInstanceKey) ->
+              RecordingExporter.agentInstanceRecords()
+                  .onlyCommandRejections()
+                  .withIntent(AgentInstanceIntent.COMPLETE)
+                  .withProcessInstanceKey(processInstanceKey)
+                  .getFirst();
+
   private final CommandWriter writer;
   private final AgentInstanceRecord record = new AgentInstanceRecord();
   private final LinkedHashSet<String> autoChangedAttributes = new LinkedHashSet<>();
@@ -226,16 +243,17 @@ public final class AgentInstanceClient {
    * rejection, the signal that closes the loop.
    */
   public Record<AgentInstanceRecordValue> complete() {
+    final boolean isBatchCompletion = record.getAgentInstanceKey() == -1L;
     final long position =
         writer.writeCommand(
             record.getAgentInstanceKey(),
             AgentInstanceIntent.COMPLETE,
             record,
             authorizedTenantIds.toArray(new String[0]));
-    final boolean isBatchCompletion = record.getAgentInstanceKey() == -1L;
-    return (isBatchCompletion || expectRejection
-            ? COMPLETE_REJECTION_EXPECTATION
-            : COMPLETED_EXPECTATION)
+    if (isBatchCompletion) {
+      return COMPLETE_BATCH_REJECTION_EXPECTATION.apply(record.getProcessInstanceKey());
+    }
+    return (expectRejection ? COMPLETE_REJECTION_EXPECTATION : COMPLETED_EXPECTATION)
         .apply(position);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentInstanceClient.java
@@ -101,11 +101,13 @@ public final class AgentInstanceClient {
   }
 
   /**
-   * Leaves {@code agentInstanceKey} unset, so {@link #complete()} drives the "batch completion"
-   * branch of {@code AGENT_INSTANCE:COMPLETE}: complete one agent instance still belonging to this
-   * process instance, self-chaining until none remain.
+   * Clears {@code agentInstanceKey} (even if a previous {@link #withAgentInstanceKey} call set it),
+   * so {@link #complete()} drives the "batch completion" branch of {@code AGENT_INSTANCE:COMPLETE}:
+   * complete one agent instance still belonging to this process instance, self-chaining until none
+   * remain.
    */
   public AgentInstanceClient withProcessInstanceKey(final long processInstanceKey) {
+    record.setAgentInstanceKey(-1L);
     record.setProcessInstanceKey(processInstanceKey);
     return this;
   }


### PR DESCRIPTION
## Description

When a process instance completes, terminates, or is canceled, `AgentInstanceBehavior.completeAgentInstancesOfProcessInstance()` loads every agent instance key for that process instance into a list and writes one `AgentInstance:COMPLETE` follow-up command per entry in the same processing round. Neither the memory load nor the number of records written is bounded, so a process instance that accumulated many agent instances over its lifetime (e.g. long-running feedback-loop patterns with repeated re-entry) can exceed the record-batch size limit and get stuck unable to complete.

This PR bounds both. `AgentInstanceIntent.COMPLETE` already completes one agent instance identified by `agentInstanceKey`; this reuses the same record and intent rather than introducing a new value type, giving it a second meaning when `agentInstanceKey` is unset and only `processInstanceKey` is present: complete one remaining agent instance belonging to that process instance, then re-append the same command as a follow-up so the next one is picked up on the next cycle. When none remain, the command is rejected `NOT_FOUND` — which doubles as the signal that the process instance's agent instances are fully cleaned up. At most two records are written per processing round (the `COMPLETED` event plus the re-issued `COMPLETE`), so this relies on the engine's existing follow-up-command batching rather than adding a bespoke batch limit or cursor.

`AgentInstanceBehavior.completeAgentInstancesOfProcessInstance()` now appends a single `AgentInstance:COMPLETE` command scoped to the process instance instead of one per agent instance key. Finding "one remaining agent instance for this process instance" is done via a new resumable lookup on `AgentInstanceState` that stops at the first match instead of materializing the full key list, so neither the state read nor the number of appended commands scales with how many agent instances the process instance has accumulated.

An earlier version of this fix (#59337) introduced a dedicated `AGENT_INSTANCE_BATCH` value type/intent/record to drive this. It's not reused here: that record carried only a subset of `AGENT_INSTANCE`'s fields, the extra self-chaining `COMPLETE` step before the terminal `COMPLETED` was unneeded overhead, and the cursor it carried is unnecessary since a completed agent instance is already removed from state by `AgentInstanceCompletedApplier` by the time the next cycle looks for one.

## Checklist

- [ ] Enable backports when necessary.
- [ ] C8 Orchestration Cluster E2E Test Suite — not touched by this change.

## Related issues

Closes #57562
Supersedes #59337 (closed in favor of this PR — see that PR's review discussion for why the `AGENT_INSTANCE_BATCH` approach was dropped)