### PR TITLE
Provision new physical tenants on cluster restart

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -317,7 +317,8 @@ public final class ClusterConfigurationManagerService
                 .currentClusterConfigurationPartitionDistributorInitializer(staticConfiguration))
         .andThen(
             new PartitionGroupExportingStateInitializer(
-                legacyExportingStates, staticConfiguration.localMemberId()));
+                legacyExportingStates, staticConfiguration.localMemberId()))
+        .andThen(new PhysicalTenantProvisioningInitializer(staticConfiguration));
   }
 
   /**
@@ -351,7 +352,8 @@ public final class ClusterConfigurationManagerService
                 .currentClusterConfigurationPartitionDistributorInitializer(staticConfiguration))
         .andThen(
             new PartitionGroupExportingStateInitializer(
-                legacyExportingStates, staticConfiguration.localMemberId()));
+                legacyExportingStates, staticConfiguration.localMemberId()))
+        .andThen(new PhysicalTenantProvisioningInitializer(staticConfiguration));
   }
 
   private Supplier<List<MemberId>> initializationMembers(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializer.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.util.AdditivePartitionReassigner;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
+import io.camunda.zeebe.dynamic.config.util.PartitionReassignmentOperationsGenerator;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provisions a brand-new physical tenant on the coordinator: if the local static configuration
+ * lists a physical tenant (a {@link PartitionId#group()}) that has no corresponding entry in {@link
+ * CurrentClusterConfiguration#partitionGroups()}, this adds an empty {@link
+ * PartitionGroupConfiguration} for it and starts a configuration change directly on that group —
+ * using {@link AdditivePartitionReassigner} to place its partitions and {@link
+ * PartitionReassignmentOperationsGenerator} to turn that placement into operations.
+ *
+ * <p>The change is started directly on the new group via {@link
+ * PartitionGroupConfiguration#startConfigurationChange(List)}, bypassing the top-level {@link
+ * io.camunda.zeebe.dynamic.config.state.PhasedChangePlan} entirely: a phased change may already be
+ * in progress for other groups when this runs, and this group is guaranteed to have no pending
+ * change of its own yet since it doesn't exist before this modifier creates it.
+ *
+ * <p>A physical tenant whose group already exists is left completely untouched, even if it's since
+ * been removed from the static configuration — this modifier only ever adds a group, never removes
+ * one.
+ *
+ * <p>Multiple new physical tenants are provisioned in the same {@link #modify(Object)} call if
+ * found, via a single joint {@link AdditivePartitionReassigner} call covering all of them at once —
+ * not one call per tenant — so their partitions are placed with knowledge of each other's load, the
+ * same way a single call already spreads a batch of new partitions for one tenant evenly. Calling
+ * the reassigner separately per tenant would place each one only against the load already on disk,
+ * blind to the other new tenants being provisioned in the same pass, and could easily pile several
+ * brand-new tenants onto the same least-loaded brokers instead of spreading them out.
+ *
+ * <p>If placing this batch fails outright (e.g. the live cluster currently has fewer members than
+ * the configured replication factor), the whole batch is skipped with a warning and retried on the
+ * next configuration initialization; if the reassignment itself succeeds but a particular tenant's
+ * target distribution ends up unchanged (e.g. it has no partitions configured at all), that one
+ * tenant alone is skipped while the rest are still provisioned.
+ */
+public class PhysicalTenantProvisioningInitializer
+    extends ClusterConfigurationModifier.CoordinatorOnly<CurrentClusterConfiguration> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(PhysicalTenantProvisioningInitializer.class);
+
+  private final Map<String, List<PartitionId>> staticPartitionIdsByTenant;
+  private final int replicationFactor;
+  private final AdditivePartitionReassigner reassigner = new AdditivePartitionReassigner();
+  private final StaticConfiguration staticConfiguration;
+
+  public PhysicalTenantProvisioningInitializer(final StaticConfiguration staticConfiguration) {
+    super(staticConfiguration.localMemberId());
+    this.staticConfiguration = staticConfiguration;
+    staticPartitionIdsByTenant =
+        staticConfiguration.partitionIds().stream()
+            .collect(Collectors.groupingBy(PartitionId::group));
+    replicationFactor = staticConfiguration.replicationFactor();
+  }
+
+  @Override
+  public ActorFuture<CurrentClusterConfiguration> modify(
+      final CurrentClusterConfiguration configuration) {
+    final var newTenantIds =
+        staticPartitionIdsByTenant.keySet().stream()
+            .filter(tenantId -> !configuration.partitionGroups().containsKey(tenantId))
+            .sorted()
+            .toList();
+    if (newTenantIds.isEmpty()) {
+      return CompletableActorFuture.completed(configuration);
+    }
+
+    try {
+      return CompletableActorFuture.completed(provisionTenants(configuration, newTenantIds));
+    } catch (final RuntimeException e) {
+      LOG.warn(
+          "Failed to provision new physical tenants {}; skipping them for now, they will be "
+              + "retried on the next configuration initialization",
+          newTenantIds,
+          e);
+      return CompletableActorFuture.completed(configuration);
+    }
+  }
+
+  /**
+   * Computes the target distribution for every new tenant's partitions in a single {@link
+   * AdditivePartitionReassigner} call, so their placement accounts for each other's load, then
+   * splits the result into one configuration change per new group.
+   */
+  private CurrentClusterConfiguration provisionTenants(
+      final CurrentClusterConfiguration configuration, final List<String> newTenantIds) {
+    final Set<MemberId> targetMembers = liveMembers(configuration);
+    final var existingPartitionIds =
+        ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(configuration).values().stream()
+            .flatMap(Set::stream)
+            .map(PartitionMetadata::id)
+            .toList();
+    final var newPartitionIds =
+        newTenantIds.stream()
+            .flatMap(tenantId -> staticPartitionIdsByTenant.get(tenantId).stream());
+    final var targetPartitionIds =
+        Stream.concat(existingPartitionIds.stream(), newPartitionIds).toList();
+
+    final var targetDistribution =
+        getTargetDistribution(configuration, targetMembers, targetPartitionIds);
+
+    final Map<String, DynamicPartitionConfig> partitionConfigByNewGroup =
+        newTenantIds.stream()
+            .collect(
+                Collectors.toMap(
+                    tenantId -> tenantId, ignored -> staticConfiguration.partitionConfig()));
+    final var operationsByGroup =
+        PartitionReassignmentOperationsGenerator.generateOperations(
+            configuration, targetDistribution, partitionConfigByNewGroup);
+
+    var result = configuration;
+    for (final var newTenantId : newTenantIds) {
+      final List<PartitionGroupOperation> tenantOperations = operationsByGroup.get(newTenantId);
+      if (tenantOperations == null || tenantOperations.isEmpty()) {
+        LOG.warn(
+            "No operations were generated to provision new physical tenant '{}'; skipping it for "
+                + "now",
+            newTenantId);
+        continue;
+      }
+      result = addGroupAndStartChange(result, newTenantId, tenantOperations);
+    }
+    return result;
+  }
+
+  /**
+   * The members eligible to host a new tenant's partitions: every broker known to the cluster
+   * except those in {@link BrokerState.State#LEFT} or {@link BrokerState.State#UNINITIALIZED} —
+   * mirroring {@link CurrentClusterConfiguration#clusterSize()}'s definition of "live". Using the
+   * raw {@code globalConfiguration().members().keySet()} instead would let a decommissioned or
+   * not-yet-joined broker be selected as a target, stalling provisioning once its bootstrap/join
+   * operation can never complete.
+   */
+  private static Set<MemberId> liveMembers(final CurrentClusterConfiguration configuration) {
+    return configuration.globalConfiguration().members().entrySet().stream()
+        .filter(
+            entry ->
+                entry.getValue().state() != BrokerState.State.LEFT
+                    && entry.getValue().state() != BrokerState.State.UNINITIALIZED)
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toSet());
+  }
+
+  private Set<PartitionMetadata> getTargetDistribution(
+      final CurrentClusterConfiguration configuration,
+      final Set<MemberId> targetMembers,
+      final List<PartitionId> targetPartitionIds) {
+
+    final boolean isZoneAwareConfig =
+        configuration
+            .globalConfiguration()
+            .partitionDistributorConfig()
+            .filter(ZoneAwareConfig.class::isInstance)
+            .isPresent();
+
+    if (isZoneAwareConfig) {
+      // AdditiveReassigner does not support zone-aware distribution, so we delegate to the
+      // configured distributor instead. ZoneAwareDistribution uses round robin assignment that
+      // means the existing tenants are also moved. Additive zone aware reassignment will be a
+      // followup.
+      return configuration
+          .globalConfiguration()
+          .partitionDistributorConfig()
+          .get()
+          .toDistributor()
+          .distributePartitions(targetMembers, targetPartitionIds, replicationFactor);
+    }
+
+    return reassigner.reassignPartitions(
+        configuration, targetMembers, targetPartitionIds, replicationFactor);
+  }
+
+  private CurrentClusterConfiguration addGroupAndStartChange(
+      final CurrentClusterConfiguration configuration,
+      final String newTenantId,
+      final List<PartitionGroupOperation> tenantOperations) {
+    final var updatedGroups = new HashMap<>(configuration.partitionGroups());
+    updatedGroups.put(
+        newTenantId,
+        PartitionGroupConfiguration.empty(PartitionGroupConfiguration.INITIAL_VERSION));
+    final var withEmptyGroup =
+        new CurrentClusterConfiguration(
+            configuration.version(),
+            configuration.globalConfiguration(),
+            updatedGroups,
+            configuration.phasedChangeState());
+
+    final List<ClusterConfigurationChangeOperation> operations = List.copyOf(tenantOperations);
+    return withEmptyGroup.updatePartitionGroupConfig(
+        newTenantId, group -> group.startConfigurationChange(operations));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializer.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.dynamic.config;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
@@ -113,8 +114,7 @@ public class PhysicalTenantProvisioningInitializer
    */
   private CurrentClusterConfiguration provisionTenants(
       final CurrentClusterConfiguration configuration, final List<String> newTenantIds) {
-    final Set<MemberId> targetMembers =
-        Set.copyOf(configuration.globalConfiguration().members().keySet());
+    final Set<MemberId> targetMembers = liveMembers(configuration);
     final var existingPartitionIds =
         ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(configuration).values().stream()
             .flatMap(Set::stream)
@@ -151,6 +151,24 @@ public class PhysicalTenantProvisioningInitializer
       result = addGroupAndStartChange(result, newTenantId, tenantOperations);
     }
     return result;
+  }
+
+  /**
+   * The members eligible to host a new tenant's partitions: every broker known to the cluster
+   * except those in {@link BrokerState.State#LEFT} or {@link BrokerState.State#UNINITIALIZED} —
+   * mirroring {@link CurrentClusterConfiguration#clusterSize()}'s definition of "live". Using the
+   * raw {@code globalConfiguration().members().keySet()} instead would let a decommissioned or
+   * not-yet-joined broker be selected as a target, stalling provisioning once its bootstrap/join
+   * operation can never complete.
+   */
+  private static Set<MemberId> liveMembers(final CurrentClusterConfiguration configuration) {
+    return configuration.globalConfiguration().members().entrySet().stream()
+        .filter(
+            entry ->
+                entry.getValue().state() != BrokerState.State.LEFT
+                    && entry.getValue().state() != BrokerState.State.UNINITIALIZED)
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toSet());
   }
 
   private Set<PartitionMetadata> getTargetDistribution(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializer.java
@@ -13,6 +13,7 @@ import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.util.AdditivePartitionReassigner;
@@ -126,8 +127,7 @@ public class PhysicalTenantProvisioningInitializer
         Stream.concat(existingPartitionIds.stream(), newPartitionIds).toList();
 
     final var targetDistribution =
-        reassigner.reassignPartitions(
-            configuration, targetMembers, targetPartitionIds, replicationFactor);
+        getTargetDistribution(configuration, targetMembers, targetPartitionIds);
 
     final Map<String, DynamicPartitionConfig> partitionConfigByNewGroup =
         newTenantIds.stream()
@@ -151,6 +151,35 @@ public class PhysicalTenantProvisioningInitializer
       result = addGroupAndStartChange(result, newTenantId, tenantOperations);
     }
     return result;
+  }
+
+  private Set<PartitionMetadata> getTargetDistribution(
+      final CurrentClusterConfiguration configuration,
+      final Set<MemberId> targetMembers,
+      final List<PartitionId> targetPartitionIds) {
+
+    final boolean isZoneAwareConfig =
+        configuration
+            .globalConfiguration()
+            .partitionDistributorConfig()
+            .filter(ZoneAwareConfig.class::isInstance)
+            .isPresent();
+
+    if (isZoneAwareConfig) {
+      // AdditiveReassigner does not support zone-aware distribution, so we delegate to the
+      // configured distributor instead. ZoneAwareDistribution uses round robin assignment that
+      // means the existing tenants are also moved. Additive zone aware reassignment will be a
+      // followup.
+      return configuration
+          .globalConfiguration()
+          .partitionDistributorConfig()
+          .get()
+          .toDistributor()
+          .distributePartitions(targetMembers, targetPartitionIds, replicationFactor);
+    }
+
+    return reassigner.reassignPartitions(
+        configuration, targetMembers, targetPartitionIds, replicationFactor);
   }
 
   private CurrentClusterConfiguration addGroupAndStartChange(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializer.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.util.AdditivePartitionReassigner;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
+import io.camunda.zeebe.dynamic.config.util.PartitionReassignmentOperationsGenerator;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provisions a brand-new physical tenant on the coordinator: if the local static configuration
+ * lists a physical tenant (a {@link PartitionId#group()}) that has no corresponding entry in {@link
+ * CurrentClusterConfiguration#partitionGroups()}, this adds an empty {@link
+ * PartitionGroupConfiguration} for it and starts a configuration change directly on that group —
+ * using {@link AdditivePartitionReassigner} to place its partitions and {@link
+ * PartitionReassignmentOperationsGenerator} to turn that placement into operations.
+ *
+ * <p>The change is started directly on the new group via {@link
+ * PartitionGroupConfiguration#startConfigurationChange(List)}, bypassing the top-level {@link
+ * io.camunda.zeebe.dynamic.config.state.PhasedChangePlan} entirely: a phased change may already be
+ * in progress for other groups when this runs, and this group is guaranteed to have no pending
+ * change of its own yet since it doesn't exist before this modifier creates it.
+ *
+ * <p>A physical tenant whose group already exists is left completely untouched, even if it's since
+ * been removed from the static configuration — this modifier only ever adds a group, never removes
+ * one.
+ *
+ * <p>Multiple new physical tenants are provisioned in the same {@link #modify(Object)} call if
+ * found, via a single joint {@link AdditivePartitionReassigner} call covering all of them at once —
+ * not one call per tenant — so their partitions are placed with knowledge of each other's load, the
+ * same way a single call already spreads a batch of new partitions for one tenant evenly. Calling
+ * the reassigner separately per tenant would place each one only against the load already on disk,
+ * blind to the other new tenants being provisioned in the same pass, and could easily pile several
+ * brand-new tenants onto the same least-loaded brokers instead of spreading them out.
+ *
+ * <p>If placing this batch fails outright (e.g. the live cluster currently has fewer members than
+ * the configured replication factor), the whole batch is skipped with a warning and retried on the
+ * next configuration initialization; if the reassignment itself succeeds but a particular tenant's
+ * target distribution ends up unchanged (e.g. it has no partitions configured at all), that one
+ * tenant alone is skipped while the rest are still provisioned.
+ */
+public class PhysicalTenantProvisioningInitializer
+    extends ClusterConfigurationModifier.CoordinatorOnly<CurrentClusterConfiguration> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(PhysicalTenantProvisioningInitializer.class);
+
+  private final Map<String, List<PartitionId>> staticPartitionIdsByTenant;
+  private final int replicationFactor;
+  private final AdditivePartitionReassigner reassigner = new AdditivePartitionReassigner();
+  private final StaticConfiguration staticConfiguration;
+
+  public PhysicalTenantProvisioningInitializer(final StaticConfiguration staticConfiguration) {
+    super(staticConfiguration.localMemberId());
+    this.staticConfiguration = staticConfiguration;
+    staticPartitionIdsByTenant =
+        staticConfiguration.partitionIds().stream()
+            .collect(Collectors.groupingBy(PartitionId::group));
+    replicationFactor = staticConfiguration.replicationFactor();
+  }
+
+  @Override
+  public ActorFuture<CurrentClusterConfiguration> modify(
+      final CurrentClusterConfiguration configuration) {
+    final var newTenantIds =
+        staticPartitionIdsByTenant.keySet().stream()
+            .filter(tenantId -> !configuration.partitionGroups().containsKey(tenantId))
+            .sorted()
+            .toList();
+    if (newTenantIds.isEmpty()) {
+      return CompletableActorFuture.completed(configuration);
+    }
+
+    try {
+      return CompletableActorFuture.completed(provisionTenants(configuration, newTenantIds));
+    } catch (final RuntimeException e) {
+      LOG.warn(
+          "Failed to provision new physical tenants {}; skipping them for now, they will be "
+              + "retried on the next configuration initialization",
+          newTenantIds,
+          e);
+      return CompletableActorFuture.completed(configuration);
+    }
+  }
+
+  /**
+   * Computes the target distribution for every new tenant's partitions in a single {@link
+   * AdditivePartitionReassigner} call, so their placement accounts for each other's load, then
+   * splits the result into one configuration change per new group.
+   */
+  private CurrentClusterConfiguration provisionTenants(
+      final CurrentClusterConfiguration configuration, final List<String> newTenantIds) {
+    final Set<MemberId> targetMembers =
+        Set.copyOf(configuration.globalConfiguration().members().keySet());
+    final var existingPartitionIds =
+        ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(configuration).values().stream()
+            .flatMap(Set::stream)
+            .map(PartitionMetadata::id)
+            .toList();
+    final var newPartitionIds =
+        newTenantIds.stream()
+            .flatMap(tenantId -> staticPartitionIdsByTenant.get(tenantId).stream());
+    final var targetPartitionIds =
+        Stream.concat(existingPartitionIds.stream(), newPartitionIds).toList();
+
+    final var targetDistribution =
+        reassigner.reassignPartitions(
+            configuration, targetMembers, targetPartitionIds, replicationFactor);
+
+    final Map<String, DynamicPartitionConfig> partitionConfigByNewGroup =
+        newTenantIds.stream()
+            .collect(
+                Collectors.toMap(
+                    tenantId -> tenantId, ignored -> staticConfiguration.partitionConfig()));
+    final var operationsByGroup =
+        PartitionReassignmentOperationsGenerator.generateOperations(
+            configuration, targetDistribution, partitionConfigByNewGroup);
+
+    var result = configuration;
+    for (final var newTenantId : newTenantIds) {
+      final List<PartitionGroupOperation> tenantOperations = operationsByGroup.get(newTenantId);
+      if (tenantOperations == null || tenantOperations.isEmpty()) {
+        LOG.warn(
+            "No operations were generated to provision new physical tenant '{}'; skipping it for "
+                + "now",
+            newTenantId);
+        continue;
+      }
+      result = addGroupAndStartChange(result, newTenantId, tenantOperations);
+    }
+    return result;
+  }
+
+  private CurrentClusterConfiguration addGroupAndStartChange(
+      final CurrentClusterConfiguration configuration,
+      final String newTenantId,
+      final List<PartitionGroupOperation> tenantOperations) {
+    final var updatedGroups = new HashMap<>(configuration.partitionGroups());
+    updatedGroups.put(
+        newTenantId,
+        PartitionGroupConfiguration.empty(PartitionGroupConfiguration.INITIAL_VERSION));
+    final var withEmptyGroup =
+        new CurrentClusterConfiguration(
+            configuration.version(),
+            configuration.globalConfiguration(),
+            updatedGroups,
+            configuration.phasedChangeState());
+
+    final List<ClusterConfigurationChangeOperation> operations = List.copyOf(tenantOperations);
+    return withEmptyGroup.updatePartitionGroupConfig(
+        newTenantId, group -> group.startConfigurationChange(operations));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializer.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.util.AdditivePartitionReassigner;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.PartitionReassignmentOperationsGenerator;
@@ -188,12 +189,14 @@ public class PhysicalTenantProvisioningInitializer
       // configured distributor instead. ZoneAwareDistribution uses round robin assignment that
       // means the existing tenants are also moved. Additive zone aware reassignment will be a
       // followup.
+      final var sortedPartitionIds =
+          targetPartitionIds.stream().sorted(PartitionId::compareTo).toList();
       return configuration
           .globalConfiguration()
           .partitionDistributorConfig()
           .get()
           .toDistributor()
-          .distributePartitions(targetMembers, targetPartitionIds, replicationFactor);
+          .distributePartitions(targetMembers, sortedPartitionIds, replicationFactor);
     }
 
     return reassigner.reassignPartitions(
@@ -207,7 +210,10 @@ public class PhysicalTenantProvisioningInitializer
     final var updatedGroups = new HashMap<>(configuration.partitionGroups());
     updatedGroups.put(
         newTenantId,
-        PartitionGroupConfiguration.empty(PartitionGroupConfiguration.INITIAL_VERSION));
+        PartitionGroupConfiguration.empty(PartitionGroupConfiguration.INITIAL_VERSION)
+            .setRoutingState(
+                RoutingState.initializeWithPartitionCount(
+                    staticPartitionIdsByTenant.get(newTenantId).size())));
     final var withEmptyGroup =
         new CurrentClusterConfiguration(
             configuration.version(),

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
@@ -16,15 +16,13 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
-import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
-import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRedistributionCompletion;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRelocationCompletion;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.StartPartitionScaleUp;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
+import io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -143,7 +141,7 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
     for (final PartitionId partition : oldPartitions) {
       final var newMetadata = newDistribution.get(partition);
       final var oldMetadata = oldDistribution.get(partition);
-      operations.addAll(movePartition(oldMetadata, newMetadata));
+      operations.addAll(PartitionReassignmentSupport.movePartition(oldMetadata, newMetadata));
     }
     final var hasNewPartitions = !newPartitions.isEmpty();
 
@@ -188,45 +186,6 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
       }
     }
 
-    return operations;
-  }
-
-  private List<ClusterConfigurationChangeOperation> movePartition(
-      final PartitionMetadata oldMetadata, final PartitionMetadata newMetadata) {
-    final Integer partitionId = newMetadata.id().number();
-    final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
-
-    final var membersToJoin =
-        newMetadata.members().stream()
-            .filter(member -> !oldMetadata.members().contains(member))
-            .map(
-                newMember ->
-                    new PartitionJoinOperation(
-                        newMember, partitionId, newMetadata.getPriority(newMember)))
-            .sorted(Comparator.comparing(ClusterConfigurationChangeOperation::memberId))
-            .toList();
-    final var membersToLeave =
-        oldMetadata.members().stream()
-            .filter(member -> !newMetadata.members().contains(member))
-            .map(oldMember -> new PartitionLeaveOperation(oldMember, partitionId, 1))
-            .sorted(Comparator.comparing(ClusterConfigurationChangeOperation::memberId))
-            .toList();
-    final var membersToChangePriority =
-        oldMetadata.members().stream()
-            .filter(memberId -> newMetadata.members().contains(memberId))
-            .filter(
-                memberId -> newMetadata.getPriority(memberId) != oldMetadata.getPriority(memberId))
-            .map(
-                memberId ->
-                    new PartitionReconfigurePriorityOperation(
-                        memberId, partitionId, newMetadata.getPriority(memberId)))
-            .sorted(Comparator.comparing(ClusterConfigurationChangeOperation::memberId))
-            .toList();
-
-    // TODO: interleave join and leave operation
-    operations.addAll(membersToJoin);
-    operations.addAll(membersToLeave);
-    operations.addAll(membersToChangePriority);
     return operations;
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGenerator.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGenerator.java
@@ -75,7 +75,8 @@ public final class PartitionReassignmentOperationsGenerator {
    *     actually needs a change — a target partition identical to its current state contributes no
    *     operations.
    * @throws IllegalArgumentException if a brand-new group in {@code targetDistribution} has no
-   *     corresponding entry in {@code partitionConfigByNewGroup}
+   *     corresponding entry in {@code partitionConfigByNewGroup}, or if {@code targetDistribution}
+   *     omits an existing partition id of a group it touches
    */
   public static Map<String, List<PartitionGroupOperation>> generateOperations(
       final CurrentClusterConfiguration currentConfiguration,
@@ -95,6 +96,16 @@ public final class PartitionReassignmentOperationsGenerator {
         targetGroups.stream()
             .flatMap(group -> distributionByGroup.getOrDefault(group, Set.of()).stream())
             .collect(Collectors.toMap(PartitionMetadata::id, Function.identity()));
+
+    // Every existing partition id of a group targetDistribution touches must be present in
+    // targetDistribution — mirroring AdditivePartitionReassigner/PartitionReassignmentSupport
+    // #validateNoRemoval. Without this, a targetDistribution that silently omits an existing
+    // partition (e.g. a caller-side bug, or a reassigner change that starts supporting removal
+    // without this generator being updated) would produce no leave operations for it at all: the
+    // partition would simply be left out of the result, never mentioned again, without any
+    // indication it was ever removed.
+    final var targetIds = targetDistribution.stream().map(PartitionMetadata::id).toList();
+    validateNoRemoval(distributionByGroup, targetGroups, targetIds);
 
     final Set<String> newGroups =
         targetGroups.stream()
@@ -144,6 +155,33 @@ public final class PartitionReassignmentOperationsGenerator {
               }
             });
     return operationsByGroup;
+  }
+
+  /**
+   * Validates that every existing partition id of every group in {@code targetGroups} is present in
+   * {@code targetIds}. Scoped to {@code targetGroups} rather than every group in {@code
+   * distributionByGroup}, matching this generator's existing convention of only ever reading/acting
+   * on groups that {@code targetDistribution} actually mentions — an untouched existing group is
+   * legitimately absent from {@code targetDistribution} and is not a removal.
+   */
+  private static void validateNoRemoval(
+      final Map<String, Set<PartitionMetadata>> distributionByGroup,
+      final Set<String> targetGroups,
+      final List<PartitionId> targetIds) {
+    final Set<PartitionId> targetIdSet = Set.copyOf(targetIds);
+    final var missing =
+        targetGroups.stream()
+            .flatMap(group -> distributionByGroup.getOrDefault(group, Set.of()).stream())
+            .map(PartitionMetadata::id)
+            .filter(id -> !targetIdSet.contains(id))
+            .toList();
+    if (!missing.isEmpty()) {
+      throw new IllegalArgumentException(
+          "targetDistribution must include every existing partition id of every group it "
+              + "touches — removing partitions or groups is not supported by this generator, but "
+              + "is missing: "
+              + missing);
+    }
   }
 
   /** A partition with no prior state: bootstrap the primary, then join every other member. */

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGenerator.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGenerator.java
@@ -15,8 +15,6 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
-import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
-import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -146,7 +144,7 @@ public final class PartitionReassignmentOperationsGenerator {
                         : Optional.empty();
                 operations = bootstrapPartition(target, config, !isNewGroup);
               } else {
-                operations = movePartition(current, target);
+                operations = PartitionReassignmentSupport.movePartition(current, target);
               }
               if (!operations.isEmpty()) {
                 operationsByGroup
@@ -203,53 +201,6 @@ public final class PartitionReassignmentOperationsGenerator {
         operations.add(new PartitionJoinOperation(member, partitionId, target.getPriority(member)));
       }
     }
-    return operations;
-  }
-
-  /**
-   * An existing partition changing shape: join new members, have removed members leave, and
-   * reconfigure the priority of any member present in both whose priority changed. A target
-   * identical to the current state produces no operations at all.
-   */
-  private static List<PartitionGroupOperation> movePartition(
-      final PartitionMetadata current, final PartitionMetadata target) {
-    final int partitionId = target.id().number();
-    final List<PartitionGroupOperation> operations = new ArrayList<>();
-
-    final var membersToJoin =
-        target.members().stream()
-            .filter(member -> !current.members().contains(member))
-            .map(
-                newMember ->
-                    (PartitionGroupOperation)
-                        new PartitionJoinOperation(
-                            newMember, partitionId, target.getPriority(newMember)))
-            .sorted(Comparator.comparing(PartitionGroupOperation::memberId))
-            .toList();
-    final var membersToLeave =
-        current.members().stream()
-            .filter(member -> !target.members().contains(member))
-            .map(
-                oldMember ->
-                    (PartitionGroupOperation)
-                        new PartitionLeaveOperation(oldMember, partitionId, 1))
-            .sorted(Comparator.comparing(PartitionGroupOperation::memberId))
-            .toList();
-    final var membersToChangePriority =
-        current.members().stream()
-            .filter(member -> target.members().contains(member))
-            .filter(member -> target.getPriority(member) != current.getPriority(member))
-            .map(
-                member ->
-                    (PartitionGroupOperation)
-                        new PartitionReconfigurePriorityOperation(
-                            member, partitionId, target.getPriority(member)))
-            .sorted(Comparator.comparing(PartitionGroupOperation::memberId))
-            .toList();
-
-    operations.addAll(membersToJoin);
-    operations.addAll(membersToLeave);
-    operations.addAll(membersToChangePriority);
     return operations;
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGenerator.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGenerator.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Generates the {@link PartitionGroupOperation}s needed to move a group's current partition
+ * distribution to a target distribution — typically one computed by a {@link PartitionReassigner}.
+ * This is the per-group-model, reusable counterpart of what {@code
+ * PartitionReassignRequestTransformer} does inline for the legacy single-group model: it does not
+ * itself decide *what* the target distribution should be (that's the reassigner's job) or *how* the
+ * resulting operations get applied (that's up to the caller — e.g. wrapping the result in a {@link
+ * io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase} and starting
+ * a pending change, whether from a bootstrap-time initializer or a runtime management-API request).
+ *
+ * <p>{@code targetDistribution} may span several groups; the current distribution for each group it
+ * touches is read from {@code currentConfiguration}. A group with no entry in {@code
+ * currentConfiguration} yet (i.e. every one of its ids is new — a brand-new physical tenant) is
+ * bootstrapped differently from a partition merely being added to an already-existing group:
+ *
+ * <ul>
+ *   <li>a brand-new group's lowest-numbered partition is bootstrapped with the {@link
+ *       DynamicPartitionConfig} supplied for it in {@code partitionConfigByNewGroup} — there is no
+ *       pre-existing partition in that group to inherit exporter/config state from, so leaving it
+ *       unspecified would silently start the tenant with an empty config instead of the one it was
+ *       actually configured with. The group's other new partitions omit the config and inherit it
+ *       from that first partition, same as {@link PartitionBootstrapOperation}'s default behavior.
+ *   <li>a brand-new group's partitions never set {@code initializeFromSnapshot} — there is no
+ *       existing data in the group to align with. A new partition added to an already-existing
+ *       group always does, matching {@code PartitionReassignRequestTransformer}'s behavior for
+ *       scaling up an existing group.
+ * </ul>
+ */
+public final class PartitionReassignmentOperationsGenerator {
+
+  private PartitionReassignmentOperationsGenerator() {}
+
+  /**
+   * @param currentConfiguration supplies the current distribution of every group present in {@code
+   *     targetDistribution}
+   * @param targetDistribution the desired distribution, e.g. computed by a {@link
+   *     PartitionReassigner}; may span multiple groups
+   * @param partitionConfigByNewGroup the {@link DynamicPartitionConfig} to bootstrap each brand-new
+   *     group's first partition with; must contain an entry for every group in {@code
+   *     targetDistribution} that has no current distribution at all. Groups that already exist are
+   *     not required to be present, since their new partitions inherit config from the group's
+   *     existing partitions instead.
+   * @return the operations needed to reach {@code targetDistribution}, grouped by {@link
+   *     PartitionId#group()}. A group only appears in the result if at least one of its partitions
+   *     actually needs a change — a target partition identical to its current state contributes no
+   *     operations.
+   * @throws IllegalArgumentException if a brand-new group in {@code targetDistribution} has no
+   *     corresponding entry in {@code partitionConfigByNewGroup}, or if {@code targetDistribution}
+   *     omits an existing partition id of a group it touches
+   */
+  public static Map<String, List<PartitionGroupOperation>> generateOperations(
+      final CurrentClusterConfiguration currentConfiguration,
+      final Set<PartitionMetadata> targetDistribution,
+      final Map<String, DynamicPartitionConfig> partitionConfigByNewGroup) {
+    if (targetDistribution.isEmpty()) {
+      return Map.of();
+    }
+
+    final Set<String> targetGroups =
+        targetDistribution.stream()
+            .map(metadata -> metadata.id().group())
+            .collect(Collectors.toSet());
+    final Map<String, Set<PartitionMetadata>> distributionByGroup =
+        ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(currentConfiguration);
+    final Map<PartitionId, PartitionMetadata> currentById =
+        targetGroups.stream()
+            .flatMap(group -> distributionByGroup.getOrDefault(group, Set.of()).stream())
+            .collect(Collectors.toMap(PartitionMetadata::id, Function.identity()));
+
+    // Every existing partition id of a group targetDistribution touches must be present in
+    // targetDistribution — mirroring AdditivePartitionReassigner/PartitionReassignmentSupport
+    // #validateNoRemoval. Without this, a targetDistribution that silently omits an existing
+    // partition (e.g. a caller-side bug, or a reassigner change that starts supporting removal
+    // without this generator being updated) would produce no leave operations for it at all: the
+    // partition would simply be left out of the result, never mentioned again, without any
+    // indication it was ever removed.
+    final var targetIds = targetDistribution.stream().map(PartitionMetadata::id).toList();
+    validateNoRemoval(distributionByGroup, targetGroups, targetIds);
+
+    final Set<String> newGroups =
+        targetGroups.stream()
+            .filter(group -> distributionByGroup.getOrDefault(group, Set.of()).isEmpty())
+            .collect(Collectors.toSet());
+    final var missingConfig =
+        newGroups.stream().filter(group -> !partitionConfigByNewGroup.containsKey(group)).toList();
+    if (!missingConfig.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Expected partitionConfigByNewGroup to contain an entry for every brand-new group, but "
+              + "missing: "
+              + missingConfig);
+    }
+
+    final Map<String, Integer> firstPartitionNumberByNewGroup = new HashMap<>();
+    targetDistribution.stream()
+        .filter(metadata -> newGroups.contains(metadata.id().group()))
+        .forEach(
+            metadata ->
+                firstPartitionNumberByNewGroup.merge(
+                    metadata.id().group(), metadata.id().number(), Math::min));
+
+    final Map<String, List<PartitionGroupOperation>> operationsByGroup = new LinkedHashMap<>();
+    targetDistribution.stream()
+        .sorted(Comparator.comparing(PartitionMetadata::id))
+        .forEach(
+            target -> {
+              final var current = currentById.get(target.id());
+              final List<PartitionGroupOperation> operations;
+              if (current == null) {
+                final String group = target.id().group();
+                final boolean isNewGroup = newGroups.contains(group);
+                final boolean isFirstPartitionOfNewGroup =
+                    isNewGroup && target.id().number() == firstPartitionNumberByNewGroup.get(group);
+                final Optional<DynamicPartitionConfig> config =
+                    isFirstPartitionOfNewGroup
+                        ? Optional.of(partitionConfigByNewGroup.get(group))
+                        : Optional.empty();
+                operations = bootstrapPartition(target, config, !isNewGroup);
+              } else {
+                operations = movePartition(current, target);
+              }
+              if (!operations.isEmpty()) {
+                operationsByGroup
+                    .computeIfAbsent(target.id().group(), group -> new ArrayList<>())
+                    .addAll(operations);
+              }
+            });
+    return operationsByGroup;
+  }
+
+  /**
+   * Validates that every existing partition id of every group in {@code targetGroups} is present in
+   * {@code targetIds}. Scoped to {@code targetGroups} rather than every group in {@code
+   * distributionByGroup}, matching this generator's existing convention of only ever reading/acting
+   * on groups that {@code targetDistribution} actually mentions — an untouched existing group is
+   * legitimately absent from {@code targetDistribution} and is not a removal.
+   */
+  private static void validateNoRemoval(
+      final Map<String, Set<PartitionMetadata>> distributionByGroup,
+      final Set<String> targetGroups,
+      final List<PartitionId> targetIds) {
+    final Set<PartitionId> targetIdSet = Set.copyOf(targetIds);
+    final var missing =
+        targetGroups.stream()
+            .flatMap(group -> distributionByGroup.getOrDefault(group, Set.of()).stream())
+            .map(PartitionMetadata::id)
+            .filter(id -> !targetIdSet.contains(id))
+            .toList();
+    if (!missing.isEmpty()) {
+      throw new IllegalArgumentException(
+          "targetDistribution must include every existing partition id of every group it "
+              + "touches — removing partitions or groups is not supported by this generator, but "
+              + "is missing: "
+              + missing);
+    }
+  }
+
+  /** A partition with no prior state: bootstrap the primary, then join every other member. */
+  private static List<PartitionGroupOperation> bootstrapPartition(
+      final PartitionMetadata target,
+      final Optional<DynamicPartitionConfig> config,
+      final boolean initializeFromSnapshot) {
+    final int partitionId = target.id().number();
+    final List<PartitionGroupOperation> operations = new ArrayList<>();
+
+    final var primary =
+        target.getPrimary().orElse(target.members().stream().findAny().orElseThrow());
+    operations.add(
+        new PartitionBootstrapOperation(
+            primary, partitionId, target.getPriority(primary), config, initializeFromSnapshot));
+
+    for (final MemberId member : target.members().stream().sorted().toList()) {
+      if (!member.equals(primary)) {
+        operations.add(new PartitionJoinOperation(member, partitionId, target.getPriority(member)));
+      }
+    }
+    return operations;
+  }
+
+  /**
+   * An existing partition changing shape: join new members, have removed members leave, and
+   * reconfigure the priority of any member present in both whose priority changed. A target
+   * identical to the current state produces no operations at all.
+   */
+  private static List<PartitionGroupOperation> movePartition(
+      final PartitionMetadata current, final PartitionMetadata target) {
+    final int partitionId = target.id().number();
+    final List<PartitionGroupOperation> operations = new ArrayList<>();
+
+    final var membersToJoin =
+        target.members().stream()
+            .filter(member -> !current.members().contains(member))
+            .map(
+                newMember ->
+                    (PartitionGroupOperation)
+                        new PartitionJoinOperation(
+                            newMember, partitionId, target.getPriority(newMember)))
+            .sorted(Comparator.comparing(PartitionGroupOperation::memberId))
+            .toList();
+    final var membersToLeave =
+        current.members().stream()
+            .filter(member -> !target.members().contains(member))
+            .map(
+                oldMember ->
+                    (PartitionGroupOperation)
+                        new PartitionLeaveOperation(oldMember, partitionId, 1))
+            .sorted(Comparator.comparing(PartitionGroupOperation::memberId))
+            .toList();
+    final var membersToChangePriority =
+        current.members().stream()
+            .filter(member -> target.members().contains(member))
+            .filter(member -> target.getPriority(member) != current.getPriority(member))
+            .map(
+                member ->
+                    (PartitionGroupOperation)
+                        new PartitionReconfigurePriorityOperation(
+                            member, partitionId, target.getPriority(member)))
+            .sorted(Comparator.comparing(PartitionGroupOperation::memberId))
+            .toList();
+
+    operations.addAll(membersToJoin);
+    operations.addAll(membersToLeave);
+    operations.addAll(membersToChangePriority);
+    return operations;
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGenerator.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGenerator.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Generates the {@link PartitionGroupOperation}s needed to move a group's current partition
+ * distribution to a target distribution — typically one computed by a {@link PartitionReassigner}.
+ * This is the per-group-model, reusable counterpart of what {@code
+ * PartitionReassignRequestTransformer} does inline for the legacy single-group model: it does not
+ * itself decide *what* the target distribution should be (that's the reassigner's job) or *how* the
+ * resulting operations get applied (that's up to the caller — e.g. wrapping the result in a {@link
+ * io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase} and starting
+ * a pending change, whether from a bootstrap-time initializer or a runtime management-API request).
+ *
+ * <p>{@code targetDistribution} may span several groups; the current distribution for each group it
+ * touches is read from {@code currentConfiguration}. A group with no entry in {@code
+ * currentConfiguration} yet (i.e. every one of its ids is new — a brand-new physical tenant) is
+ * bootstrapped differently from a partition merely being added to an already-existing group:
+ *
+ * <ul>
+ *   <li>a brand-new group's lowest-numbered partition is bootstrapped with the {@link
+ *       DynamicPartitionConfig} supplied for it in {@code partitionConfigByNewGroup} — there is no
+ *       pre-existing partition in that group to inherit exporter/config state from, so leaving it
+ *       unspecified would silently start the tenant with an empty config instead of the one it was
+ *       actually configured with. The group's other new partitions omit the config and inherit it
+ *       from that first partition, same as {@link PartitionBootstrapOperation}'s default behavior.
+ *   <li>a brand-new group's partitions never set {@code initializeFromSnapshot} — there is no
+ *       existing data in the group to align with. A new partition added to an already-existing
+ *       group always does, matching {@code PartitionReassignRequestTransformer}'s behavior for
+ *       scaling up an existing group.
+ * </ul>
+ */
+public final class PartitionReassignmentOperationsGenerator {
+
+  private PartitionReassignmentOperationsGenerator() {}
+
+  /**
+   * @param currentConfiguration supplies the current distribution of every group present in {@code
+   *     targetDistribution}
+   * @param targetDistribution the desired distribution, e.g. computed by a {@link
+   *     PartitionReassigner}; may span multiple groups
+   * @param partitionConfigByNewGroup the {@link DynamicPartitionConfig} to bootstrap each brand-new
+   *     group's first partition with; must contain an entry for every group in {@code
+   *     targetDistribution} that has no current distribution at all. Groups that already exist are
+   *     not required to be present, since their new partitions inherit config from the group's
+   *     existing partitions instead.
+   * @return the operations needed to reach {@code targetDistribution}, grouped by {@link
+   *     PartitionId#group()}. A group only appears in the result if at least one of its partitions
+   *     actually needs a change — a target partition identical to its current state contributes no
+   *     operations.
+   * @throws IllegalArgumentException if a brand-new group in {@code targetDistribution} has no
+   *     corresponding entry in {@code partitionConfigByNewGroup}
+   */
+  public static Map<String, List<PartitionGroupOperation>> generateOperations(
+      final CurrentClusterConfiguration currentConfiguration,
+      final Set<PartitionMetadata> targetDistribution,
+      final Map<String, DynamicPartitionConfig> partitionConfigByNewGroup) {
+    if (targetDistribution.isEmpty()) {
+      return Map.of();
+    }
+
+    final Set<String> targetGroups =
+        targetDistribution.stream()
+            .map(metadata -> metadata.id().group())
+            .collect(Collectors.toSet());
+    final Map<String, Set<PartitionMetadata>> distributionByGroup =
+        ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(currentConfiguration);
+    final Map<PartitionId, PartitionMetadata> currentById =
+        targetGroups.stream()
+            .flatMap(group -> distributionByGroup.getOrDefault(group, Set.of()).stream())
+            .collect(Collectors.toMap(PartitionMetadata::id, Function.identity()));
+
+    final Set<String> newGroups =
+        targetGroups.stream()
+            .filter(group -> distributionByGroup.getOrDefault(group, Set.of()).isEmpty())
+            .collect(Collectors.toSet());
+    final var missingConfig =
+        newGroups.stream().filter(group -> !partitionConfigByNewGroup.containsKey(group)).toList();
+    if (!missingConfig.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Expected partitionConfigByNewGroup to contain an entry for every brand-new group, but "
+              + "missing: "
+              + missingConfig);
+    }
+
+    final Map<String, Integer> firstPartitionNumberByNewGroup = new HashMap<>();
+    targetDistribution.stream()
+        .filter(metadata -> newGroups.contains(metadata.id().group()))
+        .forEach(
+            metadata ->
+                firstPartitionNumberByNewGroup.merge(
+                    metadata.id().group(), metadata.id().number(), Math::min));
+
+    final Map<String, List<PartitionGroupOperation>> operationsByGroup = new LinkedHashMap<>();
+    targetDistribution.stream()
+        .sorted(Comparator.comparing(PartitionMetadata::id))
+        .forEach(
+            target -> {
+              final var current = currentById.get(target.id());
+              final List<PartitionGroupOperation> operations;
+              if (current == null) {
+                final String group = target.id().group();
+                final boolean isNewGroup = newGroups.contains(group);
+                final boolean isFirstPartitionOfNewGroup =
+                    isNewGroup && target.id().number() == firstPartitionNumberByNewGroup.get(group);
+                final Optional<DynamicPartitionConfig> config =
+                    isFirstPartitionOfNewGroup
+                        ? Optional.of(partitionConfigByNewGroup.get(group))
+                        : Optional.empty();
+                operations = bootstrapPartition(target, config, !isNewGroup);
+              } else {
+                operations = movePartition(current, target);
+              }
+              if (!operations.isEmpty()) {
+                operationsByGroup
+                    .computeIfAbsent(target.id().group(), group -> new ArrayList<>())
+                    .addAll(operations);
+              }
+            });
+    return operationsByGroup;
+  }
+
+  /** A partition with no prior state: bootstrap the primary, then join every other member. */
+  private static List<PartitionGroupOperation> bootstrapPartition(
+      final PartitionMetadata target,
+      final Optional<DynamicPartitionConfig> config,
+      final boolean initializeFromSnapshot) {
+    final int partitionId = target.id().number();
+    final List<PartitionGroupOperation> operations = new ArrayList<>();
+
+    final var primary =
+        target.getPrimary().orElse(target.members().stream().findAny().orElseThrow());
+    operations.add(
+        new PartitionBootstrapOperation(
+            primary, partitionId, target.getPriority(primary), config, initializeFromSnapshot));
+
+    for (final MemberId member : target.members().stream().sorted().toList()) {
+      if (!member.equals(primary)) {
+        operations.add(new PartitionJoinOperation(member, partitionId, target.getPriority(member)));
+      }
+    }
+    return operations;
+  }
+
+  /**
+   * An existing partition changing shape: join new members, have removed members leave, and
+   * reconfigure the priority of any member present in both whose priority changed. A target
+   * identical to the current state produces no operations at all.
+   */
+  private static List<PartitionGroupOperation> movePartition(
+      final PartitionMetadata current, final PartitionMetadata target) {
+    final int partitionId = target.id().number();
+    final List<PartitionGroupOperation> operations = new ArrayList<>();
+
+    final var membersToJoin =
+        target.members().stream()
+            .filter(member -> !current.members().contains(member))
+            .map(
+                newMember ->
+                    (PartitionGroupOperation)
+                        new PartitionJoinOperation(
+                            newMember, partitionId, target.getPriority(newMember)))
+            .sorted(Comparator.comparing(PartitionGroupOperation::memberId))
+            .toList();
+    final var membersToLeave =
+        current.members().stream()
+            .filter(member -> !target.members().contains(member))
+            .map(
+                oldMember ->
+                    (PartitionGroupOperation)
+                        new PartitionLeaveOperation(oldMember, partitionId, 1))
+            .sorted(Comparator.comparing(PartitionGroupOperation::memberId))
+            .toList();
+    final var membersToChangePriority =
+        current.members().stream()
+            .filter(member -> target.members().contains(member))
+            .filter(member -> target.getPriority(member) != current.getPriority(member))
+            .map(
+                member ->
+                    (PartitionGroupOperation)
+                        new PartitionReconfigurePriorityOperation(
+                            member, partitionId, target.getPriority(member)))
+            .sorted(Comparator.comparing(PartitionGroupOperation::memberId))
+            .toList();
+
+    operations.addAll(membersToJoin);
+    operations.addAll(membersToLeave);
+    operations.addAll(membersToChangePriority);
+    return operations;
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentSupport.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentSupport.java
@@ -10,7 +10,12 @@ package io.camunda.zeebe.dynamic.config.util;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -20,7 +25,7 @@ import java.util.Queue;
 import java.util.Set;
 
 /** Shared helpers used by {@link PartitionReassigner} implementations. */
-final class PartitionReassignmentSupport {
+public final class PartitionReassignmentSupport {
 
   private PartitionReassignmentSupport() {}
 
@@ -334,6 +339,53 @@ final class PartitionReassignmentSupport {
                   .map(PartitionMetadata::id)
                   .toList());
     }
+  }
+
+  /**
+   * An existing partition changing shape: join new members, have removed members leave, and
+   * reconfigure the priority of any member present in both whose priority changed. A target
+   * identical to the current state produces no operations at all.
+   */
+  public static List<PartitionGroupOperation> movePartition(
+      final PartitionMetadata current, final PartitionMetadata target) {
+    final int partitionId = target.id().number();
+    final List<PartitionGroupOperation> operations = new ArrayList<>();
+
+    final var membersToJoin =
+        target.members().stream()
+            .filter(member -> !current.members().contains(member))
+            .map(
+                newMember ->
+                    (PartitionGroupOperation)
+                        new PartitionJoinOperation(
+                            newMember, partitionId, target.getPriority(newMember)))
+            .sorted(Comparator.comparing(PartitionGroupOperation::memberId))
+            .toList();
+    final var membersToLeave =
+        current.members().stream()
+            .filter(member -> !target.members().contains(member))
+            .map(
+                oldMember ->
+                    (PartitionGroupOperation)
+                        new PartitionLeaveOperation(oldMember, partitionId, 1))
+            .sorted(Comparator.comparing(PartitionGroupOperation::memberId))
+            .toList();
+    final var membersToChangePriority =
+        current.members().stream()
+            .filter(member -> target.members().contains(member))
+            .filter(member -> target.getPriority(member) != current.getPriority(member))
+            .map(
+                member ->
+                    (PartitionGroupOperation)
+                        new PartitionReconfigurePriorityOperation(
+                            member, partitionId, target.getPriority(member)))
+            .sorted(Comparator.comparing(PartitionGroupOperation::memberId))
+            .toList();
+
+    operations.addAll(membersToJoin);
+    operations.addAll(membersToLeave);
+    operations.addAll(membersToChangePriority);
+    return operations;
   }
 
   /**

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializerTest.java
@@ -20,6 +20,8 @@ import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import java.util.HashMap;
@@ -51,9 +53,13 @@ final class PhysicalTenantProvisioningInitializerTest {
             partition("tenantA", 1, Set.of(member(0), member(1)), member(0)),
             partition("tenantA", 2, Set.of(member(0), member(1)), member(1)));
     final var configuration = configurationWith(existingTenantA);
+    final int tenantBPartitionCount = 2;
     final var staticConfiguration =
         staticConfigWith(
-            List.of(tenantPartitionIds("tenantA", 2), tenantPartitionIds("tenantB", 2)), 2);
+            List.of(
+                tenantPartitionIds("tenantA", 2),
+                tenantPartitionIds("tenantB", tenantBPartitionCount)),
+            2);
     final var initializer = new PhysicalTenantProvisioningInitializer(staticConfiguration);
 
     // when
@@ -62,6 +68,14 @@ final class PhysicalTenantProvisioningInitializerTest {
     // then — tenantB now has an empty-but-provisioned group with a pending change to place its
     // partitions, while tenantA is completely untouched
     assertThat(result.partitionGroups()).containsKey("tenantB");
+    assertThat(result.partitionGroup("tenantB").routingState())
+        .hasValueSatisfying(
+            routingState -> {
+              assertThat(routingState.messageCorrelation())
+                  .isEqualTo(new MessageCorrelation.HashMod(tenantBPartitionCount));
+              assertThat(routingState.requestHandling())
+                  .isEqualTo(new AllPartitions(tenantBPartitionCount));
+            });
     assertThat(result.partitionGroup("tenantB").hasPendingChanges()).isTrue();
     assertThat(result.partitionGroups().get("tenantA"))
         .isEqualTo(configuration.partitionGroups().get("tenantA"));

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializerTest.java
@@ -51,7 +51,7 @@ final class PhysicalTenantProvisioningInitializerTest {
     final var configuration = configurationWith(existingTenantA);
     final var staticConfiguration =
         staticConfigWith(
-            List.of(tenantPartitionIds("tenantA", 2), tenantPartitionIds("tenantB", 2)));
+            List.of(tenantPartitionIds("tenantA", 2), tenantPartitionIds("tenantB", 2)), 2);
     final var initializer = new PhysicalTenantProvisioningInitializer(staticConfiguration);
 
     // when
@@ -168,6 +168,11 @@ final class PhysicalTenantProvisioningInitializerTest {
   }
 
   private StaticConfiguration staticConfigWith(final List<List<PartitionId>> tenantPartitionIds) {
+    return staticConfigWith(tenantPartitionIds, 1);
+  }
+
+  private StaticConfiguration staticConfigWith(
+      final List<List<PartitionId>> tenantPartitionIds, final int replicationFactor) {
     final List<PartitionId> allPartitionIds =
         tenantPartitionIds.stream().flatMap(List::stream).toList();
     return new StaticConfiguration(
@@ -175,7 +180,7 @@ final class PhysicalTenantProvisioningInitializerTest {
         Set.of(member(0), member(1), member(2)),
         LOCAL_MEMBER_ID,
         allPartitionIds,
-        1,
+        replicationFactor,
         partitionConfig,
         "clusterId");
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializerTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
+import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+final class PhysicalTenantProvisioningInitializerTest {
+
+  private static final MemberId LOCAL_MEMBER_ID = MemberId.from("0");
+
+  private final DynamicPartitionConfig partitionConfig =
+      new DynamicPartitionConfig(
+          new ExportingConfig(
+              ExportingState.EXPORTING,
+              Map.of("expA", new ExporterState(1, ExporterState.State.ENABLED, Optional.empty()))));
+
+  @Test
+  void shouldProvisionANewPhysicalTenantNotYetInTheConfiguration() {
+    // given — tenantA already exists; the static configuration additionally lists tenantB, which
+    // has no partition group yet
+    final var existingTenantA =
+        Set.of(
+            partition("tenantA", 1, Set.of(member(0), member(1)), member(0)),
+            partition("tenantA", 2, Set.of(member(0), member(1)), member(1)));
+    final var configuration = configurationWith(existingTenantA);
+    final var staticConfiguration =
+        staticConfigWith(
+            List.of(tenantPartitionIds("tenantA", 2), tenantPartitionIds("tenantB", 2)));
+    final var initializer = new PhysicalTenantProvisioningInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then — tenantB now has an empty-but-provisioned group with a pending change to place its
+    // partitions, while tenantA is completely untouched
+    assertThat(result.partitionGroups()).containsKey("tenantB");
+    assertThat(result.partitionGroup("tenantB").hasPendingChanges()).isTrue();
+    assertThat(result.partitionGroups().get("tenantA"))
+        .isEqualTo(configuration.partitionGroups().get("tenantA"));
+  }
+
+  @Test
+  void shouldNotChangeAnythingWhenNoNewPhysicalTenantExists() {
+    // given — static configuration matches the current configuration exactly
+    final var existingTenantA =
+        Set.of(partition("tenantA", 1, Set.of(member(0), member(1)), member(0)));
+    final var configuration = configurationWith(existingTenantA);
+    final var staticConfiguration = staticConfigWith(List.of(tenantPartitionIds("tenantA", 1)));
+    final var initializer = new PhysicalTenantProvisioningInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then
+    assertThat(result).isEqualTo(configuration);
+  }
+
+  @Test
+  void shouldNotTouchAGroupWhosePhysicalTenantWasRemovedFromStaticConfiguration() {
+    // given — tenantA exists in the configuration, but the static configuration no longer lists it
+    final var existingTenantA =
+        Set.of(partition("tenantA", 1, Set.of(member(0), member(1)), member(0)));
+    final var configuration = configurationWith(existingTenantA);
+    final var staticConfiguration = staticConfigWith(List.of());
+    final var initializer = new PhysicalTenantProvisioningInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then — tenantA is left exactly as-is, no removal attempted
+    assertThat(result).isEqualTo(configuration);
+  }
+
+  @Test
+  void shouldProvisionMultipleNewPhysicalTenantsInOnePass() {
+    // given — no existing groups at all; static configuration lists two brand-new tenants
+    final var configuration = configurationWith(Set.of());
+    final var staticConfiguration =
+        staticConfigWith(
+            List.of(tenantPartitionIds("tenantA", 2), tenantPartitionIds("tenantB", 2)));
+    final var initializer = new PhysicalTenantProvisioningInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then
+    assertThat(result.partitionGroups()).containsKeys("tenantA", "tenantB");
+    assertThat(result.partitionGroup("tenantA").hasPendingChanges()).isTrue();
+    assertThat(result.partitionGroup("tenantB").hasPendingChanges()).isTrue();
+  }
+
+  @Test
+  void shouldBalanceNewTenantsAgainstEachOtherNotJustAgainstExistingLoad() {
+    // given — no existing groups at all, so every member starts equally (un)loaded; two brand-new
+    // single-partition tenants are provisioned in the same pass
+    final var configuration = configurationWith(Set.of());
+    final var staticConfiguration =
+        staticConfigWith(
+            List.of(tenantPartitionIds("tenantA", 1), tenantPartitionIds("tenantB", 1)));
+    final var initializer = new PhysicalTenantProvisioningInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then — tenantA's and tenantB's sole partitions land on different members. If each tenant's
+    // placement were computed in its own separate reassignPartitions call (rather than one joint
+    // call covering both), neither call would see the other's still-JOINING partition as load, and
+    // both would independently pick the very same least-loaded member — piling both brand-new
+    // tenants onto the same broker instead of spreading them out.
+    final var tenantAOperations =
+        result.partitionGroup("tenantA").pendingChanges().orElseThrow().pendingOperations();
+    final var tenantBOperations =
+        result.partitionGroup("tenantB").pendingChanges().orElseThrow().pendingOperations();
+    final var tenantATarget = bootstrapTargetMember(tenantAOperations);
+    final var tenantBTarget = bootstrapTargetMember(tenantBOperations);
+    assertThat(tenantATarget).isNotEqualTo(tenantBTarget);
+  }
+
+  @Test
+  void shouldSkipTheWholeBatchWhenReassignmentFailsAndRetryLater() {
+    // given — replication factor 5, but the live cluster only has 2 members, so no valid
+    // placement exists for tenantA at all
+    final var configuration = configurationWith(Set.of());
+    final var staticConfiguration =
+        new StaticConfiguration(
+            new RoundRobinPartitionDistributor(),
+            Set.of(member(0), member(1)),
+            LOCAL_MEMBER_ID,
+            List.of(new PartitionId("tenantA", 1), new PartitionId("tenantA", 2)),
+            5,
+            partitionConfig,
+            "clusterId");
+    final var initializer = new PhysicalTenantProvisioningInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then — the joint reassignment computation throws (only 2 live members, RF 5), so the whole
+    // batch is skipped and the configuration is returned unchanged instead of propagating the
+    // exception out of modify()
+    assertThat(result).isEqualTo(configuration);
+  }
+
+  private StaticConfiguration staticConfigWith(final List<List<PartitionId>> tenantPartitionIds) {
+    final List<PartitionId> allPartitionIds =
+        tenantPartitionIds.stream().flatMap(List::stream).toList();
+    return new StaticConfiguration(
+        new RoundRobinPartitionDistributor(),
+        Set.of(member(0), member(1), member(2)),
+        LOCAL_MEMBER_ID,
+        allPartitionIds,
+        1,
+        partitionConfig,
+        "clusterId");
+  }
+
+  private MemberId bootstrapTargetMember(
+      final List<ClusterConfigurationChangeOperation> operations) {
+    return operations.stream()
+        .filter(op -> op instanceof PartitionBootstrapOperation)
+        .map(op -> ((PartitionBootstrapOperation) op).memberId())
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private List<PartitionId> tenantPartitionIds(final String tenantId, final int count) {
+    return IntStream.rangeClosed(1, count)
+        .mapToObj(number -> new PartitionId(tenantId, number))
+        .toList();
+  }
+
+  private CurrentClusterConfiguration configurationWith(final Set<PartitionMetadata> existing) {
+    final Set<MemberId> members = new HashSet<>();
+    existing.forEach(metadata -> members.addAll(metadata.members()));
+    // ensure the configuration always has members 0-2 available as live cluster members
+    for (int i = 0; i < 3; i++) {
+      members.add(member(i));
+    }
+    return ConfigurationUtil.getCurrentClusterConfigurationFrom(
+        members, existing, partitionConfig, "clusterId");
+  }
+
+  /**
+   * Builds a partition with a real, non-tied priority ladder (primary gets {@code members.size()},
+   * every other member gets a strictly lower, distinct priority) so round-tripping through {@link
+   * ConfigurationUtil} preserves the given primary exactly.
+   */
+  private PartitionMetadata partition(
+      final String group, final int number, final Set<MemberId> members, final MemberId primary) {
+    final Map<MemberId, Integer> priorities = new HashMap<>();
+    priorities.put(primary, members.size());
+    int nextPriority = members.size() - 1;
+    for (final var member : members.stream().sorted().toList()) {
+      if (!member.equals(primary)) {
+        priorities.put(member, nextPriority--);
+      }
+    }
+    return new PartitionMetadata(
+        new PartitionId(group, number), members, priorities, priorities.get(primary), primary);
+  }
+
+  private MemberId member(final int id) {
+    return MemberId.from(String.valueOf(id));
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializerTest.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
+import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+final class PhysicalTenantProvisioningInitializerTest {
+
+  private static final MemberId LOCAL_MEMBER_ID = MemberId.from("0");
+
+  private final DynamicPartitionConfig partitionConfig =
+      new DynamicPartitionConfig(
+          new ExportingConfig(
+              ExportingState.EXPORTING,
+              Map.of("expA", new ExporterState(1, ExporterState.State.ENABLED, Optional.empty()))));
+
+  @Test
+  void shouldProvisionANewPhysicalTenantNotYetInTheConfiguration() {
+    // given — tenantA already exists; the static configuration additionally lists tenantB, which
+    // has no partition group yet
+    final var existingTenantA =
+        Set.of(
+            partition("tenantA", 1, Set.of(member(0), member(1)), member(0)),
+            partition("tenantA", 2, Set.of(member(0), member(1)), member(1)));
+    final var configuration = configurationWith(existingTenantA);
+    final var staticConfiguration =
+        staticConfigWith(
+            List.of(tenantPartitionIds("tenantA", 2), tenantPartitionIds("tenantB", 2)), 2);
+    final var initializer = new PhysicalTenantProvisioningInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then — tenantB now has an empty-but-provisioned group with a pending change to place its
+    // partitions, while tenantA is completely untouched
+    assertThat(result.partitionGroups()).containsKey("tenantB");
+    assertThat(result.partitionGroup("tenantB").hasPendingChanges()).isTrue();
+    assertThat(result.partitionGroups().get("tenantA"))
+        .isEqualTo(configuration.partitionGroups().get("tenantA"));
+  }
+
+  @Test
+  void shouldNotChangeAnythingWhenNoNewPhysicalTenantExists() {
+    // given — static configuration matches the current configuration exactly
+    final var existingTenantA =
+        Set.of(partition("tenantA", 1, Set.of(member(0), member(1)), member(0)));
+    final var configuration = configurationWith(existingTenantA);
+    final var staticConfiguration = staticConfigWith(List.of(tenantPartitionIds("tenantA", 1)));
+    final var initializer = new PhysicalTenantProvisioningInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then
+    assertThat(result).isEqualTo(configuration);
+  }
+
+  @Test
+  void shouldNotTouchAGroupWhosePhysicalTenantWasRemovedFromStaticConfiguration() {
+    // given — tenantA exists in the configuration, but the static configuration no longer lists it
+    final var existingTenantA =
+        Set.of(partition("tenantA", 1, Set.of(member(0), member(1)), member(0)));
+    final var configuration = configurationWith(existingTenantA);
+    final var staticConfiguration = staticConfigWith(List.of());
+    final var initializer = new PhysicalTenantProvisioningInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then — tenantA is left exactly as-is, no removal attempted
+    assertThat(result).isEqualTo(configuration);
+  }
+
+  @Test
+  void shouldProvisionMultipleNewPhysicalTenantsInOnePass() {
+    // given — no existing groups at all; static configuration lists two brand-new tenants
+    final var configuration = configurationWith(Set.of());
+    final var staticConfiguration =
+        staticConfigWith(
+            List.of(tenantPartitionIds("tenantA", 2), tenantPartitionIds("tenantB", 2)));
+    final var initializer = new PhysicalTenantProvisioningInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then
+    assertThat(result.partitionGroups()).containsKeys("tenantA", "tenantB");
+    assertThat(result.partitionGroup("tenantA").hasPendingChanges()).isTrue();
+    assertThat(result.partitionGroup("tenantB").hasPendingChanges()).isTrue();
+  }
+
+  @Test
+  void shouldBalanceNewTenantsAgainstEachOtherNotJustAgainstExistingLoad() {
+    // given — no existing groups at all, so every member starts equally (un)loaded; two brand-new
+    // single-partition tenants are provisioned in the same pass
+    final var configuration = configurationWith(Set.of());
+    final var staticConfiguration =
+        staticConfigWith(
+            List.of(tenantPartitionIds("tenantA", 1), tenantPartitionIds("tenantB", 1)));
+    final var initializer = new PhysicalTenantProvisioningInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then — tenantA's and tenantB's sole partitions land on different members. If each tenant's
+    // placement were computed in its own separate reassignPartitions call (rather than one joint
+    // call covering both), neither call would see the other's still-JOINING partition as load, and
+    // both would independently pick the very same least-loaded member — piling both brand-new
+    // tenants onto the same broker instead of spreading them out.
+    final var tenantAOperations =
+        result.partitionGroup("tenantA").pendingChanges().orElseThrow().pendingOperations();
+    final var tenantBOperations =
+        result.partitionGroup("tenantB").pendingChanges().orElseThrow().pendingOperations();
+    final var tenantATarget = bootstrapTargetMember(tenantAOperations);
+    final var tenantBTarget = bootstrapTargetMember(tenantBOperations);
+    assertThat(tenantATarget).isNotEqualTo(tenantBTarget);
+  }
+
+  @Test
+  void shouldNotPlaceNewTenantPartitionsOnLeftOrUninitializedMembers() {
+    // given — members 0-2 are live (ACTIVE) but already loaded with tenantX's partitions; member
+    // 8 has never joined (UNINITIALIZED) and member 9 has left the cluster (LEFT) — both are still
+    // present in globalConfiguration().members(), just not live, and both are otherwise completely
+    // unloaded. If they weren't excluded from the candidate set, the reassigner's least-loaded
+    // tie-break would pick one of them over the more-loaded but live members 0-2.
+    final var existingTenantX =
+        Set.of(
+            partition("tenantX", 1, Set.of(member(0)), member(0)),
+            partition("tenantX", 2, Set.of(member(1)), member(1)),
+            partition("tenantX", 3, Set.of(member(2)), member(2)));
+    final var uninitializedMember = member(8);
+    final var leftMember = member(9);
+    final var baseConfiguration = configurationWith(existingTenantX);
+    final var configuration =
+        baseConfiguration.updateGlobalConfiguration(
+            global ->
+                global
+                    .addMember(uninitializedMember, BrokerState.uninitialized())
+                    .addMember(
+                        leftMember,
+                        BrokerState.initializeAsActive().setState(BrokerState.State.LEFT)));
+    final var staticConfiguration = staticConfigWith(List.of(tenantPartitionIds("tenantA", 1)), 1);
+    final var initializer = new PhysicalTenantProvisioningInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then — the new tenant's sole partition still lands on one of the loaded-but-live members
+    // 0-2, never on the unloaded-but-not-live members 8/9
+    final var operations =
+        result.partitionGroup("tenantA").pendingChanges().orElseThrow().pendingOperations();
+    final var targetedMembers =
+        operations.stream()
+            .map(ClusterConfigurationChangeOperation::memberId)
+            .collect(Collectors.toSet());
+    assertThat(targetedMembers).doesNotContain(uninitializedMember, leftMember);
+  }
+
+  @Test
+  void shouldSkipTheWholeBatchWhenReassignmentFailsAndRetryLater() {
+    // given — replication factor 5, but the live cluster only has 2 members, so no valid
+    // placement exists for tenantA at all
+    final var configuration = configurationWith(Set.of());
+    final var staticConfiguration =
+        new StaticConfiguration(
+            new RoundRobinPartitionDistributor(),
+            Set.of(member(0), member(1)),
+            LOCAL_MEMBER_ID,
+            List.of(new PartitionId("tenantA", 1), new PartitionId("tenantA", 2)),
+            5,
+            partitionConfig,
+            "clusterId");
+    final var initializer = new PhysicalTenantProvisioningInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then — the joint reassignment computation throws (only 2 live members, RF 5), so the whole
+    // batch is skipped and the configuration is returned unchanged instead of propagating the
+    // exception out of modify()
+    assertThat(result).isEqualTo(configuration);
+  }
+
+  private StaticConfiguration staticConfigWith(final List<List<PartitionId>> tenantPartitionIds) {
+    return staticConfigWith(tenantPartitionIds, 1);
+  }
+
+  private StaticConfiguration staticConfigWith(
+      final List<List<PartitionId>> tenantPartitionIds, final int replicationFactor) {
+    final List<PartitionId> allPartitionIds =
+        tenantPartitionIds.stream().flatMap(List::stream).toList();
+    return new StaticConfiguration(
+        new RoundRobinPartitionDistributor(),
+        Set.of(member(0), member(1), member(2)),
+        LOCAL_MEMBER_ID,
+        allPartitionIds,
+        replicationFactor,
+        partitionConfig,
+        "clusterId");
+  }
+
+  private MemberId bootstrapTargetMember(
+      final List<ClusterConfigurationChangeOperation> operations) {
+    return operations.stream()
+        .filter(op -> op instanceof PartitionBootstrapOperation)
+        .map(op -> ((PartitionBootstrapOperation) op).memberId())
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private List<PartitionId> tenantPartitionIds(final String tenantId, final int count) {
+    return IntStream.rangeClosed(1, count)
+        .mapToObj(number -> new PartitionId(tenantId, number))
+        .toList();
+  }
+
+  private CurrentClusterConfiguration configurationWith(final Set<PartitionMetadata> existing) {
+    final Set<MemberId> members = new HashSet<>();
+    existing.forEach(metadata -> members.addAll(metadata.members()));
+    // ensure the configuration always has members 0-2 available as live cluster members
+    for (int i = 0; i < 3; i++) {
+      members.add(member(i));
+    }
+    return ConfigurationUtil.getCurrentClusterConfigurationFrom(
+        members, existing, partitionConfig, "clusterId");
+  }
+
+  /**
+   * Builds a partition with a real, non-tied priority ladder (primary gets {@code members.size()},
+   * every other member gets a strictly lower, distinct priority) so round-tripping through {@link
+   * ConfigurationUtil} preserves the given primary exactly.
+   */
+  private PartitionMetadata partition(
+      final String group, final int number, final Set<MemberId> members, final MemberId primary) {
+    final Map<MemberId, Integer> priorities = new HashMap<>();
+    priorities.put(primary, members.size());
+    int nextPriority = members.size() - 1;
+    for (final var member : members.stream().sorted().toList()) {
+      if (!member.equals(primary)) {
+        priorities.put(member, nextPriority--);
+      }
+    }
+    return new PartitionMetadata(
+        new PartitionId(group, number), members, priorities, priorities.get(primary), primary);
+  }
+
+  private MemberId member(final int id) {
+    return MemberId.from(String.valueOf(id));
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializerTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
@@ -140,6 +142,46 @@ final class PhysicalTenantProvisioningInitializerTest {
     final var tenantATarget = bootstrapTargetMember(tenantAOperations);
     final var tenantBTarget = bootstrapTargetMember(tenantBOperations);
     assertThat(tenantATarget).isNotEqualTo(tenantBTarget);
+  }
+
+  @Test
+  void shouldNotPlaceNewTenantPartitionsOnLeftOrUninitializedMembers() {
+    // given — members 0-2 are live (ACTIVE) but already loaded with tenantX's partitions; member
+    // 8 has never joined (UNINITIALIZED) and member 9 has left the cluster (LEFT) — both are still
+    // present in globalConfiguration().members(), just not live, and both are otherwise completely
+    // unloaded. If they weren't excluded from the candidate set, the reassigner's least-loaded
+    // tie-break would pick one of them over the more-loaded but live members 0-2.
+    final var existingTenantX =
+        Set.of(
+            partition("tenantX", 1, Set.of(member(0)), member(0)),
+            partition("tenantX", 2, Set.of(member(1)), member(1)),
+            partition("tenantX", 3, Set.of(member(2)), member(2)));
+    final var uninitializedMember = member(8);
+    final var leftMember = member(9);
+    final var baseConfiguration = configurationWith(existingTenantX);
+    final var configuration =
+        baseConfiguration.updateGlobalConfiguration(
+            global ->
+                global
+                    .addMember(uninitializedMember, BrokerState.uninitialized())
+                    .addMember(
+                        leftMember,
+                        BrokerState.initializeAsActive().setState(BrokerState.State.LEFT)));
+    final var staticConfiguration = staticConfigWith(List.of(tenantPartitionIds("tenantA", 1)), 1);
+    final var initializer = new PhysicalTenantProvisioningInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then — the new tenant's sole partition still lands on one of the loaded-but-live members
+    // 0-2, never on the unloaded-but-not-live members 8/9
+    final var operations =
+        result.partitionGroup("tenantA").pendingChanges().orElseThrow().pendingOperations();
+    final var targetedMembers =
+        operations.stream()
+            .map(ClusterConfigurationChangeOperation::memberId)
+            .collect(Collectors.toSet());
+    assertThat(targetedMembers).doesNotContain(uninitializedMember, leftMember);
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGeneratorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGeneratorTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class PartitionReassignmentOperationsGeneratorTest {
+
+  private final DynamicPartitionConfig partitionConfig =
+      new DynamicPartitionConfig(
+          new ExportingConfig(
+              ExportingState.EXPORTING,
+              Map.of("expA", new ExporterState(1, ExporterState.State.ENABLED, Optional.empty()))));
+
+  /**
+   * A distinct config to prove a brand-new group's bootstrap carries its OWN config, not this one —
+   * the field above is only baked into the (unrelated) existing-partition state.
+   */
+  private final DynamicPartitionConfig newTenantConfig =
+      new DynamicPartitionConfig(
+          new ExportingConfig(
+              ExportingState.EXPORTING,
+              Map.of("expB", new ExporterState(1, ExporterState.State.ENABLED, Optional.empty()))));
+
+  @Test
+  void shouldBootstrapABrandNewGroupsFirstPartitionWithItsConfigAndNoSnapshot() {
+    // given — no existing groups at all
+    final var currentConfiguration = configurationWith(Set.of());
+    final var target =
+        Set.of(
+            PartitionMetadataFixtures.partition(
+                "tenantX", 1, Set.of(member(0), member(1)), member(0)),
+            PartitionMetadataFixtures.partition(
+                "tenantX", 2, Set.of(member(1), member(2)), member(1)));
+
+    // when
+    final var operations =
+        PartitionReassignmentOperationsGenerator.generateOperations(
+            currentConfiguration, target, Map.of("tenantX", newTenantConfig));
+
+    // then — partition 1 (the group's lowest id) carries the tenant's config and does NOT
+    // initialize from a snapshot; partition 2 inherits the config (empty here) and also skips the
+    // snapshot, since the whole group is brand new
+    assertThat(operations).containsOnlyKeys("tenantX");
+    assertThat(operations.get("tenantX"))
+        .containsExactly(
+            new PartitionBootstrapOperation(member(0), 1, 2, Optional.of(newTenantConfig), false),
+            new PartitionJoinOperation(member(1), 1, 1),
+            new PartitionBootstrapOperation(member(1), 2, 2, Optional.empty(), false),
+            new PartitionJoinOperation(member(2), 2, 1));
+  }
+
+  @Test
+  void shouldRejectABrandNewGroupWithNoConfigSupplied() {
+    // given
+    final var currentConfiguration = configurationWith(Set.of());
+    final var target =
+        Set.of(PartitionMetadataFixtures.partition("tenantX", 1, Set.of(member(0)), member(0)));
+
+    // when/then
+    assertThatThrownBy(
+            () ->
+                PartitionReassignmentOperationsGenerator.generateOperations(
+                    currentConfiguration, target, Map.of()))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldBootstrapANewPartitionInAnExistingGroupWithSnapshotAndNoExplicitConfig() {
+    // given — tenantA already has partition 1; partition 2 is new, but the GROUP already exists
+    final var existingPartition1 =
+        PartitionMetadataFixtures.partition("tenantA", 1, Set.of(member(0), member(1)), member(0));
+    final var currentConfiguration = configurationWith(Set.of(existingPartition1));
+    final var target =
+        Set.of(
+            existingPartition1, // unchanged, passed through as-is by a PartitionReassigner
+            PartitionMetadataFixtures.partition("tenantA", 2, Set.of(member(2)), member(2)));
+
+    // when — no config needed since tenantA isn't a brand-new group
+    final var operations =
+        PartitionReassignmentOperationsGenerator.generateOperations(
+            currentConfiguration, target, Map.of());
+
+    // then — only partition 2 produces operations; it initializes from a snapshot (scaling up an
+    // existing group) and inherits its config from the group's existing partition 1
+    assertThat(operations).containsOnlyKeys("tenantA");
+    assertThat(operations.get("tenantA"))
+        .containsExactly(new PartitionBootstrapOperation(member(2), 2, 1, Optional.empty(), true));
+  }
+
+  @Test
+  void shouldProduceNoOperationsForAnUnchangedPartition() {
+    // given
+    final var existingPartition =
+        PartitionMetadataFixtures.partition("tenantA", 1, Set.of(member(0), member(1)), member(0));
+    final var currentConfiguration = configurationWith(Set.of(existingPartition));
+
+    // when — target is exactly the current distribution
+    final var operations =
+        PartitionReassignmentOperationsGenerator.generateOperations(
+            currentConfiguration, Set.of(existingPartition), Map.of());
+
+    // then
+    assertThat(operations).isEmpty();
+  }
+
+  @Test
+  void shouldGenerateJoinLeaveAndPriorityReconfigureOperationsForAMovedPartition() {
+    // given — partition 1: member 1 leaves, member 3 joins, member 2's priority changes
+    final var current =
+        new PartitionMetadata(
+            new PartitionId("tenantA", 1),
+            Set.of(member(0), member(1), member(2)),
+            Map.of(member(0), 3, member(1), 2, member(2), 1),
+            3,
+            member(0));
+    final var target =
+        new PartitionMetadata(
+            new PartitionId("tenantA", 1),
+            Set.of(member(0), member(2), member(3)),
+            Map.of(member(0), 3, member(2), 2, member(3), 1),
+            3,
+            member(0));
+    final var currentConfiguration = configurationWith(Set.of(current));
+
+    // when
+    final var operations =
+        PartitionReassignmentOperationsGenerator.generateOperations(
+            currentConfiguration, Set.of(target), Map.of());
+
+    // then — joins first, then leaves, then priority reconfigures
+    assertThat(operations).containsOnlyKeys("tenantA");
+    assertThat(operations.get("tenantA"))
+        .containsExactly(
+            new PartitionJoinOperation(member(3), 1, 1),
+            new PartitionLeaveOperation(member(1), 1, 1),
+            new PartitionReconfigurePriorityOperation(member(2), 1, 2));
+  }
+
+  @Test
+  void shouldGroupOperationsByPartitionGroupAcrossMultipleGroupsInOneCall() {
+    // given — tenantA has an unchanged partition and a moved one; tenantB is brand new. Member 0's
+    // priority is deliberately kept identical (1) between old and new partition 2, so only the join
+    // of member 1 is expected — no incidental priority reconfigure for member 0.
+    final var unchangedTenantA =
+        PartitionMetadataFixtures.partition("tenantA", 1, Set.of(member(0), member(1)), member(0));
+    final var oldTenantAPartition2 =
+        new PartitionMetadata(
+            new PartitionId("tenantA", 2), Set.of(member(0)), Map.of(member(0), 1), 1, member(0));
+    final var newTenantAPartition2 =
+        new PartitionMetadata(
+            new PartitionId("tenantA", 2),
+            Set.of(member(0), member(1)),
+            Map.of(member(0), 1, member(1), 1),
+            1,
+            member(0));
+    final Set<PartitionMetadata> existing = new HashSet<>();
+    existing.add(unchangedTenantA);
+    existing.add(oldTenantAPartition2);
+    final var currentConfiguration = configurationWith(existing);
+
+    final var tenantBPartition1 =
+        PartitionMetadataFixtures.partition("tenantB", 1, Set.of(member(2)), member(2));
+    final Set<PartitionMetadata> target =
+        Set.of(unchangedTenantA, newTenantAPartition2, tenantBPartition1);
+
+    // when — only tenantB is brand new, so only it needs an entry in the config map
+    final var operations =
+        PartitionReassignmentOperationsGenerator.generateOperations(
+            currentConfiguration, target, Map.of("tenantB", newTenantConfig));
+
+    // then
+    assertThat(operations).containsOnlyKeys("tenantA", "tenantB");
+    assertThat(operations.get("tenantA"))
+        .containsExactly(new PartitionJoinOperation(member(1), 2, 1));
+    assertThat(operations.get("tenantB"))
+        .containsExactly(
+            new PartitionBootstrapOperation(member(2), 1, 1, Optional.of(newTenantConfig), false));
+  }
+
+  @Test
+  void shouldReturnEmptyMapForEmptyTargetDistribution() {
+    // given
+    final var currentConfiguration = configurationWith(Set.of());
+
+    // when
+    final var operations =
+        PartitionReassignmentOperationsGenerator.generateOperations(
+            currentConfiguration, Set.of(), Map.of());
+
+    // then
+    assertThat(operations).isEmpty();
+  }
+
+  private CurrentClusterConfiguration configurationWith(final Set<PartitionMetadata> existing) {
+    final Set<MemberId> members = new HashSet<>();
+    existing.forEach(metadata -> members.addAll(metadata.members()));
+    for (int i = 0; i < 4; i++) {
+      members.add(member(i));
+    }
+    return ConfigurationUtil.getCurrentClusterConfigurationFrom(
+        members, existing, partitionConfig, "clusterId");
+  }
+
+  private MemberId member(final int id) {
+    return MemberId.from(String.valueOf(id));
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGeneratorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGeneratorTest.java
@@ -203,6 +203,45 @@ final class PartitionReassignmentOperationsGeneratorTest {
   }
 
   @Test
+  void shouldRejectATargetDistributionThatOmitsAnExistingPartitionOfATouchedGroup() {
+    // given — tenantA already has partitions 1 and 2
+    final var existingPartition1 =
+        PartitionMetadataFixtures.partition("tenantA", 1, Set.of(member(0), member(1)), member(0));
+    final var existingPartition2 =
+        PartitionMetadataFixtures.partition("tenantA", 2, Set.of(member(1), member(2)), member(1));
+    final var currentConfiguration =
+        configurationWith(Set.of(existingPartition1, existingPartition2));
+    // target only mentions partition 1 — partition 2 is silently omitted
+    final var target = Set.of(existingPartition1);
+
+    // when/then
+    assertThatThrownBy(
+            () ->
+                PartitionReassignmentOperationsGenerator.generateOperations(
+                    currentConfiguration, target, Map.of()))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldNotRejectAnExistingGroupThatIsEntirelyAbsentFromTheTargetDistribution() {
+    // given — tenantA already has a partition, but the target distribution only concerns a
+    // brand-new tenantB — tenantA is simply left alone, not "removed"
+    final var existingTenantA =
+        PartitionMetadataFixtures.partition("tenantA", 1, Set.of(member(0), member(1)), member(0));
+    final var currentConfiguration = configurationWith(Set.of(existingTenantA));
+    final var target =
+        Set.of(PartitionMetadataFixtures.partition("tenantB", 1, Set.of(member(2)), member(2)));
+
+    // when — no exception; tenantA is simply not part of this call at all
+    final var operations =
+        PartitionReassignmentOperationsGenerator.generateOperations(
+            currentConfiguration, target, Map.of("tenantB", newTenantConfig));
+
+    // then
+    assertThat(operations).containsOnlyKeys("tenantB");
+  }
+
+  @Test
   void shouldReturnEmptyMapForEmptyTargetDistribution() {
     // given
     final var currentConfiguration = configurationWith(Set.of());

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGeneratorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGeneratorTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class PartitionReassignmentOperationsGeneratorTest {
+
+  private final DynamicPartitionConfig partitionConfig =
+      new DynamicPartitionConfig(
+          new ExportingConfig(
+              ExportingState.EXPORTING,
+              Map.of("expA", new ExporterState(1, ExporterState.State.ENABLED, Optional.empty()))));
+
+  /**
+   * A distinct config to prove a brand-new group's bootstrap carries its OWN config, not this one —
+   * the field above is only baked into the (unrelated) existing-partition state.
+   */
+  private final DynamicPartitionConfig newTenantConfig =
+      new DynamicPartitionConfig(
+          new ExportingConfig(
+              ExportingState.EXPORTING,
+              Map.of("expB", new ExporterState(1, ExporterState.State.ENABLED, Optional.empty()))));
+
+  @Test
+  void shouldBootstrapABrandNewGroupsFirstPartitionWithItsConfigAndNoSnapshot() {
+    // given — no existing groups at all
+    final var currentConfiguration = configurationWith(Set.of());
+    final var target =
+        Set.of(
+            PartitionMetadataFixtures.partition(
+                "tenantX", 1, Set.of(member(0), member(1)), member(0)),
+            PartitionMetadataFixtures.partition(
+                "tenantX", 2, Set.of(member(1), member(2)), member(1)));
+
+    // when
+    final var operations =
+        PartitionReassignmentOperationsGenerator.generateOperations(
+            currentConfiguration, target, Map.of("tenantX", newTenantConfig));
+
+    // then — partition 1 (the group's lowest id) carries the tenant's config and does NOT
+    // initialize from a snapshot; partition 2 inherits the config (empty here) and also skips the
+    // snapshot, since the whole group is brand new
+    assertThat(operations).containsOnlyKeys("tenantX");
+    assertThat(operations.get("tenantX"))
+        .containsExactly(
+            new PartitionBootstrapOperation(member(0), 1, 2, Optional.of(newTenantConfig), false),
+            new PartitionJoinOperation(member(1), 1, 1),
+            new PartitionBootstrapOperation(member(1), 2, 2, Optional.empty(), false),
+            new PartitionJoinOperation(member(2), 2, 1));
+  }
+
+  @Test
+  void shouldRejectABrandNewGroupWithNoConfigSupplied() {
+    // given
+    final var currentConfiguration = configurationWith(Set.of());
+    final var target =
+        Set.of(PartitionMetadataFixtures.partition("tenantX", 1, Set.of(member(0)), member(0)));
+
+    // when/then
+    assertThatThrownBy(
+            () ->
+                PartitionReassignmentOperationsGenerator.generateOperations(
+                    currentConfiguration, target, Map.of()))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldBootstrapANewPartitionInAnExistingGroupWithSnapshotAndNoExplicitConfig() {
+    // given — tenantA already has partition 1; partition 2 is new, but the GROUP already exists
+    final var existingPartition1 =
+        PartitionMetadataFixtures.partition("tenantA", 1, Set.of(member(0), member(1)), member(0));
+    final var currentConfiguration = configurationWith(Set.of(existingPartition1));
+    final var target =
+        Set.of(
+            existingPartition1, // unchanged, passed through as-is by a PartitionReassigner
+            PartitionMetadataFixtures.partition("tenantA", 2, Set.of(member(2)), member(2)));
+
+    // when — no config needed since tenantA isn't a brand-new group
+    final var operations =
+        PartitionReassignmentOperationsGenerator.generateOperations(
+            currentConfiguration, target, Map.of());
+
+    // then — only partition 2 produces operations; it initializes from a snapshot (scaling up an
+    // existing group) and inherits its config from the group's existing partition 1
+    assertThat(operations).containsOnlyKeys("tenantA");
+    assertThat(operations.get("tenantA"))
+        .containsExactly(new PartitionBootstrapOperation(member(2), 2, 1, Optional.empty(), true));
+  }
+
+  @Test
+  void shouldProduceNoOperationsForAnUnchangedPartition() {
+    // given
+    final var existingPartition =
+        PartitionMetadataFixtures.partition("tenantA", 1, Set.of(member(0), member(1)), member(0));
+    final var currentConfiguration = configurationWith(Set.of(existingPartition));
+
+    // when — target is exactly the current distribution
+    final var operations =
+        PartitionReassignmentOperationsGenerator.generateOperations(
+            currentConfiguration, Set.of(existingPartition), Map.of());
+
+    // then
+    assertThat(operations).isEmpty();
+  }
+
+  @Test
+  void shouldGenerateJoinLeaveAndPriorityReconfigureOperationsForAMovedPartition() {
+    // given — partition 1: member 1 leaves, member 3 joins, member 2's priority changes
+    final var current =
+        new PartitionMetadata(
+            new PartitionId("tenantA", 1),
+            Set.of(member(0), member(1), member(2)),
+            Map.of(member(0), 3, member(1), 2, member(2), 1),
+            3,
+            member(0));
+    final var target =
+        new PartitionMetadata(
+            new PartitionId("tenantA", 1),
+            Set.of(member(0), member(2), member(3)),
+            Map.of(member(0), 3, member(2), 2, member(3), 1),
+            3,
+            member(0));
+    final var currentConfiguration = configurationWith(Set.of(current));
+
+    // when
+    final var operations =
+        PartitionReassignmentOperationsGenerator.generateOperations(
+            currentConfiguration, Set.of(target), Map.of());
+
+    // then — joins first, then leaves, then priority reconfigures
+    assertThat(operations).containsOnlyKeys("tenantA");
+    assertThat(operations.get("tenantA"))
+        .containsExactly(
+            new PartitionJoinOperation(member(3), 1, 1),
+            new PartitionLeaveOperation(member(1), 1, 1),
+            new PartitionReconfigurePriorityOperation(member(2), 1, 2));
+  }
+
+  @Test
+  void shouldGroupOperationsByPartitionGroupAcrossMultipleGroupsInOneCall() {
+    // given — tenantA has an unchanged partition and a moved one; tenantB is brand new. Member 0's
+    // priority is deliberately kept identical (1) between old and new partition 2, so only the join
+    // of member 1 is expected — no incidental priority reconfigure for member 0.
+    final var unchangedTenantA =
+        PartitionMetadataFixtures.partition("tenantA", 1, Set.of(member(0), member(1)), member(0));
+    final var oldTenantAPartition2 =
+        new PartitionMetadata(
+            new PartitionId("tenantA", 2), Set.of(member(0)), Map.of(member(0), 1), 1, member(0));
+    final var newTenantAPartition2 =
+        new PartitionMetadata(
+            new PartitionId("tenantA", 2),
+            Set.of(member(0), member(1)),
+            Map.of(member(0), 1, member(1), 1),
+            1,
+            member(0));
+    final Set<PartitionMetadata> existing = new HashSet<>();
+    existing.add(unchangedTenantA);
+    existing.add(oldTenantAPartition2);
+    final var currentConfiguration = configurationWith(existing);
+
+    final var tenantBPartition1 =
+        PartitionMetadataFixtures.partition("tenantB", 1, Set.of(member(2)), member(2));
+    final Set<PartitionMetadata> target =
+        Set.of(unchangedTenantA, newTenantAPartition2, tenantBPartition1);
+
+    // when — only tenantB is brand new, so only it needs an entry in the config map
+    final var operations =
+        PartitionReassignmentOperationsGenerator.generateOperations(
+            currentConfiguration, target, Map.of("tenantB", newTenantConfig));
+
+    // then
+    assertThat(operations).containsOnlyKeys("tenantA", "tenantB");
+    assertThat(operations.get("tenantA"))
+        .containsExactly(new PartitionJoinOperation(member(1), 2, 1));
+    assertThat(operations.get("tenantB"))
+        .containsExactly(
+            new PartitionBootstrapOperation(member(2), 1, 1, Optional.of(newTenantConfig), false));
+  }
+
+  @Test
+  void shouldRejectATargetDistributionThatOmitsAnExistingPartitionOfATouchedGroup() {
+    // given — tenantA already has partitions 1 and 2
+    final var existingPartition1 =
+        PartitionMetadataFixtures.partition("tenantA", 1, Set.of(member(0), member(1)), member(0));
+    final var existingPartition2 =
+        PartitionMetadataFixtures.partition("tenantA", 2, Set.of(member(1), member(2)), member(1));
+    final var currentConfiguration =
+        configurationWith(Set.of(existingPartition1, existingPartition2));
+    // target only mentions partition 1 — partition 2 is silently omitted
+    final var target = Set.of(existingPartition1);
+
+    // when/then
+    assertThatThrownBy(
+            () ->
+                PartitionReassignmentOperationsGenerator.generateOperations(
+                    currentConfiguration, target, Map.of()))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldNotRejectAnExistingGroupThatIsEntirelyAbsentFromTheTargetDistribution() {
+    // given — tenantA already has a partition, but the target distribution only concerns a
+    // brand-new tenantB — tenantA is simply left alone, not "removed"
+    final var existingTenantA =
+        PartitionMetadataFixtures.partition("tenantA", 1, Set.of(member(0), member(1)), member(0));
+    final var currentConfiguration = configurationWith(Set.of(existingTenantA));
+    final var target =
+        Set.of(PartitionMetadataFixtures.partition("tenantB", 1, Set.of(member(2)), member(2)));
+
+    // when — no exception; tenantA is simply not part of this call at all
+    final var operations =
+        PartitionReassignmentOperationsGenerator.generateOperations(
+            currentConfiguration, target, Map.of("tenantB", newTenantConfig));
+
+    // then
+    assertThat(operations).containsOnlyKeys("tenantB");
+  }
+
+  @Test
+  void shouldReturnEmptyMapForEmptyTargetDistribution() {
+    // given
+    final var currentConfiguration = configurationWith(Set.of());
+
+    // when
+    final var operations =
+        PartitionReassignmentOperationsGenerator.generateOperations(
+            currentConfiguration, Set.of(), Map.of());
+
+    // then
+    assertThat(operations).isEmpty();
+  }
+
+  private CurrentClusterConfiguration configurationWith(final Set<PartitionMetadata> existing) {
+    final Set<MemberId> members = new HashSet<>();
+    existing.forEach(metadata -> members.addAll(metadata.members()));
+    for (int i = 0; i < 4; i++) {
+      members.add(member(i));
+    }
+    return ConfigurationUtil.getCurrentClusterConfigurationFrom(
+        members, existing, partitionConfig, "clusterId");
+  }
+
+  private MemberId member(final int id) {
+    return MemberId.from(String.valueOf(id));
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantProvisioningIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantProvisioningIT.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestClusterBuilder;
+import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * A physical tenant added to a broker's static configuration after the cluster has already been
+ * bootstrapped once must be picked up on the next restart: the coordinator's {@code
+ * PhysicalTenantProvisioningInitializer} provisions a new partition group for it directly, without
+ * a fresh full-cluster bootstrap. This verifies the whole path end-to-end: a brand-new physical
+ * tenant's partitions become visible via the client-facing (physical-tenant-scoped) topology
+ * endpoint, and a process can be deployed to and instantiated within it.
+ */
+@ZeebeIntegration
+final class PhysicalTenantProvisioningIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+  private static final int BROKERS_COUNT = 3;
+  private static final int TENANT_B_PARTITIONS_COUNT = 3;
+
+  // declared at cluster bootstrap time: only the default tenant and tenantA
+  private static final PhysicalTenantsITHelper TENANTS_BEFORE =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  // the same tenants, plus tenantB — added to the static configuration only after the cluster has
+  // already been running once, then applied on restart
+  private static final PhysicalTenantsITHelper TENANTS_AFTER =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .withTenant(TENANT_B, Storage.none())
+          .build();
+
+  @TestZeebe
+  private final TestCluster cluster =
+      new TestClusterBuilder()
+          .withBrokersCount(BROKERS_COUNT)
+          .withReplicationFactor(BROKERS_COUNT)
+          .withPartitionsCount(2)
+          .withBrokerConfig(broker -> TENANTS_BEFORE.configure(broker.withUnauthenticatedAccess()))
+          .build();
+
+  @ParameterizedTest
+  @MethodSource("restartStrategies")
+  void shouldProvisionNewPhysicalTenantAddedAfterInitialBootstrapOnRestart(
+      final Consumer<TestCluster> restarter) {
+    // given - the cluster is up and running with only the default tenant and tenantA
+    try (final var tenantAClient =
+        TENANTS_BEFORE.newClientBuilder(cluster.availableGateway(), TENANT_A).build()) {
+      await("tenantA's topology is complete before the restart")
+          .atMost(Duration.ofSeconds(60))
+          .untilAsserted(
+              () ->
+                  TopologyAssert.assertThat(tenantAClient.newTopologyRequest().send().join())
+                      .isComplete(BROKERS_COUNT, 2, BROKERS_COUNT));
+    }
+
+    // when - tenantB is added to every broker's static configuration and the cluster is restarted
+    restarter.accept(cluster);
+
+    // then - tenantB's own partition group is visible through the client-facing, physical-tenant-
+    // scoped topology endpoint (the same endpoint used to observe any other physical tenant),
+    // with the partition count configured for tenantB specifically - not cloned from another
+    // tenant's partition count
+    try (final var tenantBClient =
+        TENANTS_AFTER.newClientBuilder(cluster.availableGateway(), TENANT_B).build()) {
+      await("tenantB's newly-provisioned partitions are visible and have a leader")
+          .atMost(Duration.ofSeconds(60))
+          .ignoreExceptions()
+          .untilAsserted(
+              () ->
+                  TopologyAssert.assertThat(tenantBClient.newTopologyRequest().send().join())
+                      .isComplete(BROKERS_COUNT, TENANT_B_PARTITIONS_COUNT, BROKERS_COUNT));
+
+      // and - a process can be deployed to and instantiated within the newly-provisioned tenant
+      final String processId = "provisioning-process";
+      final BpmnModelInstance process =
+          Bpmn.createExecutableProcess(processId).startEvent().endEvent().done();
+
+      await("deployment to the newly-provisioned tenantB succeeds")
+          .atMost(Duration.ofSeconds(30))
+          .ignoreExceptions()
+          .untilAsserted(
+              () ->
+                  assertThat(
+                          tenantBClient
+                              .newDeployResourceCommand()
+                              .addProcessModel(process, processId + ".bpmn")
+                              .send()
+                              .join()
+                              .getProcesses())
+                      .isNotEmpty());
+
+      final long processInstanceKey =
+          tenantBClient
+              .newCreateInstanceCommand()
+              .bpmnProcessId(processId)
+              .latestVersion()
+              .send()
+              .join()
+              .getProcessInstanceKey();
+      assertThat(processInstanceKey).isPositive();
+    }
+
+    // and - tenantA, which already existed before the restart, is unaffected
+    try (final var tenantAClient =
+        TENANTS_AFTER.newClientBuilder(cluster.availableGateway(), TENANT_A).build()) {
+      TopologyAssert.assertThat(tenantAClient.newTopologyRequest().send().join())
+          .isComplete(BROKERS_COUNT, 2, BROKERS_COUNT);
+    }
+  }
+
+  public static Stream<Arguments> restartStrategies() {
+    return Stream.of(
+        Arguments.of(
+            Named.of(
+                "Full restart",
+                (Consumer<TestCluster>) PhysicalTenantProvisioningIT::restartCluster)),
+        Arguments.of(
+            Named.of(
+                "Rolling restart (coordinator first)",
+                (Consumer<TestCluster>) cluster -> rollingRestart(cluster, true))),
+        Arguments.of(
+            Named.of(
+                "Rolling restart (coordinator last)",
+                (Consumer<TestCluster>) cluster -> rollingRestart(cluster, false))));
+  }
+
+  private static void restartCluster(final TestCluster cluster) {
+    cluster.shutdown();
+    cluster
+        .brokers()
+        .values()
+        .forEach(
+            broker -> {
+              TENANTS_AFTER.configure(broker);
+              broker.withPtConfig(
+                  TENANT_B,
+                  camunda -> camunda.getCluster().setPartitionCount(TENANT_B_PARTITIONS_COUNT));
+            });
+    cluster.start().awaitCompleteTopology();
+  }
+
+  private static void rollingRestart(final TestCluster cluster, final boolean ascending) {
+    cluster.brokers().values().stream()
+        .sorted(
+            ascending
+                ? Comparator.comparing(b -> b.nodeId(), MemberId.ID_COMPARATOR)
+                : Comparator.comparing(b -> b.nodeId(), MemberId.ID_COMPARATOR.reversed()))
+        .forEach(
+            broker -> {
+              broker.stop();
+              TENANTS_AFTER.configure(broker);
+              broker.withPtConfig(
+                  TENANT_B,
+                  camunda -> camunda.getCluster().setPartitionCount(TENANT_B_PARTITIONS_COUNT));
+              broker.start();
+              cluster.await(TestHealthProbe.READY, Duration.ofSeconds(30));
+            });
+    cluster.start().awaitCompleteTopology();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantProvisioningIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantProvisioningIT.java
@@ -10,17 +10,25 @@ package io.camunda.zeebe.it.physicaltenant;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
 import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestClusterBuilder;
+import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import java.time.Duration;
-import org.junit.jupiter.api.Test;
+import java.util.Comparator;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * A physical tenant added to a broker's static configuration after the cluster has already been
@@ -63,8 +71,10 @@ final class PhysicalTenantProvisioningIT {
           .withBrokerConfig(broker -> TENANTS_BEFORE.configure(broker.withUnauthenticatedAccess()))
           .build();
 
-  @Test
-  void shouldProvisionNewPhysicalTenantAddedAfterInitialBootstrapOnRestart() {
+  @ParameterizedTest
+  @MethodSource("restartStrategies")
+  void shouldProvisionNewPhysicalTenantAddedAfterInitialBootstrapOnRestart(
+      final Consumer<TestCluster> restarter) {
     // given - the cluster is up and running with only the default tenant and tenantA
     try (final var tenantAClient =
         TENANTS_BEFORE.newClientBuilder(cluster.availableGateway(), TENANT_A).build()) {
@@ -77,18 +87,7 @@ final class PhysicalTenantProvisioningIT {
     }
 
     // when - tenantB is added to every broker's static configuration and the cluster is restarted
-    cluster.shutdown();
-    cluster
-        .brokers()
-        .values()
-        .forEach(
-            broker -> {
-              TENANTS_AFTER.configure(broker);
-              broker.withPtConfig(
-                  TENANT_B,
-                  camunda -> camunda.getCluster().setPartitionCount(TENANT_B_PARTITIONS_COUNT));
-            });
-    cluster.start().awaitCompleteTopology();
+    restarter.accept(cluster);
 
     // then - tenantB's own partition group is visible through the client-facing, physical-tenant-
     // scoped topology endpoint (the same endpoint used to observe any other physical tenant),
@@ -140,5 +139,55 @@ final class PhysicalTenantProvisioningIT {
       TopologyAssert.assertThat(tenantAClient.newTopologyRequest().send().join())
           .isComplete(BROKERS_COUNT, 2, BROKERS_COUNT);
     }
+  }
+
+  public static Stream<Arguments> restartStrategies() {
+    return Stream.of(
+        Arguments.of(
+            Named.of(
+                "Full restart",
+                (Consumer<TestCluster>) PhysicalTenantProvisioningIT::restartCluster)),
+        Arguments.of(
+            Named.of(
+                "Rolling restart (coordinator first)",
+                (Consumer<TestCluster>) cluster -> rollingRestart(cluster, true))),
+        Arguments.of(
+            Named.of(
+                "Rolling restart (coordinator last)",
+                (Consumer<TestCluster>) cluster -> rollingRestart(cluster, false))));
+  }
+
+  private static void restartCluster(final TestCluster cluster) {
+    cluster.shutdown();
+    cluster
+        .brokers()
+        .values()
+        .forEach(
+            broker -> {
+              TENANTS_AFTER.configure(broker);
+              broker.withPtConfig(
+                  TENANT_B,
+                  camunda -> camunda.getCluster().setPartitionCount(TENANT_B_PARTITIONS_COUNT));
+            });
+    cluster.start().awaitCompleteTopology();
+  }
+
+  private static void rollingRestart(final TestCluster cluster, final boolean ascending) {
+    cluster.brokers().values().stream()
+        .sorted(
+            ascending
+                ? Comparator.comparing(b -> b.nodeId(), MemberId.ID_COMPARATOR)
+                : Comparator.comparing(b -> b.nodeId(), MemberId.ID_COMPARATOR.reversed()))
+        .forEach(
+            broker -> {
+              broker.stop();
+              TENANTS_AFTER.configure(broker);
+              broker.withPtConfig(
+                  TENANT_B,
+                  camunda -> camunda.getCluster().setPartitionCount(TENANT_B_PARTITIONS_COUNT));
+              broker.start();
+              cluster.await(TestHealthProbe.READY, Duration.ofSeconds(30));
+            });
+    cluster.start().awaitCompleteTopology();
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantProvisioningIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantProvisioningIT.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestClusterBuilder;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A physical tenant added to a broker's static configuration after the cluster has already been
+ * bootstrapped once must be picked up on the next restart: the coordinator's {@code
+ * PhysicalTenantProvisioningInitializer} provisions a new partition group for it directly, without
+ * a fresh full-cluster bootstrap. This verifies the whole path end-to-end: a brand-new physical
+ * tenant's partitions become visible via the client-facing (physical-tenant-scoped) topology
+ * endpoint, and a process can be deployed to and instantiated within it.
+ */
+@ZeebeIntegration
+final class PhysicalTenantProvisioningIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+  private static final int BROKERS_COUNT = 3;
+  private static final int TENANT_B_PARTITIONS_COUNT = 2;
+
+  // declared at cluster bootstrap time: only the default tenant and tenantA
+  private static final PhysicalTenantsITHelper TENANTS_BEFORE =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  // the same tenants, plus tenantB — added to the static configuration only after the cluster has
+  // already been running once, then applied on restart
+  private static final PhysicalTenantsITHelper TENANTS_AFTER =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .withTenant(TENANT_B, Storage.none())
+          .build();
+
+  @TestZeebe
+  private final TestCluster cluster =
+      new TestClusterBuilder()
+          .withBrokersCount(BROKERS_COUNT)
+          .withReplicationFactor(BROKERS_COUNT)
+          .withPartitionsCount(2)
+          .withBrokerConfig(broker -> TENANTS_BEFORE.configure(broker.withUnauthenticatedAccess()))
+          .build();
+
+  @Test
+  void shouldProvisionNewPhysicalTenantAddedAfterInitialBootstrapOnRestart() {
+    // given - the cluster is up and running with only the default tenant and tenantA
+    try (final var tenantAClient =
+        TENANTS_BEFORE.newClientBuilder(cluster.availableGateway(), TENANT_A).build()) {
+      await("tenantA's topology is complete before the restart")
+          .atMost(Duration.ofSeconds(60))
+          .untilAsserted(
+              () ->
+                  TopologyAssert.assertThat(tenantAClient.newTopologyRequest().send().join())
+                      .isComplete(BROKERS_COUNT, 2, BROKERS_COUNT));
+    }
+
+    // when - tenantB is added to every broker's static configuration and the cluster is restarted
+    cluster.shutdown();
+    cluster
+        .brokers()
+        .values()
+        .forEach(
+            broker -> {
+              TENANTS_AFTER.configure(broker);
+              broker.withPtConfig(
+                  TENANT_B,
+                  camunda -> camunda.getCluster().setPartitionCount(TENANT_B_PARTITIONS_COUNT));
+            });
+    cluster.start().awaitCompleteTopology();
+
+    // then - tenantB's own partition group is visible through the client-facing, physical-tenant-
+    // scoped topology endpoint (the same endpoint used to observe any other physical tenant),
+    // with the partition count configured for tenantB specifically - not cloned from another
+    // tenant's partition count
+    try (final var tenantBClient =
+        TENANTS_AFTER.newClientBuilder(cluster.availableGateway(), TENANT_B).build()) {
+      await("tenantB's newly-provisioned partitions are visible and have a leader")
+          .atMost(Duration.ofSeconds(60))
+          .ignoreExceptions()
+          .untilAsserted(
+              () ->
+                  TopologyAssert.assertThat(tenantBClient.newTopologyRequest().send().join())
+                      .isComplete(BROKERS_COUNT, TENANT_B_PARTITIONS_COUNT, BROKERS_COUNT));
+
+      // and - a process can be deployed to and instantiated within the newly-provisioned tenant
+      final String processId = "provisioning-process";
+      final BpmnModelInstance process =
+          Bpmn.createExecutableProcess(processId).startEvent().endEvent().done();
+
+      await("deployment to the newly-provisioned tenantB succeeds")
+          .atMost(Duration.ofSeconds(30))
+          .ignoreExceptions()
+          .untilAsserted(
+              () ->
+                  assertThat(
+                          tenantBClient
+                              .newDeployResourceCommand()
+                              .addProcessModel(process, processId + ".bpmn")
+                              .send()
+                              .join()
+                              .getProcesses())
+                      .isNotEmpty());
+
+      final long processInstanceKey =
+          tenantBClient
+              .newCreateInstanceCommand()
+              .bpmnProcessId(processId)
+              .latestVersion()
+              .send()
+              .join()
+              .getProcessInstanceKey();
+      assertThat(processInstanceKey).isPositive();
+    }
+
+    // and - tenantA, which already existed before the restart, is unaffected
+    try (final var tenantAClient =
+        TENANTS_AFTER.newClientBuilder(cluster.availableGateway(), TENANT_A).build()) {
+      TopologyAssert.assertThat(tenantAClient.newTopologyRequest().send().join())
+          .isComplete(BROKERS_COUNT, 2, BROKERS_COUNT);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The previous PR added the new reassigner algorihtm. This PR adds the remaining pieces needed to provision a brand-new physical tenant on a running cluster:

- `PartitionReassignmentOperationsGenerator`: turns a reassigner's target distribution into the bootstrap/join/leave/reconfigure-priority operations needed to reach it.
- `PhysicalTenantProvisioningInitializer`: wired into the coordinator's new-model initialization chain; on init, finds every physical tenant present in static configuration but absent from the dynamic configuration, and starts a configuration change directly on a new, empty partition group for it.
    - Directly generating the configuration is not possible, because already started brokers then detect this as a conflict
    - Each broker cannot generate its own configuration with new assignment because the replicas must start in parallel for the brokers to become ready. This cannot be guaranteed in a rolling restart scenario. 
- An integration test provisions a new physical tenant by adding it to a broker's static configuration and restarting the cluster, then verifies the new tenant's partitions are visible via the client-facing topology endpoint and that a process can be deployed to and run in it.

closes #59536 