### PR TITLE
ci: bump AWS OpenSearch integration test version from 3.5 to 3.7

### DIFF
--- a/.github/actions/setup-aws-opensearch-env/README.md
+++ b/.github/actions/setup-aws-opensearch-env/README.md
@@ -11,7 +11,7 @@ for subsequent steps.
 | `vault-address`      | Vault URL to retrieve secrets from                | Yes      |
 | `vault-role-id`      | Vault Role ID to use                              | Yes      |
 | `vault-secret-id`    | Vault Secret ID to use                            | Yes      |
-| `opensearch-version` | OpenSearch version to configure (`2.19` or `3.5`) | Yes      |
+| `opensearch-version` | OpenSearch version to configure (`2.19` or `3.7`) | Yes      |
 
 ## Outputs
 

--- a/.github/actions/setup-aws-opensearch-env/action.yml
+++ b/.github/actions/setup-aws-opensearch-env/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: Vault Secret ID to use
     required: true
   opensearch-version:
-    description: OpenSearch version to configure (2.19 or 3.5)
+    description: OpenSearch version to configure (2.19 or 3.7)
     required: true
 
 outputs:
@@ -39,7 +39,7 @@ runs:
         secretId: ${{ inputs.vault-secret-id }}
         secrets: |
           secret/data/products/camunda/ci/github-actions CAMUNDA_CI_OPENSEARCH_2_19_URL;
-          secret/data/products/camunda/ci/github-actions CAMUNDA_CI_OPENSEARCH_3_5_URL;
+          secret/data/products/camunda/ci/github-actions CAMUNDA_CI_OPENSEARCH_3_7_URL;
 
     - name: Resolve OpenSearch URL and export env
       id: resolve-os-url
@@ -57,12 +57,12 @@ runs:
         then
           echo "Using OS 2.19"
           OS_URL="https://${{ steps.secrets.outputs.CAMUNDA_CI_OPENSEARCH_2_19_URL }}"
-        elif [[ "${{ inputs.opensearch-version }}" = "3.5" ]]
+        elif [[ "${{ inputs.opensearch-version }}" = "3.7" ]]
         then
-          echo "Using OS 3.5"
-          OS_URL="https://${{ steps.secrets.outputs.CAMUNDA_CI_OPENSEARCH_3_5_URL }}"
+          echo "Using OS 3.7"
+          OS_URL="https://${{ steps.secrets.outputs.CAMUNDA_CI_OPENSEARCH_3_7_URL }}"
         else
-          echo "Unsupported OpenSearch version: '${{ inputs.opensearch-version }}'. Supported versions: 2.19, 3.5."
+          echo "Unsupported OpenSearch version: '${{ inputs.opensearch-version }}'. Supported versions: 2.19, 3.7."
           exit 1
         fi
 

--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -20,7 +20,7 @@ on:
         type: choice
         options:
           - "2.19"
-          - "3.5"
+          - "3.7"
           - "all"
   schedule:
     - cron: "0 4 * * Mon-Fri"
@@ -28,11 +28,11 @@ on:
 jobs:
   # Each matrix leg below is a separate call to the reusable workflow, i.e. a fully
   # independent job graph (check version -> cleanup -> integration tests -> slack
-  # notification, sequential within that call). That's what makes the 2.19 and 3.5
+  # notification, sequential within that call). That's what makes the 2.19 and 3.7
   # chains run as two parallel, independent boxes instead of one shared job graph
   # gated on both versions at every step: a `needs:` on a matrixed job waits for ALL
   # of that job's matrix legs, not just the matching os_version, so keeping os_version
-  # as a matrix dimension on shared jobs (as before) would still serialize 2.19 and 3.5
+  # as a matrix dimension on shared jobs (as before) would still serialize 2.19 and 3.7
   # at each phase boundary even with per-version concurrency groups.
   run-aws-opensearch-tests:
     name: "AWS OpenSearch ${{ matrix.os_version }}"
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         # "all" and the unset/schedule case both expand to both versions.
-        os_version: ${{ fromJSON(format('[{0}]', (github.event.inputs.opensearch-version == 'all' || !github.event.inputs.opensearch-version) && '"2.19", "3.5"' || format('"{0}"', github.event.inputs.opensearch-version))) }}
+        os_version: ${{ fromJSON(format('[{0}]', (github.event.inputs.opensearch-version == 'all' || !github.event.inputs.opensearch-version) && '"2.19", "3.7"' || format('"{0}"', github.event.inputs.opensearch-version))) }}
     uses: ./.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
     secrets: inherit
     with:


### PR DESCRIPTION
AWS OpenSearch 3.7 is now available. We want to raise the minimum supported OpenSearch version for the 8.10 release, which first requires validating compatibility against 3.7.

Infra provisioned an instance for dev/stage/prod in infra-core (camunda/infra-core#13784). This swaps the AWS OpenSearch integration test matrix from 3.5 to 3.7.

Verified with a manual run against this branch targeting 3.7: https://github.com/camunda/camunda/actions/runs/31039301911