### PR TITLE
Partition assignment logic for adding new tenants to existing configuration

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassigner.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassigner.java
@@ -73,7 +73,7 @@ public final class AdditivePartitionReassigner implements PartitionReassigner {
 
     final Map<String, Set<PartitionMetadata>> distributionByGroup =
         ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(currentConfiguration);
-    validateNoRemoval(distributionByGroup, targetPartitionIds);
+    validateNoRemoval(distributionByGroup, targetPartitionIds, replicationFactor);
     final Map<PartitionId, PartitionMetadata> currentById =
         targetGroups.stream()
             .flatMap(group -> distributionByGroup.getOrDefault(group, Set.of()).stream())

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassigner.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassigner.java
@@ -18,7 +18,6 @@ import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -35,11 +34,11 @@ import java.util.stream.Collectors;
  * state. {@code targetPartitionIds} may span several groups in one call; every id already present
  * in its group's current distribution is passed through unchanged, and only ids that don't exist
  * yet are placed, greedily on the currently least-loaded members (breaking ties by leader count,
- * then {@link MemberId#nodeIdx()} for determinism), updating its in-memory load view after every
- * placement so a batch of new partitions — even across different groups — is itself spread evenly.
- * New-partition placement processes ids in their natural {@link PartitionId} order regardless of
- * the order {@code targetPartitionIds} was given in, so the result only depends on the id set, not
- * on incidental list ordering.
+ * then {@link MemberId#ID_COMPARATOR} for determinism), updating its in-memory load view after
+ * every placement so a batch of new partitions — even across different groups — is itself spread
+ * evenly. New-partition placement processes ids in their natural {@link PartitionId} order
+ * regardless of the order {@code targetPartitionIds} was given in, so the result only depends on
+ * the id set, not on incidental list ordering.
  *
  * <p>This implementation never moves or otherwise touches an existing partition and never adjusts
  * an existing partition's replication factor — a future general-case reassigner is expected to
@@ -67,9 +66,7 @@ public final class AdditivePartitionReassigner implements PartitionReassigner {
       final Set<MemberId> targetMembers,
       final List<PartitionId> targetPartitionIds,
       final int replicationFactor) {
-    if (targetPartitionIds.isEmpty()) {
-      return Set.of();
-    }
+
     validateTargetMembers(targetMembers, replicationFactor);
     final Set<String> targetGroups =
         targetPartitionIds.stream().map(PartitionId::group).collect(Collectors.toSet());
@@ -83,7 +80,7 @@ public final class AdditivePartitionReassigner implements PartitionReassigner {
             .collect(Collectors.toMap(PartitionMetadata::id, Function.identity()));
 
     final List<MemberId> sortedMembers =
-        targetMembers.stream().sorted(Comparator.comparingInt(MemberId::nodeIdx)).toList();
+        targetMembers.stream().sorted(MemberId.ID_COMPARATOR).toList();
     final int clusterSize = sortedMembers.size();
     final int replicaSlotCount = Math.min(replicationFactor, clusterSize);
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassigner.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassigner.java
@@ -67,6 +67,7 @@ public final class AdditivePartitionReassigner implements PartitionReassigner {
       final List<PartitionId> targetPartitionIds,
       final int replicationFactor) {
 
+    // validation
     validateTargetMembers(targetMembers, replicationFactor);
     final Set<String> targetGroups =
         targetPartitionIds.stream().map(PartitionId::group).collect(Collectors.toSet());
@@ -74,6 +75,8 @@ public final class AdditivePartitionReassigner implements PartitionReassigner {
     final Map<String, Set<PartitionMetadata>> distributionByGroup =
         ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(currentConfiguration);
     validateNoRemoval(distributionByGroup, targetPartitionIds, replicationFactor);
+
+    // generate assignment for new partitions
     final Map<PartitionId, PartitionMetadata> currentById =
         targetGroups.stream()
             .flatMap(group -> distributionByGroup.getOrDefault(group, Set.of()).stream())
@@ -82,28 +85,55 @@ public final class AdditivePartitionReassigner implements PartitionReassigner {
     final List<MemberId> sortedMembers =
         targetMembers.stream().sorted(MemberId.ID_COMPARATOR).toList();
     final int clusterSize = sortedMembers.size();
-    final int replicaSlotCount = Math.min(replicationFactor, clusterSize);
+
+    final List<PartitionId> sortedPartitionIds =
+        targetPartitionIds.stream().distinct().sorted().toList();
 
     final Map<MemberId, Integer> replicaCountByMember = new HashMap<>();
     final Map<MemberId, Integer> leaderCountByMember = new HashMap<>();
+    final var result =
+        generateAssignmentForNewPartitions(
+            sortedPartitionIds,
+            distributionByGroup,
+            replicaCountByMember,
+            leaderCountByMember,
+            currentById,
+            sortedMembers,
+            replicationFactor);
+
+    // generate the final partition metadata set, including existing partitions and new ones
+    return generatePartitionMetadata(
+        replicationFactor,
+        sortedPartitionIds,
+        currentById,
+        result.newMembersById(),
+        result.newPrimaryById(),
+        clusterSize);
+  }
+
+  private static Assignment generateAssignmentForNewPartitions(
+      final List<PartitionId> sortedPartitionIds,
+      final Map<String, Set<PartitionMetadata>> distributionByGroup,
+      final Map<MemberId, Integer> replicaCountByMember,
+      final Map<MemberId, Integer> leaderCountByMember,
+      final Map<PartitionId, PartitionMetadata> currentById,
+      final List<MemberId> sortedMembers,
+      final int replicationFactor) {
     distributionByGroup
         .values()
         .forEach(
             partitions -> accumulateLoad(partitions, replicaCountByMember, leaderCountByMember));
 
-    final List<PartitionId> processingOrder =
-        targetPartitionIds.stream().distinct().sorted().toList();
-
     final List<PartitionId> newPartitionIds = new ArrayList<>();
     final Map<PartitionId, Set<MemberId>> newMembersById = new LinkedHashMap<>();
     final Map<PartitionId, MemberId> newPrimaryById = new LinkedHashMap<>();
-    for (final PartitionId id : processingOrder) {
+    for (final PartitionId id : sortedPartitionIds) {
       if (currentById.containsKey(id)) {
         continue;
       }
       final var placement =
           selectNewPartitionMembers(
-              sortedMembers, replicaSlotCount, replicaCountByMember, leaderCountByMember);
+              sortedMembers, replicationFactor, replicaCountByMember, leaderCountByMember);
       newPartitionIds.add(id);
       newMembersById.put(id, new LinkedHashSet<>(placement.members()));
       newPrimaryById.put(id, placement.primary());
@@ -115,11 +145,21 @@ public final class AdditivePartitionReassigner implements PartitionReassigner {
     // already-selected replicas — never moving a replica, never touching an existing partition.
     rebalanceLeaders(
         newPartitionIds, newMembersById, newPrimaryById, sortedMembers, leaderCountByMember);
+    return new Assignment(newMembersById, newPrimaryById);
+  }
 
+  private static Set<PartitionMetadata> generatePartitionMetadata(
+      final int replicationFactor,
+      final List<PartitionId> processingOrder,
+      final Map<PartitionId, PartitionMetadata> currentById,
+      final Map<PartitionId, Set<MemberId>> newMembersById,
+      final Map<PartitionId, MemberId> newPrimaryById,
+      final int clusterSize) {
     final Set<PartitionMetadata> result = new HashSet<>();
     for (final PartitionId id : processingOrder) {
       final var existing = currentById.get(id);
       if (existing != null) {
+        // existing partitions are unchanged, add them as it is.
         result.add(existing);
         continue;
       }
@@ -136,4 +176,7 @@ public final class AdditivePartitionReassigner implements PartitionReassigner {
     }
     return result;
   }
+
+  private record Assignment(
+      Map<PartitionId, Set<MemberId>> newMembersById, Map<PartitionId, MemberId> newPrimaryById) {}
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassigner.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassigner.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.accumulateLoad;
+import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.rebalanceLeaders;
+import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.selectNewPartitionMembers;
+import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.validateNoRemoval;
+import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.validateTargetMembers;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link PartitionReassigner} for the case where only new partitions are being added — {@code
+ * targetMembers} and {@code replicationFactor} are unchanged from every affected group's current
+ * state. {@code targetPartitionIds} may span several groups in one call; every id already present
+ * in its group's current distribution is passed through unchanged, and only ids that don't exist
+ * yet are placed, greedily on the currently least-loaded members (breaking ties by leader count,
+ * then {@link MemberId#nodeIdx()} for determinism), updating its in-memory load view after every
+ * placement so a batch of new partitions — even across different groups — is itself spread evenly.
+ * New-partition placement processes ids in their natural {@link PartitionId} order regardless of
+ * the order {@code targetPartitionIds} was given in, so the result only depends on the id set, not
+ * on incidental list ordering.
+ *
+ * <p>This implementation never moves or otherwise touches an existing partition and never adjusts
+ * an existing partition's replication factor — a future general-case reassigner is expected to
+ * handle {@code targetMembers} or {@code replicationFactor} differing from a group's current state.
+ *
+ * <p><b>Known trade-off:</b> because existing partitions are never touched, leader (primary) count
+ * across members is <i>not</i> always guaranteed to converge to the same tight balance (gap of 1)
+ * that replica count is. If the existing distribution already has a leader-count skew, and few
+ * enough new partitions are being added, there can be no valid new-partition placement that both
+ * keeps replica count balanced and fully corrects that skew — moving leadership onto the
+ * under-represented member would require also making it a replica of a new partition, which can
+ * unbalance replica count instead. New-partition placement still actively works to reduce leader
+ * imbalance wherever a fix is possible without sacrificing replica balance; the residual imbalance
+ * is bounded by the replication factor.
+ *
+ * <p>Removing a partition or an entire group is not supported: {@code targetPartitionIds} must
+ * include every existing partition id of every existing group, not just the ones being changed —
+ * see {@link PartitionReassignmentSupport#validateNoRemoval}.
+ */
+public final class AdditivePartitionReassigner implements PartitionReassigner {
+
+  @Override
+  public Set<PartitionMetadata> reassignPartitions(
+      final CurrentClusterConfiguration currentConfiguration,
+      final Set<MemberId> targetMembers,
+      final List<PartitionId> targetPartitionIds,
+      final int replicationFactor) {
+    if (targetPartitionIds.isEmpty()) {
+      return Set.of();
+    }
+    validateTargetMembers(targetMembers, replicationFactor);
+    final Set<String> targetGroups =
+        targetPartitionIds.stream().map(PartitionId::group).collect(Collectors.toSet());
+
+    final Map<String, Set<PartitionMetadata>> distributionByGroup =
+        ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(currentConfiguration);
+    validateNoRemoval(distributionByGroup, targetPartitionIds);
+    final Map<PartitionId, PartitionMetadata> currentById =
+        targetGroups.stream()
+            .flatMap(group -> distributionByGroup.getOrDefault(group, Set.of()).stream())
+            .collect(Collectors.toMap(PartitionMetadata::id, Function.identity()));
+
+    final List<MemberId> sortedMembers =
+        targetMembers.stream().sorted(Comparator.comparingInt(MemberId::nodeIdx)).toList();
+    final int clusterSize = sortedMembers.size();
+    final int replicaSlotCount = Math.min(replicationFactor, clusterSize);
+
+    final Map<MemberId, Integer> replicaCountByMember = new HashMap<>();
+    final Map<MemberId, Integer> leaderCountByMember = new HashMap<>();
+    distributionByGroup
+        .values()
+        .forEach(
+            partitions -> accumulateLoad(partitions, replicaCountByMember, leaderCountByMember));
+
+    final List<PartitionId> processingOrder =
+        targetPartitionIds.stream().distinct().sorted().toList();
+
+    final List<PartitionId> newPartitionIds = new ArrayList<>();
+    final Map<PartitionId, Set<MemberId>> newMembersById = new LinkedHashMap<>();
+    final Map<PartitionId, MemberId> newPrimaryById = new LinkedHashMap<>();
+    for (final PartitionId id : processingOrder) {
+      if (currentById.containsKey(id)) {
+        continue;
+      }
+      final var placement =
+          selectNewPartitionMembers(
+              sortedMembers, replicaSlotCount, replicaCountByMember, leaderCountByMember);
+      newPartitionIds.add(id);
+      newMembersById.put(id, new LinkedHashSet<>(placement.members()));
+      newPrimaryById.put(id, placement.primary());
+      placement.members().forEach(member -> replicaCountByMember.merge(member, 1, Integer::sum));
+      leaderCountByMember.merge(placement.primary(), 1, Integer::sum);
+    }
+
+    // Fixes up leader-count balance across the new partitions by reassigning primary among their
+    // already-selected replicas — never moving a replica, never touching an existing partition.
+    rebalanceLeaders(
+        newPartitionIds, newMembersById, newPrimaryById, sortedMembers, leaderCountByMember);
+
+    final Set<PartitionMetadata> result = new HashSet<>();
+    for (final PartitionId id : processingOrder) {
+      final var existing = currentById.get(id);
+      if (existing != null) {
+        result.add(existing);
+        continue;
+      }
+
+      final var membersForPartition = List.copyOf(newMembersById.get(id));
+      final var primary = newPrimaryById.get(id);
+      final var priorities =
+          PartitionPriorityAssigner.assignPriorities(
+              id, membersForPartition, primary, clusterSize, replicationFactor);
+
+      result.add(
+          new PartitionMetadata(
+              id, Set.copyOf(membersForPartition), priorities, priorities.get(primary), primary));
+    }
+    return result;
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionPriorityAssigner.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionPriorityAssigner.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.cluster.PartitionId;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared Raft election priority assignment used by {@link RoundRobinPartitionDistributor} and
+ * {@link AdditivePartitionReassigner} (and, in the future, a general-case reassigner supporting
+ * broker/replication-factor changes), so they all produce the same failover behavior: the primary
+ * gets the highest priority, and which follower gets the second-highest priority alternates across
+ * partitions so that leadership loss is spread evenly across followers.
+ */
+final class PartitionPriorityAssigner {
+
+  private PartitionPriorityAssigner() {}
+
+  static Map<MemberId, Integer> assignPriorities(
+      final PartitionId partitionId,
+      final List<MemberId> membersForPartition,
+      final MemberId primary,
+      final int clusterSize,
+      final int replicationFactor) {
+    final Map<MemberId, Integer> priority = new HashMap<>();
+    final int lowestPriority = 1;
+
+    priority.put(primary, replicationFactor);
+    // To ensure that secondary priorities are distributed evenly, we alternate the nodes for which
+    // second priority is assigned. Example, clusterSize = 3 partitionCount = 12. Node 0 has highest
+    // priority (=3) for partition 1,4,7 and 10. For partition 1 and 7, node 1 gets priority 2. For
+    // partition 4 and 10, node 2 gets priority 2. This is done so that if node 0 dies, the
+    // leadership is evenly distributed on the rest of the followers.
+    if ((partitionId.number() - 1) / clusterSize % 2 == 0) {
+      int nextPriority = replicationFactor - 1;
+      for (final MemberId member : membersForPartition) {
+        if (!member.equals(primary)) {
+          priority.put(member, nextPriority);
+          nextPriority--;
+        }
+      }
+    } else {
+      int nextPriority = lowestPriority;
+      for (final MemberId member : membersForPartition) {
+        if (!member.equals(primary)) {
+          priority.put(member, nextPriority);
+          nextPriority++;
+        }
+      }
+    }
+    return priority;
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassigner.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassigner.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Computes a new partition distribution that satisfies {@code targetMembers}/{@code
+ * targetPartitionIds}/{@code replicationFactor}, changing as little as possible relative to the
+ * current distribution. Unlike {@link io.camunda.zeebe.dynamic.config.PartitionDistributor}, which
+ * always computes a full distribution from scratch, a {@code PartitionReassigner} treats the
+ * current assignment as the starting point and only moves what is necessary to reach the target
+ * state.
+ *
+ * <p>{@code targetMembers} and {@code targetPartitionIds} describe the complete desired end state —
+ * both existing and new members/ids — not just what's being added. {@code targetPartitionIds} may
+ * span several partition groups in a single call, so brokers can be reassigned across multiple
+ * physical tenants at once.
+ *
+ * <p>Whether an existing group or partition id that's absent from {@code targetPartitionIds} is
+ * treated as "leave it alone" or "remove it" — or rejected outright — is defined by each
+ * implementation, not by this interface: {@link AdditivePartitionReassigner} does not support
+ * removal at all and rejects any call that omits an existing partition or group (see {@link
+ * PartitionReassignmentSupport#validateNoRemoval}); a future implementation is expected to support
+ * explicit removal, where omitting an id means exactly that. Consult the implementation's javadoc
+ * for its specific policy.
+ *
+ * <p>The order of {@code targetPartitionIds} does not affect the result — implementations process
+ * ids in their natural {@link PartitionId} order, not list order, so two calls with the same id set
+ * in a different list order produce the same distribution.
+ *
+ * <p>This single contract covers every combination of scaling changes:
+ *
+ * <ul>
+ *   <li>adding partitions only ({@code targetPartitionIds} grows, members/RF unchanged) — no
+ *       existing partition needs to move
+ *   <li>adding brokers only ({@code targetMembers} grows, ids/RF unchanged) — some existing
+ *       partitions may need to move to use the new capacity, but the number moved should be minimal
+ *   <li>adding both partitions and brokers — new partitions are placed to prefer the new brokers,
+ *       reducing how many existing partitions need to move
+ *   <li>changing the replication factor alone — replicas are added to or removed from existing
+ *       partitions without otherwise moving them
+ * </ul>
+ *
+ * <p>The output is the new distribution for all of {@code targetPartitionIds} — both the ids that
+ * already existed and the ones newly placed by this call.
+ */
+public interface PartitionReassigner {
+
+  /**
+   * @param currentConfiguration supplies the current distribution of every group that has ids in
+   *     {@code targetPartitionIds}, plus every other group's assignments (used only as static
+   *     background load, or to enforce an implementation's removal policy)
+   * @param targetMembers the complete broker set that should be in play after the change, including
+   *     brokers already hosting partitions and any newly added ones; must not be empty
+   * @param targetPartitionIds the complete partition-id set that should exist after the change,
+   *     including ids that already exist and any newly added ones; may span multiple groups.
+   *     Whether omitting an existing id or group is permitted (and what it means) is defined by the
+   *     implementation
+   * @param replicationFactor the replication factor every partition in {@code targetPartitionIds}
+   *     should converge to; must be at least 1
+   * @return the new distribution for all of {@code targetPartitionIds}
+   * @throws IllegalArgumentException if {@code targetMembers} is empty, {@code replicationFactor}
+   *     is not positive, or the implementation's removal policy is violated
+   */
+  Set<PartitionMetadata> reassignPartitions(
+      CurrentClusterConfiguration currentConfiguration,
+      Set<MemberId> targetMembers,
+      List<PartitionId> targetPartitionIds,
+      int replicationFactor);
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentSupport.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentSupport.java
@@ -303,7 +303,8 @@ final class PartitionReassignmentSupport {
    */
   static void validateNoRemoval(
       final Map<String, Set<PartitionMetadata>> distributionByGroup,
-      final List<PartitionId> targetPartitionIds) {
+      final List<PartitionId> targetPartitionIds,
+      final int replicationFactor) {
     final Set<PartitionId> targetIdSet = Set.copyOf(targetPartitionIds);
     final var missing =
         distributionByGroup.values().stream()
@@ -317,6 +318,21 @@ final class PartitionReassignmentSupport {
               + "removing partitions or groups is not supported by this reassigner, but is "
               + "missing: "
               + missing);
+    }
+
+    final var partitionsWithReducedReplicationFactor =
+        distributionByGroup.values().stream()
+            .flatMap(Set::stream)
+            .filter(metadata -> metadata.members().size() > replicationFactor)
+            .toList();
+
+    if (!partitionsWithReducedReplicationFactor.isEmpty()) {
+      throw new IllegalArgumentException(
+          "targetPartitionIds must not reduce the replication factor of any existing partition — "
+              + "reducing replication factor is not supported by this reassigner, but the following partitions have more members than the target replication factor: "
+              + partitionsWithReducedReplicationFactor.stream()
+                  .map(PartitionMetadata::id)
+                  .toList());
     }
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentSupport.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentSupport.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import java.util.ArrayDeque;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+/** Shared helpers used by {@link PartitionReassigner} implementations. */
+final class PartitionReassignmentSupport {
+
+  private PartitionReassignmentSupport() {}
+
+  /**
+   * Adds the replica/leader counts contributed by {@code partitions} into the given maps.
+   *
+   * <p>Known limitation: {@code partitions} comes from {@link
+   * ConfigurationUtil#getPartitionDistributionPerPhysicalTenant}, which only counts partitions in
+   * {@code ACTIVE}/{@code LEAVING}/{@code RECOVERING} state and excludes {@code JOINING}. A broker
+   * that is mid-join for a partition of some other, untouched group therefore looks under-loaded
+   * here relative to its true near-future load, and could receive more new replicas than it should
+   * as a result.
+   */
+  static void accumulateLoad(
+      final Set<PartitionMetadata> partitions,
+      final Map<MemberId, Integer> replicaCountByMember,
+      final Map<MemberId, Integer> leaderCountByMember) {
+    partitions.forEach(
+        metadata -> {
+          metadata.members().forEach(member -> replicaCountByMember.merge(member, 1, Integer::sum));
+          metadata
+              .getPrimary()
+              .ifPresent(primary -> leaderCountByMember.merge(primary, 1, Integer::sum));
+        });
+  }
+
+  /**
+   * Orders members ascending by replica count, then leader count, then {@link MemberId#nodeIdx()} —
+   * the least-loaded, most-deterministic member sorts first.
+   */
+  static Comparator<MemberId> loadComparator(
+      final Map<MemberId, Integer> replicaCountByMember,
+      final Map<MemberId, Integer> leaderCountByMember) {
+    return Comparator.comparingInt(
+            (MemberId member) -> replicaCountByMember.getOrDefault(member, 0))
+        .thenComparingInt(member -> leaderCountByMember.getOrDefault(member, 0))
+        .thenComparingInt(MemberId::nodeIdx);
+  }
+
+  /**
+   * Picks the {@code replicaSlotCount} members for a brand-new partition by {@link
+   * #loadComparator}, then the primary as the first (least-loaded) member of that selection.
+   * Leader-count balance is not this method's job — replica-count selection alone can leave leader
+   * count skewed (e.g. under a small cluster with a high replication factor, where almost every
+   * member is a replica of almost every partition anyway, so replica count alone rarely
+   * discriminates in favor of whoever is lightest on leadership) — see {@link #rebalanceLeaders}
+   * for the pass that fixes that up afterward without touching any replica set.
+   *
+   * @param candidates the members eligible for this partition, in any order
+   */
+  static NewPartitionPlacement selectNewPartitionMembers(
+      final List<MemberId> candidates,
+      final int replicaSlotCount,
+      final Map<MemberId, Integer> replicaCountByMember,
+      final Map<MemberId, Integer> leaderCountByMember) {
+    final List<MemberId> members =
+        candidates.stream()
+            .sorted(loadComparator(replicaCountByMember, leaderCountByMember))
+            .limit(replicaSlotCount)
+            .toList();
+    return new NewPartitionPlacement(members, members.get(0));
+  }
+
+  /**
+   * Fixes up leader-count balance across {@code eligiblePartitionIds} by reassigning which existing
+   * replica is primary — never moving a replica, never touching a partition outside the eligible
+   * set. A direct swap (busiest hands leadership straight to quietest) only works when they already
+   * co-occur on some eligible partition; in general they don't, so each iteration instead searches
+   * for a <i>chain</i> of primary reassignments — partition A's primary changes from the busiest
+   * member to some member M, which is currently primary of a different partition B, whose primary
+   * changes to M2, and so on — that ultimately moves one unit of leadership from the busiest member
+   * to some sufficiently-quiet member several hops away, with every intermediate member's leader
+   * count unchanged (it loses a primary role but gains one, net zero). This is a standard
+   * augmenting-path search over the graph where an edge from member X to member Y exists for every
+   * eligible partition X currently leads with Y as a fellow replica.
+   *
+   * <p>Stops once every target member's leader count is within one of every other's, or once no
+   * augmenting path can be found (the busiest member cannot reach any sufficiently quiet member
+   * through any chain of eligible partitions).
+   *
+   * <p>{@code eligiblePartitionIds} lets each caller scope which partitions may have their primary
+   * changed — e.g. {@link AdditivePartitionReassigner} restricts this to newly placed partitions
+   * only, since it must never touch an existing partition at all.
+   */
+  static void rebalanceLeaders(
+      final List<PartitionId> eligiblePartitionIds,
+      final Map<PartitionId, Set<MemberId>> membersByPartition,
+      final Map<PartitionId, MemberId> primaryByPartition,
+      final List<MemberId> targetMembers,
+      final Map<MemberId, Integer> leaderCountByMember) {
+    if (targetMembers.size() < 2 || eligiblePartitionIds.isEmpty()) {
+      return;
+    }
+    final int maxIterations = targetMembers.size() * eligiblePartitionIds.size() + 1;
+    for (int iteration = 0; iteration < maxIterations; iteration++) {
+      final int max = maxLeaderCount(targetMembers, leaderCountByMember);
+      final int min = minLeaderCount(targetMembers, leaderCountByMember);
+      if (max - min <= 1) {
+        return;
+      }
+      final boolean progressed =
+          transferLeadershipFromABusiestMember(
+              eligiblePartitionIds,
+              membersByPartition,
+              primaryByPartition,
+              targetMembers,
+              leaderCountByMember,
+              max);
+      if (!progressed) {
+        return; // no busiest candidate has an augmenting path — no further progress possible
+      }
+    }
+  }
+
+  private static int maxLeaderCount(
+      final List<MemberId> targetMembers, final Map<MemberId, Integer> leaderCountByMember) {
+    return targetMembers.stream()
+        .mapToInt(member -> leaderCountByMember.getOrDefault(member, 0))
+        .max()
+        .orElseThrow();
+  }
+
+  private static int minLeaderCount(
+      final List<MemberId> targetMembers, final Map<MemberId, Integer> leaderCountByMember) {
+    return targetMembers.stream()
+        .mapToInt(member -> leaderCountByMember.getOrDefault(member, 0))
+        .min()
+        .orElseThrow();
+  }
+
+  /**
+   * Tries every member tied for busiest (leader count == {@code max}) as a transfer source, in
+   * turn, until one succeeds. Any member tied for busiest is a candidate source: one of them might
+   * have no augmenting path to a quiet-enough member while another does (e.g. two members are
+   * equally the most leader-loaded, but only one of them happens to share a partition with a member
+   * that can pass leadership further along), so every tied candidate is tried before giving up.
+   *
+   * @return {@code true} if a transfer was applied (leadership moved from some busiest candidate to
+   *     a sufficiently quiet member), {@code false} if none of the tied candidates has an
+   *     augmenting path
+   */
+  private static boolean transferLeadershipFromABusiestMember(
+      final List<PartitionId> eligiblePartitionIds,
+      final Map<PartitionId, Set<MemberId>> membersByPartition,
+      final Map<PartitionId, MemberId> primaryByPartition,
+      final List<MemberId> targetMembers,
+      final Map<MemberId, Integer> leaderCountByMember,
+      final int max) {
+    final List<MemberId> busiestCandidates =
+        targetMembers.stream()
+            .filter(member -> leaderCountByMember.getOrDefault(member, 0) == max)
+            .toList();
+    // A transfer only counts as progress if the target ends up strictly better off than the
+    // busiest member did before the transfer — otherwise a chain could just relabel who's
+    // "busiest" every iteration without ever converging.
+    final int threshold = max - 2;
+    for (final MemberId busiest : busiestCandidates) {
+      final var path =
+          findAugmentingPath(
+              busiest,
+              threshold,
+              eligiblePartitionIds,
+              membersByPartition,
+              primaryByPartition,
+              leaderCountByMember);
+      if (path != null) {
+        applyAugmentingPath(path, primaryByPartition, leaderCountByMember);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Searches for a <i>chain</i> of primary reassignments — partition A's primary changes from
+   * {@code busiest} to some member M, which is currently primary of a different partition B, whose
+   * primary changes to M2, and so on — that ultimately moves one unit of leadership from {@code
+   * busiest} to some member whose leader count is already at or below {@code threshold}, with every
+   * intermediate member's leader count unchanged (it loses a primary role but gains one, net zero).
+   * This is a standard augmenting-path search over the graph where an edge from member X to member
+   * Y exists for every eligible partition X currently leads with Y as a fellow replica.
+   *
+   * @return the found path, or {@code null} if {@code busiest} cannot reach any sufficiently quiet
+   *     member through any chain of eligible partitions
+   */
+  private static AugmentingPath findAugmentingPath(
+      final MemberId busiest,
+      final int threshold,
+      final List<PartitionId> eligiblePartitionIds,
+      final Map<PartitionId, Set<MemberId>> membersByPartition,
+      final Map<PartitionId, MemberId> primaryByPartition,
+      final Map<MemberId, Integer> leaderCountByMember) {
+    final Map<MemberId, MemberId> cameFromMember = new HashMap<>();
+    final Map<MemberId, PartitionId> cameFromPartition = new HashMap<>();
+    final Set<MemberId> visited = new HashSet<>();
+    final Set<PartitionId> usedPartitions = new HashSet<>();
+    final Queue<MemberId> queue = new ArrayDeque<>();
+    visited.add(busiest);
+    queue.add(busiest);
+    while (!queue.isEmpty()) {
+      final MemberId current = queue.poll();
+      for (final var id : eligiblePartitionIds) {
+        if (usedPartitions.contains(id) || !current.equals(primaryByPartition.get(id))) {
+          continue;
+        }
+        for (final MemberId next : membersByPartition.get(id)) {
+          if (next.equals(current) || visited.contains(next)) {
+            continue;
+          }
+          visited.add(next);
+          usedPartitions.add(id);
+          cameFromMember.put(next, current);
+          cameFromPartition.put(next, id);
+          if (leaderCountByMember.getOrDefault(next, 0) <= threshold) {
+            return new AugmentingPath(busiest, next, cameFromMember, cameFromPartition);
+          }
+          queue.add(next);
+        }
+      }
+    }
+    return null; // no augmenting path found
+  }
+
+  /**
+   * Replays a found {@link AugmentingPath}'s chain of primary reassignments and updates leader
+   * counts.
+   */
+  private static void applyAugmentingPath(
+      final AugmentingPath path,
+      final Map<PartitionId, MemberId> primaryByPartition,
+      final Map<MemberId, Integer> leaderCountByMember) {
+    MemberId node = path.target();
+    while (!node.equals(path.busiest())) {
+      primaryByPartition.put(path.cameFromPartition().get(node), node);
+      node = path.cameFromMember().get(node);
+    }
+    leaderCountByMember.merge(path.busiest(), -1, Integer::sum);
+    leaderCountByMember.merge(path.target(), 1, Integer::sum);
+  }
+
+  /**
+   * @throws IllegalArgumentException if {@code targetMembers} is empty, {@code replicationFactor}
+   *     is not positive, or {@code targetMembers} has fewer members than {@code replicationFactor}
+   *     — that combination can never be satisfied and would otherwise silently under-replicate
+   *     every partition instead of failing loudly
+   */
+  static void validateTargetMembers(
+      final Set<MemberId> targetMembers, final int replicationFactor) {
+    if (targetMembers.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Expected at least one target member, but targetMembers is empty");
+    }
+    if (replicationFactor < 1) {
+      throw new IllegalArgumentException(
+          "Expected replicationFactor to be at least 1, but was " + replicationFactor);
+    }
+    if (targetMembers.size() < replicationFactor) {
+      throw new IllegalArgumentException(
+          "Expected at least %d target member(s) to satisfy replicationFactor, but targetMembers has only %d"
+              .formatted(replicationFactor, targetMembers.size()));
+    }
+  }
+
+  /**
+   * Validates that every partition id that currently exists — in every group, not just ones
+   * mentioned in {@code targetPartitionIds} — is present in {@code targetPartitionIds}. These
+   * implementations do not support removing a partition or an entire group: {@code
+   * targetPartitionIds} must describe the complete desired state of the whole cluster's groups, not
+   * just the ones being changed. A group with no ids at all in {@code targetPartitionIds} is only
+   * permitted if it currently has no partitions of its own (e.g. a brand-new, empty group
+   * pre-seeded before this call) — there is nothing to silently remove in that case.
+   *
+   * @param distributionByGroup every group's current distribution, e.g. from {@link
+   *     ConfigurationUtil#getPartitionDistributionPerPhysicalTenant}
+   * @throws IllegalArgumentException if any existing partition id, in any group, is missing from
+   *     {@code targetPartitionIds}
+   */
+  static void validateNoRemoval(
+      final Map<String, Set<PartitionMetadata>> distributionByGroup,
+      final List<PartitionId> targetPartitionIds) {
+    final Set<PartitionId> targetIdSet = Set.copyOf(targetPartitionIds);
+    final var missing =
+        distributionByGroup.values().stream()
+            .flatMap(Set::stream)
+            .map(PartitionMetadata::id)
+            .filter(id -> !targetIdSet.contains(id))
+            .toList();
+    if (!missing.isEmpty()) {
+      throw new IllegalArgumentException(
+          "targetPartitionIds must include every existing partition id of every existing group — "
+              + "removing partitions or groups is not supported by this reassigner, but is "
+              + "missing: "
+              + missing);
+    }
+  }
+
+  /**
+   * The members and primary chosen for a newly placed partition by {@link
+   * #selectNewPartitionMembers}.
+   */
+  record NewPartitionPlacement(List<MemberId> members, MemberId primary) {}
+
+  /**
+   * A chain of primary reassignments found by {@link #findAugmentingPath} that moves one unit of
+   * leadership from {@code busiest} to {@code target}.
+   *
+   * @param cameFromMember for each member on the path (except {@code busiest}), the member it was
+   *     reached from
+   * @param cameFromPartition for each member on the path (except {@code busiest}), the eligible
+   *     partition whose primary must change to reach it
+   */
+  private record AugmentingPath(
+      MemberId busiest,
+      MemberId target,
+      Map<MemberId, MemberId> cameFromMember,
+      Map<MemberId, PartitionId> cameFromPartition) {}
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentSupport.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentSupport.java
@@ -48,8 +48,11 @@ final class PartitionReassignmentSupport {
   }
 
   /**
-   * Orders members ascending by replica count, then leader count, then {@link MemberId#nodeIdx()} —
-   * the least-loaded, most-deterministic member sorts first.
+   * Orders members ascending by replica count, then leader count, then {@link
+   * MemberId#ID_COMPARATOR} — the least-loaded, most-deterministic member sorts first. {@code
+   * nodeIdx} alone is not a total order once zoned members are involved (the same {@code nodeIdx}
+   * can occur in more than one zone), so {@code ID_COMPARATOR} — which additionally orders by zone
+   * — is used as the final tie-breaker instead.
    */
   static Comparator<MemberId> loadComparator(
       final Map<MemberId, Integer> replicaCountByMember,
@@ -57,7 +60,7 @@ final class PartitionReassignmentSupport {
     return Comparator.comparingInt(
             (MemberId member) -> replicaCountByMember.getOrDefault(member, 0))
         .thenComparingInt(member -> leaderCountByMember.getOrDefault(member, 0))
-        .thenComparingInt(MemberId::nodeIdx);
+        .thenComparing(MemberId.ID_COMPARATOR);
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributor.java
@@ -15,7 +15,6 @@ import io.camunda.cluster.ZoneLayout;
 import io.camunda.zeebe.dynamic.config.PartitionDistributor;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -114,32 +113,7 @@ public final class RoundRobinPartitionDistributor implements PartitionDistributo
       final MemberId primary,
       final int clusterSize,
       final int replicationFactor) {
-    final Map<MemberId, Integer> priority = new HashMap<>();
-    final int lowestPriority = 1;
-
-    priority.put(primary, replicationFactor);
-    // To ensure that secondary priorities are distributed evenly, we alternate the nodes for which
-    // second priority is assigned. Example, clusterSize = 3 partitionCount = 12. Node 0 has highest
-    // priority (=3) for partition 1,4,7 and 10. For partition 1 and 7, node 1 gets priority 2. For
-    // partition 4 and 10, node 2 gets priority 2. This is done so that if node 0 dies, the
-    // leadership is evenly distributed on the rest of the followers.
-    if ((partitionId.number() - 1) / clusterSize % 2 == 0) {
-      int nextPriority = replicationFactor - 1;
-      for (final MemberId member : membersForPartition) {
-        if (!member.equals(primary)) {
-          priority.put(member, nextPriority);
-          nextPriority--;
-        }
-      }
-    } else {
-      int nextPriority = lowestPriority;
-      for (final MemberId member : membersForPartition) {
-        if (!member.equals(primary)) {
-          priority.put(member, nextPriority);
-          nextPriority++;
-        }
-      }
-    }
-    return priority;
+    return PartitionPriorityAssigner.assignPriorities(
+        partitionId, membersForPartition, primary, clusterSize, replicationFactor);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerPropertyTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.IntRange;
+
+/**
+ * Property-based tests for {@link AdditivePartitionReassigner}, in the style of {@code
+ * PartitionReassignRequestTransformerTest}: for randomly generated valid inputs, the resulting
+ * distribution must satisfy a set of invariants regardless of the specific numbers involved.
+ *
+ * <p>Since {@link AdditivePartitionReassigner} only ever adds new partitions on top of an unchanged
+ * broker set and replication factor, the "current" distribution fed into each property is itself
+ * built by the same reassigner starting from an empty cluster — this guarantees it's already
+ * balanced, which is a precondition the implementation relies on (it never touches existing
+ * partitions, so it can't fix up an already-skewed starting point).
+ */
+final class AdditivePartitionReassignerPropertyTest {
+
+  private static final String GROUP = "test";
+
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+  private final AdditivePartitionReassigner reassigner = new AdditivePartitionReassigner();
+
+  @Property(tries = 50)
+  void shouldSatisfyDistributionInvariantsWhenAddingPartitions(
+      @ForAll @IntRange(min = 1, max = 4) final int replicationFactor,
+      @ForAll @IntRange(min = 0, max = 10) final int extraMembers,
+      @ForAll @IntRange(min = 1, max = 30) final int oldPartitionCount,
+      @ForAll @IntRange(min = 0, max = 20) final int additionalPartitionCount) {
+    final int clusterSize = replicationFactor + extraMembers;
+    final Set<MemberId> targetMembers = members(clusterSize);
+    final int newPartitionCount = oldPartitionCount + additionalPartitionCount;
+
+    // given — an already-balanced starting distribution, built by the reassigner itself from an
+    // empty cluster (the only kind of starting point this implementation can guarantee to keep
+    // balanced, since it never moves an existing partition)
+    final var oldDistribution =
+        reassigner.reassignPartitions(
+            configurationWith(targetMembers, Set.of()),
+            targetMembers,
+            partitionIds(1, oldPartitionCount),
+            replicationFactor);
+    final var currentConfiguration = configurationWith(targetMembers, oldDistribution);
+    final var targetPartitionIds = partitionIds(1, newPartitionCount);
+
+    // when
+    final var result =
+        reassigner.reassignPartitions(
+            currentConfiguration, targetMembers, targetPartitionIds, replicationFactor);
+
+    // then — leader-count balance is checked with a looser tolerance than replica-count balance,
+    // since AdditivePartitionReassigner's "never touch an existing partition" guarantee can make a
+    // tight gap of 1 mathematically unachievable; see
+    // PartitionDistributionInvariants.assertSatisfied
+    PartitionDistributionInvariants.assertSatisfied(
+        result, targetMembers, targetPartitionIds, replicationFactor, replicationFactor);
+  }
+
+  private CurrentClusterConfiguration configurationWith(
+      final Set<MemberId> targetMembers, final Set<PartitionMetadata> distribution) {
+    return ConfigurationUtil.getCurrentClusterConfigurationFrom(
+        targetMembers, distribution, partitionConfig, "clusterId");
+  }
+
+  private Set<MemberId> members(final int count) {
+    return IntStream.range(0, count)
+        .mapToObj(i -> MemberId.from(String.valueOf(i)))
+        .collect(Collectors.toSet());
+  }
+
+  private List<PartitionId> partitionIds(final int fromInclusive, final int toInclusive) {
+    return IntStream.rangeClosed(fromInclusive, toInclusive)
+        .mapToObj(i -> new PartitionId(GROUP, i))
+        .toList();
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerPropertyTest.java
@@ -70,7 +70,7 @@ final class AdditivePartitionReassignerPropertyTest {
     // tight gap of 1 mathematically unachievable; see
     // PartitionDistributionInvariants.assertSatisfied
     PartitionDistributionInvariants.assertSatisfied(
-        result, targetMembers, targetPartitionIds, replicationFactor, replicationFactor);
+        result, targetMembers, targetPartitionIds, replicationFactor, 3);
   }
 
   private CurrentClusterConfiguration configurationWith(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerPropertyTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
@@ -71,6 +73,10 @@ final class AdditivePartitionReassignerPropertyTest {
     // PartitionDistributionInvariants.assertSatisfied
     PartitionDistributionInvariants.assertSatisfied(
         result, targetMembers, targetPartitionIds, replicationFactor, 3);
+
+    assertThat(result)
+        .describedAs("No existing partition was moved or removed")
+        .containsAll(oldDistribution);
   }
 
   private CurrentClusterConfiguration configurationWith(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -186,6 +187,42 @@ final class AdditivePartitionReassignerTest {
 
     // then
     assertThat(first).isEqualTo(second);
+  }
+
+  @Test
+  void shouldPlaceZoneAwareMembersWithCollidingNodeIdxIdenticallyRegardlessOfIterationOrder() {
+    // given — "us_0"/"eu_0" share nodeIdx 0, "us_1"/"eu_1" share nodeIdx 1. Two target-member sets
+    // with the exact same four elements but opposite insertion/iteration order (LinkedHashSet
+    // preserves insertion order, unlike Set.of()). Sorting by nodeIdx alone (rather than the full
+    // MemberId.ID_COMPARATOR, which also orders by zone) would leave each colliding pair tied, and
+    // Java's stable sort would then preserve whatever relative order they happened to arrive in —
+    // making the outcome depend on incidental iteration order instead of the members' actual
+    // identities.
+    final var usZone0 = zoneMember("us", 0);
+    final var euZone0 = zoneMember("eu", 0);
+    final var usZone1 = zoneMember("us", 1);
+    final var euZone1 = zoneMember("eu", 1);
+    final var membersInOneOrder = new LinkedHashSet<>(List.of(usZone0, euZone0, usZone1, euZone1));
+    final var membersInReverseOrder =
+        new LinkedHashSet<>(List.of(euZone1, usZone1, euZone0, usZone0));
+    final var configuration = configurationWithExistingGroups(Map.of());
+    final var targetPartitionIds = sortedPartitionIds(NEW_GROUP, 1, 4);
+
+    // when — reassigning the exact same target members, just enumerated in a different order
+    final var first =
+        reassigner.reassignPartitions(configuration, membersInOneOrder, targetPartitionIds, 2);
+    final var second =
+        reassigner.reassignPartitions(configuration, membersInReverseOrder, targetPartitionIds, 2);
+
+    // then — the outcome is identical regardless of iteration order
+    assertThat(first).isEqualTo(second);
+
+    // and — all four zone-aware members are treated as distinct and none is silently dropped or
+    // conflated with its same-nodeIdx counterpart in the other zone
+    final var replicaCounts = countReplicasPerMember(first);
+    assertThat(replicaCounts.keySet())
+        .containsExactlyInAnyOrder(usZone0, euZone0, usZone1, euZone1);
+    assertThat(replicaCounts.values()).allMatch(count -> count == 2);
   }
 
   @Test
@@ -368,5 +405,9 @@ final class AdditivePartitionReassignerTest {
 
   private MemberId member(final int id) {
     return MemberId.from(String.valueOf(id));
+  }
+
+  private MemberId zoneMember(final String zone, final int nodeIdx) {
+    return MemberId.from(zone, nodeIdx);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerTest.java
@@ -91,14 +91,14 @@ final class AdditivePartitionReassignerTest {
             new PartitionId(NEW_GROUP, 1),
             new PartitionId(NEW_GROUP, 2));
     final var assigned =
-        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 1);
+        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 2);
 
     // then — every existing partition of both groups is unchanged, and the new tenantB partition 2
     // lands on member 3, the only member with zero load from either group
     assertThat(assigned).containsAll(tenantAPartitions);
     assertThat(assigned).contains(existingTenantB);
     final var placed = findPartition(assigned, NEW_GROUP, 2);
-    assertThat(placed.members()).containsExactly(member(3));
+    assertThat(placed.members()).containsExactlyInAnyOrder(member(3), member(2));
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerTest.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Every test here calls {@link AdditivePartitionReassigner#reassignPartitions} with {@code
+ * targetPartitionIds} consisting of ALL partition ids from ALL groups present in the current
+ * configuration (existing ids for every group, plus any new ones) — never a subset that omits a
+ * group that already exists. The one exception is a genuinely brand-new cluster with no prior state
+ * ({@link #shouldDistributeEvenlyWhenNoExistingPartitions()}), where the full target list and the
+ * new-ids list are the same thing by definition.
+ */
+final class AdditivePartitionReassignerTest {
+
+  private static final String NEW_GROUP = "tenantB";
+
+  private final DynamicPartitionConfig partitionConfig =
+      new DynamicPartitionConfig(
+          new ExportingConfig(
+              ExportingState.EXPORTING,
+              Map.of("expA", new ExporterState(1, ExporterState.State.ENABLED, Optional.empty()))));
+
+  private final AdditivePartitionReassigner reassigner = new AdditivePartitionReassigner();
+
+  @Test
+  void shouldDistributeEvenlyWhenNoExistingPartitions() {
+    // given — a fresh cluster with no partition groups yet, so the full target list is all new
+    final var configuration = configurationWithExistingGroups(Map.of());
+    final var targetMembers = members(4);
+    final var targetPartitionIds = sortedPartitionIds(NEW_GROUP, 1, 4);
+
+    // when
+    final var assigned =
+        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 3);
+
+    // then — every member ends up with the same replica count
+    assertThat(assigned).hasSize(4);
+    final var replicaCounts = countReplicasPerMember(assigned);
+    assertThat(replicaCounts.values()).allMatch(count -> count == 3);
+  }
+
+  @Test
+  void shouldPlaceNewPartitionsOnLeastLoadedMembersFirst() {
+    // given — tenantA loads member 0 twice and members 1 and 2 once each; tenantB already has
+    // partition 1 on member 1
+    final var tenantAPartitions =
+        Set.of(
+            PartitionMetadataFixtures.partition(
+                "tenantA", 1, Set.of(member(0), member(1)), member(0)),
+            PartitionMetadataFixtures.partition(
+                "tenantA", 2, Set.of(member(0), member(2)), member(0)));
+    final var existingTenantB =
+        PartitionMetadataFixtures.partition(NEW_GROUP, 1, Set.of(member(1)), member(1));
+    final var configuration =
+        configurationWithExistingGroups(
+            Map.of("tenantA", tenantAPartitions, NEW_GROUP, Set.of(existingTenantB)));
+
+    // when — the full target list covers every group: tenantA's existing partitions 1-2, plus
+    // tenantB's existing partition 1 and new partition 2
+    final var targetMembers = members(4);
+    final var targetPartitionIds =
+        List.of(
+            new PartitionId("tenantA", 1),
+            new PartitionId("tenantA", 2),
+            new PartitionId(NEW_GROUP, 1),
+            new PartitionId(NEW_GROUP, 2));
+    final var assigned =
+        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 1);
+
+    // then — every existing partition of both groups is unchanged, and the new tenantB partition 2
+    // lands on member 3, the only member with zero load from either group
+    assertThat(assigned).containsAll(tenantAPartitions);
+    assertThat(assigned).contains(existingTenantB);
+    final var placed = findPartition(assigned, NEW_GROUP, 2);
+    assertThat(placed.members()).containsExactly(member(3));
+  }
+
+  @Test
+  void shouldPassThroughExistingPartitionsOfTheSameGroupUnchanged() {
+    // given — tenantB already has partition 1; the full target list is partitions 1 and 2
+    final PartitionMetadata existingPartition =
+        new PartitionMetadata(
+            new PartitionId(NEW_GROUP, 1),
+            Set.of(member(0), member(1)),
+            Map.of(member(0), 2, member(1), 1),
+            2,
+            member(0));
+    final var configuration =
+        configurationWithExistingGroups(Map.of(NEW_GROUP, Set.of(existingPartition)));
+
+    // when
+    final var targetMembers = members(3);
+    final var targetPartitionIds = sortedPartitionIds(NEW_GROUP, 1, 2);
+    final var assigned =
+        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 2);
+
+    // then — partition 1 comes back byte-for-byte identical, only partition 2 is newly placed
+    assertThat(assigned).contains(existingPartition);
+    assertThat(assigned.stream().map(PartitionMetadata::id))
+        .containsExactlyInAnyOrder(new PartitionId(NEW_GROUP, 1), new PartitionId(NEW_GROUP, 2));
+  }
+
+  @Test
+  void shouldPassThroughEveryOtherGroupsExistingPartitionsUnchanged() {
+    // given — tenantA already has partition 1; tenantB already has partition 1
+    final PartitionMetadata tenantAPartition =
+        PartitionMetadataFixtures.partition("tenantA", 1, Set.of(member(0), member(1)), member(0));
+    final PartitionMetadata existingTenantB =
+        PartitionMetadataFixtures.partition(NEW_GROUP, 1, Set.of(member(0), member(1)), member(0));
+    final var configuration =
+        configurationWithExistingGroups(
+            Map.of("tenantA", Set.of(tenantAPartition), NEW_GROUP, Set.of(existingTenantB)));
+
+    // when — the full target list covers both groups: tenantA's existing partition 1, and
+    // tenantB's existing partition 1 plus new partition 2
+    final var targetMembers = members(3);
+    final var targetPartitionIds =
+        List.of(
+            new PartitionId("tenantA", 1),
+            new PartitionId(NEW_GROUP, 1),
+            new PartitionId(NEW_GROUP, 2));
+    final var assigned =
+        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 2);
+
+    // then — both groups' existing partitions are unchanged, and only tenantB's new partition 2
+    // is newly placed
+    assertThat(assigned).contains(tenantAPartition, existingTenantB);
+    assertThat(assigned.stream().map(PartitionMetadata::id))
+        .containsExactlyInAnyOrder(
+            new PartitionId("tenantA", 1),
+            new PartitionId(NEW_GROUP, 1),
+            new PartitionId(NEW_GROUP, 2));
+  }
+
+  @Test
+  void shouldProduceDeterministicResultsAcrossRepeatedCalls() {
+    // given — tenantA plus tenantB already has partitions 1 and 2
+    final PartitionMetadata tenantAPartition =
+        PartitionMetadataFixtures.partition(
+            "tenantA", 1, Set.of(member(0), member(1), member(2)), member(1));
+    final var existingTenantB =
+        Set.of(
+            PartitionMetadataFixtures.partition(
+                NEW_GROUP, 1, Set.of(member(0), member(1)), member(0)),
+            PartitionMetadataFixtures.partition(
+                NEW_GROUP, 2, Set.of(member(1), member(2)), member(1)));
+    final var configuration =
+        configurationWithExistingGroups(
+            Map.of("tenantA", Set.of(tenantAPartition), NEW_GROUP, existingTenantB));
+    final var targetMembers = members(5);
+    // full target list: tenantA's existing partition 1, plus tenantB's existing partitions 1-2
+    // and new partitions 3-6
+    final var targetPartitionIds = new ArrayList<>(sortedPartitionIds(NEW_GROUP, 1, 6));
+    targetPartitionIds.add(0, new PartitionId("tenantA", 1));
+
+    // when
+    final var first =
+        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 3);
+    final var second =
+        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 3);
+
+    // then
+    assertThat(first).isEqualTo(second);
+  }
+
+  @Test
+  void shouldOnlyPlaceOnTargetMembers() {
+    // given — tenantB already has partition 1 on member 0; the caller only wants members 0 and 1
+    // as candidates, even though member 2 exists in the cluster
+    final var existingTenantB =
+        PartitionMetadataFixtures.partition(NEW_GROUP, 1, Set.of(member(0)), member(0));
+    final var configuration =
+        configurationWithExistingGroups(Map.of(NEW_GROUP, Set.of(existingTenantB)));
+    final var targetMembers = Set.of(member(0), member(1));
+
+    // when — full target list: existing partition 1 plus new partition 2
+    final var targetPartitionIds = sortedPartitionIds(NEW_GROUP, 1, 2);
+    final var assigned =
+        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 2);
+
+    // then — member 2 never receives a replica, even though it exists in the cluster
+    assertThat(assigned)
+        .allSatisfy(metadata -> assertThat(metadata.members()).doesNotContain(member(2)));
+  }
+
+  @Test
+  void shouldPlaceNewPartitionsAcrossMultipleGroupsInOneCall() {
+    // given — tenantA already has partition 1 on member 0
+    final PartitionMetadata existingTenantA =
+        PartitionMetadataFixtures.partition("tenantA", 1, Set.of(member(0)), member(0));
+    final var configuration =
+        configurationWithExistingGroups(Map.of("tenantA", Set.of(existingTenantA)));
+
+    // when — the full target list spans tenantA (existing partition 1 + new partition 2) and a
+    // brand-new tenantC (new partition 1), all in one call
+    final var targetMembers = members(3);
+    final var targetPartitionIds =
+        List.of(
+            new PartitionId("tenantA", 1), // existing — must pass through unchanged
+            new PartitionId("tenantA", 2), // new
+            new PartitionId("tenantC", 1)); // new, different group entirely
+    final var assigned =
+        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 1);
+
+    // then — the existing tenantA partition is untouched, and both new ids (across the two
+    // groups) are placed, sharing the same load view so they don't both land on the same member
+    assertThat(assigned).contains(existingTenantA);
+    assertThat(assigned.stream().map(PartitionMetadata::id))
+        .containsExactlyInAnyOrder(
+            new PartitionId("tenantA", 1),
+            new PartitionId("tenantA", 2),
+            new PartitionId("tenantC", 1));
+    final var newTenantAPartition = findPartition(assigned, "tenantA", 2);
+    final var newTenantCPartition = findPartition(assigned, "tenantC", 1);
+    assertThat(newTenantAPartition.members()).isNotEqualTo(newTenantCPartition.members());
+  }
+
+  @Test
+  void shouldRejectEmptyTargetMembers() {
+    // given
+    final var configuration = configurationWithExistingGroups(Map.of());
+    final var targetPartitionIds = sortedPartitionIds(NEW_GROUP, 1, 2);
+
+    // when/then
+    assertThatThrownBy(
+            () -> reassigner.reassignPartitions(configuration, Set.of(), targetPartitionIds, 2))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldRejectNonPositiveReplicationFactor() {
+    // given
+    final var configuration = configurationWithExistingGroups(Map.of());
+    final var targetMembers = members(2);
+    final var targetPartitionIds = sortedPartitionIds(NEW_GROUP, 1, 2);
+
+    // when/then
+    assertThatThrownBy(
+            () ->
+                reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 0))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldRejectTargetMembersSmallerThanReplicationFactor() {
+    // given
+    final var configuration = configurationWithExistingGroups(Map.of());
+    final var targetMembers = members(2);
+    final var targetPartitionIds = sortedPartitionIds(NEW_GROUP, 1, 1);
+
+    // when/then — 2 target members can never satisfy RF 3
+    assertThatThrownBy(
+            () ->
+                reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 3))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldRejectTargetPartitionIdsThatOmitAnExistingIdOfATouchedGroup() {
+    // given — tenantB already has partitions 1 and 2
+    final var existingTenantB =
+        Set.of(
+            PartitionMetadataFixtures.partition(NEW_GROUP, 1, Set.of(member(0)), member(0)),
+            PartitionMetadataFixtures.partition(NEW_GROUP, 2, Set.of(member(1)), member(1)));
+    final var configuration = configurationWithExistingGroups(Map.of(NEW_GROUP, existingTenantB));
+    final var targetMembers = members(3);
+    // omits tenantB's existing partition 2 — only lists partition 1 (unchanged) and a new one
+    final var incompleteTargetPartitionIds =
+        List.of(new PartitionId(NEW_GROUP, 1), new PartitionId(NEW_GROUP, 3));
+
+    // when/then
+    assertThatThrownBy(
+            () ->
+                reassigner.reassignPartitions(
+                    configuration, targetMembers, incompleteTargetPartitionIds, 1))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldRejectTargetPartitionIdsThatOmitAnExistingGroupEntirely() {
+    // given — tenantA has an existing partition, but the target list only mentions tenantB
+    final PartitionMetadata existingTenantA =
+        PartitionMetadataFixtures.partition("tenantA", 1, Set.of(member(0)), member(0));
+    final var configuration =
+        configurationWithExistingGroups(Map.of("tenantA", Set.of(existingTenantA)));
+    final var targetMembers = members(3);
+    final var targetPartitionIdsMissingTenantA = sortedPartitionIds(NEW_GROUP, 1, 1);
+
+    // when/then — removing a whole group is not supported, so this must be rejected rather than
+    // silently leaving tenantA untouched in the background
+    assertThatThrownBy(
+            () ->
+                reassigner.reassignPartitions(
+                    configuration, targetMembers, targetPartitionIdsMissingTenantA, 1))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  private CurrentClusterConfiguration configurationWithExistingGroups(
+      final Map<String, Set<PartitionMetadata>> existingGroups) {
+    final Set<PartitionMetadata> allExisting = new HashSet<>();
+    existingGroups.values().forEach(allExisting::addAll);
+    final Set<MemberId> members = new HashSet<>();
+    allExisting.forEach(metadata -> members.addAll(metadata.members()));
+    // ensure the configuration always has at least members 0-4 available as cluster members
+    for (int i = 0; i < 5; i++) {
+      members.add(member(i));
+    }
+    return ConfigurationUtil.getCurrentClusterConfigurationFrom(
+        members, allExisting, partitionConfig, "clusterId");
+  }
+
+  private Set<MemberId> members(final int count) {
+    final Set<MemberId> members = new HashSet<>();
+    for (int i = 0; i < count; i++) {
+      members.add(member(i));
+    }
+    return members;
+  }
+
+  private PartitionMetadata findPartition(
+      final Set<PartitionMetadata> assigned, final String group, final int number) {
+    return assigned.stream()
+        .filter(metadata -> metadata.id().equals(new PartitionId(group, number)))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private Map<MemberId, Integer> countReplicasPerMember(final Set<PartitionMetadata> assigned) {
+    final Map<MemberId, Integer> counts = new HashMap<>();
+    assigned.forEach(
+        metadata -> metadata.members().forEach(member -> counts.merge(member, 1, Integer::sum)));
+    return counts;
+  }
+
+  private List<PartitionId> sortedPartitionIds(
+      final String group, final int fromInclusive, final int toInclusive) {
+    final List<PartitionId> ids = new ArrayList<>();
+    for (int i = fromInclusive; i <= toInclusive; i++) {
+      ids.add(new PartitionId(group, i));
+    }
+    return ids;
+  }
+
+  private MemberId member(final int id) {
+    return MemberId.from(String.valueOf(id));
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PartitionDistributionInvariants.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PartitionDistributionInvariants.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Shared invariant assertions used by {@link AdditivePartitionReassigner}'s property-based test:
+ * given a resulting distribution, verifies it actually satisfies the four properties every valid
+ * reassignment must have, regardless of the specific input sizes exercised by a given property run.
+ */
+final class PartitionDistributionInvariants {
+
+  private PartitionDistributionInvariants() {}
+
+  /**
+   * @param leaderBalanceTolerance the maximum allowed gap between the most- and least-leader-loaded
+   *     target member. {@link AdditivePartitionReassigner} cannot always guarantee a tight gap of 1
+   *     here: it never touches an existing partition, so when few new partitions are added relative
+   *     to a pre-existing skew, there can be no valid output that both keeps replica count balanced
+   *     (gap 1) and fully corrects leader count — see {@link AdditivePartitionReassigner}'s class
+   *     javadoc. The worst case is bounded by the replication factor: a single new partition can
+   *     shift at most one member's leader count by one relative to the others already at the
+   *     replication-factor-driven ceiling.
+   */
+  static void assertSatisfied(
+      final Set<PartitionMetadata> result,
+      final Set<MemberId> targetMembers,
+      final List<PartitionId> targetPartitionIds,
+      final int replicationFactor,
+      final int leaderBalanceTolerance) {
+    // 1. every target partition id is present in the result
+    assertThat(result.stream().map(PartitionMetadata::id).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrderElementsOf(targetPartitionIds);
+
+    // 4. no partition has more than one replica on the same broker
+    result.forEach(
+        metadata ->
+            assertThat(Set.copyOf(metadata.members()))
+                .as(
+                    "partition %s must have %s distinct replicas, but found members %s",
+                    metadata.id(), replicationFactor, metadata.members())
+                .hasSize(replicationFactor));
+
+    final Map<MemberId, Integer> replicaCountByMember = new HashMap<>();
+    final Map<MemberId, Integer> leaderCountByMember = new HashMap<>();
+    targetMembers.forEach(
+        member -> {
+          replicaCountByMember.put(member, 0);
+          leaderCountByMember.put(member, 0);
+        });
+    result.forEach(
+        metadata -> {
+          metadata.members().forEach(member -> replicaCountByMember.merge(member, 1, Integer::sum));
+          metadata
+              .getPrimary()
+              .ifPresent(primary -> leaderCountByMember.merge(primary, 1, Integer::sum));
+        });
+
+    // 2. replica count per broker is balanced
+    assertBalanced(replicaCountByMember, "replica", 1);
+    // 3. leader count per broker is balanced
+    assertBalanced(leaderCountByMember, "leader", leaderBalanceTolerance);
+  }
+
+  private static void assertBalanced(
+      final Map<MemberId, Integer> countByMember, final String kind, final int tolerance) {
+    final int max = countByMember.values().stream().mapToInt(Integer::intValue).max().orElse(0);
+    final int min = countByMember.values().stream().mapToInt(Integer::intValue).min().orElse(0);
+    assertThat(max - min)
+        .as("%s count per broker must be balanced, but was %s", kind, countByMember)
+        .isLessThanOrEqualTo(tolerance);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PartitionMetadataFixtures.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PartitionMetadataFixtures.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/** Shared test fixtures for building {@link PartitionMetadata} instances in reassigner tests. */
+final class PartitionMetadataFixtures {
+
+  private PartitionMetadataFixtures() {}
+
+  /**
+   * Builds a partition with a real, non-tied priority ladder (primary gets {@code members.size()},
+   * every other member gets a strictly lower, distinct priority) so round-tripping through {@link
+   * ConfigurationUtil} preserves the given primary exactly.
+   */
+  static PartitionMetadata partition(
+      final String group, final int number, final Set<MemberId> members, final MemberId primary) {
+    final Map<MemberId, Integer> priorities = new HashMap<>();
+    priorities.put(primary, members.size());
+    int nextPriority = members.size() - 1;
+    for (final var member : members.stream().sorted().toList()) {
+      if (!member.equals(primary)) {
+        priorities.put(member, nextPriority--);
+      }
+    }
+    return new PartitionMetadata(
+        new PartitionId(group, number), members, priorities, priorities.get(primary), primary);
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a new partition distribution algorithm that assigns newly provisioned tenants without disrupting existing tenants partition placement. The Additive Reassigner only allows adding new tenants. The new interface added would cover more usecases such as a new algorithm to be used for scaling instead of RoundRobin to minimize the disruption during scaling. 

The reassigner can be used both to provisiong new tenants from config on startup as well as in an api. The goal of the original issue is to provision from config on startup. 

Deleting existing tenants/partitions are out of scope. 

## Related issues

related #59536 
