### PR TITLE
feat: per physical tenant document store credentials

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Document.java
+++ b/configuration/src/main/java/io/camunda/configuration/Document.java
@@ -164,6 +164,16 @@ public class Document {
     private Boolean chunkedEncodingEnabled;
     private Boolean supportLegacyMd5;
 
+    /**
+     * Access key of the credentials this store authenticates with. Must be set together with {@code
+     * secret-key}. When neither is set, the store uses the credentials the AWS SDK resolves from
+     * the process environment, which are shared with every other store.
+     */
+    private String accessKey;
+
+    /** Secret key of the credentials this store authenticates with. See {@code access-key}. */
+    private String secretKey;
+
     public String getBucketName() {
       return bucketName;
     }
@@ -226,6 +236,22 @@ public class Document {
 
     public void setSupportLegacyMd5(final Boolean supportLegacyMd5) {
       this.supportLegacyMd5 = supportLegacyMd5;
+    }
+
+    public String getAccessKey() {
+      return accessKey;
+    }
+
+    public void setAccessKey(final String accessKey) {
+      this.accessKey = accessKey;
+    }
+
+    public String getSecretKey() {
+      return secretKey;
+    }
+
+    public void setSecretKey(final String secretKey) {
+      this.secretKey = secretKey;
     }
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/Document.java
+++ b/configuration/src/main/java/io/camunda/configuration/Document.java
@@ -259,6 +259,12 @@ public class Document {
     private String bucketName;
     private String prefix;
 
+    /**
+     * Path to the service account key file this store authenticates with. When unset, the store
+     * uses the application default credentials, which are shared with every other store.
+     */
+    private String credentialsPath;
+
     public String getBucketName() {
       return bucketName;
     }
@@ -273,6 +279,14 @@ public class Document {
 
     public void setPrefix(final String prefix) {
       this.prefix = prefix;
+    }
+
+    public String getCredentialsPath() {
+      return credentialsPath;
+    }
+
+    public void setCredentialsPath(final String credentialsPath) {
+      this.credentialsPath = credentialsPath;
     }
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
@@ -19,6 +19,7 @@ import io.camunda.configuration.physicaltenants.MapOverlaySpec.MapDescriptor;
 import io.camunda.configuration.physicaltenants.MapOverlaySpec.OverlayContext;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.boot.context.properties.bind.Bindable;
@@ -58,7 +59,39 @@ public final class PhysicalTenantDocumentConfigurations {
 
   private static void postProcess(final OverlayContext context, final Document doc) {
     validateStoreIdUniqueness(context.tenantId(), doc);
+    validateCredentialOverridesAreComplete(context);
     narrowToAssigned(context, doc);
+  }
+
+  /**
+   * Rejects a tenant that restates only one half of an AWS key pair.
+   *
+   * <p>The overlay merges field by field, so the unrestated half is inherited from the root and the
+   * store ends up with an access key and a secret key belonging to two different identities. Both
+   * are non-null, so the store's own both-or-neither check passes, the client builds, and the
+   * mismatch first appears as an S3 signature failure at the first document operation — an error
+   * that names nothing about the merge that produced it. The delta is only visible here, before it
+   * is folded into the root, so this is the one place the pairing can be enforced.
+   */
+  private static void validateCredentialOverridesAreComplete(final OverlayContext context) {
+    final Map<String, AwsStore> overrides =
+        context
+            .binder()
+            .bind(context.ptPrefix() + ".aws", Bindable.mapOf(String.class, AwsStore.class))
+            .orElseGet(Map::of);
+    overrides.forEach(
+        (storeId, store) -> {
+          if ((store.getAccessKey() == null) == (store.getSecretKey() == null)) {
+            return;
+          }
+          throw new UnifiedConfigurationException(
+              "Physical tenant '"
+                  + context.tenantId()
+                  + "' overrides only one of 'access-key' and 'secret-key' for document store '"
+                  + storeId
+                  + "'. The other half would be inherited from the root configuration, pairing two"
+                  + " keys that belong to different identities. Override both or neither.");
+        });
   }
 
   private static void validateStoreIdUniqueness(final String tenantId, final Document doc) {

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
@@ -64,14 +64,11 @@ public final class PhysicalTenantDocumentConfigurations {
   }
 
   /**
-   * Rejects a tenant that restates only one half of an AWS key pair.
-   *
-   * <p>The overlay merges field by field, so the unrestated half is inherited from the root and the
-   * store ends up with an access key and a secret key belonging to two different identities. Both
-   * are non-null, so the store's own both-or-neither check passes, the client builds, and the
-   * mismatch first appears as an S3 signature failure at the first document operation — an error
-   * that names nothing about the merge that produced it. The delta is only visible here, before it
-   * is folded into the root, so this is the one place the pairing can be enforced.
+   * The overlay merges field by field, so a tenant restating only one half of an AWS key pair
+   * inherits the other from the root and ends up with two halves of different identities. Both are
+   * non-null, so the store's own both-or-neither check passes and the mismatch first appears as an
+   * S3 signature failure that names nothing about the merge. Enforced here because the tenant's
+   * delta is only distinguishable from an inheritance before it is folded into the root.
    */
   private static void validateCredentialOverridesAreComplete(final OverlayContext context) {
     final Map<String, AwsStore> overrides =

--- a/configuration/src/test/java/io/camunda/configuration/DocumentTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DocumentTest.java
@@ -27,6 +27,8 @@ class DocumentTest {
         "camunda.document.aws.aws1.bucket-path=prod/",
         "camunda.document.aws.aws1.region=eu-west-1",
         "camunda.document.aws.aws1.bucket-ttl=30",
+        "camunda.document.aws.aws1.access-key=aws1-key",
+        "camunda.document.aws.aws1.secret-key=aws1-secret",
         "camunda.document.gcp.gcp1.bucket-name=gcp-docs",
         "camunda.document.gcp.gcp1.prefix=temp/",
         "camunda.document.azure.az1.container-name=docs",
@@ -56,6 +58,8 @@ class DocumentTest {
                 assertThat(awsStore.getBucketPath()).isEqualTo("prod/");
                 assertThat(awsStore.getRegion()).isEqualTo("eu-west-1");
                 assertThat(awsStore.getBucketTtl()).isEqualTo(30L);
+                assertThat(awsStore.getAccessKey()).isEqualTo("aws1-key");
+                assertThat(awsStore.getSecretKey()).isEqualTo("aws1-secret");
               });
     }
 

--- a/configuration/src/test/java/io/camunda/configuration/DocumentTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DocumentTest.java
@@ -31,6 +31,7 @@ class DocumentTest {
         "camunda.document.aws.aws1.secret-key=aws1-secret",
         "camunda.document.gcp.gcp1.bucket-name=gcp-docs",
         "camunda.document.gcp.gcp1.prefix=temp/",
+        "camunda.document.gcp.gcp1.credentials-path=/var/secrets/gcp1.json",
         "camunda.document.azure.az1.container-name=docs",
         "camunda.document.azure.az1.endpoint=https://account.blob.core.windows.net",
         "camunda.document.local.local1.path=/var/camunda/documents"
@@ -70,6 +71,7 @@ class DocumentTest {
               gcpStore -> {
                 assertThat(gcpStore.getBucketName()).isEqualTo("gcp-docs");
                 assertThat(gcpStore.getPrefix()).isEqualTo("temp/");
+                assertThat(gcpStore.getCredentialsPath()).isEqualTo("/var/secrets/gcp1.json");
               });
 
       assertThat(unifiedConfiguration.getCamunda().getDocument().getAzure().get("az1"))

--- a/configuration/src/test/java/io/camunda/configuration/DocumentTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DocumentTest.java
@@ -33,7 +33,9 @@ class DocumentTest {
         "camunda.document.gcp.gcp1.prefix=temp/",
         "camunda.document.gcp.gcp1.credentials-path=/var/secrets/gcp1.json",
         "camunda.document.azure.az1.container-name=docs",
+        "camunda.document.azure.az1.container-path=tenant-a/",
         "camunda.document.azure.az1.endpoint=https://account.blob.core.windows.net",
+        "camunda.document.azure.az1.connection-string=AccountName=acc;AccountKey=az1-key",
         "camunda.document.local.local1.path=/var/camunda/documents"
       })
   class WithUnifiedDocumentConfiguration {
@@ -78,8 +80,11 @@ class DocumentTest {
           .satisfies(
               azureStore -> {
                 assertThat(azureStore.getContainerName()).isEqualTo("docs");
+                assertThat(azureStore.getContainerPath()).isEqualTo("tenant-a/");
                 assertThat(azureStore.getEndpoint())
                     .isEqualTo("https://account.blob.core.windows.net");
+                assertThat(azureStore.getConnectionString())
+                    .isEqualTo("AccountName=acc;AccountKey=az1-key");
               });
 
       assertThat(unifiedConfiguration.getCamunda().getDocument().getLocal().get("local1"))

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
@@ -254,4 +254,35 @@ class PhysicalTenantDocumentOverlayTest {
             () -> PhysicalTenantDocumentAssignedValidation.validateRootAssignedAbsent(environment))
         .doesNotThrowAnyException();
   }
+
+  @Test
+  void shouldResolveCredentialsPerPhysicalTenant() {
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.document.aws.store.bucket-name", "root-bucket",
+                    "camunda.document.aws.store.access-key", "root-key",
+                    "camunda.document.aws.store.secret-key", "root-secret",
+                    "camunda.physical-tenants.tenanta.document.aws.store.access-key",
+                        "tenant-a-key",
+                    "camunda.physical-tenants.tenanta.document.aws.store.secret-key",
+                        "tenant-a-secret")));
+
+    final Document tenantA =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
+    final Document tenantB =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenantb", environment);
+
+    assertThat(tenantA.getAws().get("store").getAccessKey()).isEqualTo("tenant-a-key");
+    assertThat(tenantA.getAws().get("store").getSecretKey()).isEqualTo("tenant-a-secret");
+    // the tenant restated only its credentials, so the root bucket must survive the overlay
+    assertThat(tenantA.getAws().get("store").getBucketName()).isEqualTo("root-bucket");
+
+    // a tenant without an override keeps the root credentials
+    assertThat(tenantB.getAws().get("store").getAccessKey()).isEqualTo("root-key");
+    assertThat(tenantB.getAws().get("store").getSecretKey()).isEqualTo("root-secret");
+  }
 }

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
@@ -295,9 +295,8 @@ class PhysicalTenantDocumentOverlayTest {
 
   @Test
   void shouldRejectATenantOverridingOnlyOneHalfOfTheKeyPair() {
-    // the unrestated half is inherited from the root, so the store would be built with an access
-    // key and a secret key belonging to two different identities — a pairing that passes the
-    // store's both-or-neither check and only fails at the first document operation
+    // the inherited half pairs two different identities, which passes the store's both-or-neither
+    // check and only fails at the first document operation
     environment
         .getPropertySources()
         .addFirst(

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
@@ -294,6 +294,53 @@ class PhysicalTenantDocumentOverlayTest {
   }
 
   @Test
+  void shouldRejectATenantOverridingOnlyOneHalfOfTheKeyPair() {
+    // the unrestated half is inherited from the root, so the store would be built with an access
+    // key and a secret key belonging to two different identities — a pairing that passes the
+    // store's both-or-neither check and only fails at the first document operation
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.document.aws.store.bucket-name", "root-bucket",
+                    "camunda.document.aws.store.access-key", "root-key",
+                    "camunda.document.aws.store.secret-key", "root-secret",
+                    "camunda.physical-tenants.tenanta.document.aws.store.access-key",
+                        "tenant-a-key")));
+
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(
+            () -> PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("store")
+        .withMessageContaining("access-key")
+        .withMessageContaining("secret-key");
+  }
+
+  @Test
+  void shouldAcceptATenantOverridingNeitherHalfOfTheKeyPair() {
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.document.aws.store.bucket-name", "root-bucket",
+                    "camunda.document.aws.store.access-key", "root-key",
+                    "camunda.document.aws.store.secret-key", "root-secret",
+                    "camunda.physical-tenants.tenanta.document.aws.store.bucket-path",
+                        "tenant-a")));
+
+    final Document doc =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
+
+    assertThat(doc.getAws().get("store").getAccessKey()).isEqualTo("root-key");
+    assertThat(doc.getAws().get("store").getSecretKey()).isEqualTo("root-secret");
+  }
+
+  @Test
   void shouldResolveAzureConnectionStringPerPhysicalTenant() {
     environment
         .getPropertySources()

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
@@ -292,4 +292,67 @@ class PhysicalTenantDocumentOverlayTest {
     assertThat(tenantB.getAws().get("store").getSecretKey()).isEqualTo("root-secret");
     assertThat(tenantB.getGcp().get("gcs").getCredentialsPath()).isEqualTo("/secrets/root.json");
   }
+
+  @Test
+  void shouldResolveAzureConnectionStringPerPhysicalTenant() {
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.document.azure.blobs.container-name", "root-container",
+                    "camunda.document.azure.blobs.container-path", "root/path",
+                    "camunda.document.azure.blobs.connection-string",
+                        "AccountName=root;AccountKey=root-key",
+                    "camunda.physical-tenants.tenanta.document.azure.blobs.connection-string",
+                        "AccountName=tenanta;AccountKey=tenant-a-key")));
+
+    final Document tenantA =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
+    final Document tenantB =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenantb", environment);
+
+    assertThat(tenantA.getAzure().get("blobs").getConnectionString())
+        .isEqualTo("AccountName=tenanta;AccountKey=tenant-a-key");
+    // the tenant restated only its connection string, so the root container must survive the
+    // overlay — losing it would silently send the tenant's documents to the default container
+    assertThat(tenantA.getAzure().get("blobs").getContainerName()).isEqualTo("root-container");
+    assertThat(tenantA.getAzure().get("blobs").getContainerPath()).isEqualTo("root/path");
+
+    // a tenant without an override keeps the root connection string
+    assertThat(tenantB.getAzure().get("blobs").getConnectionString())
+        .isEqualTo("AccountName=root;AccountKey=root-key");
+  }
+
+  @Test
+  void shouldGiveEachPhysicalTenantItsOwnAzureStore() {
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.physical-tenants.tenanta.document.azure.blobs-a.container-name",
+                        "container-a",
+                    "camunda.physical-tenants.tenanta.document.azure.blobs-a.connection-string",
+                        "AccountName=tenanta;AccountKey=tenant-a-key",
+                    "camunda.physical-tenants.tenantb.document.azure.blobs-b.container-name",
+                        "container-b",
+                    "camunda.physical-tenants.tenantb.document.azure.blobs-b.connection-string",
+                        "AccountName=tenantb;AccountKey=tenant-b-key")));
+
+    final Document tenantA =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
+    final Document tenantB =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenantb", environment);
+
+    // neither tenant may see the other's store, let alone its credentials
+    assertThat(tenantA.getAzure()).containsOnlyKeys("blobs-a");
+    assertThat(tenantB.getAzure()).containsOnlyKeys("blobs-b");
+    assertThat(tenantA.getAzure().get("blobs-a").getConnectionString())
+        .isEqualTo("AccountName=tenanta;AccountKey=tenant-a-key");
+    assertThat(tenantB.getAzure().get("blobs-b").getConnectionString())
+        .isEqualTo("AccountName=tenantb;AccountKey=tenant-b-key");
+  }
 }

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
@@ -266,10 +266,14 @@ class PhysicalTenantDocumentOverlayTest {
                     "camunda.document.aws.store.bucket-name", "root-bucket",
                     "camunda.document.aws.store.access-key", "root-key",
                     "camunda.document.aws.store.secret-key", "root-secret",
+                    "camunda.document.gcp.gcs.bucket-name", "root-gcs",
+                    "camunda.document.gcp.gcs.credentials-path", "/secrets/root.json",
                     "camunda.physical-tenants.tenanta.document.aws.store.access-key",
                         "tenant-a-key",
                     "camunda.physical-tenants.tenanta.document.aws.store.secret-key",
-                        "tenant-a-secret")));
+                        "tenant-a-secret",
+                    "camunda.physical-tenants.tenanta.document.gcp.gcs.credentials-path",
+                        "/secrets/tenant-a.json")));
 
     final Document tenantA =
         PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
@@ -278,11 +282,14 @@ class PhysicalTenantDocumentOverlayTest {
 
     assertThat(tenantA.getAws().get("store").getAccessKey()).isEqualTo("tenant-a-key");
     assertThat(tenantA.getAws().get("store").getSecretKey()).isEqualTo("tenant-a-secret");
+    assertThat(tenantA.getGcp().get("gcs").getCredentialsPath())
+        .isEqualTo("/secrets/tenant-a.json");
     // the tenant restated only its credentials, so the root bucket must survive the overlay
     assertThat(tenantA.getAws().get("store").getBucketName()).isEqualTo("root-bucket");
 
     // a tenant without an override keeps the root credentials
     assertThat(tenantB.getAws().get("store").getAccessKey()).isEqualTo("root-key");
     assertThat(tenantB.getAws().get("store").getSecretKey()).isEqualTo("root-secret");
+    assertThat(tenantB.getGcp().get("gcs").getCredentialsPath()).isEqualTo("/secrets/root.json");
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
+++ b/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
@@ -121,6 +121,13 @@ public final class CamundaDocumentStoreConfigurationLoader
     final Map<String, String> properties = new LinkedHashMap<>();
     putResolved(properties, GCP, storeId, "bucket-name", "BUCKET", store.getBucketName());
     putResolved(properties, GCP, storeId, "prefix", "PREFIX", store.getPrefix());
+    putResolved(
+        properties,
+        GCP,
+        storeId,
+        "credentials-path",
+        "CREDENTIALS_PATH",
+        store.getCredentialsPath());
     return toRecord(storeId, GcpDocumentStoreProvider.class, properties);
   }
 

--- a/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
+++ b/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
@@ -110,6 +110,9 @@ public final class CamundaDocumentStoreConfigurationLoader
         "support-legacy-md5",
         "SUPPORT_LEGACY_MD5",
         store.getSupportLegacyMd5());
+    putResolved(properties, AWS, storeId, "access-key", "ACCESS_KEY", store.getAccessKey());
+    putResolvedSensitive(
+        properties, AWS, storeId, "secret-key", "SECRET_KEY", store.getSecretKey());
     return toRecord(storeId, AwsDocumentStoreProvider.class, properties);
   }
 
@@ -158,27 +161,65 @@ public final class CamundaDocumentStoreConfigurationLoader
       final String unifiedField,
       final String propertyKey,
       final Object unifiedValue) {
+    putResolved(properties, storeType, storeId, unifiedField, propertyKey, unifiedValue, false);
+  }
+
+  /**
+   * Same as {@link #putResolved}, for a value that must never be written to a log line: the
+   * legacy-configuration check reports conflicts by printing the values it compared.
+   */
+  private static void putResolvedSensitive(
+      final Map<String, String> properties,
+      final String storeType,
+      final String storeId,
+      final String unifiedField,
+      final String propertyKey,
+      final Object unifiedValue) {
+    putResolved(properties, storeType, storeId, unifiedField, propertyKey, unifiedValue, true);
+  }
+
+  private static void putResolved(
+      final Map<String, String> properties,
+      final String storeType,
+      final String storeId,
+      final String unifiedField,
+      final String propertyKey,
+      final Object unifiedValue,
+      final boolean sensitive) {
+    final String unifiedProperty = PREFIX + storeType + "." + storeId + "." + unifiedField;
+    final Set<String> legacyProperties =
+        Set.of(LEGACY_STORE_PREFIX + storeId.toUpperCase() + "_" + propertyKey);
+
     if (unifiedValue != null) {
-      UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
-          PREFIX + storeType + "." + storeId + "." + unifiedField,
-          String.valueOf(unifiedValue),
-          String.class,
-          BackwardsCompatibilityMode.SUPPORTED,
-          Set.of(LEGACY_STORE_PREFIX + storeId.toUpperCase() + "_" + propertyKey));
+      validate(unifiedProperty, String.valueOf(unifiedValue), legacyProperties, sensitive);
       properties.put(propertyKey, String.valueOf(unifiedValue));
       return;
     }
 
-    final String resolved =
-        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
-            PREFIX + storeType + "." + storeId + "." + unifiedField,
-            null,
-            String.class,
-            BackwardsCompatibilityMode.SUPPORTED,
-            Set.of(LEGACY_STORE_PREFIX + storeId.toUpperCase() + "_" + propertyKey));
+    final String resolved = validate(unifiedProperty, null, legacyProperties, sensitive);
     if (resolved != null) {
       properties.put(propertyKey, resolved);
     }
+  }
+
+  private static String validate(
+      final String unifiedProperty,
+      final String unifiedValue,
+      final Set<String> legacyProperties,
+      final boolean sensitive) {
+    return sensitive
+        ? UnifiedConfigurationHelper.validateSensitiveLegacyConfiguration(
+            unifiedProperty,
+            unifiedValue,
+            String.class,
+            BackwardsCompatibilityMode.SUPPORTED,
+            legacyProperties)
+        : UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+            unifiedProperty,
+            unifiedValue,
+            String.class,
+            BackwardsCompatibilityMode.SUPPORTED,
+            legacyProperties);
   }
 
   private static DocumentStoreConfigurationRecord toRecord(

--- a/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
+++ b/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
@@ -139,7 +139,7 @@ public final class CamundaDocumentStoreConfigurationLoader
     putResolved(
         properties, AZURE, storeId, "container-path", "CONTAINER_PATH", store.getContainerPath());
     putResolved(properties, AZURE, storeId, "endpoint", "ENDPOINT", store.getEndpoint());
-    putResolved(
+    putResolvedSensitive(
         properties,
         AZURE,
         storeId,

--- a/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
+++ b/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
@@ -110,7 +110,7 @@ public final class CamundaDocumentStoreConfigurationLoader
         "support-legacy-md5",
         "SUPPORT_LEGACY_MD5",
         store.getSupportLegacyMd5());
-    putResolved(properties, AWS, storeId, "access-key", "ACCESS_KEY", store.getAccessKey());
+    putResolvedSensitive(properties, AWS, storeId, "access-key", "ACCESS_KEY", store.getAccessKey());
     putResolvedSensitive(
         properties, AWS, storeId, "secret-key", "SECRET_KEY", store.getSecretKey());
     return toRecord(storeId, AwsDocumentStoreProvider.class, properties);

--- a/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
+++ b/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
@@ -196,9 +196,6 @@ public final class CamundaDocumentStoreConfigurationLoader
       final Object unifiedValue,
       final boolean sensitive) {
     final String unifiedProperty = PREFIX + storeType + "." + storeId + "." + unifiedField;
-    // Locale.ROOT, not the default locale: under a Turkish locale 'i' upper-cases to 'İ', so a
-    // store id containing it would derive a legacy key no environment variable can ever match and
-    // the value would be dropped without a word.
     final Set<String> legacyProperties =
         Set.of(LEGACY_STORE_PREFIX + storeId.toUpperCase(Locale.ROOT) + "_" + propertyKey);
 

--- a/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
+++ b/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
@@ -23,6 +23,7 @@ import io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider;
 import io.camunda.document.store.localstorage.LocalStorageDocumentStoreProvider;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -110,7 +111,8 @@ public final class CamundaDocumentStoreConfigurationLoader
         "support-legacy-md5",
         "SUPPORT_LEGACY_MD5",
         store.getSupportLegacyMd5());
-    putResolvedSensitive(properties, AWS, storeId, "access-key", "ACCESS_KEY", store.getAccessKey());
+    putResolvedSensitive(
+        properties, AWS, storeId, "access-key", "ACCESS_KEY", store.getAccessKey());
     putResolvedSensitive(
         properties, AWS, storeId, "secret-key", "SECRET_KEY", store.getSecretKey());
     return toRecord(storeId, AwsDocumentStoreProvider.class, properties);
@@ -194,8 +196,11 @@ public final class CamundaDocumentStoreConfigurationLoader
       final Object unifiedValue,
       final boolean sensitive) {
     final String unifiedProperty = PREFIX + storeType + "." + storeId + "." + unifiedField;
+    // Locale.ROOT, not the default locale: under a Turkish locale 'i' upper-cases to 'İ', so a
+    // store id containing it would derive a legacy key no environment variable can ever match and
+    // the value would be dropped without a word.
     final Set<String> legacyProperties =
-        Set.of(LEGACY_STORE_PREFIX + storeId.toUpperCase() + "_" + propertyKey);
+        Set.of(LEGACY_STORE_PREFIX + storeId.toUpperCase(Locale.ROOT) + "_" + propertyKey);
 
     if (unifiedValue != null) {
       validate(unifiedProperty, String.valueOf(unifiedValue), legacyProperties, sensitive);

--- a/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
@@ -276,6 +276,11 @@ class CamundaDocumentStoreConfigurationLoaderTest {
     gcpStore.setCredentialsPath("/var/secrets/gcp/tenant-a.json");
     camunda.getDocument().getGcp().put("gcp1", gcpStore);
 
+    final Document.AzureStore azureStore = new Document.AzureStore();
+    azureStore.setContainerName("container");
+    azureStore.setConnectionString("AccountName=acc;AccountKey=tenant-a-key");
+    camunda.getDocument().getAzure().put("az1", azureStore);
+
     final var mockEnv = new MockEnvironment();
     mockEnv.setProperty("camunda.document.default-store-id", "aws1");
     mockEnv.setProperty("camunda.document.aws.aws1.bucket-name", "docs");
@@ -284,6 +289,9 @@ class CamundaDocumentStoreConfigurationLoaderTest {
     mockEnv.setProperty("camunda.document.gcp.gcp1.bucket-name", "gcp-docs");
     mockEnv.setProperty(
         "camunda.document.gcp.gcp1.credentials-path", "/var/secrets/gcp/tenant-a.json");
+    mockEnv.setProperty("camunda.document.azure.az1.container-name", "container");
+    mockEnv.setProperty(
+        "camunda.document.azure.az1.connection-string", "AccountName=acc;AccountKey=tenant-a-key");
     UnifiedConfigurationHelper.setCustomEnvironment(mockEnv);
 
     try {
@@ -297,6 +305,8 @@ class CamundaDocumentStoreConfigurationLoaderTest {
           .containsEntry("SECRET_KEY", "tenant-a-secret");
       assertThat(store("gcp1", configuration.documentStores()).properties())
           .containsEntry("CREDENTIALS_PATH", "/var/secrets/gcp/tenant-a.json");
+      assertThat(store("az1", configuration.documentStores()).properties())
+          .containsEntry("CONNECTION_STRING", "AccountName=acc;AccountKey=tenant-a-key");
     } finally {
       UnifiedConfigurationHelper.setCustomEnvironment(null);
     }

--- a/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
@@ -259,6 +259,75 @@ class CamundaDocumentStoreConfigurationLoaderTest {
     }
   }
 
+  @Test
+  void shouldLoadPerStoreCredentials() {
+    // given
+    final Camunda camunda = new Camunda();
+    camunda.getDocument().setDefaultStoreId("aws1");
+
+    final Document.AwsStore awsStore = new Document.AwsStore();
+    awsStore.setBucketName("docs");
+    awsStore.setAccessKey("tenant-a-key");
+    awsStore.setSecretKey("tenant-a-secret");
+    camunda.getDocument().getAws().put("aws1", awsStore);
+
+    final var mockEnv = new MockEnvironment();
+    mockEnv.setProperty("camunda.document.default-store-id", "aws1");
+    mockEnv.setProperty("camunda.document.aws.aws1.bucket-name", "docs");
+    mockEnv.setProperty("camunda.document.aws.aws1.access-key", "tenant-a-key");
+    mockEnv.setProperty("camunda.document.aws.aws1.secret-key", "tenant-a-secret");
+    UnifiedConfigurationHelper.setCustomEnvironment(mockEnv);
+
+    try {
+      // when
+      final var configuration =
+          new CamundaDocumentStoreConfigurationLoader(camunda).loadConfiguration();
+
+      // then
+      assertThat(store("aws1", configuration.documentStores()).properties())
+          .containsEntry("ACCESS_KEY", "tenant-a-key")
+          .containsEntry("SECRET_KEY", "tenant-a-secret");
+    } finally {
+      UnifiedConfigurationHelper.setCustomEnvironment(null);
+    }
+  }
+
+  @Test
+  void shouldLoadPerStoreCredentialsFromLegacyProperties() {
+    // given
+    final Camunda camunda = new Camunda();
+    camunda.getDocument().setDefaultStoreId("aws");
+
+    final var mockEnv = new MockEnvironment();
+    mockEnv.setProperty("DOCUMENT_DEFAULT_STORE_ID", "aws");
+    mockEnv.setProperty("DOCUMENT_STORE_AWS_ACCESS_KEY", "legacy-key");
+    mockEnv.setProperty("DOCUMENT_STORE_AWS_SECRET_KEY", "legacy-secret");
+    UnifiedConfigurationHelper.setCustomEnvironment(mockEnv);
+
+    System.setProperty(
+        "DOCUMENT_STORE_AWS_CLASS", "io.camunda.document.store.aws.AwsDocumentStoreProvider");
+    System.setProperty("DOCUMENT_STORE_AWS_BUCKET", "shared-bucket");
+    System.setProperty("DOCUMENT_STORE_AWS_ACCESS_KEY", "legacy-key");
+    System.setProperty("DOCUMENT_STORE_AWS_SECRET_KEY", "legacy-secret");
+
+    try {
+      // when
+      final var configuration =
+          new CamundaDocumentStoreConfigurationLoader(camunda).loadConfiguration();
+
+      // then
+      assertThat(store("aws", configuration.documentStores()).properties())
+          .containsEntry("ACCESS_KEY", "legacy-key")
+          .containsEntry("SECRET_KEY", "legacy-secret");
+    } finally {
+      UnifiedConfigurationHelper.setCustomEnvironment(null);
+      System.clearProperty("DOCUMENT_STORE_AWS_CLASS");
+      System.clearProperty("DOCUMENT_STORE_AWS_BUCKET");
+      System.clearProperty("DOCUMENT_STORE_AWS_ACCESS_KEY");
+      System.clearProperty("DOCUMENT_STORE_AWS_SECRET_KEY");
+    }
+  }
+
   private static DocumentStoreConfigurationRecord store(
       final String id, final List<DocumentStoreConfigurationRecord> stores) {
     return stores.stream().filter(store -> store.id().equals(id)).findFirst().orElseThrow();

--- a/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
@@ -351,9 +351,8 @@ class CamundaDocumentStoreConfigurationLoaderTest {
 
   @Test
   void shouldDeriveLegacyPropertyNamesIndependentlyOfTheDefaultLocale() {
-    // given — under a Turkish locale, upper-casing 'i' with the default locale yields 'İ', so a
-    // store id containing it would derive a legacy key no environment variable can ever match and
-    // the credential would be dropped without a word
+    // given — the store is declared through unified configuration, so its credential can only come
+    // back through the legacy bridge, which is the path the default locale breaks
     final Locale defaultLocale = Locale.getDefault();
     Locale.setDefault(Locale.forLanguageTag("tr"));
 

--- a/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
@@ -271,11 +271,19 @@ class CamundaDocumentStoreConfigurationLoaderTest {
     awsStore.setSecretKey("tenant-a-secret");
     camunda.getDocument().getAws().put("aws1", awsStore);
 
+    final Document.GcpStore gcpStore = new Document.GcpStore();
+    gcpStore.setBucketName("gcp-docs");
+    gcpStore.setCredentialsPath("/var/secrets/gcp/tenant-a.json");
+    camunda.getDocument().getGcp().put("gcp1", gcpStore);
+
     final var mockEnv = new MockEnvironment();
     mockEnv.setProperty("camunda.document.default-store-id", "aws1");
     mockEnv.setProperty("camunda.document.aws.aws1.bucket-name", "docs");
     mockEnv.setProperty("camunda.document.aws.aws1.access-key", "tenant-a-key");
     mockEnv.setProperty("camunda.document.aws.aws1.secret-key", "tenant-a-secret");
+    mockEnv.setProperty("camunda.document.gcp.gcp1.bucket-name", "gcp-docs");
+    mockEnv.setProperty(
+        "camunda.document.gcp.gcp1.credentials-path", "/var/secrets/gcp/tenant-a.json");
     UnifiedConfigurationHelper.setCustomEnvironment(mockEnv);
 
     try {
@@ -287,6 +295,8 @@ class CamundaDocumentStoreConfigurationLoaderTest {
       assertThat(store("aws1", configuration.documentStores()).properties())
           .containsEntry("ACCESS_KEY", "tenant-a-key")
           .containsEntry("SECRET_KEY", "tenant-a-secret");
+      assertThat(store("gcp1", configuration.documentStores()).properties())
+          .containsEntry("CREDENTIALS_PATH", "/var/secrets/gcp/tenant-a.json");
     } finally {
       UnifiedConfigurationHelper.setCustomEnvironment(null);
     }

--- a/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
@@ -18,6 +18,7 @@ import io.camunda.document.store.azure.AzureBlobDocumentStoreProvider;
 import io.camunda.document.store.gcp.GcpDocumentStoreProvider;
 import io.camunda.document.store.localstorage.LocalStorageDocumentStoreProvider;
 import java.util.List;
+import java.util.Locale;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -345,6 +346,43 @@ class CamundaDocumentStoreConfigurationLoaderTest {
       System.clearProperty("DOCUMENT_STORE_AWS_BUCKET");
       System.clearProperty("DOCUMENT_STORE_AWS_ACCESS_KEY");
       System.clearProperty("DOCUMENT_STORE_AWS_SECRET_KEY");
+    }
+  }
+
+  @Test
+  void shouldDeriveLegacyPropertyNamesIndependentlyOfTheDefaultLocale() {
+    // given — under a Turkish locale, upper-casing 'i' with the default locale yields 'İ', so a
+    // store id containing it would derive a legacy key no environment variable can ever match and
+    // the credential would be dropped without a word
+    final Locale defaultLocale = Locale.getDefault();
+    Locale.setDefault(Locale.forLanguageTag("tr"));
+
+    final Camunda camunda = new Camunda();
+    camunda.getDocument().setDefaultStoreId("minio");
+
+    final Document.AwsStore awsStore = new Document.AwsStore();
+    awsStore.setBucketName("docs");
+    camunda.getDocument().getAws().put("minio", awsStore);
+
+    final var mockEnv = new MockEnvironment();
+    mockEnv.setProperty("camunda.document.default-store-id", "minio");
+    mockEnv.setProperty("camunda.document.aws.minio.bucket-name", "docs");
+    mockEnv.setProperty("DOCUMENT_STORE_MINIO_ACCESS_KEY", "legacy-key");
+    mockEnv.setProperty("DOCUMENT_STORE_MINIO_SECRET_KEY", "legacy-secret");
+    UnifiedConfigurationHelper.setCustomEnvironment(mockEnv);
+
+    try {
+      // when
+      final var configuration =
+          new CamundaDocumentStoreConfigurationLoader(camunda).loadConfiguration();
+
+      // then
+      assertThat(store("minio", configuration.documentStores()).properties())
+          .containsEntry("ACCESS_KEY", "legacy-key")
+          .containsEntry("SECRET_KEY", "legacy-secret");
+    } finally {
+      UnifiedConfigurationHelper.setCustomEnvironment(null);
+      Locale.setDefault(defaultLocale);
     }
   }
 

--- a/document/api/src/main/java/io/camunda/document/api/DocumentStoreConfiguration.java
+++ b/document/api/src/main/java/io/camunda/document/api/DocumentStoreConfiguration.java
@@ -24,13 +24,20 @@ public record DocumentStoreConfiguration(
       Map<String, String> properties) {
 
     /**
-     * Property keys whose values authenticate against the backing store. Their values must never
-     * reach a log line or an exception message, so {@link #toString()} replaces them with {@link
-     * #REDACTED}. Matched case-insensitively because store properties also arrive through the
-     * legacy {@code DOCUMENT_STORE_<ID>_<PROPERTY>} environment bridge.
+     * Substrings that mark a property key as carrying a credential. Such values must never reach a
+     * log line or an exception message, so {@link #toString()} replaces them with {@link
+     * #REDACTED}.
+     *
+     * <p>Matched as case-insensitive substrings rather than as an exact-name allowlist: store
+     * properties also arrive through the legacy {@code DOCUMENT_STORE_<ID>_<PROPERTY>} environment
+     * bridge, which forwards whatever property name it finds, so an allowlist would print in the
+     * clear every credential key it had not been taught about.
+     *
+     * <p>{@code CREDENTIALS_PATH} is deliberately not covered — it names a key file rather than
+     * holding a key, and it is the one value worth seeing when a store fails to read it.
      */
-    private static final Set<String> SENSITIVE_PROPERTIES =
-        Set.of("CONNECTION_STRING", "SECRET_KEY");
+    private static final Set<String> SENSITIVE_KEY_MARKERS =
+        Set.of("SECRET", "PASSWORD", "TOKEN", "KEY", "CONNECTION_STRING", "SIGNATURE");
 
     private static final String REDACTED = "<redacted>";
 
@@ -60,7 +67,11 @@ public record DocumentStoreConfiguration(
     }
 
     private static boolean isSensitive(final String key) {
-      return key != null && SENSITIVE_PROPERTIES.contains(key.toUpperCase(Locale.ROOT));
+      if (key == null) {
+        return false;
+      }
+      final String normalized = key.toUpperCase(Locale.ROOT);
+      return SENSITIVE_KEY_MARKERS.stream().anyMatch(normalized::contains);
     }
   }
 }

--- a/document/api/src/main/java/io/camunda/document/api/DocumentStoreConfiguration.java
+++ b/document/api/src/main/java/io/camunda/document/api/DocumentStoreConfiguration.java
@@ -7,8 +7,11 @@
  */
 package io.camunda.document.api;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 public record DocumentStoreConfiguration(
     String defaultDocumentStoreId,
@@ -18,5 +21,45 @@ public record DocumentStoreConfiguration(
   public record DocumentStoreConfigurationRecord(
       String id,
       Class<? extends DocumentStoreProvider> providerClass,
-      Map<String, String> properties) {}
+      Map<String, String> properties) {
+
+    /**
+     * Property keys whose values authenticate against the backing store. Their values must never
+     * reach a log line or an exception message, so {@link #toString()} replaces them with {@link
+     * #REDACTED}. Matched case-insensitively because store properties also arrive through the
+     * legacy {@code DOCUMENT_STORE_<ID>_<PROPERTY>} environment bridge.
+     */
+    private static final Set<String> SENSITIVE_PROPERTIES = Set.of("CONNECTION_STRING");
+
+    private static final String REDACTED = "<redacted>";
+
+    /**
+     * Renders the record with every credential-bearing property masked. The default record {@code
+     * toString} would print the raw properties map, and this record is interpolated into
+     * configuration error messages that end up in broker logs.
+     */
+    @Override
+    public String toString() {
+      return "DocumentStoreConfigurationRecord[id="
+          + id
+          + ", providerClass="
+          + (providerClass == null ? null : providerClass.getName())
+          + ", properties="
+          + redactedProperties()
+          + "]";
+    }
+
+    private Map<String, String> redactedProperties() {
+      if (properties == null) {
+        return null;
+      }
+      final Map<String, String> redacted = new LinkedHashMap<>();
+      properties.forEach((key, value) -> redacted.put(key, isSensitive(key) ? REDACTED : value));
+      return redacted;
+    }
+
+    private static boolean isSensitive(final String key) {
+      return key != null && SENSITIVE_PROPERTIES.contains(key.toUpperCase(Locale.ROOT));
+    }
+  }
 }

--- a/document/api/src/main/java/io/camunda/document/api/DocumentStoreConfiguration.java
+++ b/document/api/src/main/java/io/camunda/document/api/DocumentStoreConfiguration.java
@@ -29,7 +29,8 @@ public record DocumentStoreConfiguration(
      * #REDACTED}. Matched case-insensitively because store properties also arrive through the
      * legacy {@code DOCUMENT_STORE_<ID>_<PROPERTY>} environment bridge.
      */
-    private static final Set<String> SENSITIVE_PROPERTIES = Set.of("CONNECTION_STRING");
+    private static final Set<String> SENSITIVE_PROPERTIES =
+        Set.of("CONNECTION_STRING", "SECRET_KEY");
 
     private static final String REDACTED = "<redacted>";
 

--- a/document/api/src/main/java/io/camunda/document/api/DocumentStoreConfiguration.java
+++ b/document/api/src/main/java/io/camunda/document/api/DocumentStoreConfiguration.java
@@ -24,20 +24,18 @@ public record DocumentStoreConfiguration(
       Map<String, String> properties) {
 
     /**
-     * Substrings that mark a property key as carrying a credential. Such values must never reach a
-     * log line or an exception message, so {@link #toString()} replaces them with {@link
-     * #REDACTED}.
+     * Property keys whose values authenticate against the backing store. {@link #toString()}
+     * replaces them with {@link #REDACTED}. Matched case-insensitively because store properties
+     * also arrive through the legacy {@code DOCUMENT_STORE_<ID>_<PROPERTY>} environment bridge.
      *
-     * <p>Matched as case-insensitive substrings rather than as an exact-name allowlist: store
-     * properties also arrive through the legacy {@code DOCUMENT_STORE_<ID>_<PROPERTY>} environment
-     * bridge, which forwards whatever property name it finds, so an allowlist would print in the
-     * clear every credential key it had not been taught about.
+     * <p>Extend this when a provider gains a credential property: a value under a key absent here
+     * is printed in the clear.
      *
-     * <p>{@code CREDENTIALS_PATH} is deliberately not covered — it names a key file rather than
-     * holding a key, and it is the one value worth seeing when a store fails to read it.
+     * <p>{@code CREDENTIALS_PATH} is deliberately absent — it names a key file rather than holding
+     * a key, and it is the value worth seeing when a store fails to read it.
      */
-    private static final Set<String> SENSITIVE_KEY_MARKERS =
-        Set.of("SECRET", "PASSWORD", "TOKEN", "KEY", "CONNECTION_STRING", "SIGNATURE");
+    private static final Set<String> SENSITIVE_PROPERTIES =
+        Set.of("ACCESS_KEY", "SECRET_KEY", "CONNECTION_STRING");
 
     private static final String REDACTED = "<redacted>";
 
@@ -67,11 +65,7 @@ public record DocumentStoreConfiguration(
     }
 
     private static boolean isSensitive(final String key) {
-      if (key == null) {
-        return false;
-      }
-      final String normalized = key.toUpperCase(Locale.ROOT);
-      return SENSITIVE_KEY_MARKERS.stream().anyMatch(normalized::contains);
+      return key != null && SENSITIVE_PROPERTIES.contains(key.toUpperCase(Locale.ROOT));
     }
   }
 }

--- a/document/store/pom.xml
+++ b/document/store/pom.xml
@@ -62,6 +62,14 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>regions</artifactId>
     </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>auth</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>identity-spi</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.azure</groupId>
@@ -144,6 +152,10 @@
         <configuration>
           <ignoredNonTestScopedDependencies>
             <ignoredNonTestScopedDependency>software.amazon.awssdk:aws-core</ignoredNonTestScopedDependency>
+            <!-- the credentials provider passed to the S3 client builder is typed against
+                 identity-spi, so main code needs it on the compile classpath even though only
+                 tests name its types directly -->
+            <ignoredNonTestScopedDependency>software.amazon.awssdk:identity-spi</ignoredNonTestScopedDependency>
           </ignoredNonTestScopedDependencies>
         </configuration>
       </plugin>

--- a/document/store/pom.xml
+++ b/document/store/pom.xml
@@ -42,6 +42,16 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-credentials</artifactId>
+    </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>

--- a/document/store/pom.xml
+++ b/document/store/pom.xml
@@ -58,6 +58,10 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>regions</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.azure</groupId>

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsClientOptions.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsClientOptions.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.store.aws;
+
+import java.net.URI;
+
+/**
+ * Per-store overrides applied to the S3 client and presigner of a single AWS document store. Every
+ * component is optional: a {@code null} means "leave it to the AWS SDK", which resolves it from the
+ * process environment.
+ */
+public record AwsClientOptions(
+    URI endpointOverride,
+    Boolean forcePathStyle,
+    Boolean chunkedEncodingEnabled,
+    Boolean supportLegacyMd5) {
+
+  public static AwsClientOptions sdkDefaults() {
+    return new AwsClientOptions(null, null, null, null);
+  }
+}

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsClientOptions.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsClientOptions.java
@@ -18,9 +18,10 @@ public record AwsClientOptions(
     URI endpointOverride,
     Boolean forcePathStyle,
     Boolean chunkedEncodingEnabled,
-    Boolean supportLegacyMd5) {
+    Boolean supportLegacyMd5,
+    String region) {
 
   public static AwsClientOptions sdkDefaults() {
-    return new AwsClientOptions(null, null, null, null);
+    return new AwsClientOptions(null, null, null, null, null);
   }
 }

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsClientOptions.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsClientOptions.java
@@ -31,6 +31,22 @@ public record AwsClientOptions(
 
   private static final String REDACTED = "<redacted>";
 
+  /**
+   * Guards the one combination that fails silently instead of loudly: with only one half of the key
+   * pair {@link #hasStaticCredentials()} is false, so the store keeps the AWS SDK default chain —
+   * the process-wide credentials it was configured to stop using. Callers reaching this record
+   * through {@link AwsDocumentStoreProvider} are already rejected there with a message naming the
+   * store and the offending properties; this covers whoever constructs it directly.
+   */
+  public AwsClientOptions {
+    if ((accessKey == null) != (secretKey == null)) {
+      throw new IllegalArgumentException(
+          "accessKey and secretKey must be set together: with only one of them the store"
+              + " authenticates with the AWS SDK default credential chain, which is shared with"
+              + " every other store in the process.");
+    }
+  }
+
   public static AwsClientOptions sdkDefaults() {
     return new AwsClientOptions(null, null, null, null, null, null, null);
   }

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsClientOptions.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsClientOptions.java
@@ -8,6 +8,9 @@
 package io.camunda.document.store.aws;
 
 import java.net.URI;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 
 /**
  * Per-store overrides applied to the S3 client and presigner of a single AWS document store. Every
@@ -19,9 +22,47 @@ public record AwsClientOptions(
     Boolean forcePathStyle,
     Boolean chunkedEncodingEnabled,
     Boolean supportLegacyMd5,
-    String region) {
+    String region,
+    String accessKey,
+    String secretKey) {
 
   public static AwsClientOptions sdkDefaults() {
-    return new AwsClientOptions(null, null, null, null, null);
+    return new AwsClientOptions(null, null, null, null, null, null, null);
+  }
+
+  /** Whether this store authenticates with its own key pair instead of the process credentials. */
+  public boolean hasStaticCredentials() {
+    return accessKey != null && secretKey != null;
+  }
+
+  /**
+   * The credentials provider for this store, or {@code null} when it has no key pair of its own —
+   * in which case the caller must leave the builder untouched so the SDK applies its default
+   * credentials chain.
+   */
+  public AwsCredentialsProvider credentialsProvider() {
+    return hasStaticCredentials()
+        ? StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey))
+        : null;
+  }
+
+  /** Renders the options with the secret key masked, so they are safe to log. */
+  @Override
+  public String toString() {
+    return "AwsClientOptions[endpointOverride="
+        + endpointOverride
+        + ", forcePathStyle="
+        + forcePathStyle
+        + ", chunkedEncodingEnabled="
+        + chunkedEncodingEnabled
+        + ", supportLegacyMd5="
+        + supportLegacyMd5
+        + ", region="
+        + region
+        + ", accessKey="
+        + accessKey
+        + ", secretKey="
+        + (secretKey == null ? null : "<redacted>")
+        + "]";
   }
 }

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsClientOptions.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsClientOptions.java
@@ -29,6 +29,8 @@ public record AwsClientOptions(
     @Nullable String accessKey,
     @Nullable String secretKey) {
 
+  private static final String REDACTED = "<redacted>";
+
   public static AwsClientOptions sdkDefaults() {
     return new AwsClientOptions(null, null, null, null, null, null, null);
   }
@@ -67,7 +69,11 @@ public record AwsClientOptions(
         : null;
   }
 
-  /** Renders the options with the secret key masked, so they are safe to log. */
+  /**
+   * Renders the options with both halves of the key pair masked, so they are safe to log. The
+   * access key is masked too: it names the IAM principal the store acts as, which is exactly what
+   * an attacker reading a log needs in order to know which secret is worth hunting for.
+   */
   @Override
   public String toString() {
     return "AwsClientOptions[endpointOverride="
@@ -81,9 +87,9 @@ public record AwsClientOptions(
         + ", region="
         + region
         + ", accessKey="
-        + accessKey
+        + (accessKey == null ? null : REDACTED)
         + ", secretKey="
-        + (secretKey == null ? null : "<redacted>")
+        + (secretKey == null ? null : REDACTED)
         + "]";
   }
 }

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsClientOptions.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsClientOptions.java
@@ -41,14 +41,12 @@ public record AwsClientOptions(
   }
 
   /**
-   * Whether every setting that addresses the backing store is left to the AWS SDK — no endpoint,
-   * region, path-style or chunked-encoding override, and no key pair of this store's own.
+   * Whether the caller must return the plain {@code S3Client.create()} / {@code
+   * S3Presigner.create()} rather than configure a builder, leaving the SDK to resolve everything
+   * from the process environment as it did before per-store clients existed.
    *
-   * <p>When true the caller must return the plain {@code S3Client.create()} / {@code
-   * S3Presigner.create()} instead of configuring a builder, so the SDK resolves all of it from the
-   * process environment as it did before per-store clients existed. Kept here, as one predicate
-   * both builders share, so the two cannot drift apart: a setting added to the record but forgotten
-   * in one of the two lists would silently strand that builder on the wrong path.
+   * <p>Shared by both builders so they cannot drift: a component added to the record but forgotten
+   * in one of two hand-maintained conditions would silently strand that builder on the wrong path.
    */
   public boolean usesSdkDefaults() {
     return endpointOverride == null
@@ -70,9 +68,9 @@ public record AwsClientOptions(
   }
 
   /**
-   * Renders the options with both halves of the key pair masked, so they are safe to log. The
-   * access key is masked too: it names the IAM principal the store acts as, which is exactly what
-   * an attacker reading a log needs in order to know which secret is worth hunting for.
+   * Renders the options safely to log. The access key is masked alongside the secret because it
+   * names the IAM principal the store acts as — what a reader of the log would need to know which
+   * secret is worth hunting for.
    */
   @Override
   public String toString() {

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsClientOptions.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsClientOptions.java
@@ -8,6 +8,8 @@
 package io.camunda.document.store.aws;
 
 import java.net.URI;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -17,14 +19,15 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
  * component is optional: a {@code null} means "leave it to the AWS SDK", which resolves it from the
  * process environment.
  */
+@NullMarked
 public record AwsClientOptions(
-    URI endpointOverride,
-    Boolean forcePathStyle,
-    Boolean chunkedEncodingEnabled,
-    Boolean supportLegacyMd5,
-    String region,
-    String accessKey,
-    String secretKey) {
+    @Nullable URI endpointOverride,
+    @Nullable Boolean forcePathStyle,
+    @Nullable Boolean chunkedEncodingEnabled,
+    @Nullable Boolean supportLegacyMd5,
+    @Nullable String region,
+    @Nullable String accessKey,
+    @Nullable String secretKey) {
 
   public static AwsClientOptions sdkDefaults() {
     return new AwsClientOptions(null, null, null, null, null, null, null);
@@ -36,11 +39,29 @@ public record AwsClientOptions(
   }
 
   /**
+   * Whether every setting that addresses the backing store is left to the AWS SDK — no endpoint,
+   * region, path-style or chunked-encoding override, and no key pair of this store's own.
+   *
+   * <p>When true the caller must return the plain {@code S3Client.create()} / {@code
+   * S3Presigner.create()} instead of configuring a builder, so the SDK resolves all of it from the
+   * process environment as it did before per-store clients existed. Kept here, as one predicate
+   * both builders share, so the two cannot drift apart: a setting added to the record but forgotten
+   * in one of the two lists would silently strand that builder on the wrong path.
+   */
+  public boolean usesSdkDefaults() {
+    return endpointOverride == null
+        && forcePathStyle == null
+        && chunkedEncodingEnabled == null
+        && region == null
+        && !hasStaticCredentials();
+  }
+
+  /**
    * The credentials provider for this store, or {@code null} when it has no key pair of its own —
    * in which case the caller must leave the builder untouched so the SDK applies its default
    * credentials chain.
    */
-  public AwsCredentialsProvider credentialsProvider() {
+  public @Nullable AwsCredentialsProvider credentialsProvider() {
     return hasStaticCredentials()
         ? StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey))
         : null;

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
@@ -138,6 +138,7 @@ public class AwsDocumentStore implements DocumentStore {
         && options.forcePathStyle() == null
         && options.chunkedEncodingEnabled() == null
         && options.region() == null
+        && !options.hasStaticCredentials()
         && !Boolean.TRUE.equals(options.supportLegacyMd5())) {
       return S3Client.create();
     }
@@ -147,6 +148,9 @@ public class AwsDocumentStore implements DocumentStore {
     }
     if (options.region() != null) {
       builder.region(Region.of(options.region()));
+    }
+    if (options.hasStaticCredentials()) {
+      builder.credentialsProvider(options.credentialsProvider());
     }
     if (Boolean.TRUE.equals(options.supportLegacyMd5())) {
       builder.addPlugin(LegacyMd5Plugin.create());
@@ -160,7 +164,8 @@ public class AwsDocumentStore implements DocumentStore {
     if (options.endpointOverride() == null
         && options.forcePathStyle() == null
         && options.chunkedEncodingEnabled() == null
-        && options.region() == null) {
+        && options.region() == null
+        && !options.hasStaticCredentials()) {
       return S3Presigner.create();
     }
     final S3Presigner.Builder builder = S3Presigner.builder();
@@ -169,6 +174,9 @@ public class AwsDocumentStore implements DocumentStore {
     }
     if (options.region() != null) {
       builder.region(Region.of(options.region()));
+    }
+    if (options.hasStaticCredentials()) {
+      builder.credentialsProvider(options.credentialsProvider());
     }
     builder.serviceConfiguration(buildS3Configuration(options));
     return builder.build();

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
@@ -22,6 +22,7 @@ import io.camunda.document.store.InputStreamHashCalculator;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -87,6 +88,61 @@ public class AwsDocumentStore implements DocumentStore {
       final String bucketPath,
       final ExecutorService executor) {
     this(bucketName, defaultTTL, bucketPath, executor, AwsClientOptions.sdkDefaults());
+  }
+
+  /**
+   * @deprecated superseded by {@link #AwsDocumentStore(String, Long, String, ExecutorService,
+   *     AwsClientOptions)}, which also carries the store's own region and credentials. Kept so a
+   *     caller compiled against an earlier release still links.
+   */
+  @Deprecated(forRemoval = true)
+  public AwsDocumentStore(
+      final String bucketName,
+      final Long defaultTTL,
+      final String bucketPath,
+      final ExecutorService executor,
+      final URI endpointOverride,
+      final Boolean forcePathStyle,
+      final Boolean chunkedEncodingEnabled) {
+    this(
+        bucketName,
+        defaultTTL,
+        bucketPath,
+        executor,
+        endpointOverride,
+        forcePathStyle,
+        chunkedEncodingEnabled,
+        null);
+  }
+
+  /**
+   * @deprecated superseded by {@link #AwsDocumentStore(String, Long, String, ExecutorService,
+   *     AwsClientOptions)}, which also carries the store's own region and credentials. Kept so a
+   *     caller compiled against an earlier release still links.
+   */
+  @Deprecated(forRemoval = true)
+  public AwsDocumentStore(
+      final String bucketName,
+      final Long defaultTTL,
+      final String bucketPath,
+      final ExecutorService executor,
+      final URI endpointOverride,
+      final Boolean forcePathStyle,
+      final Boolean chunkedEncodingEnabled,
+      final Boolean supportLegacyMd5) {
+    this(
+        bucketName,
+        defaultTTL,
+        bucketPath,
+        executor,
+        new AwsClientOptions(
+            endpointOverride,
+            forcePathStyle,
+            chunkedEncodingEnabled,
+            supportLegacyMd5,
+            null,
+            null,
+            null));
   }
 
   public AwsDocumentStore(

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
@@ -22,7 +22,6 @@ import io.camunda.document.store.InputStreamHashCalculator;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -81,69 +80,6 @@ public class AwsDocumentStore implements DocumentStore {
   private final Long defaultTTL;
   private final String bucketPath;
   private final boolean requiresBuffering;
-
-  public AwsDocumentStore(
-      final String bucketName,
-      final Long defaultTTL,
-      final String bucketPath,
-      final ExecutorService executor) {
-    this(bucketName, defaultTTL, bucketPath, executor, AwsClientOptions.sdkDefaults());
-  }
-
-  /**
-   * @deprecated superseded by {@link #AwsDocumentStore(String, Long, String, ExecutorService,
-   *     AwsClientOptions)}, which also carries the store's own region and credentials. Kept so a
-   *     caller compiled against an earlier release still links.
-   */
-  @Deprecated(forRemoval = true)
-  public AwsDocumentStore(
-      final String bucketName,
-      final Long defaultTTL,
-      final String bucketPath,
-      final ExecutorService executor,
-      final URI endpointOverride,
-      final Boolean forcePathStyle,
-      final Boolean chunkedEncodingEnabled) {
-    this(
-        bucketName,
-        defaultTTL,
-        bucketPath,
-        executor,
-        endpointOverride,
-        forcePathStyle,
-        chunkedEncodingEnabled,
-        null);
-  }
-
-  /**
-   * @deprecated superseded by {@link #AwsDocumentStore(String, Long, String, ExecutorService,
-   *     AwsClientOptions)}, which also carries the store's own region and credentials. Kept so a
-   *     caller compiled against an earlier release still links.
-   */
-  @Deprecated(forRemoval = true)
-  public AwsDocumentStore(
-      final String bucketName,
-      final Long defaultTTL,
-      final String bucketPath,
-      final ExecutorService executor,
-      final URI endpointOverride,
-      final Boolean forcePathStyle,
-      final Boolean chunkedEncodingEnabled,
-      final Boolean supportLegacyMd5) {
-    this(
-        bucketName,
-        defaultTTL,
-        bucketPath,
-        executor,
-        new AwsClientOptions(
-            endpointOverride,
-            forcePathStyle,
-            chunkedEncodingEnabled,
-            supportLegacyMd5,
-            null,
-            null,
-            null));
-  }
 
   public AwsDocumentStore(
       final String bucketName,

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
@@ -21,7 +21,6 @@ import io.camunda.document.api.DocumentStore;
 import io.camunda.document.store.InputStreamHashCalculator;
 import io.camunda.zeebe.util.Either;
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -85,7 +84,7 @@ public class AwsDocumentStore implements DocumentStore {
       final Long defaultTTL,
       final String bucketPath,
       final ExecutorService executor) {
-    this(bucketName, defaultTTL, bucketPath, executor, null, null, null);
+    this(bucketName, defaultTTL, bucketPath, executor, AwsClientOptions.sdkDefaults());
   }
 
   public AwsDocumentStore(
@@ -93,37 +92,15 @@ public class AwsDocumentStore implements DocumentStore {
       final Long defaultTTL,
       final String bucketPath,
       final ExecutorService executor,
-      final URI endpointOverride,
-      final Boolean forcePathStyle,
-      final Boolean chunkedEncodingEnabled) {
+      final AwsClientOptions clientOptions) {
     this(
         bucketName,
         defaultTTL,
         bucketPath,
+        buildClient(clientOptions),
         executor,
-        endpointOverride,
-        forcePathStyle,
-        chunkedEncodingEnabled,
-        null);
-  }
-
-  public AwsDocumentStore(
-      final String bucketName,
-      final Long defaultTTL,
-      final String bucketPath,
-      final ExecutorService executor,
-      final URI endpointOverride,
-      final Boolean forcePathStyle,
-      final Boolean chunkedEncodingEnabled,
-      final Boolean supportLegacyMd5) {
-    this(
-        bucketName,
-        defaultTTL,
-        bucketPath,
-        buildClient(endpointOverride, forcePathStyle, chunkedEncodingEnabled, supportLegacyMd5),
-        executor,
-        buildPresigner(endpointOverride, forcePathStyle, chunkedEncodingEnabled),
-        Boolean.FALSE.equals(chunkedEncodingEnabled));
+        buildPresigner(clientOptions),
+        Boolean.FALSE.equals(clientOptions.chunkedEncodingEnabled()));
   }
 
   public AwsDocumentStore(
@@ -153,54 +130,47 @@ public class AwsDocumentStore implements DocumentStore {
     this.requiresBuffering = requiresBuffering;
   }
 
-  private static S3Client buildClient(
-      final URI endpointOverride,
-      final Boolean forcePathStyle,
-      final Boolean chunkedEncodingEnabled,
-      final Boolean supportLegacyMd5) {
-    if (endpointOverride == null
-        && forcePathStyle == null
-        && chunkedEncodingEnabled == null
-        && !Boolean.TRUE.equals(supportLegacyMd5)) {
+  private static S3Client buildClient(final AwsClientOptions options) {
+    if (options.endpointOverride() == null
+        && options.forcePathStyle() == null
+        && options.chunkedEncodingEnabled() == null
+        && !Boolean.TRUE.equals(options.supportLegacyMd5())) {
       return S3Client.create();
     }
     final S3ClientBuilder builder = S3Client.builder();
-    if (endpointOverride != null) {
-      builder.endpointOverride(endpointOverride);
+    if (options.endpointOverride() != null) {
+      builder.endpointOverride(options.endpointOverride());
     }
-    if (Boolean.TRUE.equals(supportLegacyMd5)) {
+    if (Boolean.TRUE.equals(options.supportLegacyMd5())) {
       builder.addPlugin(LegacyMd5Plugin.create());
     }
-    builder.serviceConfiguration(
-        buildS3Configuration(endpointOverride, forcePathStyle, chunkedEncodingEnabled));
+    builder.serviceConfiguration(buildS3Configuration(options));
     return builder.build();
   }
 
-  private static S3Presigner buildPresigner(
-      final URI endpointOverride,
-      final Boolean forcePathStyle,
-      final Boolean chunkedEncodingEnabled) {
-    if (endpointOverride == null && forcePathStyle == null && chunkedEncodingEnabled == null) {
+  private static S3Presigner buildPresigner(final AwsClientOptions options) {
+    if (options.endpointOverride() == null
+        && options.forcePathStyle() == null
+        && options.chunkedEncodingEnabled() == null) {
       return S3Presigner.create();
     }
     final S3Presigner.Builder builder = S3Presigner.builder();
-    if (endpointOverride != null) {
-      builder.endpointOverride(endpointOverride);
+    if (options.endpointOverride() != null) {
+      builder.endpointOverride(options.endpointOverride());
     }
-    builder.serviceConfiguration(
-        buildS3Configuration(endpointOverride, forcePathStyle, chunkedEncodingEnabled));
+    builder.serviceConfiguration(buildS3Configuration(options));
     return builder.build();
   }
 
-  private static S3Configuration buildS3Configuration(
-      final URI endpointOverride,
-      final Boolean forcePathStyle,
-      final Boolean chunkedEncodingEnabled) {
-    final boolean usePathStyle = forcePathStyle != null ? forcePathStyle : endpointOverride != null;
+  private static S3Configuration buildS3Configuration(final AwsClientOptions options) {
+    final boolean usePathStyle =
+        options.forcePathStyle() != null
+            ? options.forcePathStyle()
+            : options.endpointOverride() != null;
     final S3Configuration.Builder s3config =
         S3Configuration.builder().pathStyleAccessEnabled(usePathStyle);
-    if (chunkedEncodingEnabled != null) {
-      s3config.chunkedEncodingEnabled(chunkedEncodingEnabled);
+    if (options.chunkedEncodingEnabled() != null) {
+      s3config.chunkedEncodingEnabled(options.chunkedEncodingEnabled());
     }
     return s3config.build();
   }

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
@@ -20,6 +20,7 @@ import io.camunda.document.api.DocumentReference;
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.store.InputStreamHashCalculator;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -40,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.HttpStatusCode;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.LegacyMd5Plugin;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
@@ -130,16 +132,21 @@ public class AwsDocumentStore implements DocumentStore {
     this.requiresBuffering = requiresBuffering;
   }
 
-  private static S3Client buildClient(final AwsClientOptions options) {
+  @VisibleForTesting
+  static S3Client buildClient(final AwsClientOptions options) {
     if (options.endpointOverride() == null
         && options.forcePathStyle() == null
         && options.chunkedEncodingEnabled() == null
+        && options.region() == null
         && !Boolean.TRUE.equals(options.supportLegacyMd5())) {
       return S3Client.create();
     }
     final S3ClientBuilder builder = S3Client.builder();
     if (options.endpointOverride() != null) {
       builder.endpointOverride(options.endpointOverride());
+    }
+    if (options.region() != null) {
+      builder.region(Region.of(options.region()));
     }
     if (Boolean.TRUE.equals(options.supportLegacyMd5())) {
       builder.addPlugin(LegacyMd5Plugin.create());
@@ -148,15 +155,20 @@ public class AwsDocumentStore implements DocumentStore {
     return builder.build();
   }
 
-  private static S3Presigner buildPresigner(final AwsClientOptions options) {
+  @VisibleForTesting
+  static S3Presigner buildPresigner(final AwsClientOptions options) {
     if (options.endpointOverride() == null
         && options.forcePathStyle() == null
-        && options.chunkedEncodingEnabled() == null) {
+        && options.chunkedEncodingEnabled() == null
+        && options.region() == null) {
       return S3Presigner.create();
     }
     final S3Presigner.Builder builder = S3Presigner.builder();
     if (options.endpointOverride() != null) {
       builder.endpointOverride(options.endpointOverride());
+    }
+    if (options.region() != null) {
+      builder.region(Region.of(options.region()));
     }
     builder.serviceConfiguration(buildS3Configuration(options));
     return builder.build();

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
@@ -134,12 +134,9 @@ public class AwsDocumentStore implements DocumentStore {
 
   @VisibleForTesting
   static S3Client buildClient(final AwsClientOptions options) {
-    if (options.endpointOverride() == null
-        && options.forcePathStyle() == null
-        && options.chunkedEncodingEnabled() == null
-        && options.region() == null
-        && !options.hasStaticCredentials()
-        && !Boolean.TRUE.equals(options.supportLegacyMd5())) {
+    // supportLegacyMd5 is a client-only plugin, which is why it forces the builder path here but
+    // not in buildPresigner.
+    if (options.usesSdkDefaults() && !Boolean.TRUE.equals(options.supportLegacyMd5())) {
       return S3Client.create();
     }
     final S3ClientBuilder builder = S3Client.builder();
@@ -161,11 +158,7 @@ public class AwsDocumentStore implements DocumentStore {
 
   @VisibleForTesting
   static S3Presigner buildPresigner(final AwsClientOptions options) {
-    if (options.endpointOverride() == null
-        && options.forcePathStyle() == null
-        && options.chunkedEncodingEnabled() == null
-        && options.region() == null
-        && !options.hasStaticCredentials()) {
+    if (options.usesSdkDefaults()) {
       return S3Presigner.create();
     }
     final S3Presigner.Builder builder = S3Presigner.builder();

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
@@ -91,9 +91,8 @@ public class AwsDocumentStore implements DocumentStore {
   }
 
   /**
-   * @deprecated superseded by {@link #AwsDocumentStore(String, Long, String, ExecutorService,
-   *     AwsClientOptions)}, which also carries the store's own region and credentials. Kept so a
-   *     caller compiled against an earlier release still links.
+   * @deprecated use the {@link AwsClientOptions} overload; kept only so callers compiled against an
+   *     earlier release still link.
    */
   @Deprecated(forRemoval = true)
   public AwsDocumentStore(
@@ -116,9 +115,8 @@ public class AwsDocumentStore implements DocumentStore {
   }
 
   /**
-   * @deprecated superseded by {@link #AwsDocumentStore(String, Long, String, ExecutorService,
-   *     AwsClientOptions)}, which also carries the store's own region and credentials. Kept so a
-   *     caller compiled against an earlier release still links.
+   * @deprecated use the {@link AwsClientOptions} overload; kept only so callers compiled against an
+   *     earlier release still link.
    */
   @Deprecated(forRemoval = true)
   public AwsDocumentStore(

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
@@ -21,9 +21,8 @@ public class AwsDocumentStoreFactory {
   }
 
   /**
-   * @deprecated superseded by {@link #create(String, Long, String, ExecutorService,
-   *     AwsClientOptions)}, which also carries the store's own region and credentials. Kept so a
-   *     caller compiled against an earlier release still links.
+   * @deprecated use the {@link AwsClientOptions} overload; kept only so callers compiled against an
+   *     earlier release still link.
    */
   @Deprecated(forRemoval = true)
   public static AwsDocumentStore create(
@@ -46,9 +45,8 @@ public class AwsDocumentStoreFactory {
   }
 
   /**
-   * @deprecated superseded by {@link #create(String, Long, String, ExecutorService,
-   *     AwsClientOptions)}, which also carries the store's own region and credentials. Kept so a
-   *     caller compiled against an earlier release still links.
+   * @deprecated use the {@link AwsClientOptions} overload; kept only so callers compiled against an
+   *     earlier release still link.
    */
   @Deprecated(forRemoval = true)
   public static AwsDocumentStore create(

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.document.store.aws;
 
+import java.net.URI;
 import java.util.concurrent.ExecutorService;
 
 public class AwsDocumentStoreFactory {
@@ -17,6 +18,61 @@ public class AwsDocumentStoreFactory {
       final String bucketPath,
       final ExecutorService executor) {
     return create(bucketName, defaultTTL, bucketPath, executor, AwsClientOptions.sdkDefaults());
+  }
+
+  /**
+   * @deprecated superseded by {@link #create(String, Long, String, ExecutorService,
+   *     AwsClientOptions)}, which also carries the store's own region and credentials. Kept so a
+   *     caller compiled against an earlier release still links.
+   */
+  @Deprecated(forRemoval = true)
+  public static AwsDocumentStore create(
+      final String bucketName,
+      final Long defaultTTL,
+      final String bucketPath,
+      final ExecutorService executor,
+      final URI endpointOverride,
+      final Boolean forcePathStyle,
+      final Boolean chunkedEncodingEnabled) {
+    return create(
+        bucketName,
+        defaultTTL,
+        bucketPath,
+        executor,
+        endpointOverride,
+        forcePathStyle,
+        chunkedEncodingEnabled,
+        null);
+  }
+
+  /**
+   * @deprecated superseded by {@link #create(String, Long, String, ExecutorService,
+   *     AwsClientOptions)}, which also carries the store's own region and credentials. Kept so a
+   *     caller compiled against an earlier release still links.
+   */
+  @Deprecated(forRemoval = true)
+  public static AwsDocumentStore create(
+      final String bucketName,
+      final Long defaultTTL,
+      final String bucketPath,
+      final ExecutorService executor,
+      final URI endpointOverride,
+      final Boolean forcePathStyle,
+      final Boolean chunkedEncodingEnabled,
+      final Boolean supportLegacyMd5) {
+    return create(
+        bucketName,
+        defaultTTL,
+        bucketPath,
+        executor,
+        new AwsClientOptions(
+            endpointOverride,
+            forcePathStyle,
+            chunkedEncodingEnabled,
+            supportLegacyMd5,
+            null,
+            null,
+            null));
   }
 
   public static AwsDocumentStore create(

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
@@ -7,16 +7,16 @@
  */
 package io.camunda.document.store.aws;
 
-import java.net.URI;
 import java.util.concurrent.ExecutorService;
 
 public class AwsDocumentStoreFactory {
+
   public static AwsDocumentStore create(
       final String bucketName,
       final Long defaultTTL,
       final String bucketPath,
       final ExecutorService executor) {
-    return new AwsDocumentStore(bucketName, defaultTTL, bucketPath, executor);
+    return create(bucketName, defaultTTL, bucketPath, executor, AwsClientOptions.sdkDefaults());
   }
 
   public static AwsDocumentStore create(
@@ -24,37 +24,7 @@ public class AwsDocumentStoreFactory {
       final Long defaultTTL,
       final String bucketPath,
       final ExecutorService executor,
-      final URI endpointOverride,
-      final Boolean forcePathStyle,
-      final Boolean chunkedEncodingEnabled) {
-    return create(
-        bucketName,
-        defaultTTL,
-        bucketPath,
-        executor,
-        endpointOverride,
-        forcePathStyle,
-        chunkedEncodingEnabled,
-        null);
-  }
-
-  public static AwsDocumentStore create(
-      final String bucketName,
-      final Long defaultTTL,
-      final String bucketPath,
-      final ExecutorService executor,
-      final URI endpointOverride,
-      final Boolean forcePathStyle,
-      final Boolean chunkedEncodingEnabled,
-      final Boolean supportLegacyMd5) {
-    return new AwsDocumentStore(
-        bucketName,
-        defaultTTL,
-        bucketPath,
-        executor,
-        endpointOverride,
-        forcePathStyle,
-        chunkedEncodingEnabled,
-        supportLegacyMd5);
+      final AwsClientOptions clientOptions) {
+    return new AwsDocumentStore(bucketName, defaultTTL, bucketPath, executor, clientOptions);
   }
 }

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
@@ -7,73 +7,9 @@
  */
 package io.camunda.document.store.aws;
 
-import java.net.URI;
 import java.util.concurrent.ExecutorService;
 
 public class AwsDocumentStoreFactory {
-
-  public static AwsDocumentStore create(
-      final String bucketName,
-      final Long defaultTTL,
-      final String bucketPath,
-      final ExecutorService executor) {
-    return create(bucketName, defaultTTL, bucketPath, executor, AwsClientOptions.sdkDefaults());
-  }
-
-  /**
-   * @deprecated superseded by {@link #create(String, Long, String, ExecutorService,
-   *     AwsClientOptions)}, which also carries the store's own region and credentials. Kept so a
-   *     caller compiled against an earlier release still links.
-   */
-  @Deprecated(forRemoval = true)
-  public static AwsDocumentStore create(
-      final String bucketName,
-      final Long defaultTTL,
-      final String bucketPath,
-      final ExecutorService executor,
-      final URI endpointOverride,
-      final Boolean forcePathStyle,
-      final Boolean chunkedEncodingEnabled) {
-    return create(
-        bucketName,
-        defaultTTL,
-        bucketPath,
-        executor,
-        endpointOverride,
-        forcePathStyle,
-        chunkedEncodingEnabled,
-        null);
-  }
-
-  /**
-   * @deprecated superseded by {@link #create(String, Long, String, ExecutorService,
-   *     AwsClientOptions)}, which also carries the store's own region and credentials. Kept so a
-   *     caller compiled against an earlier release still links.
-   */
-  @Deprecated(forRemoval = true)
-  public static AwsDocumentStore create(
-      final String bucketName,
-      final Long defaultTTL,
-      final String bucketPath,
-      final ExecutorService executor,
-      final URI endpointOverride,
-      final Boolean forcePathStyle,
-      final Boolean chunkedEncodingEnabled,
-      final Boolean supportLegacyMd5) {
-    return create(
-        bucketName,
-        defaultTTL,
-        bucketPath,
-        executor,
-        new AwsClientOptions(
-            endpointOverride,
-            forcePathStyle,
-            chunkedEncodingEnabled,
-            supportLegacyMd5,
-            null,
-            null,
-            null));
-  }
 
   public static AwsDocumentStore create(
       final String bucketName,

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
@@ -32,6 +32,7 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
   private static final String FORCE_PATH_STYLE = "FORCE_PATH_STYLE";
   private static final String CHUNKED_ENCODING_ENABLED = "CHUNKED_ENCODING_ENABLED";
   private static final String SUPPORT_LEGACY_MD5 = "SUPPORT_LEGACY_MD5";
+  private static final String REGION = "REGION";
 
   @Override
   public DocumentStore createDocumentStore(
@@ -56,7 +57,8 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
             getEndpoint(configuration),
             getForcePathStyle(configuration),
             getChunkedEncodingEnabled(configuration),
-            getSupportLegacyMd5(configuration)));
+            getSupportLegacyMd5(configuration),
+            getRegion(configuration)));
   }
 
   private static Long getDefaultTTL(final DocumentStoreConfigurationRecord configuration) {
@@ -112,6 +114,11 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
               + endpoint,
           e);
     }
+  }
+
+  private static String getRegion(final DocumentStoreConfigurationRecord configuration) {
+    final String region = configuration.properties().get(REGION);
+    return region == null || region.isBlank() ? null : region.trim();
   }
 
   private static Boolean getForcePathStyle(final DocumentStoreConfigurationRecord configuration) {

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
@@ -19,11 +19,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.regions.Region;
 
 public class AwsDocumentStoreProvider implements DocumentStoreProvider {
 
   private static final Logger LOG = LoggerFactory.getLogger(AwsDocumentStoreProvider.class);
   private static final Pattern INVALID_CHARACTERS = Pattern.compile("[\\u0000-\\u001F\\\\]");
+  private static final Pattern REGION_PATTERN = Pattern.compile("[a-z0-9]+(-[a-z0-9]+)*");
 
   private static final String BUCKET_NAME_PROPERTY = "BUCKET";
   private static final String BUCKET_TTL = "BUCKET_TTL";
@@ -50,9 +52,11 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
                             + BUCKET_NAME_PROPERTY
                             + "'"));
 
+    final URI endpoint = getEndpoint(configuration);
     final String accessKey = getTrimmedProperty(configuration, ACCESS_KEY);
     final String secretKey = getTrimmedProperty(configuration, SECRET_KEY);
     validateCredentialPair(configuration, accessKey, secretKey);
+    logCredentialSource(configuration, accessKey);
 
     return AwsDocumentStoreFactory.create(
         bucketName,
@@ -60,13 +64,36 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
         getBucketPath(configuration),
         executorService,
         new AwsClientOptions(
-            getEndpoint(configuration),
+            endpoint,
             getForcePathStyle(configuration),
             getChunkedEncodingEnabled(configuration),
             getSupportLegacyMd5(configuration),
-            getRegion(configuration),
+            getRegion(configuration, endpoint),
             accessKey,
             secretKey));
+  }
+
+  /**
+   * Records which identity the store ended up with. {@code ACCESS_KEY} and {@code SECRET_KEY} were
+   * accepted but ignored before per-store credentials existed, so a deployment that still carries
+   * them — a stale {@code DOCUMENT_STORE_<ID>_ACCESS_KEY} beside an instance role, say — changes
+   * credential source on the first restart after the upgrade. Say which source won, so that switch
+   * is legible in the startup log instead of surfacing later as an opaque S3 403.
+   */
+  private static void logCredentialSource(
+      final DocumentStoreConfigurationRecord configuration, final String accessKey) {
+    if (accessKey == null) {
+      LOG.info(
+          "Document store '{}' authenticates with the credentials of the AWS SDK default chain,"
+              + " which are shared with every other store in this process.",
+          configuration.id());
+    } else {
+      LOG.info(
+          "Document store '{}' authenticates with the key pair configured as '{}'/'{}'.",
+          configuration.id(),
+          ACCESS_KEY,
+          SECRET_KEY);
+    }
   }
 
   /**
@@ -148,8 +175,42 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
     }
   }
 
-  private static String getRegion(final DocumentStoreConfigurationRecord configuration) {
-    return getTrimmedProperty(configuration, REGION);
+  /**
+   * The region this store's client and presigner target, or {@code null} to leave it to the AWS
+   * SDK.
+   *
+   * <p>{@code Region.of} accepts any string it is handed, so an unchecked region only surfaces at
+   * the first document operation as a redirect or an unresolvable host — and because the region
+   * property was accepted but ignored until per-store clients existed, an upgrading deployment may
+   * carry one nobody has ever exercised. Reject a structurally impossible region outright; only
+   * warn about one this SDK does not recognise, since a region newer than the bundled SDK, or an
+   * S3-compatible backend behind an endpoint override, is legitimately unknown to it.
+   */
+  private static String getRegion(
+      final DocumentStoreConfigurationRecord configuration, final URI endpoint) {
+    final String region = getTrimmedProperty(configuration, REGION);
+    if (region == null) {
+      return null;
+    }
+    if (!REGION_PATTERN.matcher(region).matches()) {
+      throw new IllegalArgumentException(
+          "Failed to configure document store with id '"
+              + configuration.id()
+              + "': '"
+              + REGION
+              + "' is not a valid region: "
+              + region);
+    }
+    if (endpoint == null && !Region.regions().contains(Region.of(region))) {
+      LOG.warn(
+          "Document store '{}' is configured with '{}' '{}', which this AWS SDK does not know."
+              + " Requests are addressed to a host derived from it, so a typo here fails at the"
+              + " first document operation rather than at startup.",
+          configuration.id(),
+          REGION,
+          region);
+    }
+    return region;
   }
 
   private static String getTrimmedProperty(

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
@@ -74,11 +74,10 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
   }
 
   /**
-   * Records which identity the store ended up with. {@code ACCESS_KEY} and {@code SECRET_KEY} were
-   * accepted but ignored before per-store credentials existed, so a deployment that still carries
-   * them — a stale {@code DOCUMENT_STORE_<ID>_ACCESS_KEY} beside an instance role, say — changes
-   * credential source on the first restart after the upgrade. Say which source won, so that switch
-   * is legible in the startup log instead of surfacing later as an opaque S3 403.
+   * {@code ACCESS_KEY} and {@code SECRET_KEY} were accepted but ignored before per-store
+   * credentials existed, so a deployment still carrying a stale pair beside an instance role
+   * changes credential source on the first restart after the upgrade. Name the source that won, so
+   * the switch is legible at startup instead of surfacing later as an opaque S3 403.
    */
   private static void logCredentialSource(
       final DocumentStoreConfigurationRecord configuration, final String accessKey) {
@@ -176,15 +175,12 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
   }
 
   /**
-   * The region this store's client and presigner target, or {@code null} to leave it to the AWS
-   * SDK.
-   *
-   * <p>{@code Region.of} accepts any string it is handed, so an unchecked region only surfaces at
-   * the first document operation as a redirect or an unresolvable host — and because the region
-   * property was accepted but ignored until per-store clients existed, an upgrading deployment may
-   * carry one nobody has ever exercised. Reject a structurally impossible region outright; only
-   * warn about one this SDK does not recognise, since a region newer than the bundled SDK, or an
-   * S3-compatible backend behind an endpoint override, is legitimately unknown to it.
+   * {@code Region.of} accepts any string, so an unchecked region only surfaces at the first
+   * document operation as a redirect or an unresolvable host — and since the property was accepted
+   * but ignored until per-store clients existed, an upgrading deployment may carry one nobody has
+   * ever exercised. A structurally impossible region is rejected; one the SDK merely does not
+   * recognise is only warned about, because a region newer than the bundled SDK, or an
+   * S3-compatible backend's own name, is legitimately unknown to it.
    */
   private static String getRegion(
       final DocumentStoreConfigurationRecord configuration, final URI endpoint) {

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
@@ -45,12 +45,8 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
         Optional.ofNullable(configuration.properties().get(BUCKET_NAME_PROPERTY))
             .orElseThrow(
                 () ->
-                    new IllegalArgumentException(
-                        "Failed to configure document store with id '"
-                            + configuration.id()
-                            + "': missing required property '"
-                            + BUCKET_NAME_PROPERTY
-                            + "'"));
+                    configurationError(
+                        configuration, "missing required property '" + BUCKET_NAME_PROPERTY + "'"));
 
     final URI endpoint = getEndpoint(configuration);
     final String accessKey = getTrimmedProperty(configuration, ACCESS_KEY);
@@ -65,9 +61,9 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
         executorService,
         new AwsClientOptions(
             endpoint,
-            getForcePathStyle(configuration),
-            getChunkedEncodingEnabled(configuration),
-            getSupportLegacyMd5(configuration),
+            getBoolean(configuration, FORCE_PATH_STYLE),
+            getBoolean(configuration, CHUNKED_ENCODING_ENABLED),
+            getBoolean(configuration, SUPPORT_LEGACY_MD5),
             getRegion(configuration, endpoint),
             accessKey,
             secretKey));
@@ -108,10 +104,9 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
     if ((accessKey == null) == (secretKey == null)) {
       return;
     }
-    throw new IllegalArgumentException(
-        "Failed to configure document store with id '"
-            + configuration.id()
-            + "': '"
+    throw configurationError(
+        configuration,
+        "'"
             + ACCESS_KEY
             + "' and '"
             + SECRET_KEY
@@ -130,12 +125,7 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
     try {
       return Long.valueOf(bucketTTL);
     } catch (final NumberFormatException e) {
-      throw new IllegalArgumentException(
-          "Failed to configure document store with id '"
-              + configuration.id()
-              + "': '"
-              + BUCKET_TTL
-              + " must be a number'");
+      throw configurationError(configuration, "'" + BUCKET_TTL + " must be a number'");
     }
   }
 
@@ -144,33 +134,23 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
         Objects.requireNonNullElse(configuration.properties().get(BUCKET_PATH), "");
 
     if (INVALID_CHARACTERS.matcher(bucketPath).find()) {
-      throw new IllegalArgumentException(
-          "Failed to configure document store with id '"
-              + configuration.id()
-              + "': '"
-              + BUCKET_PATH
-              + " is invalid. Must not contain \\ character'");
+      throw configurationError(
+          configuration, "'" + BUCKET_PATH + " is invalid. Must not contain \\ character'");
     }
 
     return DocumentStorePaths.keyPrefix(bucketPath);
   }
 
   private static URI getEndpoint(final DocumentStoreConfigurationRecord configuration) {
-    final String endpoint = configuration.properties().get(ENDPOINT);
-    if (endpoint == null || endpoint.isBlank()) {
+    final String endpoint = getTrimmedProperty(configuration, ENDPOINT);
+    if (endpoint == null) {
       return null;
     }
     try {
       return new URI(endpoint);
     } catch (final URISyntaxException e) {
-      throw new IllegalArgumentException(
-          "Failed to configure document store with id '"
-              + configuration.id()
-              + "': '"
-              + ENDPOINT
-              + "' is not a valid URI: "
-              + endpoint,
-          e);
+      throw configurationError(
+          configuration, "'" + ENDPOINT + "' is not a valid URI: " + endpoint, e);
     }
   }
 
@@ -189,13 +169,7 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
       return null;
     }
     if (!REGION_PATTERN.matcher(region).matches()) {
-      throw new IllegalArgumentException(
-          "Failed to configure document store with id '"
-              + configuration.id()
-              + "': '"
-              + REGION
-              + "' is not a valid region: "
-              + region);
+      throw configurationError(configuration, "'" + REGION + "' is not a valid region: " + region);
     }
     if (endpoint == null && !Region.regions().contains(Region.of(region))) {
       LOG.warn(
@@ -215,19 +189,23 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
     return value == null || value.isBlank() ? null : value.trim();
   }
 
-  private static Boolean getForcePathStyle(final DocumentStoreConfigurationRecord configuration) {
-    final String value = configuration.properties().get(FORCE_PATH_STYLE);
+  private static Boolean getBoolean(
+      final DocumentStoreConfigurationRecord configuration, final String property) {
+    final String value = configuration.properties().get(property);
     return value == null ? null : Boolean.parseBoolean(value);
   }
 
-  private static Boolean getChunkedEncodingEnabled(
-      final DocumentStoreConfigurationRecord configuration) {
-    final String value = configuration.properties().get(CHUNKED_ENCODING_ENABLED);
-    return value == null ? null : Boolean.parseBoolean(value);
+  private static IllegalArgumentException configurationError(
+      final DocumentStoreConfigurationRecord configuration, final String message) {
+    return configurationError(configuration, message, null);
   }
 
-  private static Boolean getSupportLegacyMd5(final DocumentStoreConfigurationRecord configuration) {
-    final String value = configuration.properties().get(SUPPORT_LEGACY_MD5);
-    return value == null ? null : Boolean.parseBoolean(value);
+  private static IllegalArgumentException configurationError(
+      final DocumentStoreConfigurationRecord configuration,
+      final String message,
+      final Throwable cause) {
+    return new IllegalArgumentException(
+        "Failed to configure document store with id '" + configuration.id() + "': " + message,
+        cause);
   }
 }

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
@@ -52,10 +52,11 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
         getDefaultTTL(configuration),
         getBucketPath(configuration),
         executorService,
-        getEndpoint(configuration),
-        getForcePathStyle(configuration),
-        getChunkedEncodingEnabled(configuration),
-        getSupportLegacyMd5(configuration));
+        new AwsClientOptions(
+            getEndpoint(configuration),
+            getForcePathStyle(configuration),
+            getChunkedEncodingEnabled(configuration),
+            getSupportLegacyMd5(configuration)));
   }
 
   private static Long getDefaultTTL(final DocumentStoreConfigurationRecord configuration) {

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
@@ -33,6 +33,8 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
   private static final String CHUNKED_ENCODING_ENABLED = "CHUNKED_ENCODING_ENABLED";
   private static final String SUPPORT_LEGACY_MD5 = "SUPPORT_LEGACY_MD5";
   private static final String REGION = "REGION";
+  private static final String ACCESS_KEY = "ACCESS_KEY";
+  private static final String SECRET_KEY = "SECRET_KEY";
 
   @Override
   public DocumentStore createDocumentStore(
@@ -48,6 +50,10 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
                             + BUCKET_NAME_PROPERTY
                             + "'"));
 
+    final String accessKey = getTrimmedProperty(configuration, ACCESS_KEY);
+    final String secretKey = getTrimmedProperty(configuration, SECRET_KEY);
+    validateCredentialPair(configuration, accessKey, secretKey);
+
     return AwsDocumentStoreFactory.create(
         bucketName,
         getDefaultTTL(configuration),
@@ -58,7 +64,33 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
             getForcePathStyle(configuration),
             getChunkedEncodingEnabled(configuration),
             getSupportLegacyMd5(configuration),
-            getRegion(configuration)));
+            getRegion(configuration),
+            accessKey,
+            secretKey));
+  }
+
+  /**
+   * A half-configured key pair must fail loudly: silently falling back to the SDK default chain
+   * would let a store that was meant to use its own identity read and write with the process-wide
+   * credentials instead, which for a physical tenant means reaching storage that belongs to
+   * somebody else.
+   */
+  private static void validateCredentialPair(
+      final DocumentStoreConfigurationRecord configuration,
+      final String accessKey,
+      final String secretKey) {
+    if ((accessKey == null) == (secretKey == null)) {
+      return;
+    }
+    throw new IllegalArgumentException(
+        "Failed to configure document store with id '"
+            + configuration.id()
+            + "': '"
+            + ACCESS_KEY
+            + "' and '"
+            + SECRET_KEY
+            + "' must be configured together. Configure both to authenticate this store with its"
+            + " own credentials, or neither to use the credentials of the AWS SDK default chain.");
   }
 
   private static Long getDefaultTTL(final DocumentStoreConfigurationRecord configuration) {
@@ -117,8 +149,13 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
   }
 
   private static String getRegion(final DocumentStoreConfigurationRecord configuration) {
-    final String region = configuration.properties().get(REGION);
-    return region == null || region.isBlank() ? null : region.trim();
+    return getTrimmedProperty(configuration, REGION);
+  }
+
+  private static String getTrimmedProperty(
+      final DocumentStoreConfigurationRecord configuration, final String property) {
+    final String value = configuration.properties().get(property);
+    return value == null || value.isBlank() ? null : value.trim();
   }
 
   private static Boolean getForcePathStyle(final DocumentStoreConfigurationRecord configuration) {

--- a/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStoreProvider.java
@@ -72,7 +72,8 @@ public class GcpDocumentStoreProvider implements DocumentStoreProvider {
    * or — when it has none — from the application default credentials, which are shared by every
    * store in the process.
    */
-  private Storage createStorage(final DocumentStoreConfigurationRecord configuration) {
+  @VisibleForTesting
+  static Storage createStorage(final DocumentStoreConfigurationRecord configuration) {
     final String credentialsPath = configuration.properties().get(CREDENTIALS_PATH_PROPERTY);
     if (credentialsPath == null || credentialsPath.isBlank()) {
       return StorageOptions.getDefaultInstance().getService();

--- a/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStoreProvider.java
@@ -7,12 +7,18 @@
  */
 package io.camunda.document.store.gcp;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
 import io.camunda.document.api.DocumentStoreProvider;
 import io.camunda.zeebe.util.VisibleForTesting;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
@@ -24,6 +30,7 @@ public class GcpDocumentStoreProvider implements DocumentStoreProvider {
 
   private static final String BUCKET_NAME_PROPERTY = "BUCKET";
   private static final String PREFIX_PROPERTY = "PREFIX";
+  private static final String CREDENTIALS_PATH_PROPERTY = "CREDENTIALS_PATH";
 
   private static final String DEFAULT_PREFIX = "temp/";
 
@@ -42,7 +49,7 @@ public class GcpDocumentStoreProvider implements DocumentStoreProvider {
     return new GcpDocumentStore(
         getBucketNameProperty(configuration),
         getPrefixProperty(configuration),
-        override != null ? override.get() : StorageOptions.getDefaultInstance().getService(),
+        override != null ? override.get() : createStorage(configuration),
         executorService);
   }
 
@@ -58,6 +65,35 @@ public class GcpDocumentStoreProvider implements DocumentStoreProvider {
   @VisibleForTesting
   public static void clearStorageOverrideForTests() {
     storageOverride = null;
+  }
+
+  /**
+   * Builds the GCS client for this store: from the service account key file it was configured with,
+   * or — when it has none — from the application default credentials, which are shared by every
+   * store in the process.
+   */
+  private Storage createStorage(final DocumentStoreConfigurationRecord configuration) {
+    final String credentialsPath = configuration.properties().get(CREDENTIALS_PATH_PROPERTY);
+    if (credentialsPath == null || credentialsPath.isBlank()) {
+      return StorageOptions.getDefaultInstance().getService();
+    }
+
+    try (final InputStream keyFile = Files.newInputStream(Path.of(credentialsPath.trim()))) {
+      return StorageOptions.newBuilder()
+          .setCredentials(GoogleCredentials.fromStream(keyFile))
+          .build()
+          .getService();
+    } catch (final IOException | InvalidPathException e) {
+      throw new IllegalArgumentException(
+          "Failed to configure document store with id '"
+              + configuration.id()
+              + "': could not read GCP credentials from '"
+              + credentialsPath
+              + "' configured as '"
+              + CREDENTIALS_PATH_PROPERTY
+              + "'",
+          e);
+    }
   }
 
   private String getBucketNameProperty(final DocumentStoreConfigurationRecord configuration) {

--- a/document/store/src/test/java/io/camunda/document/store/SimpleDocumentStoreRegistryTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/SimpleDocumentStoreRegistryTest.java
@@ -10,11 +10,15 @@ package io.camunda.document.store;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreConfiguration;
+import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
+import io.camunda.document.api.DocumentStoreProvider;
 import io.camunda.document.store.inmemory.InMemoryDocumentStore;
 import io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import org.junit.jupiter.api.Test;
 
@@ -130,5 +134,37 @@ public class SimpleDocumentStoreRegistryTest {
     final var executor = ((TestDocumentStoreProvider.DummyDocumentStore) store).executorService();
     assertThat(executor).isInstanceOf(ThreadPoolExecutor.class);
     assertThat(((ThreadPoolExecutor) executor).getMaximumPoolSize()).isEqualTo(10);
+  }
+
+  @Test
+  public void shouldNotExposeCredentialsInConfigurationErrorMessage() {
+    // given
+    final DocumentStoreConfigurationRecord configurationRecord =
+        new DocumentStoreConfigurationRecord(
+            "azure-store",
+            UnregisteredDocumentStoreProvider.class,
+            Map.of("CONTAINER", "documents", "CONNECTION_STRING", "AccountKey=super-secret-key"));
+    final DocumentStoreConfiguration configuration =
+        new DocumentStoreConfiguration("azure-store", null, List.of(configurationRecord));
+
+    // when
+    // then
+    assertThatThrownBy(() -> new SimpleDocumentStoreRegistry(() -> configuration))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("azure-store")
+        .hasMessageContaining("documents")
+        .hasMessageContaining("<redacted>")
+        .hasMessageNotContaining("super-secret-key");
+  }
+
+  /** Deliberately absent from {@code META-INF/services}, so the registry fails to resolve it. */
+  private static final class UnregisteredDocumentStoreProvider implements DocumentStoreProvider {
+
+    @Override
+    public DocumentStore createDocumentStore(
+        final DocumentStoreConfigurationRecord configuration,
+        final ExecutorService executorService) {
+      throw new UnsupportedOperationException("not reachable");
+    }
   }
 }

--- a/document/store/src/test/java/io/camunda/document/store/SimpleDocumentStoreRegistryTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/SimpleDocumentStoreRegistryTest.java
@@ -158,27 +158,6 @@ public class SimpleDocumentStoreRegistryTest {
   }
 
   @Test
-  public void shouldNotExposeCredentialsUnderAnUnanticipatedPropertyName() {
-    // given — the legacy DOCUMENT_STORE_<ID>_<PROPERTY> bridge forwards whatever property name it
-    // finds, so a store can carry a credential under a key no allowlist was written for
-    final DocumentStoreConfigurationRecord configurationRecord =
-        new DocumentStoreConfigurationRecord(
-            "azure-store",
-            UnregisteredDocumentStoreProvider.class,
-            Map.of("CONTAINER", "documents", "SAS_TOKEN", "sv=2024-01-01&sig=super-secret-sig"));
-    final DocumentStoreConfiguration configuration =
-        new DocumentStoreConfiguration("azure-store", null, List.of(configurationRecord));
-
-    // when
-    // then
-    assertThatThrownBy(() -> new SimpleDocumentStoreRegistry(() -> configuration))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("documents")
-        .hasMessageContaining("<redacted>")
-        .hasMessageNotContaining("super-secret-sig");
-  }
-
-  @Test
   public void shouldNotExposeTheAwsAccessKey() {
     // given — the access key names the IAM principal the store acts as, so it is masked alongside
     // the secret it pairs with

--- a/document/store/src/test/java/io/camunda/document/store/SimpleDocumentStoreRegistryTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/SimpleDocumentStoreRegistryTest.java
@@ -157,6 +157,48 @@ public class SimpleDocumentStoreRegistryTest {
         .hasMessageNotContaining("super-secret-key");
   }
 
+  @Test
+  public void shouldNotExposeCredentialsUnderAnUnanticipatedPropertyName() {
+    // given — the legacy DOCUMENT_STORE_<ID>_<PROPERTY> bridge forwards whatever property name it
+    // finds, so a store can carry a credential under a key no allowlist was written for
+    final DocumentStoreConfigurationRecord configurationRecord =
+        new DocumentStoreConfigurationRecord(
+            "azure-store",
+            UnregisteredDocumentStoreProvider.class,
+            Map.of("CONTAINER", "documents", "SAS_TOKEN", "sv=2024-01-01&sig=super-secret-sig"));
+    final DocumentStoreConfiguration configuration =
+        new DocumentStoreConfiguration("azure-store", null, List.of(configurationRecord));
+
+    // when
+    // then
+    assertThatThrownBy(() -> new SimpleDocumentStoreRegistry(() -> configuration))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("documents")
+        .hasMessageContaining("<redacted>")
+        .hasMessageNotContaining("super-secret-sig");
+  }
+
+  @Test
+  public void shouldNotExposeTheAwsAccessKey() {
+    // given — the access key names the IAM principal the store acts as, so it is masked alongside
+    // the secret it pairs with
+    final DocumentStoreConfigurationRecord configurationRecord =
+        new DocumentStoreConfigurationRecord(
+            "aws-store",
+            UnregisteredDocumentStoreProvider.class,
+            Map.of("BUCKET", "documents", "ACCESS_KEY", "AKIAEXAMPLEPRINCIPAL"));
+    final DocumentStoreConfiguration configuration =
+        new DocumentStoreConfiguration("aws-store", null, List.of(configurationRecord));
+
+    // when
+    // then
+    assertThatThrownBy(() -> new SimpleDocumentStoreRegistry(() -> configuration))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("documents")
+        .hasMessageContaining("<redacted>")
+        .hasMessageNotContaining("AKIAEXAMPLEPRINCIPAL");
+  }
+
   /** Deliberately absent from {@code META-INF/services}, so the registry fails to resolve it. */
   private static final class UnregisteredDocumentStoreProvider implements DocumentStoreProvider {
 

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
@@ -322,4 +322,146 @@ public class AwsDocumentStoreProviderTest {
       assertThat(presigner).isNotNull();
     }
   }
+
+  @Test
+  public void shouldPassConfiguredCredentials() {
+    try (final var mockedFactory = mockStatic(AwsDocumentStoreFactory.class)) {
+      // given
+      final AwsDocumentStore mockDocumentStore = mock(AwsDocumentStore.class);
+      final ArgumentCaptor<AwsClientOptions> optionsCaptor =
+          ArgumentCaptor.forClass(AwsClientOptions.class);
+      mockedFactory
+          .when(
+              () ->
+                  AwsDocumentStoreFactory.create(
+                      any(), any(), any(), any(), optionsCaptor.capture()))
+          .thenReturn(mockDocumentStore);
+
+      final DocumentStoreConfigurationRecord configuration =
+          new DocumentStoreConfigurationRecord(
+              "aws", AwsDocumentStoreProvider.class, new HashMap<>());
+      configuration.properties().put("BUCKET", "bucket");
+      configuration.properties().put("ACCESS_KEY", "tenant-a-key");
+      configuration.properties().put("SECRET_KEY", "tenant-a-secret");
+
+      // when
+      new AwsDocumentStoreProvider()
+          .createDocumentStore(configuration, Executors.newSingleThreadExecutor());
+
+      // then
+      assertThat(optionsCaptor.getValue().accessKey()).isEqualTo("tenant-a-key");
+      assertThat(optionsCaptor.getValue().secretKey()).isEqualTo("tenant-a-secret");
+      assertThat(optionsCaptor.getValue().hasStaticCredentials()).isTrue();
+    }
+  }
+
+  @Test
+  public void shouldFallBackToTheSdkCredentialChainWhenNoKeyPairIsConfigured() {
+    try (final var mockedFactory = mockStatic(AwsDocumentStoreFactory.class)) {
+      // given
+      final AwsDocumentStore mockDocumentStore = mock(AwsDocumentStore.class);
+      final ArgumentCaptor<AwsClientOptions> optionsCaptor =
+          ArgumentCaptor.forClass(AwsClientOptions.class);
+      mockedFactory
+          .when(
+              () ->
+                  AwsDocumentStoreFactory.create(
+                      any(), any(), any(), any(), optionsCaptor.capture()))
+          .thenReturn(mockDocumentStore);
+
+      final DocumentStoreConfigurationRecord configuration =
+          new DocumentStoreConfigurationRecord(
+              "aws", AwsDocumentStoreProvider.class, new HashMap<>());
+      configuration.properties().put("BUCKET", "bucket");
+
+      // when
+      new AwsDocumentStoreProvider()
+          .createDocumentStore(configuration, Executors.newSingleThreadExecutor());
+
+      // then
+      assertThat(optionsCaptor.getValue().hasStaticCredentials()).isFalse();
+      assertThat(optionsCaptor.getValue().credentialsProvider()).isNull();
+    }
+  }
+
+  @Test
+  public void shouldThrowIfOnlyAccessKeyIsConfigured() {
+    // given
+    final DocumentStoreConfigurationRecord configuration =
+        new DocumentStoreConfigurationRecord(
+            "my-aws", AwsDocumentStoreProvider.class, new HashMap<>());
+    configuration.properties().put("BUCKET", "bucket");
+    configuration.properties().put("ACCESS_KEY", "tenant-a-key");
+
+    final AwsDocumentStoreProvider provider = new AwsDocumentStoreProvider();
+
+    // when / then
+    final var ex =
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                () ->
+                    provider.createDocumentStore(
+                        configuration, Executors.newSingleThreadExecutor()))
+            .actual();
+    assertThat(ex.getMessage())
+        .startsWith(
+            "Failed to configure document store with id 'my-aws': 'ACCESS_KEY' and 'SECRET_KEY' must be configured together");
+  }
+
+  @Test
+  public void shouldThrowIfOnlySecretKeyIsConfigured() {
+    // given
+    final DocumentStoreConfigurationRecord configuration =
+        new DocumentStoreConfigurationRecord(
+            "my-aws", AwsDocumentStoreProvider.class, new HashMap<>());
+    configuration.properties().put("BUCKET", "bucket");
+    configuration.properties().put("SECRET_KEY", "tenant-a-secret");
+
+    final AwsDocumentStoreProvider provider = new AwsDocumentStoreProvider();
+
+    // when / then
+    final var ex =
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                () ->
+                    provider.createDocumentStore(
+                        configuration, Executors.newSingleThreadExecutor()))
+            .actual();
+    assertThat(ex.getMessage())
+        .startsWith(
+            "Failed to configure document store with id 'my-aws': 'ACCESS_KEY' and 'SECRET_KEY' must be configured together");
+  }
+
+  @Test
+  public void shouldSignWithTheConfiguredCredentials() {
+    // given
+    final AwsClientOptions options =
+        new AwsClientOptions(
+            null, null, null, null, "eu-central-1", "tenant-a-key", "tenant-a-secret");
+
+    // when
+    try (final var client = AwsDocumentStore.buildClient(options)) {
+
+      // then
+      final var credentials =
+          client.serviceClientConfiguration().credentialsProvider().resolveIdentity().join();
+      assertThat(credentials.accessKeyId()).isEqualTo("tenant-a-key");
+      assertThat(credentials.secretAccessKey()).isEqualTo("tenant-a-secret");
+    }
+  }
+
+  @Test
+  public void shouldNotExposeTheSecretKeyWhenPrinted() {
+    // given
+    final AwsClientOptions options =
+        new AwsClientOptions(
+            null, null, null, null, "eu-central-1", "tenant-a-key", "tenant-a-secret");
+
+    // when
+    final String printed = options.toString();
+
+    // then
+    assertThat(printed).contains("tenant-a-key").contains("<redacted>");
+    assertThat(printed).doesNotContain("tenant-a-secret");
+  }
 }

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
@@ -309,7 +309,8 @@ public class AwsDocumentStoreProviderTest {
   @Test
   public void shouldTargetTheConfiguredRegionFromClientAndPresigner() {
     // given
-    final AwsClientOptions options = new AwsClientOptions(null, null, null, null, "eu-central-1");
+    final AwsClientOptions options =
+        new AwsClientOptions(null, null, null, null, "eu-central-1", null, null);
 
     // when
     try (final var client = AwsDocumentStore.buildClient(options);

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
@@ -466,6 +466,17 @@ public class AwsDocumentStoreProviderTest {
   }
 
   @Test
+  public void shouldRejectHalfOfAKeyPair() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> new AwsClientOptions(null, null, null, null, null, "tenant-a-key", null))
+        .withMessageContaining("must be set together");
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () -> new AwsClientOptions(null, null, null, null, null, null, "tenant-a-secret"))
+        .withMessageContaining("must be set together");
+  }
+
+  @Test
   public void shouldLeaveEverySettingToTheSdkWhenNothingIsOverridden() {
     // the path every deployment without per-store credentials still takes, and the one no
     // integration test can exercise

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.regions.Region;
 
 public class AwsDocumentStoreProviderTest {
 
@@ -244,6 +245,80 @@ public class AwsDocumentStoreProviderTest {
 
       // then
       assertThat(optionsCaptor.getValue().chunkedEncodingEnabled()).isFalse();
+    }
+  }
+
+  @Test
+  public void shouldPassConfiguredRegion() {
+    try (final var mockedFactory = mockStatic(AwsDocumentStoreFactory.class)) {
+      // given
+      final AwsDocumentStore mockDocumentStore = mock(AwsDocumentStore.class);
+      final ArgumentCaptor<AwsClientOptions> optionsCaptor =
+          ArgumentCaptor.forClass(AwsClientOptions.class);
+      mockedFactory
+          .when(
+              () ->
+                  AwsDocumentStoreFactory.create(
+                      any(), any(), any(), any(), optionsCaptor.capture()))
+          .thenReturn(mockDocumentStore);
+
+      final DocumentStoreConfigurationRecord configuration =
+          new DocumentStoreConfigurationRecord(
+              "aws", AwsDocumentStoreProvider.class, new HashMap<>());
+      configuration.properties().put("BUCKET", "bucket");
+      configuration.properties().put("REGION", "eu-central-1");
+
+      // when
+      new AwsDocumentStoreProvider()
+          .createDocumentStore(configuration, Executors.newSingleThreadExecutor());
+
+      // then
+      assertThat(optionsCaptor.getValue().region()).isEqualTo("eu-central-1");
+    }
+  }
+
+  @Test
+  public void shouldLeaveRegionToTheSdkWhenNotConfigured() {
+    try (final var mockedFactory = mockStatic(AwsDocumentStoreFactory.class)) {
+      // given
+      final AwsDocumentStore mockDocumentStore = mock(AwsDocumentStore.class);
+      final ArgumentCaptor<AwsClientOptions> optionsCaptor =
+          ArgumentCaptor.forClass(AwsClientOptions.class);
+      mockedFactory
+          .when(
+              () ->
+                  AwsDocumentStoreFactory.create(
+                      any(), any(), any(), any(), optionsCaptor.capture()))
+          .thenReturn(mockDocumentStore);
+
+      final DocumentStoreConfigurationRecord configuration =
+          new DocumentStoreConfigurationRecord(
+              "aws", AwsDocumentStoreProvider.class, new HashMap<>());
+      configuration.properties().put("BUCKET", "bucket");
+      configuration.properties().put("REGION", "  ");
+
+      // when
+      new AwsDocumentStoreProvider()
+          .createDocumentStore(configuration, Executors.newSingleThreadExecutor());
+
+      // then
+      assertThat(optionsCaptor.getValue().region()).isNull();
+    }
+  }
+
+  @Test
+  public void shouldTargetTheConfiguredRegionFromClientAndPresigner() {
+    // given
+    final AwsClientOptions options = new AwsClientOptions(null, null, null, null, "eu-central-1");
+
+    // when
+    try (final var client = AwsDocumentStore.buildClient(options);
+        final var presigner = AwsDocumentStore.buildPresigner(options)) {
+
+      // then
+      assertThat(client.serviceClientConfiguration().region()).isEqualTo(Region.of("eu-central-1"));
+      // the presigner does not expose its region; it only builds at all once one is resolvable
+      assertThat(presigner).isNotNull();
     }
   }
 }

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
@@ -464,4 +464,37 @@ public class AwsDocumentStoreProviderTest {
     assertThat(printed).contains("tenant-a-key").contains("<redacted>");
     assertThat(printed).doesNotContain("tenant-a-secret");
   }
+
+  @Test
+  public void shouldLeaveEverySettingToTheSdkWhenNothingIsOverridden() {
+    // a store with no overrides must keep taking the S3Client.create() / S3Presigner.create() path,
+    // where the SDK resolves region and credentials from AWS_REGION, an instance profile, and the
+    // rest of the default chain — the path every deployment without per-store credentials still
+    // uses, and the one no integration test can exercise
+    assertThat(AwsClientOptions.sdkDefaults().usesSdkDefaults()).isTrue();
+  }
+
+  @Test
+  public void shouldNotFallBackToTheSdkWhenAnySingleSettingIsOverridden() {
+    // given / when / then — each override alone is enough to take the builder path; a store that
+    // configures only its credentials, or only its region, must not silently address the process
+    // environment instead
+    assertThat(
+            new AwsClientOptions(
+                    URI.create("http://minio.local:9000"), null, null, null, null, null, null)
+                .usesSdkDefaults())
+        .isFalse();
+    assertThat(new AwsClientOptions(null, true, null, null, null, null, null).usesSdkDefaults())
+        .isFalse();
+    assertThat(new AwsClientOptions(null, null, false, null, null, null, null).usesSdkDefaults())
+        .isFalse();
+    assertThat(
+            new AwsClientOptions(null, null, null, null, "eu-central-1", null, null)
+                .usesSdkDefaults())
+        .isFalse();
+    assertThat(
+            new AwsClientOptions(null, null, null, null, null, "tenant-a-key", "tenant-a-secret")
+                .usesSdkDefaults())
+        .isFalse();
+  }
 }

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
@@ -467,18 +467,15 @@ public class AwsDocumentStoreProviderTest {
 
   @Test
   public void shouldLeaveEverySettingToTheSdkWhenNothingIsOverridden() {
-    // a store with no overrides must keep taking the S3Client.create() / S3Presigner.create() path,
-    // where the SDK resolves region and credentials from AWS_REGION, an instance profile, and the
-    // rest of the default chain — the path every deployment without per-store credentials still
-    // uses, and the one no integration test can exercise
+    // the path every deployment without per-store credentials still takes, and the one no
+    // integration test can exercise
     assertThat(AwsClientOptions.sdkDefaults().usesSdkDefaults()).isTrue();
   }
 
   @Test
   public void shouldNotFallBackToTheSdkWhenAnySingleSettingIsOverridden() {
-    // given / when / then — each override alone is enough to take the builder path; a store that
-    // configures only its credentials, or only its region, must not silently address the process
-    // environment instead
+    // a store configuring only its credentials, or only its region, must not silently keep
+    // addressing the process environment
     assertThat(
             new AwsClientOptions(
                     URI.create("http://minio.local:9000"), null, null, null, null, null, null)
@@ -500,8 +497,7 @@ public class AwsDocumentStoreProviderTest {
 
   @Test
   public void shouldThrowIfRegionIsNotAValidRegion() {
-    // given — Region.of accepts any string, so an unchecked region would only surface at the first
-    // document operation as an unresolvable host
+    // given
     final DocumentStoreConfigurationRecord configuration =
         new DocumentStoreConfigurationRecord(
             "my-aws", AwsDocumentStoreProvider.class, new HashMap<>());
@@ -526,8 +522,7 @@ public class AwsDocumentStoreProviderTest {
   @Test
   public void shouldAcceptARegionTheSdkDoesNotKnow() {
     try (final var mockedFactory = mockStatic(AwsDocumentStoreFactory.class)) {
-      // given — a region newer than the bundled SDK, or an S3-compatible backend's own region name,
-      // must still be accepted; only a structurally impossible one is rejected
+      // given — a region newer than the bundled SDK, or an S3-compatible backend's own name
       final AwsDocumentStore mockDocumentStore = mock(AwsDocumentStore.class);
       final ArgumentCaptor<AwsClientOptions> optionsCaptor =
           ArgumentCaptor.forClass(AwsClientOptions.class);

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
@@ -497,4 +497,59 @@ public class AwsDocumentStoreProviderTest {
                 .usesSdkDefaults())
         .isFalse();
   }
+
+  @Test
+  public void shouldThrowIfRegionIsNotAValidRegion() {
+    // given — Region.of accepts any string, so an unchecked region would only surface at the first
+    // document operation as an unresolvable host
+    final DocumentStoreConfigurationRecord configuration =
+        new DocumentStoreConfigurationRecord(
+            "my-aws", AwsDocumentStoreProvider.class, new HashMap<>());
+    configuration.properties().put("BUCKET", "bucket");
+    configuration.properties().put("REGION", "EU West 1");
+
+    final AwsDocumentStoreProvider provider = new AwsDocumentStoreProvider();
+
+    // when / then
+    final var ex =
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                () ->
+                    provider.createDocumentStore(
+                        configuration, Executors.newSingleThreadExecutor()))
+            .actual();
+    assertThat(ex.getMessage())
+        .isEqualTo(
+            "Failed to configure document store with id 'my-aws': 'REGION' is not a valid region: EU West 1");
+  }
+
+  @Test
+  public void shouldAcceptARegionTheSdkDoesNotKnow() {
+    try (final var mockedFactory = mockStatic(AwsDocumentStoreFactory.class)) {
+      // given — a region newer than the bundled SDK, or an S3-compatible backend's own region name,
+      // must still be accepted; only a structurally impossible one is rejected
+      final AwsDocumentStore mockDocumentStore = mock(AwsDocumentStore.class);
+      final ArgumentCaptor<AwsClientOptions> optionsCaptor =
+          ArgumentCaptor.forClass(AwsClientOptions.class);
+      mockedFactory
+          .when(
+              () ->
+                  AwsDocumentStoreFactory.create(
+                      any(), any(), any(), any(), optionsCaptor.capture()))
+          .thenReturn(mockDocumentStore);
+
+      final DocumentStoreConfigurationRecord configuration =
+          new DocumentStoreConfigurationRecord(
+              "aws", AwsDocumentStoreProvider.class, new HashMap<>());
+      configuration.properties().put("BUCKET", "bucket");
+      configuration.properties().put("REGION", "xx-fictional-9");
+
+      // when
+      new AwsDocumentStoreProvider()
+          .createDocumentStore(configuration, Executors.newSingleThreadExecutor());
+
+      // then
+      assertThat(optionsCaptor.getValue().region()).isEqualTo("xx-fictional-9");
+    }
+  }
 }

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
@@ -41,10 +41,7 @@ public class AwsDocumentStoreProviderTest {
                       eq(bucketTtl),
                       eq(""),
                       any(),
-                      eq((URI) null),
-                      eq((Boolean) null),
-                      eq((Boolean) null),
-                      eq((Boolean) null)))
+                      eq(AwsClientOptions.sdkDefaults())))
           .thenReturn(mockDocumentStore);
 
       final DocumentStoreConfigurationRecord configuration =
@@ -140,20 +137,13 @@ public class AwsDocumentStoreProviderTest {
     try (final var mockedFactory = mockStatic(AwsDocumentStoreFactory.class)) {
       // given
       final AwsDocumentStore mockDocumentStore = mock(AwsDocumentStore.class);
-      final ArgumentCaptor<URI> endpointCaptor = ArgumentCaptor.forClass(URI.class);
-      final ArgumentCaptor<Boolean> pathStyleCaptor = ArgumentCaptor.forClass(Boolean.class);
+      final ArgumentCaptor<AwsClientOptions> optionsCaptor =
+          ArgumentCaptor.forClass(AwsClientOptions.class);
       mockedFactory
           .when(
               () ->
                   AwsDocumentStoreFactory.create(
-                      any(),
-                      any(),
-                      any(),
-                      any(),
-                      endpointCaptor.capture(),
-                      pathStyleCaptor.capture(),
-                      any(),
-                      any()))
+                      any(), any(), any(), any(), optionsCaptor.capture()))
           .thenReturn(mockDocumentStore);
 
       final DocumentStoreConfigurationRecord configuration =
@@ -167,8 +157,9 @@ public class AwsDocumentStoreProviderTest {
           .createDocumentStore(configuration, Executors.newSingleThreadExecutor());
 
       // then
-      assertThat(endpointCaptor.getValue()).isEqualTo(URI.create("http://minio.local:9000"));
-      assertThat(pathStyleCaptor.getValue()).isNull();
+      assertThat(optionsCaptor.getValue().endpointOverride())
+          .isEqualTo(URI.create("http://minio.local:9000"));
+      assertThat(optionsCaptor.getValue().forcePathStyle()).isNull();
     }
   }
 
@@ -177,12 +168,13 @@ public class AwsDocumentStoreProviderTest {
     try (final var mockedFactory = mockStatic(AwsDocumentStoreFactory.class)) {
       // given
       final AwsDocumentStore mockDocumentStore = mock(AwsDocumentStore.class);
-      final ArgumentCaptor<Boolean> pathStyleCaptor = ArgumentCaptor.forClass(Boolean.class);
+      final ArgumentCaptor<AwsClientOptions> optionsCaptor =
+          ArgumentCaptor.forClass(AwsClientOptions.class);
       mockedFactory
           .when(
               () ->
                   AwsDocumentStoreFactory.create(
-                      any(), any(), any(), any(), any(), pathStyleCaptor.capture(), any(), any()))
+                      any(), any(), any(), any(), optionsCaptor.capture()))
           .thenReturn(mockDocumentStore);
 
       final DocumentStoreConfigurationRecord configuration =
@@ -197,7 +189,7 @@ public class AwsDocumentStoreProviderTest {
           .createDocumentStore(configuration, Executors.newSingleThreadExecutor());
 
       // then
-      assertThat(pathStyleCaptor.getValue()).isFalse();
+      assertThat(optionsCaptor.getValue().forcePathStyle()).isFalse();
     }
   }
 
@@ -230,12 +222,13 @@ public class AwsDocumentStoreProviderTest {
     try (final var mockedFactory = mockStatic(AwsDocumentStoreFactory.class)) {
       // given
       final AwsDocumentStore mockDocumentStore = mock(AwsDocumentStore.class);
-      final ArgumentCaptor<Boolean> chunkedCaptor = ArgumentCaptor.forClass(Boolean.class);
+      final ArgumentCaptor<AwsClientOptions> optionsCaptor =
+          ArgumentCaptor.forClass(AwsClientOptions.class);
       mockedFactory
           .when(
               () ->
                   AwsDocumentStoreFactory.create(
-                      any(), any(), any(), any(), any(), any(), chunkedCaptor.capture(), any()))
+                      any(), any(), any(), any(), optionsCaptor.capture()))
           .thenReturn(mockDocumentStore);
 
       final DocumentStoreConfigurationRecord configuration =
@@ -250,7 +243,7 @@ public class AwsDocumentStoreProviderTest {
           .createDocumentStore(configuration, Executors.newSingleThreadExecutor());
 
       // then
-      assertThat(chunkedCaptor.getValue()).isFalse();
+      assertThat(optionsCaptor.getValue().chunkedEncodingEnabled()).isFalse();
     }
   }
 }

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
@@ -451,7 +451,7 @@ public class AwsDocumentStoreProviderTest {
   }
 
   @Test
-  public void shouldNotExposeTheSecretKeyWhenPrinted() {
+  public void shouldNotExposeEitherHalfOfTheKeyPairWhenPrinted() {
     // given
     final AwsClientOptions options =
         new AwsClientOptions(
@@ -461,8 +461,8 @@ public class AwsDocumentStoreProviderTest {
     final String printed = options.toString();
 
     // then
-    assertThat(printed).contains("tenant-a-key").contains("<redacted>");
-    assertThat(printed).doesNotContain("tenant-a-secret");
+    assertThat(printed).contains("eu-central-1").contains("<redacted>");
+    assertThat(printed).doesNotContain("tenant-a-secret").doesNotContain("tenant-a-key");
   }
 
   @Test

--- a/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreProviderTest.java
@@ -10,6 +10,8 @@ package io.camunda.document.store.gcp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
+import com.google.auth.oauth2.UserCredentials;
+import com.google.cloud.storage.Storage;
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
 import java.io.IOException;
@@ -115,14 +117,16 @@ public class GcpDocumentStoreProviderTest {
             "gcp", GcpDocumentStoreProvider.class, new HashMap<>());
     configuration.properties().put("BUCKET", "bucketName");
     configuration.properties().put("CREDENTIALS_PATH", keyFile.toString());
-    final GcpDocumentStoreProvider provider = new GcpDocumentStoreProvider();
 
     // when
-    final DocumentStore documentStore =
-        provider.createDocumentStore(configuration, Executors.newSingleThreadExecutor());
+    final Storage storage = GcpDocumentStoreProvider.createStorage(configuration);
 
-    // then
-    assertThat(documentStore).isNotNull();
+    // then — the identity the client will sign with must come from the key file, not from the
+    // application default credentials that every store in the process shares
+    assertThat(storage.getOptions().getCredentials())
+        .isInstanceOfSatisfying(
+            UserCredentials.class,
+            credentials -> assertThat(credentials.getClientId()).isEqualTo("tenant-a-client"));
   }
 
   @Test

--- a/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreProviderTest.java
@@ -121,8 +121,8 @@ public class GcpDocumentStoreProviderTest {
     // when
     final Storage storage = GcpDocumentStoreProvider.createStorage(configuration);
 
-    // then — the identity the client will sign with must come from the key file, not from the
-    // application default credentials that every store in the process shares
+    // then — the identity must come from the key file, not from the application default
+    // credentials every store in the process shares
     assertThat(storage.getOptions().getCredentials())
         .isInstanceOfSatisfying(
             UserCredentials.class,

--- a/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreProviderTest.java
@@ -12,9 +12,13 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class GcpDocumentStoreProviderTest {
 
@@ -89,5 +93,59 @@ public class GcpDocumentStoreProviderTest {
 
     // then
     assertThat(documentStore).isNotNull();
+  }
+
+  @Test
+  public void shouldUseTheConfiguredCredentialsFile(@TempDir final Path tempDir)
+      throws IOException {
+    // given
+    final Path keyFile = tempDir.resolve("tenant-a.json");
+    Files.writeString(
+        keyFile,
+        """
+        {
+          "type": "authorized_user",
+          "client_id": "tenant-a-client",
+          "client_secret": "tenant-a-secret",
+          "refresh_token": "tenant-a-refresh-token"
+        }
+        """);
+    final DocumentStoreConfigurationRecord configuration =
+        new DocumentStoreConfigurationRecord(
+            "gcp", GcpDocumentStoreProvider.class, new HashMap<>());
+    configuration.properties().put("BUCKET", "bucketName");
+    configuration.properties().put("CREDENTIALS_PATH", keyFile.toString());
+    final GcpDocumentStoreProvider provider = new GcpDocumentStoreProvider();
+
+    // when
+    final DocumentStore documentStore =
+        provider.createDocumentStore(configuration, Executors.newSingleThreadExecutor());
+
+    // then
+    assertThat(documentStore).isNotNull();
+  }
+
+  @Test
+  public void shouldThrowIfCredentialsFileCannotBeRead(@TempDir final Path tempDir) {
+    // given
+    final Path missing = tempDir.resolve("absent.json");
+    final DocumentStoreConfigurationRecord configuration =
+        new DocumentStoreConfigurationRecord(
+            "my-gcp", GcpDocumentStoreProvider.class, new HashMap<>());
+    configuration.properties().put("BUCKET", "bucketName");
+    configuration.properties().put("CREDENTIALS_PATH", missing.toString());
+    final GcpDocumentStoreProvider provider = new GcpDocumentStoreProvider();
+
+    // when / then
+    final var ex =
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                () ->
+                    provider.createDocumentStore(
+                        configuration, Executors.newSingleThreadExecutor()))
+            .actual();
+    assertThat(ex.getMessage())
+        .startsWith(
+            "Failed to configure document store with id 'my-gcp': could not read GCP credentials from");
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAwsIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAwsIT.java
@@ -57,12 +57,11 @@ final class DocumentIsolationAwsIT extends AbstractDocumentIsolationIT {
       client.createBucket(cfg -> cfg.bucket(BUCKET_B)).join();
     }
 
-    // Each store gets its own Minio user, scoped to the one bucket that store writes into, and the
-    // root key pair is never handed to the broker. That makes the credentials load-bearing: a
-    // regression that drops the per-store key pair falls back to the AWS SDK default chain, which
-    // has nothing to offer here, and a store built with a sibling's key pair is refused by Minio
-    // with AccessDenied. It cannot separate store-a from store-c, which share bucket-a — those two
-    // stay isolated by prefix alone, as the class javadoc of AbstractDocumentIsolationIT describes.
+    // The root key pair is never handed to the broker, which makes the per-store credentials
+    // load-bearing: dropping them falls back to the AWS SDK default chain, which has nothing to
+    // offer here, and a store built with a sibling's pair is refused with AccessDenied. It cannot
+    // separate store-a from store-c, which share bucket-a — those stay isolated by prefix alone,
+    // as the class javadoc of AbstractDocumentIsolationIT describes.
     MINIO.createScopedUser(USER_DEFAULT, USER_DEFAULT + "-secret", BUCKET_B);
     MINIO.createScopedUser(USER_A, USER_A + "-secret", BUCKET_A);
     MINIO.createScopedUser(USER_B, USER_B + "-secret", BUCKET_B);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAwsIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAwsIT.java
@@ -26,6 +26,10 @@ final class DocumentIsolationAwsIT extends AbstractDocumentIsolationIT {
 
   private static final String BUCKET_A = "bucket-a";
   private static final String BUCKET_B = "bucket-b";
+  private static final String USER_DEFAULT = "store-default-user";
+  private static final String USER_A = "store-a-user";
+  private static final String USER_B = "store-b-user";
+  private static final String USER_C = "store-c-user";
   private static final Network NETWORK = Network.newNetwork();
 
   @Container
@@ -52,6 +56,17 @@ final class DocumentIsolationAwsIT extends AbstractDocumentIsolationIT {
       client.createBucket(cfg -> cfg.bucket(BUCKET_A)).join();
       client.createBucket(cfg -> cfg.bucket(BUCKET_B)).join();
     }
+
+    // Each store gets its own Minio user, scoped to the one bucket that store writes into, and the
+    // root key pair is never handed to the broker. That makes the credentials load-bearing: a
+    // regression that drops the per-store key pair falls back to the AWS SDK default chain, which
+    // has nothing to offer here, and a store built with a sibling's key pair is refused by Minio
+    // with AccessDenied. It cannot separate store-a from store-c, which share bucket-a — those two
+    // stay isolated by prefix alone, as the class javadoc of AbstractDocumentIsolationIT describes.
+    MINIO.createScopedUser(USER_DEFAULT, USER_DEFAULT + "-secret", BUCKET_B);
+    MINIO.createScopedUser(USER_A, USER_A + "-secret", BUCKET_A);
+    MINIO.createScopedUser(USER_B, USER_B + "-secret", BUCKET_B);
+    MINIO.createScopedUser(USER_C, USER_C + "-secret", BUCKET_A);
 
     // every store is configured with its own endpoint, region and credentials, so nothing is read
     // from the process environment. An IP-based endpoint forces path-style access in the AWS SDK
@@ -82,13 +97,13 @@ final class DocumentIsolationAwsIT extends AbstractDocumentIsolationIT {
         .withProperty("camunda.physical-tenants.tenantc.document.default-store-id", STORE_C)
         .withProperty("camunda.physical-tenants.tenantc.document.assigned[0]", STORE_C);
 
-    withStoreConnection(BROKER, "camunda.document.aws.store-default", minioEndpoint);
+    withStoreConnection(BROKER, "camunda.document.aws.store-default", minioEndpoint, USER_DEFAULT);
     withStoreConnection(
-        BROKER, "camunda.physical-tenants.tenanta.document.aws.store-a", minioEndpoint);
+        BROKER, "camunda.physical-tenants.tenanta.document.aws.store-a", minioEndpoint, USER_A);
     withStoreConnection(
-        BROKER, "camunda.physical-tenants.tenantb.document.aws.store-b", minioEndpoint);
+        BROKER, "camunda.physical-tenants.tenantb.document.aws.store-b", minioEndpoint, USER_B);
     withStoreConnection(
-        BROKER, "camunda.physical-tenants.tenantc.document.aws.store-c", minioEndpoint);
+        BROKER, "camunda.physical-tenants.tenantc.document.aws.store-c", minioEndpoint, USER_C);
 
     BROKER.start();
 
@@ -96,17 +111,20 @@ final class DocumentIsolationAwsIT extends AbstractDocumentIsolationIT {
   }
 
   /**
-   * Points a single document store at Minio with its own credentials. Configuring them per store —
-   * rather than through the AWS SDK's process-wide environment — is what lets each physical tenant
-   * reach its storage under its own identity.
+   * Points a single document store at Minio with the key pair of the user created for it.
+   * Configuring credentials per store — rather than through the AWS SDK's process-wide environment
+   * — is what lets each physical tenant reach its storage under its own identity.
    */
   private static void withStoreConnection(
-      final TestStandaloneBroker broker, final String storePrefix, final String endpoint) {
+      final TestStandaloneBroker broker,
+      final String storePrefix,
+      final String endpoint,
+      final String user) {
     broker
         .withProperty(storePrefix + ".endpoint", endpoint)
         .withProperty(storePrefix + ".region", MINIO.region())
-        .withProperty(storePrefix + ".access-key", MINIO.accessKey())
-        .withProperty(storePrefix + ".secret-key", MINIO.secretKey());
+        .withProperty(storePrefix + ".access-key", user)
+        .withProperty(storePrefix + ".secret-key", user + "-secret");
   }
 
   @AfterAll

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAwsIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAwsIT.java
@@ -53,17 +53,13 @@ final class DocumentIsolationAwsIT extends AbstractDocumentIsolationIT {
       client.createBucket(cfg -> cfg.bucket(BUCKET_B)).join();
     }
 
-    // AwsDocumentStore uses S3Client.create() which reads from system properties.
-    // Using an IP-based endpoint forces path-style access in the AWS SDK v2.
+    // every store is configured with its own endpoint, region and credentials, so nothing is read
+    // from the process environment. An IP-based endpoint forces path-style access in the AWS SDK
+    // v2.
     final String minioEndpoint = "http://127.0.0.1:" + MINIO.getMappedPort(9000);
-    System.setProperty("aws.endpointUrl", minioEndpoint);
-    System.setProperty("aws.accessKeyId", MINIO.accessKey());
-    System.setProperty("aws.secretAccessKey", MINIO.secretKey());
-    System.setProperty("aws.region", MINIO.region());
 
     BROKER
         .withProperty("camunda.document.aws.store-default.bucket-name", BUCKET_B)
-        .withProperty("camunda.document.aws.store-default.region", MINIO.region())
         .withProperty("camunda.document.aws.store-default.bucket-path", "default/")
         .withProperty("camunda.document.default-store-id", STORE_DEFAULT)
         .withProperty("camunda.physical-tenants.tenanta.document.aws.store-a.bucket-name", BUCKET_A)
@@ -83,22 +79,39 @@ final class DocumentIsolationAwsIT extends AbstractDocumentIsolationIT {
         .withProperty("camunda.physical-tenants.tenantc.document.aws.store-c.bucket-name", BUCKET_A)
         .withProperty(
             "camunda.physical-tenants.tenantc.document.aws.store-c.bucket-path", "tenantc/")
-        .withProperty(
-            "camunda.physical-tenants.tenantc.document.aws.store-c.region", MINIO.region())
         .withProperty("camunda.physical-tenants.tenantc.document.default-store-id", STORE_C)
-        .withProperty("camunda.physical-tenants.tenantc.document.assigned[0]", STORE_C)
-        .start();
+        .withProperty("camunda.physical-tenants.tenantc.document.assigned[0]", STORE_C);
+
+    withStoreConnection(BROKER, "camunda.document.aws.store-default", minioEndpoint);
+    withStoreConnection(
+        BROKER, "camunda.physical-tenants.tenanta.document.aws.store-a", minioEndpoint);
+    withStoreConnection(
+        BROKER, "camunda.physical-tenants.tenantb.document.aws.store-b", minioEndpoint);
+    withStoreConnection(
+        BROKER, "camunda.physical-tenants.tenantc.document.aws.store-c", minioEndpoint);
+
+    BROKER.start();
 
     startClients(BROKER);
+  }
+
+  /**
+   * Points a single document store at Minio with its own credentials. Configuring them per store —
+   * rather than through the AWS SDK's process-wide environment — is what lets each physical tenant
+   * reach its storage under its own identity.
+   */
+  private static void withStoreConnection(
+      final TestStandaloneBroker broker, final String storePrefix, final String endpoint) {
+    broker
+        .withProperty(storePrefix + ".endpoint", endpoint)
+        .withProperty(storePrefix + ".region", MINIO.region())
+        .withProperty(storePrefix + ".access-key", MINIO.accessKey())
+        .withProperty(storePrefix + ".secret-key", MINIO.secretKey());
   }
 
   @AfterAll
   static void tearDown() {
     closeClients();
-    System.clearProperty("aws.endpointUrl");
-    System.clearProperty("aws.accessKeyId");
-    System.clearProperty("aws.secretAccessKey");
-    System.clearProperty("aws.region");
     NETWORK.close();
   }
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/testcontainers/MinioContainer.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/testcontainers/MinioContainer.java
@@ -7,9 +7,13 @@
  */
 package io.camunda.zeebe.test.testcontainers;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
@@ -35,6 +39,9 @@ public final class MinioContainer extends GenericContainer<MinioContainer> {
   private static final String DEFAULT_REGION = "us-east-1";
   private static final String DEFAULT_ACCESS_KEY = "accessKey";
   private static final String DEFAULT_SECRET_KEY = "secretKey";
+
+  /** Name the {@code mc} client uses inside the container for this Minio instance. */
+  private static final String ALIAS = "local";
 
   private String domain;
 
@@ -143,6 +150,72 @@ public final class MinioContainer extends GenericContainer<MinioContainer> {
     }
 
     return this;
+  }
+
+  /**
+   * Creates a Minio user with a policy granting it full access to exactly the named buckets, and to
+   * nothing else. The container must already be started.
+   *
+   * <p>Give each client under test its own user whenever the point of the test is that the client
+   * authenticates as its own identity rather than as the process. Handing every client the root key
+   * pair cannot show that: a client that silently falls back to the ambient credentials, or that
+   * picks up a sibling's, still reaches the bucket and the test stays green. With a scoped user it
+   * fails with {@code AccessDenied} instead.
+   *
+   * @param accessKey the user's access key, also used to name its policy
+   * @param secretKey the user's secret key; Minio requires at least 8 characters
+   * @param buckets the buckets the user may access — at least one
+   */
+  public void createScopedUser(
+      final String accessKey, final String secretKey, final String... buckets) {
+    if (buckets.length == 0) {
+      throw new IllegalArgumentException(
+          "must scope the user to at least one bucket, otherwise it can reach nothing");
+    }
+
+    final String policyName = accessKey + "-policy";
+    final String policyFile = "/tmp/" + policyName + ".json";
+    final String resources =
+        Arrays.stream(buckets)
+            .flatMap(bucket -> Stream.of(bucket, bucket + "/*"))
+            .map("\"arn:aws:s3:::%s\""::formatted)
+            .collect(Collectors.joining(","));
+    final String policy =
+        "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"s3:*\"],"
+            + "\"Resource\":[%s]}]}".formatted(resources);
+
+    mc("alias", "set", ALIAS, "http://localhost:" + PORT, accessKey(), secretKey());
+    exec("sh", "-c", "printf '%s' '" + policy + "' > " + policyFile);
+    mc("admin", "user", "add", ALIAS, accessKey, secretKey);
+    mc("admin", "policy", "create", ALIAS, policyName, policyFile);
+    mc("admin", "policy", "attach", ALIAS, policyName, "--user", accessKey);
+  }
+
+  private void mc(final String... arguments) {
+    final String[] command = new String[arguments.length + 1];
+    command[0] = "mc";
+    System.arraycopy(arguments, 0, command, 1, arguments.length);
+    exec(command);
+  }
+
+  private void exec(final String... command) {
+    try {
+      final var result = execInContainer(command);
+      if (result.getExitCode() != 0) {
+        throw new IllegalStateException(
+            "Failed to run '%s' in the Minio container (exit code %d): %s%s"
+                .formatted(
+                    String.join(" ", command),
+                    result.getExitCode(),
+                    result.getStdout(),
+                    result.getStderr()));
+      }
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(e);
+    }
   }
 
   private String internalHost() {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/testcontainers/MinioContainer.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/testcontainers/MinioContainer.java
@@ -153,14 +153,13 @@ public final class MinioContainer extends GenericContainer<MinioContainer> {
   }
 
   /**
-   * Creates a Minio user with a policy granting it full access to exactly the named buckets, and to
-   * nothing else. The container must already be started.
+   * Creates a Minio user with a policy granting it full access to the named buckets and nothing
+   * else. The container must already be started.
    *
-   * <p>Give each client under test its own user whenever the point of the test is that the client
-   * authenticates as its own identity rather than as the process. Handing every client the root key
-   * pair cannot show that: a client that silently falls back to the ambient credentials, or that
-   * picks up a sibling's, still reaches the bucket and the test stays green. With a scoped user it
-   * fails with {@code AccessDenied} instead.
+   * <p>Give each client under test its own user when the point of the test is that the client
+   * authenticates as itself. Sharing the root key pair cannot show that: a client falling back to
+   * the ambient credentials, or picking up a sibling's, still reaches the bucket and the test stays
+   * green. Against a scoped user it fails with {@code AccessDenied}.
    *
    * @param accessKey the user's access key, also used to name its policy
    * @param secretKey the user's secret key; Minio requires at least 8 characters


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53496
