### PR TITLE
fix: propagate only mapped paths of a nested output mapping target

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Engine.java
+++ b/configuration/src/main/java/io/camunda/configuration/Engine.java
@@ -20,6 +20,7 @@ public class Engine {
       Set.of("zeebe.broker.experimental.engine.maxProcessDepth");
 
   private static final boolean DEFAULT_EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER = true;
+  private static final boolean DEFAULT_PROPAGATE_ONLY_MAPPED_NESTED_OUTPUT_PATHS = true;
 
   /** Configuration properties for the engine's distribution settings. */
   @NestedConfigurationProperty private Distribution distribution = new Distribution();
@@ -63,6 +64,18 @@ public class Engine {
    */
   private boolean evaluateDuplicateOutputMappingTargetsInOrder =
       DEFAULT_EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER;
+
+  /**
+   * Controls which parts of a variable an output mapping propagates to the parent scope when the
+   * mapping targets a nested path (e.g. {@code data.result}). When enabled (default), only the
+   * mapped paths are propagated, merged into the value the parent scope already holds. When
+   * disabled, the whole variable as it exists on the completing element is propagated, so branches
+   * the process never mapped - for example other fields a form or job returned - are merged into
+   * the parent as well. Disabling this restores the behavior prior to this change, but is a
+   * compatibility escape hatch, not something to reach for by default.
+   */
+  private boolean propagateOnlyMappedNestedOutputPaths =
+      DEFAULT_PROPAGATE_ONLY_MAPPED_NESTED_OUTPUT_PATHS;
 
   public Distribution getDistribution() {
     return distribution;
@@ -149,5 +162,14 @@ public class Engine {
       final boolean evaluateDuplicateOutputMappingTargetsInOrder) {
     this.evaluateDuplicateOutputMappingTargetsInOrder =
         evaluateDuplicateOutputMappingTargetsInOrder;
+  }
+
+  public boolean isPropagateOnlyMappedNestedOutputPaths() {
+    return propagateOnlyMappedNestedOutputPaths;
+  }
+
+  public void setPropagateOnlyMappedNestedOutputPaths(
+      final boolean propagateOnlyMappedNestedOutputPaths) {
+    this.propagateOnlyMappedNestedOutputPaths = propagateOnlyMappedNestedOutputPaths;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -272,6 +272,12 @@ public class BrokerBasedPropertiesOverride {
 
     override
         .getExperimental()
+        .getFeatures()
+        .setPropagateOnlyMappedNestedOutputPaths(
+            camunda.getProcessing().getEngine().isPropagateOnlyMappedNestedOutputPaths());
+
+    override
+        .getExperimental()
         .getEngine()
         .setMaxProcessDepth(camunda.getProcessing().getEngine().getMaxProcessDepth());
   }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -293,6 +293,7 @@ processing.engine.job.timeout-checker-polling-interval
 processing.engine.max-process-depth
 processing.engine.messages.ttl-checker-batch-limit
 processing.engine.messages.ttl-checker-interval
+processing.engine.propagate-only-mapped-nested-output-paths
 processing.engine.secrets.batch-resolution-limit
 processing.engine.secrets.interval
 processing.engine.secrets.retry-backoff-factor

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
@@ -42,6 +42,8 @@ public final class FeatureFlagsCfg {
       DEFAULT_SETTINGS.evaluateBoundaryEventCorrelationKeyInActivityScope();
   private boolean evaluateDuplicateOutputMappingTargetsInOrder =
       DEFAULT_SETTINGS.evaluateDuplicateOutputMappingTargetsInOrder();
+  private boolean propagateOnlyMappedNestedOutputPaths =
+      DEFAULT_SETTINGS.propagateOnlyMappedNestedOutputPaths();
 
   public boolean isEnableYieldingDueDateChecker() {
     return enableYieldingDueDateChecker;
@@ -112,6 +114,15 @@ public final class FeatureFlagsCfg {
         evaluateDuplicateOutputMappingTargetsInOrder;
   }
 
+  public boolean isPropagateOnlyMappedNestedOutputPaths() {
+    return propagateOnlyMappedNestedOutputPaths;
+  }
+
+  public void setPropagateOnlyMappedNestedOutputPaths(
+      final boolean propagateOnlyMappedNestedOutputPaths) {
+    this.propagateOnlyMappedNestedOutputPaths = propagateOnlyMappedNestedOutputPaths;
+  }
+
   public FeatureFlags toFeatureFlags() {
     return new FeatureFlags(
         enableYieldingDueDateChecker,
@@ -121,7 +132,8 @@ public final class FeatureFlagsCfg {
         enableStraightThroughProcessingLoopDetector,
         enableMessageBodyOnExpired,
         evaluateBoundaryEventCorrelationKeyInActivityScope,
-        evaluateDuplicateOutputMappingTargetsInOrder
+        evaluateDuplicateOutputMappingTargetsInOrder,
+        propagateOnlyMappedNestedOutputPaths
         /*, enableFoo*/ );
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -233,8 +233,10 @@ class PartitionManagerStepTest {
     @Test
     void shouldPassDistinctFeatureFlagsToEachPhysicalTenant() throws Exception {
       // given — two tenants each with a distinct FeatureFlags instance
-      final var flagsA = new FeatureFlags(true, false, false, false, false, false, true, true);
-      final var flagsB = new FeatureFlags(false, false, true, false, false, false, false, true);
+      final var flagsA =
+          new FeatureFlags(true, false, false, false, false, false, true, true, true);
+      final var flagsB =
+          new FeatureFlags(false, false, true, false, false, false, false, true, true);
       final var secondTenantId = "second";
 
       final var secCfg = EngineSecurityConfigurations.unauthenticatedAndUnauthorized();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -270,6 +270,7 @@ public final class EngineProcessors {
             messageCorrelationMetrics,
             featureFlags.evaluateBoundaryEventCorrelationKeyInActivityScope(),
             featureFlags.evaluateDuplicateOutputMappingTargetsInOrder(),
+            featureFlags.propagateOnlyMappedNestedOutputPaths(),
             cslCheck,
             tenantCheck);
 
@@ -620,6 +621,7 @@ public final class EngineProcessors {
       final MessageCorrelationMetrics messageCorrelationMetrics,
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
       final boolean evaluateDuplicateOutputMappingTargetsInOrder,
+      final boolean propagateOnlyMappedNestedOutputPaths,
       final CslAuthorizationCheck cslCheck,
       final CslTenantCheck tenantCheck) {
     return new BpmnBehaviorsImpl(
@@ -639,6 +641,7 @@ public final class EngineProcessors {
         messageCorrelationMetrics,
         evaluateBoundaryEventCorrelationKeyInActivityScope,
         evaluateDuplicateOutputMappingTargetsInOrder,
+        propagateOnlyMappedNestedOutputPaths,
         cslCheck,
         tenantCheck);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -89,6 +89,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final MessageCorrelationMetrics messageCorrelationMetrics,
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
       final boolean evaluateDuplicateOutputMappingTargetsInOrder,
+      final boolean propagateOnlyMappedNestedOutputPaths,
       final CslAuthorizationCheck cslCheck,
       final CslTenantCheck tenantCheck) {
 
@@ -197,7 +198,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             processingState,
             variableBehavior,
             eventTriggerBehavior,
-            evaluateDuplicateOutputMappingTargetsInOrder);
+            evaluateDuplicateOutputMappingTargetsInOrder,
+            propagateOnlyMappedNestedOutputPaths);
 
     eventSubscriptionBehavior =
         new BpmnEventSubscriptionBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 import org.agrona.DirectBuffer;
 import org.jspecify.annotations.NonNull;
 
@@ -49,13 +50,15 @@ public final class BpmnVariableMappingBehavior {
 
   private final EventTriggerBehavior eventTriggerBehavior;
   private final boolean evaluateDuplicateOutputMappingTargetsInOrder;
+  private final boolean propagateOnlyMappedNestedOutputPaths;
 
   public BpmnVariableMappingBehavior(
       final ExpressionProcessor expressionProcessor,
       final ProcessingState processingState,
       final VariableBehavior variableBehavior,
       final EventTriggerBehavior eventTriggerBehavior,
-      final boolean evaluateDuplicateOutputMappingTargetsInOrder) {
+      final boolean evaluateDuplicateOutputMappingTargetsInOrder,
+      final boolean propagateOnlyMappedNestedOutputPaths) {
     this.expressionProcessor = expressionProcessor;
     inputMappingExpressionProcessor = expressionProcessor.withSecretReferenceContext();
     elementInstanceState = processingState.getElementInstanceState();
@@ -65,6 +68,7 @@ public final class BpmnVariableMappingBehavior {
     this.eventTriggerBehavior = eventTriggerBehavior;
     this.evaluateDuplicateOutputMappingTargetsInOrder =
         evaluateDuplicateOutputMappingTargetsInOrder;
+    this.propagateOnlyMappedNestedOutputPaths = propagateOnlyMappedNestedOutputPaths;
   }
 
   /**
@@ -155,17 +159,30 @@ public final class BpmnVariableMappingBehavior {
         }
       }
 
-      // Resolves the current scope value at a nested target's path so the builder can merge into
-      // it and keep the existing sibling properties: look up the top-level variable in the element
-      // scope, then navigate into it along the remaining path segments (null when absent).
-      final var resultBuilder =
-          new MappingResultBuilder(
-              path ->
+      final long variableScopeKey = getVariableScopeKey(context);
+      // Resolves a nested target's path against the element's scope chain. Seeds the evaluation
+      // view, so a source expression can still read any branch visible to the element.
+      final Function<List<String>, DirectBuffer> scopeChainResolver =
+          path ->
+              Optional.ofNullable(
+                      variablesState.getVariable(
+                          elementInstanceKey, BufferUtil.wrapString(path.getFirst())))
+                  .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
+                  .orElse(null);
+      // Resolves the same path against the scope the result is merged into. Seeds the emitted
+      // document, so only mapped paths propagate and the target scope's own siblings survive.
+      // With the kill-switch off, both views share the scope chain, reproducing the old behavior
+      // where an unmapped local branch was propagated too.
+      final Function<List<String>, DirectBuffer> mergeTargetResolver =
+          propagateOnlyMappedNestedOutputPaths
+              ? path ->
                   Optional.ofNullable(
                           variablesState.getVariable(
-                              elementInstanceKey, BufferUtil.wrapString(path.getFirst())))
+                              variableScopeKey, BufferUtil.wrapString(path.getFirst())))
                       .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
-                      .orElse(null));
+                      .orElse(null)
+              : scopeChainResolver;
+      final var resultBuilder = new MappingResultBuilder(scopeChainResolver, mergeTargetResolver);
       final var processor =
           expressionProcessor.prependContext(name -> Either.left(resultBuilder.getVariable(name)));
 
@@ -183,8 +200,7 @@ public final class BpmnVariableMappingBehavior {
         }
         resultBuilder.put(mapping.targetPath(), result.get());
       }
-      return mapVariables(
-          context, element, getVariableScopeKey(context), resultBuilder.toDocument());
+      return mapVariables(context, element, variableScopeKey, resultBuilder.toDocument());
 
     } else if (hasVariables) {
       // merge/propagate the event variables by default

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilder.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.msgpack.spec.MsgPackReader;
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -27,18 +28,23 @@ import org.jspecify.annotations.Nullable;
 /**
  * Accumulates the results of variable mappings that are evaluated one by one in modeling order.
  * Each mapping's result is stored under its (possibly nested) target path, and can be looked up by
- * its top-level variable name so that subsequent mappings can reference the values produced by
- * earlier mappings. {@link #toDocument()} returns the accumulated results as a single MsgPack
- * document to be merged into the element's local scope.
+ * {@link #getVariable(String)} under its top-level variable name so that subsequent mappings can
+ * reference the values produced by earlier mappings.
+ *
+ * <p>That lookup view and the document returned by {@link #toDocument()} are built separately and
+ * can differ. The lookup view is seeded from the element's scope chain, so a mapping's source
+ * expression can read any branch visible to the element. The document contains only the paths a
+ * mapping explicitly wrote, seeded from the scope the document is merged into.
  *
  * <p>For input mappings (no-arg constructor), a mapping to a nested target descends into (or
  * creates) intermediate objects; a mapping whose target collides structurally with an earlier one
- * (a value where an object is needed, or vice versa) replaces the earlier entry — last-wins.
+ * (a value where an object is needed, or vice versa) replaces the earlier entry — last-wins. Both
+ * resolvers are empty there, so neither view merges with an existing scope value.
  *
- * <p>For output mappings (constructor with a {@code scopeValueResolver}), a nested target instead
- * merges with the existing scope variable at every path level: a level that is absent or holds a
- * plain value is seeded from the current scope value at that path. A non-context scope value
- * poisons the level to null, matching FEEL's {@code context merge(<non-context>, {...})} behavior.
+ * <p>For output mappings (two-resolver constructor), a nested target instead merges with the
+ * existing scope variable at every path level: a level that is absent or holds a plain value is
+ * seeded from the resolved scope value at that path. A non-context scope value poisons the level to
+ * null, matching FEEL's {@code context merge(<non-context>, {...})} behavior.
  */
 @NullMarked
 public final class MappingResultBuilder {
@@ -59,25 +65,29 @@ public final class MappingResultBuilder {
 
   private final MsgPackWriter writer = new MsgPackWriter();
 
-  private final Function<List<String>, @Nullable DirectBuffer> scopeValueResolver;
+  private final Function<List<String>, @Nullable DirectBuffer> scopeChainResolver;
+  private final Function<List<String>, @Nullable DirectBuffer> mergeTargetResolver;
+
+  /** Recorded in modeling order; replayed by {@link #toDocument()} against the merge target. */
+  private final List<Map.Entry<List<String>, DirectBuffer>> writes = new ArrayList<>();
 
   /** Builder for input mappings: nested targets never merge with existing scope values. */
   public MappingResultBuilder() {
-    this(path -> null);
+    this(path -> null, path -> null);
   }
 
   /**
-   * Builder for output mappings: when a nested target path needs a map at a level that is absent
-   * (or currently holds a plain value), the level is seeded from the existing scope value at that
-   * path. A non-context scope value poisons the level to null, matching FEEL's {@code context
-   * merge} behavior.
+   * Builder for output mappings. See the class doc for why two resolvers are needed.
    *
-   * @param scopeValueResolver resolves a target-path prefix to the current scope value at that
-   *     path, or {@code null} when there is none; invoked only when a level must be (re)created
+   * @param scopeChainResolver resolves a target-path prefix against the element's scope chain
+   * @param mergeTargetResolver resolves a target-path prefix against the scope the result is merged
+   *     into
    */
   public MappingResultBuilder(
-      final Function<List<String>, @Nullable DirectBuffer> scopeValueResolver) {
-    this.scopeValueResolver = scopeValueResolver;
+      final Function<List<String>, @Nullable DirectBuffer> scopeChainResolver,
+      final Function<List<String>, @Nullable DirectBuffer> mergeTargetResolver) {
+    this.scopeChainResolver = scopeChainResolver;
+    this.mergeTargetResolver = mergeTargetResolver;
   }
 
   /**
@@ -85,15 +95,9 @@ public final class MappingResultBuilder {
    * because evaluation result buffers are transient and may be reused by the next evaluation.
    */
   public void put(final List<String> targetPath, final DirectBuffer value) {
-    Map<String, Object> current = entries;
-    for (int i = 0; i < targetPath.size() - 1; i++) {
-      final var next = getOrSeedNested(current, targetPath.subList(0, i + 1));
-      if (next == null) {
-        return; // level is poisoned: the mapped value is discarded, the level stays null
-      }
-      current = next;
-    }
-    current.put(targetPath.getLast(), BufferUtil.cloneBuffer(value));
+    final var copy = BufferUtil.cloneBuffer(value);
+    writes.add(Map.entry(targetPath, copy));
+    apply(entries, targetPath, copy, scopeChainResolver);
   }
 
   /**
@@ -115,19 +119,47 @@ public final class MappingResultBuilder {
     }
   }
 
-  /** Returns all accumulated results as a single MsgPack document (a map). */
+  /**
+   * Returns the paths that mappings explicitly wrote as a single MsgPack document, replayed against
+   * the merge-target resolver rather than the {@link #getVariable(String)} lookup view.
+   *
+   * @see #getVariable(String)
+   * @see <a href="https://github.com/camunda/camunda/issues/35251">#35251</a>
+   */
   public DirectBuffer toDocument() {
-    return serialize(entries);
+    final Map<String, Object> emitted = new LinkedHashMap<>();
+    for (final var write : writes) {
+      apply(emitted, write.getKey(), write.getValue(), mergeTargetResolver);
+    }
+    return serialize(emitted);
+  }
+
+  private void apply(
+      final Map<String, Object> root,
+      final List<String> targetPath,
+      final DirectBuffer value,
+      final Function<List<String>, @Nullable DirectBuffer> resolver) {
+    Map<String, Object> current = root;
+    for (int i = 0; i < targetPath.size() - 1; i++) {
+      final var next = getOrSeedNested(current, targetPath.subList(0, i + 1), resolver);
+      if (next == null) {
+        return; // level is poisoned: the mapped value is discarded, the level stays null
+      }
+      current = next;
+    }
+    current.put(targetPath.getLast(), value);
   }
 
   /**
    * Returns the map at the given path prefix, creating it if the current entry is absent or a plain
-   * value. A newly created map is seeded with the top-level entries of the existing scope value at
+   * value. A newly created map is seeded with the top-level entries of the resolved scope value at
    * that path (children stay opaque buffers); a non-context scope value poisons the level instead.
    * Returns {@code null} when the level is (or becomes) poisoned.
    */
   private @Nullable Map<String, Object> getOrSeedNested(
-      final Map<String, Object> parent, final List<String> pathPrefix) {
+      final Map<String, Object> parent,
+      final List<String> pathPrefix,
+      final Function<List<String>, @Nullable DirectBuffer> resolver) {
     final var key = pathPrefix.getLast();
     final var entry = parent.get(key);
     if (entry == POISON) {
@@ -138,7 +170,7 @@ public final class MappingResultBuilder {
     }
     // absent, or a plain value from an earlier mapping: re-seed the (re)created level from the
     // scope value at this path, dropping the earlier plain value
-    final var scopeValue = scopeValueResolver.apply(pathPrefix);
+    final var scopeValue = resolver.apply(pathPrefix);
     if (scopeValue == null || isNil(scopeValue)) {
       final var fresh = new LinkedHashMap<String, Object>();
       parent.put(key, fresh);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/variables/ContainerElementVariablePropagationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/variables/ContainerElementVariablePropagationTest.java
@@ -410,7 +410,6 @@ public final class ContainerElementVariablePropagationTest {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/35251")
   public void shouldNotLeakUntouchedLocalSiblingIntoParentScope() {
     // given: 'a' is set locally on the sub-process with an untouched sibling 'p' that is never
     // targeted by any output mapping

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilderTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.agrona.DirectBuffer;
 import org.junit.jupiter.api.Test;
 
 final class MappingResultBuilderTest {
@@ -141,7 +142,9 @@ final class MappingResultBuilderTest {
   void shouldSeedNestedTargetFromScopeValue() {
     // given: scope has a = {'c': 2}
     final var builder =
-        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
+        new MappingResultBuilder(
+            path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null,
+            path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
 
     // when
     builder.put(List.of("a", "b"), asMsgPack("1"));
@@ -157,7 +160,7 @@ final class MappingResultBuilderTest {
         Map.of(
             List.of("a"), asMsgPack("{'b': {'d': 2}, 'e': 3}"),
             List.of("a", "b"), asMsgPack("{'d': 2}"));
-    final var builder = new MappingResultBuilder(scope::get);
+    final var builder = new MappingResultBuilder(scope::get, scope::get);
 
     // when
     builder.put(List.of("a", "b", "c"), asMsgPack("1"));
@@ -167,10 +170,31 @@ final class MappingResultBuilderTest {
   }
 
   @Test
+  void shouldDivergeBetweenViewsTwoLevelsDown() {
+    // given: 'a' is absent from both views (so both freshly create it), but at 'a.b' the scope
+    // chain holds a plain 5 while the merge target holds a map with sibling 'd' - the two views
+    // diverge below the top level, not at it
+    final Map<List<String>, DirectBuffer> scopeChain = Map.of(List.of("a", "b"), asMsgPack("5"));
+    final Map<List<String>, DirectBuffer> mergeTarget =
+        Map.of(List.of("a", "b"), asMsgPack("{'d': 2}"));
+    final var builder = new MappingResultBuilder(scopeChain::get, mergeTarget::get);
+
+    // when
+    builder.put(List.of("a", "b", "c"), asMsgPack("1"));
+
+    // then: the evaluation view is poisoned two levels down
+    assertEquality(builder.getVariable("a"), "{'b': null}");
+    // ... but the document seeds cleanly at that same depth and keeps the sibling 'd'
+    assertEquality(builder.toDocument(), "{'a': {'b': {'c': 1, 'd': 2}}}");
+  }
+
+  @Test
   void shouldPoisonLevelWhenScopeValueIsNotAMap() {
     // given: scope has a = 5
     final var builder =
-        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
+        new MappingResultBuilder(
+            path -> path.equals(List.of("a")) ? asMsgPack("5") : null,
+            path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
 
     // when
     builder.put(List.of("a", "b"), asMsgPack("1"));
@@ -183,7 +207,9 @@ final class MappingResultBuilderTest {
   @Test
   void shouldDiscardFurtherPutsUnderPoisonedLevel() {
     final var builder =
-        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
+        new MappingResultBuilder(
+            path -> path.equals(List.of("a")) ? asMsgPack("5") : null,
+            path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
 
     // when
     builder.put(List.of("a", "b"), asMsgPack("1"));
@@ -194,9 +220,45 @@ final class MappingResultBuilderTest {
   }
 
   @Test
+  void shouldPoisonEvaluationViewWithoutPoisoningMergeTarget() {
+    // given: the element's own scope has a = 5 (not a map), but the merge target's a = {'c': 2}
+    final var builder =
+        new MappingResultBuilder(
+            path -> path.equals(List.of("a")) ? asMsgPack("5") : null,
+            path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
+
+    // when
+    builder.put(List.of("a", "b"), asMsgPack("1"));
+
+    // then: a back-reference sees the evaluation view poisoned by the element's own non-map value
+    assertEquality(builder.getVariable("a"), "null");
+    // ... but the document merges into the (unpoisoned) merge target and keeps its sibling 'c'
+    assertEquality(builder.toDocument(), "{'a': {'b': 1, 'c': 2}}");
+  }
+
+  @Test
+  void shouldPoisonMergeTargetWithoutPoisoningEvaluationView() {
+    // given: the element's own scope has a = {'c': 2}, but the merge target's a = 5 (not a map)
+    final var builder =
+        new MappingResultBuilder(
+            path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null,
+            path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
+
+    // when
+    builder.put(List.of("a", "b"), asMsgPack("1"));
+
+    // then: a back-reference still sees the unpoisoned evaluation view, sibling 'c' and all
+    assertEquality(builder.getVariable("a"), "{'b': 1, 'c': 2}");
+    // ... but the document is poisoned to null, like FEEL's context merge(5, {...})
+    assertEquality(builder.toDocument(), "{'a': null}");
+  }
+
+  @Test
   void shouldReplacePoisonedLevelWithPlainTargetPut() {
     final var builder =
-        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
+        new MappingResultBuilder(
+            path -> path.equals(List.of("a")) ? asMsgPack("5") : null,
+            path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
 
     // when: a nested put poisons 'a', then a plain put replaces it
     builder.put(List.of("a", "b"), asMsgPack("1"));
@@ -210,7 +272,9 @@ final class MappingResultBuilderTest {
   void shouldReseedFromScopeWhenNestedPutFollowsPlainPut() {
     // given: scope a = {'c': 2}; a plain put stored a value buffer for 'a'
     final var builder =
-        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
+        new MappingResultBuilder(
+            path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null,
+            path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
     builder.put(List.of("a"), asMsgPack("{'z': 9}"));
 
     // when: the shape flips back to a map — the plain mapping's value is discarded and the fresh
@@ -225,7 +289,9 @@ final class MappingResultBuilderTest {
   void shouldSeedFreshMapWhenScopeValueIsNil() {
     // given: scope has a = null — FEEL's `if (a != null)` takes the else branch
     final var builder =
-        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("null") : null);
+        new MappingResultBuilder(
+            path -> path.equals(List.of("a")) ? asMsgPack("null") : null,
+            path -> path.equals(List.of("a")) ? asMsgPack("null") : null);
 
     // when
     builder.put(List.of("a", "b"), asMsgPack("1"));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityOutputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityOutputMappingTest.java
@@ -163,12 +163,11 @@ public final class ActivityOutputMappingTest {
         scopeVariables(variable("a", "{\"b\":null,\"e\":3}"))
       },
       {
-        // the merge seed is read from the element-local scope walking up: a local variable
-        // created by an input mapping contributes its properties to the propagated result
-        // (#35251 behavior — intentionally preserved in this PR, fix tracked separately)
+        // only the mapped path is propagated: 'a' exists locally because of the input mapping, so
+        // its 'l' property is not merged into the parent scope (#35251)
         "{'x': {'l': 1}, 'y': 2}",
         mapping(b -> b.zeebeInputExpression("x", "a").zeebeOutputExpression("y", "a.m")),
-        scopeVariables(variable("a", "{\"l\":1,\"m\":2}"))
+        scopeVariables(variable("a", "{\"m\":2}"))
       },
       {
         // mappings are evaluated in modeling order, so a later mapping can reference the target

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/NestedOutputPathPropagationFeatureFlagTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/NestedOutputPathPropagationFeatureFlagTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.test.util.JsonUtil;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Characterization test for the {@code propagateOnlyMappedNestedOutputPaths} kill-switch: with the
+ * flag disabled, a nested output mapping target propagates the completing element's whole variable
+ * again, including branches no mapping ever targeted (the pre-#35251 behavior).
+ */
+public final class NestedOutputPathPropagationFeatureFlagTest {
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withFeatureFlags(f -> f.setPropagateOnlyMappedNestedOutputPaths(false));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldPropagateUnmappedLocalBranchWhenDisabled() {
+    // given: the same model as NestedOutputPathPropagationTest's discriminator
+    final var processId = "nested-output-flag-off";
+    final var process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .subProcess(
+                "sp",
+                sp ->
+                    sp.zeebeInputExpression("={p:0}", "a")
+                        .zeebeOutputExpression("1", "a.b")
+                        .embeddedSubProcess()
+                        .startEvent()
+                        .endEvent())
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariables("{\"a\":{\"c\":2}}")
+            .create();
+
+    // then: the element-local 'p' is merged into the parent again
+    final var records =
+        RecordingExporter.records()
+            .limitToProcessInstance(processInstanceKey)
+            .variableRecords()
+            .withScopeKey(processInstanceKey)
+            .withName("a")
+            .asList();
+    assertThat(records).isNotEmpty();
+    JsonUtil.assertEquality(records.getLast().getValue().getValue(), "{\"p\":0,\"b\":1}");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/NestedOutputPathPropagationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/NestedOutputPathPropagationTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.test.util.JsonUtil;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Runtime coverage for https://github.com/camunda/camunda/issues/35251: an output mapping targeting
+ * a nested path propagates only the mapped paths, merged into what the parent scope already holds.
+ */
+public final class NestedOutputPathPropagationTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldKeepParentSiblingAndDropLocalSibling() {
+    // given: the parent holds a={c:2}; the sub-process creates its own a={p:0} locally
+    final var processId = "nested-output-discriminator";
+    final var process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .subProcess(
+                "sp",
+                sp ->
+                    sp.zeebeInputExpression("={p:0}", "a")
+                        .zeebeOutputExpression("1", "a.b")
+                        .embeddedSubProcess()
+                        .startEvent()
+                        .endEvent())
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariables("{\"a\":{\"c\":2}}")
+            .create();
+
+    // then: 'c' belongs to the parent and survives; 'p' was only local and does not propagate
+    JsonUtil.assertEquality(lastRootValueOf(processInstanceKey, "a"), "{\"c\":2,\"b\":1}");
+  }
+
+  @Test
+  public void shouldPropagateOnlyMappedBranchesOfAUserTaskResult() {
+    // given: the issue's shape - a form writes three branches, only two are mapped
+    final var processId = "nested-output-user-task";
+    final var process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .userTask("task")
+            .zeebeUserTask()
+            .zeebeOutputExpression("processData.humanTask.outcome", "processData.humanTask.outcome")
+            .zeebeOutputExpression("processData.fault.errors", "processData.fault.errors")
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    final long userTaskKey =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // when
+    ENGINE
+        .userTask()
+        .withKey(userTaskKey)
+        .withVariables(
+            "{\"processData\":{\"humanTask\":{\"outcome\":\"approved\"},"
+                + "\"fault\":{\"errors\":[\"e1\"]},\"test\":{\"value\":\"junk\"}}}")
+        .complete();
+
+    // then: both mapped branches propagate, the unmapped 'test' branch does not
+    JsonUtil.assertEquality(
+        lastRootValueOf(processInstanceKey, "processData"),
+        "{\"humanTask\":{\"outcome\":\"approved\"},\"fault\":{\"errors\":[\"e1\"]}}");
+  }
+
+  @Test
+  public void shouldMergeAtEveryLevelOfADeepTarget() {
+    // given: the parent holds siblings at two levels; the sub-process adds a local-only branch
+    final var processId = "nested-output-deep";
+    final var process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .subProcess(
+                "sp",
+                sp ->
+                    sp.zeebeInputExpression("={junk:0}", "a")
+                        .zeebeOutputExpression("1", "a.b.c")
+                        .embeddedSubProcess()
+                        .startEvent()
+                        .endEvent())
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariables("{\"a\":{\"b\":{\"keep\":1},\"top\":2}}")
+            .create();
+
+    // then: 'keep' and 'top' survive, the local 'junk' never enters
+    JsonUtil.assertEquality(
+        lastRootValueOf(processInstanceKey, "a"), "{\"b\":{\"keep\":1,\"c\":1},\"top\":2}");
+  }
+
+  @Test
+  public void shouldNotChangeMultiInstanceOutputMappingPropagation() {
+    // given: an inner multi-instance activity merges into its OWN scope, so seed and merge target
+    // were already the same - this pins that the fix leaves that path alone
+    final var processId = "nested-output-multi-instance";
+    final var jobType = "nestedOutputMiJob";
+    final var process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType(jobType)
+                        .zeebeInputExpression("={p:0}", "a")
+                        .zeebeOutputExpression("1", "a.b")
+                        .multiInstance(
+                            mi ->
+                                mi.zeebeInputCollectionExpression("=[1]")
+                                    .zeebeInputElement("item")))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    // when
+    ENGINE.jobs().withType(jobType).activate();
+    ENGINE.job().ofInstance(processInstanceKey).withType(jobType).complete();
+
+    // then: 'a' stays on the inner instance with its local sibling, and never reaches the root
+    final var rootValues =
+        RecordingExporter.records()
+            .limitToProcessInstance(processInstanceKey)
+            .variableRecords()
+            .withScopeKey(processInstanceKey)
+            .withName("a")
+            .asList();
+    assertThat(rootValues).isEmpty();
+
+    final var innerValues =
+        RecordingExporter.records()
+            .limitToProcessInstance(processInstanceKey)
+            .variableRecords()
+            .withName("a")
+            .asList();
+    assertThat(innerValues).isNotEmpty();
+    JsonUtil.assertEquality(innerValues.getLast().getValue().getValue(), "{\"p\":0,\"b\":1}");
+  }
+
+  @Test
+  public void shouldPropagateOnlyMappedBranchesFromACallActivity() {
+    // given: the child produces a two-branch 'data'; the call activity maps only one branch
+    final var childId = "nested-output-call-child";
+    final var parentId = "nested-output-call-parent";
+    final var child =
+        Bpmn.createExecutableProcess(childId)
+            .startEvent()
+            .intermediateThrowEvent(
+                "produce", e -> e.zeebeOutputExpression("={wanted:1,unwanted:2}", "data"))
+            .endEvent()
+            .done();
+    final var parent =
+        Bpmn.createExecutableProcess(parentId)
+            .startEvent()
+            .callActivity(
+                "call",
+                c -> c.zeebeProcessId(childId).zeebeOutputExpression("data.wanted", "data.wanted"))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(child).withXmlResource(parent).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(parentId).create();
+
+    // then: the child's unmapped branch does not reach the parent process
+    JsonUtil.assertEquality(lastRootValueOf(processInstanceKey, "data"), "{\"wanted\":1}");
+  }
+
+  private static String lastRootValueOf(final long processInstanceKey, final String name) {
+    final List<Record<VariableRecordValue>> records =
+        RecordingExporter.records()
+            .limitToProcessInstance(processInstanceKey)
+            .variableRecords()
+            .withScopeKey(processInstanceKey)
+            .withName(name)
+            .asList();
+    assertThat(records)
+        .describedAs("expected a '%s' variable at the root scope", name)
+        .isNotEmpty();
+    return records.getLast().getValue().getValue();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
@@ -217,16 +217,7 @@ public final class VariableOutputMappingTransformerTest {
     final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
 
     // when: evaluate one by one, stopping at the first failure (mirrors runtime fail-fast)
-    final var resultBuilder =
-        new MappingResultBuilder(
-            path ->
-                Optional.ofNullable(variables.get(path.getFirst()))
-                    .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
-                    .orElse(null),
-            path ->
-                Optional.ofNullable(variables.get(path.getFirst()))
-                    .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
-                    .orElse(null));
+    final var resultBuilder = new MappingResultBuilder(resolver(variables), resolver(variables));
     EvaluationResult failure = null;
     for (final var mapping : outputMappings) {
       final EvaluationContext context =
@@ -291,6 +282,65 @@ public final class VariableOutputMappingTransformerTest {
 
     // then: both mapped branches survive, the unmapped one is not propagated
     MsgPackUtil.assertEquality(document, "{'data':{'wanted1':'A','wanted2':'B'}}");
+  }
+
+  @Test
+  void shouldResolveBackReferenceToAWrittenNestedPath() {
+    // given
+    final var mappings = List.of(mapping("1", "a.b"), mapping("a.b", "foo"));
+    final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
+
+    // when
+    final var document = evaluateOutputMappings(outputMappings, Map.of(), Map.of());
+
+    // then
+    MsgPackUtil.assertEquality(document, "{'a':{'b':1}, 'foo':1}");
+  }
+
+  @Test
+  void shouldMergeWrittenNestedPathIntoTheMergeTargetValue() {
+    // given: the merge target already holds 'a' with its own sibling 'c', which is therefore also
+    // visible to the element by walking up the scope chain
+    final var mappings = List.of(mapping("1", "a.b"), mapping("a.b", "foo"));
+    final Map<String, DirectBuffer> variables = Map.of("a", asMsgPack("{'c':2}"));
+    final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
+
+    // when
+    final var document = evaluateOutputMappings(outputMappings, variables, variables);
+
+    // then: 'c' survives because it belongs to the merge target
+    MsgPackUtil.assertEquality(document, "{'a':{'b':1,'c':2}, 'foo':1}");
+  }
+
+  @Test
+  void shouldResolveBackReferenceToAnUnwrittenBranchFromTheScopeChain() {
+    // given: 'a.c' exists only on the element and is never a mapping target
+    final var mappings = List.of(mapping("1", "a.b"), mapping("a.c", "foo"));
+    final Map<String, DirectBuffer> scopeChain = Map.of("a", asMsgPack("{'c':9}"));
+    final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
+
+    // when
+    final var document = evaluateOutputMappings(outputMappings, scopeChain, Map.of());
+
+    // then: the back-reference reads 'c' even though the earlier write did not include it, and 'c'
+    // still does not propagate
+    MsgPackUtil.assertEquality(document, "{'a':{'b':1}, 'foo':9}");
+  }
+
+  @Test
+  void shouldSeedEvaluationAndMergeTargetIndependently() {
+    // given: 'p' and 'q' are element-local, 'c' belongs to the merge target (and is therefore
+    // visible on the scope chain too)
+    final var mappings = List.of(mapping("1", "a.b"), mapping("a", "d"));
+    final Map<String, DirectBuffer> scopeChain = Map.of("a", asMsgPack("{'p':0,'q':1,'c':2}"));
+    final Map<String, DirectBuffer> mergeTarget = Map.of("a", asMsgPack("{'c':2}"));
+    final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
+
+    // when
+    final var document = evaluateOutputMappings(outputMappings, scopeChain, mergeTarget);
+
+    // then
+    MsgPackUtil.assertEquality(document, "{'a':{'c':2,'b':1}, 'd':{'p':0,'q':1,'c':2,'b':1}}");
   }
 
   // evaluates output mappings one by one in modeling order, mirroring

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.el.EvaluationResult;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
+import io.camunda.zeebe.engine.processing.deployment.model.element.OutputMapping;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.VariableMappingTransformer;
 import io.camunda.zeebe.engine.processing.variable.MappingResultBuilder;
 import io.camunda.zeebe.engine.processing.variable.MsgPackPath;
@@ -25,6 +26,7 @@ import java.time.InstantSource;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import org.agrona.DirectBuffer;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -199,30 +201,11 @@ public final class VariableOutputMappingTransformerTest {
                 .describedAs("Expected valid expression: %s", mapping.source().getFailureMessage())
                 .isTrue());
 
-    // when: evaluate the mappings one by one in modeling order, same as
-    // BpmnVariableMappingBehavior.applyOutputMappings does at runtime — accumulated results
-    // shadow the scope variables, and nested targets merge with the scope value at every level
-    final var resultBuilder =
-        new MappingResultBuilder(
-            path ->
-                Optional.ofNullable(variables.get(path.getFirst()))
-                    .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
-                    .orElse(null));
-    for (final var mapping : outputMappings) {
-      final EvaluationContext context =
-          name -> {
-            final var accumulated = resultBuilder.getVariable(name);
-            return Either.left(accumulated != null ? accumulated : variables.get(name));
-          };
-      final var result = expressionLanguage.evaluateExpression(mapping.source(), context);
-      assertThat(result.isFailure())
-          .describedAs("Expected successful evaluation: %s", result.getFailureMessage())
-          .isFalse();
-      resultBuilder.put(mapping.targetPath(), result.toBuffer());
-    }
+    // when
+    final var document = evaluateOutputMappings(outputMappings, variables, variables);
 
     // then
-    MsgPackUtil.assertEquality(resultBuilder.toDocument(), expectedOutput);
+    MsgPackUtil.assertEquality(document, expectedOutput);
   }
 
   @ParameterizedTest(name = "{index}: mapping {0} fails with: {2}")
@@ -327,6 +310,40 @@ public final class VariableOutputMappingTransformerTest {
 
     // then
     MsgPackUtil.assertEquality(resultBuilder.toDocument(), "{'a':{'b':1}, 'd':{'p':0}}");
+  }
+
+  // evaluates output mappings one by one in modeling order, mirroring
+  // BpmnVariableMappingBehavior.applyOutputMappings; a parent-only variable belongs in BOTH
+  // scopeChain and mergeTarget, since it's visible both to the element and to the merge target -
+  // only element-local variables appear in scopeChain alone
+  private DirectBuffer evaluateOutputMappings(
+      final List<OutputMapping> outputMappings,
+      final Map<String, DirectBuffer> scopeChain,
+      final Map<String, DirectBuffer> mergeTarget) {
+    // Task 3 switches this to the two-resolver constructor; until then both views share the scope
+    // chain, which is exactly today's behavior.
+    final var resultBuilder = new MappingResultBuilder(resolver(scopeChain));
+    for (final var mapping : outputMappings) {
+      final EvaluationContext context =
+          name -> {
+            final var accumulated = resultBuilder.getVariable(name);
+            return Either.left(accumulated != null ? accumulated : scopeChain.get(name));
+          };
+      final var result = expressionLanguage.evaluateExpression(mapping.source(), context);
+      assertThat(result.isFailure())
+          .describedAs("Expected successful evaluation: %s", result.getFailureMessage())
+          .isFalse();
+      resultBuilder.put(mapping.targetPath(), result.toBuffer());
+    }
+    return resultBuilder.toDocument();
+  }
+
+  private static Function<List<String>, DirectBuffer> resolver(
+      final Map<String, DirectBuffer> variables) {
+    return path ->
+        Optional.ofNullable(variables.get(path.getFirst()))
+            .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
+            .orElse(null);
   }
 
   private static ZeebeMapping mapping(final String source, final String target) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -223,6 +222,10 @@ public final class VariableOutputMappingTransformerTest {
             path ->
                 Optional.ofNullable(variables.get(path.getFirst()))
                     .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
+                    .orElse(null),
+            path ->
+                Optional.ofNullable(variables.get(path.getFirst()))
+                    .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
                     .orElse(null));
     EvaluationResult failure = null;
     for (final var mapping : outputMappings) {
@@ -245,71 +248,49 @@ public final class VariableOutputMappingTransformerTest {
   }
 
   @Test
-  @Disabled(
-      "context merge() with the current scope leaks an untouched sibling ('p') into the merge "
-          + "target and a later back-reference to it, instead of building a mapping-only result "
-          + "(input mappings already do this post-#58801). Cannot be enabled without the #35251 "
-          + "fix: the desired drop-the-sibling result conflicts with the pinned 'merge target "
-          + "with variable' case, which requires the sibling to be kept — both go through the "
-          + "same seed-from-scope path. Tracked under "
-          + "https://github.com/camunda/camunda/issues/35251.")
-  void shouldNotLeakUntouchedSiblingIntoMergeTargetOrBackReference() {
-    final var mappings = List.of(mapping("1", "a.b"), mapping("a", "d"));
-    final Map<String, DirectBuffer> variables = Map.of("a", asMsgPack("{'p':0}"));
+  void shouldNotLeakUntouchedSiblingIntoMergeTargetOppositeOrder() {
+    // given: 'a' exists only on the element, with an untouched sibling 'p'
+    final var mappings = List.of(mapping("a", "d"), mapping("1", "a.b"));
+    final Map<String, DirectBuffer> scopeChain = Map.of("a", asMsgPack("{'p':0}"));
     final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
 
     // when
-    final var resultBuilder =
-        new MappingResultBuilder(
-            path ->
-                Optional.ofNullable(variables.get(path.getFirst()))
-                    .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
-                    .orElse(null));
-    for (final var mapping : outputMappings) {
-      final EvaluationContext context =
-          name -> {
-            final var accumulated = resultBuilder.getVariable(name);
-            return Either.left(accumulated != null ? accumulated : variables.get(name));
-          };
-      final var result = expressionLanguage.evaluateExpression(mapping.source(), context);
-      resultBuilder.put(mapping.targetPath(), result.toBuffer());
-    }
+    final var document = evaluateOutputMappings(outputMappings, scopeChain, Map.of());
 
-    // then
-    MsgPackUtil.assertEquality(resultBuilder.toDocument(), "{'a':{'b':1}, 'd':{'b':1}}");
+    // then: the back-reference ran before 'a' was written, so it reads the scope chain
+    MsgPackUtil.assertEquality(document, "{'a':{'b':1}, 'd':{'p':0}}");
   }
 
   @Test
-  @Disabled(
-      "Same leak as shouldNotLeakUntouchedSiblingIntoMergeTargetOrBackReference, opposite "
-          + "mapping order: the back-reference runs before 'a' is ever written, so it correctly "
-          + "keeps 'p'; only the later merge target should drop it. Cannot be enabled without "
-          + "the #35251 fix (see the sibling case). Tracked under "
-          + "https://github.com/camunda/camunda/issues/35251.")
-  void shouldNotLeakUntouchedSiblingIntoMergeTargetOppositeOrder() {
-    final var mappings = List.of(mapping("a", "d"), mapping("1", "a.b"));
-    final Map<String, DirectBuffer> variables = Map.of("a", asMsgPack("{'p':0}"));
+  void shouldNotLeakUntouchedSiblingIntoMergeTargetOrBackReference() {
+    // given: same as the sibling case, but the nested write happens first
+    final var mappings = List.of(mapping("1", "a.b"), mapping("a", "d"));
+    final Map<String, DirectBuffer> scopeChain = Map.of("a", asMsgPack("{'p':0}"));
     final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
 
     // when
-    final var resultBuilder =
-        new MappingResultBuilder(
-            path ->
-                Optional.ofNullable(variables.get(path.getFirst()))
-                    .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
-                    .orElse(null));
-    for (final var mapping : outputMappings) {
-      final EvaluationContext context =
-          name -> {
-            final var accumulated = resultBuilder.getVariable(name);
-            return Either.left(accumulated != null ? accumulated : variables.get(name));
-          };
-      final var result = expressionLanguage.evaluateExpression(mapping.source(), context);
-      resultBuilder.put(mapping.targetPath(), result.toBuffer());
-    }
+    final var document = evaluateOutputMappings(outputMappings, scopeChain, Map.of());
 
-    // then
-    MsgPackUtil.assertEquality(resultBuilder.toDocument(), "{'a':{'b':1}, 'd':{'p':0}}");
+    // then: 'a' propagates only the mapped path, but the later back-reference still reads the
+    // element's own view of 'a' - the write does not hide branches nobody mapped
+    MsgPackUtil.assertEquality(document, "{'a':{'b':1}, 'd':{'p':0,'b':1}}");
+  }
+
+  @Test
+  void shouldEvaluateAgainstScopeChainButEmitOnlyMappedPaths() {
+    // given: 'data' is visible to the element with three branches; only two are mapped, and the
+    // second mapping reads a branch the first one did not write
+    final var mappings =
+        List.of(mapping("data.wanted1", "data.wanted1"), mapping("data.wanted2", "data.wanted2"));
+    final Map<String, DirectBuffer> scopeChain =
+        Map.of("data", asMsgPack("{'wanted1':'A','wanted2':'B','unmapped':'C'}"));
+    final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
+
+    // when
+    final var document = evaluateOutputMappings(outputMappings, scopeChain, Map.of());
+
+    // then: both mapped branches survive, the unmapped one is not propagated
+    MsgPackUtil.assertEquality(document, "{'data':{'wanted1':'A','wanted2':'B'}}");
   }
 
   // evaluates output mappings one by one in modeling order, mirroring
@@ -320,9 +301,7 @@ public final class VariableOutputMappingTransformerTest {
       final List<OutputMapping> outputMappings,
       final Map<String, DirectBuffer> scopeChain,
       final Map<String, DirectBuffer> mergeTarget) {
-    // Task 3 switches this to the two-resolver constructor; until then both views share the scope
-    // chain, which is exactly today's behavior.
-    final var resultBuilder = new MappingResultBuilder(resolver(scopeChain));
+    final var resultBuilder = new MappingResultBuilder(resolver(scopeChain), resolver(mergeTarget));
     for (final var mapping : outputMappings) {
       final EvaluationContext context =
           name -> {

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
@@ -51,6 +51,8 @@ public final class FeatureFlags {
   private static final boolean EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE = true;
   // Kill-switch for a bug fix; intentionally enabled by default.
   private static final boolean EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER = true;
+  // Kill-switch for a bug fix; intentionally enabled by default.
+  private static final boolean PROPAGATE_ONLY_MAPPED_NESTED_OUTPUT_PATHS = true;
 
   private boolean yieldingDueDateChecker;
   private boolean enableActorMetrics;
@@ -60,6 +62,7 @@ public final class FeatureFlags {
   private boolean enableMessageBodyOnExpired;
   private boolean evaluateBoundaryEventCorrelationKeyInActivityScope;
   private boolean evaluateDuplicateOutputMappingTargetsInOrder;
+  private boolean propagateOnlyMappedNestedOutputPaths;
 
   public FeatureFlags(
       final boolean yieldingDueDateChecker,
@@ -69,7 +72,8 @@ public final class FeatureFlags {
       final boolean enableStraightThroughProcessingLoopDetector,
       final boolean enableMessageBodyOnExpired,
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
-      final boolean evaluateDuplicateOutputMappingTargetsInOrder
+      final boolean evaluateDuplicateOutputMappingTargetsInOrder,
+      final boolean propagateOnlyMappedNestedOutputPaths
       /*, boolean foo*/ ) {
     this.yieldingDueDateChecker = yieldingDueDateChecker;
     this.enableActorMetrics = enableActorMetrics;
@@ -81,6 +85,7 @@ public final class FeatureFlags {
         evaluateBoundaryEventCorrelationKeyInActivityScope;
     this.evaluateDuplicateOutputMappingTargetsInOrder =
         evaluateDuplicateOutputMappingTargetsInOrder;
+    this.propagateOnlyMappedNestedOutputPaths = propagateOnlyMappedNestedOutputPaths;
   }
 
   public static FeatureFlags createDefault() {
@@ -92,7 +97,8 @@ public final class FeatureFlags {
         ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR,
         ENABLE_MESSAGE_BODY_ON_EXPIRED,
         EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE,
-        EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER
+        EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER,
+        PROPAGATE_ONLY_MAPPED_NESTED_OUTPUT_PATHS
         /*, FOO_DEFAULT*/ );
   }
 
@@ -110,7 +116,8 @@ public final class FeatureFlags {
         true, /* ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR */
         false, /* ENABLE_MESSAGE_BODY_ON_EXPIRED */
         true, /* EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE */
-        true /* EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER */
+        true, /* EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER */
+        true /* PROPAGATE_ONLY_MAPPED_NESTED_OUTPUT_PATHS */
         /*, FOO_DEFAULT*/ );
   }
 
@@ -144,6 +151,10 @@ public final class FeatureFlags {
 
   public boolean evaluateDuplicateOutputMappingTargetsInOrder() {
     return evaluateDuplicateOutputMappingTargetsInOrder;
+  }
+
+  public boolean propagateOnlyMappedNestedOutputPaths() {
+    return propagateOnlyMappedNestedOutputPaths;
   }
 
   public void setYieldingDueDateChecker(final boolean yieldingDueDateChecker) {
@@ -181,6 +192,11 @@ public final class FeatureFlags {
       final boolean evaluateDuplicateOutputMappingTargetsInOrder) {
     this.evaluateDuplicateOutputMappingTargetsInOrder =
         evaluateDuplicateOutputMappingTargetsInOrder;
+  }
+
+  public void setPropagateOnlyMappedNestedOutputPaths(
+      final boolean propagateOnlyMappedNestedOutputPaths) {
+    this.propagateOnlyMappedNestedOutputPaths = propagateOnlyMappedNestedOutputPaths;
   }
 
   @Override


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

When an output mapping targets a nested path like `data.result`, we were merging the completing element's *entire* `data` into the parent scope, including branches no mapping ever touched. So if a form or a job returned extra fields, they'd silently turn up in the parent scope alongside the one value you actually mapped.

The cause is that `MappingResultBuilder` used one seeded structure for two different jobs: answering `getVariable()` while source expressions are evaluated, and producing the document we merge into the parent. Seeding it from the element's scope chain is right for the first job and wrong for the second, because the seed then drags element-local branches into a document that gets written to a different scope.

This turned out to be more troublesome than I had anticipated. The obvious fix is to point that seed at the merge target instead, and it passes every test we had, but it quietly breaks the exact scenario the issue reports:

1. The seed also feeds source resolution. So a mapping reading `processData.fault.errors` *after* an earlier mapping wrote `processData.humanTask.outcome` would only see what had been written so far, resolve to `null`, and raise no incident.
2. Nothing caught it, because every existing multi-mapping test happens to use a source root that differs from its target root, which is the one shape where this can't bite.

So instead I split the two concerns. The evaluation view is completely untouched and still seeded from the scope chain, and the emitted document is built by replaying only the paths a mapping explicitly wrote, against the scope we're merging into. One behaviour call in there worth a look: a back-reference after a nested write now sees the local value with the write layered on top, rather than only the write. The issue only constrains what propagates to the parent, and the alternative is exactly what produces the `null` above.

It's all behind `propagateOnlyMappedNestedOutputPaths`, enabled by default, following the `evaluateDuplicateOutputMappingTargetsInOrder` pattern. It's processing-time only, no event applier, state class or record schema is touched, so replay of existing logs is unaffected.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #35251 
