### PR TITLE
ci(operate): cache npm dependencies in ci-operate.yml

### DIFF
--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -148,6 +148,8 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "22"
+          cache: npm
+          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -197,6 +199,8 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "22"
+          cache: npm
+          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -242,6 +246,8 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "22"
+          cache: npm
+          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -281,6 +287,8 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "22"
+          cache: npm
+          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -324,6 +332,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "22"
+          cache: npm
+          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install node dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -374,6 +384,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "22"
+          cache: npm
+          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install node dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -422,6 +434,8 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "22"
+          cache: npm
+          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:


### PR DESCRIPTION
## What

stable/8.8 companion to #59529. Adds `cache: npm` (keyed on `operate/client/package-lock.json`) to the setup-node steps in this workflow.

## Why

None of these jobs cache npm dependencies today, so every run does a full cold install (~400MB for operate/client). That cold-install time is what's tripping the tight 2-3 minute `npm-ci-with-retry` timeouts configured on these same jobs — root-caused while triaging INC-6959 on main, where a cold-cache `npm ci` took ~185s against a 180s (3 min) timeout, got killed, and the retry then failed on `ENOTEMPTY` from the half-extracted install (see #59528, the node_modules-wipe backport for this branch).

Caching brings typical install time down well under the existing timeout, instead of requiring a wider timeout budget that would also eat into these jobs' overall 12-minute job timeout.