### PR TITLE
ci: check out triage's own tooling instead of the caller's tree

### DIFF
--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -256,6 +256,8 @@ jobs:
         run: echo "name=ag-${SURFACE}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
 
       - name: Stage workspace manifest
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
         run: |
           set -euo pipefail
           mkdir -p "$HOME/.workspace-templates"
@@ -263,6 +265,26 @@ jobs:
              "$HOME/.workspace-templates/alwaysgreen.yaml"
           cp .github/workspace-templates/alwaysgreen.guidance.md \
              "$HOME/.workspace-templates/alwaysgreen.guidance.md"
+
+          # The monorepo is the one repo that is branch-scoped: a stable/8.x failure has
+          # to be read and fixed on that branch. The other three have no release branches
+          # and stay on main. Rewrite only the camunda entry, so the workspace is created
+          # on the failing branch rather than created on main and moved afterwards.
+          python3 - "$HOME/.workspace-templates/alwaysgreen.yaml" "${BASE_REF}" <<'PY'
+          import sys
+          path, base_ref = sys.argv[1], sys.argv[2]
+          lines = open(path).read().splitlines(keepends=True)
+          in_camunda = False
+          for i, line in enumerate(lines):
+              if line.lstrip().startswith('- url:'):
+                  in_camunda = line.rstrip().endswith('camunda/camunda.git')
+              elif in_camunda and line.lstrip().startswith('default_branch:'):
+                  indent = line[: len(line) - len(line.lstrip())]
+                  lines[i] = f'{indent}default_branch: {base_ref}\n'
+                  break
+          open(path, 'w').writelines(lines)
+          PY
+          grep -A2 'camunda/camunda.git' "$HOME/.workspace-templates/alwaysgreen.yaml"
 
       - name: Create workspace
         run: workspace create "${{ steps.ws.outputs.name }}" --manifest alwaysgreen

--- a/.github/workflows/alwaysgreen-triage.yml
+++ b/.github/workflows/alwaysgreen-triage.yml
@@ -105,12 +105,17 @@ jobs:
       # Called from stable/8.x that is a tree with no .github/actions/alwaysgreen-flag and
       # no .github/scripts/alwaysgreen, and the job dies on the first of them. There is no
       # context value for "the ref this workflow was loaded from": job_workflow_sha is
-      # absent at runtime and workflow_sha is the caller's. On workflow_dispatch the
-      # dispatched ref is already the right tree, so only workflow_call needs the default.
+      # absent at runtime and workflow_sha is the caller's.
+      #
+      # run_id tells the two entry paths apart. github.event_name cannot: inside a called
+      # workflow it reports the RUN's event, so a manually dispatched pipeline calling
+      # triage looks identical to triage being dispatched itself. run_id is required on
+      # triage's own workflow_dispatch and absent on workflow_call, so it is only set when
+      # github.ref_name really is this workflow's ref.
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.tooling_ref || (github.event_name == 'workflow_dispatch' && github.ref_name) || 'main' }}
+          ref: ${{ inputs.tooling_ref || (inputs.run_id && github.ref_name) || 'main' }}
           sparse-checkout: .github
           persist-credentials: false
 

--- a/.github/workflows/alwaysgreen-triage.yml
+++ b/.github/workflows/alwaysgreen-triage.yml
@@ -41,6 +41,14 @@ on:
         required: false
         type: string
         default: ''
+      tooling_ref:
+        description: >
+          Ref carrying this workflow's local actions and scripts. A reusable workflow's
+          checkout takes the CALLER's ref, and a stable branch has none of them, so the
+          tooling ref has to be named rather than inherited.
+        required: false
+        type: string
+        default: ''
   workflow_dispatch:
     inputs:
       run_id:
@@ -62,6 +70,10 @@ on:
         description: 'Cap on fix-agent dispatches'
         required: false
         default: '2'
+      tooling_ref:
+        description: 'Ref carrying the AlwaysGreen tooling (defaults to the dispatched ref)'
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -88,11 +100,33 @@ jobs:
     steps:
       # Checkout first: the flag lives in a local composite action, and the flag
       # decides whether anything else runs.
+      #
+      # The ref is explicit because a reusable workflow's checkout follows the CALLER.
+      # Called from stable/8.x that is a tree with no .github/actions/alwaysgreen-flag and
+      # no .github/scripts/alwaysgreen, and the job dies on the first of them. There is no
+      # context value for "the ref this workflow was loaded from": job_workflow_sha is
+      # absent at runtime and workflow_sha is the caller's. On workflow_dispatch the
+      # dispatched ref is already the right tree, so only workflow_call needs the default.
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ inputs.tooling_ref || (github.event_name == 'workflow_dispatch' && github.ref_name) || 'main' }}
           sparse-checkout: .github
           persist-credentials: false
+
+      # Without this the symptom is actions/checkout's "Can't find action.yml", which
+      # reads as a missing checkout rather than a checkout of the wrong tree.
+      - name: Verify the tooling is present
+        run: |
+          set -euo pipefail
+          missing=""
+          for p in .github/actions/alwaysgreen-flag .github/scripts/alwaysgreen/discover.py; do
+            [ -e "$p" ] || missing="${missing} ${p}"
+          done
+          if [ -n "${missing}" ]; then
+            echo "::error::AlwaysGreen tooling missing from the checked-out ref:${missing}"
+            exit 1
+          fi
 
       # Kill switch and mode, from ALWAYSGREEN_FIX_AGENT at
       # secret/data/products/qa/ci/common:


### PR DESCRIPTION
## Description

**Triage cannot run when it is called from a stable branch** — which is exactly what #59388
sets up. Found by the first in-pipeline AlwaysGreen test on 8.9 lineage
([run 31082029389](https://github.com/camunda/camunda/actions/runs/31082029389)): the deliberate
e2e failure happened as designed, then triage died on its first step and no agent was dispatched.

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'.github/actions/alwaysgreen-flag'. Did you forget to run actions/checkout
before running your local action?
```

A reusable workflow's `actions/checkout` follows the **caller's** ref, not the ref the workflow
was loaded from. Triage then resolves its local dependencies out of that tree, and stable
branches carry none of them — the tooling lives only on `main`:

| Path triage needs | On a `stable/8.x` caller |
|---|---|
| `.github/actions/alwaysgreen-flag/` | missing |
| `.github/scripts/alwaysgreen/discover.py` | missing |

So the first real `stable/8.9` failure would have produced no classification, no alert and no
agent. Manual replays never showed it: a `workflow_dispatch` checkout is already the workflow's
own ref. Only an in-pipeline `workflow_call` from a stable branch exposes it.

## Why the ref has to be named

There is no context value for "the ref this reusable workflow came from". Probed from an
8.9-lineage caller:

```
GITHUB_WORKFLOW_REF = …/tmp-probe-caller.yml@refs/heads/ci/alwaysgreen-89-live-check   ← caller
GITHUB_JOB_WORKFLOW_SHA = <unset>
github.job_workflow_sha = <absent>          github.workflow_sha = <the caller's sha>
default checkout → caller's tree → tooling ABSENT
```

`job_workflow_sha` is documented but absent at runtime here, and `actionlint` does not know it
either. So the ref is explicit:

- `workflow_call` → `main` (where the tooling lives)
- `workflow_dispatch` → the dispatched ref, which is already the right tree
- `tooling_ref` input overrides both, so a modified triage can still be tested from a branch

Plus a guard that fails with the real reason instead of a message that reads like a forgotten
checkout.

## Also in this PR: the workspace is created on the failing branch

Same class of bug, one layer down. `alwaysgreen.yaml` pinned the monorepo to
`default_branch: main` for every dispatch, so a `stable/8.x` fix agent got a workspace
created on `main` and only then moved onto the failing branch by a follow-up checkout. The
tree ended up correct, but what the manifest tells the agent the repo *is* — and what git
reports as its branch — said `main`.

The monorepo is the only branch-scoped repo here; `c8-cross-component-e2e-tests`,
`camunda-platform-helm` and `camunda-docs` have no release branches and stay on `main`. So
only the camunda entry is rewritten, while the manifest is staged.

Executed the staging script directly against a copy of the manifest:

| `BASE_REF` | resulting `default_branch` values |
|---|---|
| `stable/8.9` | `['stable/8.9', 'main', 'main', 'main']` |
| `main` | `['main', 'main', 'main', 'main']` |

## Verification

- The failure and each ref value above were reproduced with a throwaway reusable workflow called
  from an 8.9-lineage branch; both probe workflows have been removed.
- `actionlint -shellcheck=shellcheck` passes.
- **Verified by calling triage from an 8.9-lineage branch**, the same reusable-call shape as the
  real pipeline:

  | Step | Before ([31082029389](https://github.com/camunda/camunda/actions/runs/31082029389)) | With this fix ([31096501904](https://github.com/camunda/camunda/actions/runs/31096501904)) |
  |---|---|---|
  | Verify the tooling is present | — | **success** |
  | Resolve run mode | **failure** | **success** |
  | Discover and plan | skipped | **success** |

  Triage now runs to completion from a stable-lineage caller.

  The first attempt at this fix keyed on `github.event_name == 'workflow_dispatch'`, which is
  wrong: inside a called workflow that reports the RUN's event, so a manually dispatched
  pipeline calling triage looked identical to triage being dispatched itself and the checkout
  fell back to the caller's ref. The tooling guard caught it on a dispatched stable-lineage run
  ([31097511751](https://github.com/camunda/camunda/actions/runs/31097511751)) — a push-triggered
  probe had taken a different branch of the same expression and passed. It now keys on
  `inputs.run_id`, which exists only on triage's own `workflow_dispatch`, and the re-probe
  ([31100737273](https://github.com/camunda/camunda/actions/runs/31100737273)) fetches
  `refs/heads/main` with the guard green. The throwaway probe workflows have been removed.
- The manifest change is not exercised by that probe — it lives in the fix workflow, which a
  dry-run triage does not dispatch. Re-running the full 8.9 in-pipeline test after merge would
  cover it.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Blocks #59388 — enabling `stable/8.9` before this merges ships a triage path that cannot run.
No backport labels: `alwaysgreen-triage.yml` exists only on `main`.


