### PR TITLE
ci: retry yarn install to survive prebuilt binary download flakes

### DIFF
--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -38,9 +38,9 @@ runs:
 
     - name: Install node dependencies (yarn)
       if: ${{ inputs.package-manager == 'yarn' }}
-      working-directory: ${{ inputs.directory }}
-      shell: bash
-      run: yarn
+      uses: ./.github/actions/yarn-install-with-retry
+      with:
+        directory: ${{ inputs.directory }}
 
     - name: Install node dependencies (npm)
       if: ${{ inputs.package-manager == 'npm' }}

--- a/.github/actions/frontend-sbom-snyk/action.yml
+++ b/.github/actions/frontend-sbom-snyk/action.yml
@@ -60,14 +60,10 @@ runs:
 
     - name: Install dependencies with yarn
       if: inputs.package-manager == 'yarn'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: ./.github/actions/yarn-install-with-retry
       with:
-        max_attempts: 3
-        retry_on: error
-        retry_wait_seconds: 15
-        timeout_minutes: 10
-        command: |
-          cd "${{ inputs.directory }}" && yarn install --frozen-lockfile
+        directory: ${{ inputs.directory }}
+        args: install --frozen-lockfile
 
     - name: Generate SBOM with npm
       if: inputs.package-manager == 'npm'

--- a/.github/actions/yarn-install-with-retry/action.yml
+++ b/.github/actions/yarn-install-with-retry/action.yml
@@ -16,6 +16,10 @@ inputs:
       repository root and ignores `working-directory`, so this must be passed
       explicitly.
     required: true
+  args:
+    description: Extra arguments to pass to `yarn`, e.g. `--frozen-lockfile`.
+    required: false
+    default: ""
   max_attempts:
     description: Maximum number of attempts before giving up.
     required: false
@@ -41,5 +45,10 @@ runs:
         # Pin to bash so a forward-slash `directory` works consistently on
         # Linux, container images, and Windows runners (git-bash).
         shell: bash
+        # yarn installs incrementally, so a killed attempt can leave a partially
+        # extracted node_modules that the next one would install on top of. The
+        # GHA cache holds the global yarn dir, not node_modules, so discarding it
+        # costs a re-link rather than a re-download.
+        on_retry_command: rm -rf "${{ inputs.directory }}/node_modules"
         command: |
-          cd "${{ inputs.directory }}" && yarn
+          cd "${{ inputs.directory }}" && yarn ${{ inputs.args }}

--- a/.github/actions/yarn-install-with-retry/action.yml
+++ b/.github/actions/yarn-install-with-retry/action.yml
@@ -1,0 +1,45 @@
+---
+name: yarn install with retry
+
+# owner: @camunda/engineering-operations
+
+description: >
+  Runs `yarn` wrapped in retry logic so a singular transient network failure
+  does not fail the whole job. Beyond the registry itself, postinstall scripts
+  of native dependencies (e.g. sharp) fetch prebuilt binaries straight from
+  GitHub releases, which aborts often enough to be a recurring flake.
+
+inputs:
+  directory:
+    description: >
+      Directory to install dependencies in. The retry action runs from the
+      repository root and ignores `working-directory`, so this must be passed
+      explicitly.
+    required: true
+  max_attempts:
+    description: Maximum number of attempts before giving up.
+    required: false
+    default: "3"
+  retry_wait_seconds:
+    description: Seconds to wait between attempts.
+    required: false
+    default: "5"
+  timeout_minutes:
+    description: Timeout per attempt in minutes.
+    required: false
+    default: "10"
+
+runs:
+  using: composite
+  steps:
+    - name: Install node dependencies
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      with:
+        max_attempts: ${{ inputs.max_attempts }}
+        retry_wait_seconds: ${{ inputs.retry_wait_seconds }}
+        timeout_minutes: ${{ inputs.timeout_minutes }}
+        # Pin to bash so a forward-slash `directory` works consistently on
+        # Linux, container images, and Windows runners (git-bash).
+        shell: bash
+        command: |
+          cd "${{ inputs.directory }}" && yarn

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -299,7 +299,10 @@ jobs:
         with:
           directory: optimize/client
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        uses: ./.github/actions/yarn-install-with-retry
+        with:
+          directory: optimize/client
+          args: install --frozen-lockfile
       - name: Unit tests
         run: yarn test:ci
       - name: Upload test results


### PR DESCRIPTION
## Description

The Optimize E2E smoke job failed on a scheduled `main` run because `yarn` aborted mid-install:

```
sharp: Downloading .../libvips-8.14.5-linux-x64.tar.br
sharp: Installation error: aborted
```

`sharp` is a transitive dependency of `optimize/client` whose postinstall script pulls a prebuilt libvips tarball straight from GitHub releases. That download sits outside the registry and outside the yarn cache, so a single aborted connection kills the install. The documented fallback (`node install/can-compile && node-gyp rebuild`) cannot save it either, because the runners carry no libvips build toolchain.

`build-frontend` already guarded its npm branch with `npm-ci-with-retry`, but the yarn branch was a bare `run: yarn` — leaving every yarn consumer of the action exposed to this class of failure. This extracts the same pattern into a `yarn-install-with-retry` action and delegates to it, keeping the two package-manager branches symmetric.

Retry rather than provisioning libvips on the runners: the failure is a transient network abort, not a missing dependency, and a re-download succeeds. Installing the toolchain would slow every frontend job down to work around a fault that only bites occasionally.

Affects all workflows using `build-frontend` with yarn, but only changes behaviour on failure.

- Incident: https://camunda.slack.com/archives/C0BM90XTAAX
- Failed run: https://github.com/camunda/camunda/actions/runs/30736896609/job/91467816553

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).