### PR TITLE
fix: resolve secrets in the background instead of failing every reference

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Secrets.java
+++ b/configuration/src/main/java/io/camunda/configuration/Secrets.java
@@ -32,6 +32,10 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  *   <li>{@code camunda.secrets.stores.gcp.<id>.container-secret-id}
  * </ul>
  *
+ * <p>Exactly one store per physical tenant is supported, and its {@code <id>} must be {@code
+ * default} — that is the store id a {@code camunda.secrets.<name>} reference addresses. A store
+ * under any other id is rejected at startup, since nothing could ever read it.
+ *
  * <p>Secrets configuration is overridable per physical tenant via {@code
  * camunda.physical-tenants.<id>.secrets.*}.
  */

--- a/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.application.commons.secrets;
 
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Secrets.AwsSecretsManagerStore;
 import io.camunda.configuration.Secrets.FileStore;
@@ -26,6 +27,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
@@ -48,11 +50,11 @@ public class SecretStoreConfiguration {
    */
   private static final List<StoreBinding<?>> STORE_BINDINGS =
       List.of(
-          new StoreBinding<>("file", Stores::getFile, SecretStoreConfiguration::fileStore),
+          new StoreBinding<>("file", "file", Stores::getFile, SecretStoreConfiguration::fileStore),
           new StoreBinding<>(
-              "AWS Secrets Manager", Stores::getAws, SecretStoreConfiguration::awsStore),
+              "aws", "AWS Secrets Manager", Stores::getAws, SecretStoreConfiguration::awsStore),
           new StoreBinding<>(
-              "GCP Secret Manager", Stores::getGcp, SecretStoreConfiguration::gcpStore));
+              "gcp", "GCP Secret Manager", Stores::getGcp, SecretStoreConfiguration::gcpStore));
 
   @Bean
   public SecretStoreRegistries secretStoreRegistries(final PhysicalTenantResolver resolver) {
@@ -78,7 +80,7 @@ public class SecretStoreConfiguration {
       final String tenantId, final Stores config, final List<SecretStore> created) {
     // cap is one store total per tenant, counted across all store types combined
     final long totalStores =
-        STORE_BINDINGS.stream().mapToLong(binding -> binding.count(config)).sum();
+        STORE_BINDINGS.stream().mapToLong(binding -> binding.ids(config).size()).sum();
     if (totalStores > 1) {
       throw new IllegalStateException(
           "Physical tenant '"
@@ -87,10 +89,15 @@ public class SecretStoreConfiguration {
               + totalStores
               + " secret stores configured, but only one is supported at this time");
     }
+    // both rules are checked before any store is built, so the operator gets the configuration
+    // error rather than whatever the store's own construction fails with — an AWS or GCP store
+    // eagerly builds a client and probes credentials, which would otherwise surface first for a
+    // configuration that is rejected anyway
+    STORE_BINDINGS.forEach(binding -> binding.requireSupportedStoreIds(config, tenantId));
     final Map<String, SecretStore> stores = new LinkedHashMap<>();
     STORE_BINDINGS.forEach(binding -> binding.registerAll(config, stores, created, tenantId));
     if (stores.isEmpty()) {
-      stores.put("default", NOOP_STORE);
+      stores.put(SecretStoreRegistry.DEFAULT_STORE_ID, NOOP_STORE);
       LOG.info("No secret stores configured for physical tenant '{}', using noop store", tenantId);
     }
     return new SecretStoreRegistry(Map.copyOf(stores));
@@ -109,11 +116,10 @@ public class SecretStoreConfiguration {
   private static void registerStore(
       final Map<String, SecretStore> stores,
       final List<SecretStore> created,
-      final String storeId,
+      final String normalizedId,
       final String tenantId,
       final String storeType,
       final SecretStore store) {
-    final var normalizedId = storeId.trim().toLowerCase();
     stores.put(normalizedId, store);
     created.add(store);
     LOG.info(
@@ -121,6 +127,41 @@ public class SecretStoreConfiguration {
         storeType,
         normalizedId,
         tenantId);
+  }
+
+  /** The store ID as it is registered and looked up: trimmed and case-insensitive. */
+  private static String normalizeStoreId(final String storeId) {
+    return storeId.trim().toLowerCase();
+  }
+
+  /**
+   * Rejects a store under an ID no secret reference can address. A {@code camunda.secrets.<name>}
+   * reference addresses {@link SecretStoreRegistry#DEFAULT_STORE_ID} and the store lookup that
+   * resolves it is exact, so a store under any other ID would never be reached.
+   *
+   * @param storeId the ID as the operator wrote it, so the property this names is the one to find
+   *     in their configuration; the rule itself is checked against the normalized form
+   */
+  private static void requireSupportedStoreId(
+      final String storeId, final String tenantId, final String storeTypeProperty) {
+    if (SecretStoreRegistry.DEFAULT_STORE_ID.equals(normalizeStoreId(storeId))) {
+      return;
+    }
+    final var storesProperty =
+        (PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(tenantId)
+                ? "camunda.secrets.stores."
+                : "camunda.physical-tenants." + tenantId + ".secrets.stores.")
+            + storeTypeProperty;
+    throw new IllegalStateException(
+        "Physical tenant '%s' configures secret store '%s', but the only supported store id is '%s'; rename %s.%s to %s.%s"
+            .formatted(
+                tenantId,
+                storeId,
+                SecretStoreRegistry.DEFAULT_STORE_ID,
+                storesProperty,
+                storeId,
+                storesProperty,
+                SecretStoreRegistry.DEFAULT_STORE_ID));
   }
 
   private static SecretStore fileStore(
@@ -172,15 +213,24 @@ public class SecretStoreConfiguration {
    * and the factory's input type in lock-step, so the registration loop can iterate a heterogeneous
    * {@code List<StoreBinding<?>>} without any casts.
    *
+   * @param propertyKey the {@code camunda.secrets.stores.<key>} segment this type binds to, so a
+   *     configuration error can name the exact property the operator has to change
    * @param displayName human-readable store type name used in log messages
    * @param selector reads this type's {@code storeId -> config} entries from the tenant's stores
    * @param factory builds a store from one entry, applying any per-type validation
    */
   private record StoreBinding<C>(
-      String displayName, Function<Stores, Map<String, C>> selector, StoreFactory<C> factory) {
+      String propertyKey,
+      String displayName,
+      Function<Stores, Map<String, C>> selector,
+      StoreFactory<C> factory) {
 
-    private int count(final Stores config) {
-      return selector.apply(config).size();
+    private Set<String> ids(final Stores config) {
+      return selector.apply(config).keySet();
+    }
+
+    private void requireSupportedStoreIds(final Stores config, final String tenantId) {
+      ids(config).forEach(storeId -> requireSupportedStoreId(storeId, tenantId, propertyKey));
     }
 
     private void registerAll(
@@ -195,9 +245,11 @@ public class SecretStoreConfiguration {
                   registerStore(
                       stores,
                       created,
-                      storeId,
+                      normalizeStoreId(storeId),
                       tenantId,
                       displayName,
+                      // the raw id is what the operator wrote, so it is what a factory names in its
+                      // own validation errors
                       factory.create(storeId, tenantId, entry)));
     }
   }

--- a/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
@@ -20,6 +20,7 @@ import io.camunda.secretstore.SecretErrorCode;
 import io.camunda.secretstore.SecretResolutionResult.Failed;
 import io.camunda.secretstore.SecretResolutionResult.Resolved;
 import io.camunda.secretstore.SecretStore;
+import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.secretstore.aws.AwsSecretsManagerSecretStore;
 import io.camunda.secretstore.file.FileBasedSecretStore;
 import java.io.IOException;
@@ -61,28 +62,29 @@ class SecretStoreConfigurationTest {
     // configuration constructed
     Files.writeString(secretsDir.resolve("token"), "token-value");
     final var resolver =
-        resolverFor(Map.of("camunda.secrets.stores.file.main.path", secretsDir.toString()));
+        resolverFor(Map.of("camunda.secrets.stores.file.default.path", secretsDir.toString()));
 
     // when
     final var registries = CONFIG.secretStoreRegistries(resolver).byPhysicalTenant();
 
     // then the configured directory is what the store reads
     final var registry = registries.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-    assertThat(registry.getStores()).containsKey("main");
-    final var store = registry.getStores().get("main");
+    assertThat(registry.getStores()).containsKey(SecretStoreRegistry.DEFAULT_STORE_ID);
+    final var store = registry.getStores().get(SecretStoreRegistry.DEFAULT_STORE_ID);
     assertThat(store.list()).containsExactly("token");
     assertThat(store.resolve(Set.of("token"))).containsEntry("token", new Resolved("token-value"));
   }
 
   @Test
   void shouldThrowWhenFileStoreHasBlankPath() {
-    // given
-    final var resolver = resolverFor(Map.of("camunda.secrets.stores.file.bad.path", ""));
+    // given a store under the only supported id, so the store id rule passes and the path is what
+    // the configuration is rejected for
+    final var resolver = resolverFor(Map.of("camunda.secrets.stores.file.default.path", ""));
 
     // when / then
     assertThatIllegalStateException()
         .isThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
-        .withMessageContaining("bad")
+        .withMessageContaining("no path configured")
         .withMessageContaining(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
   }
 
@@ -106,29 +108,105 @@ class SecretStoreConfigurationTest {
   void shouldNormalizeStoreIdToLowercase() {
     // given
     final var resolver =
-        resolverFor(Map.of("camunda.secrets.stores.file.MyStore.path", "/etc/camunda/secrets"));
+        resolverFor(Map.of("camunda.secrets.stores.file.Default.path", "/etc/camunda/secrets"));
 
     // when
     final var registries = CONFIG.secretStoreRegistries(resolver).byPhysicalTenant();
 
     // then
     final var registry = registries.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-    assertThat(registry.getStores()).containsOnlyKeys("mystore");
+    assertThat(registry.getStores()).containsOnlyKeys(SecretStoreRegistry.DEFAULT_STORE_ID);
   }
 
   @Test
-  void shouldNotAddNoopStoreWhenStoresAreConfigured() {
-    // given
+  void shouldThrowWhenConfiguredStoreIsNotNamedDefault() {
+    // given a single store under an id no secret reference can address
     final var resolver =
         resolverFor(Map.of("camunda.secrets.stores.file.main.path", "/etc/camunda/secrets"));
+
+    // when / then
+    assertThatIllegalStateException()
+        .isThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
+        .withMessageContaining(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+        .withMessageContaining("main")
+        .withMessageContaining("the only supported store id is 'default'")
+        // the full property the operator has to change, type segment included, so it can be
+        // matched against their configuration as it is written there
+        .withMessageContaining("camunda.secrets.stores.file.main")
+        .withMessageContaining("camunda.secrets.stores.file.default");
+  }
+
+  @Test
+  void shouldNameTheMisnamedStoreIdAsTheOperatorWroteIt() {
+    // given a store id that is not lowercase, and so does not match the id it is registered under
+    final var resolver =
+        resolverFor(Map.of("camunda.secrets.stores.file.MyStore.path", "/etc/camunda/secrets"));
+
+    // when / then — the normalized id appears in no configuration file, so naming it would send
+    // the operator looking for a property they never wrote
+    assertThatIllegalStateException()
+        .isThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
+        .withMessageContaining("camunda.secrets.stores.file.MyStore")
+        .withMessageNotContaining("mystore");
+  }
+
+  @Test
+  void shouldNameTheTenantScopedPropertyWhenAPhysicalTenantsStoreIsNotNamedDefault() {
+    // given a store misnamed under a physical tenant, whose property carries the tenant prefix
+    final var resolver =
+        resolverFor(
+            Map.of(
+                "camunda.physical-tenants.tenanta.secrets.stores.file.main.path",
+                "/etc/tenanta/secrets",
+                "camunda.physical-tenants.tenanta.security.initialization.default-roles.admin.users[0]",
+                "tenanta-admin",
+                "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+                "tenanta"));
+
+    // when / then — pointing at camunda.secrets.stores would send the operator to configure a
+    // different tenant, leaving this one's store misnamed
+    assertThatIllegalStateException()
+        .isThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
+        .withMessageContaining("camunda.physical-tenants.tenanta.secrets.stores.file.default")
+        .withMessageNotContaining("rename camunda.secrets.stores");
+  }
+
+  @Test
+  void shouldRejectStoreUnderAnotherIdBeforeBuildingIt() {
+    // given an aws store under an id no secret reference can address. Its construction eagerly
+    // builds a client and probes credentials, so building it first would surface an unrelated aws
+    // error for a configuration that is rejected either way.
+    try (var construction = mockConstruction(AwsSecretsManagerSecretStore.class)) {
+      final var resolver =
+          resolverFor(Map.of("camunda.secrets.stores.aws.aws-main.region", "eu-west-1"));
+
+      // when / then
+      assertThatIllegalStateException()
+          .isThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
+          .withMessageContaining("the only supported store id is 'default'");
+
+      // then — nothing was built, so nothing had to be rolled back
+      assertThat(construction.constructed()).isEmpty();
+    }
+  }
+
+  @Test
+  void shouldNotAddNoopStoreWhenStoresAreConfigured(@TempDir final Path secretsDir)
+      throws IOException {
+    // given — the configured store and the noop fallback share the id 'default', so the only way to
+    // tell them apart is by what the registered store reads
+    Files.writeString(secretsDir.resolve("token"), "token-value");
+    final var resolver =
+        resolverFor(Map.of("camunda.secrets.stores.file.default.path", secretsDir.toString()));
 
     // when
     final var registries = CONFIG.secretStoreRegistries(resolver).byPhysicalTenant();
 
-    // then
+    // then the configured store stands, rather than being replaced by the noop fallback
     final var registry = registries.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-    assertThat(registry.getStores()).containsOnlyKeys("main");
-    assertThat(registry.getStores()).doesNotContainKey("default");
+    assertThat(registry.getStores()).containsOnlyKeys(SecretStoreRegistry.DEFAULT_STORE_ID);
+    assertThat(registry.getStores().get(SecretStoreRegistry.DEFAULT_STORE_ID).list())
+        .containsExactly("token");
   }
 
   @Test
@@ -153,19 +231,25 @@ class SecretStoreConfigurationTest {
   }
 
   @Test
-  void shouldProduceOneRegistryPerPhysicalTenant() {
-    // given two tenants with different store configurations
+  void shouldProduceOneRegistryPerPhysicalTenant(@TempDir final Path secretsRoot)
+      throws IOException {
+    // given two tenants each with their own store — both under the id 'default', the only supported
+    // one, so the stores are told apart by the directory each reads
+    final var tenantASecrets = Files.createDirectory(secretsRoot.resolve("tenanta"));
+    Files.writeString(tenantASecrets.resolve("tenanta-token"), "a");
+    final var tenantBSecrets = Files.createDirectory(secretsRoot.resolve("tenantb"));
+    Files.writeString(tenantBSecrets.resolve("tenantb-token"), "b");
     final var resolver =
         resolverFor(
             Map.of(
-                "camunda.physical-tenants.tenanta.secrets.stores.file.main.path",
-                "/etc/tenanta/secrets",
+                "camunda.physical-tenants.tenanta.secrets.stores.file.default.path",
+                tenantASecrets.toString(),
                 "camunda.physical-tenants.tenanta.security.initialization.default-roles.admin.users[0]",
                 "tenanta-admin",
                 "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
                 "tenanta",
-                "camunda.physical-tenants.tenantb.secrets.stores.file.other.path",
-                "/etc/tenantb/secrets",
+                "camunda.physical-tenants.tenantb.secrets.stores.file.default.path",
+                tenantBSecrets.toString(),
                 "camunda.physical-tenants.tenantb.security.initialization.default-roles.admin.users[0]",
                 "tenantb-admin",
                 "camunda.physical-tenants.tenantb.data.secondary-storage.elasticsearch.index-prefix",
@@ -176,8 +260,12 @@ class SecretStoreConfigurationTest {
 
     // then each tenant has its own registry with its own store
     assertThat(registries).containsKeys("tenanta", "tenantb");
-    assertThat(registries.get("tenanta").getStores()).containsKey("main");
-    assertThat(registries.get("tenantb").getStores()).containsKey("other");
+    assertThat(
+            registries.get("tenanta").getStores().get(SecretStoreRegistry.DEFAULT_STORE_ID).list())
+        .containsExactly("tenanta-token");
+    assertThat(
+            registries.get("tenantb").getStores().get(SecretStoreRegistry.DEFAULT_STORE_ID).list())
+        .containsExactly("tenantb-token");
   }
 
   @Test
@@ -192,16 +280,20 @@ class SecretStoreConfigurationTest {
     final var resolver =
         resolverFor(
             Map.of(
-                "camunda.secrets.stores.aws.aws-main.region", "eu-west-1",
-                "camunda.secrets.stores.aws.aws-main.path-prefix", "camunda/"));
+                "camunda.secrets.stores.aws.default.region", "eu-west-1",
+                "camunda.secrets.stores.aws.default.path-prefix", "camunda/"));
 
     // when
     final var registries = CONFIG.secretStoreRegistries(resolver).byPhysicalTenant();
 
     // then the aws branch is what built the store, not the noop fallback or another store type
     final var registry = registries.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-    assertThat(registry.getStores()).containsKey("aws-main");
-    assertThat(registry.getStores().get("aws-main").is(AwsSecretsManagerSecretStore.class))
+    assertThat(registry.getStores()).containsKey(SecretStoreRegistry.DEFAULT_STORE_ID);
+    assertThat(
+            registry
+                .getStores()
+                .get(SecretStoreRegistry.DEFAULT_STORE_ID)
+                .is(AwsSecretsManagerSecretStore.class))
         .isTrue();
   }
 
@@ -254,13 +346,13 @@ class SecretStoreConfigurationTest {
       final var resolver =
           resolverFor(
               Map.of(
-                  "camunda.physical-tenants.tenanta.secrets.stores.file.main.path",
+                  "camunda.physical-tenants.tenanta.secrets.stores.file.default.path",
                   "/etc/tenanta/secrets",
                   "camunda.physical-tenants.tenanta.security.initialization.default-roles.admin.users[0]",
                   "tenanta-admin",
                   "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
                   "tenanta",
-                  "camunda.physical-tenants.tenantb.secrets.stores.file.other.path",
+                  "camunda.physical-tenants.tenantb.secrets.stores.file.default.path",
                   "/etc/tenantb/secrets",
                   "camunda.physical-tenants.tenantb.security.initialization.default-roles.admin.users[0]",
                   "tenantb-admin",

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStoreRegistry.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStoreRegistry.java
@@ -28,6 +28,13 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public final class SecretStoreRegistry {
 
+  /**
+   * The store ID a {@code camunda.secrets.<name>} reference addresses. The syntax carries no store
+   * dimension, so it names the default store; once several stores are supported, {@code
+   * camunda.secrets.X} keeps meaning {@code camunda.secrets.default.X}.
+   */
+  public static final String DEFAULT_STORE_ID = "default";
+
   private final Map<String, LocallyCachedSecretStore> stores;
 
   public SecretStoreRegistry(final Map<String, SecretStore> stores) {
@@ -57,9 +64,8 @@ public final class SecretStoreRegistry {
   /**
    * Returns all configured secret stores, keyed by store ID.
    *
-   * <p>A lookup in this map is exact: an empty store ID addresses no store, even when a single
-   * store is configured. Reading an empty store ID as the sole configured store is a rule of the
-   * {@code camunda.secrets.<name>} reference syntax and belongs to the caller that knows it.
+   * <p>A lookup in this map is exact, so a store ID that names no configured store addresses none.
+   * A {@code camunda.secrets.<name>} reference addresses {@link #DEFAULT_STORE_ID}.
    */
   public Map<String, LocallyCachedSecretStore> getStores() {
     return stores;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.clustervariable;
 
+import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
@@ -122,7 +123,10 @@ public class ClusterVariableCreateProcessor
         .scan(record.getValueBuffer())
         .map(
             references -> {
-              references.forEach(ref -> record.addSecretReference("", ref.name(), ref.pointer()));
+              references.forEach(
+                  ref ->
+                      record.addSecretReference(
+                          SecretStoreRegistry.DEFAULT_STORE_ID, ref.name(), ref.pointer()));
               return record;
             });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.clustervariable;
 
+import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
@@ -122,7 +123,10 @@ public class ClusterVariableUpdateProcessor
         .scan(command.getValueBuffer())
         .map(
             references -> {
-              references.forEach(ref -> command.addSecretReference("", ref.name(), ref.pointer()));
+              references.forEach(
+                  ref ->
+                      command.addSecretReference(
+                          SecretStoreRegistry.DEFAULT_STORE_ID, ref.name(), ref.pointer()));
               return command;
             });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
+import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.impl.FeelExpression;
 import java.util.ArrayDeque;
@@ -62,13 +63,14 @@ public record SecretReference(String storeId, String name) {
   private static final int REFERENCE_SEGMENT_COUNT = 3;
 
   /**
-   * Creates a reference with no store id. The {@code camunda.secrets.<name>} syntax carries no
-   * store dimension, so the store is left empty until store selection is wired to the engine
-   * (tracked under the Secret Resolution epic, <a
-   * href="https://github.com/camunda/camunda/issues/56563">#56563</a>).
+   * Creates a reference to the default store. The {@code camunda.secrets.<name>} syntax carries no
+   * store dimension, so it addresses {@link SecretStoreRegistry#DEFAULT_STORE_ID}; once store
+   * selection is wired to the engine (tracked under the Secret Resolution epic, <a
+   * href="https://github.com/camunda/camunda/issues/56563">#56563</a>), {@code camunda.secrets.X}
+   * keeps meaning {@code camunda.secrets.default.X}.
    */
   public SecretReference(final String name) {
-    this("", name);
+    this(SecretStoreRegistry.DEFAULT_STORE_ID, name);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.camunda.secretstore.LocallyCachedSecretStore;
 import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
@@ -186,26 +185,12 @@ public final class JobSecretInjector {
     if (values.containsKey(reference)) {
       return true;
     }
+    // the store lookup is exact: a reference naming no configured store addresses none
     final Optional<String> value =
-        storeFor(reference.storeId()).flatMap(store -> store.lookupLocal(reference.name()));
+        Optional.ofNullable(secretStoreRegistry.getStores().get(reference.storeId()))
+            .flatMap(store -> store.lookupLocal(reference.name()));
     value.ifPresent(cachedValue -> values.put(reference, cachedValue));
     return value.isPresent();
-  }
-
-  /**
-   * Returns the store the reference addresses, or empty when it addresses none.
-   *
-   * <p>The {@code camunda.secrets.<name>} syntax carries no store dimension yet, so a reference
-   * written that way has an empty store ID and addresses the sole configured store; with several
-   * stores an empty store ID is ambiguous and addresses none. This rule belongs to the reference
-   * syntax rather than to the registry, whose own lookup is exact.
-   */
-  private Optional<LocallyCachedSecretStore> storeFor(final String storeId) {
-    final var stores = secretStoreRegistry.getStores();
-    if (!storeId.isEmpty()) {
-      return Optional.ofNullable(stores.get(storeId));
-    }
-    return stores.size() == 1 ? Optional.of(stores.values().iterator().next()) : Optional.empty();
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceBatchCreateIncidentsProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceBatchCreateIncidentsProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.secretreference;
 
+import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
@@ -161,11 +162,12 @@ public final class SecretReferenceBatchCreateIncidentsProcessor
 
   /**
    * The {@code camunda.secrets.<name>} syntax carries no store id yet (store selection is tracked
-   * under <a href="https://github.com/camunda/camunda/issues/56563">#56563</a>), so an empty id
-   * addresses the configured store and must not be quoted in the incident message.
+   * under <a href="https://github.com/camunda/camunda/issues/56563">#56563</a>), so every reference
+   * names the default store. Naming it in the incident message would tell the reader nothing while
+   * it is the only store there is.
    */
   private static String describeStore(final String storeId) {
-    return storeId.isEmpty()
+    return SecretStoreRegistry.DEFAULT_STORE_ID.equals(storeId)
         ? "the configured secret store"
         : "secret store '%s'".formatted(storeId);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
@@ -260,8 +260,10 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
     final StoreRetryState retryState =
         storeRetryStates.getOrDefault(storeId, StoreRetryState.INITIAL);
 
-    // a pending reference is keyed by the store ID its record carries, which for a
-    // camunda.secrets.<name> reference is empty and addresses no store here (see #59432)
+    // a pending reference is keyed by the store ID its record carried, and every reference carries
+    // the default store ID, which startup validation guarantees is configured. An ID naming no
+    // configured store is therefore failed rather than mapped onto the default: mapping one ID onto
+    // another is what let this path and job activation disagree about an empty ID (see #59432).
     final var store = secretStoreRegistry.getStores().get(storeId);
     if (store == null) {
       LOG.warn(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableSecretReferenceMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableSecretReferenceMultiPartitionTest.java
@@ -62,7 +62,7 @@ public final class ClusterVariableSecretReferenceMultiPartitionTest {
             ClusterVariableSecretReferenceValue::getStoreId,
             ClusterVariableSecretReferenceValue::getSecretReference,
             ClusterVariableSecretReferenceValue::getPath)
-        .containsExactly(tuple("", "token", "/auth"));
+        .containsExactly(tuple("default", "token", "/auth"));
 
     // and every distributed partition's CREATED event carries the identical reference
     for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
@@ -78,7 +78,7 @@ public final class ClusterVariableSecretReferenceMultiPartitionTest {
               ClusterVariableSecretReferenceValue::getStoreId,
               ClusterVariableSecretReferenceValue::getSecretReference,
               ClusterVariableSecretReferenceValue::getPath)
-          .containsExactly(tuple("", "token", "/auth"));
+          .containsExactly(tuple("default", "token", "/auth"));
     }
   }
 
@@ -116,7 +116,7 @@ public final class ClusterVariableSecretReferenceMultiPartitionTest {
             ClusterVariableSecretReferenceValue::getStoreId,
             ClusterVariableSecretReferenceValue::getSecretReference,
             ClusterVariableSecretReferenceValue::getPath)
-        .containsExactly(tuple("", "rotated", "/auth"));
+        .containsExactly(tuple("default", "rotated", "/auth"));
     assertThat(updated.getValue().getKind()).isEqualTo(ClusterVariableKind.SECRET_REFERENCE);
 
     // and every distributed partition's UPDATED event carries the identical reference
@@ -133,7 +133,7 @@ public final class ClusterVariableSecretReferenceMultiPartitionTest {
               ClusterVariableSecretReferenceValue::getStoreId,
               ClusterVariableSecretReferenceValue::getSecretReference,
               ClusterVariableSecretReferenceValue::getPath)
-          .containsExactly(tuple("", "rotated", "/auth"));
+          .containsExactly(tuple("default", "rotated", "/auth"));
       assertThat(updatedOnReceiver.getValue().getKind())
           .isEqualTo(ClusterVariableKind.SECRET_REFERENCE);
     }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableSecretReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableSecretReferenceTest.java
@@ -48,7 +48,7 @@ public final class ClusterVariableSecretReferenceTest {
             ClusterVariableSecretReferenceValue::getStoreId,
             ClusterVariableSecretReferenceValue::getSecretReference,
             ClusterVariableSecretReferenceValue::getPath)
-        .containsExactly(tuple("", "token", "/auth"));
+        .containsExactly(tuple("default", "token", "/auth"));
   }
 
   @Test
@@ -69,7 +69,7 @@ public final class ClusterVariableSecretReferenceTest {
             ClusterVariableSecretReferenceValue::getStoreId,
             ClusterVariableSecretReferenceValue::getSecretReference,
             ClusterVariableSecretReferenceValue::getPath)
-        .containsExactly(tuple("", "token", ""));
+        .containsExactly(tuple("default", "token", ""));
   }
 
   @Test
@@ -93,7 +93,7 @@ public final class ClusterVariableSecretReferenceTest {
             ClusterVariableSecretReferenceValue::getStoreId,
             ClusterVariableSecretReferenceValue::getSecretReference,
             ClusterVariableSecretReferenceValue::getPath)
-        .containsExactlyInAnyOrder(tuple("", "x", "/a/b"), tuple("", "y", "/list/0"));
+        .containsExactlyInAnyOrder(tuple("default", "x", "/a/b"), tuple("default", "y", "/list/0"));
   }
 
   @Test
@@ -114,7 +114,7 @@ public final class ClusterVariableSecretReferenceTest {
             ClusterVariableSecretReferenceValue::getStoreId,
             ClusterVariableSecretReferenceValue::getSecretReference,
             ClusterVariableSecretReferenceValue::getPath)
-        .containsExactly(tuple("", "a", ""), tuple("", "b", ""));
+        .containsExactly(tuple("default", "a", ""), tuple("default", "b", ""));
   }
 
   @Test
@@ -185,6 +185,6 @@ public final class ClusterVariableSecretReferenceTest {
             ClusterVariableSecretReferenceValue::getStoreId,
             ClusterVariableSecretReferenceValue::getSecretReference,
             ClusterVariableSecretReferenceValue::getPath)
-        .containsExactly(tuple("", "token", "/auth"));
+        .containsExactly(tuple("default", "token", "/auth"));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -78,7 +78,8 @@ final class JobBatchCollectorTest {
   private final JobSecretInjector secretInjector =
       new JobSecretInjector(
           new SecretStoreRegistry(
-              Map.of("default", new NoopSecretStore()), Map.of("default", secretCache)));
+              Map.of(SecretStoreRegistry.DEFAULT_STORE_ID, new NoopSecretStore()),
+              Map.of(SecretStoreRegistry.DEFAULT_STORE_ID, secretCache)));
 
   @SuppressWarnings("unused") // injected by the extension
   private MutableProcessingState state;
@@ -757,7 +758,9 @@ final class JobBatchCollectorTest {
             .setElementInstanceKey(variableScopeKey)
             .setType(JOB_TYPE)
             .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-    jobRecord.addSecretReference("", secretName, "/auth");
+    // the store a camunda.secrets.<name> reference addresses; the injector looks it up exactly, so
+    // a job carrying any other store id is skipped no matter what the cache holds
+    jobRecord.addSecretReference(SecretStoreRegistry.DEFAULT_STORE_ID, secretName, "/auth");
     final long jobKey = state.getKeyGenerator().nextKey();
 
     state.getJobState().create(jobKey, jobRecord);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretActivationInjectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretActivationInjectionTest.java
@@ -128,7 +128,7 @@ public final class JobSecretActivationInjectionTest {
         RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_REQUESTED)
             .withSecretReference("token")
             .getFirst();
-    assertThat(requested.getValue().getStoreId()).isEmpty();
+    assertThat(requested.getValue().getStoreId()).isEqualTo(SecretStoreRegistry.DEFAULT_STORE_ID);
     assertThat(requested.getValue().getJobKeys()).containsExactly(jobKey);
 
     // and - the job is parked: a later activation does not hand it out again, even once the value

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 
 final class JobSecretInjectorTest {
 
-  private static final String STORE_ID = "";
+  private static final String STORE_ID = SecretStoreRegistry.DEFAULT_STORE_ID;
 
   private static JobSecretInjector injector(final Map<String, String> cachedSecrets) {
     final var cache = new InMemorySecretCache();
@@ -348,30 +348,25 @@ final class JobSecretInjectorTest {
                   new SecretRef("store-b", "token", "/auth")));
 
       // then - the job is skipped rather than served from the store that happens to hold the name:
-      // a named store is looked up exactly, and the sole-store rule is only for a reference that
-      // names none
+      // the store lookup is exact
       assertThat(jobKeysOf(batch)).isEmpty();
     }
 
     @Test
-    void shouldNotResolveReferenceWithoutStoreIdWhenSeveralStoresAreConfigured() {
-      // given - both stores cache the secret, but the reference names no store, which is
-      // ambiguous with more than one configured store
-      final var cacheA = new InMemorySecretCache();
-      cacheA.put("token", "a");
-      final var cacheB = new InMemorySecretCache();
-      cacheB.put("token", "b");
+    void shouldNotResolveDefaultReferenceFromAStoreUnderAnotherId() {
+      // given - a store holding the secret under an id other than the default one
+      final var cache = new InMemorySecretCache();
+      cache.put("token", "resolved");
       final var registry =
           new SecretStoreRegistry(
-              Map.of("store-a", new NoopSecretStore(), "store-b", new NoopSecretStore()),
-              Map.of("store-a", cacheA, "store-b", cacheB));
+              Map.of("store-a", new NoopSecretStore()), Map.of("store-a", cache));
       final var injector = new JobSecretInjector(registry);
 
-      // when
+      // when - the reference addresses the default store, as camunda.secrets.<name> always does
       final var batch =
           collect(injector, job(Map.of("auth", "camunda.secrets.token"), ref("token", "/auth")));
 
-      // then - the job is skipped instead of guessing a store
+      // then - the job is skipped instead of falling back to the sole configured store
       assertThat(jobKeysOf(batch)).isEmpty();
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretReferenceTest.java
@@ -68,7 +68,7 @@ public final class JobSecretReferenceTest {
             JobSecretReferenceValue::getStoreId,
             JobSecretReferenceValue::getSecretReference,
             JobSecretReferenceValue::getPath)
-        .containsExactly(tuple("", "token", "/tokens/externalSystemToken"));
+        .containsExactly(tuple("default", "token", "/tokens/externalSystemToken"));
   }
 
   @Test
@@ -99,8 +99,8 @@ public final class JobSecretReferenceTest {
             JobSecretReferenceValue::getSecretReference,
             JobSecretReferenceValue::getPath)
         .containsExactlyInAnyOrder(
-            tuple("", "token", "/tokens/externalSystemToken"),
-            tuple("", "postfix", "/tokens/externalSystemToken"));
+            tuple("default", "token", "/tokens/externalSystemToken"),
+            tuple("default", "postfix", "/tokens/externalSystemToken"));
   }
 
   @Test
@@ -130,7 +130,7 @@ public final class JobSecretReferenceTest {
             JobSecretReferenceValue::getSecretReference,
             JobSecretReferenceValue::getPath)
         .containsExactlyInAnyOrder(
-            tuple("", "token", "/auth/token"), tuple("", "apiKey", "/auth/key"));
+            tuple("default", "token", "/auth/token"), tuple("default", "apiKey", "/auth/key"));
   }
 
   @Test
@@ -180,7 +180,7 @@ public final class JobSecretReferenceTest {
             JobSecretReferenceValue::getStoreId,
             JobSecretReferenceValue::getSecretReference,
             JobSecretReferenceValue::getPath)
-        .containsExactly(tuple("", "token", "/auth/token"));
+        .containsExactly(tuple("default", "token", "/auth/token"));
   }
 
   @Test
@@ -270,7 +270,7 @@ public final class JobSecretReferenceTest {
             JobSecretReferenceValue::getStoreId,
             JobSecretReferenceValue::getSecretReference,
             JobSecretReferenceValue::getPath)
-        .containsExactly(tuple("", "token", "/auth/token"));
+        .containsExactly(tuple("default", "token", "/auth/token"));
   }
 
   private static BpmnModelInstance processWithServiceTask(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/DefaultStoreIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/DefaultStoreIdTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.secretreference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.secretstore.SecretStoreRegistry;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableSecretReference;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobSecretReference;
+import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the store ID the secret reference records default to against {@link
+ * SecretStoreRegistry#DEFAULT_STORE_ID}.
+ *
+ * <p>The record layer stays free of the secret store API, so the three records repeat the
+ * constant's value as a literal. This module sees both, so it is the only place the two can be
+ * compared. Without this, renaming the constant would leave the records defaulting to a store the
+ * registry no longer has — an exact lookup that misses every time, which is the failure this
+ * default was introduced to remove (#59432).
+ */
+final class DefaultStoreIdTest {
+
+  @Test
+  void shouldDefaultEverySecretReferenceRecordToTheDefaultStore() {
+    // given / when - records whose store ID was never set
+    // then
+    assertThat(new SecretReferenceRecord().getStoreId())
+        .isEqualTo(SecretStoreRegistry.DEFAULT_STORE_ID);
+    assertThat(new JobSecretReference().getStoreId())
+        .isEqualTo(SecretStoreRegistry.DEFAULT_STORE_ID);
+    assertThat(new ClusterVariableSecretReference().getStoreId())
+        .isEqualTo(SecretStoreRegistry.DEFAULT_STORE_ID);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceBatchCreateIncidentsProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceBatchCreateIncidentsProcessorTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -220,22 +221,28 @@ public final class SecretReferenceBatchCreateIncidentsProcessorTest {
   }
 
   @Test
-  void shouldReferenceConfiguredStoreInIncidentMessageWhenStoreIdIsEmpty() {
-    // given - camunda.secrets.<name> references carry no store id until store selection exists
-    createWaitingJob(1L, 11L, "");
-    final var value = new SecretReferenceRecord().setSecretReference(SECRET_REF).addJobKey(1L);
+  void shouldReferenceConfiguredStoreInIncidentMessageWhenStoreIsTheDefaultOne() {
+    // given - camunda.secrets.<name> references address the default store until store selection
+    // exists, so it is the only store there is
+    createWaitingJob(1L, 11L, SecretStoreRegistry.DEFAULT_STORE_ID);
+    final var value =
+        new SecretReferenceRecord()
+            .setStoreId(SecretStoreRegistry.DEFAULT_STORE_ID)
+            .setSecretReference(SECRET_REF)
+            .addJobKey(1L);
 
     // when
     processor.processRecord(command(value));
 
-    // then - the message points to the configured store instead of quoting an empty id
+    // then - the message points to the configured store instead of naming an id that tells the
+    // reader nothing
     final var incidentCaptor = ArgumentCaptor.forClass(IncidentRecord.class);
     verify(stateWriter)
         .appendFollowUpEvent(eq(999L), eq(IncidentIntent.CREATED), incidentCaptor.capture());
     Assertions.assertThat(incidentCaptor.getValue().getErrorMessage())
         .contains(SECRET_REF)
         .contains("the configured secret store")
-        .doesNotContain("''");
+        .doesNotContain("'" + SecretStoreRegistry.DEFAULT_STORE_ID + "'");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionLifecycleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionLifecycleTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.secretreference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+import io.camunda.secretstore.SecretStoreRegistry;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.SecretStoreRegistries;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.ResolutionState;
+import io.camunda.zeebe.protocol.record.value.SecretReferenceRecordValue;
+import io.camunda.zeebe.stream.api.CommandResponseWriter;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.Map;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.awaitility.Awaitility;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+
+/**
+ * Covers the whole loop a secret that is not cached yet goes through: the job is parked, the
+ * background resolution reads the store, and the job is reactivated with the value injected.
+ *
+ * <p>The registry here is deliberately a real one with a cold cache rather than {@link
+ * SecretStoreRegistries#resolveAll(String)}, whose cache answers every name so nothing ever parks
+ * and the scheduler is never involved. That gap let a reference addressing no configured store ship
+ * unnoticed, failing every background resolution (#59432).
+ */
+public final class SecretResolutionLifecycleTest {
+
+  private static final String PROCESS_ID = "process";
+  private static final String TASK_ID = "task";
+  private static final String JOB_TYPE = "task-type";
+  private static final String SECRET_VALUE = "resolved-secret";
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withSecretStoreRegistry(
+              SecretStoreRegistries.resolvingFromStore(Map.of("token", SECRET_VALUE)))
+          // the default interval is 5s, which would make every assertion below wait on it
+          .withEngineConfig(config -> config.setSecretResolutionInterval(Duration.ofMillis(100)));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private CommandResponseWriter mockResponseWriter;
+  private volatile JobBatchRecord activationResponse;
+
+  @Before
+  public void setUp() {
+    mockResponseWriter = engine.getCommandResponseWriter();
+    interceptResponseWriter();
+  }
+
+  @Test
+  public void shouldResolveParkedSecretInBackgroundAndReactivateTheJob() {
+    // given - a job whose secret the store holds but the cache does not
+    deploy();
+    final long jobKey = createInstanceAndAwaitJob();
+
+    // when - the first activation parks the job and requests the resolution
+    final Record<JobBatchRecordValue> parked =
+        engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
+    assertThat(parked.getValue().getJobs()).isEmpty();
+
+    // then - the request addresses the default store, which is the one configured
+    final Record<SecretReferenceRecordValue> requested =
+        RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_REQUESTED)
+            .withSecretReference("token")
+            .getFirst();
+    assertThat(requested.getValue().getStoreId()).isEqualTo(SecretStoreRegistry.DEFAULT_STORE_ID);
+    assertThat(requested.getValue().getJobKeys()).containsExactly(jobKey);
+
+    // and - the background resolution succeeds against that store
+    final Record<SecretReferenceRecordValue> resolved =
+        RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_COMPLETED)
+            .withSecretReference("token")
+            .getFirst();
+    assertThat(resolved.getValue().getResolutionState()).isEqualTo(ResolutionState.SUCCESS);
+
+    // and - the job is reactivated and the next activation injects the value into the response only
+    final Record<SecretReferenceRecordValue> reactivated =
+        RecordingExporter.secretReferenceRecords(SecretReferenceIntent.BATCH_JOBS_REACTIVATED)
+            .withSecretReference("token")
+            .getFirst();
+    assertThat(reactivated.getValue().getJobKeys()).containsExactly(jobKey);
+    final Record<JobBatchRecordValue> activated =
+        engine.jobs().withType(JOB_TYPE).withRequestStreamId(2).withRequestId(2L).activate();
+    assertThat(activated.getValue().getJobKeys()).containsExactly(jobKey);
+    // the parked activation above already wrote its own (empty) response, so the wait must be for
+    // the response carrying the job rather than for any response at all, and must hold on to the
+    // record it saw: a response written later would otherwise replace it before it is asserted on
+    final JobBatchRecord response =
+        Awaitility.await("until the activation response carrying the job is written")
+            .atMost(Duration.ofSeconds(5))
+            .until(
+                () -> activationResponse,
+                written -> written != null && !written.getJobs().isEmpty());
+    assertThat(response.getJobs().get(0).getVariables())
+        .containsEntry("authorization", "Bearer " + SECRET_VALUE);
+
+    // and - no incident was raised, and no exported record leaks the value
+    assertThat(RecordingExporter.getRecords())
+        .filteredOn(record -> record.getIntent() == IncidentIntent.CREATED)
+        .isEmpty();
+    assertThat(RecordingExporter.getRecords())
+        .noneMatch(record -> record.toString().contains(SECRET_VALUE));
+  }
+
+  /** Returns the key of the job the created instance waits on, once that job exists. */
+  private long createInstanceAndAwaitJob() {
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    return RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst()
+        .getKey();
+  }
+
+  private void deploy() {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                TASK_ID,
+                t ->
+                    t.zeebeJobType(JOB_TYPE)
+                        .zeebeInputExpression(
+                            "\"Bearer \" + camunda.secrets.token", "authorization"))
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+  }
+
+  private void interceptResponseWriter() {
+    doAnswer(
+            (Answer<CommandResponseWriter>)
+                invocation -> {
+                  final var arguments = invocation.getArguments();
+                  if (arguments != null
+                      && arguments.length == 1
+                      && arguments[0] instanceof final JobBatchRecord jobBatchRecord) {
+                    // copy the record: engine record objects are reused across commands, so the
+                    // captured reference could otherwise be overwritten by a later command
+                    final var copy = new JobBatchRecord();
+                    final MutableDirectBuffer buffer =
+                        new UnsafeBuffer(new byte[jobBatchRecord.getLength()]);
+                    jobBatchRecord.write(buffer, 0);
+                    copy.wrap(buffer);
+                    activationResponse = copy;
+                  }
+                  return mockResponseWriter;
+                })
+        .when(mockResponseWriter)
+        .valueWriter(any());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionLifecycleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionLifecycleTest.java
@@ -20,7 +20,9 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ResolutionState;
 import io.camunda.zeebe.protocol.record.value.SecretReferenceRecordValue;
@@ -78,7 +80,8 @@ public final class SecretResolutionLifecycleTest {
   public void shouldResolveParkedSecretInBackgroundAndReactivateTheJob() {
     // given - a job whose secret the store holds but the cache does not
     deploy();
-    final long jobKey = createInstanceAndAwaitJob();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long jobKey = awaitJob(processInstanceKey);
 
     // when - the first activation parks the job and requests the resolution
     final Record<JobBatchRecordValue> parked =
@@ -121,6 +124,15 @@ public final class SecretResolutionLifecycleTest {
     assertThat(response.getJobs().get(0).getVariables())
         .containsEntry("authorization", "Bearer " + SECRET_VALUE);
 
+    // and - the job completes and the instance reaches its end, so the whole loop is over and
+    // nothing further will be processed: only then does the absence of an incident below mean the
+    // run never raised one, rather than that none had been raised by the time the records were read
+    engine.job().withKey(jobKey).complete();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .getFirst();
+
     // and - no incident was raised, and no exported record leaks the value
     assertThat(RecordingExporter.getRecords())
         .filteredOn(record -> record.getIntent() == IncidentIntent.CREATED)
@@ -129,9 +141,8 @@ public final class SecretResolutionLifecycleTest {
         .noneMatch(record -> record.toString().contains(SECRET_VALUE));
   }
 
-  /** Returns the key of the job the created instance waits on, once that job exists. */
-  private long createInstanceAndAwaitJob() {
-    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+  /** Returns the key of the job the given instance waits on, once that job exists. */
+  private long awaitJob(final long processInstanceKey) {
     return RecordingExporter.jobRecords(JobIntent.CREATED)
         .withProcessInstanceKey(processInstanceKey)
         .getFirst()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -56,6 +56,8 @@ final class SecretResolutionSchedulerTest {
 
   @Mock private SecretStore secretStore;
   @Mock private SecretCache secretCache;
+  @Mock private SecretStore defaultStore;
+  @Mock private SecretCache defaultCache;
   @Mock private ScheduledTaskState scheduledTaskState;
   @Mock private SecretReferenceState secretReferenceState;
   @Mock private ReadonlyStreamProcessorContext context;
@@ -75,7 +77,9 @@ final class SecretResolutionSchedulerTest {
 
     final Supplier<ScheduledTaskState> stateFactory = () -> scheduledTaskState;
     final var registry =
-        new SecretStoreRegistry(Map.of("my-store", secretStore), Map.of("my-store", secretCache));
+        new SecretStoreRegistry(
+            Map.of("my-store", secretStore, SecretStoreRegistry.DEFAULT_STORE_ID, defaultStore),
+            Map.of("my-store", secretCache, SecretStoreRegistry.DEFAULT_STORE_ID, defaultCache));
     final var config = new EngineConfiguration();
     scheduler = new SecretResolutionScheduler(stateFactory, registry, config);
     scheduler.onRecovered(context);
@@ -99,6 +103,27 @@ final class SecretResolutionSchedulerTest {
     assertThat(intentCaptor.getValue()).isEqualTo(SecretReferenceIntent.RESOLUTION_COMPLETE);
     assertThat(recordCaptor.getValue().getStoreId()).isEqualTo("my-store");
     assertThat(recordCaptor.getValue().getSecretReference()).isEqualTo("db-password");
+    assertThat(recordCaptor.getValue().getResolutionState()).isEqualTo(ResolutionState.SUCCESS);
+  }
+
+  @Test
+  void shouldResolveReferenceAddressingTheDefaultStore() throws Exception {
+    // given — the store id every camunda.secrets.<name> reference carries; it used to be empty,
+    // which addressed no store and failed every background resolution (#59432)
+    stubPending(SecretStoreRegistry.DEFAULT_STORE_ID, "db-password");
+    when(defaultStore.resolve(Set.of("db-password")))
+        .thenReturn(Map.of("db-password", new SecretResolutionResult.Resolved("s3cr3t")));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then
+    final var intentCaptor = ArgumentCaptor.forClass(SecretReferenceIntent.class);
+    final var recordCaptor = ArgumentCaptor.forClass(SecretReferenceRecord.class);
+    verify(resultBuilder).appendCommandRecord(intentCaptor.capture(), recordCaptor.capture());
+    assertThat(intentCaptor.getValue()).isEqualTo(SecretReferenceIntent.RESOLUTION_COMPLETE);
+    assertThat(recordCaptor.getValue().getStoreId())
+        .isEqualTo(SecretStoreRegistry.DEFAULT_STORE_ID);
     assertThat(recordCaptor.getValue().getResolutionState()).isEqualTo(ResolutionState.SUCCESS);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -54,10 +54,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 final class SecretResolutionSchedulerTest {
 
+  /**
+   * The only store ID an operator can configure — startup validation rejects any other — and so the
+   * one every {@code camunda.secrets.<name>} reference carries. It used to be empty, which
+   * addressed no store and failed every background resolution (#59432).
+   */
+  private static final String STORE_ID = SecretStoreRegistry.DEFAULT_STORE_ID;
+
   @Mock private SecretStore secretStore;
   @Mock private SecretCache secretCache;
-  @Mock private SecretStore defaultStore;
-  @Mock private SecretCache defaultCache;
   @Mock private ScheduledTaskState scheduledTaskState;
   @Mock private SecretReferenceState secretReferenceState;
   @Mock private ReadonlyStreamProcessorContext context;
@@ -77,9 +82,7 @@ final class SecretResolutionSchedulerTest {
 
     final Supplier<ScheduledTaskState> stateFactory = () -> scheduledTaskState;
     final var registry =
-        new SecretStoreRegistry(
-            Map.of("my-store", secretStore, SecretStoreRegistry.DEFAULT_STORE_ID, defaultStore),
-            Map.of("my-store", secretCache, SecretStoreRegistry.DEFAULT_STORE_ID, defaultCache));
+        new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, secretCache));
     final var config = new EngineConfiguration();
     scheduler = new SecretResolutionScheduler(stateFactory, registry, config);
     scheduler.onRecovered(context);
@@ -88,7 +91,7 @@ final class SecretResolutionSchedulerTest {
   @Test
   void shouldPopulateCacheAndWriteResolutionCompleteOnSuccess() throws Exception {
     // given
-    stubPending("my-store", "db-password");
+    stubPending(STORE_ID, "db-password");
     when(secretStore.resolve(Set.of("db-password")))
         .thenReturn(Map.of("db-password", new SecretResolutionResult.Resolved("s3cr3t")));
 
@@ -101,36 +104,15 @@ final class SecretResolutionSchedulerTest {
     final var recordCaptor = ArgumentCaptor.forClass(SecretReferenceRecord.class);
     verify(resultBuilder).appendCommandRecord(intentCaptor.capture(), recordCaptor.capture());
     assertThat(intentCaptor.getValue()).isEqualTo(SecretReferenceIntent.RESOLUTION_COMPLETE);
-    assertThat(recordCaptor.getValue().getStoreId()).isEqualTo("my-store");
+    assertThat(recordCaptor.getValue().getStoreId()).isEqualTo(STORE_ID);
     assertThat(recordCaptor.getValue().getSecretReference()).isEqualTo("db-password");
-    assertThat(recordCaptor.getValue().getResolutionState()).isEqualTo(ResolutionState.SUCCESS);
-  }
-
-  @Test
-  void shouldResolveReferenceAddressingTheDefaultStore() throws Exception {
-    // given — the store id every camunda.secrets.<name> reference carries; it used to be empty,
-    // which addressed no store and failed every background resolution (#59432)
-    stubPending(SecretStoreRegistry.DEFAULT_STORE_ID, "db-password");
-    when(defaultStore.resolve(Set.of("db-password")))
-        .thenReturn(Map.of("db-password", new SecretResolutionResult.Resolved("s3cr3t")));
-
-    // when
-    scheduler.resolveSecrets(resultBuilder);
-
-    // then
-    final var intentCaptor = ArgumentCaptor.forClass(SecretReferenceIntent.class);
-    final var recordCaptor = ArgumentCaptor.forClass(SecretReferenceRecord.class);
-    verify(resultBuilder).appendCommandRecord(intentCaptor.capture(), recordCaptor.capture());
-    assertThat(intentCaptor.getValue()).isEqualTo(SecretReferenceIntent.RESOLUTION_COMPLETE);
-    assertThat(recordCaptor.getValue().getStoreId())
-        .isEqualTo(SecretStoreRegistry.DEFAULT_STORE_ID);
     assertThat(recordCaptor.getValue().getResolutionState()).isEqualTo(ResolutionState.SUCCESS);
   }
 
   @Test
   void shouldNotPopulateCacheAndWriteResolutionFailOnPermanentPerSecretError() throws Exception {
     // given
-    stubPending("my-store", "missing-key");
+    stubPending(STORE_ID, "missing-key");
     when(secretStore.resolve(Set.of("missing-key")))
         .thenReturn(
             Map.of(
@@ -147,7 +129,7 @@ final class SecretResolutionSchedulerTest {
     final var recordCaptor = ArgumentCaptor.forClass(SecretReferenceRecord.class);
     verify(resultBuilder).appendCommandRecord(intentCaptor.capture(), recordCaptor.capture());
     assertThat(intentCaptor.getValue()).isEqualTo(SecretReferenceIntent.RESOLUTION_FAIL);
-    assertThat(recordCaptor.getValue().getStoreId()).isEqualTo("my-store");
+    assertThat(recordCaptor.getValue().getStoreId()).isEqualTo(STORE_ID);
     assertThat(recordCaptor.getValue().getSecretReference()).isEqualTo("missing-key");
     assertThat(recordCaptor.getValue().getResolutionState()).isEqualTo(ResolutionState.NOT_FOUND);
   }
@@ -155,7 +137,7 @@ final class SecretResolutionSchedulerTest {
   @Test
   void shouldRetryAndNotWriteCommandOnFirstStoreUnavailable() throws Exception {
     // given
-    stubPending("my-store", "db-password");
+    stubPending(STORE_ID, "db-password");
     when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
 
     // when
@@ -175,12 +157,12 @@ final class SecretResolutionSchedulerTest {
     when(clock.millis()).thenAnswer(inv -> nowMs.getAndAdd(Duration.ofDays(1).toMillis()));
     final int maxAttempts = EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_MAX_ATTEMPTS;
     for (int i = 0; i < maxAttempts - 1; i++) {
-      stubPending("my-store", "db-password");
+      stubPending(STORE_ID, "db-password");
       scheduler.resolveSecrets(resultBuilder);
     }
 
     // when — this call hits maxAttempts
-    stubPending("my-store", "db-password");
+    stubPending(STORE_ID, "db-password");
     scheduler.resolveSecrets(resultBuilder);
 
     // then
@@ -188,7 +170,7 @@ final class SecretResolutionSchedulerTest {
     final var recordCaptor = ArgumentCaptor.forClass(SecretReferenceRecord.class);
     verify(resultBuilder).appendCommandRecord(intentCaptor.capture(), recordCaptor.capture());
     assertThat(intentCaptor.getValue()).isEqualTo(SecretReferenceIntent.RESOLUTION_FAIL);
-    assertThat(recordCaptor.getValue().getStoreId()).isEqualTo("my-store");
+    assertThat(recordCaptor.getValue().getStoreId()).isEqualTo(STORE_ID);
     assertThat(recordCaptor.getValue().getSecretReference()).isEqualTo("db-password");
     assertThat(recordCaptor.getValue().getResolutionState())
         .isEqualTo(ResolutionState.STORE_UNAVAILABLE);
@@ -222,7 +204,7 @@ final class SecretResolutionSchedulerTest {
 
     // when
     for (int i = 0; i < maxAttempts; i++) {
-      stubPending("my-store", "a", "b");
+      stubPending(STORE_ID, "a", "b");
       scheduler.resolveSecrets(resultBuilder);
     }
 
@@ -241,12 +223,12 @@ final class SecretResolutionSchedulerTest {
   @Test
   void shouldCacheTheValueOfAStoreTheRegistryWasGivenNoCacheFor() throws Exception {
     // given a registry built without a cache for the configured store
-    final var registry = new SecretStoreRegistry(Map.of("my-store", secretStore), Map.of());
+    final var registry = new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of());
     final var localScheduler =
         new SecretResolutionScheduler(
             () -> scheduledTaskState, registry, new EngineConfiguration());
     localScheduler.onRecovered(context);
-    stubPending("my-store", "db-password");
+    stubPending(STORE_ID, "db-password");
     when(secretStore.resolve(Set.of("db-password")))
         .thenReturn(Map.of("db-password", new SecretResolutionResult.Resolved("v")));
 
@@ -255,7 +237,7 @@ final class SecretResolutionSchedulerTest {
 
     // then the store's own cache took the value and the reference completes: a configured store
     // always caches, so resolving cannot strand a job by completing it uncached
-    assertThat(registry.getStores().get("my-store").lookupLocal("db-password")).contains("v");
+    assertThat(registry.getStores().get(STORE_ID).lookupLocal("db-password")).contains("v");
     verify(resultBuilder).appendCommandRecord(eq(SecretReferenceIntent.RESOLUTION_COMPLETE), any());
   }
 
@@ -266,12 +248,12 @@ final class SecretResolutionSchedulerTest {
     final var cache = new InMemorySecretCache();
     cache.put("db-password", "already-held");
     final var registry =
-        new SecretStoreRegistry(Map.of("my-store", secretStore), Map.of("my-store", cache));
+        new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, cache));
     final var localScheduler =
         new SecretResolutionScheduler(
             () -> scheduledTaskState, registry, new EngineConfiguration());
     localScheduler.onRecovered(context);
-    stubPending("my-store", "db-password");
+    stubPending(STORE_ID, "db-password");
     when(secretStore.resolve(Set.of("db-password")))
         .thenReturn(
             Map.of(
@@ -292,13 +274,13 @@ final class SecretResolutionSchedulerTest {
   @Test
   void shouldSkipStoreInCooldownPeriod() throws Exception {
     // given — first execute causes a retry (cooldown starts at t=0)
-    stubPending("my-store", "db-password");
+    stubPending(STORE_ID, "db-password");
     when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
     when(clock.millis()).thenReturn(0L);
     scheduler.resolveSecrets(resultBuilder);
 
     // when — second execute while still in cooldown (clock still at 0)
-    stubPending("my-store", "db-password");
+    stubPending(STORE_ID, "db-password");
     scheduler.resolveSecrets(resultBuilder);
 
     // then — store called only once; the cooldown store's ref is excluded during collection, so
@@ -311,7 +293,7 @@ final class SecretResolutionSchedulerTest {
   @Test
   void shouldResetRetryStateAfterSuccessfulResolution() throws Exception {
     // given — first execute fails (enters retry state)
-    stubPending("my-store", "db-password");
+    stubPending(STORE_ID, "db-password");
     when(secretStore.resolve(any()))
         .thenThrow(new SecretStoreUnavailableException("store down"))
         .thenReturn(Map.of("db-password", new SecretResolutionResult.Resolved("value")));
@@ -319,7 +301,7 @@ final class SecretResolutionSchedulerTest {
     scheduler.resolveSecrets(resultBuilder); // first: fails
 
     // when — second execute succeeds
-    stubPending("my-store", "db-password");
+    stubPending(STORE_ID, "db-password");
     scheduler.resolveSecrets(resultBuilder);
 
     // then — cache written, RESOLUTION_COMPLETE written
@@ -328,14 +310,14 @@ final class SecretResolutionSchedulerTest {
     final var recordCaptor = ArgumentCaptor.forClass(SecretReferenceRecord.class);
     verify(resultBuilder).appendCommandRecord(intentCaptor.capture(), recordCaptor.capture());
     assertThat(intentCaptor.getValue()).isEqualTo(SecretReferenceIntent.RESOLUTION_COMPLETE);
-    assertThat(recordCaptor.getValue().getStoreId()).isEqualTo("my-store");
+    assertThat(recordCaptor.getValue().getStoreId()).isEqualTo(STORE_ID);
     assertThat(recordCaptor.getValue().getSecretReference()).isEqualTo("db-password");
   }
 
   @Test
   void shouldScheduleEarlierThanIntervalWhenRetryDeadlineIsSooner() throws Exception {
     // given — store fails; retry due in retryInitialDelay (1s) which is < schedulingInterval (5s)
-    stubPending("my-store", "db-password");
+    stubPending(STORE_ID, "db-password");
     when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
     when(clock.millis()).thenReturn(0L);
 
@@ -354,7 +336,7 @@ final class SecretResolutionSchedulerTest {
   @Test
   void shouldPruneRetryStateForStoresWithNoPendingRefs() throws Exception {
     // given — store fails (enters retry state)
-    stubPending("my-store", "db-password");
+    stubPending(STORE_ID, "db-password");
     when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
     when(clock.millis()).thenReturn(0L);
     scheduler.resolveSecrets(resultBuilder);
@@ -503,7 +485,7 @@ final class SecretResolutionSchedulerTest {
   @Test
   void shouldLeaveRefsPendingWhenStoreThrowsUnexpectedException() throws Exception {
     // given
-    stubPending("my-store", "db-password");
+    stubPending(STORE_ID, "db-password");
     when(secretStore.resolve(any())).thenThrow(new IllegalStateException("boom"));
 
     // when
@@ -554,7 +536,7 @@ final class SecretResolutionSchedulerTest {
   @Test
   void shouldBatchAllRefsOfStoreIntoSingleResolveCall() throws Exception {
     // given
-    stubPending("my-store", "ref-1", "ref-2");
+    stubPending(STORE_ID, "ref-1", "ref-2");
     when(secretStore.resolve(Set.of("ref-1", "ref-2")))
         .thenReturn(
             Map.of(
@@ -577,11 +559,10 @@ final class SecretResolutionSchedulerTest {
     final var localScheduler =
         new SecretResolutionScheduler(
             () -> scheduledTaskState,
-            new SecretStoreRegistry(
-                Map.of("my-store", secretStore), Map.of("my-store", secretCache)),
+            new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, secretCache)),
             config);
     localScheduler.onRecovered(context);
-    stubPending("my-store", "ref-1", "ref-2", "ref-3");
+    stubPending(STORE_ID, "ref-1", "ref-2", "ref-3");
     when(secretStore.resolve(Set.of("ref-1", "ref-2")))
         .thenReturn(
             Map.of(
@@ -659,12 +640,11 @@ final class SecretResolutionSchedulerTest {
     final var localScheduler =
         new SecretResolutionScheduler(
             () -> scheduledTaskState,
-            new SecretStoreRegistry(
-                Map.of("my-store", secretStore), Map.of("my-store", secretCache)),
+            new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, secretCache)),
             config);
     localScheduler.onRecovered(context);
     reset(scheduleService);
-    stubPending("my-store", "ref-1", "ref-2", "ref-3");
+    stubPending(STORE_ID, "ref-1", "ref-2", "ref-3");
     when(secretStore.resolve(any()))
         .thenReturn(
             Map.of(
@@ -687,12 +667,11 @@ final class SecretResolutionSchedulerTest {
     final var localScheduler =
         new SecretResolutionScheduler(
             () -> scheduledTaskState,
-            new SecretStoreRegistry(
-                Map.of("my-store", secretStore), Map.of("my-store", secretCache)),
+            new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, secretCache)),
             config);
     localScheduler.onRecovered(context);
     reset(scheduleService);
-    stubPending("my-store", "ref-1", "ref-2");
+    stubPending(STORE_ID, "ref-1", "ref-2");
     when(secretStore.resolve(Set.of("ref-1", "ref-2")))
         .thenReturn(
             Map.of(
@@ -719,20 +698,19 @@ final class SecretResolutionSchedulerTest {
     final var localScheduler =
         new SecretResolutionScheduler(
             () -> scheduledTaskState,
-            new SecretStoreRegistry(
-                Map.of("my-store", secretStore), Map.of("my-store", secretCache)),
+            new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, secretCache)),
             config);
     localScheduler.onRecovered(context);
     reset(scheduleService);
     when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
 
     // when — first cycle: store fails, enters retry cooldown
-    stubPending("my-store", "ref-1", "ref-2");
+    stubPending(STORE_ID, "ref-1", "ref-2");
     localScheduler.resolveSecrets(resultBuilder);
 
     // when — second cycle: still within the cooldown window; the cooldown store's ref is excluded
     // from collection entirely, so nothing is capped and nothing is resolved
-    stubPending("my-store", "ref-1", "ref-2");
+    stubPending(STORE_ID, "ref-1", "ref-2");
     localScheduler.resolveSecrets(resultBuilder);
 
     // then — the store was only attempted once; the second cycle skipped it during collection
@@ -751,11 +729,11 @@ final class SecretResolutionSchedulerTest {
   void shouldResumeCollectionFromCursorOnNextCycle() throws Exception {
     // given — cycle 1's collection stops early and reports a resume cursor at the last entry the
     // visitor was offered before being told to stop
-    final var cycle1Cursor = new SecretReferenceState.PendingRefCursor("my-store", "ref-1");
+    final var cycle1Cursor = new SecretReferenceState.PendingRefCursor(STORE_ID, "ref-1");
     doAnswer(
             inv -> {
               final var visitor = (BiPredicate<String, String>) inv.getArgument(1);
-              visitor.test("my-store", "ref-1");
+              visitor.test(STORE_ID, "ref-1");
               return cycle1Cursor;
             })
         .when(secretReferenceState)
@@ -765,7 +743,7 @@ final class SecretResolutionSchedulerTest {
     scheduler.resolveSecrets(resultBuilder);
 
     // and — cycle 2
-    stubPending("my-store", "ref-2");
+    stubPending(STORE_ID, "ref-2");
     scheduler.resolveSecrets(resultBuilder);
 
     // then — cycle 2 resumed from exactly where cycle 1 left off, not from the beginning; this is
@@ -871,7 +849,7 @@ final class SecretResolutionSchedulerTest {
   @Test
   void shouldRescheduleImmediatelyWhenTaskResultBatchIsFull() throws Exception {
     // given
-    stubPending("my-store", "db-password");
+    stubPending(STORE_ID, "db-password");
     when(secretStore.resolve(Set.of("db-password")))
         .thenReturn(Map.of("db-password", new SecretResolutionResult.Resolved("s3cr3t")));
     when(resultBuilder.appendCommandRecord(any(), any())).thenReturn(false);
@@ -922,11 +900,11 @@ final class SecretResolutionSchedulerTest {
     when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
     when(clock.millis()).thenReturn(0L, 10_000L);
 
-    stubPending("my-store", "db-password");
+    stubPending(STORE_ID, "db-password");
     scheduler.resolveSecrets(resultBuilder);
 
     // when — cooldown (1s) has elapsed by the time of the second run (clock now at 10s)
-    stubPending("my-store", "db-password");
+    stubPending(STORE_ID, "db-password");
     scheduler.resolveSecrets(resultBuilder);
 
     // then — second attempt happened because the cooldown expired

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/SecretStoreRegistries.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/SecretStoreRegistries.java
@@ -9,9 +9,15 @@ package io.camunda.zeebe.engine.util;
 
 import io.camunda.secretstore.NoopSecretStore;
 import io.camunda.secretstore.SecretCache;
+import io.camunda.secretstore.SecretErrorCode;
+import io.camunda.secretstore.SecretResolutionResult;
+import io.camunda.secretstore.SecretStore;
 import io.camunda.secretstore.SecretStoreRegistry;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /** Factories for {@link SecretStoreRegistry} instances used in engine tests. */
 public final class SecretStoreRegistries {
@@ -34,6 +40,43 @@ public final class SecretStoreRegistries {
           public void put(final String name, final String ignored) {}
         };
     return new SecretStoreRegistry(
-        Map.of("default", new NoopSecretStore()), Map.of("default", resolveAllCache));
+        Map.of(SecretStoreRegistry.DEFAULT_STORE_ID, new NoopSecretStore()),
+        Map.of(SecretStoreRegistry.DEFAULT_STORE_ID, resolveAllCache));
+  }
+
+  /**
+   * Returns a single-store registry whose default store holds the given secrets but starts with a
+   * cold cache, so a job referencing one of them is parked on its first activation and only becomes
+   * activatable once the background resolution has read the store. This is what {@link
+   * #resolveAll(String)} cannot exercise: its cache answers every name, so nothing ever parks.
+   */
+  public static SecretStoreRegistry resolvingFromStore(final Map<String, String> secrets) {
+    // one-argument constructor: the registry puts a fresh in-memory cache in front of the store
+    return new SecretStoreRegistry(
+        Map.of(SecretStoreRegistry.DEFAULT_STORE_ID, new MapSecretStore(Map.copyOf(secrets))));
+  }
+
+  /** A store answering from a fixed map, so a read of it can be told apart from a cache hit. */
+  private record MapSecretStore(Map<String, String> secrets) implements SecretStore {
+
+    @Override
+    public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
+      return names.stream()
+          .collect(
+              Collectors.toMap(
+                  name -> name,
+                  name ->
+                      Optional.ofNullable(secrets.get(name))
+                          .<SecretResolutionResult>map(SecretResolutionResult.Resolved::new)
+                          .orElseGet(
+                              () ->
+                                  new SecretResolutionResult.Failed(
+                                      SecretErrorCode.NOT_FOUND, "no such secret", null))));
+    }
+
+    @Override
+    public List<String> list() {
+      return List.copyOf(secrets.keySet());
+    }
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableSecretReference.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableSecretReference.java
@@ -27,7 +27,10 @@ public final class ClusterVariableSecretReference extends ObjectValue
   private static final StringValue SECRET_REFERENCE_KEY = new StringValue("secretReference");
   private static final StringValue PATH_KEY = new StringValue("path");
 
-  private final StringProperty storeIdProp = new StringProperty(STORE_ID_KEY, "");
+  // mirrors io.camunda.secretstore.SecretStoreRegistry#DEFAULT_STORE_ID: the record layer stays
+  // free of the secret store API, so the value is repeated here and pinned against the constant
+  // by DefaultStoreIdTest. An unset store ID names the default store, not no store at all.
+  private final StringProperty storeIdProp = new StringProperty(STORE_ID_KEY, "default");
   private final StringProperty secretReferenceProp = new StringProperty(SECRET_REFERENCE_KEY, "");
   // RFC 6901 JSON pointer of the value leaf the reference was found in
   private final StringProperty pathProp = new StringProperty(PATH_KEY, "");

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobSecretReference.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobSecretReference.java
@@ -28,7 +28,10 @@ public final class JobSecretReference extends ObjectValue implements JobSecretRe
   private static final StringValue SECRET_REFERENCE_KEY = new StringValue("secretReference");
   private static final StringValue PATH_KEY = new StringValue("path");
 
-  private final StringProperty storeIdProp = new StringProperty(STORE_ID_KEY, "");
+  // mirrors io.camunda.secretstore.SecretStoreRegistry#DEFAULT_STORE_ID: the record layer stays
+  // free of the secret store API, so the value is repeated here and pinned against the constant
+  // by DefaultStoreIdTest. An unset store ID names the default store, not no store at all.
+  private final StringProperty storeIdProp = new StringProperty(STORE_ID_KEY, "default");
   private final StringProperty secretReferenceProp = new StringProperty(SECRET_REFERENCE_KEY, "");
   // RFC 6901 JSON pointer where the resolved secret is injected into the job variables on
   // activation

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/secretreference/SecretReferenceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/secretreference/SecretReferenceRecord.java
@@ -22,7 +22,10 @@ import java.util.stream.StreamSupport;
 public final class SecretReferenceRecord extends UnifiedRecordValue
     implements SecretReferenceRecordValue {
 
-  private final StringProperty storeIdProp = new StringProperty("storeId", "");
+  // mirrors io.camunda.secretstore.SecretStoreRegistry#DEFAULT_STORE_ID: the record layer stays
+  // free of the secret store API, so the value is repeated here and pinned against the constant
+  // by DefaultStoreIdTest. An unset store ID names the default store, not no store at all.
+  private final StringProperty storeIdProp = new StringProperty("storeId", "default");
   private final StringProperty secretReferenceProp = new StringProperty("secretReference", "");
   private final EnumProperty<ResolutionState> resolutionStateProp =
       new EnumProperty<>("resolutionState", ResolutionState.class, ResolutionState.UNSPECIFIED);

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3497,7 +3497,7 @@ final class JsonSerializableToJsonTest {
                         new UnsafeBuffer(
                             MsgPackConverter.convertToMsgPack(Map.of("credentialType", "OAUTH2"))))
                     .setKind(ClusterVariableKind.SECRET_REFERENCE)
-                    .addSecretReference("", "token", "/auth"),
+                    .addSecretReference("default", "token", "/auth"),
         """
                 {
                   "name": "secretVar",
@@ -3508,7 +3508,7 @@ final class JsonSerializableToJsonTest {
                   "kind": "SECRET_REFERENCE",
                   "secretReferences": [
                     {
-                      "storeId": "",
+                      "storeId": "default",
                       "secretReference": "token",
                       "path": "/auth"
                     }
@@ -5388,7 +5388,7 @@ final class JsonSerializableToJsonTest {
         (Supplier<UnifiedRecordValue>) SecretReferenceRecord::new,
         """
         {
-          "storeId": "",
+          "storeId": "default",
           "secretReference": "",
           "resolutionState": "UNSPECIFIED",
           "jobKeys": []

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableSecretReference.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableSecretReference.golden
@@ -27,7 +27,10 @@ public final class ClusterVariableSecretReference extends ObjectValue
   private static final StringValue SECRET_REFERENCE_KEY = new StringValue("secretReference");
   private static final StringValue PATH_KEY = new StringValue("path");
 
-  private final StringProperty storeIdProp = new StringProperty(STORE_ID_KEY, "");
+  // mirrors io.camunda.secretstore.SecretStoreRegistry#DEFAULT_STORE_ID: the record layer stays
+  // free of the secret store API, so the value is repeated here and pinned against the constant
+  // by DefaultStoreIdTest. An unset store ID names the default store, not no store at all.
+  private final StringProperty storeIdProp = new StringProperty(STORE_ID_KEY, "default");
   private final StringProperty secretReferenceProp = new StringProperty(SECRET_REFERENCE_KEY, "");
   // RFC 6901 JSON pointer of the value leaf the reference was found in
   private final StringProperty pathProp = new StringProperty(PATH_KEY, "");

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobSecretReference.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobSecretReference.golden
@@ -17,7 +17,7 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
 @JsonIgnoreProperties({
-  /* These fields are inherited from ObjectValue; they have no purpose in exported JSON records*/
+  /* Inherited from ObjectValue. They have no purpose in exported JSON records. */
   "encodedLength",
   "empty"
 })
@@ -28,8 +28,13 @@ public final class JobSecretReference extends ObjectValue implements JobSecretRe
   private static final StringValue SECRET_REFERENCE_KEY = new StringValue("secretReference");
   private static final StringValue PATH_KEY = new StringValue("path");
 
-  private final StringProperty storeIdProp = new StringProperty(STORE_ID_KEY, "");
+  // mirrors io.camunda.secretstore.SecretStoreRegistry#DEFAULT_STORE_ID: the record layer stays
+  // free of the secret store API, so the value is repeated here and pinned against the constant
+  // by DefaultStoreIdTest. An unset store ID names the default store, not no store at all.
+  private final StringProperty storeIdProp = new StringProperty(STORE_ID_KEY, "default");
   private final StringProperty secretReferenceProp = new StringProperty(SECRET_REFERENCE_KEY, "");
+  // RFC 6901 JSON pointer where the resolved secret is injected into the job variables on
+  // activation
   private final StringProperty pathProp = new StringProperty(PATH_KEY, "");
 
   public JobSecretReference() {

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/SecretReferenceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/SecretReferenceRecord.golden
@@ -22,7 +22,10 @@ import java.util.stream.StreamSupport;
 public final class SecretReferenceRecord extends UnifiedRecordValue
     implements SecretReferenceRecordValue {
 
-  private final StringProperty storeIdProp = new StringProperty("storeId", "");
+  // mirrors io.camunda.secretstore.SecretStoreRegistry#DEFAULT_STORE_ID: the record layer stays
+  // free of the secret store API, so the value is repeated here and pinned against the constant
+  // by DefaultStoreIdTest. An unset store ID names the default store, not no store at all.
+  private final StringProperty storeIdProp = new StringProperty("storeId", "default");
   private final StringProperty secretReferenceProp = new StringProperty("secretReference", "");
   private final EnumProperty<ResolutionState> resolutionStateProp =
       new EnumProperty<>("resolutionState", ResolutionState.class, ResolutionState.UNSPECIFIED);

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -60,8 +60,12 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
   public static final String DEFAULT_MAPPING_RULE_CLAIM_VALUE = "default";
   public static final String RECORDING_EXPORTER_ID = "recordingExporter";
 
-  // a physical tenant is capped at one configured secret store, so the ID only has to be stable
-  private static final String SECRET_STORE_ID = "test";
+  // the only store ID a camunda.secrets.<name> reference can address, and the only one the broker
+  // accepts at startup — a store under any other ID makes it refuse to boot. Mirrors
+  // io.camunda.secretstore.SecretStoreRegistry#DEFAULT_STORE_ID, which this module only sees
+  // transitively; declaring that dependency to read one constant is not worth it, and getting the
+  // value wrong here fails loudly at broker startup rather than silently.
+  private static final String SECRET_STORE_ID = "default";
   private static final Logger LOGGER = LoggerFactory.getLogger(TestStandaloneBroker.class);
 
   private boolean isGatewayEnabled = true;


### PR DESCRIPTION


## Description

- background secret resolution failed 100% of the time because eery secret reference carried an empty store ID, but `SecretResolutionScheduler` looks its store up by exact ID. Since no configured store is ever named `""`, every pending reference failed
- a reference now carries the store ID `default` at its source instead of an empty one
- scheduler can keep using exact lookup
- using secrets now means configuring exactly one store named `default`, a store under any other ID is rejected at startup 

## Testing

- new `SecretResolutionLifecycleTest` covers full park → background resolve → reactivate → inject loop against a real store with a cold cache

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #59432
