### PR TITLE
fix: route Operate and Optimize CI job failures away from Core Features

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -455,3 +455,7 @@ optimize.Dockerfile         @camunda/core-features
 # Operate frontend: overrides the broad /operate/ rule above, which predates the
 # operate-frontend/operate-backend team split.
 /operate/client/            @camunda/operate-frontend
+
+# Optimize frontend: overrides the broad /optimize/ rule above, which predates the
+# optimize-frontend/optimize-backend team split.
+/optimize/client/           @camunda/optimize-frontend

--- a/.codeowners
+++ b/.codeowners
@@ -451,3 +451,7 @@ optimize.Dockerfile         @camunda/core-features
 /zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/*/*     @camunda/core-features @camunda/zeebe-distributed-platform
 /zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/*/*/*   @camunda/core-features @camunda/zeebe-distributed-platform
 /zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/*         @camunda/core-features @camunda/zeebe-distributed-platform
+
+# Operate frontend: overrides the broad /operate/ rule above, which predates the
+# operate-frontend/operate-backend team split.
+/operate/client/            @camunda/operate-frontend

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -129,6 +129,7 @@ jobs:
         shardTotal: [4]
     env:
       TEST_TYPE: Unit
+      TEST_OWNER: '@camunda/operate-frontend'
     defaults:
       run:
         working-directory: ${{ env.CLIENT_DIR }}
@@ -384,6 +385,7 @@ jobs:
         shardTotal: [4]
     env:
       TEST_TYPE: visual-regression
+      TEST_OWNER: '@camunda/operate-frontend'
     container:
       image: mcr.microsoft.com/playwright:v1.61.1
       options: --user 1001:1000

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -424,6 +424,7 @@ jobs:
     permissions: { }
     env:
       TEST_TYPE: E2E
+      TEST_OWNER: '@camunda/optimize'
 
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
@@ -585,6 +586,7 @@ jobs:
     permissions: { }  # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: E2E
+      TEST_OWNER: '@camunda/optimize'
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
       - name: Checkout code

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -424,7 +424,7 @@ jobs:
     permissions: { }
     env:
       TEST_TYPE: E2E
-      TEST_OWNER: '@camunda/optimize'
+      TEST_OWNER: '@camunda/optimize-frontend'
 
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
@@ -586,7 +586,7 @@ jobs:
     permissions: { }  # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: E2E
-      TEST_OWNER: '@camunda/optimize'
+      TEST_OWNER: '@camunda/optimize-frontend'
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
       - name: Checkout code


### PR DESCRIPTION
## Description

`ci-operate.yml` and `ci-optimize.yml` each set a single file-level `TEST_OWNER`, so every `base-branch-unsuccessful-job` alert for any job in either file paged Core Features regardless of which product actually owns the failing test. This drove several L1 CI incidents to the wrong medic:

- Operate: INC-6888, INC-6892, INC-6914, INC-6930
- Optimize: INC-6887, INC-6899, INC-6932

This PR adds per-job `TEST_OWNER` overrides for the specific jobs behind those incidents:

- `ci-operate.yml`: `fe-unit-tests`, `operate-fe-visual-regression-tests` → `@camunda/operate-frontend`
- `ci-optimize.yml`: `optimize-e2e-smoke`, `e2e-cloud-test` → `@camunda/optimize-frontend`

It also adds a `.codeowners` override for `/operate/client/`, since the existing blanket `/operate/` rule predates the `operate-frontend`/`operate-backend` team split and currently attributes all PR reviews on Operate's own frontend code to Core Features (same for optimize).

