### PR TITLE
Define AgentDefinitionRecord, intents & value type

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
+import io.camunda.zeebe.protocol.record.intent.AgentDefinitionIntent;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.AsyncRequestIntent;
@@ -172,6 +173,7 @@ public final class EventAppliers implements EventApplier {
     registerJobMetricsBatchEventAppliers(state);
     registerAgentInstanceEventAppliers(state);
     registerAgentHistoryEventAppliers(state);
+    registerAgentDefinitionEventAppliers();
     registerSecretReferenceEventAppliers(state);
     return this;
   }
@@ -199,6 +201,11 @@ public final class EventAppliers implements EventApplier {
     register(AgentHistoryIntent.CREATED, new AgentHistoryCreatedApplier(state));
     register(AgentHistoryIntent.COMMITTED, new AgentHistoryCommittedApplier(state));
     register(AgentHistoryIntent.DISCARDED, new AgentHistoryDiscardedApplier(state));
+  }
+
+  private void registerAgentDefinitionEventAppliers() {
+    register(AgentDefinitionIntent.CREATED, NOOP_EVENT_APPLIER);
+    register(AgentDefinitionIntent.DELETED, NOOP_EVENT_APPLIER);
   }
 
   private void registerAgentInstanceEventAppliers(final MutableProcessingState state) {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -128,15 +128,16 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
       case GLOBAL_LISTENER -> index.globalListener;
       case AGENT_INSTANCE -> index.agentInstance;
       case AGENT_HISTORY -> index.agentHistory;
+      case AGENT_DEFINITION -> index.agentDefinition;
       default -> false;
     };
   }
 
   /**
    * Not all value records are required to be exported from 8.8 onward. The following included
-   * records are required by Optimize and Zeebe-Analytics (and {@code AGENT_INSTANCE} by ad-hoc
-   * sub-process / agent features) so they must continue to be exported by the {@link
-   * ElasticsearchExporter}:
+   * records are required by Optimize and Zeebe-Analytics (and {@code AGENT_INSTANCE}/{@code
+   * AGENT_DEFINITION} by ad-hoc sub-process / agent features) so they must continue to be exported
+   * by the {@link ElasticsearchExporter}:
    *
    * @param valueType the value type of the record
    * @return true if the record should be indexed, false otherwise
@@ -152,6 +153,7 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
       case USER_TASK -> index.userTask;
       case JOB -> index.job;
       case AGENT_INSTANCE -> index.agentInstance;
+      case AGENT_DEFINITION -> index.agentDefinition;
       default -> false;
     };
   }
@@ -266,6 +268,7 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
 
     public boolean agentInstance = true;
     public boolean agentHistory = true;
+    public boolean agentDefinition = true;
 
     // index settings
     private Integer numberOfShards = null;

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
@@ -220,6 +220,9 @@ public class ElasticsearchExporterSchemaManager {
       if (index.agentHistory) {
         createValueIndexTemplate(ValueType.AGENT_HISTORY, version);
       }
+      if (index.agentDefinition) {
+        createValueIndexTemplate(ValueType.AGENT_DEFINITION, version);
+      }
     }
 
     indexTemplatesCreated.add(version);

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-definition-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-definition-template.json
@@ -40,6 +40,9 @@
             "processDefinitionVersion": {
               "type": "integer"
             },
+            "processDefinitionVersionTag": {
+              "type": "keyword"
+            },
             "tenantId": {
               "type": "keyword"
             }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-definition-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-definition-template.json
@@ -1,0 +1,51 @@
+{
+  "index_patterns": [
+    "zeebe-record_agent-definition_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 1,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-agent-definition": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "agentDefinitionKey": {
+              "type": "long"
+            },
+            "agentType": {
+              "type": "keyword"
+            },
+            "name": {
+              "type": "text"
+            },
+            "elementId": {
+              "type": "keyword"
+            },
+            "bpmnProcessId": {
+              "type": "keyword"
+            },
+            "processDefinitionKey": {
+              "type": "long"
+            },
+            "processDefinitionVersion": {
+              "type": "integer"
+            },
+            "tenantId": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -310,7 +310,8 @@ final class ElasticsearchExporterIT {
         || valueType == ValueType.USER_TASK
         || valueType == ValueType.DEPLOYMENT
         || valueType == ValueType.JOB
-        || valueType == ValueType.AGENT_INSTANCE) {
+        || valueType == ValueType.AGENT_INSTANCE
+        || valueType == ValueType.AGENT_DEFINITION) {
       final var response = testClient.getExportedDocumentFor(record);
       assertThat(response)
           .extracting(GetResponse::index, GetResponse::id, GetResponse::routing)

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -305,7 +305,8 @@ final class ElasticsearchExporterTest {
           || valueType == ValueType.USER_TASK
           || valueType == ValueType.DEPLOYMENT
           || valueType == ValueType.JOB
-          || valueType == ValueType.AGENT_INSTANCE) {
+          || valueType == ValueType.AGENT_INSTANCE
+          || valueType == ValueType.AGENT_DEFINITION) {
         verify(client, times(1)).putIndexTemplate(valueType, version);
       } else {
         verify(client, never()).putIndexTemplate(any(), any());

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -87,6 +87,7 @@ final class TestSupport {
       case GLOBAL_LISTENER -> config.globalListener = value;
       case AGENT_INSTANCE -> config.agentInstance = value;
       case AGENT_HISTORY -> config.agentHistory = value;
+      case AGENT_DEFINITION -> config.agentDefinition = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -173,15 +173,16 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
       case GLOBAL_LISTENER -> index.globalListener;
       case AGENT_INSTANCE -> index.agentInstance;
       case AGENT_HISTORY -> index.agentHistory;
+      case AGENT_DEFINITION -> index.agentDefinition;
       default -> false;
     };
   }
 
   /**
    * Not all value records are required to be exported from 8.8 onward. The following included
-   * records are required by Optimize and Zeebe-Analytics (and {@code AGENT_INSTANCE} by ad-hoc
-   * sub-process / agent features) so they must continue to be exported by the {@link
-   * OpensearchExporter}:
+   * records are required by Optimize and Zeebe-Analytics (and {@code AGENT_INSTANCE}/{@code
+   * AGENT_DEFINITION} by ad-hoc sub-process / agent features) so they must continue to be exported
+   * by the {@link OpensearchExporter}:
    *
    * @param valueType the value type of the record
    * @return true if the record should be indexed, false otherwise
@@ -197,6 +198,7 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
       case USER_TASK -> index.userTask;
       case JOB -> index.job;
       case AGENT_INSTANCE -> index.agentInstance;
+      case AGENT_DEFINITION -> index.agentDefinition;
       default -> false;
     };
   }
@@ -295,6 +297,7 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
 
     public boolean agentInstance = true;
     public boolean agentHistory = true;
+    public boolean agentDefinition = true;
 
     // index settings
     private Integer numberOfShards = null;

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterSchemaManager.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterSchemaManager.java
@@ -194,6 +194,9 @@ public class OpensearchExporterSchemaManager {
       if (index.agentHistory) {
         createValueIndexTemplate(ValueType.AGENT_HISTORY, version);
       }
+      if (index.agentDefinition) {
+        createValueIndexTemplate(ValueType.AGENT_DEFINITION, version);
+      }
     }
 
     indexTemplatesCreated.add(version);

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-definition-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-definition-template.json
@@ -46,6 +46,9 @@
             "processDefinitionVersion": {
               "type": "integer"
             },
+            "processDefinitionVersionTag": {
+              "type": "keyword"
+            },
             "tenantId": {
               "type": "keyword"
             }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-definition-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-definition-template.json
@@ -1,0 +1,57 @@
+{
+  "index_patterns": [
+    "zeebe-record_agent-definition_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "index": {
+        "number_of_shards": "1",
+        "number_of_replicas": "1",
+        "queries": {
+          "cache": {
+            "enabled": false
+          }
+        }
+      }
+    },
+    "aliases": {
+      "zeebe-record-agent-definition": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "agentDefinitionKey": {
+              "type": "long"
+            },
+            "agentType": {
+              "type": "keyword"
+            },
+            "name": {
+              "type": "text"
+            },
+            "elementId": {
+              "type": "keyword"
+            },
+            "bpmnProcessId": {
+              "type": "keyword"
+            },
+            "processDefinitionKey": {
+              "type": "long"
+            },
+            "processDefinitionVersion": {
+              "type": "integer"
+            },
+            "tenantId": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -405,7 +405,8 @@ final class OpensearchExporterIT {
         || valueType == ValueType.USER_TASK
         || valueType == ValueType.DEPLOYMENT
         || valueType == ValueType.JOB
-        || valueType == ValueType.AGENT_INSTANCE) {
+        || valueType == ValueType.AGENT_INSTANCE
+        || valueType == ValueType.AGENT_DEFINITION) {
       final var response = testClient.getExportedDocumentFor(record);
       assertThat(response)
           .extracting(GetResponse::index, GetResponse::id, GetResponse::routing)

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -412,7 +412,8 @@ final class OpensearchExporterTest {
           || valueType == ValueType.USER_TASK
           || valueType == ValueType.DEPLOYMENT
           || valueType == ValueType.JOB
-          || valueType == ValueType.AGENT_INSTANCE) {
+          || valueType == ValueType.AGENT_INSTANCE
+          || valueType == ValueType.AGENT_DEFINITION) {
         verify(client, times(1)).putIndexTemplate(valueType, version);
       } else {
         verify(client, never()).putIndexTemplate(any(), any());

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -88,6 +88,7 @@ final class TestSupport {
       case GLOBAL_LISTENER -> config.globalListener = value;
       case AGENT_INSTANCE -> config.agentInstance = value;
       case AGENT_HISTORY -> config.agentHistory = value;
+      case AGENT_DEFINITION -> config.agentDefinition = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.AsyncRequestRecord;
 import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentdefinition.AgentDefinitionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
@@ -231,6 +232,7 @@ public class UnifiedRecordValue extends UnpackedObject implements RecordValue {
       case ValueType.GLOBAL_LISTENER -> new GlobalListenerRecord();
       case ValueType.AGENT_HISTORY -> new AgentHistoryRecord();
       case ValueType.AGENT_INSTANCE -> new AgentInstanceRecord();
+      case ValueType.AGENT_DEFINITION -> new AgentDefinitionRecord();
       case ValueType.SECRET_REFERENCE -> new SecretReferenceRecord();
       case ValueType.SBE_UNKNOWN -> null;
       case ValueType.NULL_VAL -> null;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentdefinition/AgentDefinitionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentdefinition/AgentDefinitionRecord.java
@@ -30,11 +30,13 @@ public final class AgentDefinitionRecord extends UnifiedRecordValue
       new LongProperty("processDefinitionKey", -1L);
   private final IntegerProperty processDefinitionVersionProp =
       new IntegerProperty("processDefinitionVersion", -1);
+  private final StringProperty processDefinitionVersionTagProp =
+      new StringProperty("processDefinitionVersionTag", "");
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public AgentDefinitionRecord() {
-    super(8);
+    super(9);
     declareProperty(agentDefinitionKeyProp)
         .declareProperty(agentTypeProp)
         .declareProperty(nameProp)
@@ -42,6 +44,7 @@ public final class AgentDefinitionRecord extends UnifiedRecordValue
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(processDefinitionVersionProp)
+        .declareProperty(processDefinitionVersionTagProp)
         .declareProperty(tenantIdProp);
   }
 
@@ -112,6 +115,17 @@ public final class AgentDefinitionRecord extends UnifiedRecordValue
 
   public AgentDefinitionRecord setProcessDefinitionVersion(final int processDefinitionVersion) {
     processDefinitionVersionProp.setValue(processDefinitionVersion);
+    return this;
+  }
+
+  @Override
+  public String getProcessDefinitionVersionTag() {
+    return BufferUtil.bufferAsString(processDefinitionVersionTagProp.getValue());
+  }
+
+  public AgentDefinitionRecord setProcessDefinitionVersionTag(
+      final String processDefinitionVersionTag) {
+    processDefinitionVersionTagProp.setValue(processDefinitionVersionTag);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentdefinition/AgentDefinitionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentdefinition/AgentDefinitionRecord.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.agentdefinition;
+
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentDefinitionRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentDefinitionType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+
+public final class AgentDefinitionRecord extends UnifiedRecordValue
+    implements AgentDefinitionRecordValue {
+
+  private final LongProperty agentDefinitionKeyProp = new LongProperty("agentDefinitionKey", -1L);
+  private final EnumProperty<AgentDefinitionType> agentTypeProp =
+      new EnumProperty<>("agentType", AgentDefinitionType.class, AgentDefinitionType.UNSPECIFIED);
+  private final StringProperty nameProp = new StringProperty("name", "");
+  private final StringProperty elementIdProp = new StringProperty("elementId", "");
+  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
+  private final LongProperty processDefinitionKeyProp =
+      new LongProperty("processDefinitionKey", -1L);
+  private final IntegerProperty processDefinitionVersionProp =
+      new IntegerProperty("processDefinitionVersion", -1);
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+  public AgentDefinitionRecord() {
+    super(8);
+    declareProperty(agentDefinitionKeyProp)
+        .declareProperty(agentTypeProp)
+        .declareProperty(nameProp)
+        .declareProperty(elementIdProp)
+        .declareProperty(bpmnProcessIdProp)
+        .declareProperty(processDefinitionKeyProp)
+        .declareProperty(processDefinitionVersionProp)
+        .declareProperty(tenantIdProp);
+  }
+
+  @Override
+  public long getAgentDefinitionKey() {
+    return agentDefinitionKeyProp.getValue();
+  }
+
+  public AgentDefinitionRecord setAgentDefinitionKey(final long agentDefinitionKey) {
+    agentDefinitionKeyProp.setValue(agentDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public AgentDefinitionType getAgentType() {
+    return agentTypeProp.getValue();
+  }
+
+  public AgentDefinitionRecord setAgentType(final AgentDefinitionType agentType) {
+    agentTypeProp.setValue(agentType);
+    return this;
+  }
+
+  @Override
+  public String getName() {
+    return BufferUtil.bufferAsString(nameProp.getValue());
+  }
+
+  public AgentDefinitionRecord setName(final String name) {
+    nameProp.setValue(name);
+    return this;
+  }
+
+  @Override
+  public String getElementId() {
+    return BufferUtil.bufferAsString(elementIdProp.getValue());
+  }
+
+  public AgentDefinitionRecord setElementId(final String elementId) {
+    elementIdProp.setValue(elementId);
+    return this;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  public AgentDefinitionRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKeyProp.getValue();
+  }
+
+  public AgentDefinitionRecord setProcessDefinitionKey(final long processDefinitionKey) {
+    processDefinitionKeyProp.setValue(processDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public int getProcessDefinitionVersion() {
+    return processDefinitionVersionProp.getValue();
+  }
+
+  public AgentDefinitionRecord setProcessDefinitionVersion(final int processDefinitionVersion) {
+    processDefinitionVersionProp.setValue(processDefinitionVersion);
+    return this;
+  }
+
+  @Override
+  public String getTenantId() {
+    return BufferUtil.bufferAsString(tenantIdProp.getValue());
+  }
+
+  public AgentDefinitionRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -5075,6 +5075,7 @@ final class JsonSerializableToJsonTest {
                     .setBpmnProcessId("invoice-handling-process")
                     .setProcessDefinitionKey(2251799813685100L)
                     .setProcessDefinitionVersion(3)
+                    .setProcessDefinitionVersionTag("v1.0")
                     .setTenantId("<default>"),
         """
         {
@@ -5085,6 +5086,7 @@ final class JsonSerializableToJsonTest {
           "bpmnProcessId": "invoice-handling-process",
           "processDefinitionKey": 2251799813685100,
           "processDefinitionVersion": 3,
+          "processDefinitionVersionTag": "v1.0",
           "tenantId": "<default>"
         }
         """
@@ -5101,6 +5103,7 @@ final class JsonSerializableToJsonTest {
           "bpmnProcessId": "",
           "processDefinitionKey": -1,
           "processDefinitionVersion": -1,
+          "processDefinitionVersionTag": "",
           "tenantId": "<default>"
         }
         """

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.VersionInfo;
 import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentdefinition.AgentDefinitionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryEmbeddedToolCall;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
@@ -110,6 +111,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentDefinitionType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
@@ -5055,6 +5057,51 @@ final class JsonSerializableToJsonTest {
           "resourceName": "",
           "duplicate": false,
           "version": -1
+        }
+        """
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////////// AgentDefinitionRecord ////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "AgentDefinitionRecord",
+        (Supplier<UnifiedRecordValue>)
+            () ->
+                new AgentDefinitionRecord()
+                    .setAgentDefinitionKey(2251799813685251L)
+                    .setAgentType(AgentDefinitionType.AI_AGENT_TASK)
+                    .setName("Invoice Data Extraction")
+                    .setElementId("invoice-data-extraction-agent")
+                    .setBpmnProcessId("invoice-handling-process")
+                    .setProcessDefinitionKey(2251799813685100L)
+                    .setProcessDefinitionVersion(3)
+                    .setTenantId("<default>"),
+        """
+        {
+          "agentDefinitionKey": 2251799813685251,
+          "agentType": "AI_AGENT_TASK",
+          "name": "Invoice Data Extraction",
+          "elementId": "invoice-data-extraction-agent",
+          "bpmnProcessId": "invoice-handling-process",
+          "processDefinitionKey": 2251799813685100,
+          "processDefinitionVersion": 3,
+          "tenantId": "<default>"
+        }
+        """
+      },
+      {
+        "Empty AgentDefinitionRecord",
+        (Supplier<UnifiedRecordValue>) AgentDefinitionRecord::new,
+        """
+        {
+          "agentDefinitionKey": -1,
+          "agentType": "UNSPECIFIED",
+          "name": "",
+          "elementId": "",
+          "bpmnProcessId": "",
+          "processDefinitionKey": -1,
+          "processDefinitionVersion": -1,
+          "tenantId": "<default>"
         }
         """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentdefinition/AgentDefinitionRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentdefinition/AgentDefinitionRecordTest.java
@@ -27,6 +27,7 @@ final class AgentDefinitionRecordTest {
     assertThat(record.getBpmnProcessId()).isEmpty();
     assertThat(record.getProcessDefinitionKey()).isEqualTo(-1L);
     assertThat(record.getProcessDefinitionVersion()).isEqualTo(-1);
+    assertThat(record.getProcessDefinitionVersionTag()).isEmpty();
     assertThat(record.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   }
 
@@ -41,6 +42,7 @@ final class AgentDefinitionRecordTest {
             .setBpmnProcessId("invoice-handling-process")
             .setProcessDefinitionKey(2251799813685100L)
             .setProcessDefinitionVersion(3)
+            .setProcessDefinitionVersionTag("v1.0")
             .setTenantId("acme");
 
     // when
@@ -55,6 +57,8 @@ final class AgentDefinitionRecordTest {
     assertThat(copy.getProcessDefinitionKey()).isEqualTo(original.getProcessDefinitionKey());
     assertThat(copy.getProcessDefinitionVersion())
         .isEqualTo(original.getProcessDefinitionVersion());
+    assertThat(copy.getProcessDefinitionVersionTag())
+        .isEqualTo(original.getProcessDefinitionVersionTag());
     assertThat(copy.getTenantId()).isEqualTo(original.getTenantId());
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentdefinition/AgentDefinitionRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentdefinition/AgentDefinitionRecordTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.agentdefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.record.value.AgentDefinitionType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import org.junit.jupiter.api.Test;
+
+final class AgentDefinitionRecordTest {
+
+  @Test
+  void shouldExposeIdentityDefaults() {
+    // given
+    final AgentDefinitionRecord record = new AgentDefinitionRecord();
+
+    // then
+    assertThat(record.getAgentDefinitionKey()).isEqualTo(-1L);
+    assertThat(record.getName()).isEmpty();
+    assertThat(record.getElementId()).isEmpty();
+    assertThat(record.getBpmnProcessId()).isEmpty();
+    assertThat(record.getProcessDefinitionKey()).isEqualTo(-1L);
+    assertThat(record.getProcessDefinitionVersion()).isEqualTo(-1);
+    assertThat(record.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  @Test
+  void shouldRoundTripIdentityFieldsViaMsgPack() {
+    // given
+    final AgentDefinitionRecord original =
+        new AgentDefinitionRecord()
+            .setAgentDefinitionKey(2251799813685251L)
+            .setName("Invoice Data Extraction")
+            .setElementId("invoice-data-extraction-agent")
+            .setBpmnProcessId("invoice-handling-process")
+            .setProcessDefinitionKey(2251799813685100L)
+            .setProcessDefinitionVersion(3)
+            .setTenantId("acme");
+
+    // when
+    final AgentDefinitionRecord copy = new AgentDefinitionRecord();
+    copy.copyFrom(original);
+
+    // then
+    assertThat(copy.getAgentDefinitionKey()).isEqualTo(original.getAgentDefinitionKey());
+    assertThat(copy.getName()).isEqualTo(original.getName());
+    assertThat(copy.getElementId()).isEqualTo(original.getElementId());
+    assertThat(copy.getBpmnProcessId()).isEqualTo(original.getBpmnProcessId());
+    assertThat(copy.getProcessDefinitionKey()).isEqualTo(original.getProcessDefinitionKey());
+    assertThat(copy.getProcessDefinitionVersion())
+        .isEqualTo(original.getProcessDefinitionVersion());
+    assertThat(copy.getTenantId()).isEqualTo(original.getTenantId());
+  }
+
+  @Test
+  void shouldDefaultAgentTypeToUnspecified() {
+    // given
+    final AgentDefinitionRecord record = new AgentDefinitionRecord();
+
+    // then
+    assertThat(record.getAgentType()).isEqualTo(AgentDefinitionType.UNSPECIFIED);
+  }
+
+  @Test
+  void shouldRoundTripAgentTypeViaMsgPack() {
+    // given
+    final AgentDefinitionRecord original =
+        new AgentDefinitionRecord().setAgentType(AgentDefinitionType.AI_AGENT_SUB_PROCESS);
+
+    // when
+    final AgentDefinitionRecord copy = new AgentDefinitionRecord();
+    copy.copyFrom(original);
+
+    // then
+    assertThat(copy.getAgentType()).isEqualTo(AgentDefinitionType.AI_AGENT_SUB_PROCESS);
+  }
+}

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentDefinitionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentDefinitionRecord.golden
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.agentdefinition;
+
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentDefinitionRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentDefinitionType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+
+public final class AgentDefinitionRecord extends UnifiedRecordValue
+    implements AgentDefinitionRecordValue {
+
+  private final LongProperty agentDefinitionKeyProp =
+      new LongProperty("agentDefinitionKey", -1L);
+  private final EnumProperty<AgentDefinitionType> agentTypeProp =
+      new EnumProperty<>("agentType", AgentDefinitionType.class, AgentDefinitionType.UNSPECIFIED);
+  private final StringProperty nameProp = new StringProperty("name", "");
+  private final StringProperty elementIdProp = new StringProperty("elementId", "");
+  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
+  private final LongProperty processDefinitionKeyProp =
+      new LongProperty("processDefinitionKey", -1L);
+  private final IntegerProperty processDefinitionVersionProp =
+      new IntegerProperty("processDefinitionVersion", -1);
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+  public AgentDefinitionRecord() {
+    super(8);
+    declareProperty(agentDefinitionKeyProp)
+        .declareProperty(agentTypeProp)
+        .declareProperty(nameProp)
+        .declareProperty(elementIdProp)
+        .declareProperty(bpmnProcessIdProp)
+        .declareProperty(processDefinitionKeyProp)
+        .declareProperty(processDefinitionVersionProp)
+        .declareProperty(tenantIdProp);
+  }
+
+  @Override
+  public long getAgentDefinitionKey() {
+    return agentDefinitionKeyProp.getValue();
+  }
+
+  public AgentDefinitionRecord setAgentDefinitionKey(final long agentDefinitionKey) {
+    agentDefinitionKeyProp.setValue(agentDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public AgentDefinitionType getAgentType() {
+    return agentTypeProp.getValue();
+  }
+
+  public AgentDefinitionRecord setAgentType(final AgentDefinitionType agentType) {
+    agentTypeProp.setValue(agentType);
+    return this;
+  }
+
+  @Override
+  public String getName() {
+    return BufferUtil.bufferAsString(nameProp.getValue());
+  }
+
+  public AgentDefinitionRecord setName(final String name) {
+    nameProp.setValue(name);
+    return this;
+  }
+
+  @Override
+  public String getElementId() {
+    return BufferUtil.bufferAsString(elementIdProp.getValue());
+  }
+
+  public AgentDefinitionRecord setElementId(final String elementId) {
+    elementIdProp.setValue(elementId);
+    return this;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  public AgentDefinitionRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKeyProp.getValue();
+  }
+
+  public AgentDefinitionRecord setProcessDefinitionKey(final long processDefinitionKey) {
+    processDefinitionKeyProp.setValue(processDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public int getProcessDefinitionVersion() {
+    return processDefinitionVersionProp.getValue();
+  }
+
+  public AgentDefinitionRecord setProcessDefinitionVersion(final int processDefinitionVersion) {
+    processDefinitionVersionProp.setValue(processDefinitionVersion);
+    return this;
+  }
+
+  @Override
+  public String getTenantId() {
+    return BufferUtil.bufferAsString(tenantIdProp.getValue());
+  }
+
+  public AgentDefinitionRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentDefinitionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentDefinitionRecord.golden
@@ -20,8 +20,7 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 public final class AgentDefinitionRecord extends UnifiedRecordValue
     implements AgentDefinitionRecordValue {
 
-  private final LongProperty agentDefinitionKeyProp =
-      new LongProperty("agentDefinitionKey", -1L);
+  private final LongProperty agentDefinitionKeyProp = new LongProperty("agentDefinitionKey", -1L);
   private final EnumProperty<AgentDefinitionType> agentTypeProp =
       new EnumProperty<>("agentType", AgentDefinitionType.class, AgentDefinitionType.UNSPECIFIED);
   private final StringProperty nameProp = new StringProperty("name", "");
@@ -31,11 +30,13 @@ public final class AgentDefinitionRecord extends UnifiedRecordValue
       new LongProperty("processDefinitionKey", -1L);
   private final IntegerProperty processDefinitionVersionProp =
       new IntegerProperty("processDefinitionVersion", -1);
+  private final StringProperty processDefinitionVersionTagProp =
+      new StringProperty("processDefinitionVersionTag", "");
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public AgentDefinitionRecord() {
-    super(8);
+    super(9);
     declareProperty(agentDefinitionKeyProp)
         .declareProperty(agentTypeProp)
         .declareProperty(nameProp)
@@ -43,6 +44,7 @@ public final class AgentDefinitionRecord extends UnifiedRecordValue
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(processDefinitionVersionProp)
+        .declareProperty(processDefinitionVersionTagProp)
         .declareProperty(tenantIdProp);
   }
 
@@ -113,6 +115,17 @@ public final class AgentDefinitionRecord extends UnifiedRecordValue
 
   public AgentDefinitionRecord setProcessDefinitionVersion(final int processDefinitionVersion) {
     processDefinitionVersionProp.setValue(processDefinitionVersion);
+    return this;
+  }
+
+  @Override
+  public String getProcessDefinitionVersionTag() {
+    return BufferUtil.bufferAsString(processDefinitionVersionTagProp.getValue());
+  }
+
+  public AgentDefinitionRecord setProcessDefinitionVersionTag(
+      final String processDefinitionVersionTag) {
+    processDefinitionVersionTagProp.setValue(processDefinitionVersionTag);
     return this;
   }
 

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ImplRecordValuePopulator.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ImplRecordValuePopulator.java
@@ -21,6 +21,8 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.ValueTypeMapping;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -105,7 +107,7 @@ final class ImplRecordValuePopulator {
       if (typeArgs.length > 0
           && typeArgs[0] instanceof final Class<?> enumClass
           && enumClass.isEnum()) {
-        final Object[] enumConstants = enumClass.getEnumConstants();
+        final Object[] enumConstants = enumConstantsFor(enumClass);
         if (enumConstants.length > 0) {
           final Object randomEnum = enumConstants[random.nextInt(enumConstants.length)];
           final EnumProperty enumProperty = (EnumProperty<?>) field.get(implInstance);
@@ -113,6 +115,19 @@ final class ImplRecordValuePopulator {
         }
       }
     }
+  }
+
+  /**
+   * Returns the constants to randomly pick from for the given enum type. For {@link ValueType},
+   * this excludes {@link ValueType#NULL_VAL} and {@link ValueType#SBE_UNKNOWN}, as these are
+   * synthetic placeholder values created by SBE and are never valid on an actual record - picking
+   * one here would produce a record value with an inner value type that no consumer can handle.
+   */
+  private static Object[] enumConstantsFor(final Class<?> enumClass) {
+    if (enumClass == ValueType.class) {
+      return ValueTypeMapping.getAcceptedValueTypes().toArray();
+    }
+    return enumClass.getEnumConstants();
   }
 
   private static void populateStringProperty(

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.protocol.record;
 import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
+import io.camunda.zeebe.protocol.record.intent.AgentDefinitionIntent;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.AsyncRequestIntent;
@@ -88,6 +89,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentDefinitionRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.AsyncRequestRecordValue;
@@ -396,6 +398,9 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.AGENT_HISTORY,
         new Mapping<>(AgentHistoryRecordValue.class, AgentHistoryIntent.class));
+    mapping.put(
+        ValueType.AGENT_DEFINITION,
+        new Mapping<>(AgentDefinitionRecordValue.class, AgentDefinitionIntent.class));
     mapping.put(
         ValueType.SECRET_REFERENCE,
         new Mapping<>(SecretReferenceRecordValue.class, SecretReferenceIntent.class));

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AgentDefinitionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AgentDefinitionIntent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum AgentDefinitionIntent implements Intent {
+  CREATED(0),
+  DELETED(1);
+
+  private final short value;
+
+  AgentDefinitionIntent(final int value) {
+    this.value = (short) value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return CREATED;
+      case 1:
+        return DELETED;
+      default:
+        return UNKNOWN;
+    }
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -51,6 +51,7 @@ public interface Intent {
   static Map<ValueType, Class<? extends Intent>> computeValueTypeToIntentMap() {
     final Map<ValueType, Class<? extends Intent>> map = new LinkedHashMap<>();
     map.put(ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION, AdHocSubProcessInstructionIntent.class);
+    map.put(ValueType.AGENT_DEFINITION, AgentDefinitionIntent.class);
     map.put(ValueType.AGENT_HISTORY, AgentHistoryIntent.class);
     map.put(ValueType.AGENT_INSTANCE, AgentInstanceIntent.class);
     map.put(ValueType.ASYNC_REQUEST, AsyncRequestIntent.class);

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentDefinitionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentDefinitionRecordValue.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableAgentDefinitionRecordValue.Builder.class)
+public interface AgentDefinitionRecordValue extends RecordValue, TenantOwned {
+
+  /**
+   * @return the unique key of the agent definition
+   */
+  long getAgentDefinitionKey();
+
+  /**
+   * @return the kind of agent this definition describes
+   */
+  AgentDefinitionType getAgentType();
+
+  /**
+   * @return the human-readable name of the process element that owns the agent
+   */
+  String getName();
+
+  /**
+   * @return the ID of the process element that owns the agent
+   */
+  String getElementId();
+
+  /**
+   * @return the BPMN process ID of the process definition that owns the agent
+   */
+  String getBpmnProcessId();
+
+  /**
+   * @return the key of the process definition that owns the agent
+   */
+  long getProcessDefinitionKey();
+
+  /**
+   * @return the version of the process definition that owns the agent
+   */
+  int getProcessDefinitionVersion();
+
+  /**
+   * @return the ID of the tenant that owns this agent definition
+   */
+  @Override
+  String getTenantId();
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentDefinitionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentDefinitionRecordValue.java
@@ -59,6 +59,11 @@ public interface AgentDefinitionRecordValue extends RecordValue, TenantOwned {
   int getProcessDefinitionVersion();
 
   /**
+   * @return the version tag of the process definition that owns the agent
+   */
+  String getProcessDefinitionVersionTag();
+
+  /**
    * @return the ID of the tenant that owns this agent definition
    */
   @Override

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentDefinitionType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentDefinitionType.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+public enum AgentDefinitionType {
+  UNSPECIFIED,
+  AI_AGENT_SUB_PROCESS,
+  AI_AGENT_TASK,
+  EXTERNAL
+}

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -100,6 +100,7 @@
       <validValue name="PROCESS_INSTANCE_BUSINESS_ID">74</validValue>
       <validValue name="SECRET_REFERENCE">75</validValue>
       <validValue name="PROCESS_INSTANCE_BUFFERED_COMMAND">76</validValue>
+      <validValue name="AGENT_DEFINITION">77</validValue>
 
       <!-- Management records / record not related to process automation -->
       <!-- value 252 was used for "REDISTRIBUTION, do not use-->

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
@@ -54,6 +54,7 @@ final class IntentEncodingDecodingTest {
 
   private static Stream<ParameterSet> parameters() {
     final List<ParameterSet> result = new ArrayList<>();
+    result.addAll(buildParameterSets(AgentDefinitionIntent.class, AgentDefinitionIntent::from));
     result.addAll(buildParameterSets(AgentHistoryIntent.class, AgentHistoryIntent::from));
     result.addAll(buildParameterSets(AgentInstanceIntent.class, AgentInstanceIntent::from));
     result.addAll(

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -588,8 +588,13 @@ public class CompactRecordLogger {
         .append("[")
         .append(shortenKey(value.getProcessDefinitionKey()))
         .append("] v")
-        .append(value.getProcessDefinitionVersion())
-        .append(">");
+        .append(value.getProcessDefinitionVersion());
+
+    if (StringUtils.isNotEmpty(value.getProcessDefinitionVersionTag())) {
+      result.append(" tag:").append(value.getProcessDefinitionVersionTag());
+    }
+
+    result.append(">");
 
     return result.toString();
   }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -74,6 +74,7 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentDefinitionRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
@@ -347,6 +348,7 @@ public class CompactRecordLogger {
     valueLoggers.put(RESOURCE_REEXPORT, this::summarizeResourceReexport);
     valueLoggers.put(ValueType.AGENT_INSTANCE, this::summarizeAgentInstance);
     valueLoggers.put(ValueType.AGENT_HISTORY, this::summarizeAgentHistory);
+    valueLoggers.put(ValueType.AGENT_DEFINITION, this::summarizeAgentDefinition);
     valueLoggers.put(ValueType.SECRET_REFERENCE, this::summarizeSecretReference);
   }
 
@@ -560,6 +562,34 @@ public class CompactRecordLogger {
                   .map(CompactRecordLogger::abbreviateToFirstLetters)
                   .toList());
     }
+
+    return result.toString();
+  }
+
+  protected String summarizeAgentDefinition(final Record<?> record) {
+    final var value = (AgentDefinitionRecordValue) record.getValue();
+    final var result = new StringBuilder();
+
+    result
+        .append(shortenKey(value.getAgentDefinitionKey()))
+        .append(" ")
+        .append(value.getAgentType())
+        .append(" @")
+        .append(formatId(value.getElementId()));
+
+    // name defaults to elementId when no element name is set; avoid logging it twice
+    if (StringUtils.isNotBlank(value.getName()) && !value.getName().equals(value.getElementId())) {
+      result.append(" ").append(formatId(value.getName()));
+    }
+
+    result
+        .append(" of <process ")
+        .append(formatId(value.getBpmnProcessId()))
+        .append("[")
+        .append(shortenKey(value.getProcessDefinitionKey()))
+        .append("] v")
+        .append(value.getProcessDefinitionVersion())
+        .append(">");
 
     return result.toString();
   }

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/CompactRecordLoggerTest.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/CompactRecordLoggerTest.java
@@ -11,8 +11,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.protocol.record.ImmutableRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.AgentDefinitionType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentDefinitionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryEmbeddedToolCallValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryMessageContentValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryMetricsValue;
@@ -146,6 +148,60 @@ class CompactRecordLoggerTest {
           .contains(
               """
               in <process "procID"[K123]"bizzID">""");
+    }
+
+    @Test
+    void shouldSummarizeAgentDefinitionRecord() {
+      // given
+      final var logger = new CompactRecordLogger(List.of());
+      final var record =
+          ImmutableRecord.builder()
+              .withValueType(ValueType.AGENT_DEFINITION)
+              .withValue(
+                  ImmutableAgentDefinitionRecordValue.builder()
+                      .withAgentDefinitionKey(1L)
+                      .withAgentType(AgentDefinitionType.AI_AGENT_TASK)
+                      .withName("Customer Support Escalation Agent")
+                      .withElementId("Activity_1")
+                      .withBpmnProcessId("orderProcess")
+                      .withProcessDefinitionKey(2L)
+                      .withProcessDefinitionVersion(3)
+                      .build())
+              .build();
+
+      // when
+      final String result = logger.summarizeAgentDefinition(record);
+
+      // then
+      assertThat(result)
+          .isEqualTo(
+              "K1 AI_AGENT_TASK @\"Activity_1\" \"Custome..n Agent\" of <process \"orderProcess\"[K2] v3>");
+    }
+
+    @Test
+    void shouldSummarizeAgentDefinitionRecordWithoutName() {
+      // given
+      final var logger = new CompactRecordLogger(List.of());
+      final var record =
+          ImmutableRecord.builder()
+              .withValueType(ValueType.AGENT_DEFINITION)
+              .withValue(
+                  ImmutableAgentDefinitionRecordValue.builder()
+                      .withAgentDefinitionKey(1L)
+                      .withAgentType(AgentDefinitionType.AI_AGENT_TASK)
+                      .withElementId("Activity_1")
+                      .withBpmnProcessId("orderProcess")
+                      .withProcessDefinitionKey(2L)
+                      .withProcessDefinitionVersion(3)
+                      .build())
+              .build();
+
+      // when
+      final String result = logger.summarizeAgentDefinition(record);
+
+      // then
+      assertThat(result)
+          .isEqualTo("K1 AI_AGENT_TASK @\"Activity_1\" of <process \"orderProcess\"[K2] v3>");
     }
 
     @Test

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/CompactRecordLoggerTest.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/CompactRecordLoggerTest.java
@@ -166,6 +166,7 @@ class CompactRecordLoggerTest {
                       .withBpmnProcessId("orderProcess")
                       .withProcessDefinitionKey(2L)
                       .withProcessDefinitionVersion(3)
+                      .withProcessDefinitionVersionTag("v1.0")
                       .build())
               .build();
 
@@ -175,7 +176,7 @@ class CompactRecordLoggerTest {
       // then
       assertThat(result)
           .isEqualTo(
-              "K1 AI_AGENT_TASK @\"Activity_1\" \"Custome..n Agent\" of <process \"orderProcess\"[K2] v3>");
+              "K1 AI_AGENT_TASK @\"Activity_1\" \"Custome..n Agent\" of <process \"orderProcess\"[K2] v3 tag:v1.0>");
     }
 
     @Test


### PR DESCRIPTION
## Description

Defines `AgentDefinitionRecord` with `CREATED`/`DELETED` events (`AgentDefinitionIntent`, `ValueType.AGENT_DEFINITION`) and wires it end-to-end through the engine and exporter pipeline, laying the groundwork for representing ad-hoc-sub-process/task-level agent definitions as first-class records.

**What this PR adds:**
- `AgentDefinitionIntent` (`CREATED`/`DELETED`) and the `AGENT_DEFINITION` `ValueType`.
- `AgentDefinitionRecordValue`/`AgentDefinitionRecord`, exposing `agentDefinitionKey`, `agentType`, `name`, `elementId`, `bpmnProcessId`, `processDefinitionKey`, `processDefinitionVersion`, `processDefinitionVersionTag`, and `tenantId` (kept as `RecordValue`/`TenantOwned`, not `ProcessInstanceRelated`, since it's deploy-time/definition-scoped rather than instance-scoped).
- `NOOP` event applier registration (plus golden files) for both intents, so the applier golden-file test suite covers them from day one.
- Compact record logging (`summarizeAgentDefinition` in `CompactRecordLogger`) so `AgentDefinitionRecord` events render readably in test failure logs, abbreviating a possibly-long `name` the same way `elementId`/`bpmnProcessId` already are, and skipping `name` when it equals `elementId` (a follow-up change will default `name` to `elementId` when no element name is set).
- Elasticsearch/Opensearch exporter wiring: index templates, `IndexConfiguration.agentDefinition` (defaulted to `true`, since this is user-facing data like `agentInstance`/`agentHistory`), and the required test-support/parameterized-test updates.
- Dedicated unit tests for the new record (`AgentDefinitionRecordTest`, modeled on `AgentInstanceRecordTest`/`AgentHistoryRecordTest`) and for the new compact-logging behavior.

Note on naming: following existing convention, the process definition identifier is named `bpmnProcessId` on the record (matching `AgentInstanceRecord`, `JobRecord`, `UserTaskRecord` etc.), while it is expected to be named as `processDefinitionId` at the exporter/REST-API layer in a later change, consistent with other models.

> [!NOTE]
> This PR also includes test-infrastructure fix (`fix: exclude synthetic ValueType placeholders from randomized test values`). `ImplRecordValuePopulator` picked random `ValueType` constants directly from `values()` for nested `ValueType` fields (e.g. on `CommandDistributionRecordValue`), which could pick the SBE-only synthetic placeholders `NULL_VAL`/`SBE_UNKNOWN` that the ES/Opensearch client rejects. Since `ProtocolFactory` uses a fixed seed, adding `AGENT_DEFINITION` shifted a seeded index onto `SBE_UNKNOWN`, breaking `OpensearchExporterIT#shouldSerializeAndIndexUsingImplementationRecordValue` in this PR's CI, even though the failing record type is unrelated to agent definitions. It's kept in this PR since it was discovered here and is required for CI to pass.

**Out of scope** (left for follow-up PRs):
- Any BPMN-parsing/engine-processor logic that actually creates/deletes `AgentDefinitionRecord`s (this PR only defines the record and its plumbing — no processor emits it yet).
- Camunda ES/OS and RDBMS exporters.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #58980

