### PR TITLE
ci(operate): cache npm dependencies in ci-operate.yml

### DIFF
--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -140,6 +140,8 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          cache: npm
+          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -189,6 +191,8 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          cache: npm
+          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -225,6 +229,8 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          cache: npm
+          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -264,6 +270,8 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          cache: npm
+          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -302,6 +310,8 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          cache: npm
+          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -345,6 +355,8 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          cache: npm
+          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install node dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -400,6 +412,8 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          cache: npm
+          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install node dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -450,6 +464,8 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          cache: npm
+          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install node dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -493,6 +509,8 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          cache: npm
+          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:


### PR DESCRIPTION
## What

Adds `cache: npm` (keyed on `operate/client/package-lock.json`) to all 9 `actions/setup-node` steps in this workflow.

## Why

None of these jobs cache npm dependencies today, so every run does a full cold install (~400MB for operate/client). That cold-install time is what's tripping the tight 2-3 minute `npm-ci-with-retry` timeouts configured on these same jobs — root-caused while triaging INC-6959, where a cold-cache `npm ci` took ~185s against a 180s (3 min) timeout, got killed, and the retry then failed on `ENOTEMPTY` from the half-extracted install.

Caching brings typical install time down well under the existing timeout, instead of requiring a wider timeout budget that would also eat into these jobs' overall 12-minute job timeout.

Companion fix for stable/8.8 to follow separately (workflow file differs enough between branches to need its own PR).