### PR TITLE
feat: add business-value-target Optimize index (dual-backend, tenant-scoped)

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetIT.java
@@ -14,6 +14,7 @@ import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetD
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
 import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
 import io.camunda.optimize.service.db.writer.BusinessValueTargetWriter;
+import io.camunda.optimize.service.util.importing.ZeebeConstants;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -28,7 +29,7 @@ import org.junit.jupiter.api.Test;
 class BusinessValueTargetIT extends AbstractBrokerlessZeebeCCSMIT {
 
   private static final String PROCESS_KEY = "invoice-automation";
-  private static final String DEFAULT_TENANT = "<default>";
+  private static final String DEFAULT_TENANT = ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
   private static final String OTHER_TENANT = "tenant-b";
 
   private BusinessValueTargetWriter writer;
@@ -49,7 +50,7 @@ class BusinessValueTargetIT extends AbstractBrokerlessZeebeCCSMIT {
     writer.upsertTarget(target);
 
     // then
-    final Optional<BusinessValueTargetDto> read = repository.getByKey(PROCESS_KEY, DEFAULT_TENANT);
+    final Optional<BusinessValueTargetDto> read = repository.getByKey(DEFAULT_TENANT, PROCESS_KEY);
     assertThat(read).contains(target);
   }
 
@@ -63,7 +64,7 @@ class BusinessValueTargetIT extends AbstractBrokerlessZeebeCCSMIT {
     writer.upsertTarget(updated);
 
     // then
-    assertThat(repository.getByKey(PROCESS_KEY, DEFAULT_TENANT)).contains(updated);
+    assertThat(repository.getByKey(DEFAULT_TENANT, PROCESS_KEY)).contains(updated);
   }
 
   @Test
@@ -79,13 +80,13 @@ class BusinessValueTargetIT extends AbstractBrokerlessZeebeCCSMIT {
     writer.upsertTarget(otherTenantTarget);
 
     // then neither overwrites the other
-    assertThat(repository.getByKey(PROCESS_KEY, DEFAULT_TENANT)).contains(defaultTenantTarget);
-    assertThat(repository.getByKey(PROCESS_KEY, OTHER_TENANT)).contains(otherTenantTarget);
+    assertThat(repository.getByKey(DEFAULT_TENANT, PROCESS_KEY)).contains(defaultTenantTarget);
+    assertThat(repository.getByKey(OTHER_TENANT, PROCESS_KEY)).contains(otherTenantTarget);
   }
 
   @Test
   void shouldReturnEmptyForMissingKey() {
-    assertThat(repository.getByKey("does-not-exist", DEFAULT_TENANT)).isEmpty();
+    assertThat(repository.getByKey(DEFAULT_TENANT, "does-not-exist")).isEmpty();
   }
 
   @Test
@@ -95,7 +96,7 @@ class BusinessValueTargetIT extends AbstractBrokerlessZeebeCCSMIT {
 
     // when reading with a tenant that never wrote
     // then no row is returned
-    assertThat(repository.getByKey(PROCESS_KEY, OTHER_TENANT)).isEmpty();
+    assertThat(repository.getByKey(OTHER_TENANT, PROCESS_KEY)).isEmpty();
   }
 
   @Test

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetIT.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.businessvalue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
+import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
+import io.camunda.optimize.service.db.writer.BusinessValueTargetWriter;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the {@code business-value-target} index round-trips a target document and enforces
+ * tenant isolation at the doc-id level. Runs against whichever backend the IT suite is configured
+ * with (Elasticsearch or OpenSearch).
+ */
+class BusinessValueTargetIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private static final String PROCESS_KEY = "invoice-automation";
+  private static final String DEFAULT_TENANT = "<default>";
+  private static final String OTHER_TENANT = "tenant-b";
+
+  private BusinessValueTargetWriter writer;
+  private BusinessValueTargetRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    writer = embeddedOptimizeExtension.getBean(BusinessValueTargetWriter.class);
+    repository = embeddedOptimizeExtension.getBean(BusinessValueTargetRepository.class);
+  }
+
+  @Test
+  void shouldRoundTripUpsertAndRead() {
+    // given
+    final BusinessValueTargetDto target = target(PROCESS_KEY, DEFAULT_TENANT, 28_800_000L, 85);
+
+    // when
+    writer.upsertTarget(target);
+
+    // then
+    final Optional<BusinessValueTargetDto> read = repository.getByKey(PROCESS_KEY, DEFAULT_TENANT);
+    assertThat(read).contains(target);
+  }
+
+  @Test
+  void shouldOverwriteExistingTargetOnSameTenantAndKey() {
+    // given
+    writer.upsertTarget(target(PROCESS_KEY, DEFAULT_TENANT, 28_800_000L, 85));
+
+    // when
+    final BusinessValueTargetDto updated = target(PROCESS_KEY, DEFAULT_TENANT, 14_400_000L, 90);
+    writer.upsertTarget(updated);
+
+    // then
+    assertThat(repository.getByKey(PROCESS_KEY, DEFAULT_TENANT)).contains(updated);
+  }
+
+  @Test
+  void shouldIsolateTargetsAcrossTenants() {
+    // given two tenants set different targets on the same processDefinitionKey
+    final BusinessValueTargetDto defaultTenantTarget =
+        target(PROCESS_KEY, DEFAULT_TENANT, 28_800_000L, 85);
+    final BusinessValueTargetDto otherTenantTarget =
+        target(PROCESS_KEY, OTHER_TENANT, 3_600_000L, 50);
+
+    // when
+    writer.upsertTarget(defaultTenantTarget);
+    writer.upsertTarget(otherTenantTarget);
+
+    // then neither overwrites the other
+    assertThat(repository.getByKey(PROCESS_KEY, DEFAULT_TENANT)).contains(defaultTenantTarget);
+    assertThat(repository.getByKey(PROCESS_KEY, OTHER_TENANT)).contains(otherTenantTarget);
+  }
+
+  @Test
+  void shouldReturnEmptyForMissingKey() {
+    assertThat(repository.getByKey("does-not-exist", DEFAULT_TENANT)).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyWhenTenantMismatches() {
+    // given
+    writer.upsertTarget(target(PROCESS_KEY, DEFAULT_TENANT, 28_800_000L, 85));
+
+    // when reading with a tenant that never wrote
+    // then no row is returned
+    assertThat(repository.getByKey(PROCESS_KEY, OTHER_TENANT)).isEmpty();
+  }
+
+  @Test
+  void scanAllReturnsRowsAcrossTenants() {
+    // given
+    final BusinessValueTargetDto a = target(PROCESS_KEY, DEFAULT_TENANT, 28_800_000L, 85);
+    final BusinessValueTargetDto b = target(PROCESS_KEY, OTHER_TENANT, 3_600_000L, 50);
+    final BusinessValueTargetDto c = target("hr-onboarding", DEFAULT_TENANT, null, 70);
+    writer.upsertTarget(a);
+    writer.upsertTarget(b);
+    writer.upsertTarget(c);
+
+    // when
+    final List<BusinessValueTargetDto> all = repository.scanAll();
+
+    // then
+    assertThat(all).containsExactlyInAnyOrder(a, b, c);
+  }
+
+  private BusinessValueTargetDto target(
+      final String processDefinitionKey,
+      final String tenantId,
+      final Long cycleTimeMillis,
+      final Integer automationRatePct) {
+    return new BusinessValueTargetDto(
+        processDefinitionKey,
+        tenantId,
+        cycleTimeMillis,
+        cycleTimeMillis == null ? null : TargetValueUnit.HOURS,
+        automationRatePct,
+        OffsetDateTime.parse("2026-08-05T10:15:00Z"),
+        "sherrin@camunda.com");
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetIT.java
@@ -100,7 +100,7 @@ class BusinessValueTargetIT extends AbstractBrokerlessZeebeCCSMIT {
   }
 
   @Test
-  void scanAllReturnsRowsAcrossTenants() {
+  void shouldReturnAllRowsAcrossTenantsOnScanAll() {
     // given
     final BusinessValueTargetDto a = target(PROCESS_KEY, DEFAULT_TENANT, 28_800_000L, 85);
     final BusinessValueTargetDto b = target(PROCESS_KEY, OTHER_TENANT, 3_600_000L, 50);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepository.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepository.java
@@ -17,7 +17,7 @@ public interface BusinessValueTargetRepository {
 
   void upsert(BusinessValueTargetDto target);
 
-  Optional<BusinessValueTargetDto> getByKey(String processDefinitionKey, String tenantId);
+  Optional<BusinessValueTargetDto> getByKey(String tenantId, String processDefinitionKey);
 
   List<BusinessValueTargetDto> scanAll();
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepository.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepository.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
+import java.util.List;
+import java.util.Optional;
+
+public interface BusinessValueTargetRepository {
+
+  String ID_SEPARATOR = "::";
+
+  void upsert(BusinessValueTargetDto target);
+
+  Optional<BusinessValueTargetDto> getByKey(String processDefinitionKey, String tenantId);
+
+  List<BusinessValueTargetDto> scanAll();
+
+  static String documentId(final String tenantId, final String processDefinitionKey) {
+    if (tenantId == null) {
+      throw new IllegalArgumentException("tenantId must not be null on a business-value target");
+    }
+    if (processDefinitionKey == null) {
+      throw new IllegalArgumentException(
+          "processDefinitionKey must not be null on a business-value target");
+    }
+    return tenantId + ID_SEPARATOR + processDefinitionKey;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/BusinessValueTargetRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/BusinessValueTargetRepositoryES.java
@@ -69,7 +69,7 @@ public class BusinessValueTargetRepositoryES implements BusinessValueTargetRepos
 
   @Override
   public Optional<BusinessValueTargetDto> getByKey(
-      final String processDefinitionKey, final String tenantId) {
+      final String tenantId, final String processDefinitionKey) {
     final String documentId =
         BusinessValueTargetRepository.documentId(tenantId, processDefinitionKey);
     try {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/BusinessValueTargetRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/BusinessValueTargetRepositoryES.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository.es;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.BUSINESS_VALUE_TARGET_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
+
+import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.db.es.builders.OptimizeGetRequestBuilderES;
+import io.camunda.optimize.service.db.es.builders.OptimizeIndexRequestBuilderES;
+import io.camunda.optimize.service.db.es.builders.OptimizeSearchRequestBuilderES;
+import io.camunda.optimize.service.db.es.reader.ElasticsearchReaderUtil;
+import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(ElasticSearchCondition.class)
+public class BusinessValueTargetRepositoryES implements BusinessValueTargetRepository {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(BusinessValueTargetRepositoryES.class);
+
+  private final OptimizeElasticsearchClient esClient;
+  private final ObjectMapper objectMapper;
+
+  public BusinessValueTargetRepositoryES(
+      final OptimizeElasticsearchClient esClient, final ObjectMapper objectMapper) {
+    this.esClient = esClient;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public void upsert(final BusinessValueTargetDto target) {
+    final String documentId =
+        BusinessValueTargetRepository.documentId(
+            target.getTenantId(), target.getProcessDefinitionKey());
+    try {
+      esClient.index(
+          OptimizeIndexRequestBuilderES.of(
+              b ->
+                  b.optimizeIndex(esClient, BUSINESS_VALUE_TARGET_INDEX_NAME)
+                      .id(documentId)
+                      .document(target)
+                      .refresh(Refresh.True)));
+    } catch (final IOException e) {
+      final String errorMessage =
+          String.format("Could not upsert business-value target for id [%s].", documentId);
+      LOG.error(errorMessage, e);
+      throw new OptimizeRuntimeException(errorMessage, e);
+    }
+  }
+
+  @Override
+  public Optional<BusinessValueTargetDto> getByKey(
+      final String processDefinitionKey, final String tenantId) {
+    final String documentId =
+        BusinessValueTargetRepository.documentId(tenantId, processDefinitionKey);
+    try {
+      final var response =
+          esClient.get(
+              OptimizeGetRequestBuilderES.of(
+                  g -> g.optimizeIndex(esClient, BUSINESS_VALUE_TARGET_INDEX_NAME).id(documentId)),
+              BusinessValueTargetDto.class);
+      return response.found() ? Optional.ofNullable(response.source()) : Optional.empty();
+    } catch (final IOException e) {
+      final String errorMessage =
+          String.format("Could not read business-value target for id [%s].", documentId);
+      LOG.error(errorMessage, e);
+      throw new OptimizeRuntimeException(errorMessage, e);
+    }
+  }
+
+  @Override
+  public List<BusinessValueTargetDto> scanAll() {
+    final SearchRequest searchRequest =
+        OptimizeSearchRequestBuilderES.of(
+            b ->
+                b.optimizeIndex(esClient, BUSINESS_VALUE_TARGET_INDEX_NAME)
+                    .query(q -> q.matchAll(m -> m))
+                    .size(LIST_FETCH_LIMIT));
+    final SearchResponse<BusinessValueTargetDto> response;
+    try {
+      response = esClient.search(searchRequest, BusinessValueTargetDto.class);
+    } catch (final IOException e) {
+      final String errorMessage = "Could not scan business-value targets.";
+      LOG.error(errorMessage, e);
+      throw new OptimizeRuntimeException(errorMessage, e);
+    }
+    return ElasticsearchReaderUtil.mapHits(
+        response.hits(), BusinessValueTargetDto.class, objectMapper);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/BusinessValueTargetRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/BusinessValueTargetRepositoryES.java
@@ -11,6 +11,8 @@ import static io.camunda.optimize.service.db.DatabaseConstants.BUSINESS_VALUE_TA
 import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
 
 import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch._types.Result;
+import co.elastic.clients.elasticsearch.core.IndexResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -52,13 +54,22 @@ public class BusinessValueTargetRepositoryES implements BusinessValueTargetRepos
         BusinessValueTargetRepository.documentId(
             target.getTenantId(), target.getProcessDefinitionKey());
     try {
-      esClient.index(
-          OptimizeIndexRequestBuilderES.of(
-              b ->
-                  b.optimizeIndex(esClient, BUSINESS_VALUE_TARGET_INDEX_NAME)
-                      .id(documentId)
-                      .document(target)
-                      .refresh(Refresh.True)));
+      final IndexResponse response =
+          esClient.index(
+              OptimizeIndexRequestBuilderES.of(
+                  b ->
+                      b.optimizeIndex(esClient, BUSINESS_VALUE_TARGET_INDEX_NAME)
+                          .id(documentId)
+                          .document(target)
+                          .refresh(Refresh.True)));
+      if (response.result() != Result.Created && response.result() != Result.Updated) {
+        final String message =
+            String.format(
+                "Could not upsert business-value target for id [%s]. Result: [%s].",
+                documentId, response.result());
+        LOG.error(message);
+        throw new OptimizeRuntimeException(message);
+      }
     } catch (final IOException e) {
       final String errorMessage =
           String.format("Could not upsert business-value target for id [%s].", documentId);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/BusinessValueTargetRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/BusinessValueTargetRepositoryOS.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service.db.repository.os;
 
 import static io.camunda.optimize.service.db.DatabaseConstants.BUSINESS_VALUE_TARGET_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
+import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.matchAll;
 import static java.lang.String.format;
 
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
@@ -92,6 +93,7 @@ public class BusinessValueTargetRepositoryOS implements BusinessValueTargetRepos
     final SearchRequest.Builder requestBuilder =
         new SearchRequest.Builder()
             .index(indexNameService.getOptimizeIndexAliasForIndex(BUSINESS_VALUE_TARGET_INDEX_NAME))
+            .query(matchAll())
             .size(LIST_FETCH_LIMIT);
 
     return osClient.searchValues(requestBuilder, BusinessValueTargetDto.class);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/BusinessValueTargetRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/BusinessValueTargetRepositoryOS.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository.os;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.BUSINESS_VALUE_TARGET_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
+import static java.lang.String.format;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
+import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
+import io.camunda.optimize.service.db.schema.OptimizeIndexNameService;
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.List;
+import java.util.Optional;
+import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.opensearch._types.Result;
+import org.opensearch.client.opensearch.core.GetRequest;
+import org.opensearch.client.opensearch.core.GetResponse;
+import org.opensearch.client.opensearch.core.IndexRequest;
+import org.opensearch.client.opensearch.core.IndexResponse;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.slf4j.Logger;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(OpenSearchCondition.class)
+public class BusinessValueTargetRepositoryOS implements BusinessValueTargetRepository {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(BusinessValueTargetRepositoryOS.class);
+
+  private final OptimizeOpenSearchClient osClient;
+  private final OptimizeIndexNameService indexNameService;
+
+  public BusinessValueTargetRepositoryOS(
+      final OptimizeOpenSearchClient osClient, final OptimizeIndexNameService indexNameService) {
+    this.osClient = osClient;
+    this.indexNameService = indexNameService;
+  }
+
+  @Override
+  public void upsert(final BusinessValueTargetDto target) {
+    final String documentId =
+        BusinessValueTargetRepository.documentId(
+            target.getTenantId(), target.getProcessDefinitionKey());
+
+    final IndexRequest.Builder<BusinessValueTargetDto> request =
+        new IndexRequest.Builder<BusinessValueTargetDto>()
+            .index(indexNameService.getOptimizeIndexAliasForIndex(BUSINESS_VALUE_TARGET_INDEX_NAME))
+            .id(documentId)
+            .document(target)
+            .refresh(Refresh.True);
+
+    final IndexResponse response = osClient.index(request);
+    if (response.result() != Result.Created && response.result() != Result.Updated) {
+      final String message =
+          format(
+              "Could not upsert business-value target for id [%s]. Result: [%s].",
+              documentId, response.result());
+      LOG.error(message);
+      throw new OptimizeRuntimeException(message);
+    }
+  }
+
+  @Override
+  public Optional<BusinessValueTargetDto> getByKey(
+      final String processDefinitionKey, final String tenantId) {
+    final String documentId =
+        BusinessValueTargetRepository.documentId(tenantId, processDefinitionKey);
+    final GetRequest.Builder requestBuilder =
+        new GetRequest.Builder()
+            .index(indexNameService.getOptimizeIndexAliasForIndex(BUSINESS_VALUE_TARGET_INDEX_NAME))
+            .id(documentId);
+
+    final String errorMessage =
+        format("Could not read business-value target for id [%s].", documentId);
+    final GetResponse<BusinessValueTargetDto> response =
+        osClient.get(requestBuilder, BusinessValueTargetDto.class, errorMessage);
+    return response.found() ? Optional.ofNullable(response.source()) : Optional.empty();
+  }
+
+  @Override
+  public List<BusinessValueTargetDto> scanAll() {
+    final SearchRequest.Builder requestBuilder =
+        new SearchRequest.Builder()
+            .index(indexNameService.getOptimizeIndexAliasForIndex(BUSINESS_VALUE_TARGET_INDEX_NAME))
+            .size(LIST_FETCH_LIMIT);
+
+    return osClient.searchValues(requestBuilder, BusinessValueTargetDto.class);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/BusinessValueTargetRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/BusinessValueTargetRepositoryOS.java
@@ -72,7 +72,7 @@ public class BusinessValueTargetRepositoryOS implements BusinessValueTargetRepos
 
   @Override
   public Optional<BusinessValueTargetDto> getByKey(
-      final String processDefinitionKey, final String tenantId) {
+      final String tenantId, final String processDefinitionKey) {
     final String documentId =
         BusinessValueTargetRepository.documentId(tenantId, processDefinitionKey);
     final GetRequest.Builder requestBuilder =

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/BusinessValueTargetWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/BusinessValueTargetWriter.java
@@ -51,8 +51,9 @@ public class BusinessValueTargetWriter {
     if (target.getProcessDefinitionKey() == null || target.getProcessDefinitionKey().isBlank()) {
       throw new IllegalArgumentException("processDefinitionKey must not be null or blank");
     }
-    if (target.getTenantId() == null) {
-      throw new IllegalArgumentException("tenantId must not be null on a business-value target");
+    if (target.getTenantId() == null || target.getTenantId().isBlank()) {
+      throw new IllegalArgumentException(
+          "tenantId must not be null or blank on a business-value target");
     }
     final Long cycleTimeMillis = target.getCycleTimeTargetMillis();
     final TargetValueUnit unit = target.getCycleTimeTargetUnit();
@@ -64,6 +65,10 @@ public class BusinessValueTargetWriter {
               + "] unit=["
               + unit
               + "]");
+    }
+    if (cycleTimeMillis != null && cycleTimeMillis < 0) {
+      throw new IllegalArgumentException(
+          "cycleTimeTargetMillis must be non-negative but was " + cycleTimeMillis);
     }
     if (unit != null && !SUPPORTED_CYCLE_TIME_UNITS.contains(unit)) {
       throw new IllegalArgumentException(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/BusinessValueTargetWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/BusinessValueTargetWriter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.writer;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
+import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
+import java.util.EnumSet;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BusinessValueTargetWriter {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(BusinessValueTargetWriter.class);
+
+  private static final Set<TargetValueUnit> SUPPORTED_CYCLE_TIME_UNITS =
+      EnumSet.of(
+          TargetValueUnit.MILLIS,
+          TargetValueUnit.SECONDS,
+          TargetValueUnit.MINUTES,
+          TargetValueUnit.HOURS,
+          TargetValueUnit.DAYS);
+
+  private final BusinessValueTargetRepository repository;
+
+  public BusinessValueTargetWriter(final BusinessValueTargetRepository repository) {
+    this.repository = repository;
+  }
+
+  public void upsertTarget(final BusinessValueTargetDto target) {
+    validate(target);
+    LOG.debug(
+        "Upserting business-value target for definition [{}] tenant [{}]",
+        target.getProcessDefinitionKey(),
+        target.getTenantId());
+    repository.upsert(target);
+  }
+
+  private void validate(final BusinessValueTargetDto target) {
+    if (target == null) {
+      throw new IllegalArgumentException("target must not be null");
+    }
+    if (target.getProcessDefinitionKey() == null || target.getProcessDefinitionKey().isBlank()) {
+      throw new IllegalArgumentException("processDefinitionKey must not be null or blank");
+    }
+    if (target.getTenantId() == null) {
+      throw new IllegalArgumentException("tenantId must not be null on a business-value target");
+    }
+    final Long cycleTimeMillis = target.getCycleTimeTargetMillis();
+    final TargetValueUnit unit = target.getCycleTimeTargetUnit();
+    if ((cycleTimeMillis == null) != (unit == null)) {
+      throw new IllegalArgumentException(
+          "cycleTimeTargetMillis and cycleTimeTargetUnit must both be null or both be set, "
+              + "but got millis=["
+              + cycleTimeMillis
+              + "] unit=["
+              + unit
+              + "]");
+    }
+    if (unit != null && !SUPPORTED_CYCLE_TIME_UNITS.contains(unit)) {
+      throw new IllegalArgumentException(
+          "cycleTimeTargetUnit ["
+              + unit
+              + "] is not supported by business-value targets; allowed: "
+              + SUPPORTED_CYCLE_TIME_UNITS);
+    }
+    final Integer pct = target.getAutomationRateTargetPct();
+    if (pct != null && (pct < 0 || pct > 100)) {
+      throw new IllegalArgumentException(
+          "automationRateTargetPct must be within [0, 100] but was " + pct);
+    }
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepositoryTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepositoryTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class BusinessValueTargetRepositoryTest {
+
+  @Test
+  void documentIdCombinesTenantAndProcessKey() {
+    assertThat(BusinessValueTargetRepository.documentId("<default>", "invoice-automation"))
+        .isEqualTo("<default>::invoice-automation");
+  }
+
+  @Test
+  void differentTenantsProduceDifferentDocumentIds() {
+    final String a = BusinessValueTargetRepository.documentId("tenant-a", "invoice-automation");
+    final String b = BusinessValueTargetRepository.documentId("tenant-b", "invoice-automation");
+    assertThat(a).isNotEqualTo(b);
+  }
+
+  @Test
+  void nullTenantRejected() {
+    assertThatThrownBy(() -> BusinessValueTargetRepository.documentId(null, "any-key"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId");
+  }
+
+  @Test
+  void nullProcessKeyRejected() {
+    assertThatThrownBy(() -> BusinessValueTargetRepository.documentId("<default>", null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("processDefinitionKey");
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepositoryTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepositoryTest.java
@@ -10,33 +10,39 @@ package io.camunda.optimize.service.db.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.optimize.service.util.importing.ZeebeConstants;
 import org.junit.jupiter.api.Test;
 
 class BusinessValueTargetRepositoryTest {
 
   @Test
-  void documentIdCombinesTenantAndProcessKey() {
-    assertThat(BusinessValueTargetRepository.documentId("<default>", "invoice-automation"))
-        .isEqualTo("<default>::invoice-automation");
+  void shouldCombineTenantAndProcessKeyIntoDocumentId() {
+    assertThat(
+            BusinessValueTargetRepository.documentId(
+                ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID, "invoice-automation"))
+        .isEqualTo(ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID + "::invoice-automation");
   }
 
   @Test
-  void differentTenantsProduceDifferentDocumentIds() {
+  void shouldReturnDifferentDocumentIdsForDifferentTenants() {
     final String a = BusinessValueTargetRepository.documentId("tenant-a", "invoice-automation");
     final String b = BusinessValueTargetRepository.documentId("tenant-b", "invoice-automation");
     assertThat(a).isNotEqualTo(b);
   }
 
   @Test
-  void nullTenantRejected() {
+  void shouldRejectNullTenant() {
     assertThatThrownBy(() -> BusinessValueTargetRepository.documentId(null, "any-key"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tenantId");
   }
 
   @Test
-  void nullProcessKeyRejected() {
-    assertThatThrownBy(() -> BusinessValueTargetRepository.documentId("<default>", null))
+  void shouldRejectNullProcessKey() {
+    assertThatThrownBy(
+            () ->
+                BusinessValueTargetRepository.documentId(
+                    ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID, null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("processDefinitionKey");
   }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/writer/BusinessValueTargetWriterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/writer/BusinessValueTargetWriterTest.java
@@ -68,6 +68,58 @@ class BusinessValueTargetWriterTest {
   }
 
   @Test
+  void shouldRejectBlankTenantId() {
+    // given
+    final BusinessValueTargetDto target = validTarget();
+    target.setTenantId("   ");
+
+    // when + then
+    assertThatThrownBy(() -> writer.upsertTarget(target))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectEmptyTenantId() {
+    // given
+    final BusinessValueTargetDto target = validTarget();
+    target.setTenantId("");
+
+    // when + then
+    assertThatThrownBy(() -> writer.upsertTarget(target))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectNegativeCycleTimeMillis() {
+    // given a negative duration is not a valid target
+    final BusinessValueTargetDto target = validTarget();
+    target.setCycleTimeTargetMillis(-1L);
+
+    // when + then
+    assertThatThrownBy(() -> writer.upsertTarget(target))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("cycleTimeTargetMillis");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldAcceptZeroCycleTimeMillis() {
+    // given zero is a valid (albeit tight) target
+    final BusinessValueTargetDto target = validTarget();
+    target.setCycleTimeTargetMillis(0L);
+
+    // when
+    writer.upsertTarget(target);
+
+    // then
+    verify(repository).upsert(target);
+  }
+
+  @Test
   void shouldRejectBlankProcessDefinitionKey() {
     // given
     final BusinessValueTargetDto target = validTarget();

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/writer/BusinessValueTargetWriterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/writer/BusinessValueTargetWriterTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.writer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
+import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class BusinessValueTargetWriterTest {
+
+  private BusinessValueTargetRepository repository;
+  private BusinessValueTargetWriter writer;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(BusinessValueTargetRepository.class);
+    writer = new BusinessValueTargetWriter(repository);
+  }
+
+  @Test
+  void shouldDelegateValidTargetToRepository() {
+    // given
+    final BusinessValueTargetDto target = validTarget();
+
+    // when
+    writer.upsertTarget(target);
+
+    // then
+    verify(repository).upsert(target);
+  }
+
+  @Test
+  void shouldRejectNullTarget() {
+    assertThatThrownBy(() -> writer.upsertTarget(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("target");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectNullTenantId() {
+    // given
+    final BusinessValueTargetDto target = validTarget();
+    target.setTenantId(null);
+
+    // when + then
+    assertThatThrownBy(() -> writer.upsertTarget(target))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectBlankProcessDefinitionKey() {
+    // given
+    final BusinessValueTargetDto target = validTarget();
+    target.setProcessDefinitionKey("");
+
+    // when + then
+    assertThatThrownBy(() -> writer.upsertTarget(target))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("processDefinitionKey");
+    verifyNoInteractions(repository);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = TargetValueUnit.class,
+      names = {"WEEKS", "MONTHS", "YEARS"})
+  void shouldRejectUnsupportedCycleTimeUnit(final TargetValueUnit unsupported) {
+    // given
+    final BusinessValueTargetDto target = validTarget();
+    target.setCycleTimeTargetUnit(unsupported);
+
+    // when + then
+    assertThatThrownBy(() -> writer.upsertTarget(target))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("cycleTimeTargetUnit");
+    verifyNoInteractions(repository);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = TargetValueUnit.class,
+      names = {"MILLIS", "SECONDS", "MINUTES", "HOURS", "DAYS"})
+  void shouldAcceptSupportedCycleTimeUnit(final TargetValueUnit supported) {
+    // given
+    final BusinessValueTargetDto target = validTarget();
+    target.setCycleTimeTargetUnit(supported);
+
+    // when
+    writer.upsertTarget(target);
+
+    // then
+    verify(repository).upsert(target);
+  }
+
+  @Test
+  void shouldAcceptNullCycleTimeTargetUnit() {
+    // given
+    final BusinessValueTargetDto target = validTarget();
+    target.setCycleTimeTargetMillis(null);
+    target.setCycleTimeTargetUnit(null);
+
+    // when
+    writer.upsertTarget(target);
+
+    // then
+    verify(repository).upsert(target);
+  }
+
+  @Test
+  void shouldRejectMillisWithoutUnit() {
+    // given a duration value with no unit to interpret it
+    final BusinessValueTargetDto target = validTarget();
+    target.setCycleTimeTargetUnit(null);
+
+    // when + then
+    assertThatThrownBy(() -> writer.upsertTarget(target))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("cycleTimeTargetMillis")
+        .hasMessageContaining("cycleTimeTargetUnit");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectUnitWithoutMillis() {
+    // given a unit with no numeric duration
+    final BusinessValueTargetDto target = validTarget();
+    target.setCycleTimeTargetMillis(null);
+
+    // when + then
+    assertThatThrownBy(() -> writer.upsertTarget(target))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("cycleTimeTargetMillis")
+        .hasMessageContaining("cycleTimeTargetUnit");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectAutomationRateOutOfRange() {
+    // given
+    final BusinessValueTargetDto target = validTarget();
+    target.setAutomationRateTargetPct(101);
+
+    // when + then
+    assertThatThrownBy(() -> writer.upsertTarget(target))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("automationRateTargetPct");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldAcceptAutomationRateAtBoundaries() {
+    // given
+    final BusinessValueTargetDto lower = validTarget();
+    lower.setAutomationRateTargetPct(0);
+    final BusinessValueTargetDto upper = validTarget();
+    upper.setAutomationRateTargetPct(100);
+
+    // when
+    writer.upsertTarget(lower);
+    writer.upsertTarget(upper);
+
+    // then
+    verify(repository).upsert(lower);
+    verify(repository).upsert(upper);
+  }
+
+  private BusinessValueTargetDto validTarget() {
+    final BusinessValueTargetDto dto = new BusinessValueTargetDto();
+    dto.setProcessDefinitionKey("invoice-automation");
+    dto.setTenantId("<default>");
+    dto.setCycleTimeTargetMillis(28_800_000L);
+    dto.setCycleTimeTargetUnit(TargetValueUnit.HOURS);
+    dto.setAutomationRateTargetPct(85);
+    dto.setUpdatedAt(OffsetDateTime.parse("2026-08-05T10:15:00Z"));
+    dto.setUpdatedBy("sherrin@camunda.com");
+    assertThat(dto.getTenantId()).isNotNull();
+    return dto;
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/writer/BusinessValueTargetWriterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/writer/BusinessValueTargetWriterTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
 import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
+import io.camunda.optimize.service.util.importing.ZeebeConstants;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -186,7 +187,7 @@ class BusinessValueTargetWriterTest {
   private BusinessValueTargetDto validTarget() {
     final BusinessValueTargetDto dto = new BusinessValueTargetDto();
     dto.setProcessDefinitionKey("invoice-automation");
-    dto.setTenantId("<default>");
+    dto.setTenantId(ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID);
     dto.setCycleTimeTargetMillis(28_800_000L);
     dto.setCycleTimeTargetUnit(TargetValueUnit.HOURS);
     dto.setAutomationRateTargetPct(85);

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/Upgrade89to810PlanFactory.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/Upgrade89to810PlanFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.upgrade.plan.factories;
+
+import io.camunda.optimize.service.db.es.schema.index.BusinessValueTargetIndexES;
+import io.camunda.optimize.upgrade.plan.UpgradeExecutionDependencies;
+import io.camunda.optimize.upgrade.plan.UpgradePlan;
+import io.camunda.optimize.upgrade.plan.UpgradePlanBuilder;
+import io.camunda.optimize.upgrade.steps.schema.CreateIndexStep;
+
+public class Upgrade89to810PlanFactory implements UpgradePlanFactory {
+
+  @Override
+  public UpgradePlan createUpgradePlan(final UpgradeExecutionDependencies dependencies) {
+    return UpgradePlanBuilder.createUpgradePlan()
+        .fromVersion("8.9")
+        .toVersion("8.10.0")
+        .addUpgradeStep(new CreateIndexStep(new BusinessValueTargetIndexES()))
+        .build();
+  }
+}

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/plan/factories/Upgrade89to810PlanFactoryIT.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/plan/factories/Upgrade89to810PlanFactoryIT.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.upgrade.plan.factories;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.service.db.es.schema.index.BusinessValueTargetIndexES;
+import io.camunda.optimize.service.db.os.schema.index.BusinessValueTargetIndexOS;
+import io.camunda.optimize.service.db.schema.IndexMappingCreator;
+import io.camunda.optimize.upgrade.AbstractUpgradeIT;
+import io.camunda.optimize.upgrade.plan.UpgradePlan;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link Upgrade89to810PlanFactory} creates the {@code business-value-target} index
+ * on an 8.9 cluster, so upgraded and fresh-install schemas stay in parity.
+ */
+public class Upgrade89to810PlanFactoryIT extends AbstractUpgradeIT {
+
+  private static final String FROM_MINOR = "8.9";
+  private static final String FROM_PATCH = "8.9.0";
+
+  @Test
+  public void shouldCreateBusinessValueTargetIndexOnUpgrade() {
+    // given an 8.9 cluster (schema version is set to the previous minor)
+    setMetadataVersion(FROM_PATCH);
+    final IndexMappingCreator businessValueTargetIndex = businessValueTargetIndex();
+    assertThat(getIndicesForMapping(businessValueTargetIndex))
+        .as("business-value-target index must not exist before the upgrade runs")
+        .isEmpty();
+
+    // when the 8.9 -> 8.10 upgrade plan runs
+    final UpgradePlan plan = new Upgrade89to810PlanFactory().createUpgradePlan(upgradeDependencies);
+    upgradeProcedure.performUpgrade(plan);
+
+    // then the business-value-target index exists in the database
+    assertThat(getIndicesForMapping(businessValueTargetIndex))
+        .as("business-value-target index must exist after the upgrade runs")
+        .isNotEmpty();
+  }
+
+  private IndexMappingCreator businessValueTargetIndex() {
+    return isElasticSearchUpgrade()
+        ? new BusinessValueTargetIndexES()
+        : new BusinessValueTargetIndexOS();
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/businessvalue/BusinessValueTargetDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/businessvalue/BusinessValueTargetDto.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.businessvalue;
+
+import io.camunda.optimize.dto.optimize.OptimizeDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+public class BusinessValueTargetDto implements OptimizeDto {
+
+  private String processDefinitionKey;
+  private String tenantId;
+  private Long cycleTimeTargetMillis;
+  private TargetValueUnit cycleTimeTargetUnit;
+  private Integer automationRateTargetPct;
+  private OffsetDateTime updatedAt;
+  private String updatedBy;
+
+  public BusinessValueTargetDto() {}
+
+  public BusinessValueTargetDto(
+      final String processDefinitionKey,
+      final String tenantId,
+      final Long cycleTimeTargetMillis,
+      final TargetValueUnit cycleTimeTargetUnit,
+      final Integer automationRateTargetPct,
+      final OffsetDateTime updatedAt,
+      final String updatedBy) {
+    this.processDefinitionKey = processDefinitionKey;
+    this.tenantId = tenantId;
+    this.cycleTimeTargetMillis = cycleTimeTargetMillis;
+    this.cycleTimeTargetUnit = cycleTimeTargetUnit;
+    this.automationRateTargetPct = automationRateTargetPct;
+    this.updatedAt = updatedAt;
+    this.updatedBy = updatedBy;
+  }
+
+  public String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public Long getCycleTimeTargetMillis() {
+    return cycleTimeTargetMillis;
+  }
+
+  public void setCycleTimeTargetMillis(final Long cycleTimeTargetMillis) {
+    this.cycleTimeTargetMillis = cycleTimeTargetMillis;
+  }
+
+  public TargetValueUnit getCycleTimeTargetUnit() {
+    return cycleTimeTargetUnit;
+  }
+
+  public void setCycleTimeTargetUnit(final TargetValueUnit cycleTimeTargetUnit) {
+    this.cycleTimeTargetUnit = cycleTimeTargetUnit;
+  }
+
+  public Integer getAutomationRateTargetPct() {
+    return automationRateTargetPct;
+  }
+
+  public void setAutomationRateTargetPct(final Integer automationRateTargetPct) {
+    this.automationRateTargetPct = automationRateTargetPct;
+  }
+
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public void setUpdatedAt(final OffsetDateTime updatedAt) {
+    this.updatedAt = updatedAt;
+  }
+
+  public String getUpdatedBy() {
+    return updatedBy;
+  }
+
+  public void setUpdatedBy(final String updatedBy) {
+    this.updatedBy = updatedBy;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BusinessValueTargetDto that = (BusinessValueTargetDto) o;
+    return Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(cycleTimeTargetMillis, that.cycleTimeTargetMillis)
+        && cycleTimeTargetUnit == that.cycleTimeTargetUnit
+        && Objects.equals(automationRateTargetPct, that.automationRateTargetPct)
+        && Objects.equals(updatedAt, that.updatedAt)
+        && Objects.equals(updatedBy, that.updatedBy);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        processDefinitionKey,
+        tenantId,
+        cycleTimeTargetMillis,
+        cycleTimeTargetUnit,
+        automationRateTargetPct,
+        updatedAt,
+        updatedBy);
+  }
+
+  @Override
+  public String toString() {
+    return "BusinessValueTargetDto(processDefinitionKey="
+        + processDefinitionKey
+        + ", tenantId="
+        + tenantId
+        + ", cycleTimeTargetMillis="
+        + cycleTimeTargetMillis
+        + ", cycleTimeTargetUnit="
+        + cycleTimeTargetUnit
+        + ", automationRateTargetPct="
+        + automationRateTargetPct
+        + ", updatedAt="
+        + updatedAt
+        + ", updatedBy="
+        + updatedBy
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
+  public static final class Fields {
+
+    public static final String processDefinitionKey = "processDefinitionKey";
+    public static final String tenantId = "tenantId";
+    public static final String cycleTimeTargetMillis = "cycleTimeTargetMillis";
+    public static final String cycleTimeTargetUnit = "cycleTimeTargetUnit";
+    public static final String automationRateTargetPct = "automationRateTargetPct";
+    public static final String updatedAt = "updatedAt";
+    public static final String updatedBy = "updatedBy";
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseConstants.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseConstants.java
@@ -50,6 +50,7 @@ public final class DatabaseConstants {
   public static final String TENANT_INDEX_NAME = "tenant";
   public static final String VARIABLE_LABEL_INDEX_NAME = "variable-label";
   public static final String PROCESS_OVERVIEW_INDEX_NAME = "process-overview";
+  public static final String BUSINESS_VALUE_TARGET_INDEX_NAME = "business-value-target";
   public static final String INSTANT_DASHBOARD_INDEX_NAME = "instant-dashboard";
   public static final String ZEEBE_PROCESS_DEFINITION_INDEX_NAME = "process";
   public static final String ZEEBE_PROCESS_INSTANCE_INDEX_NAME = "process-instance";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/ElasticSearchSchemaManager.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/ElasticSearchSchemaManager.java
@@ -24,6 +24,7 @@ import io.camunda.optimize.service.db.es.MappingMetadataUtilES;
 import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
 import io.camunda.optimize.service.db.es.schema.index.AlertIndexES;
 import io.camunda.optimize.service.db.es.schema.index.BusinessKeyIndexES;
+import io.camunda.optimize.service.db.es.schema.index.BusinessValueTargetIndexES;
 import io.camunda.optimize.service.db.es.schema.index.CollectionIndexES;
 import io.camunda.optimize.service.db.es.schema.index.DashboardIndexES;
 import io.camunda.optimize.service.db.es.schema.index.DashboardShareIndexES;
@@ -379,6 +380,7 @@ public class ElasticSearchSchemaManager
     return Arrays.asList(
         new AlertIndexES(),
         new BusinessKeyIndexES(),
+        new BusinessValueTargetIndexES(),
         new CollectionIndexES(),
         new DashboardIndexES(),
         new DashboardShareIndexES(),

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/index/BusinessValueTargetIndexES.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/index/BusinessValueTargetIndexES.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.schema.index;
+
+import co.elastic.clients.elasticsearch.indices.IndexSettings;
+import io.camunda.optimize.service.db.schema.index.BusinessValueTargetIndex;
+import java.io.IOException;
+
+public class BusinessValueTargetIndexES extends BusinessValueTargetIndex<IndexSettings.Builder> {
+
+  @Override
+  public IndexSettings.Builder addStaticSetting(
+      final String key, final int value, final IndexSettings.Builder builder) throws IOException {
+    return builder.numberOfShards(Integer.toString(value));
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/OpenSearchSchemaManager.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/OpenSearchSchemaManager.java
@@ -22,6 +22,7 @@ import io.camunda.optimize.service.db.os.MappingMetadataUtilOS;
 import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.os.schema.index.AlertIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.BusinessKeyIndexOS;
+import io.camunda.optimize.service.db.os.schema.index.BusinessValueTargetIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.CollectionIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.DashboardIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.DashboardShareIndexOS;
@@ -550,6 +551,7 @@ public class OpenSearchSchemaManager
     return Arrays.asList(
         new AlertIndexOS(),
         new BusinessKeyIndexOS(),
+        new BusinessValueTargetIndexOS(),
         new CollectionIndexOS(),
         new DashboardIndexOS(),
         new DashboardShareIndexOS(),

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/index/BusinessValueTargetIndexOS.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/index/BusinessValueTargetIndexOS.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.schema.index;
+
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchUtil;
+import io.camunda.optimize.service.db.schema.index.BusinessValueTargetIndex;
+import org.opensearch.client.opensearch.indices.IndexSettings;
+
+public class BusinessValueTargetIndexOS extends BusinessValueTargetIndex<IndexSettings.Builder> {
+
+  @Override
+  public IndexSettings.Builder addStaticSetting(
+      final String key, final int value, final IndexSettings.Builder contentBuilder) {
+    return OptimizeOpenSearchUtil.addStaticSetting(key, value, contentBuilder);
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/IndexLookupUtil.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/IndexLookupUtil.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service.db.schema;
 
 import io.camunda.optimize.service.db.es.schema.index.AlertIndexES;
 import io.camunda.optimize.service.db.es.schema.index.BusinessKeyIndexES;
+import io.camunda.optimize.service.db.es.schema.index.BusinessValueTargetIndexES;
 import io.camunda.optimize.service.db.es.schema.index.CollectionIndexES;
 import io.camunda.optimize.service.db.es.schema.index.DashboardIndexES;
 import io.camunda.optimize.service.db.es.schema.index.DashboardShareIndexES;
@@ -33,6 +34,7 @@ import io.camunda.optimize.service.db.es.schema.index.report.SingleDecisionRepor
 import io.camunda.optimize.service.db.es.schema.index.report.SingleProcessReportIndexES;
 import io.camunda.optimize.service.db.os.schema.index.AlertIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.BusinessKeyIndexOS;
+import io.camunda.optimize.service.db.os.schema.index.BusinessValueTargetIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.CollectionIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.DashboardIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.DashboardShareIndexOS;
@@ -110,6 +112,9 @@ public class IndexLookupUtil {
     final Map<String, Function<String, IndexMappingCreator>> lookupMap = new HashMap<>();
     lookupMap.put(AlertIndexES.class.getSimpleName(), index -> new AlertIndexOS());
     lookupMap.put(BusinessKeyIndexES.class.getSimpleName(), index -> new BusinessKeyIndexOS());
+    lookupMap.put(
+        BusinessValueTargetIndexES.class.getSimpleName(),
+        index -> new BusinessValueTargetIndexOS());
     lookupMap.put(CollectionIndexES.class.getSimpleName(), index -> new CollectionIndexOS());
     lookupMap.put(DashboardIndexES.class.getSimpleName(), index -> new DashboardIndexOS());
     lookupMap.put(
@@ -160,6 +165,9 @@ public class IndexLookupUtil {
     // OpenSearch -> ElasticSearch Index lookup functions
     lookupMap.put(AlertIndexOS.class.getSimpleName(), index -> new AlertIndexES());
     lookupMap.put(BusinessKeyIndexOS.class.getSimpleName(), index -> new BusinessKeyIndexES());
+    lookupMap.put(
+        BusinessValueTargetIndexOS.class.getSimpleName(),
+        index -> new BusinessValueTargetIndexES());
     lookupMap.put(CollectionIndexOS.class.getSimpleName(), index -> new CollectionIndexES());
     lookupMap.put(DashboardIndexOS.class.getSimpleName(), index -> new DashboardIndexES());
     lookupMap.put(

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/BusinessValueTargetIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/BusinessValueTargetIndex.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.schema.index;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.OPTIMIZE_DATE_FORMAT;
+
+import co.elastic.clients.elasticsearch._types.mapping.Property;
+import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
+import io.camunda.optimize.service.db.DatabaseConstants;
+import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+
+public abstract class BusinessValueTargetIndex<TBuilder>
+    extends DefaultIndexMappingCreator<TBuilder> {
+
+  public static final int VERSION = 1;
+
+  public static final String PROCESS_DEFINITION_KEY =
+      BusinessValueTargetDto.Fields.processDefinitionKey;
+  public static final String TENANT_ID = BusinessValueTargetDto.Fields.tenantId;
+  public static final String CYCLE_TIME_TARGET_MILLIS =
+      BusinessValueTargetDto.Fields.cycleTimeTargetMillis;
+  public static final String CYCLE_TIME_TARGET_UNIT =
+      BusinessValueTargetDto.Fields.cycleTimeTargetUnit;
+  public static final String AUTOMATION_RATE_TARGET_PCT =
+      BusinessValueTargetDto.Fields.automationRateTargetPct;
+  public static final String UPDATED_AT = BusinessValueTargetDto.Fields.updatedAt;
+  public static final String UPDATED_BY = BusinessValueTargetDto.Fields.updatedBy;
+
+  @Override
+  public String getIndexName() {
+    return DatabaseConstants.BUSINESS_VALUE_TARGET_INDEX_NAME;
+  }
+
+  @Override
+  public int getVersion() {
+    return VERSION;
+  }
+
+  @Override
+  public TypeMapping.Builder addProperties(final TypeMapping.Builder builder) {
+    return builder
+        .properties(PROCESS_DEFINITION_KEY, p -> p.keyword(k -> k))
+        .properties(TENANT_ID, p -> p.keyword(k -> k))
+        .properties(CYCLE_TIME_TARGET_MILLIS, p -> p.long_(l -> l))
+        .properties(CYCLE_TIME_TARGET_UNIT, p -> p.keyword(k -> k))
+        .properties(AUTOMATION_RATE_TARGET_PCT, p -> p.integer(i -> i))
+        .properties(UPDATED_AT, Property.of(p -> p.date(d -> d.format(OPTIMIZE_DATE_FORMAT))))
+        .properties(UPDATED_BY, p -> p.keyword(k -> k));
+  }
+}


### PR DESCRIPTION
## Summary

Adds the `business-value-target` Optimize index that stores per-process KPI targets (cycle time, automation rate) for the Business Value Dashboard. Dual-backend (Elasticsearch + OpenSearch), one doc per `(tenantId, processDefinitionKey)` so targets survive redeploys and cannot silently collide across tenants that reuse the same BPMN id.

Includes: DTO, index (abstract + ES/OS concretes), writer with validation, dual-backend repository, schema-manager + `IndexLookupUtil` registration, unit tests (25 tests), and integration test scenarios (round-trip, overwrite, tenant isolation, missing-key, wrong-tenant, scanAll).

Scope is strictly the index scaffolding — REST endpoints, the L0 overview index, and seed defaults are separate M2 tickets.

Design rationale + alternatives will be documented on camunda/camunda-hub#27017.

## Refresh policy — deviation from tech design

The BVD technical design originally specified `Refresh.WaitFor` (`WAIT_UNTIL`). This PR uses **`Refresh.True`** instead. Every existing repository under `optimize/backend/service/db/repository/` uses `Refresh.True`; target writes are rare (a handful per week per cluster) so the immediate-refresh cost is negligible; both policies satisfy the modal's "next read sees the write" guarantee. Chose codebase consistency over the design doc.

## Tenancy — deviation from ProcessOverviewIndex precedent

`ProcessOverviewIndex` keys per-key config by `processDefinitionKey` alone and has a latent same-key-cross-tenant collision. BVD makes that collision user-visible through the target modal, so this new index carries `tenantId` on the doc and composes `_id = {tenantId}::{processDefinitionKey}`. The null-tenant sentinel is the canonical `TenantOwned.DEFAULT_TENANT_IDENTIFIER` (`<default>`) from `zeebe/protocol`.

Closes camunda/camunda-hub#27017

## Test plan

- [ ] Unit tests green: `./mvnw -f optimize/backend/pom.xml test -Dtest='BusinessValueTargetWriterTest,BusinessValueTargetRepositoryTest,IndexLookupUtilTest' -DskipITs -Dquickly -DskipTests=false`
- [ ] IT green against ES: `./mvnw -f optimize/backend/pom.xml verify -Dit.test=BusinessValueTargetIT -DskipUTs -Dquickly -DskipTests=false`
- [ ] IT green against OS (env: `CAMUNDA_OPTIMIZE_DATABASE=opensearch`)
- [ ] Boot Optimize locally; confirm `business-value-target` index shows up via `curl /_cat/indices?v`
- [ ] `./mvnw install -Dquickly -T1C` compiles the full repo