### PR TITLE
ci: backport node_modules wipe on npm ci retry to stable/8.8

### DIFF
--- a/.github/actions/npm-ci-with-retry/action.yml
+++ b/.github/actions/npm-ci-with-retry/action.yml
@@ -41,3 +41,8 @@ runs:
         shell: bash
         command: |
           cd "${{ inputs.directory }}" && npm ci
+        # A killed attempt (timeout) can leave node_modules half-extracted,
+        # which makes the next attempt fail deterministically (e.g. ENOTEMPTY)
+        # instead of getting a clean retry.
+        on_retry_command: |
+          rm -rf "${{ inputs.directory }}/node_modules"


### PR DESCRIPTION
## What

Backports the `on_retry_command` fix from `main`'s `.github/actions/npm-ci-with-retry/action.yml` to `stable/8.8`.

## Why

A timed-out `npm ci` attempt can leave `node_modules` half-extracted. Without a clean wipe before the next attempt, the retry fails deterministically on `ENOTEMPTY` instead of getting a genuine second try. `main` already wipes `node_modules` in `on_retry_command` before retrying; `stable/8.8` never received this backport, so the same failure mode is still live there.

Root-caused while triaging INC-6959 (operate-fe-visual-regression-tests-1 on main): attempt 1 timed out at the 3 minute budget, attempt 2 failed in ~2.4s on `ENOTEMPTY` unpacking a font asset left over from the killed attempt.

## Note

This only fixes the retry-corruption half of the problem. The timeout itself (2-3 min per attempt across these jobs, against a cold-cache ~400MB install) is a separate, still-open issue — see the companion npm-caching PR.