### PR TITLE
ci: load-test: fix Renovate automerge configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -728,6 +728,19 @@
         "**Manual verification required before merging:** maven-failsafe-plugin must be updated together with maven-surefire-plugin. Check that [apache/maven-surefire#3203](https://github.com/apache/maven-surefire/issues/3203) (inner class test report bug in 3.5.4) and the ArchUnit issue in 3.5.3 are fixed before updating both plugins.",
       ],
     },
+
+    {
+      // Disable automerge for all the load test updates, by default.
+      // Automerge can be turned on, on a case by case basis, as needed, until
+      // the teams are more confident about the updates received.
+      matchFileNames: ["load-tests/**"],
+      automerge: false,
+      prBodyNotes: [
+        "**:warning: Manual verification required before merging :warning:**",
+        "Confirm with the team(s) affected by the update (if any) that the update is safe to merge.",
+      ],
+    },
+
     {
       description: "Prevent supply-chain-attacks by not creating branches or PRs before the minimum release age.",
       matchPackageNames: [

--- a/.github/renovate/team-reliability-testing.json5
+++ b/.github/renovate/team-reliability-testing.json5
@@ -27,13 +27,10 @@
   ],
 
   packageRules: [
-    {
-      // Disable automerge for all the load test updates, by default.
-      // Automerge can be turned on, on a case by case basis, as needed, until
-      // the teams are more confident about the updates received.
-      matchFileNames: ["load-tests/**"],
-      automerge: false,
-    },
+    // Automerge is disabled for all load test updates in the .github/renovate.json5 file.
+    // We can't configure this behavior here, as the content of
+    // .github/renovate.json5 takes precedence over this file, and automerge is
+    // globally enabled in .github/renovate.json5.
 
     {
       // Simplify the commit message when updating the Camunda Platform Helm Chart for load tests


### PR DESCRIPTION
## Description

Since we [include our team preset *first*](https://github.com/camunda/camunda/blob/f3391c3291865da6dc316647f2df52a9794c645c/.github/renovate.json5#L9), then the configuration from `.github/renovate.json5` applies, the [global "automerge as much as possible" behavior](https://github.com/camunda/camunda/blob/f3391c3291865da6dc316647f2df52a9794c645c/.github/renovate.json5#L695-L704) takes precedence over [ours](https://github.com/camunda/camunda/blob/f3391c3291865da6dc316647f2df52a9794c645c/.github/renovate/team-reliability-testing.json5#L30-L36).

Noticed via the 2 new PRs for OpenSearch, which should definitely not be automerged:

* https://github.com/camunda/camunda/pull/59483
* https://github.com/camunda/camunda/pull/59485

This moves the "disable automerge for load tests" configuration into the main Renovate configuration file to disable automerge for load tests for real.

Also added a PR body note, as configured for the other packages with automerge disabled (just above in the code).

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/pull/59410
* https://camunda.slack.com/archives/C07N9H8FSSW/p1785938474089379?thread_ts=1785845773.648929&cid=C07N9H8FSSW
* https://github.com/camunda/camunda/issues/58912
