### PR TITLE
ci: add OpenSearch 3.8.0 to db-versions.yml

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -30,6 +30,7 @@ opensearch:
     - "3.5.0"
     - "3.6.0"
     - "3.7.0"
+    - "3.8.0"
 
 # ── RDBMS databases ─────────────────────────────────────────────────────────────
 # Each entry is a Docker image tag representing one supported major version.


### PR DESCRIPTION
## Summary
- Add 3.8.0 as the newest tested os3 version in `.ci/db-versions.yml`

Closes #59510