### PR TITLE
ci: stop an example expression from breaking post-failure-feedback

### DIFF
--- a/.github/actions/post-failure-feedback/action.yml
+++ b/.github/actions/post-failure-feedback/action.yml
@@ -41,9 +41,11 @@ inputs:
   pr_is_draft:
     description: >
       Draft state of `pr` when the caller already knows it — on a pull_request
-      trigger pass ${{ github.event.pull_request.draft }}, on merge_group pass
+      trigger pass the event's pull_request.draft value, on merge_group pass
       "false" (a draft cannot enter a merge queue). Empty means resolve it via
-      the API, which needs github_token.
+      the API, which needs github_token. Do not write an expression here: the
+      template engine evaluates it and the github context is unavailable in an
+      action's input metadata, which makes the whole action fail to load.
     required: false
     default: ""
   skip_on_draft:


### PR DESCRIPTION
## Description

**AlwaysGreen failure alerting is currently broken on `main`.** The `post-failure-feedback` action
fails to load, so no Slack alert is posted and the job around it fails:

```
##[error].github/actions/post-failure-feedback/action.yml (Line: 42, Col: 18):
Unrecognized named-value: 'github'.
Located at position 1 within expression: github.event.pull_request.draft
```

The cause is documentation, not logic. #59386 added the `pr_is_draft` input and documented its
usage inside the **description**:

```yaml
  pr_is_draft:
    description: >
      … on a pull_request trigger pass ${{ github.event.pull_request.draft }}, …
```

The template engine evaluates `${{ }}` anywhere in an action file, including input metadata, where
the `github` context does not exist. So the example expression makes the entire action unloadable.

## Why it has not been noticed

Nothing since the merge has had a failure that actually invokes the action. Both candidate `main`
runs failed in the **SaaS trigger** while the **helm** feedback step was `skipped`:

| Run | When | Failing job | Feedback step |
|---|---|---|---|
| [30924611582](https://github.com/camunda/camunda/actions/runs/30924611582) | 08-04 15:31 | Trigger SaaS E2E tests | skipped |
| [30992674680](https://github.com/camunda/camunda/actions/runs/30992674680) | 08-05 09:18 | Trigger SaaS E2E tests | skipped |

#59454 has since added a SaaS-side call to the same action, so the next failure of **either** kind
hits this. It is latent, not harmless.

Found by a live end-to-end test ([run 31018288615](https://github.com/camunda/camunda/actions/runs/31018288615))
whose deliberate helm e2e failure did invoke it: no feedback message was posted, and the triage
summary started its own Slack thread instead of replying under one — which is how the missing parent
surfaced.

## Fix

Describe the value in prose, and record why an expression must never go there.

## Verification

- The action file parses, and the only remaining `${{ }}` uses are in `runs:`/`with:`/`outputs:`,
  where contexts are available.
- `actionlint` does not catch this class of error — it is a GitHub-side template validation that
  only fires when the action is loaded at runtime, which is exactly why it reached `main`.
- **Proven by loading the action both ways.** A throwaway probe workflow invoked
  `post-failure-feedback` from two branches that differed only in this description:

  | Action file | Run | Result | `Unrecognized named-value` errors |
  |---|---|---|---|
  | unfixed (= `main`) | [31073682378](https://github.com/camunda/camunda/actions/runs/31073682378) | failure | **2** |
  | description fixed | [31073684639](https://github.com/camunda/camunda/actions/runs/31073684639) | success | **0** |

  The probe passed no `slack_channel` and no `github_token`, so nothing was posted anywhere — it
  only established whether the action loads. Both probe branches have since been removed; this PR
  is the one-file change.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Fixes a regression from #59386. Note its three backports (#59402, #59403, #59404) carry the same
broken description — they need this fix too, or they will break alerting on `stable/8.7`, `8.8` and
`8.9` as they merge.

