### PR TITLE
feat: export DRAINING process-definition state

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/ProcessDefinitionState.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/ProcessDefinitionState.java
@@ -17,6 +17,7 @@ package io.camunda.client.api.search.enums;
 
 public enum ProcessDefinitionState {
   ACTIVE,
+  DRAINING,
   DELETED,
   UNKNOWN_ENUM_VALUE;
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessDefinitionMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessDefinitionMapper.java
@@ -42,5 +42,7 @@ public interface ProcessDefinitionMapper {
 
   void markDeleted(Long processDefinitionKey);
 
+  void markDraining(Long processDefinitionKey);
+
   void deleteByKeys(List<Long> processDefinitionKeys);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessDefinitionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessDefinitionWriter.java
@@ -46,6 +46,16 @@ public class ProcessDefinitionWriter implements RdbmsWriter {
             processDefinitionKey));
   }
 
+  public void markDraining(final Long processDefinitionKey) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.PROCESS_DEFINITION,
+            WriteStatementType.UPDATE,
+            processDefinitionKey,
+            "io.camunda.db.rdbms.sql.ProcessDefinitionMapper.markDraining",
+            processDefinitionKey));
+  }
+
   public void deleteByKeys(final List<Long> processDefinitionKeys) {
     processDefinitionMapper.deleteByKeys(processDefinitionKeys);
   }

--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -370,6 +370,14 @@
     WHERE PROCESS_DEFINITION_KEY = #{processDefinitionKey}
   </update>
 
+  <update id="markDraining" parameterType="java.lang.Long">
+    <bind name="state"
+      value="@io.camunda.search.entities.ProcessDefinitionEntity$ProcessDefinitionState@DRAINING"/>
+    UPDATE ${prefix}PROCESS_DEFINITION
+    SET STATE = #{state}
+    WHERE PROCESS_DEFINITION_KEY = #{processDefinitionKey}
+  </update>
+
   <sql id="processInstanceStatisticsWhere">
     <where>
       pi.STATE = 'ACTIVE'

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/ProcessDefinitionWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/ProcessDefinitionWriterTest.java
@@ -70,4 +70,21 @@ class ProcessDefinitionWriterTest {
                     "io.camunda.db.rdbms.sql.ProcessDefinitionMapper.markDeleted",
                     processDefinitionKey)));
   }
+
+  @Test
+  void shouldMarkProcessDefinitionDraining() {
+    final Long processDefinitionKey = 123L;
+
+    writer.markDraining(processDefinitionKey);
+
+    verify(executionQueue)
+        .executeInQueue(
+            eq(
+                new QueueItem(
+                    ContextType.PROCESS_DEFINITION,
+                    WriteStatementType.UPDATE,
+                    processDefinitionKey,
+                    "io.camunda.db.rdbms.sql.ProcessDefinitionMapper.markDraining",
+                    processDefinitionKey)));
+  }
 }

--- a/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
+++ b/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
@@ -296,8 +296,8 @@
               },
               "state": {
                 "type": "string",
-                "enum": ["ACTIVE", "DELETED"],
-                "description": "Filter by the process definition's state. When not set, process definitions in any state are returned. Set to `ACTIVE` to exclude deleted definitions (recommended for most use cases). Set to `DELETED` to return only definitions that have been deleted but are still retained in secondary storage. "
+                "enum": ["ACTIVE", "DRAINING", "DELETED"],
+                "description": "Filter by the process definition's state. When not set, process definitions in any state are returned. Set to `ACTIVE` to exclude draining and deleted definitions (recommended for most use cases). Set to `DRAINING` to return only definitions that are being deleted but still have active process instances draining. Set to `DELETED` to return only definitions that have been deleted but are still retained in secondary storage. "
               },
               "version": {
                 "type": "integer",

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ProcessDefinitionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ProcessDefinitionEntity.java
@@ -34,6 +34,7 @@ public record ProcessDefinitionEntity(
 
   public enum ProcessDefinitionState {
     ACTIVE,
+    DRAINING,
     DELETED
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/ProcessDefinitionState.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/ProcessDefinitionState.java
@@ -9,5 +9,6 @@ package io.camunda.webapps.schema.entities;
 
 public enum ProcessDefinitionState {
   ACTIVE,
+  DRAINING,
   DELETED
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -56,6 +56,7 @@ import io.camunda.exporter.handlers.MessageSubscriptionFromProcessMessageSubscri
 import io.camunda.exporter.handlers.MigratedVariableHandler;
 import io.camunda.exporter.handlers.PostImporterQueueFromIncidentHandler;
 import io.camunda.exporter.handlers.ProcessDeletedHandler;
+import io.camunda.exporter.handlers.ProcessDrainingHandler;
 import io.camunda.exporter.handlers.ProcessHandler;
 import io.camunda.exporter.handlers.ResourceCreatedHandler;
 import io.camunda.exporter.handlers.ResourceDeletedHandler;
@@ -306,6 +307,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 processCache,
                 configuration.getExtensionProperties()),
             new ProcessDeletedHandler(
+                indexDescriptors.get(ProcessIndex.class).getFullQualifiedName()),
+            new ProcessDrainingHandler(
                 indexDescriptors.get(ProcessIndex.class).getFullQualifiedName()),
             new EmbeddedFormHandler(indexDescriptors.get(FormIndex.class).getFullQualifiedName()),
             new FormHandler(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessDrainingHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessDrainingHandler.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import io.camunda.webapps.schema.entities.ProcessDefinitionState;
+import io.camunda.webapps.schema.entities.ProcessEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.Process;
+import java.util.List;
+import java.util.Map;
+
+public class ProcessDrainingHandler implements ExportHandler<ProcessEntity, Process> {
+
+  private final String indexName;
+
+  public ProcessDrainingHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.PROCESS;
+  }
+
+  @Override
+  public Class<ProcessEntity> getEntityType() {
+    return ProcessEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<Process> record) {
+    return record.getIntent() == ProcessIntent.DRAINING;
+  }
+
+  @Override
+  public List<String> generateIds(final Record<Process> record) {
+    return List.of(String.valueOf(record.getValue().getProcessDefinitionKey()));
+  }
+
+  @Override
+  public ProcessEntity createNewEntity(final String id) {
+    return new ProcessEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(final Record<Process> record, final ProcessEntity entity) {
+    entity.setState(ProcessDefinitionState.DRAINING);
+  }
+
+  @Override
+  public void flush(
+      final TargetIndex index, final ProcessEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    batchRequest.update(
+        index, entity.getId(), Map.of(ProcessIndex.STATE, ProcessDefinitionState.DRAINING));
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessDrainingHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessDrainingHandlerTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import io.camunda.webapps.schema.entities.ProcessDefinitionState;
+import io.camunda.webapps.schema.entities.ProcessEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableProcess;
+import io.camunda.zeebe.protocol.record.value.deployment.Process;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+
+class ProcessDrainingHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-process";
+  private final ProcessDrainingHandler underTest = new ProcessDrainingHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.PROCESS);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(ProcessEntity.class);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ProcessIntent.class,
+      names = {"DRAINING"},
+      mode = Mode.INCLUDE)
+  void shouldHandleRecord(final ProcessIntent intent) {
+    // given
+    final Record<Process> record =
+        factory.generateRecord(ValueType.PROCESS, r -> r.withIntent(intent));
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isTrue();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ProcessIntent.class,
+      names = {"DRAINING"},
+      mode = Mode.EXCLUDE)
+  void shouldNotHandleRecord(final ProcessIntent intent) {
+    // given
+    final Record<Process> record =
+        factory.generateRecord(ValueType.PROCESS, r -> r.withIntent(intent));
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldGenerateIdFromProcessDefinitionKey() {
+    // given
+    final long expectedKey = 123L;
+    final Process value =
+        ImmutableProcess.builder()
+            .from(factory.generateObject(ImmutableProcess.class))
+            .withProcessDefinitionKey(expectedKey)
+            .build();
+    final Record<Process> record =
+        factory.generateRecord(
+            ValueType.PROCESS, r -> r.withIntent(ProcessIntent.DRAINING).withValue(value));
+
+    // when
+    final var ids = underTest.generateIds(record);
+
+    // then
+    assertThat(ids).containsExactly(String.valueOf(expectedKey));
+  }
+
+  @Test
+  void shouldCreateNewEntityWithId() {
+    // when
+    final var entity = underTest.createNewEntity("456");
+
+    // then
+    assertThat(entity).isNotNull();
+    assertThat(entity.getId()).isEqualTo("456");
+    assertThat(entity.getState()).isEqualTo(ProcessDefinitionState.ACTIVE);
+  }
+
+  @Test
+  void shouldSetStateDrainingOnUpdateEntity() {
+    // given
+    final Record<Process> record =
+        factory.generateRecord(ValueType.PROCESS, r -> r.withIntent(ProcessIntent.DRAINING));
+    final ProcessEntity entity = new ProcessEntity();
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getState()).isEqualTo(ProcessDefinitionState.DRAINING);
+  }
+
+  @Test
+  void shouldFlushPartialUpdateWithStateDraining() throws Exception {
+    // given
+    final ProcessEntity entity = new ProcessEntity().setId("789");
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(index, entity, mockRequest);
+
+    // then
+    verify(mockRequest)
+        .update(index, "789", Map.of(ProcessIndex.STATE, ProcessDefinitionState.DRAINING));
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandler.java
@@ -43,6 +43,7 @@ public class ProcessExportHandler implements RdbmsExportHandler<Process> {
   public boolean canExport(final Record<Process> record) {
     return record.getValueType() == ValueType.PROCESS
         && (record.getIntent() == ProcessIntent.CREATED
+            || record.getIntent() == ProcessIntent.DRAINING
             || record.getIntent() == ProcessIntent.DELETED);
   }
 
@@ -50,6 +51,10 @@ public class ProcessExportHandler implements RdbmsExportHandler<Process> {
   public void export(final Record<Process> record) {
     if (record.getIntent() == ProcessIntent.DELETED) {
       processDefinitionWriter.markDeleted(record.getValue().getProcessDefinitionKey());
+      return;
+    }
+    if (record.getIntent() == ProcessIntent.DRAINING) {
+      processDefinitionWriter.markDraining(record.getValue().getProcessDefinitionKey());
       return;
     }
 

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandlerTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.db.rdbms.write.service.ProcessDefinitionWriter;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableProcess;
+import io.camunda.zeebe.protocol.record.value.deployment.Process;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+
+class ProcessExportHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final ProcessDefinitionWriter processDefinitionWriter =
+      mock(ProcessDefinitionWriter.class);
+
+  @SuppressWarnings("unchecked")
+  private final ProcessExportHandler underTest =
+      new ProcessExportHandler(
+          processDefinitionWriter,
+          mock(ExporterEntityCache.class),
+          mock(ExtensionPropertyConfiguration.class));
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ProcessIntent.class,
+      names = {"CREATED", "DRAINING", "DELETED"},
+      mode = Mode.INCLUDE)
+  void shouldExportHandledIntents(final ProcessIntent intent) {
+    // given
+    final Record<Process> record =
+        factory.generateRecord(ValueType.PROCESS, r -> r.withIntent(intent));
+
+    // when - then
+    assertThat(underTest.canExport(record)).isTrue();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ProcessIntent.class,
+      names = {"CREATED", "DRAINING", "DELETED"},
+      mode = Mode.EXCLUDE)
+  void shouldNotExportOtherIntents(final ProcessIntent intent) {
+    // given
+    final Record<Process> record =
+        factory.generateRecord(ValueType.PROCESS, r -> r.withIntent(intent));
+
+    // when - then
+    assertThat(underTest.canExport(record)).isFalse();
+  }
+
+  @Test
+  void shouldMarkDrainingOnDrainingRecord() {
+    // given
+    final long processDefinitionKey = 123L;
+    final Process value =
+        ImmutableProcess.builder()
+            .from(factory.generateObject(ImmutableProcess.class))
+            .withProcessDefinitionKey(processDefinitionKey)
+            .build();
+    final Record<Process> record =
+        factory.generateRecord(
+            ValueType.PROCESS, r -> r.withIntent(ProcessIntent.DRAINING).withValue(value));
+
+    // when
+    underTest.export(record);
+
+    // then
+    verify(processDefinitionWriter).markDraining(processDefinitionKey);
+  }
+
+  @Test
+  void shouldMarkDeletedOnDeletedRecord() {
+    // given
+    final long processDefinitionKey = 456L;
+    final Process value =
+        ImmutableProcess.builder()
+            .from(factory.generateObject(ImmutableProcess.class))
+            .withProcessDefinitionKey(processDefinitionKey)
+            .build();
+    final Record<Process> record =
+        factory.generateRecord(
+            ValueType.PROCESS, r -> r.withIntent(ProcessIntent.DELETED).withValue(value));
+
+    // when
+    underTest.export(record);
+
+    // then
+    verify(processDefinitionWriter).markDeleted(processDefinitionKey);
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
@@ -470,12 +470,15 @@ components:
           description: |
             Filter by the process definition's state.
             When not set, process definitions in any state are returned.
-            Set to `ACTIVE` to exclude deleted definitions (recommended for most use cases).
+            Set to `ACTIVE` to exclude draining and deleted definitions (recommended for most use cases).
+            Set to `DRAINING` to return only definitions that are being deleted but still have
+            active process instances draining.
             Set to `DELETED` to return only definitions that have been deleted but are still
             retained in secondary storage.
           type: string
           enum:
             - ACTIVE
+            - DRAINING
             - DELETED
 
     ProcessDefinitionSearchQueryResult:
@@ -535,10 +538,14 @@ components:
           description: Indicates whether the start event of the process has an associated Form Key.
           type: boolean
         state:
-          description: The state of this process definition.
+          description: |
+            The state of this process definition.
+            `DRAINING` indicates the definition is being deleted but still has active process
+            instances draining before it is removed.
           type: string
           enum:
             - ACTIVE
+            - DRAINING
             - DELETED
 
     ProcessDefinitionElementStatisticsQuery:


### PR DESCRIPTION
## Description

- add DRAINING to Java client process-definition state enum
- expose DRAINING in process-definition REST API
- persist DRAINING process-definition state in rdbms-exporter
- persist DRAINING process-definition state in camunda-exporter
- add DRAINING process-definition state

## Related issues

related to https://github.com/camunda/camunda/issues/56987
