### PR TITLE
feat: add bounded secret cache

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
@@ -22,7 +22,10 @@ import io.camunda.secretstore.aws.AwsSecretsManagerStoreConfig;
 import io.camunda.secretstore.file.FileBasedSecretStore;
 import io.camunda.secretstore.gcp.GcpSecretManagerSecretStore;
 import io.camunda.secretstore.gcp.GcpSecretManagerStoreConfig;
+import io.camunda.zeebe.shared.management.ActorClockService;
 import java.nio.file.Path;
+import java.time.Instant;
+import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -57,18 +60,21 @@ public class SecretStoreConfiguration {
               "gcp", "GCP Secret Manager", Stores::getGcp, SecretStoreConfiguration::gcpStore));
 
   @Bean
-  public SecretStoreRegistries secretStoreRegistries(final PhysicalTenantResolver resolver) {
+  public SecretStoreRegistries secretStoreRegistries(
+      final PhysicalTenantResolver resolver, final ActorClockService clockService) {
     final Map<String, SecretStoreRegistry> registries = new LinkedHashMap<>();
     // tracks every store successfully constructed across all tenants processed so far, so a
     // failure partway through (e.g. a later tenant's AWS store failing to build) can close
     // them instead of leaking their underlying clients/connections
     final List<SecretStore> created = new ArrayList<>();
+    final var timeSource = new ActorClockInstantSource(clockService);
     try {
       resolver
           .mapValues(Camunda::getSecrets)
           .forEach(
               (tenantId, secrets) ->
-                  registries.put(tenantId, buildRegistry(tenantId, secrets.getStores(), created)));
+                  registries.put(
+                      tenantId, buildRegistry(tenantId, secrets.getStores(), created, timeSource)));
     } catch (final RuntimeException e) {
       closeAll(created);
       throw e;
@@ -77,7 +83,10 @@ public class SecretStoreConfiguration {
   }
 
   private static SecretStoreRegistry buildRegistry(
-      final String tenantId, final Stores config, final List<SecretStore> created) {
+      final String tenantId,
+      final Stores config,
+      final List<SecretStore> created,
+      final InstantSource timeSource) {
     // cap is one store total per tenant, counted across all store types combined
     final long totalStores =
         STORE_BINDINGS.stream().mapToLong(binding -> binding.ids(config).size()).sum();
@@ -100,7 +109,7 @@ public class SecretStoreConfiguration {
       stores.put(SecretStoreRegistry.DEFAULT_STORE_ID, NOOP_STORE);
       LOG.info("No secret stores configured for physical tenant '{}', using noop store", tenantId);
     }
-    return new SecretStoreRegistry(Map.copyOf(stores));
+    return new SecretStoreRegistry(Map.copyOf(stores), Map.of(), timeSource);
   }
 
   private static void closeAll(final List<SecretStore> stores) {
@@ -199,6 +208,31 @@ public class SecretStoreConfiguration {
             config.getPathPrefix(),
             config.getEndpoint(),
             config.getContainerSecretId()));
+  }
+
+  /**
+   * Adapts {@link ActorClockService}, which exposes only epoch millis, into an {@link
+   * InstantSource} for the secret cache's expiry — so {@code /actuator/clock} time travel reaches
+   * cached secrets, and both broker and gateway share the same time source as the rest of the
+   * platform.
+   *
+   * <p>Overrides {@link #millis()} rather than relying on the default {@code
+   * instant().toEpochMilli()}, since the cache reads its ticker on every lookup, including on the
+   * job-activation path where an allocation per lookup is exactly what that path's contract rules
+   * out. {@link io.camunda.zeebe.scheduler.clock.ActorClock} overrides the same pair for the same
+   * reason.
+   */
+  private record ActorClockInstantSource(ActorClockService clockService) implements InstantSource {
+
+    @Override
+    public Instant instant() {
+      return Instant.ofEpochMilli(clockService.epochMilli());
+    }
+
+    @Override
+    public long millis() {
+      return clockService.epochMilli();
+    }
   }
 
   /** Builds one {@link SecretStore} from a single configured entry of a given store type. */

--- a/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.secretstore.CaffeineSecretCache;
 import io.camunda.secretstore.SecretErrorCode;
 import io.camunda.secretstore.SecretResolutionResult.Failed;
 import io.camunda.secretstore.SecretResolutionResult.Resolved;
@@ -23,6 +24,10 @@ import io.camunda.secretstore.SecretStore;
 import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.secretstore.aws.AwsSecretsManagerSecretStore;
 import io.camunda.secretstore.file.FileBasedSecretStore;
+import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
+import io.camunda.zeebe.shared.management.ActorClockEndpoint;
+import io.camunda.zeebe.shared.management.ActorClockService;
+import io.camunda.zeebe.shared.management.ControlledActorClockService;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -38,6 +43,7 @@ import org.springframework.mock.env.MockEnvironment;
 class SecretStoreConfigurationTest {
 
   private static final SecretStoreConfiguration CONFIG = new SecretStoreConfiguration();
+  private static final ActorClockService CLOCK_SERVICE = System::currentTimeMillis;
 
   @Test
   void shouldFallbackToNoopStoreForDefaultTenantWhenNoStoresConfigured() {
@@ -45,7 +51,7 @@ class SecretStoreConfigurationTest {
     final var resolver = resolverFor(Map.of());
 
     // when
-    final var registries = CONFIG.secretStoreRegistries(resolver).byPhysicalTenant();
+    final var registries = registries(resolver).byPhysicalTenant();
 
     // then
     assertThat(registries).containsKey(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
@@ -65,7 +71,7 @@ class SecretStoreConfigurationTest {
         resolverFor(Map.of("camunda.secrets.stores.file.default.path", secretsDir.toString()));
 
     // when
-    final var registries = CONFIG.secretStoreRegistries(resolver).byPhysicalTenant();
+    final var registries = registries(resolver).byPhysicalTenant();
 
     // then the configured directory is what the store reads
     final var registry = registries.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
@@ -83,7 +89,7 @@ class SecretStoreConfigurationTest {
 
     // when / then
     assertThatIllegalStateException()
-        .isThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
+        .isThrownBy(() -> registries(resolver))
         .withMessageContaining("no path configured")
         .withMessageContaining(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
   }
@@ -99,7 +105,7 @@ class SecretStoreConfigurationTest {
 
     // when / then
     assertThatIllegalStateException()
-        .isThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
+        .isThrownBy(() -> registries(resolver))
         .withMessageContaining(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
         .withMessageContaining("only one is supported");
   }
@@ -111,7 +117,7 @@ class SecretStoreConfigurationTest {
         resolverFor(Map.of("camunda.secrets.stores.file.Default.path", "/etc/camunda/secrets"));
 
     // when
-    final var registries = CONFIG.secretStoreRegistries(resolver).byPhysicalTenant();
+    final var registries = registries(resolver).byPhysicalTenant();
 
     // then
     final var registry = registries.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
@@ -126,7 +132,7 @@ class SecretStoreConfigurationTest {
 
     // when / then
     assertThatIllegalStateException()
-        .isThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
+        .isThrownBy(() -> registries(resolver))
         .withMessageContaining(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
         .withMessageContaining("main")
         .withMessageContaining("the only supported store id is 'default'")
@@ -145,7 +151,7 @@ class SecretStoreConfigurationTest {
     // when / then — the normalized id appears in no configuration file, so naming it would send
     // the operator looking for a property they never wrote
     assertThatIllegalStateException()
-        .isThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
+        .isThrownBy(() -> registries(resolver))
         .withMessageContaining("camunda.secrets.stores.file.MyStore")
         .withMessageNotContaining("mystore");
   }
@@ -166,7 +172,7 @@ class SecretStoreConfigurationTest {
     // when / then — pointing at camunda.secrets.stores would send the operator to configure a
     // different tenant, leaving this one's store misnamed
     assertThatIllegalStateException()
-        .isThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
+        .isThrownBy(() -> registries(resolver))
         .withMessageContaining("camunda.physical-tenants.tenanta.secrets.stores.file.default")
         .withMessageNotContaining("rename camunda.secrets.stores");
   }
@@ -182,7 +188,7 @@ class SecretStoreConfigurationTest {
 
       // when / then
       assertThatIllegalStateException()
-          .isThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
+          .isThrownBy(() -> registries(resolver))
           .withMessageContaining("the only supported store id is 'default'");
 
       // then — nothing was built, so nothing had to be rolled back
@@ -200,7 +206,7 @@ class SecretStoreConfigurationTest {
         resolverFor(Map.of("camunda.secrets.stores.file.default.path", secretsDir.toString()));
 
     // when
-    final var registries = CONFIG.secretStoreRegistries(resolver).byPhysicalTenant();
+    final var registries = registries(resolver).byPhysicalTenant();
 
     // then the configured store stands, rather than being replaced by the noop fallback
     final var registry = registries.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
@@ -221,7 +227,7 @@ class SecretStoreConfigurationTest {
                 "mytenant"));
 
     // when
-    final var registries = CONFIG.secretStoreRegistries(resolver).byPhysicalTenant();
+    final var registries = registries(resolver).byPhysicalTenant();
 
     // then
     assertThat(registries).containsKey("mytenant");
@@ -256,7 +262,7 @@ class SecretStoreConfigurationTest {
                 "tenantb"));
 
     // when
-    final var registries = CONFIG.secretStoreRegistries(resolver).byPhysicalTenant();
+    final var registries = registries(resolver).byPhysicalTenant();
 
     // then each tenant has its own registry with its own store
     assertThat(registries).containsKeys("tenanta", "tenantb");
@@ -284,7 +290,7 @@ class SecretStoreConfigurationTest {
                 "camunda.secrets.stores.aws.default.path-prefix", "camunda/"));
 
     // when
-    final var registries = CONFIG.secretStoreRegistries(resolver).byPhysicalTenant();
+    final var registries = registries(resolver).byPhysicalTenant();
 
     // then the aws branch is what built the store, not the noop fallback or another store type
     final var registry = registries.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
@@ -298,6 +304,37 @@ class SecretStoreConfigurationTest {
   }
 
   @Test
+  void shouldExpireACachedSecretWhenTheClockEndpointTravelsForward(@TempDir final Path secretsDir)
+      throws IOException {
+    // given a file store, resolved once so the value is cached
+    Files.writeString(secretsDir.resolve("token"), "token-value");
+    final var resolver =
+        resolverFor(Map.of("camunda.secrets.stores.file.default.path", secretsDir.toString()));
+    final var clockService = new ControlledActorClockService(new ControlledActorClock());
+    final var registries = CONFIG.secretStoreRegistries(resolver, clockService).byPhysicalTenant();
+    final var store =
+        registries
+            .get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+            .getStores()
+            .get(SecretStoreRegistry.DEFAULT_STORE_ID);
+    store.resolve(Set.of("token"));
+    assertThat(store.lookupLocal("token")).contains("token-value");
+
+    // when the /actuator/clock endpoint travels forward past the cache's TTL — driven through the
+    // real endpoint rather than the mutable clock directly, since ControlledActorClock only
+    // reflects a mutation once update() runs, which is exactly what the endpoint does for every
+    // write; adding (never pinning) keeps the ticker moving forward relative to the write
+    // timestamp already recorded for the cached entry
+    final var response =
+        new ActorClockEndpoint(clockService)
+            .modify("add", null, CaffeineSecretCache.DEFAULT_TTL.plusMinutes(1).toMillis());
+    assertThat(response.getStatus()).isEqualTo(200);
+
+    // then the cached secret has expired
+    assertThat(store.lookupLocal("token")).isEmpty();
+  }
+
+  @Test
   void shouldThrowWhenFileAndAwsSecretsManagerStoresCombinedExceedOne() {
     // given one file store and one aws store for the same tenant
     final var resolver =
@@ -308,7 +345,7 @@ class SecretStoreConfigurationTest {
 
     // when / then
     assertThatIllegalStateException()
-        .isThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
+        .isThrownBy(() -> registries(resolver))
         .withMessageContaining(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
         .withMessageContaining("only one is supported");
   }
@@ -324,7 +361,7 @@ class SecretStoreConfigurationTest {
 
     // when / then — the per-tenant cap is enforced before any GCP client is built
     assertThatIllegalStateException()
-        .isThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
+        .isThrownBy(() -> registries(resolver))
         .withMessageContaining(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
         .withMessageContaining("only one is supported");
   }
@@ -361,7 +398,7 @@ class SecretStoreConfigurationTest {
 
       // when / then — the build fails and the failure propagates (Mockito wraps the construction
       // failure, but it is still a RuntimeException the rollback path catches)
-      assertThatThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
+      assertThatThrownBy(() -> registries(resolver))
           .isInstanceOf(RuntimeException.class)
           .hasRootCauseInstanceOf(IllegalStateException.class);
 
@@ -380,6 +417,10 @@ class SecretStoreConfigurationTest {
     assertThat(store.resolve(Set.of("token")))
         .containsEntry(
             "token", new Failed(SecretErrorCode.NOT_FOUND, "No secret store configured", null));
+  }
+
+  private static SecretStoreRegistries registries(final PhysicalTenantResolver resolver) {
+    return CONFIG.secretStoreRegistries(resolver, CLOCK_SERVICE);
   }
 
   private static PhysicalTenantResolver resolverFor(final Map<String, Object> properties) {

--- a/secret-store/secret-store-api/pom.xml
+++ b/secret-store/secret-store-api/pom.xml
@@ -20,6 +20,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
     </dependency>

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/CachingSecretStore.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/CachingSecretStore.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.secretstore;
 
+import io.camunda.secretstore.SecretResolutionResult.Failed;
+import io.camunda.secretstore.SecretResolutionResult.Resolved;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -21,9 +23,15 @@ import org.jspecify.annotations.NullMarked;
  * cache itself. The cache is this store's own: no caller is handed one alongside it, and nothing
  * reaches the wrapped store except through here.
  *
- * <p>Only a resolved value is cached: a failure has to stay retryable, or a secret that was briefly
- * unreadable would stay unresolvable until the process restarts. {@link #list()} goes straight to
- * the store, since a cache holds the values read so far rather than the store's set of secrets.
+ * <p>A resolved value is cached by either read, but only {@link #resolveFromStore} treats a failure
+ * as authoritative: a permanent {@link SecretErrorCode} there clears any stale cached value for
+ * that name, while a {@link SecretErrorCode#UNREADABLE} failure is transient and leaves the stale
+ * value in place rather than dropping a still-healthy secret over a read blip. A failure from
+ * {@link #resolve}'s own cache-miss read never clears anything: that read only ever runs for a name
+ * already absent from the cache, so treating it as authoritative would let a request-time read that
+ * failed for reasons of its own erase a value {@link #resolveFromStore} just established as
+ * current. {@link #list()} goes straight to the store, since a cache holds the values read so far
+ * rather than the store's set of secrets.
  *
  * <p>What the cache holds is also what {@link #lookupLocal} answers with, so a value read by one
  * caller is what a later cache-only lookup of another sees.
@@ -46,7 +54,10 @@ public final class CachingSecretStore implements LocallyCachedSecretStore {
    * Resolves the given names, serving the cached ones and asking the store only for the rest.
    *
    * <p>A name the store answers without a result for is left out of the returned map, exactly as
-   * the store left it out, so a caller can still tell an unanswered name apart from a failed one.
+   * the store left it out, so a caller can still tell an unanswered name apart from a failed one. A
+   * store failure here is returned but never clears a cached value: this read only ever reaches the
+   * store for a name already absent from the cache, so it is not the authoritative source a stale
+   * value should be invalidated against — {@link #resolveFromStore} is.
    */
   @Override
   public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
@@ -57,20 +68,62 @@ public final class CachingSecretStore implements LocallyCachedSecretStore {
       if (cached == null) {
         misses.add(name);
       } else {
-        results.put(name, new SecretResolutionResult.Resolved(cached));
+        results.put(name, new Resolved(cached));
       }
     }
     if (misses.isEmpty()) {
       return results;
     }
 
-    results.putAll(resolveAndCache(misses));
+    store
+        .resolve(misses)
+        .forEach(
+            (name, result) -> {
+              if (result instanceof Resolved(final var value)) {
+                cache.put(name, value);
+              }
+              results.put(name, result);
+            });
     return results;
   }
 
+  /**
+   * Asks the store for the given names regardless of what the cache holds, and updates the cache
+   * with what it answers: a resolved value replaces what was held, and a permanent failure clears
+   * it. This is the one path allowed to invalidate a stale cached value, since it is the only
+   * caller that treats the store's answer as authoritative rather than a request-time convenience.
+   */
   @Override
   public Map<String, SecretResolutionResult> resolveFromStore(final Set<String> names) {
-    return resolveAndCache(names);
+    final Map<String, SecretResolutionResult> results = new LinkedHashMap<>();
+    store
+        .resolve(names)
+        .forEach(
+            (name, result) -> {
+              switch (result) {
+                case Resolved(final var value) -> cache.put(name, value);
+                case final Failed failed -> invalidateOnPermanentFailure(name, failed.code());
+              }
+              results.put(name, result);
+            });
+    return results;
+  }
+
+  /**
+   * Clears a cached value only for a permanent failure. {@link SecretErrorCode#UNREADABLE} is
+   * transient, so the stale value is left in place rather than dropping a still-healthy secret over
+   * a read blip. The switch is exhaustive and without a {@code default}, so a code added later has
+   * to be classified here explicitly instead of silently falling into either branch.
+   */
+  private void invalidateOnPermanentFailure(final String name, final SecretErrorCode code) {
+    final boolean permanent =
+        switch (code) {
+          case NOT_FOUND, ACCESS_DENIED, INVALID_REF -> true;
+          case UNREADABLE -> false;
+        };
+    if (permanent) {
+      cache.remove(name);
+    }
   }
 
   /** Serves what the cache holds, never reading the wrapped store. */
@@ -94,20 +147,5 @@ public final class CachingSecretStore implements LocallyCachedSecretStore {
   @Override
   public boolean is(final Class<? extends SecretStore> storeType) {
     return store.is(storeType);
-  }
-
-  /** Asks the store for the given names and caches every value it answers with. */
-  private Map<String, SecretResolutionResult> resolveAndCache(final Set<String> names) {
-    final Map<String, SecretResolutionResult> results = new LinkedHashMap<>();
-    store
-        .resolve(names)
-        .forEach(
-            (name, result) -> {
-              if (result instanceof final SecretResolutionResult.Resolved resolved) {
-                cache.put(name, resolved.value());
-              }
-              results.put(name, result);
-            });
-    return results;
   }
 }

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/CachingSecretStore.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/CachingSecretStore.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.secretstore;
 
+import io.camunda.secretstore.SecretResolutionResult.Failed;
+import io.camunda.secretstore.SecretResolutionResult.Resolved;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -21,9 +23,15 @@ import org.jspecify.annotations.NullMarked;
  * cache itself. The cache is this store's own: no caller is handed one alongside it, and nothing
  * reaches the wrapped store except through here.
  *
- * <p>Only a resolved value is cached: a failure has to stay retryable, or a secret that was briefly
- * unreadable would stay unresolvable until the process restarts. {@link #list()} goes straight to
- * the store, since a cache holds the values read so far rather than the store's set of secrets.
+ * <p>A resolved value is cached by either read, but only {@link #resolveFromStore} treats a failure
+ * as authoritative: a permanent {@link SecretErrorCode} there clears any stale cached value for
+ * that name, while a {@link SecretErrorCode#UNREADABLE} failure is transient and leaves the stale
+ * value in place rather than dropping a still-healthy secret over a read blip. A failure from
+ * {@link #resolve}'s own cache-miss read never clears anything: that read only ever runs for a name
+ * already absent from the cache, so treating it as authoritative would let a request-time read that
+ * failed for reasons of its own erase a value {@link #resolveFromStore} just established as
+ * current. {@link #list()} goes straight to the store, since a cache holds the values read so far
+ * rather than the store's set of secrets.
  *
  * <p>What the cache holds is also what {@link #lookupLocal} answers with, so a value read by one
  * caller is what a later cache-only lookup of another sees.
@@ -46,7 +54,10 @@ public final class CachingSecretStore implements LocallyCachedSecretStore {
    * Resolves the given names, serving the cached ones and asking the store only for the rest.
    *
    * <p>A name the store answers without a result for is left out of the returned map, exactly as
-   * the store left it out, so a caller can still tell an unanswered name apart from a failed one.
+   * the store left it out, so a caller can still tell an unanswered name apart from a failed one. A
+   * store failure here is returned but never clears a cached value: this read only ever reaches the
+   * store for a name already absent from the cache, so it is not the authoritative source a stale
+   * value should be invalidated against — {@link #resolveFromStore} is.
    */
   @Override
   public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
@@ -57,20 +68,49 @@ public final class CachingSecretStore implements LocallyCachedSecretStore {
       if (cached == null) {
         misses.add(name);
       } else {
-        results.put(name, new SecretResolutionResult.Resolved(cached));
+        results.put(name, new Resolved(cached));
       }
     }
     if (misses.isEmpty()) {
       return results;
     }
 
-    results.putAll(resolveAndCache(misses));
+    store
+        .resolve(misses)
+        .forEach(
+            (name, result) -> {
+              if (result instanceof Resolved(final var value)) {
+                cache.put(name, value);
+              }
+              results.put(name, result);
+            });
     return results;
   }
 
+  /**
+   * Asks the store for the given names regardless of what the cache holds, and updates the cache
+   * with what it answers: a resolved value replaces what was held, and a permanent failure clears
+   * it. This is the one path allowed to invalidate a stale cached value, since it is the only
+   * caller that treats the store's answer as authoritative rather than a request-time convenience.
+   */
   @Override
   public Map<String, SecretResolutionResult> resolveFromStore(final Set<String> names) {
-    return resolveAndCache(names);
+    final Map<String, SecretResolutionResult> results = new LinkedHashMap<>();
+    store
+        .resolve(names)
+        .forEach(
+            (name, result) -> {
+              switch (result) {
+                case Resolved(final var value) -> cache.put(name, value);
+                case final Failed failed when failed.code() != SecretErrorCode.UNREADABLE ->
+                    cache.remove(name);
+                case final Failed ignored -> {
+                  // UNREADABLE: transient, leave the stale value in place
+                }
+              }
+              results.put(name, result);
+            });
+    return results;
   }
 
   /** Serves what the cache holds, never reading the wrapped store. */
@@ -94,20 +134,5 @@ public final class CachingSecretStore implements LocallyCachedSecretStore {
   @Override
   public boolean is(final Class<? extends SecretStore> storeType) {
     return store.is(storeType);
-  }
-
-  /** Asks the store for the given names and caches every value it answers with. */
-  private Map<String, SecretResolutionResult> resolveAndCache(final Set<String> names) {
-    final Map<String, SecretResolutionResult> results = new LinkedHashMap<>();
-    store
-        .resolve(names)
-        .forEach(
-            (name, result) -> {
-              if (result instanceof final SecretResolutionResult.Resolved resolved) {
-                cache.put(name, resolved.value());
-              }
-              results.put(name, result);
-            });
-    return results;
   }
 }

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/CaffeineSecretCache.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/CaffeineSecretCache.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Ticker;
+import java.time.Duration;
+import java.time.InstantSource;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The production default {@link SecretCache}: a value expires {@link #DEFAULT_TTL} after it was
+ * cached, so a secret rotated in the store is picked up without a restart, and the cache never
+ * grows past {@link #DEFAULT_MAX_SIZE} entries. One instance is created per configured store (see
+ * {@link SecretStoreRegistry}), so the bound is per store, and that same construction is what keeps
+ * entries of different stores apart.
+ *
+ * <p>Expiry is driven by an injected {@link InstantSource} rather than the wall clock directly, so
+ * a test can advance time instead of sleeping, and so a controlled clock (as {@code
+ * /actuator/clock} mutates in production) reaches the cache. Caffeine expects a monotonic ticker: a
+ * source that steps backward (an NTP correction, or a controlled clock reset after a forward {@code
+ * /actuator/clock} jump) can make an entry live longer than the TTL, or in a narrow window let an
+ * already-expired one be served once more before Caffeine's own asynchronous removal catches up.
+ * The bound on this is what matters: it can only delay expiry, never corrupt a value, and only a
+ * clock movement large enough to rival the TTL can trigger it — ordinary wall-clock drift can't, so
+ * this only bites the controlled-clock, {@code /actuator/clock}-driven tests and tooling that this
+ * feature itself exists to support, not the default uncontrolled clock production runs on.
+ *
+ * <p>Eviction of expired or excess entries happens asynchronously; {@link #cleanUp()} forces it
+ * synchronously, which is only useful in tests that need to observe the bound immediately.
+ */
+public final class CaffeineSecretCache implements SecretCache {
+
+  public static final Duration DEFAULT_TTL = Duration.ofMinutes(20);
+  public static final int DEFAULT_MAX_SIZE = 1000;
+
+  private final Cache<String, String> cache;
+
+  private CaffeineSecretCache(final Cache<String, String> cache) {
+    this.cache = cache;
+  }
+
+  /**
+   * Creates a cache bounded by the given size and expiring entries the given duration after write.
+   */
+  public static CaffeineSecretCache create(
+      final int maxSize, final Duration ttl, final InstantSource timeSource) {
+    return new CaffeineSecretCache(
+        Caffeine.newBuilder()
+            .maximumSize(maxSize)
+            .expireAfterWrite(ttl)
+            .ticker(toTicker(timeSource))
+            .build());
+  }
+
+  /**
+   * Creates a new cache with {@link #DEFAULT_MAX_SIZE} and {@link #DEFAULT_TTL}.
+   *
+   * @return a new cache
+   */
+  public static CaffeineSecretCache createDefault(final InstantSource timeSource) {
+    return create(DEFAULT_MAX_SIZE, DEFAULT_TTL, timeSource);
+  }
+
+  private static Ticker toTicker(final InstantSource timeSource) {
+    return () -> TimeUnit.MILLISECONDS.toNanos(timeSource.millis());
+  }
+
+  @Override
+  public Optional<String> get(final String name) {
+    return Optional.ofNullable(cache.getIfPresent(name));
+  }
+
+  @Override
+  public void put(final String name, final String value) {
+    cache.put(name, value);
+  }
+
+  @Override
+  public void remove(final String name) {
+    cache.invalidate(name);
+  }
+
+  /**
+   * Performs any pending maintenance operations needed by the cache, including eviction of expired
+   * or excess entries. This method is primarily useful in tests to force synchronous eviction,
+   * since Caffeine performs eviction asynchronously by default.
+   */
+  public void cleanUp() {
+    cache.cleanUp();
+  }
+}

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/InMemorySecretCache.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/InMemorySecretCache.java
@@ -12,9 +12,10 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * A minimal {@link SecretCache} backed by a {@link ConcurrentHashMap}, with no eviction or expiry.
- * The concurrent map makes it safe to use in front of a thread-safe {@link SecretStore} and rejects
- * {@code null} keys and values.
+ * A minimal {@link SecretCache} backed by a {@link ConcurrentHashMap}, with no eviction or expiry
+ * by design — for callers and tests that want none. {@link CaffeineSecretCache} is what {@link
+ * SecretStoreRegistry} defaults to. The concurrent map makes it safe to use in front of a
+ * thread-safe {@link SecretStore} and rejects {@code null} keys and values.
  */
 public final class InMemorySecretCache implements SecretCache {
 
@@ -28,5 +29,10 @@ public final class InMemorySecretCache implements SecretCache {
   @Override
   public void put(final String name, final String value) {
     values.put(name, value);
+  }
+
+  @Override
+  public void remove(final String name) {
+    values.remove(name);
   }
 }

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/LocallyCachedSecretStore.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/LocallyCachedSecretStore.java
@@ -49,12 +49,17 @@ public interface LocallyCachedSecretStore extends SecretStore {
 
   /**
    * Resolves the given names against the backing store even where a value for them is already held,
-   * holding on to what the store answers with just as {@link #resolve} does.
+   * holding on to a resolved value just as {@link #resolve} does.
    *
    * <p>For the caller whose outcome outlives the value: the background resolution writes a durable,
    * exported record stating that a secret resolved, which an exporter and a later activation both
    * act on, so it has to ask the store rather than trust a value held since before the secret may
    * have been deleted. Every other caller wants {@link #resolve}, which is cache-first.
+   *
+   * <p>This is also the only read whose failure clears an already-held value, since it is the one
+   * caller treating the store's answer as authoritative: {@link #resolve} only ever reaches the
+   * store for a name it does not hold, so a failure there has nothing of this store's own to
+   * invalidate.
    */
   Map<String, SecretResolutionResult> resolveFromStore(Set<String> names);
 }

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretCache.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretCache.java
@@ -16,9 +16,9 @@ import java.util.Optional;
  * <p>Implementations must be thread-safe: a {@link SecretStore} may be resolved concurrently, so
  * the cache in front of it is accessed concurrently too.
  *
- * <p>This is the stable contract callers resolve secrets through; the minimal {@link
- * InMemorySecretCache} has no eviction or expiry, and a TTL/eviction variant replaces it later
- * behind this same interface.
+ * <p>This is the stable contract callers resolve secrets through. {@link CaffeineSecretCache} is
+ * the production default, bounding both staleness and size; the minimal {@link InMemorySecretCache}
+ * has no eviction or expiry and is kept for callers and tests that want none.
  */
 public interface SecretCache {
 
@@ -31,4 +31,7 @@ public interface SecretCache {
 
   /** Stores the resolved value for the secret name, overwriting any previously cached value. */
   void put(String name, String value);
+
+  /** Removes any cached value for the secret name. */
+  void remove(String name);
 }

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStoreRegistry.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStoreRegistry.java
@@ -7,13 +7,13 @@
  */
 package io.camunda.secretstore;
 
+import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -42,13 +42,15 @@ public final class SecretStoreRegistry {
   }
 
   /**
-   * Creates a registry whose stores cache in the given caches instead of the default in-memory one.
-   * This is the seam for a cache implementation other than {@link InMemorySecretCache} — a TTL and
-   * eviction variant, or a test double. A store the caches do not cover still gets an in-memory
-   * cache, so every store handed out holds what it resolved whichever constructor is used.
+   * Creates a registry whose stores cache in the given caches instead of the default {@link
+   * CaffeineSecretCache}. This is the seam for a test double, or a per-store cache the caller wants
+   * instead of the default. A store the caches do not cover still gets the default cache, and a
+   * store that caches natively is left as it is, so every store handed out holds what it resolved
+   * whichever constructor is used.
    *
-   * <p>A cache given for a store that caches natively is ignored rather than put in front of it:
-   * the store's own cache stands, so this seam reaches only the stores this registry wraps.
+   * <p>Uses the system clock for any store the caches do not cover — see the three-argument
+   * constructor to drive the default cache's expiry from another time source (production wiring
+   * passes the actor clock, so {@code /actuator/clock} time travel reaches it).
    *
    * @throws IllegalArgumentException if a cache is given for a store ID nothing is configured for,
    *     or if two store IDs are given the same cache instance — the cache is keyed by the bare
@@ -57,12 +59,24 @@ public final class SecretStoreRegistry {
    */
   public SecretStoreRegistry(
       final Map<String, SecretStore> stores, final Map<String, SecretCache> caches) {
-    rejectUnusableCaches(stores, caches);
-    this.stores = locallyCachedStores(stores, caches);
+    this(stores, caches, InstantSource.system());
   }
 
   /**
-   * Returns all configured secret stores, keyed by store ID.
+   * Creates a registry as the two-argument constructor does, but drives the default cache's expiry
+   * from {@code timeSource} instead of the system clock — the choice of default cache is already
+   * the registry's job, and that default is now time-driven.
+   */
+  public SecretStoreRegistry(
+      final Map<String, SecretStore> stores,
+      final Map<String, SecretCache> caches,
+      final InstantSource timeSource) {
+    rejectUnusableCaches(stores, caches);
+    this.stores = locallyCachedStores(stores, caches, timeSource);
+  }
+
+  /**
+   * Returns all configured stores as locally cached stores, keyed by store ID.
    *
    * <p>A lookup in this map is exact, so a store ID that names no configured store addresses none.
    * A {@code camunda.secrets.<name>} reference addresses {@link #DEFAULT_STORE_ID}.
@@ -105,24 +119,31 @@ public final class SecretStoreRegistry {
   }
 
   private static Map<String, LocallyCachedSecretStore> locallyCachedStores(
-      final Map<String, SecretStore> stores, final Map<String, SecretCache> caches) {
+      final Map<String, SecretStore> stores,
+      final Map<String, SecretCache> caches,
+      final InstantSource timeSource) {
     final Map<String, LocallyCachedSecretStore> locallyCached = new LinkedHashMap<>();
     stores.forEach(
-        (storeId, store) -> locallyCached.put(storeId, locallyCached(storeId, store, caches)));
+        (storeId, store) ->
+            locallyCached.put(storeId, locallyCached(storeId, store, caches, timeSource)));
     return Collections.unmodifiableMap(locallyCached);
   }
 
   /**
    * Returns the store itself when it caches natively — wrapping it would put a second cache in
    * front of its own — and otherwise the store behind the cache configured for it, or a fresh
-   * in-memory one when the configured caches do not cover it.
+   * time-and-size-bounded one when the configured caches do not cover it.
    */
   private static LocallyCachedSecretStore locallyCached(
-      final String storeId, final SecretStore store, final Map<String, SecretCache> caches) {
+      final String storeId,
+      final SecretStore store,
+      final Map<String, SecretCache> caches,
+      final InstantSource timeSource) {
     if (store instanceof final LocallyCachedSecretStore locallyCached) {
       return locallyCached;
     }
-    final var cache = Optional.ofNullable(caches.get(storeId)).orElseGet(InMemorySecretCache::new);
-    return new CachingSecretStore(store, cache);
+    final var configured = caches.get(storeId);
+    return new CachingSecretStore(
+        store, configured != null ? configured : CaffeineSecretCache.createDefault(timeSource));
   }
 }

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CachingSecretStoreTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CachingSecretStoreTest.java
@@ -11,6 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.secretstore.SecretResolutionResult.Failed;
 import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -175,6 +177,40 @@ class CachingSecretStoreTest {
     assertThat(store.resolveCalls).containsExactly(Set.of("token"));
     assertThat(results.get("token"))
         .isEqualTo(new Failed(SecretErrorCode.NOT_FOUND, "failed: token", null));
+    assertThat(cachingStore.lookupLocal("token")).isEmpty();
+  }
+
+  @Test
+  void shouldInvalidateACachedValueWhenResolvingFromTheStoreFails() {
+    // given a cached value that the store now fails authoritatively
+    cache.put("token", "cached-value");
+    store.fails("token", SecretErrorCode.ACCESS_DENIED);
+
+    // when
+    cachingStore.resolveFromStore(Set.of("token"));
+
+    // then the stale value is no longer available to cache-only readers
+    assertThat(cachingStore.lookupLocal("token")).isEmpty();
+  }
+
+  @Test
+  void shouldInvalidateOnlyFailedNamesInABatchResolvedFromTheStore() {
+    // given two cached values, where the store now resolves one and rejects the other
+    cache.put("token", "old-token");
+    cache.put("apiKey", "old-api-key");
+    store.holds("token", "new-token");
+    store.fails("apiKey", SecretErrorCode.ACCESS_DENIED);
+
+    // when
+    final var results = cachingStore.resolveFromStore(Set.of("token", "apiKey"));
+
+    // then the successful result refreshes its cache entry, and the failed result clears only its
+    // stale value
+    assertThat(results)
+        .containsEntry("token", new Resolved("new-token"))
+        .containsEntry("apiKey", new Failed(SecretErrorCode.ACCESS_DENIED, "failed: apiKey", null));
+    assertThat(cachingStore.lookupLocal("token")).contains("new-token");
+    assertThat(cachingStore.lookupLocal("apiKey")).isEmpty();
   }
 
   @Test
@@ -204,6 +240,19 @@ class CachingSecretStoreTest {
   }
 
   @Test
+  void shouldKeepAStaleCachedValueWhenTheStoreFailsWithATransientError() {
+    // given a cached value the store can no longer read due to a transient error
+    cache.put("token", "cached-value");
+    store.fails("token", SecretErrorCode.UNREADABLE);
+
+    // when
+    cachingStore.resolveFromStore(Set.of("token"));
+
+    // then the stale value stays available rather than being dropped over a read blip
+    assertThat(cachingStore.lookupLocal("token")).contains("cached-value");
+  }
+
+  @Test
   void shouldAnswerATypeCheckForTheStoreItWraps() {
     // when / then the wrapper answers for the store it caches for, so a caller can tell which store
     // was configured whether or not it had to be wrapped
@@ -227,6 +276,38 @@ class CachingSecretStoreTest {
   void shouldAnswerATypeCheckForAStoreThatIsNotWrapped() {
     // when / then an unwrapped store answers for itself, so the same check serves both
     assertThat(store.is(RecordingSecretStore.class)).isTrue();
+  }
+
+  @Test
+  void shouldResolveARotatedValueOnceTheTtlElapses() {
+    // given a store whose value changes, cached through a TTL-bounded cache instead of the
+    // never-expiring in-memory fake the other tests use
+    final var timeSource = new ControlledInstantSource(Instant.parse("2026-01-01T00:00:00Z"));
+    final var ttl = Duration.ofMinutes(20);
+    final var ttlCache =
+        CaffeineSecretCache.create(CaffeineSecretCache.DEFAULT_MAX_SIZE, ttl, timeSource);
+    final var ttlStore = new CachingSecretStore(store, ttlCache);
+    store.holds("token", "v1");
+
+    // when resolved once, the store is read and the value cached
+    assertThat(ttlStore.resolve(Set.of("token")).get("token")).isEqualTo(new Resolved("v1"));
+    assertThat(store.resolveCalls).containsExactly(Set.of("token"));
+
+    // and when the store's value changes before the TTL elapses
+    store.holds("token", "v2");
+    ttlStore.resolve(Set.of("token"));
+
+    // then the cache still answers with the stale value, and the store was not asked again
+    assertThat(ttlStore.resolve(Set.of("token")).get("token")).isEqualTo(new Resolved("v1"));
+    assertThat(store.resolveCalls).containsExactly(Set.of("token"));
+
+    // when the TTL elapses
+    timeSource.advance(ttl);
+
+    // then the next resolution reads the store again and picks up the rotated value, with no
+    // restart required
+    assertThat(ttlStore.resolve(Set.of("token")).get("token")).isEqualTo(new Resolved("v2"));
+    assertThat(store.resolveCalls).containsExactly(Set.of("token"), Set.of("token"));
   }
 
   private static final class RecordingSecretStore implements SecretStore {

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CaffeineSecretCacheTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CaffeineSecretCacheTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+final class CaffeineSecretCacheTest {
+
+  private final ControlledInstantSource timeSource =
+      new ControlledInstantSource(Instant.parse("2026-01-01T00:00:00Z"));
+  private final CaffeineSecretCache cache =
+      CaffeineSecretCache.create(
+          CaffeineSecretCache.DEFAULT_MAX_SIZE, Duration.ofMinutes(20), timeSource);
+
+  @Test
+  void shouldServeAValueBeforeTheTtlElapses() {
+    // given
+    cache.put("token", "secret-value");
+    timeSource.advance(Duration.ofMinutes(19));
+
+    // when / then
+    assertThat(cache.get("token")).contains("secret-value");
+  }
+
+  @Test
+  void shouldMissAfterTheTtlElapses() {
+    // given
+    cache.put("token", "secret-value");
+
+    // when the TTL elapses
+    timeSource.advance(Duration.ofMinutes(20));
+
+    // then the next lookup misses, without a cleanUp() call: Caffeine checks expiry against the
+    // ticker on the read path itself
+    assertThat(cache.get("token")).isEmpty();
+  }
+
+  @Test
+  void shouldNotExpireJustBeforeTheTtlElapses() {
+    // given
+    cache.put("token", "secret-value");
+
+    // when one millisecond short of the TTL
+    timeSource.advance(Duration.ofMinutes(20).minusMillis(1));
+
+    // then still present, pinning the boundary against an off-by-one
+    assertThat(cache.get("token")).contains("secret-value");
+  }
+
+  @Test
+  void shouldNotGrowBeyondTheMaximumSize() {
+    // given a cache bounded to a small size
+    final var bounded = CaffeineSecretCache.create(10, Duration.ofMinutes(20), timeSource);
+
+    // when more distinct names are written than the bound allows
+    for (int i = 0; i < 100; i++) {
+      bounded.put("secret-" + i, "value-" + i);
+    }
+    // Caffeine evicts asynchronously; force maintenance rather than asserting on an exact count
+    // immediately
+    bounded.cleanUp();
+
+    // then no more than the bound survived
+    final var survivors =
+        (int) IntStream.range(0, 100).filter(i -> bounded.get("secret-" + i).isPresent()).count();
+    assertThat(survivors).isEqualTo(10);
+  }
+
+  @Test
+  void shouldOverwriteValueOnSecondPut() {
+    // given
+    cache.put("token", "old-value");
+
+    // when
+    cache.put("token", "new-value");
+
+    // then
+    assertThat(cache.get("token")).contains("new-value");
+  }
+
+  @Test
+  void shouldRemoveAValue() {
+    // given
+    cache.put("token", "secret-value");
+
+    // when
+    cache.remove("token");
+
+    // then
+    assertThat(cache.get("token")).isEmpty();
+  }
+
+  @Test
+  void shouldIsolateDistinctReferences() {
+    // given
+    cache.put("token", "token-value");
+    cache.put("apiKey", "api-key-value");
+
+    // when / then
+    assertThat(cache.get("token")).contains("token-value");
+    assertThat(cache.get("apiKey")).contains("api-key-value");
+    assertThat(cache.get("unknown")).isEmpty();
+  }
+
+  @Test
+  void shouldRejectNullValue() {
+    // when / then — a resolved value is never null; Caffeine guards against it the same way
+    // InMemorySecretCache's ConcurrentHashMap does
+    assertThatThrownBy(() -> cache.put("token", null)).isInstanceOf(NullPointerException.class);
+  }
+}

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/ControlledInstantSource.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/ControlledInstantSource.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.InstantSource;
+
+/** A mutable {@link InstantSource} test double, advanced explicitly instead of sleeping. */
+final class ControlledInstantSource implements InstantSource {
+
+  private Instant instant;
+
+  ControlledInstantSource(final Instant instant) {
+    this.instant = instant;
+  }
+
+  void advance(final Duration duration) {
+    instant = instant.plus(duration);
+  }
+
+  @Override
+  public Instant instant() {
+    return instant;
+  }
+}

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/InMemorySecretCacheTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/InMemorySecretCacheTest.java
@@ -72,6 +72,19 @@ final class InMemorySecretCacheTest {
   }
 
   @Test
+  void shouldRemoveValue() {
+    // given
+    final var reference = "token";
+    cache.put(reference, "secret-value");
+
+    // when
+    cache.remove(reference);
+
+    // then
+    assertThat(cache.get(reference)).isEmpty();
+  }
+
+  @Test
   void shouldIsolateDistinctReferences() {
     // given
     cache.put("token", "token-value");

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretStoreRegistryTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretStoreRegistryTest.java
@@ -13,6 +13,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.secretstore.SecretResolutionResult.Failed;
 import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -177,6 +179,70 @@ class SecretStoreRegistryTest {
     assertThat(lookupLocal(registry, "default", "token")).isEmpty();
   }
 
+  @Test
+  void shouldExpireTheDefaultCacheOfAStoreAfterTheTtl() {
+    // given a registry using the default cache, driven by an injected time source instead of the
+    // system clock
+    final var timeSource = new ControlledInstantSource(Instant.parse("2026-01-01T00:00:00Z"));
+    final var registry =
+        new SecretStoreRegistry(
+            Map.of("default", storeHolding("token", "value")), Map.of(), timeSource);
+    registry.getStores().get("default").resolve(Set.of("token"));
+    assertThat(lookupLocal(registry, "default", "token")).contains("value");
+
+    // when the default cache's TTL elapses
+    timeSource.advance(CaffeineSecretCache.DEFAULT_TTL);
+
+    // then the cached value is gone, proving the registry's construction site actually wires the
+    // injected time source into the default cache
+    assertThat(lookupLocal(registry, "default", "token")).isEmpty();
+  }
+
+  @Test
+  void shouldKeepTheDefaultCachesOfTwoStoresApart() {
+    // given two stores holding a different value under the same name, both on the default cache
+    // (as opposed to shouldKeepTheCachedValuesOfTwoStoresApart, which covers the no-time-source
+    // one-argument constructor)
+    final var timeSource = new ControlledInstantSource(Instant.parse("2026-01-01T00:00:00Z"));
+    final var registry =
+        new SecretStoreRegistry(
+            Map.of("store-a", storeHolding("token", "a"), "store-b", storeHolding("token", "b")),
+            Map.of(),
+            timeSource);
+
+    // when only one of them resolves it
+    registry.getStores().get("store-a").resolve(Set.of("token"));
+
+    // then the other one holds nothing: what a store caches is its own
+    assertThat(lookupLocal(registry, "store-a", "token")).contains("a");
+    assertThat(lookupLocal(registry, "store-b", "token")).isEmpty();
+  }
+
+  @Test
+  void shouldResolveARotatedValueAfterTheTtlThroughTheRegistry() {
+    // given a store whose value changes, resolved through the registry's default cache
+    final var timeSource = new ControlledInstantSource(Instant.parse("2026-01-01T00:00:00Z"));
+    final var store = new MutableSecretStore("token", "v1");
+    final var registry = new SecretStoreRegistry(Map.of("default", store), Map.of(), timeSource);
+    registry.getStores().get("default").resolve(Set.of("token"));
+
+    // when the store's value changes before the TTL elapses
+    store.holds("token", "v2");
+    registry.getStores().get("default").resolve(Set.of("token"));
+
+    // then the registry still answers with the cached value, and the store was not asked again
+    assertThat(lookupLocal(registry, "default", "token")).contains("v1");
+    assertThat(store.resolveCalls).containsExactly(Set.of("token"));
+
+    // when the TTL elapses
+    timeSource.advance(CaffeineSecretCache.DEFAULT_TTL);
+    registry.getStores().get("default").resolve(Set.of("token"));
+
+    // then the rotated value is picked up, with no restart required
+    assertThat(lookupLocal(registry, "default", "token")).contains("v2");
+    assertThat(store.resolveCalls).containsExactly(Set.of("token"), Set.of("token"));
+  }
+
   private static Optional<String> lookupLocal(
       final SecretStoreRegistry registry, final String storeId, final String name) {
     return registry.getStores().get(storeId).lookupLocal(name);
@@ -210,6 +276,32 @@ class SecretStoreRegistryTest {
                   : new Resolved(value));
         });
     return results;
+  }
+
+  /** A store whose set of secrets can change, to tell a held value apart from the store's own. */
+  private static final class MutableSecretStore implements SecretStore {
+
+    private final Map<String, String> values = new LinkedHashMap<>();
+    private final List<Set<String>> resolveCalls = new ArrayList<>();
+
+    private MutableSecretStore(final String name, final String value) {
+      values.put(name, value);
+    }
+
+    @Override
+    public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
+      resolveCalls.add(Set.copyOf(names));
+      return resultsFor(names, values);
+    }
+
+    @Override
+    public List<String> list() {
+      return List.copyOf(values.keySet());
+    }
+
+    void holds(final String name, final String value) {
+      values.put(name, value);
+    }
   }
 
   /**

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretActivationInjectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretActivationInjectionTest.java
@@ -440,5 +440,10 @@ public final class JobSecretActivationInjectionTest {
     public void put(final String name, final String value) {
       cachedSecrets.put(name, value);
     }
+
+    @Override
+    public void remove(final String name) {
+      cachedSecrets.remove(name);
+    }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
@@ -276,6 +276,9 @@ final class JobSecretInjectorTest {
 
             @Override
             public void put(final String name, final String value) {}
+
+            @Override
+            public void remove(final String name) {}
           };
       final var injector = new JobSecretInjector(registryWith(throwingCache));
       final var job = job(Map.of("auth", "camunda.secrets.token"), ref("token", "/auth"));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobWaitingForSecretResolutionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobWaitingForSecretResolutionTest.java
@@ -247,5 +247,10 @@ public final class JobWaitingForSecretResolutionTest {
     public void put(final String name, final String value) {
       cachedSecrets.put(name, value);
     }
+
+    @Override
+    public void remove(final String name) {
+      cachedSecrets.remove(name);
+    }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -266,9 +266,45 @@ final class SecretResolutionSchedulerTest {
     // then the store is asked even for a cached reference and the reference fails: the completion
     // record is durable and exported, so it must not claim a secret the store no longer has
     verify(secretStore).resolve(Set.of("db-password"));
+    assertThat(registry.getStores().get(STORE_ID).lookupLocal("db-password")).isEmpty();
     verify(resultBuilder).appendCommandRecord(eq(SecretReferenceIntent.RESOLUTION_FAIL), any());
     verify(resultBuilder, never())
         .appendCommandRecord(eq(SecretReferenceIntent.RESOLUTION_COMPLETE), any());
+  }
+
+  @Test
+  void shouldInvalidateOnlyFailedCachedReferencesInAMixedBatch() throws Exception {
+    // given two cached references, where an authoritative store read refreshes one and fails the
+    // other in the same scheduler batch
+    final var cache = new InMemorySecretCache();
+    cache.put("db-password", "old-password");
+    cache.put("api-key", "old-api-key");
+    final var registry =
+        new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, cache));
+    final var localScheduler =
+        new SecretResolutionScheduler(
+            () -> scheduledTaskState, registry, new EngineConfiguration());
+    localScheduler.onRecovered(context);
+    stubPending(STORE_ID, "db-password", "api-key");
+    when(secretStore.resolve(Set.of("db-password", "api-key")))
+        .thenReturn(
+            Map.of(
+                "db-password",
+                new SecretResolutionResult.Resolved("new-password"),
+                "api-key",
+                new SecretResolutionResult.Failed(
+                    SecretErrorCode.ACCESS_DENIED, "access denied", null)));
+
+    // when
+    localScheduler.resolveSecrets(resultBuilder);
+
+    // then the successful reference is still held locally with the refreshed value, while the
+    // failed reference is cleared so later cache-only activation cannot reveal it
+    assertThat(registry.getStores().get(STORE_ID).lookupLocal("db-password"))
+        .contains("new-password");
+    assertThat(registry.getStores().get(STORE_ID).lookupLocal("api-key")).isEmpty();
+    verify(resultBuilder).appendCommandRecord(eq(SecretReferenceIntent.RESOLUTION_COMPLETE), any());
+    verify(resultBuilder).appendCommandRecord(eq(SecretReferenceIntent.RESOLUTION_FAIL), any());
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/SecretActivationResponseCapture.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/SecretActivationResponseCapture.java
@@ -119,4 +119,9 @@ public final class SecretActivationResponseCapture implements SecretCache {
   public void put(final String name, final String value) {
     cachedSecrets.put(name, value);
   }
+
+  @Override
+  public void remove(final String name) {
+    cachedSecrets.remove(name);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/SecretStoreRegistries.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/SecretStoreRegistries.java
@@ -38,6 +38,9 @@ public final class SecretStoreRegistries {
 
           @Override
           public void put(final String name, final String ignored) {}
+
+          @Override
+          public void remove(final String name) {}
         };
     return new SecretStoreRegistry(
         Map.of(SecretStoreRegistry.DEFAULT_STORE_ID, new NoopSecretStore()),


### PR DESCRIPTION
## Description

Adds a bounded, TTL-based `SecretCache` implementation backed by Caffeine and makes it the default cache used by `SecretStoreRegistry` for stores that do not cache natively.

The registry now creates locally cached stores with a per-store cache by default. The cache bounds both size and staleness, and authoritative store failures invalidate stale cached values so deleted or denied secrets are not served by later cache-only reads.

The dist wiring passes the platform actor clock into the registry so default cache expiry follows `/actuator/clock`, making expiry deterministic in tests and consistent with the rest of the runtime.

## Test coverage

- Caffeine cache TTL expiry, boundary behavior, max-size eviction, overwrite, removal, null-value rejection, and monotonic behavior when the actor clock moves backward.
- Registry default-cache behavior, per-store cache isolation, and injected time-source expiry.
- Authoritative store failure invalidation, including mixed batches where resolved secrets refresh their cache entries while failed secrets clear only their own stale entries.
- Scheduler-level mixed-batch regression proving background resolution refreshes successful cached values and clears failed cached values before later cache-only reads.
- Dist wiring for actor-clock-driven expiry via `/actuator/clock`.

Close: https://github.com/camunda/camunda/issues/59314

