### PR TITLE
ClusterAdmin can perform tenant mode changes

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminBasicSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminBasicSecurityConfiguration.java
@@ -31,7 +31,7 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.context.NullSecurityContextRepository;
+import org.springframework.security.web.context.RequestAttributeSecurityContextRepository;
 import org.springframework.security.web.savedrequest.NullRequestCache;
 
 /**
@@ -48,9 +48,9 @@ import org.springframework.security.web.savedrequest.NullRequestCache;
  * credentials to fall through to the global manager. Without this isolation, a DB-backed user could
  * authenticate on {@code /cluster/v2/**}.
  *
- * <p><strong>Statelessness:</strong> the chain binds a session-free {@link
- * NullSecurityContextRepository} explicitly and never creates a session, so an existing webapp
- * session cookie can never authenticate {@code /cluster/v2/**}.
+ * <p><strong>Statelessness:</strong> the chain binds a request-scoped, session-free {@link
+ * RequestAttributeSecurityContextRepository} explicitly and never creates a session, so an existing
+ * webapp session cookie can never authenticate {@code /cluster/v2/**}.
  *
  * <p><strong>OIDC:</strong> handled by separate {@link ClusterAdminOidcSecurityConfiguration},
  * gated by {@code @ConditionalOnAuthenticationMethod(OIDC)}.
@@ -96,11 +96,19 @@ public class ClusterAdminBasicSecurityConfiguration {
         .cors(AbstractHttpConfigurer::disable)
         .formLogin(AbstractHttpConfigurer::disable)
         .anonymous(AbstractHttpConfigurer::disable)
+        .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         // Explicit session-free context repository so a webapp session cookie can't authenticate
         // this chain. Explicit is required: STATELESS installs one only if none was set already
         // (SessionManagementConfigurer's `if (repo == null)` guard).
-        .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-        .securityContext(sc -> sc.securityContextRepository(new NullSecurityContextRepository()))
+        //
+        // Request-scoped rather than null: the cluster-admin endpoints return a CompletableFuture,
+        // so Spring MVC runs this chain a second time on the ASYNC dispatch and reloads the context
+        // from this repository. A NullSecurityContextRepository stores nothing, so that second pass
+        // finds no authentication and answers 401 even for a valid credential. Request scope keeps
+        // the chain session-free while surviving the dispatches of one request, and matches the
+        // OIDC chain.
+        .securityContext(
+            sc -> sc.securityContextRepository(new RequestAttributeSecurityContextRepository()))
         .requestCache(cache -> cache.requestCache(new NullRequestCache()))
         .csrf(AbstractHttpConfigurer::disable);
 

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -30,6 +30,7 @@ import io.camunda.service.AuditLogServices;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.BatchOperationServices;
 import io.camunda.service.ClockServices;
+import io.camunda.service.ClusterRecoveryServices;
 import io.camunda.service.ClusterStatusServices;
 import io.camunda.service.ClusterVariableServices;
 import io.camunda.service.ConditionalServices;
@@ -523,6 +524,8 @@ public class CamundaServicesConfiguration {
         new ClusterStatusServices(
             topologyServicesByTenant,
             physicalTenantId -> secondaryStorageReadiness.getObject().isReady(physicalTenantId)));
+
+    builder.clusterRecoveryServices(new ClusterRecoveryServices(clusterConfigurationRequestSender));
 
     return builder.build();
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 public class ClusterAdminBasicAuthenticationIT {
 
   public static final String PATH_CLUSTER_TOPOLOGY = "cluster/v2/topology";
+  public static final String PATH_CLUSTER_MODE = "cluster/v2/mode?mode=RECOVERING&dryRun=true";
   public static final String PATH_CLUSTER_STATUS = "cluster/v2/status";
   public static final String PATH_V2_AUTHENTICATION_ME = "v2/authentication/me";
 
@@ -110,6 +111,20 @@ public class ClusterAdminBasicAuthenticationIT {
         send(clusterUri(PATH_CLUSTER_TOPOLOGY), basicAuth(DB_USERNAME, DB_PASSWORD));
 
     // then — the cluster-admin chain has its own isolated store; a DB user is not known to it
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  @Test
+  void shouldRejectModeChangeWithoutCredentials() throws Exception {
+    // when — the mode change is a state-changing cluster-admin endpoint, so it must sit inside the
+    // protected chain rather than under a pattern the chain does not match
+    final HttpRequest.Builder builder =
+        HttpRequest.newBuilder(clusterUri(PATH_CLUSTER_MODE))
+            .method("PATCH", HttpRequest.BodyPublishers.noBody());
+    final HttpResponse<String> response =
+        httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+
+    // then
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminModeChangeIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminModeChangeIT.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Base64;
+import java.util.List;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+class ClusterAdminModeChangeIT {
+
+  private static final String CLUSTER_ADMIN_USER = "cluster-operator";
+  private static final String CLUSTER_ADMIN_PASSWORD = "cluster-secret";
+  private static final String DB_USERNAME = "db_user";
+  private static final String DB_PASSWORD = "db_password";
+
+  @MultiDbTestApplication
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withAuthenticatedAccess()
+          .withProperty("camunda.security.cluster-admin.basic.users[0].name", CLUSTER_ADMIN_USER)
+          .withProperty(
+              "camunda.security.cluster-admin.basic.users[0].password", CLUSTER_ADMIN_PASSWORD);
+
+  // A real, secondary-storage-backed user — used to prove it cannot reach the cluster-admin chain.
+  @UserDefinition
+  private static final TestUser DB_USER = new TestUser(DB_USERNAME, DB_PASSWORD, List.of());
+
+  private static CamundaClient camundaClient;
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
+
+  @Test
+  void shouldRejectModeChangeWithoutCredentials() throws Exception {
+    // when
+    final var response = changeMode("mode=RECOVERING&dryRun=true", null);
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  @Test
+  void shouldRejectModeChangeWithWrongClusterAdminPassword() throws Exception {
+    // when
+    final var response =
+        changeMode("mode=RECOVERING&dryRun=true", basicAuth(CLUSTER_ADMIN_USER, "wrong-password"));
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  @Test
+  void shouldRejectModeChangeForSecondaryStorageBackedUser() throws Exception {
+    // when — a real DB-backed user presents valid credentials to the cluster-admin API
+    final var response =
+        changeMode("mode=RECOVERING&dryRun=true", basicAuth(DB_USERNAME, DB_PASSWORD));
+
+    // then — the cluster-admin store is isolated, so a DB user is not known to this chain
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  @Test
+  void shouldPlanModeChangeForEveryPhysicalTenant() throws Exception {
+    // when — no physicalTenantId, so every physical tenant of the cluster is transitioned
+    final var response =
+        changeMode(
+            "mode=RECOVERING&dryRun=true", basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD));
+
+    // then — one change covering the whole request, with the transition planned per broker
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
+    final var body = new ObjectMapper().readTree(response.body());
+    assertThat(body.get("changeId").asText()).isNotBlank();
+    assertThat(body.get("plannedChanges")).isNotEmpty();
+    assertThat(body.get("plannedChanges"))
+        .allSatisfy(change -> assertThat(change.get("mode").asText()).isEqualTo("RECOVERING"));
+    assertThat(body.get("plannedChanges"))
+        .anySatisfy(
+            change -> assertThat(change.get("operation").asText()).isEqualTo("ModeChangeOperation"))
+        .anySatisfy(
+            change ->
+                assertThat(change.get("operation").asText()).isEqualTo("AwaitModeChangeOperation"));
+  }
+
+  @Test
+  void shouldPlanModeChangeForTheDefaultPhysicalTenant() throws Exception {
+    // when — the default tenant is addressable on every cluster
+    final var response =
+        changeMode(
+            "mode=RECOVERING&physicalTenantId=default&dryRun=true",
+            basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD));
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
+  }
+
+  @Test
+  void shouldRejectModeChangeScopedToAnUnknownPhysicalTenant() throws Exception {
+    // when — a cluster with a single partition group shares one mode across all tenants, so it
+    // cannot transition another tenant on its own
+    final var response =
+        changeMode(
+            "mode=RECOVERING&physicalTenantId=does-not-exist&dryRun=true",
+            basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD));
+
+    // then — a bad request, not an internal error
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
+    assertThat(response.body()).contains("does-not-exist");
+  }
+
+  @Test
+  void shouldRejectAnUnknownMode() throws Exception {
+    // when
+    final var response =
+        changeMode(
+            "mode=NOT_A_MODE&dryRun=true", basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD));
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
+  }
+
+  private HttpResponse<String> changeMode(final String query, final String authorizationHeader)
+      throws Exception {
+    final HttpRequest.Builder builder =
+        HttpRequest.newBuilder(clusterUri("cluster/v2/mode?" + query));
+    if (authorizationHeader != null) {
+      builder.header("Authorization", authorizationHeader);
+    }
+    builder.method("PATCH", BodyPublishers.noBody());
+    return httpClient.send(builder.build(), BodyHandlers.ofString());
+  }
+
+  private static String basicAuth(final String user, final String password) {
+    return "Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes());
+  }
+
+  // The cluster-admin API is cluster-wide, so it is always addressed at the gateway root — never
+  // under a /physical-tenants/<id> prefix that the client's REST address may carry.
+  private static URI clusterUri(final String path) {
+    final String base =
+        camundaClient
+            .getConfiguration()
+            .getRestAddress()
+            .toString()
+            .replaceAll("/+$", "")
+            .replaceFirst("/physical-tenants/[^/]+$", "");
+    return URI.create(base + "/" + path);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminModeChangeIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminModeChangeIT.java
@@ -10,12 +10,9 @@ package io.camunda.it.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.client.CamundaClient;
-import io.camunda.qa.util.auth.TestUser;
-import io.camunda.qa.util.auth.UserDefinition;
-import io.camunda.qa.util.multidb.MultiDbTest;
-import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -24,64 +21,24 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.util.Base64;
-import java.util.List;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-@MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
-class ClusterAdminModeChangeIT {
+@ZeebeIntegration
+final class ClusterAdminModeChangeIT {
 
   private static final String CLUSTER_ADMIN_USER = "cluster-operator";
   private static final String CLUSTER_ADMIN_PASSWORD = "cluster-secret";
-  private static final String DB_USERNAME = "db_user";
-  private static final String DB_PASSWORD = "db_password";
 
-  @MultiDbTestApplication
+  @TestZeebe(purgeAfterEach = false)
   private static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker()
-          .withBasicAuth()
-          .withAuthenticatedAccess()
+          .withUnauthenticatedAccess()
           .withProperty("camunda.security.cluster-admin.basic.users[0].name", CLUSTER_ADMIN_USER)
           .withProperty(
               "camunda.security.cluster-admin.basic.users[0].password", CLUSTER_ADMIN_PASSWORD);
 
-  // A real, secondary-storage-backed user — used to prove it cannot reach the cluster-admin chain.
-  @UserDefinition
-  private static final TestUser DB_USER = new TestUser(DB_USERNAME, DB_PASSWORD, List.of());
-
-  private static CamundaClient camundaClient;
   @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
-
-  @Test
-  void shouldRejectModeChangeWithoutCredentials() throws Exception {
-    // when
-    final var response = changeMode("mode=RECOVERING&dryRun=true", null);
-
-    // then
-    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
-  }
-
-  @Test
-  void shouldRejectModeChangeWithWrongClusterAdminPassword() throws Exception {
-    // when
-    final var response =
-        changeMode("mode=RECOVERING&dryRun=true", basicAuth(CLUSTER_ADMIN_USER, "wrong-password"));
-
-    // then
-    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
-  }
-
-  @Test
-  void shouldRejectModeChangeForSecondaryStorageBackedUser() throws Exception {
-    // when — a real DB-backed user presents valid credentials to the cluster-admin API
-    final var response =
-        changeMode("mode=RECOVERING&dryRun=true", basicAuth(DB_USERNAME, DB_PASSWORD));
-
-    // then — the cluster-admin store is isolated, so a DB user is not known to this chain
-    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
-  }
 
   @Test
   void shouldPlanModeChangeForEveryPhysicalTenant() throws Exception {
@@ -94,10 +51,8 @@ class ClusterAdminModeChangeIT {
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
     final var body = new ObjectMapper().readTree(response.body());
     assertThat(body.get("changeId").asText()).isNotBlank();
-    assertThat(body.get("plannedChanges")).isNotEmpty();
     assertThat(body.get("plannedChanges"))
-        .allSatisfy(change -> assertThat(change.get("mode").asText()).isEqualTo("RECOVERING"));
-    assertThat(body.get("plannedChanges"))
+        .allSatisfy(change -> assertThat(change.get("mode").asText()).isEqualTo("RECOVERING"))
         .anySatisfy(
             change -> assertThat(change.get("operation").asText()).isEqualTo("ModeChangeOperation"))
         .anySatisfy(
@@ -119,15 +74,14 @@ class ClusterAdminModeChangeIT {
 
   @Test
   void shouldRejectModeChangeScopedToAnUnknownPhysicalTenant() throws Exception {
-    // when — a cluster with a single partition group shares one mode across all tenants, so it
-    // cannot transition another tenant on its own
+    // when — the tenant has no partition group on this cluster, so it cannot be transitioned
     final var response =
         changeMode(
             "mode=RECOVERING&physicalTenantId=does-not-exist&dryRun=true",
             basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD));
 
-    // then — a bad request, not an internal error
-    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
+    // then — the tenant is reported as missing, not as an internal error
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
     assertThat(response.body()).contains("does-not-exist");
   }
 
@@ -144,8 +98,7 @@ class ClusterAdminModeChangeIT {
 
   private HttpResponse<String> changeMode(final String query, final String authorizationHeader)
       throws Exception {
-    final HttpRequest.Builder builder =
-        HttpRequest.newBuilder(clusterUri("cluster/v2/mode?" + query));
+    final HttpRequest.Builder builder = HttpRequest.newBuilder(clusterUri(query));
     if (authorizationHeader != null) {
       builder.header("Authorization", authorizationHeader);
     }
@@ -158,15 +111,8 @@ class ClusterAdminModeChangeIT {
   }
 
   // The cluster-admin API is cluster-wide, so it is always addressed at the gateway root — never
-  // under a /physical-tenants/<id> prefix that the client's REST address may carry.
-  private static URI clusterUri(final String path) {
-    final String base =
-        camundaClient
-            .getConfiguration()
-            .getRestAddress()
-            .toString()
-            .replaceAll("/+$", "")
-            .replaceFirst("/physical-tenants/[^/]+$", "");
-    return URI.create(base + "/" + path);
+  // under a /physical-tenants/<id> prefix.
+  private static URI clusterUri(final String query) {
+    return BROKER.restAddress().resolve("cluster/v2/mode?" + query);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminModeChangeIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminModeChangeIT.java
@@ -47,17 +47,29 @@ final class ClusterAdminModeChangeIT {
         changeMode(
             "mode=RECOVERING&dryRun=true", basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD));
 
-    // then — one change covering the whole request, with the transition planned per broker
+    // then — one change covering the whole request, with the transition planned per broker of the
+    // only physical tenant this cluster has
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
     final var body = new ObjectMapper().readTree(response.body());
     assertThat(body.get("changeId").asText()).isNotBlank();
     assertThat(body.get("plannedChanges"))
-        .allSatisfy(change -> assertThat(change.get("mode").asText()).isEqualTo("RECOVERING"))
-        .anySatisfy(
-            change -> assertThat(change.get("operation").asText()).isEqualTo("ModeChangeOperation"))
-        .anySatisfy(
-            change ->
-                assertThat(change.get("operation").asText()).isEqualTo("AwaitModeChangeOperation"));
+        .singleElement()
+        .satisfies(
+            change -> {
+              assertThat(change.get("physicalTenantId").asText()).isEqualTo("default");
+              assertThat(change.get("operations"))
+                  .allSatisfy(
+                      operation ->
+                          assertThat(operation.get("mode").asText()).isEqualTo("RECOVERING"))
+                  .anySatisfy(
+                      operation ->
+                          assertThat(operation.get("operation").asText())
+                              .isEqualTo("ModeChangeOperation"))
+                  .anySatisfy(
+                      operation ->
+                          assertThat(operation.get("operation").asText())
+                              .isEqualTo("AwaitModeChangeOperation"));
+            });
   }
 
   @Test

--- a/service/src/main/java/io/camunda/service/ClusterRecoveryServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterRecoveryServices.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
+import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.util.Either;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Recovery operations that span the whole cluster, backing the cluster-admin API under {@code
+ * /cluster/v2}.
+ */
+@NullMarked
+public final class ClusterRecoveryServices {
+
+  private final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender;
+
+  public ClusterRecoveryServices(
+      final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender) {
+    this.clusterConfigurationRequestSender = clusterConfigurationRequestSender;
+  }
+
+  /**
+   * Transitions partitions between processing and recovery mode.
+   *
+   * @param physicalTenantId the physical tenant to transition, or {@code null} for every physical
+   *     tenant
+   */
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> changeMode(
+      final @Nullable String physicalTenantId, final Mode mode, final boolean dryRun) {
+    return clusterConfigurationRequestSender.modeChange(
+        new ModeChangeRequest(Optional.ofNullable(physicalTenantId), mode, dryRun));
+  }
+}

--- a/service/src/main/java/io/camunda/service/RecoveryServices.java
+++ b/service/src/main/java/io/camunda/service/RecoveryServices.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.util.Either;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import org.jspecify.annotations.NullMarked;

--- a/service/src/main/java/io/camunda/service/RecoveryServices.java
+++ b/service/src/main/java/io/camunda/service/RecoveryServices.java
@@ -27,6 +27,8 @@ import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import org.jspecify.annotations.NullMarked;
@@ -70,7 +72,7 @@ public final class RecoveryServices extends PhysicalTenantScopedApiServices<Reco
         authentication,
         () ->
             clusterConfigurationRequestSender.modeChange(
-                new ModeChangeRequest(getPhysicalTenantId(), mode, dryRun)));
+                new ModeChangeRequest(Optional.of(getPhysicalTenantId()), mode, dryRun)));
   }
 
   public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> restore(

--- a/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
@@ -14,6 +14,7 @@ import io.camunda.service.AuditLogServices;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.BatchOperationServices;
 import io.camunda.service.ClockServices;
+import io.camunda.service.ClusterRecoveryServices;
 import io.camunda.service.ClusterStatusServices;
 import io.camunda.service.ClusterVariableServices;
 import io.camunda.service.ConditionalServices;
@@ -95,6 +96,7 @@ public record DefaultServiceRegistry(
     Map<String, UserServices> userByTenant,
     Map<String, UserTaskServices> userTaskByTenant,
     Map<String, VariableServices> variableByTenant,
+    ClusterRecoveryServices clusterRecoveryServices,
     ClusterStatusServices clusterStatusServices,
     ManagementServices managementServices)
     implements ServiceRegistry {
@@ -300,6 +302,11 @@ public record DefaultServiceRegistry(
   }
 
   @Override
+  public ClusterRecoveryServices clusterRecoveryServices() {
+    return clusterRecoveryServices;
+  }
+
+  @Override
   public ClusterStatusServices clusterStatusServices() {
     return clusterStatusServices;
   }
@@ -386,6 +393,7 @@ public record DefaultServiceRegistry(
     private final Map<String, UserServices> userByTenant = new HashMap<>();
     private final Map<String, UserTaskServices> userTaskByTenant = new HashMap<>();
     private final Map<String, VariableServices> variableByTenant = new HashMap<>();
+    private ClusterRecoveryServices clusterRecoveryServices;
     private ClusterStatusServices clusterStatusServices;
     private ManagementServices managementServices;
 
@@ -592,6 +600,11 @@ public record DefaultServiceRegistry(
       return this;
     }
 
+    public Builder clusterRecoveryServices(final ClusterRecoveryServices service) {
+      clusterRecoveryServices = service;
+      return this;
+    }
+
     public Builder clusterStatusServices(final ClusterStatusServices service) {
       clusterStatusServices = service;
       return this;
@@ -642,6 +655,7 @@ public record DefaultServiceRegistry(
           Map.copyOf(userByTenant),
           Map.copyOf(userTaskByTenant),
           Map.copyOf(variableByTenant),
+          clusterRecoveryServices,
           clusterStatusServices,
           managementServices);
     }

--- a/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
@@ -14,6 +14,7 @@ import io.camunda.service.AuditLogServices;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.BatchOperationServices;
 import io.camunda.service.ClockServices;
+import io.camunda.service.ClusterRecoveryServices;
 import io.camunda.service.ClusterStatusServices;
 import io.camunda.service.ClusterVariableServices;
 import io.camunda.service.ConditionalServices;
@@ -138,6 +139,8 @@ public interface ServiceRegistry {
   // -- cluster-wide --
 
   ClusterStatusServices clusterStatusServices();
+
+  ClusterRecoveryServices clusterRecoveryServices();
 
   ManagementServices managementServices();
 }

--- a/service/src/test/java/io/camunda/service/ClusterRecoveryServicesTest.java
+++ b/service/src/test/java/io/camunda/service/ClusterRecoveryServicesTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
+import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
+import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+
+final class ClusterRecoveryServicesTest {
+
+  private static final String TENANT_B = "tenant-b";
+
+  private final ClusterConfigurationManagementRequestSender sender =
+      mock(ClusterConfigurationManagementRequestSender.class);
+  private final ClusterRecoveryServices services = new ClusterRecoveryServices(sender);
+
+  @Test
+  void shouldRequestEveryPhysicalTenantWhenNoneIsGiven() {
+    // given
+    givenModeChangeAccepted();
+
+    // when
+    services.changeMode(null, Mode.RECOVERING, false).join();
+
+    // then — the tenants are left for the cluster to resolve from its own configuration
+    verify(sender).modeChange(new ModeChangeRequest(Optional.empty(), Mode.RECOVERING, false));
+  }
+
+  @Test
+  void shouldRequestOnlyTheGivenPhysicalTenant() {
+    // given
+    givenModeChangeAccepted();
+
+    // when
+    services.changeMode(TENANT_B, Mode.RECOVERING, false).join();
+
+    // then
+    verify(sender).modeChange(new ModeChangeRequest(Optional.of(TENANT_B), Mode.RECOVERING, false));
+  }
+
+  @Test
+  void shouldPassDryRunThrough() {
+    // given
+    givenModeChangeAccepted();
+
+    // when
+    services.changeMode(TENANT_B, Mode.PROCESSING, true).join();
+
+    // then
+    verify(sender).modeChange(new ModeChangeRequest(Optional.of(TENANT_B), Mode.PROCESSING, true));
+  }
+
+  @Test
+  void shouldReturnTheAcceptedChange() {
+    // given
+    givenModeChangeAccepted();
+
+    // when
+    final var result = services.changeMode(null, Mode.RECOVERING, false).join();
+
+    // then — a single change covering every tenant
+    assertThat(result.isRight()).isTrue();
+    assertThat(result.get().changeId()).isEqualTo(7L);
+  }
+
+  @Test
+  void shouldReturnTheRejectionOfTheCluster() {
+    // given
+    when(sender.modeChange(any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.left(new ErrorResponse(ErrorCode.INVALID_STATE, "a change is ongoing"))));
+
+    // when
+    final var result = services.changeMode(null, Mode.RECOVERING, false).join();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().code()).isEqualTo(ErrorCode.INVALID_STATE);
+  }
+
+  private void givenModeChangeAccepted() {
+    when(sender.modeChange(any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.right(
+                    new ClusterConfigurationChangeResponse(
+                        7L,
+                        new LegacyConfigurationChangeResponse(Map.of(), Map.of(), List.of()),
+                        null))));
+  }
+}

--- a/service/src/test/java/io/camunda/service/RecoveryServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RecoveryServicesTest.java
@@ -380,9 +380,199 @@ public class RecoveryServicesTest {
     assertThat(future.join().getLeft()).isEqualTo(rejection);
   }
 
+  @Test
+  public void shouldForwardRestoreRequestUnchanged() {
+    // given
+    final var request =
+        new RestoreRequest(
+            PHYSICAL_TENANT_ID, List.of(100L, 101L), null, null, "elasticsearch", false, false);
+    stubRestoreSuccess();
+
+    // when
+    final var future = services.restore(request, authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    verify(clusterConfigurationRequestSender).restore(request);
+  }
+
+  @Test
+  public void shouldRestoreWhenAuthorizationsDisabled() {
+    // given
+    stubRestoreSuccess();
+
+    // when
+    final var future = services.restore(restoreRequest(), authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    verify(clusterConfigurationRequestSender).restore(any());
+  }
+
+  @Test
+  public void shouldRestoreWhenUserHasBackupRestorePermission() {
+    // given
+    grant(AuthorizationResourceType.BACKUP, PermissionType.RESTORE);
+    stubRestoreSuccess();
+
+    // when
+    final var future = services.restore(restoreRequest(), authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    verify(clusterConfigurationRequestSender).restore(any());
+  }
+
+  @Test
+  public void shouldFailRestoreWithForbiddenWhenUserHasNoAuthorizations() {
+    // given
+    authorizationsConfig.setEnabled(true);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Collections.emptySet());
+
+    // when
+    final var future = services.restore(restoreRequest(), authentication);
+
+    // then
+    assertForbidden(future);
+    verify(clusterConfigurationRequestSender, never()).restore(any());
+  }
+
+  @Test
+  public void shouldFailRestoreWithForbiddenWhenUserOnlyHasSystemUpdatePermission() {
+    // given - unlike the mode change, restoring is not OR-gated: SYSTEM:UPDATE alone must not
+    // authorize consuming a backup
+    grant(AuthorizationResourceType.SYSTEM, PermissionType.UPDATE);
+
+    // when
+    final var future = services.restore(restoreRequest(), authentication);
+
+    // then
+    assertForbidden(future);
+    verify(clusterConfigurationRequestSender, never()).restore(any());
+  }
+
+  @Test
+  public void shouldReportBackupRestoreWhenRestoreIsDenied() {
+    // given
+    authorizationsConfig.setEnabled(true);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Collections.emptySet());
+
+    // when
+    final var future = services.restore(restoreRequest(), authentication);
+
+    // then
+    assertThat(future)
+        .failsWithin(ofSeconds(1))
+        .withThrowableOfType(ExecutionException.class)
+        .havingCause()
+        .withMessageContaining("RESTORE")
+        .withMessageContaining("BACKUP");
+  }
+
+  @Test
+  public void shouldPassRestoreCoordinatorRejectionThroughUnchanged() {
+    // given
+    final var rejection = new ErrorResponse(ErrorCode.INVALID_STATE, "restore already running");
+    when(clusterConfigurationRequestSender.restore(any()))
+        .thenReturn(CompletableFuture.completedFuture(Either.left(rejection)));
+
+    // when
+    final var future = services.restore(restoreRequest(), authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    assertThat(future.join().getLeft()).isEqualTo(rejection);
+  }
+
+  @Test
+  public void shouldGetRestoreStatusWhenAuthorizationsDisabled() {
+    // given
+    stubTopologySuccess();
+
+    // when
+    final var future = services.restoreStatus(authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    verify(clusterConfigurationRequestSender).getTopology();
+  }
+
+  @Test
+  public void shouldGetRestoreStatusWhenUserHasBackupRestorePermission() {
+    // given
+    grant(AuthorizationResourceType.BACKUP, PermissionType.RESTORE);
+    stubTopologySuccess();
+
+    // when
+    final var future = services.restoreStatus(authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    verify(clusterConfigurationRequestSender).getTopology();
+  }
+
+  @Test
+  public void shouldFailGetRestoreStatusWithForbiddenWhenUserHasNoAuthorizations() {
+    // given
+    authorizationsConfig.setEnabled(true);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Collections.emptySet());
+
+    // when
+    final var future = services.restoreStatus(authentication);
+
+    // then
+    assertForbidden(future);
+    verify(clusterConfigurationRequestSender, never()).getTopology();
+  }
+
+  @Test
+  public void shouldFailGetRestoreStatusWithForbiddenWhenUserOnlyHasSystemUpdatePermission() {
+    // given - reading the restore status is gated the same as triggering one: SYSTEM:UPDATE alone
+    // must not suffice
+    grant(AuthorizationResourceType.SYSTEM, PermissionType.UPDATE);
+
+    // when
+    final var future = services.restoreStatus(authentication);
+
+    // then
+    assertForbidden(future);
+    verify(clusterConfigurationRequestSender, never()).getTopology();
+  }
+
+  @Test
+  public void shouldPassGetRestoreStatusCoordinatorRejectionThroughUnchanged() {
+    // given
+    final var rejection = new ErrorResponse(ErrorCode.INTERNAL_ERROR, "topology is unavailable");
+    when(clusterConfigurationRequestSender.getTopology())
+        .thenReturn(CompletableFuture.completedFuture(Either.left(rejection)));
+
+    // when
+    final var future = services.restoreStatus(authentication);
+
+    // then
+    assertThat(future).succeedsWithin(ofSeconds(1));
+    assertThat(future.join().getLeft()).isEqualTo(rejection);
+  }
+
   private static RestoreRequest restoreRequest() {
     return new RestoreRequest(
         PHYSICAL_TENANT_ID, List.of(100L), null, null, "elasticsearch", false, false);
+  }
+
+  private void stubRestoreSuccess() {
+    when(clusterConfigurationRequestSender.restore(any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.right(
+                    new ClusterConfigurationChangeResponse(0L, Map.of(), Map.of(), List.of()))));
+  }
+
+  private void stubTopologySuccess() {
+    when(clusterConfigurationRequestSender.getTopology())
+        .thenReturn(CompletableFuture.completedFuture(Either.right(ClusterConfiguration.init())));
   }
 
   private void stubRestoreSuccess() {
@@ -394,11 +584,6 @@ public class RecoveryServicesTest {
                         0L,
                         new LegacyConfigurationChangeResponse(Map.of(), Map.of(), List.of()),
                         null))));
-  }
-
-  private void stubTopologySuccess() {
-    when(clusterConfigurationRequestSender.getTopology())
-        .thenReturn(CompletableFuture.completedFuture(Either.right(ClusterConfiguration.init())));
   }
 
   private void grant(

--- a/service/src/test/java/io/camunda/service/RecoveryServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RecoveryServicesTest.java
@@ -40,6 +40,7 @@ import io.camunda.zeebe.util.Either;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -92,7 +93,7 @@ public class RecoveryServicesTest {
     // then
     assertThat(future).succeedsWithin(ofSeconds(1));
     verify(clusterConfigurationRequestSender)
-        .modeChange(new ModeChangeRequest(PHYSICAL_TENANT_ID, mode, true));
+        .modeChange(new ModeChangeRequest(Optional.of(PHYSICAL_TENANT_ID), mode, true));
   }
 
   @Test
@@ -380,194 +381,9 @@ public class RecoveryServicesTest {
     assertThat(future.join().getLeft()).isEqualTo(rejection);
   }
 
-  @Test
-  public void shouldForwardRestoreRequestUnchanged() {
-    // given
-    final var request =
-        new RestoreRequest(
-            PHYSICAL_TENANT_ID, List.of(100L, 101L), null, null, "elasticsearch", false, false);
-    stubRestoreSuccess();
-
-    // when
-    final var future = services.restore(request, authentication);
-
-    // then
-    assertThat(future).succeedsWithin(ofSeconds(1));
-    verify(clusterConfigurationRequestSender).restore(request);
-  }
-
-  @Test
-  public void shouldRestoreWhenAuthorizationsDisabled() {
-    // given
-    stubRestoreSuccess();
-
-    // when
-    final var future = services.restore(restoreRequest(), authentication);
-
-    // then
-    assertThat(future).succeedsWithin(ofSeconds(1));
-    verify(clusterConfigurationRequestSender).restore(any());
-  }
-
-  @Test
-  public void shouldRestoreWhenUserHasBackupRestorePermission() {
-    // given
-    grant(AuthorizationResourceType.BACKUP, PermissionType.RESTORE);
-    stubRestoreSuccess();
-
-    // when
-    final var future = services.restore(restoreRequest(), authentication);
-
-    // then
-    assertThat(future).succeedsWithin(ofSeconds(1));
-    verify(clusterConfigurationRequestSender).restore(any());
-  }
-
-  @Test
-  public void shouldFailRestoreWithForbiddenWhenUserHasNoAuthorizations() {
-    // given
-    authorizationsConfig.setEnabled(true);
-    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
-        .thenReturn(Collections.emptySet());
-
-    // when
-    final var future = services.restore(restoreRequest(), authentication);
-
-    // then
-    assertForbidden(future);
-    verify(clusterConfigurationRequestSender, never()).restore(any());
-  }
-
-  @Test
-  public void shouldFailRestoreWithForbiddenWhenUserOnlyHasSystemUpdatePermission() {
-    // given - unlike the mode change, restoring is not OR-gated: SYSTEM:UPDATE alone must not
-    // authorize consuming a backup
-    grant(AuthorizationResourceType.SYSTEM, PermissionType.UPDATE);
-
-    // when
-    final var future = services.restore(restoreRequest(), authentication);
-
-    // then
-    assertForbidden(future);
-    verify(clusterConfigurationRequestSender, never()).restore(any());
-  }
-
-  @Test
-  public void shouldReportBackupRestoreWhenRestoreIsDenied() {
-    // given
-    authorizationsConfig.setEnabled(true);
-    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
-        .thenReturn(Collections.emptySet());
-
-    // when
-    final var future = services.restore(restoreRequest(), authentication);
-
-    // then
-    assertThat(future)
-        .failsWithin(ofSeconds(1))
-        .withThrowableOfType(ExecutionException.class)
-        .havingCause()
-        .withMessageContaining("RESTORE")
-        .withMessageContaining("BACKUP");
-  }
-
-  @Test
-  public void shouldPassRestoreCoordinatorRejectionThroughUnchanged() {
-    // given
-    final var rejection = new ErrorResponse(ErrorCode.INVALID_STATE, "restore already running");
-    when(clusterConfigurationRequestSender.restore(any()))
-        .thenReturn(CompletableFuture.completedFuture(Either.left(rejection)));
-
-    // when
-    final var future = services.restore(restoreRequest(), authentication);
-
-    // then
-    assertThat(future).succeedsWithin(ofSeconds(1));
-    assertThat(future.join().getLeft()).isEqualTo(rejection);
-  }
-
-  @Test
-  public void shouldGetRestoreStatusWhenAuthorizationsDisabled() {
-    // given
-    stubTopologySuccess();
-
-    // when
-    final var future = services.restoreStatus(authentication);
-
-    // then
-    assertThat(future).succeedsWithin(ofSeconds(1));
-    verify(clusterConfigurationRequestSender).getTopology();
-  }
-
-  @Test
-  public void shouldGetRestoreStatusWhenUserHasBackupRestorePermission() {
-    // given
-    grant(AuthorizationResourceType.BACKUP, PermissionType.RESTORE);
-    stubTopologySuccess();
-
-    // when
-    final var future = services.restoreStatus(authentication);
-
-    // then
-    assertThat(future).succeedsWithin(ofSeconds(1));
-    verify(clusterConfigurationRequestSender).getTopology();
-  }
-
-  @Test
-  public void shouldFailGetRestoreStatusWithForbiddenWhenUserHasNoAuthorizations() {
-    // given
-    authorizationsConfig.setEnabled(true);
-    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
-        .thenReturn(Collections.emptySet());
-
-    // when
-    final var future = services.restoreStatus(authentication);
-
-    // then
-    assertForbidden(future);
-    verify(clusterConfigurationRequestSender, never()).getTopology();
-  }
-
-  @Test
-  public void shouldFailGetRestoreStatusWithForbiddenWhenUserOnlyHasSystemUpdatePermission() {
-    // given - reading the restore status is gated the same as triggering one: SYSTEM:UPDATE alone
-    // must not suffice
-    grant(AuthorizationResourceType.SYSTEM, PermissionType.UPDATE);
-
-    // when
-    final var future = services.restoreStatus(authentication);
-
-    // then
-    assertForbidden(future);
-    verify(clusterConfigurationRequestSender, never()).getTopology();
-  }
-
-  @Test
-  public void shouldPassGetRestoreStatusCoordinatorRejectionThroughUnchanged() {
-    // given
-    final var rejection = new ErrorResponse(ErrorCode.INTERNAL_ERROR, "topology is unavailable");
-    when(clusterConfigurationRequestSender.getTopology())
-        .thenReturn(CompletableFuture.completedFuture(Either.left(rejection)));
-
-    // when
-    final var future = services.restoreStatus(authentication);
-
-    // then
-    assertThat(future).succeedsWithin(ofSeconds(1));
-    assertThat(future.join().getLeft()).isEqualTo(rejection);
-  }
-
   private static RestoreRequest restoreRequest() {
     return new RestoreRequest(
         PHYSICAL_TENANT_ID, List.of(100L), null, null, "elasticsearch", false, false);
-  }
-
-  private void stubRestoreSuccess() {
-    when(clusterConfigurationRequestSender.restore(any()))
-        .thenReturn(
-            CompletableFuture.completedFuture(
-                Either.right(
-                    new ClusterConfigurationChangeResponse(0L, Map.of(), Map.of(), List.of()))));
   }
 
   private void stubTopologySuccess() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandler.java
@@ -32,10 +32,11 @@ import org.slf4j.LoggerFactory;
  * <p>One handler is built per physical tenant by the {@link
  * io.camunda.zeebe.broker.bootstrap.PartitionManagerStep} that owns the tenant, reusing that
  * tenant's {@link TopologyManagerImpl}, and is closed when the step shuts the partition manager
- * down. Only the default tenant participates in cluster configuration changes, so only its handler
- * registers as the broker's {@link ModeChangeExecutor} and stays registered across mode changes. A
- * transition stops the active manager, recreates it in the target mode, starts it, and re-publishes
- * it on the {@link BrokerStartupContext}.
+ * down. Each handler registers as the {@link ModeChangeExecutor} of its own partition group and
+ * stays registered across mode changes, so a cluster configuration change can transition one
+ * physical tenant while the others keep processing. A transition stops the active manager,
+ * recreates it in the target mode, starts it, and re-publishes it on the {@link
+ * BrokerStartupContext}.
  *
  * <p>The handler keeps no partition manager reference of its own; the active manager and the
  * remaining dependencies are resolved from the {@link BrokerStartupContext} on demand.
@@ -85,10 +86,8 @@ public final class PartitionModeHandler implements ModeChangeExecutor, AsyncClos
   }
 
   /**
-   * Registers this handler as the broker's mode change executor. Only the default tenant
-   * participates in cluster configuration changes, so only its handler registers. The partition
-   * change executors are registered by the partition manager itself on {@link
-   * PartitionManager#start()}.
+   * Registers this handler as the mode change executor of its partition group. The partition change
+   * executors are registered by the partition manager itself on {@link PartitionManager#start()}.
    */
   public void register() {
     clusterConfigurationService().registerModeChangeExecutor(partitionGroup, this);
@@ -236,10 +235,6 @@ public final class PartitionModeHandler implements ModeChangeExecutor, AsyncClos
 
   private boolean isRecovering() {
     return currentManager() instanceof RecoveryPartitionManager;
-  }
-
-  private boolean isDefaultGroup() {
-    return PartitionManager.isDefaultPhysicalTenant(partitionGroup);
   }
 
   private ConcurrencyControl concurrencyControl() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -182,16 +182,20 @@ public sealed interface ClusterConfigurationManagementRequest {
     }
   }
 
-  record ModeChangeRequest(String physicalTenantId, Mode mode, boolean dryRun)
+  /**
+   * @param physicalTenantId the physical tenant to transition, or empty for every physical tenant
+   *     of the cluster
+   */
+  record ModeChangeRequest(Optional<String> physicalTenantId, Mode mode, boolean dryRun)
       implements ClusterConfigurationManagementRequest {
 
     public static ModeChangeRequest recovering(
-        final String physicalTenantId, final boolean dryRun) {
+        final Optional<String> physicalTenantId, final boolean dryRun) {
       return new ModeChangeRequest(physicalTenantId, Mode.RECOVERING, dryRun);
     }
 
     public static ModeChangeRequest processing(
-        final String physicalTenantId, final boolean dryRun) {
+        final Optional<String> physicalTenantId, final boolean dryRun) {
       return new ModeChangeRequest(physicalTenantId, Mode.PROCESSING, dryRun);
     }
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -165,16 +165,20 @@ public sealed interface ClusterConfigurationManagementRequest {
     }
   }
 
-  record ModeChangeRequest(String physicalTenantId, Mode mode, boolean dryRun)
+  /**
+   * @param physicalTenantId the physical tenant to transition, or empty for every physical tenant
+   *     of the cluster
+   */
+  record ModeChangeRequest(Optional<String> physicalTenantId, Mode mode, boolean dryRun)
       implements ClusterConfigurationManagementRequest {
 
     public static ModeChangeRequest recovering(
-        final String physicalTenantId, final boolean dryRun) {
+        final Optional<String> physicalTenantId, final boolean dryRun) {
       return new ModeChangeRequest(physicalTenantId, Mode.RECOVERING, dryRun);
     }
 
     public static ModeChangeRequest processing(
-        final String physicalTenantId, final boolean dryRun) {
+        final Optional<String> physicalTenantId, final boolean dryRun) {
       return new ModeChangeRequest(physicalTenantId, Mode.PROCESSING, dryRun);
     }
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -267,9 +267,7 @@ public final class ClusterConfigurationManagementRequestsHandler
   public ActorFuture<ClusterConfigurationChangeResponse> modeChange(
       final ModeChangeRequest modeChangeRequest) {
     return handleRequest(
-        modeChangeRequest.dryRun(),
-        new ModeChangeRequestTransformer(
-            modeChangeRequest.physicalTenantId(), modeChangeRequest.mode()));
+        modeChangeRequest.dryRun(), new ModeChangeRequestTransformer(modeChangeRequest));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -263,9 +263,7 @@ public final class ClusterConfigurationManagementRequestsHandler
   public ActorFuture<ClusterConfigurationChangeResponse> modeChange(
       final ModeChangeRequest modeChangeRequest) {
     return handleRequest(
-        modeChangeRequest.dryRun(),
-        new ModeChangeRequestTransformer(
-            modeChangeRequest.physicalTenantId(), modeChangeRequest.mode()));
+        modeChangeRequest.dryRun(), new ModeChangeRequestTransformer(modeChangeRequest));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformer.java
@@ -91,9 +91,14 @@ public final class ModeChangeRequestTransformer implements ConfigurationChangeRe
     return Either.right(List.of(new PartitionGroupParallelPhase(operationsPerGroup)));
   }
 
-  /** The brokers of the group that are not in the target mode yet. */
+  /**
+   * The brokers active in the group that are not in the target mode yet. A broker is active in a
+   * group iff it holds partitions there; one that holds none has nothing to transition, and
+   * awaiting a mode change from it would never complete.
+   */
   private List<MemberId> membersToTransition(final PartitionGroupConfiguration partitionGroup) {
     return partitionGroup.members().entrySet().stream()
+        .filter(member -> !member.getValue().partitions().isEmpty())
         .filter(member -> member.getValue().mode() != request.mode())
         .map(Entry::getKey)
         .toList();

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformer.java
@@ -7,32 +7,44 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState.State;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
+/**
+ * Transitions partitions between {@link Mode#PROCESSING} and {@link Mode#RECOVERING}, either for
+ * one physical tenant or for every physical tenant of the cluster.
+ */
 public final class ModeChangeRequestTransformer implements ConfigurationChangeRequest {
 
-  private final String physicalTenantId;
-  private final Mode mode;
+  private final ModeChangeRequest request;
 
-  public ModeChangeRequestTransformer(final String physicalTenantId, final Mode mode) {
-    this.physicalTenantId = physicalTenantId;
-    this.mode = mode;
+  public ModeChangeRequestTransformer(final ModeChangeRequest request) {
+    this.request = request;
   }
 
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration clusterConfiguration) {
-    final State sourceState = mode == Mode.RECOVERING ? State.ACTIVE : State.RECOVERING;
+    final State sourceState = request.mode() == Mode.RECOVERING ? State.ACTIVE : State.RECOVERING;
     final var members =
         clusterConfiguration.members().entrySet().stream()
             .filter(e -> e.getValue().state() == sourceState)
@@ -42,9 +54,60 @@ public final class ModeChangeRequestTransformer implements ConfigurationChangeRe
     // All members first start the change operation and complete it async
     // Following up with a verification step that the operation completed successfully
     final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
-    members.forEach(memberId -> operations.add(new ModeChangeOperation(memberId, mode)));
-    members.forEach(memberId -> operations.add(new AwaitModeChangeOperation(memberId, mode)));
+    members.forEach(memberId -> operations.add(new ModeChangeOperation(memberId, request.mode())));
+    members.forEach(
+        memberId -> operations.add(new AwaitModeChangeOperation(memberId, request.mode())));
 
     return Either.right(operations);
+  }
+
+  @Override
+  public Either<Exception, List<Phase>> phases(
+      final CurrentClusterConfiguration clusterConfiguration) {
+    final var physicalTenantId = request.physicalTenantId();
+    if (physicalTenantId.isPresent()
+        && !clusterConfiguration.hasPartitionGroup(physicalTenantId.get())) {
+      return Either.left(
+          new InvalidRequest(
+              "Expected to change the mode of physical tenant '%s', but it has no partition group in this cluster"
+                  .formatted(physicalTenantId.get())));
+    }
+
+    final Map<String, List<PartitionGroupOperation>> operationsPerGroup = new LinkedHashMap<>();
+    clusterConfiguration.partitionGroups().entrySet().stream()
+        .filter(
+            group -> physicalTenantId.isEmpty() || physicalTenantId.get().equals(group.getKey()))
+        .forEach(
+            group -> {
+              final var operations = modeChangeOperations(membersToTransition(group.getValue()));
+              if (!operations.isEmpty()) {
+                operationsPerGroup.put(group.getKey(), operations);
+              }
+            });
+
+    if (operationsPerGroup.isEmpty()) {
+      return Either.right(List.of());
+    }
+    return Either.right(List.of(new PartitionGroupParallelPhase(operationsPerGroup)));
+  }
+
+  /** The brokers of the group that are not in the target mode yet. */
+  private List<MemberId> membersToTransition(final PartitionGroupConfiguration partitionGroup) {
+    return partitionGroup.members().entrySet().stream()
+        .filter(member -> member.getValue().mode() != request.mode())
+        .map(Entry::getKey)
+        .toList();
+  }
+
+  /**
+   * All members first start the change operation and complete it async. Following up with a
+   * verification step that the operation completed successfully.
+   */
+  private List<PartitionGroupOperation> modeChangeOperations(final List<MemberId> members) {
+    final List<PartitionGroupOperation> operations = new ArrayList<>();
+    members.forEach(memberId -> operations.add(new ModeChangeOperation(memberId, request.mode())));
+    members.forEach(
+        memberId -> operations.add(new AwaitModeChangeOperation(memberId, request.mode())));
+    return operations;
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformer.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
@@ -68,8 +68,8 @@ public final class ModeChangeRequestTransformer implements ConfigurationChangeRe
     if (physicalTenantId.isPresent()
         && !clusterConfiguration.hasPartitionGroup(physicalTenantId.get())) {
       return Either.left(
-          new InvalidRequest(
-              "Expected to change the mode of physical tenant '%s', but it has no partition group in this cluster"
+          new NotFound(
+              "Expected to change the mode of physical tenant '%s', but there's no such tenant"
                   .formatted(physicalTenantId.get())));
     }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1567,12 +1567,12 @@ public class ProtoBufSerializer
 
   @Override
   public byte[] encodeModeChangeRequest(final ModeChangeRequest modeChangeRequest) {
-    return Requests.ModeChangeRequest.newBuilder()
-        .setMode(toProtoRequestMode(modeChangeRequest.mode()))
-        .setDryRun(modeChangeRequest.dryRun())
-        .setPhysicalTenantId(modeChangeRequest.physicalTenantId())
-        .build()
-        .toByteArray();
+    final var builder =
+        Requests.ModeChangeRequest.newBuilder()
+            .setMode(toProtoRequestMode(modeChangeRequest.mode()))
+            .setDryRun(modeChangeRequest.dryRun());
+    modeChangeRequest.physicalTenantId().ifPresent(builder::setPhysicalTenantId);
+    return builder.build().toByteArray();
   }
 
   @Override
@@ -1580,7 +1580,11 @@ public class ProtoBufSerializer
     try {
       final var request = Requests.ModeChangeRequest.parseFrom(encodedRequest);
       return new ModeChangeRequest(
-          request.getPhysicalTenantId(), toMode(request.getMode()), request.getDryRun());
+          request.hasPhysicalTenantId()
+              ? Optional.of(request.getPhysicalTenantId())
+              : Optional.empty(),
+          toMode(request.getMode()),
+          request.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1593,12 +1593,12 @@ public class ProtoBufSerializer
 
   @Override
   public byte[] encodeModeChangeRequest(final ModeChangeRequest modeChangeRequest) {
-    return Requests.ModeChangeRequest.newBuilder()
-        .setMode(toProtoRequestMode(modeChangeRequest.mode()))
-        .setDryRun(modeChangeRequest.dryRun())
-        .setPhysicalTenantId(modeChangeRequest.physicalTenantId())
-        .build()
-        .toByteArray();
+    final var builder =
+        Requests.ModeChangeRequest.newBuilder()
+            .setMode(toProtoRequestMode(modeChangeRequest.mode()))
+            .setDryRun(modeChangeRequest.dryRun());
+    modeChangeRequest.physicalTenantId().ifPresent(builder::setPhysicalTenantId);
+    return builder.build().toByteArray();
   }
 
   @Override
@@ -1606,7 +1606,11 @@ public class ProtoBufSerializer
     try {
       final var request = Requests.ModeChangeRequest.parseFrom(encodedRequest);
       return new ModeChangeRequest(
-          request.getPhysicalTenantId(), toMode(request.getMode()), request.getDryRun());
+          request.hasPhysicalTenantId()
+              ? Optional.of(request.getPhysicalTenantId())
+              : Optional.empty(),
+          toMode(request.getMode()),
+          request.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -137,7 +137,7 @@ message ExportingStateChangeRequest {
 message ModeChangeRequest {
   Mode mode = 1;
   bool dryRun = 2;
-  string physicalTenantId = 3;
+  optional string physicalTenantId = 3;
 }
 
 message CancelTopologyChangeRequest {

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -128,7 +128,7 @@ message ExportingStateChangeRequest {
 message ModeChangeRequest {
   Mode mode = 1;
   bool dryRun = 2;
-  string physicalTenantId = 3;
+  optional string physicalTenantId = 3;
 }
 
 message CancelTopologyChangeRequest {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
@@ -44,6 +44,7 @@ import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor.No
 import io.camunda.zeebe.dynamic.config.changes.RestoreChangeExecutor.NoopRestoreChangeExecutor;
 import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
@@ -59,6 +60,7 @@ import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PreScalingOpe
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
@@ -92,6 +94,7 @@ import org.junit.jupiter.api.io.TempDir;
  */
 final class NewModelManagementApiEndpointsTest {
 
+  private static final String TENANT_B = "tenant-b";
   private static final MemberId ID_0 = MemberId.from("0");
   private static final MemberId ID_1 = MemberId.from("1");
   private static final MemberId ID_2 = MemberId.from("2");
@@ -509,6 +512,83 @@ final class NewModelManagementApiEndpointsTest {
     assertThat(
             config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).getMember(ID_0).mode())
         .isEqualTo(Mode.RECOVERING);
+  }
+
+  @Test
+  void shouldApplyModeChangeToEveryPhysicalTenantInOnePlan() {
+    // given
+    wireTwoPhysicalTenants();
+
+    // when
+    handler.modeChange(new ModeChangeRequest(Optional.empty(), Mode.RECOVERING, false)).join();
+
+    // then
+    final var config = manager.getMultiConfiguration().join();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    assertThat(
+            config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).getMember(ID_0).mode())
+        .isEqualTo(Mode.RECOVERING);
+    assertThat(config.partitionGroup(TENANT_B).getMember(ID_0).mode()).isEqualTo(Mode.RECOVERING);
+  }
+
+  @Test
+  void shouldApplyModeChangeToOnlyTheRequestedPhysicalTenant() {
+    // given
+    wireTwoPhysicalTenants();
+
+    // when
+    handler.modeChange(new ModeChangeRequest(Optional.of(TENANT_B), Mode.RECOVERING, false)).join();
+
+    // then
+    final var config = manager.getMultiConfiguration().join();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    assertThat(config.partitionGroup(TENANT_B).getMember(ID_0).mode()).isEqualTo(Mode.RECOVERING);
+    assertThat(
+            config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).getMember(ID_0).mode())
+        .isEqualTo(Mode.PROCESSING);
+  }
+
+  /**
+   * Wires a cluster with two physical tenants — the default group and {@link #TENANT_B} — both
+   * hosted by {@link #ID_0} and both processing.
+   */
+  private void wireTwoPhysicalTenants() {
+    wire(
+        ClusterConfiguration.init()
+            .addMember(
+                ID_0,
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, partitionConfig)))));
+    manager.registerPartitionGroupChangeAppliers(
+        TENANT_B,
+        new PartitionGroupConfigurationChangeAppliersImpl(
+            new NoopPartitionChangeExecutor(),
+            new NoopPartitionScalingChangeExecutor(),
+            new NoopClusterChangeExecutor(),
+            new NoopModeChangeExecutor(),
+            new NoopRestoreChangeExecutor()));
+    manager
+        .updateMultiConfiguration(
+            current ->
+                new CurrentClusterConfiguration(
+                    current.version(),
+                    current.globalConfiguration(),
+                    Map.of(
+                        CurrentClusterConfiguration.DEFAULT_GROUP,
+                        current.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP),
+                        TENANT_B,
+                        new PartitionGroupConfiguration(
+                            1,
+                            0,
+                            Map.of(
+                                ID_0,
+                                BrokerPartitionState.initialize(
+                                    Map.of(1, PartitionState.active(1, partitionConfig)))),
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.empty())),
+                    current.phasedChangeState()))
+        .join();
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
@@ -44,6 +44,7 @@ import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor.No
 import io.camunda.zeebe.dynamic.config.changes.RestoreChangeExecutor.NoopRestoreChangeExecutor;
 import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
@@ -59,6 +60,7 @@ import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PreScalingOpe
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
@@ -92,6 +94,7 @@ import org.junit.jupiter.api.io.TempDir;
  */
 final class NewModelManagementApiEndpointsTest {
 
+  private static final String TENANT_B = "tenant-b";
   private static final MemberId ID_0 = MemberId.from("0");
   private static final MemberId ID_1 = MemberId.from("1");
   private static final MemberId ID_2 = MemberId.from("2");
@@ -513,6 +516,83 @@ final class NewModelManagementApiEndpointsTest {
     assertThat(
             config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).getMember(ID_0).mode())
         .isEqualTo(Mode.RECOVERING);
+  }
+
+  @Test
+  void shouldApplyModeChangeToEveryPhysicalTenantInOnePlan() {
+    // given
+    wireTwoPhysicalTenants();
+
+    // when
+    handler.modeChange(new ModeChangeRequest(Optional.empty(), Mode.RECOVERING, false)).join();
+
+    // then
+    final var config = manager.getMultiConfiguration().join();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    assertThat(
+            config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).getMember(ID_0).mode())
+        .isEqualTo(Mode.RECOVERING);
+    assertThat(config.partitionGroup(TENANT_B).getMember(ID_0).mode()).isEqualTo(Mode.RECOVERING);
+  }
+
+  @Test
+  void shouldApplyModeChangeToOnlyTheRequestedPhysicalTenant() {
+    // given
+    wireTwoPhysicalTenants();
+
+    // when
+    handler.modeChange(new ModeChangeRequest(Optional.of(TENANT_B), Mode.RECOVERING, false)).join();
+
+    // then
+    final var config = manager.getMultiConfiguration().join();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    assertThat(config.partitionGroup(TENANT_B).getMember(ID_0).mode()).isEqualTo(Mode.RECOVERING);
+    assertThat(
+            config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).getMember(ID_0).mode())
+        .isEqualTo(Mode.PROCESSING);
+  }
+
+  /**
+   * Wires a cluster with two physical tenants — the default group and {@link #TENANT_B} — both
+   * hosted by {@link #ID_0} and both processing.
+   */
+  private void wireTwoPhysicalTenants() {
+    wire(
+        ClusterConfiguration.init()
+            .addMember(
+                ID_0,
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, partitionConfig)))));
+    manager.registerPartitionGroupChangeAppliers(
+        TENANT_B,
+        new PartitionGroupConfigurationChangeAppliersImpl(
+            new NoopPartitionChangeExecutor(),
+            new NoopPartitionScalingChangeExecutor(),
+            new NoopClusterChangeExecutor(),
+            new NoopModeChangeExecutor(),
+            new NoopRestoreChangeExecutor()));
+    manager
+        .updateMultiConfiguration(
+            current ->
+                new CurrentClusterConfiguration(
+                    current.version(),
+                    current.globalConfiguration(),
+                    Map.of(
+                        CurrentClusterConfiguration.DEFAULT_GROUP,
+                        current.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP),
+                        TENANT_B,
+                        new PartitionGroupConfiguration(
+                            1,
+                            0,
+                            Map.of(
+                                ID_0,
+                                BrokerPartitionState.initialize(
+                                    Map.of(1, PartitionState.active(1, partitionConfig)))),
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.empty())),
+                    current.phasedChangeState()))
+        .join();
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
@@ -568,7 +568,6 @@ final class NewModelManagementApiEndpointsTest {
         new PartitionGroupConfigurationChangeAppliersImpl(
             new NoopPartitionChangeExecutor(),
             new NoopPartitionScalingChangeExecutor(),
-            new NoopClusterChangeExecutor(),
             new NoopModeChangeExecutor(),
             new NoopRestoreChangeExecutor()));
     manager

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
@@ -504,7 +504,7 @@ final class NewModelManagementApiEndpointsTest {
     handler
         .modeChange(
             new ModeChangeRequest(
-                CurrentClusterConfiguration.DEFAULT_GROUP, Mode.RECOVERING, false))
+                Optional.of(CurrentClusterConfiguration.DEFAULT_GROUP), Mode.RECOVERING, false))
         .join();
 
     // then — the plan is applied and the local member is now in recovery mode

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
@@ -500,7 +500,7 @@ final class NewModelManagementApiEndpointsTest {
     handler
         .modeChange(
             new ModeChangeRequest(
-                CurrentClusterConfiguration.DEFAULT_GROUP, Mode.RECOVERING, false))
+                Optional.of(CurrentClusterConfiguration.DEFAULT_GROUP), Mode.RECOVERING, false))
         .join();
 
     // then — the plan is applied and the local member is now in recovery mode

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformerTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -154,9 +154,9 @@ final class ModeChangeRequestTransformerTest {
     // when
     final var result = transformer.phases(twoTenantCluster(Mode.PROCESSING, Mode.PROCESSING));
 
-    // then — a bad request, so the caller gets 400 rather than 500
+    // then — the tenant does not exist, so the caller gets 404 rather than 500
     EitherAssert.assertThat(result).isLeft();
-    assertThat(result.getLeft()).isInstanceOf(InvalidRequest.class).hasMessageContaining("unknown");
+    assertThat(result.getLeft()).isInstanceOf(NotFound.class).hasMessageContaining("unknown");
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformerTest.java
@@ -32,6 +32,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 final class ModeChangeRequestTransformerTest {
@@ -80,6 +81,52 @@ final class ModeChangeRequestTransformerTest {
     EitherAssert.assertThat(scoped).isRight();
     EitherAssert.assertThat(unscoped).isRight();
     assertThat(scoped.get()).isNotEmpty().isEqualTo(unscoped.get());
+  }
+
+  @Test
+  void shouldNotTransitionABrokerThatHostsNoPartitionOfTheGroup() {
+    // given — both brokers are listed in the default group and both are still PROCESSING, but only
+    // id0 hosts a partition there; id1 holds nothing and merely lingers in the member map. Both are
+    // ACTIVE cluster-wide, so only the group can tell them apart.
+    final var transformer = recoveringTransformer(Optional.empty());
+    final var clusterConfiguration =
+        cluster(
+            Map.of(
+                DEFAULT_GROUP,
+                group(
+                    Map.of(
+                        id0, hostingAPartition(Mode.PROCESSING),
+                        id1, hostingNothing(Mode.PROCESSING)))));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then — id1 is left out: it has no partition to transition, and awaiting a mode change from it
+    // would never complete and would stall the whole plan
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get())
+        .containsExactly(
+            new PartitionGroupParallelPhase(
+                Map.of(
+                    DEFAULT_GROUP,
+                    List.of(
+                        new ModeChangeOperation(id0, Mode.RECOVERING),
+                        new AwaitModeChangeOperation(id0, Mode.RECOVERING)))));
+  }
+
+  @Test
+  void shouldSucceedWithNoPhasesWhenNoBrokerToTransitionHostsAPartitionOfTheGroup() {
+    // given — the only broker still PROCESSING in the group hosts nothing there
+    final var transformer = recoveringTransformer(Optional.empty());
+    final var clusterConfiguration =
+        cluster(Map.of(DEFAULT_GROUP, group(Map.of(id0, hostingNothing(Mode.PROCESSING)))));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then — nothing to plan, rather than a plan that can never complete
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get()).isEmpty();
   }
 
   @Test
@@ -178,39 +225,43 @@ final class ModeChangeRequestTransformerTest {
         new ModeChangeRequest(physicalTenantId, Mode.RECOVERING, false));
   }
 
-  /**
-   * A cluster with one partition group per physical tenant: the default group hosted by member 0
-   * and {@link #TENANT_B}'s group hosted by member 1, each in the given mode.
-   */
   private CurrentClusterConfiguration twoTenantCluster(
       final Mode defaultGroupMode, final Mode tenantBMode) {
+    return cluster(
+        Map.of(
+            DEFAULT_GROUP, group(Map.of(id0, hostingAPartition(defaultGroupMode))),
+            TENANT_B, group(Map.of(id1, hostingAPartition(tenantBMode)))));
+  }
+
+  private CurrentClusterConfiguration cluster(
+      final Map<String, PartitionGroupConfiguration> partitionGroups) {
+    final var brokers =
+        partitionGroups.values().stream()
+            .flatMap(group -> group.members().keySet().stream())
+            .distinct()
+            .collect(
+                Collectors.toMap(
+                    memberId -> memberId,
+                    memberId -> new BrokerState(0, Instant.EPOCH, BrokerState.State.ACTIVE)));
     return new CurrentClusterConfiguration(
         CurrentClusterConfiguration.INITIAL_VERSION,
         new GlobalConfiguration(
-            1,
-            Optional.empty(),
-            Map.of(
-                id0, new BrokerState(0, Instant.EPOCH, BrokerState.State.ACTIVE),
-                id1, new BrokerState(0, Instant.EPOCH, BrokerState.State.ACTIVE)),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty()),
-        Map.of(
-            DEFAULT_GROUP, singleMemberGroup(id0, defaultGroupMode),
-            TENANT_B, singleMemberGroup(id1, tenantBMode)),
+            1, Optional.empty(), brokers, Optional.empty(), Optional.empty(), Optional.empty()),
+        partitionGroups,
         PhasedChangeState.empty());
   }
 
-  private PartitionGroupConfiguration singleMemberGroup(final MemberId memberId, final Mode mode) {
+  private PartitionGroupConfiguration group(final Map<MemberId, BrokerPartitionState> members) {
     return new PartitionGroupConfiguration(
-        1,
-        0,
-        Map.of(
-            memberId,
-            BrokerPartitionState.initialize(Map.of(1, PartitionState.active(1, partitionConfig)))
-                .setMode(mode)),
-        Optional.empty(),
-        Optional.empty(),
-        Optional.empty());
+        1, 0, members, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  private BrokerPartitionState hostingAPartition(final Mode mode) {
+    return BrokerPartitionState.initialize(Map.of(1, PartitionState.active(1, partitionConfig)))
+        .setMode(mode);
+  }
+
+  private BrokerPartitionState hostingNothing(final Mode mode) {
+    return BrokerPartitionState.initialize(Map.of()).setMode(mode);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformerTest.java
@@ -43,20 +43,43 @@ final class ModeChangeRequestTransformerTest {
   private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
 
   @Test
-  void shouldNotPlanOnTheLegacySingleGroupModel() {
-    // given — the legacy model keeps one mode per broker, shared by every physical tenant, so a
-    // per-group plan cannot be expressed on it
-    final var transformer = recoveringTransformer(Optional.of(TENANT_B));
+  void shouldTargetOnlyMembersNotAlreadyInTheTargetModeOnTheLegacySingleGroupModel() {
+    // given — a legacy single-group configuration (the mode lives on the member and is shared by
+    // all of its partitions) where one member is active and one is already recovering
+    final var transformer = recoveringTransformer(Optional.empty());
     final var clusterConfiguration =
-        ClusterConfiguration.init().addMember(id0, MemberState.initializeAsActive(Map.of()));
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()))
+            .addMember(id1, MemberState.initializeAsActive(Map.of()).toRecovering());
 
     // when
     final var result = transformer.operations(clusterConfiguration);
 
-    // then — rejected rather than silently changing the mode of every tenant; planning happens in
-    // phases() instead, which the coordinator is the only caller of
-    EitherAssert.assertThat(result).isLeft();
-    assertThat(result.getLeft()).isInstanceOf(InvalidRequest.class);
+    // then — only the active member is transitioned, so re-sending the request is idempotent
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get())
+        .containsExactly(
+            new ModeChangeOperation(id0, Mode.RECOVERING),
+            new AwaitModeChangeOperation(id0, Mode.RECOVERING));
+  }
+
+  @Test
+  void shouldIgnoreTheRequestedPhysicalTenantOnTheLegacySingleGroupModel() {
+    // given — the same cluster planned twice: once scoped to a physical tenant, once unscoped
+    final var clusterConfiguration =
+        ClusterConfiguration.init().addMember(id0, MemberState.initializeAsActive(Map.of()));
+
+    // when
+    final var scoped =
+        recoveringTransformer(Optional.of(TENANT_B)).operations(clusterConfiguration);
+    final var unscoped = recoveringTransformer(Optional.empty()).operations(clusterConfiguration);
+
+    // then — the scope makes no difference: the legacy model has no per-tenant mode, so the whole
+    // cluster transitions either way. Scoping to one tenant is only expressible on the multi-group
+    // model, via phases(), which is the only method the coordinator calls.
+    EitherAssert.assertThat(scoped).isRight();
+    EitherAssert.assertThat(unscoped).isRight();
+    assertThat(scoped.get()).isNotEmpty().isEqualTo(unscoped.get());
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformerTest.java
@@ -7,142 +7,187 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration.DEFAULT_GROUP;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.time.Instant;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 final class ModeChangeRequestTransformerTest {
 
+  private static final String TENANT_B = "tenant-b";
+
   private final MemberId id0 = MemberId.from("0");
   private final MemberId id1 = MemberId.from("1");
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
 
   @Test
-  void shouldGenerateRecoveringOperationsForAllActiveMembers() {
-    // given
-    final var transformer = new ModeChangeRequestTransformer("default", Mode.RECOVERING);
-    final var clusterConfiguration =
-        ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()));
-
-    // when
-    final var result = transformer.operations(clusterConfiguration);
-
-    EitherAssert.assertThat(result).isRight();
-    final var operations = result.get();
-    assertThat(operations).hasSize(4);
-    assertThat(operations.subList(0, 2))
-        .containsExactlyInAnyOrder(
-            new ModeChangeOperation(id0, Mode.RECOVERING),
-            new ModeChangeOperation(id1, Mode.RECOVERING));
-    assertThat(operations.subList(2, 4))
-        .containsExactlyInAnyOrder(
-            new AwaitModeChangeOperation(id0, Mode.RECOVERING),
-            new AwaitModeChangeOperation(id1, Mode.RECOVERING));
-  }
-
-  @Test
-  void shouldGenerateProcessingOperationsForAllRecoveringMembers() {
-    // given
-    final var transformer = new ModeChangeRequestTransformer("default", Mode.PROCESSING);
-    final var clusterConfiguration =
-        ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()).toRecovering())
-            .addMember(id1, MemberState.initializeAsActive(Map.of()).toRecovering());
-
-    // when
-    final var result = transformer.operations(clusterConfiguration);
-
-    // then
-    EitherAssert.assertThat(result).isRight();
-    final var operations = result.get();
-    assertThat(operations).hasSize(4);
-    assertThat(operations.subList(0, 2))
-        .containsExactlyInAnyOrder(
-            new ModeChangeOperation(id0, Mode.PROCESSING),
-            new ModeChangeOperation(id1, Mode.PROCESSING));
-    assertThat(operations.subList(2, 4))
-        .containsExactlyInAnyOrder(
-            new AwaitModeChangeOperation(id0, Mode.PROCESSING),
-            new AwaitModeChangeOperation(id1, Mode.PROCESSING));
-  }
-
-  @Test
-  void shouldOnlyTargetActiveMembersWhenEnteringRecovery() {
-    // given — id0 active, id1 already recovering
-    final var transformer = new ModeChangeRequestTransformer("default", Mode.RECOVERING);
-    final var clusterConfiguration =
-        ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()).toRecovering());
-
-    // when
-    final var result = transformer.operations(clusterConfiguration);
-
-    // then
-    EitherAssert.assertThat(result).isRight();
-    assertThat(result.get())
-        .containsExactly(
-            new ModeChangeOperation(id0, Mode.RECOVERING),
-            new AwaitModeChangeOperation(id0, Mode.RECOVERING));
-  }
-
-  @Test
-  void shouldOnlyTargetRecoveringMembersWhenExitingRecovery() {
-    // given — id0 still active, id1 recovering
-    final var transformer = new ModeChangeRequestTransformer("default", Mode.PROCESSING);
-    final var clusterConfiguration =
-        ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()).toRecovering());
-
-    // when
-    final var result = transformer.operations(clusterConfiguration);
-
-    // then
-    EitherAssert.assertThat(result).isRight();
-    assertThat(result.get())
-        .containsExactly(
-            new ModeChangeOperation(id1, Mode.PROCESSING),
-            new AwaitModeChangeOperation(id1, Mode.PROCESSING));
-  }
-
-  @Test
-  void shouldSucceedWithNoOperationsWhenEnteringRecoveryAndNoActiveMembers() {
-    // given — all members already recovering, so the request is a no-op
-    final var transformer = new ModeChangeRequestTransformer("default", Mode.RECOVERING);
-    final var clusterConfiguration =
-        ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()).toRecovering());
-
-    // when
-    final var result = transformer.operations(clusterConfiguration);
-
-    // then — idempotent: re-sending the request succeeds without generating operations
-    EitherAssert.assertThat(result).isRight();
-    assertThat(result.get()).isEmpty();
-  }
-
-  @Test
-  void shouldSucceedWithNoOperationsWhenExitingRecoveryAndNoRecoveringMembers() {
-    // given — all members active, so the request is a no-op
-    final var transformer = new ModeChangeRequestTransformer("default", Mode.PROCESSING);
+  void shouldNotPlanOnTheLegacySingleGroupModel() {
+    // given — the legacy model keeps one mode per broker, shared by every physical tenant, so a
+    // per-group plan cannot be expressed on it
+    final var transformer = recoveringTransformer(Optional.of(TENANT_B));
     final var clusterConfiguration =
         ClusterConfiguration.init().addMember(id0, MemberState.initializeAsActive(Map.of()));
 
     // when
     final var result = transformer.operations(clusterConfiguration);
 
-    // then — idempotent: re-sending the request succeeds without generating operations
+    // then — rejected rather than silently changing the mode of every tenant; planning happens in
+    // phases() instead, which the coordinator is the only caller of
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft()).isInstanceOf(InvalidRequest.class);
+  }
+
+  @Test
+  void shouldTargetOnlyTheRequestedPhysicalTenantsPartitionGroup() {
+    // given
+    final var transformer = recoveringTransformer(Optional.of(TENANT_B));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster(Mode.PROCESSING, Mode.PROCESSING));
+
+    // then — the default group keeps processing
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get())
+        .containsExactly(
+            new PartitionGroupParallelPhase(
+                Map.of(
+                    TENANT_B,
+                    List.of(
+                        new ModeChangeOperation(id1, Mode.RECOVERING),
+                        new AwaitModeChangeOperation(id1, Mode.RECOVERING)))));
+  }
+
+  @Test
+  void shouldTransitionEveryPhysicalTenantInParallelWhenNoneIsRequested() {
+    // given
+    final var transformer = recoveringTransformer(Optional.empty());
+
+    // when
+    final var result = transformer.phases(twoTenantCluster(Mode.PROCESSING, Mode.PROCESSING));
+
+    // then — one phase carrying both groups, so their partitions transition concurrently
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get())
+        .containsExactly(
+            new PartitionGroupParallelPhase(
+                Map.of(
+                    DEFAULT_GROUP,
+                    List.of(
+                        new ModeChangeOperation(id0, Mode.RECOVERING),
+                        new AwaitModeChangeOperation(id0, Mode.RECOVERING)),
+                    TENANT_B,
+                    List.of(
+                        new ModeChangeOperation(id1, Mode.RECOVERING),
+                        new AwaitModeChangeOperation(id1, Mode.RECOVERING)))));
+  }
+
+  @Test
+  void shouldSkipPhysicalTenantsAlreadyInTheTargetMode() {
+    // given — tenant-b already transitioned, the default group did not
+    final var transformer = recoveringTransformer(Optional.empty());
+
+    // when
+    final var result = transformer.phases(twoTenantCluster(Mode.PROCESSING, Mode.RECOVERING));
+
+    // then — the group that has nothing to do is left out of the phase entirely
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get())
+        .containsExactly(
+            new PartitionGroupParallelPhase(
+                Map.of(
+                    DEFAULT_GROUP,
+                    List.of(
+                        new ModeChangeOperation(id0, Mode.RECOVERING),
+                        new AwaitModeChangeOperation(id0, Mode.RECOVERING)))));
+  }
+
+  @Test
+  void shouldRejectUnknownPhysicalTenant() {
+    // given
+    final var transformer = recoveringTransformer(Optional.of("unknown"));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster(Mode.PROCESSING, Mode.PROCESSING));
+
+    // then — a bad request, so the caller gets 400 rather than 500
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft()).isInstanceOf(InvalidRequest.class).hasMessageContaining("unknown");
+  }
+
+  @Test
+  void shouldSucceedWithNoPhasesWhenThePartitionGroupIsAlreadyInTheTargetMode() {
+    // given — tenant-b already transitioned, the default group did not
+    final var transformer = recoveringTransformer(Optional.of(TENANT_B));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster(Mode.PROCESSING, Mode.RECOVERING));
+
+    // then — idempotent, and the group that did not transition is left alone
     EitherAssert.assertThat(result).isRight();
     assertThat(result.get()).isEmpty();
+  }
+
+  private static ModeChangeRequestTransformer recoveringTransformer(
+      final Optional<String> physicalTenantId) {
+    return new ModeChangeRequestTransformer(
+        new ModeChangeRequest(physicalTenantId, Mode.RECOVERING, false));
+  }
+
+  /**
+   * A cluster with one partition group per physical tenant: the default group hosted by member 0
+   * and {@link #TENANT_B}'s group hosted by member 1, each in the given mode.
+   */
+  private CurrentClusterConfiguration twoTenantCluster(
+      final Mode defaultGroupMode, final Mode tenantBMode) {
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        new GlobalConfiguration(
+            1,
+            Optional.empty(),
+            Map.of(
+                id0, new BrokerState(0, Instant.EPOCH, BrokerState.State.ACTIVE),
+                id1, new BrokerState(0, Instant.EPOCH, BrokerState.State.ACTIVE)),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty()),
+        Map.of(
+            DEFAULT_GROUP, singleMemberGroup(id0, defaultGroupMode),
+            TENANT_B, singleMemberGroup(id1, tenantBMode)),
+        PhasedChangeState.empty());
+  }
+
+  private PartitionGroupConfiguration singleMemberGroup(final MemberId memberId, final Mode mode) {
+    return new PartitionGroupConfiguration(
+        1,
+        0,
+        Map.of(
+            memberId,
+            BrokerPartitionState.initialize(Map.of(1, PartitionState.active(1, partitionConfig)))
+                .setMode(mode)),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceZoneRemoveRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
@@ -80,6 +81,32 @@ final class ProtoBufSerializerTest {
 
     // then
     final var decodedRequest = protoBufSerializer.decodeClusterZoneMigrationRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(request);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeModeChangeRequestForOnePhysicalTenant() {
+    // given
+    final var request = new ModeChangeRequest(Optional.of("tenant-b"), Mode.RECOVERING, false);
+
+    // when
+    final var encodedRequest = protoBufSerializer.encodeModeChangeRequest(request);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeModeChangeRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(request);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeModeChangeRequestForEveryPhysicalTenant() {
+    // given — an absent tenant means every physical tenant
+    final var request = new ModeChangeRequest(Optional.empty(), Mode.RECOVERING, false);
+
+    // when
+    final var encodedRequest = protoBufSerializer.encodeModeChangeRequest(request);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeModeChangeRequest(encodedRequest);
     assertThat(decodedRequest).isEqualTo(request);
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceZoneRemoveRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
@@ -78,6 +79,32 @@ final class ProtoBufSerializerTest {
 
     // then
     final var decodedRequest = protoBufSerializer.decodeClusterZoneMigrationRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(request);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeModeChangeRequestForOnePhysicalTenant() {
+    // given
+    final var request = new ModeChangeRequest(Optional.of("tenant-b"), Mode.RECOVERING, false);
+
+    // when
+    final var encodedRequest = protoBufSerializer.encodeModeChangeRequest(request);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeModeChangeRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(request);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeModeChangeRequestForEveryPhysicalTenant() {
+    // given — an absent tenant means every physical tenant
+    final var request = new ModeChangeRequest(Optional.empty(), Mode.RECOVERING, false);
+
+    // when
+    final var encodedRequest = protoBufSerializer.encodeModeChangeRequest(request);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeModeChangeRequest(encodedRequest);
     assertThat(decodedRequest).isEqualTo(request);
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -7,10 +7,10 @@ paths:
       tags:
         - Cluster
       operationId: getTopology
-      x-required-permissions: []
+      x-required-permissions: [ ]
       security:
-        - bearerAuth: []
-        - basicAuth: []
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
       summary: Get cluster topology
       description: Obtains the current topology of the cluster the gateway is part of.
       responses:
@@ -23,7 +23,7 @@ paths:
         "401":
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
         "500":
-            $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.5"
 
   /status:
@@ -32,11 +32,11 @@ paths:
       tags:
         - Cluster
       operationId: getStatus
-      x-required-permissions: []
+      x-required-permissions: [ ]
       # Public health-check endpoint — declared unauthenticated at runtime
       # via SecurityPathAdapter. `security: []` overrides the conditional
       # enforcement on the global schemes for this operation.
-      security: []
+      security: [ ]
       summary: Get physical tenant status
       description: >-
         Checks the health status of the default physical tenant by verifying if there's at least one
@@ -77,11 +77,11 @@ paths:
       tags:
         - Cluster
       operationId: getClusterStatus
-      x-required-permissions: []
+      x-required-permissions: [ ]
       # Public health-check endpoint — declared unauthenticated at runtime
       # via SecurityPathAdapter. `security: []` overrides the conditional
       # enforcement on the global schemes for this operation.
-      security: []
+      security: [ ]
       summary: Get the status of the whole cluster
       description: >-
         Checks the health status of the whole cluster, aggregated over all physical tenants. Returns
@@ -103,6 +103,62 @@ paths:
                 $ref: '#/components/schemas/ClusterStatusResponse'
       x-added-in-version: "8.10"
 
+  # Not served under the document's `/v2` server base,
+  # hence the path-item `servers` override below
+  /cluster/v2/mode:
+    servers:
+      - url: "{schema}://{host}:{port}"
+        variables:
+          host:
+            default: localhost
+            description: The hostname of the Orchestration Cluster REST Gateway.
+          port:
+            default: "8080"
+            description: The port of the Orchestration Cluster REST API server.
+          schema:
+            default: http
+            description: The schema of the Orchestration Cluster REST API server.
+    patch:
+      x-eventually-consistent: false
+      tags:
+        - Recovery
+      operationId: changeClusterModeAsClusterAdmin
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: Change the cluster mode of one or every physical tenant
+      description: >-
+        Transitions physical tenants between processing and recovery mode.
+
+
+        If the `physicalTenantId` parameter is not provided, all available physical tenants are
+        transitioned individually.
+      parameters:
+        - $ref: '#/components/parameters/ModeParameter'
+        - $ref: '#/components/parameters/PhysicalTenantIdParameter'
+        - $ref: '#/components/parameters/DryRunParameter'
+      responses:
+        "200":
+          description: >-
+            The mode change request was accepted; returns the planned cluster change covering every
+            requested physical tenant.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterModeChangeResponse'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "409":
+          description: >-
+            The mode change conflicts with the cluster state, for example because another
+            configuration change is in progress.
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.10"
+
   /mode:
     patch:
       x-eventually-consistent: false
@@ -114,8 +170,8 @@ paths:
             - { resourceType: SYSTEM, permissionType: UPDATE }
             - { resourceType: BACKUP, permissionType: RESTORE }
       security:
-        - bearerAuth: []
-        - basicAuth: []
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
       summary: Change cluster mode
       description: >-
         Transitions the cluster between processing and recovery mode. This is a non-blocking
@@ -153,8 +209,8 @@ paths:
       x-required-permissions:
         - { resourceType: BACKUP, permissionType: RESTORE }
       security:
-        - bearerAuth: []
-        - basicAuth: []
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
       summary: Restore from a backup
       description: >-
         Restores the cluster from a backup. The restore is described either by a single backup ID
@@ -195,8 +251,8 @@ paths:
       x-required-permissions:
         - { resourceType: BACKUP, permissionType: RESTORE }
       security:
-        - bearerAuth: []
-        - basicAuth: []
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
       summary: Get the status of the restore that is currently in progress
       description: >-
         Returns the status of the restore that is currently in progress, reported per broker and
@@ -241,6 +297,16 @@ components:
       schema:
         type: boolean
         default: false
+    PhysicalTenantIdParameter:
+      name: physicalTenantId
+      in: query
+      required: false
+      description: >-
+        The physical tenant to apply the change to. When omitted, the change is applied to every
+        physical tenant of the cluster.
+      schema:
+        type: string
+        example: default
 
   schemas:
     ClusterStatusResponse:
@@ -489,7 +555,7 @@ components:
           items:
             type: integer
             format: int64
-          example: [100, 101]
+          example: [ 100, 101 ]
 
     RestoreStatusResponse:
       description: The status of the restore that is currently in progress.
@@ -582,7 +648,7 @@ components:
           items:
             type: integer
             format: int64
-          example: [100, 101]
+          example: [ 100, 101 ]
         completedAt:
           description: >-
             The time the partition was restored, as an ISO 8601 timestamp; null unless the partition

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -151,6 +151,12 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "401":
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "404":
+          description: The requested `physicalTenantId` does not exist in this cluster.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "409":
           description: >-
             The mode change conflicts with the cluster state, for example because another

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -514,7 +514,30 @@ components:
           type: string
           example: "7"
         plannedChanges:
-          description: The ordered list of operations that will be applied to complete the change.
+          description: >-
+            The operations that will be applied to complete the change, grouped by the physical
+            tenant they belong to. Groups are transitioned in parallel; the operations within a
+            group are applied in the given order.
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterModeChangePlannedChange'
+
+    ClusterModeChangePlannedChange:
+      description: The operations of a cluster mode change that apply to one physical tenant.
+      type: object
+      required:
+        - physicalTenantId
+        - operations
+      properties:
+        physicalTenantId:
+          description: >-
+            The physical tenant the operations apply to; null for operations that are not scoped to
+            a single physical tenant, such as broker lifecycle operations.
+          type: string
+          nullable: true
+          example: default
+        operations:
+          description: The ordered list of operations that will be applied to the physical tenant.
           type: array
           items:
             $ref: '#/components/schemas/ClusterModeChangeOperation'

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -7,10 +7,10 @@ paths:
       tags:
         - Cluster
       operationId: getTopology
-      x-required-permissions: []
+      x-required-permissions: [ ]
       security:
-        - bearerAuth: []
-        - basicAuth: []
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
       summary: Get cluster topology
       description: Obtains the current topology of the cluster the gateway is part of.
       responses:
@@ -23,7 +23,7 @@ paths:
         "401":
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
         "500":
-            $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.5"
 
   /status:
@@ -32,11 +32,11 @@ paths:
       tags:
         - Cluster
       operationId: getStatus
-      x-required-permissions: []
+      x-required-permissions: [ ]
       # Public health-check endpoint — declared unauthenticated at runtime
       # via SecurityPathAdapter. `security: []` overrides the conditional
       # enforcement on the global schemes for this operation.
-      security: []
+      security: [ ]
       summary: Get physical tenant status
       description: >-
         Checks the health status of the default physical tenant by verifying if there's at least one
@@ -77,11 +77,11 @@ paths:
       tags:
         - Cluster
       operationId: getClusterStatus
-      x-required-permissions: []
+      x-required-permissions: [ ]
       # Public health-check endpoint — declared unauthenticated at runtime
       # via SecurityPathAdapter. `security: []` overrides the conditional
       # enforcement on the global schemes for this operation.
-      security: []
+      security: [ ]
       summary: Get the status of the whole cluster
       description: >-
         Checks the health status of the whole cluster, aggregated over all physical tenants. Returns
@@ -103,6 +103,62 @@ paths:
                 $ref: '#/components/schemas/ClusterStatusResponse'
       x-added-in-version: "8.10"
 
+  # Not served under the document's `/v2` server base,
+  # hence the path-item `servers` override below
+  /cluster/v2/mode:
+    servers:
+      - url: "{schema}://{host}:{port}"
+        variables:
+          host:
+            default: localhost
+            description: The hostname of the Orchestration Cluster REST Gateway.
+          port:
+            default: "8080"
+            description: The port of the Orchestration Cluster REST API server.
+          schema:
+            default: http
+            description: The schema of the Orchestration Cluster REST API server.
+    patch:
+      x-eventually-consistent: false
+      tags:
+        - Recovery
+      operationId: changeClusterModeAsClusterAdmin
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: Change the cluster mode of one or every physical tenant
+      description: >-
+        Transitions physical tenants between processing and recovery mode.
+
+
+        If the `physicalTenantId` parameter is not provided, all available physical tenants are
+        transitioned individually.
+      parameters:
+        - $ref: '#/components/parameters/ModeParameter'
+        - $ref: '#/components/parameters/PhysicalTenantIdParameter'
+        - $ref: '#/components/parameters/DryRunParameter'
+      responses:
+        "200":
+          description: >-
+            The mode change request was accepted; returns the planned cluster change covering every
+            requested physical tenant.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterModeChangeResponse'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "409":
+          description: >-
+            The mode change conflicts with the cluster state, for example because another
+            configuration change is in progress.
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.10"
+
   /mode:
     patch:
       x-eventually-consistent: false
@@ -114,8 +170,8 @@ paths:
             - { resourceType: SYSTEM, permissionType: UPDATE }
             - { resourceType: BACKUP, permissionType: RESTORE }
       security:
-        - bearerAuth: []
-        - basicAuth: []
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
       summary: Change cluster mode
       description: >-
         Transitions the cluster between processing and recovery mode. This is a non-blocking
@@ -153,8 +209,8 @@ paths:
       x-required-permissions:
         - { resourceType: BACKUP, permissionType: RESTORE }
       security:
-        - bearerAuth: []
-        - basicAuth: []
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
       summary: Restore from a backup
       description: >-
         Restores the cluster from a backup. The restore is described either by a single backup ID
@@ -193,8 +249,8 @@ paths:
       x-required-permissions:
         - { resourceType: BACKUP, permissionType: RESTORE }
       security:
-        - bearerAuth: []
-        - basicAuth: []
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
       summary: Get the status of the restore that is currently in progress
       description: >-
         Returns the status of the restore that is currently in progress, reported per broker and
@@ -239,6 +295,16 @@ components:
       schema:
         type: boolean
         default: false
+    PhysicalTenantIdParameter:
+      name: physicalTenantId
+      in: query
+      required: false
+      description: >-
+        The physical tenant to apply the change to. When omitted, the change is applied to every
+        physical tenant of the cluster.
+      schema:
+        type: string
+        example: default
 
   schemas:
     ClusterStatusResponse:
@@ -487,7 +553,7 @@ components:
           items:
             type: integer
             format: int64
-          example: [100, 101]
+          example: [ 100, 101 ]
 
     RestoreStatusResponse:
       description: The status of the restore that is currently in progress.
@@ -580,7 +646,7 @@ components:
           items:
             type: integer
             format: int64
-          example: [100, 101]
+          example: [ 100, 101 ]
         completedAt:
           description: >-
             The time the partition was restored, as an ISO 8601 timestamp; null unless the partition

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -498,6 +498,8 @@ paths:
     $ref: 'cluster.yaml#/paths/~1topology'
   /mode:
     $ref: 'cluster.yaml#/paths/~1mode'
+  /cluster/v2/mode: # New /cluster/v2/mode endpoint that works for all physical tenants.
+    $ref: 'cluster.yaml#/paths/~1cluster~1v2~1mode'
   /restore:
     $ref: 'cluster.yaml#/paths/~1restore'
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterModeChangeMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterModeChangeMapper.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.gateway.protocol.model.ClusterModeChangeOperation;
+import io.camunda.gateway.protocol.model.ClusterModeChangeResponse;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Maps the cluster configuration change plan of a mode transition onto the REST response, shared by
+ * the per-physical-tenant {@link RecoveryController} and the cluster-wide {@link
+ * ClusterRecoveryController}.
+ */
+@NullMarked
+final class ClusterModeChangeMapper {
+
+  private ClusterModeChangeMapper() {}
+
+  static <T> T unwrapOrThrow(final Either<ErrorResponse, T> result) {
+    if (result.isRight()) {
+      return result.get();
+    }
+    final var error = result.getLeft();
+    throw new ServiceException(error.message(), mapErrorStatus(error.code()));
+  }
+
+  static ClusterModeChangeResponse toClusterModeChangeResponse(
+      final ClusterConfigurationChangeResponse response) {
+    return ClusterModeChangeResponse.Builder.create()
+        .changeId(Long.toString(response.changeId()))
+        .plannedChanges(toPlannedChanges(response))
+        .build();
+  }
+
+  private static List<ClusterModeChangeOperation> toPlannedChanges(
+      final ClusterConfigurationChangeResponse response) {
+    return response.legacyResponse().plannedChanges().stream()
+        .map(ClusterModeChangeMapper::toClusterModeChangeOperation)
+        .toList();
+  }
+
+  private static Status mapErrorStatus(final ErrorResponse.ErrorCode code) {
+    return switch (code) {
+      case INVALID_REQUEST -> Status.INVALID_ARGUMENT;
+      case OPERATION_NOT_ALLOWED -> Status.FORBIDDEN;
+      case CONCURRENT_MODIFICATION, INVALID_STATE -> Status.INVALID_STATE;
+      case INTERNAL_ERROR -> Status.INTERNAL;
+      case NOT_FOUND -> Status.NOT_FOUND;
+    };
+  }
+
+  private static ClusterModeChangeOperation toClusterModeChangeOperation(
+      final ClusterConfigurationChangeOperation operation) {
+    final @Nullable String mode =
+        switch (operation) {
+          case final ModeChangeOperation modeChange -> modeChange.mode().name();
+          case final AwaitModeChangeOperation awaitModeChange -> awaitModeChange.mode().name();
+          default -> null;
+        };
+    return ClusterModeChangeOperation.Builder.create()
+        .operation(operation.getClass().getSimpleName())
+        .mode(mode)
+        .build();
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterModeChangeMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterModeChangeMapper.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.gateway.protocol.model.ClusterModeChangeOperation;
 import io.camunda.gateway.protocol.model.ClusterModeChangeResponse;
 import io.camunda.service.exception.ServiceException;
@@ -49,7 +51,7 @@ final class ClusterModeChangeMapper {
 
   private static List<ClusterModeChangeOperation> toPlannedChanges(
       final ClusterConfigurationChangeResponse response) {
-    return response.legacyResponse().plannedChanges().stream()
+    return requireNonNull(response.response()).plannedChanges().stream()
         .map(ClusterModeChangeMapper::toClusterModeChangeOperation)
         .toList();
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterModeChangeMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterModeChangeMapper.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.rest.controller;
 import static java.util.Objects.requireNonNull;
 
 import io.camunda.gateway.protocol.model.ClusterModeChangeOperation;
+import io.camunda.gateway.protocol.model.ClusterModeChangePlannedChange;
 import io.camunda.gateway.protocol.model.ClusterModeChangeResponse;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
@@ -18,8 +19,14 @@ import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -49,11 +56,52 @@ final class ClusterModeChangeMapper {
         .build();
   }
 
-  private static List<ClusterModeChangeOperation> toPlannedChanges(
+  /**
+   * Flattens the phases of the change plan into one entry per physical tenant, keyed by the
+   * partition group the operations were planned for. Sorted by tenant so that a response never
+   * depends on the iteration order of the plan's group map.
+   */
+  private static List<ClusterModeChangePlannedChange> toPlannedChanges(
       final ClusterConfigurationChangeResponse response) {
-    return requireNonNull(response.response()).plannedChanges().stream()
-        .map(ClusterModeChangeMapper::toClusterModeChangeOperation)
-        .toList();
+    final Map<String, List<ClusterModeChangeOperation>> operationsPerTenant = new TreeMap<>();
+    final List<ClusterModeChangeOperation> clusterWideOperations = new ArrayList<>();
+    for (final Phase phase : requireNonNull(response.response()).phases()) {
+      switch (phase) {
+        case final PartitionGroupParallelPhase parallelPhase ->
+            parallelPhase
+                .groupOperations()
+                .forEach(
+                    (physicalTenantId, operations) ->
+                        operationsPerTenant
+                            .computeIfAbsent(physicalTenantId, tenant -> new ArrayList<>())
+                            .addAll(toClusterModeChangeOperations(operations)));
+        // Broker lifecycle operations belong to the cluster, not to any single physical tenant.
+        case final GlobalPhase globalPhase ->
+            clusterWideOperations.addAll(toClusterModeChangeOperations(globalPhase.operations()));
+      }
+    }
+
+    final var plannedChanges = new ArrayList<ClusterModeChangePlannedChange>();
+    operationsPerTenant.forEach(
+        (physicalTenantId, operations) ->
+            plannedChanges.add(toPlannedChange(physicalTenantId, operations)));
+    if (!clusterWideOperations.isEmpty()) {
+      plannedChanges.add(toPlannedChange(null, clusterWideOperations));
+    }
+    return plannedChanges;
+  }
+
+  private static ClusterModeChangePlannedChange toPlannedChange(
+      final @Nullable String physicalTenantId, final List<ClusterModeChangeOperation> operations) {
+    return ClusterModeChangePlannedChange.Builder.create()
+        .physicalTenantId(physicalTenantId)
+        .operations(operations)
+        .build();
+  }
+
+  private static List<ClusterModeChangeOperation> toClusterModeChangeOperations(
+      final List<? extends ClusterConfigurationChangeOperation> operations) {
+    return operations.stream().map(ClusterModeChangeMapper::toClusterModeChangeOperation).toList();
   }
 
   private static Status mapErrorStatus(final ErrorResponse.ErrorCode code) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryController.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
@@ -47,6 +49,11 @@ public final class ClusterRecoveryController {
       @RequestParam final Mode mode,
       @RequestParam(required = false) final @Nullable String physicalTenantId,
       @RequestParam(name = "dryRun", defaultValue = "false") final boolean dryRun) {
+    if (physicalTenantId != null && physicalTenantId.isBlank()) {
+      throw new ServiceException(
+          "Expected physicalTenantId to identify a physical tenant, but it was empty.",
+          Status.INVALID_ARGUMENT);
+    }
     LOG.debug(
         "Requested cluster mode change to {} for {}",
         mode,

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryController.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
+import io.camunda.zeebe.gateway.rest.annotation.ClusterScoped;
+import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
+import java.util.concurrent.CompletableFuture;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * Recovery operations that span the whole cluster, authenticated by the cluster-admin security
+ * chain
+ */
+@CamundaRestController
+@ClusterScoped
+@RequestMapping("/cluster/v2")
+@NullMarked
+public final class ClusterRecoveryController {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ClusterRecoveryController.class);
+
+  private final ServiceRegistry serviceRegistry;
+
+  public ClusterRecoveryController(final ServiceRegistry serviceRegistry) {
+    this.serviceRegistry = serviceRegistry;
+  }
+
+  @CamundaPatchMapping(
+      path = "/mode",
+      consumes = {})
+  public CompletableFuture<ResponseEntity<Object>> changeClusterMode(
+      @RequestParam final Mode mode,
+      @RequestParam(required = false) final @Nullable String physicalTenantId,
+      @RequestParam(name = "dryRun", defaultValue = "false") final boolean dryRun) {
+    LOG.debug(
+        "Requested cluster mode change to {} for {}",
+        mode,
+        physicalTenantId == null ? "all tenants" : physicalTenantId);
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            serviceRegistry
+                .clusterRecoveryServices()
+                .changeMode(physicalTenantId, mode, dryRun)
+                .thenApply(ClusterModeChangeMapper::unwrapOrThrow),
+        ClusterModeChangeMapper::toClusterModeChangeResponse,
+        HttpStatus.OK);
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
-import io.camunda.gateway.protocol.model.ClusterModeChangeOperation;
-import io.camunda.gateway.protocol.model.ClusterModeChangeResponse;
 import io.camunda.gateway.protocol.model.RestoreBrokerStatus;
 import io.camunda.gateway.protocol.model.RestorePartitionStatus;
 import io.camunda.gateway.protocol.model.RestoreStatusResponse;
@@ -17,24 +15,18 @@ import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.spring.utils.DatabaseTypeUtils;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
-import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.api.RestoreStatus;
 import io.camunda.zeebe.dynamic.config.api.RestoreStatus.BrokerRestoreStatus;
 import io.camunda.zeebe.dynamic.config.api.RestoreStatus.PartitionRestoreStatus;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.Mode;
-import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
-import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
-import io.camunda.zeebe.util.Either;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -83,8 +75,8 @@ public final class RecoveryController {
             serviceRegistry
                 .recoveryServices(physicalTenantId)
                 .changeMode(mode, dryRun, authentication)
-                .thenApply(RecoveryController::unwrapOrThrow),
-        RecoveryController::toClusterModeChangeResponse,
+                .thenApply(ClusterModeChangeMapper::unwrapOrThrow),
+        ClusterModeChangeMapper::toClusterModeChangeResponse,
         HttpStatus.OK);
   }
 
@@ -102,8 +94,8 @@ public final class RecoveryController {
             serviceRegistry
                 .recoveryServices(physicalTenantId)
                 .restore(request, authentication)
-                .thenApply(RecoveryController::unwrapOrThrow),
-        RecoveryController::toClusterModeChangeResponse,
+                .thenApply(ClusterModeChangeMapper::unwrapOrThrow),
+        ClusterModeChangeMapper::toClusterModeChangeResponse,
         HttpStatus.ACCEPTED);
   }
 
@@ -117,7 +109,7 @@ public final class RecoveryController {
             serviceRegistry
                 .recoveryServices(physicalTenantId)
                 .restoreStatus(authentication)
-                .thenApply(RecoveryController::unwrapOrThrow)
+                .thenApply(ClusterModeChangeMapper::unwrapOrThrow)
                 .thenApply(RecoveryController::restoreStatus),
         RecoveryController::mapRestoreStatus,
         HttpStatus.OK);
@@ -144,50 +136,6 @@ public final class RecoveryController {
         databaseType,
         continuousBackups,
         dryRun);
-  }
-
-  private static <T> T unwrapOrThrow(final Either<ErrorResponse, T> result) {
-    if (result.isRight()) {
-      return result.get();
-    }
-    final var error = result.getLeft();
-    throw new ServiceException(error.message(), mapErrorStatus(error.code()));
-  }
-
-  private static Status mapErrorStatus(final ErrorResponse.ErrorCode code) {
-    return switch (code) {
-      case INVALID_REQUEST -> Status.INVALID_ARGUMENT;
-      case OPERATION_NOT_ALLOWED -> Status.FORBIDDEN;
-      case CONCURRENT_MODIFICATION, INVALID_STATE -> Status.INVALID_STATE;
-      case INTERNAL_ERROR -> Status.INTERNAL;
-      case NOT_FOUND -> Status.NOT_FOUND;
-    };
-  }
-
-  private static ClusterModeChangeResponse toClusterModeChangeResponse(
-      final ClusterConfigurationChangeResponse response) {
-    final List<ClusterModeChangeOperation> plannedChanges =
-        response.legacyResponse().plannedChanges().stream()
-            .map(RecoveryController::toClusterModeChangeOperation)
-            .toList();
-    return ClusterModeChangeResponse.Builder.create()
-        .changeId(Long.toString(response.changeId()))
-        .plannedChanges(plannedChanges)
-        .build();
-  }
-
-  private static ClusterModeChangeOperation toClusterModeChangeOperation(
-      final ClusterConfigurationChangeOperation operation) {
-    final String mode =
-        switch (operation) {
-          case final ModeChangeOperation modeChange -> modeChange.mode().name();
-          case final AwaitModeChangeOperation awaitModeChange -> awaitModeChange.mode().name();
-          default -> null;
-        };
-    return ClusterModeChangeOperation.Builder.create()
-        .operation(operation.getClass().getSimpleName())
-        .mode(mode)
-        .build();
   }
 
   private static RestoreStatus restoreStatus(final ClusterConfiguration configuration) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
@@ -20,9 +20,12 @@ import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.util.Either;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -48,12 +51,15 @@ class ClusterRecoveryControllerTest extends RestControllerTest {
 
   @Test
   void shouldReportThePlannedChangeCoveringEveryPhysicalTenant() {
-    // given
+    // given — a plan that transitions two physical tenants at once
     when(clusterRecoveryServices.changeMode(
             Mockito.isNull(), Mockito.eq(Mode.RECOVERING), Mockito.eq(false)))
-        .thenReturn(CompletableFuture.completedFuture(Either.right(plannedChange(7L))));
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.right(plannedChange(7L, "tenant-b", "default"))));
 
-    // when / then
+    // when / then — every tenant keeps its own operations, ordered by tenant so that the response
+    // does not depend on the iteration order of the plan
     webClient
         .patch()
         .uri(MODE_URL + "?mode=RECOVERING")
@@ -66,7 +72,18 @@ class ClusterRecoveryControllerTest extends RestControllerTest {
             {
               "changeId": "7",
               "plannedChanges": [
-                { "operation": "ModeChangeOperation", "mode": "RECOVERING" }
+                {
+                  "physicalTenantId": "default",
+                  "operations": [
+                    { "operation": "ModeChangeOperation", "mode": "RECOVERING" }
+                  ]
+                },
+                {
+                  "physicalTenantId": "tenant-b",
+                  "operations": [
+                    { "operation": "ModeChangeOperation", "mode": "RECOVERING" }
+                  ]
+                }
               ]
             }
             """,
@@ -78,9 +95,9 @@ class ClusterRecoveryControllerTest extends RestControllerTest {
     // given
     when(clusterRecoveryServices.changeMode(
             Mockito.eq("tenant-b"), Mockito.eq(Mode.RECOVERING), Mockito.eq(false)))
-        .thenReturn(CompletableFuture.completedFuture(Either.right(plannedChange(8L))));
+        .thenReturn(CompletableFuture.completedFuture(Either.right(plannedChange(8L, "tenant-b"))));
 
-    // when / then
+    // when / then — the plan names the requested tenant and no other
     webClient
         .patch()
         .uri(MODE_URL + "?mode=RECOVERING&physicalTenantId=tenant-b")
@@ -88,8 +105,21 @@ class ClusterRecoveryControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .jsonPath("$.changeId")
-        .isEqualTo("8");
+        .json(
+            """
+            {
+              "changeId": "8",
+              "plannedChanges": [
+                {
+                  "physicalTenantId": "tenant-b",
+                  "operations": [
+                    { "operation": "ModeChangeOperation", "mode": "RECOVERING" }
+                  ]
+                }
+              ]
+            }
+            """,
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -155,16 +185,20 @@ class ClusterRecoveryControllerTest extends RestControllerTest {
         .changeMode(Mockito.any(), Mockito.any(), Mockito.anyBoolean());
   }
 
-  private ClusterConfigurationChangeResponse plannedChange(final long changeId) {
-    final var plannedChanges =
-        List.<ClusterConfigurationChangeOperation>of(
-            new ModeChangeOperation(MemberId.from("0"), Mode.RECOVERING));
+  private ClusterConfigurationChangeResponse plannedChange(
+      final long changeId, final String... physicalTenantIds) {
+    final var operation = new ModeChangeOperation(MemberId.from("0"), Mode.RECOVERING);
+    final Map<String, List<PartitionGroupOperation>> operationsPerTenant = new HashMap<>();
+    for (final var physicalTenantId : physicalTenantIds) {
+      operationsPerTenant.put(physicalTenantId, List.of(operation));
+    }
     return new ClusterConfigurationChangeResponse(
         changeId,
-        new LegacyConfigurationChangeResponse(Map.of(), Map.of(), plannedChanges),
+        new LegacyConfigurationChangeResponse(
+            Map.of(), Map.of(), List.<ClusterConfigurationChangeOperation>of(operation)),
         new CurrentConfigurationChangeResponse(
             CurrentClusterConfiguration.uninitialized(),
             CurrentClusterConfiguration.uninitialized(),
-            plannedChanges));
+            List.of(new PartitionGroupParallelPhase(operationsPerTenant))));
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.service.ClusterRecoveryServices;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
+import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
+
+@WebMvcTest(ClusterRecoveryController.class)
+class ClusterRecoveryControllerTest extends RestControllerTest {
+
+  private static final String MODE_URL = "/cluster/v2/mode";
+
+  @MockitoBean ClusterRecoveryServices clusterRecoveryServices;
+  @MockitoBean ServiceRegistry serviceRegistry;
+
+  @BeforeEach
+  void setup() {
+    when(serviceRegistry.clusterRecoveryServices()).thenReturn(clusterRecoveryServices);
+  }
+
+  @Test
+  void shouldReportThePlannedChangeCoveringEveryPhysicalTenant() {
+    // given
+    when(clusterRecoveryServices.changeMode(
+            Mockito.isNull(), Mockito.eq(Mode.RECOVERING), Mockito.eq(false)))
+        .thenReturn(CompletableFuture.completedFuture(Either.right(plannedChange(7L))));
+
+    // when / then
+    webClient
+        .patch()
+        .uri(MODE_URL + "?mode=RECOVERING")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            {
+              "changeId": "7",
+              "plannedChanges": [
+                { "operation": "ModeChangeOperation", "mode": "RECOVERING" }
+              ]
+            }
+            """,
+            JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldChangeModeOfTheRequestedPhysicalTenantOnly() {
+    // given
+    when(clusterRecoveryServices.changeMode(
+            Mockito.eq("tenant-b"), Mockito.eq(Mode.RECOVERING), Mockito.eq(false)))
+        .thenReturn(CompletableFuture.completedFuture(Either.right(plannedChange(8L))));
+
+    // when / then
+    webClient
+        .patch()
+        .uri(MODE_URL + "?mode=RECOVERING&physicalTenantId=tenant-b")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.changeId")
+        .isEqualTo("8");
+  }
+
+  @Test
+  void shouldValidateWithoutApplyingWhenDryRunIsRequested() {
+    // given
+    when(clusterRecoveryServices.changeMode(
+            Mockito.isNull(), Mockito.eq(Mode.PROCESSING), Mockito.eq(true)))
+        .thenReturn(CompletableFuture.completedFuture(Either.right(plannedChange(7L))));
+
+    // when / then
+    webClient
+        .patch()
+        .uri(MODE_URL + "?mode=PROCESSING&dryRun=true")
+        .exchange()
+        .expectStatus()
+        .isOk();
+  }
+
+  @Test
+  void shouldMapRejectedModeChangeToClientError() {
+    // given
+    when(clusterRecoveryServices.changeMode(
+            Mockito.isNull(), Mockito.eq(Mode.RECOVERING), Mockito.eq(false)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.left(
+                    new ErrorResponse(
+                        ErrorCode.INVALID_REQUEST, "this cluster has a single partition group"))));
+
+    // when / then
+    webClient.patch().uri(MODE_URL + "?mode=RECOVERING").exchange().expectStatus().isBadRequest();
+  }
+
+  private ClusterConfigurationChangeResponse plannedChange(final long changeId) {
+    return new ClusterConfigurationChangeResponse(
+        changeId,
+        new LegacyConfigurationChangeResponse(
+            Map.of(),
+            Map.of(),
+            List.of(new ModeChangeOperation(MemberId.from("0"), Mode.RECOVERING))),
+        null);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
@@ -141,6 +141,20 @@ class ClusterRecoveryControllerTest extends RestControllerTest {
         .isNotFound();
   }
 
+  @Test
+  void shouldRejectABlankPhysicalTenantAsAMalformedRequest() {
+    // when / then
+    webClient
+        .patch()
+        .uri(MODE_URL + "?mode=RECOVERING&physicalTenantId=")
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    Mockito.verify(clusterRecoveryServices, Mockito.never())
+        .changeMode(Mockito.any(), Mockito.any(), Mockito.anyBoolean());
+  }
+
   private ClusterConfigurationChangeResponse plannedChange(final long changeId) {
     final var plannedChanges =
         List.<ClusterConfigurationChangeOperation>of(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
@@ -13,9 +13,12 @@ import io.atomix.cluster.MemberId;
 import io.camunda.service.ClusterRecoveryServices;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.CurrentConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
@@ -120,13 +123,34 @@ class ClusterRecoveryControllerTest extends RestControllerTest {
     webClient.patch().uri(MODE_URL + "?mode=RECOVERING").exchange().expectStatus().isBadRequest();
   }
 
+  @Test
+  void shouldMapUnknownPhysicalTenantToNotFound() {
+    // given
+    when(clusterRecoveryServices.changeMode(
+            Mockito.eq("tenant-b"), Mockito.eq(Mode.RECOVERING), Mockito.eq(false)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.left(new ErrorResponse(ErrorCode.NOT_FOUND, "it has no partition group"))));
+
+    // when / then
+    webClient
+        .patch()
+        .uri(MODE_URL + "?mode=RECOVERING&physicalTenantId=tenant-b")
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+  }
+
   private ClusterConfigurationChangeResponse plannedChange(final long changeId) {
+    final var plannedChanges =
+        List.<ClusterConfigurationChangeOperation>of(
+            new ModeChangeOperation(MemberId.from("0"), Mode.RECOVERING));
     return new ClusterConfigurationChangeResponse(
         changeId,
-        new LegacyConfigurationChangeResponse(
-            Map.of(),
-            Map.of(),
-            List.of(new ModeChangeOperation(MemberId.from("0"), Mode.RECOVERING))),
-        null);
+        new LegacyConfigurationChangeResponse(Map.of(), Map.of(), plannedChanges),
+        new CurrentConfigurationChangeResponse(
+            CurrentClusterConfiguration.uninitialized(),
+            CurrentClusterConfiguration.uninitialized(),
+            plannedChanges));
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -205,6 +205,27 @@ public class RecoveryControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldRejectRestoreWhenCallerIsNotAuthorized() {
+    // given
+    Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException(
+                    "Unauthorized to perform operation 'RESTORE' on resource 'BACKUP'",
+                    ServiceException.Status.FORBIDDEN)));
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/restore")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupIds\": [100]}")
+        .exchange()
+        .expectStatus()
+        .isForbidden();
+  }
+
+  @Test
   void shouldMapInvalidRequestErrorFromCoordinator() {
     // given
     Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.any()))

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -32,6 +32,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
@@ -73,14 +74,19 @@ public class RecoveryControllerTest extends RestControllerTest {
 
   private void stubValidationSuccess() {
     Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.any()))
-        .thenReturn(
-            CompletableFuture.completedFuture(
-                Either.right(
-                    new ClusterConfigurationChangeResponse(
-                        0L,
-                        new ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse(
-                            Map.of(), Map.of(), List.of()),
-                        null))));
+        .thenReturn(CompletableFuture.completedFuture(Either.right(changeResponse(0L, List.of()))));
+  }
+
+  private static ClusterConfigurationChangeResponse changeResponse(
+      final long changeId, final List<ClusterConfigurationChangeOperation> plannedChanges) {
+    return new ClusterConfigurationChangeResponse(
+        changeId,
+        new ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse(
+            Map.of(), Map.of(), plannedChanges),
+        new ClusterConfigurationChangeResponse.CurrentConfigurationChangeResponse(
+            CurrentClusterConfiguration.uninitialized(),
+            CurrentClusterConfiguration.uninitialized(),
+            plannedChanges));
   }
 
   @ParameterizedTest
@@ -88,13 +94,7 @@ public class RecoveryControllerTest extends RestControllerTest {
   void shouldChangeClusterModeAndReturnPlannedChanges(final String baseUrl) {
     // given
     final var changeResponse =
-        new ClusterConfigurationChangeResponse(
-            7L,
-            new ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse(
-                Map.of(),
-                Map.of(),
-                List.of(new ModeChangeOperation(MemberId.from("0"), Mode.RECOVERING))),
-            null);
+        changeResponse(7L, List.of(new ModeChangeOperation(MemberId.from("0"), Mode.RECOVERING)));
     Mockito.when(
             recoveryServices.changeMode(
                 Mockito.eq(Mode.RECOVERING), Mockito.eq(false), Mockito.any()))

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -34,9 +34,12 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.util.Either;
 import java.time.Instant;
@@ -77,16 +80,23 @@ public class RecoveryControllerTest extends RestControllerTest {
         .thenReturn(CompletableFuture.completedFuture(Either.right(changeResponse(0L, List.of()))));
   }
 
+  /** A change plan that transitions the physical tenant this controller is addressed at. */
   private static ClusterConfigurationChangeResponse changeResponse(
-      final long changeId, final List<ClusterConfigurationChangeOperation> plannedChanges) {
+      final long changeId, final List<PartitionGroupOperation> plannedChanges) {
+    final var phases =
+        plannedChanges.isEmpty()
+            ? List.<Phase>of()
+            : List.<Phase>of(
+                new PartitionGroupParallelPhase(
+                    Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, plannedChanges)));
     return new ClusterConfigurationChangeResponse(
         changeId,
         new ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse(
-            Map.of(), Map.of(), plannedChanges),
+            Map.of(), Map.of(), List.<ClusterConfigurationChangeOperation>copyOf(plannedChanges)),
         new ClusterConfigurationChangeResponse.CurrentConfigurationChangeResponse(
             CurrentClusterConfiguration.uninitialized(),
             CurrentClusterConfiguration.uninitialized(),
-            plannedChanges));
+            phases));
   }
 
   @ParameterizedTest
@@ -106,8 +116,13 @@ public class RecoveryControllerTest extends RestControllerTest {
           "changeId": "7",
           "plannedChanges": [
             {
-              "operation": "ModeChangeOperation",
-              "mode": "RECOVERING"
+              "physicalTenantId": "default",
+              "operations": [
+                {
+                  "operation": "ModeChangeOperation",
+                  "mode": "RECOVERING"
+                }
+              ]
             }
           ]
         }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -205,27 +205,6 @@ public class RecoveryControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldRejectRestoreWhenCallerIsNotAuthorized() {
-    // given
-    Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.any()))
-        .thenReturn(
-            CompletableFuture.failedFuture(
-                new ServiceException(
-                    "Unauthorized to perform operation 'RESTORE' on resource 'BACKUP'",
-                    ServiceException.Status.FORBIDDEN)));
-
-    // when / then
-    webClient
-        .post()
-        .uri("/v2/restore")
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue("{\"backupIds\": [100]}")
-        .exchange()
-        .expectStatus()
-        .isForbidden();
-  }
-
-  @Test
   void shouldMapInvalidRequestErrorFromCoordinator() {
     // given
     Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.any()))

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterAdminMultiBrokerModeChangeIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterAdminMultiBrokerModeChangeIT.java
@@ -31,6 +31,8 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
@@ -104,15 +106,28 @@ final class ClusterAdminMultiBrokerModeChangeIT {
       // awaited, so no broker and no tenant is silently left behind
       final var plannedChanges = plannedChanges(response.body());
       assertThat(plannedChanges)
-          .as("one ModeChangeOperation and one AwaitModeChangeOperation per broker per group")
-          .hasSize(2 * BROKERS_COUNT * GROUPS.size())
-          .allSatisfy(change -> assertThat(change.get("mode").asText()).isEqualTo("RECOVERING"));
-      assertThat(plannedChanges)
-          .filteredOn(change -> "ModeChangeOperation".equals(change.get("operation").asText()))
-          .hasSize(BROKERS_COUNT * GROUPS.size());
-      assertThat(plannedChanges)
-          .filteredOn(change -> "AwaitModeChangeOperation".equals(change.get("operation").asText()))
-          .hasSize(BROKERS_COUNT * GROUPS.size());
+          .as("the plan names every physical tenant")
+          .containsOnlyKeys(GROUPS.toArray(String[]::new));
+      assertThat(plannedChanges.values())
+          .allSatisfy(
+              operations -> {
+                assertThat(operations)
+                    .as("one ModeChangeOperation and one AwaitModeChangeOperation per broker")
+                    .hasSize(2 * BROKERS_COUNT)
+                    .allSatisfy(
+                        operation ->
+                            assertThat(operation.get("mode").asText()).isEqualTo("RECOVERING"));
+                assertThat(operations)
+                    .filteredOn(
+                        operation ->
+                            "ModeChangeOperation".equals(operation.get("operation").asText()))
+                    .hasSize(BROKERS_COUNT);
+                assertThat(operations)
+                    .filteredOn(
+                        operation ->
+                            "AwaitModeChangeOperation".equals(operation.get("operation").asText()))
+                    .hasSize(BROKERS_COUNT);
+              });
 
       // and — both tenants really stop processing, on every broker
       awaitCommandsRejected(defaultClient, defaultProcessId);
@@ -147,7 +162,9 @@ final class ClusterAdminMultiBrokerModeChangeIT {
       // tenant
       assertThat(plannedChanges(response.body()))
           .as("one ModeChangeOperation and one AwaitModeChangeOperation per broker, one group only")
-          .hasSize(2 * BROKERS_COUNT);
+          .containsOnlyKeys(TENANT_A)
+          .hasEntrySatisfying(
+              TENANT_A, operations -> assertThat(operations).hasSize(2 * BROKERS_COUNT));
 
       // and — the isolation holds across brokers: tenant A stops, the default tenant does not
       awaitCommandsRejected(tenantAClient, tenantAProcessId);
@@ -176,10 +193,16 @@ final class ClusterAdminMultiBrokerModeChangeIT {
     return httpClient.send(request, BodyHandlers.ofString());
   }
 
-  private static List<JsonNode> plannedChanges(final String body) throws Exception {
+  /** The planned operations of the change, keyed by the physical tenant they apply to. */
+  private static Map<String, List<JsonNode>> plannedChanges(final String body) throws Exception {
     final var changes = JSON.readTree(body).get("plannedChanges");
     assertThat(changes).as("response carries a plan: %s", body).isNotNull();
-    return StreamSupport.stream(changes.spliterator(), false).toList();
+    return StreamSupport.stream(changes.spliterator(), false)
+        .collect(
+            Collectors.toMap(
+                change -> change.get("physicalTenantId").asText(),
+                change ->
+                    StreamSupport.stream(change.get("operations").spliterator(), false).toList()));
   }
 
   private static String basicAuth(final String user, final String password) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterAdminMultiBrokerModeChangeIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterAdminMultiBrokerModeChangeIT.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestClusterBuilder;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import java.util.stream.StreamSupport;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+final class ClusterAdminMultiBrokerModeChangeIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final List<String> GROUPS =
+      List.of(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, TENANT_A);
+  private static final int BROKERS_COUNT = 3;
+  private static final String CLUSTER_ADMIN_USER = "cluster-operator";
+  private static final String CLUSTER_ADMIN_PASSWORD = "cluster-secret";
+  private static final Duration TRANSITION_TIMEOUT = Duration.ofSeconds(90);
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+  // Routing through PhysicalTenantsITHelper both supplies a real config diff (secondary storage =
+  // none) so the tenant is discovered and bootstrapped, and declares the per-tenant
+  // security.initialization block that PhysicalTenantRequiredOverrideValidation requires once a
+  // non-default tenant exists.
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  private static final ObjectMapper JSON = new ObjectMapper();
+
+  @TestZeebe
+  private final TestCluster cluster =
+      new TestClusterBuilder()
+          .withBrokersCount(BROKERS_COUNT)
+          .withReplicationFactor(BROKERS_COUNT)
+          .withPartitionsCount(2)
+          .withBrokerConfig(
+              broker ->
+                  TENANTS.configure(
+                      broker
+                          .withUnauthenticatedAccess()
+                          .withProperty(
+                              "camunda.security.cluster-admin.basic.users[0].name",
+                              CLUSTER_ADMIN_USER)
+                          .withProperty(
+                              "camunda.security.cluster-admin.basic.users[0].password",
+                              CLUSTER_ADMIN_PASSWORD)))
+          .build();
+
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
+
+  @Test
+  void shouldRecoverEveryPhysicalTenantOnEveryBrokerWhenNoTenantIsRequested() throws Exception {
+    // given — both physical tenants process commands on their own group, replicated over every
+    // broker
+    try (final var defaultClient = newClient(PhysicalTenantsITHelper.DEFAULT_TENANT_ID);
+        final var tenantAClient = newClient(TENANT_A)) {
+      final String defaultProcessId = "multi-broker-default";
+      final String tenantAProcessId = "multi-broker-tenanta";
+      deployProcess(defaultClient, defaultProcessId);
+      deployProcess(tenantAClient, tenantAProcessId);
+      assertThat(createInstance(defaultClient, defaultProcessId)).isPositive();
+      assertThat(createInstance(tenantAClient, tenantAProcessId)).isPositive();
+
+      // when — the cluster admin moves the whole cluster into recovery, naming no tenant
+      final var response = changeMode("RECOVERING", null);
+      assertThat(response.statusCode())
+          .as("mode change rejected: %s", response.body())
+          .isEqualTo(HttpURLConnection.HTTP_OK);
+
+      // then — the plan covers every broker of every group: each is asked to change mode and then
+      // awaited, so no broker and no tenant is silently left behind
+      final var plannedChanges = plannedChanges(response.body());
+      assertThat(plannedChanges)
+          .as("one ModeChangeOperation and one AwaitModeChangeOperation per broker per group")
+          .hasSize(2 * BROKERS_COUNT * GROUPS.size())
+          .allSatisfy(change -> assertThat(change.get("mode").asText()).isEqualTo("RECOVERING"));
+      assertThat(plannedChanges)
+          .filteredOn(change -> "ModeChangeOperation".equals(change.get("operation").asText()))
+          .hasSize(BROKERS_COUNT * GROUPS.size());
+      assertThat(plannedChanges)
+          .filteredOn(change -> "AwaitModeChangeOperation".equals(change.get("operation").asText()))
+          .hasSize(BROKERS_COUNT * GROUPS.size());
+
+      // and — both tenants really stop processing, on every broker
+      awaitCommandsRejected(defaultClient, defaultProcessId);
+      awaitCommandsRejected(tenantAClient, tenantAProcessId);
+
+      // and — the cluster-wide transition is reversible for both tenants at once
+      awaitModeChangeAccepted("PROCESSING", null);
+      awaitCommandsAccepted(defaultClient, defaultProcessId);
+      awaitCommandsAccepted(tenantAClient, tenantAProcessId);
+    }
+  }
+
+  @Test
+  void shouldRecoverOneTenantOnEveryBrokerWhileTheOtherKeepsProcessing() throws Exception {
+    // given — both physical tenants process commands on their own group
+    try (final var defaultClient = newClient(PhysicalTenantsITHelper.DEFAULT_TENANT_ID);
+        final var tenantAClient = newClient(TENANT_A)) {
+      final String defaultProcessId = "multi-broker-isolated-default";
+      final String tenantAProcessId = "multi-broker-isolated-tenanta";
+      deployProcess(defaultClient, defaultProcessId);
+      deployProcess(tenantAClient, tenantAProcessId);
+      assertThat(createInstance(defaultClient, defaultProcessId)).isPositive();
+      assertThat(createInstance(tenantAClient, tenantAProcessId)).isPositive();
+
+      // when — only tenant A is moved into recovery
+      final var response = changeMode("RECOVERING", TENANT_A);
+      assertThat(response.statusCode())
+          .as("mode change rejected: %s", response.body())
+          .isEqualTo(HttpURLConnection.HTTP_OK);
+
+      // then — the plan stops at tenant A's group: every broker transitions, but only for that
+      // tenant
+      assertThat(plannedChanges(response.body()))
+          .as("one ModeChangeOperation and one AwaitModeChangeOperation per broker, one group only")
+          .hasSize(2 * BROKERS_COUNT);
+
+      // and — the isolation holds across brokers: tenant A stops, the default tenant does not
+      awaitCommandsRejected(tenantAClient, tenantAProcessId);
+      assertThat(createInstance(defaultClient, defaultProcessId)).isPositive();
+
+      // and — tenant A can be handed back to processing on its own
+      awaitModeChangeAccepted("PROCESSING", TENANT_A);
+      awaitCommandsAccepted(tenantAClient, tenantAProcessId);
+    }
+  }
+
+  private HttpResponse<String> changeMode(final String mode, final String physicalTenantId)
+      throws Exception {
+    final var query =
+        physicalTenantId == null
+            ? "mode=" + mode
+            : "mode=%s&physicalTenantId=%s".formatted(mode, physicalTenantId);
+    // The cluster-admin API is cluster-wide, so it is always addressed at the gateway root — never
+    // under a /physical-tenants/<id> prefix.
+    final URI uri = cluster.availableGateway().restAddress().resolve("cluster/v2/mode?" + query);
+    final HttpRequest request =
+        HttpRequest.newBuilder(uri)
+            .header("Authorization", basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD))
+            .method("PATCH", BodyPublishers.noBody())
+            .build();
+    return httpClient.send(request, BodyHandlers.ofString());
+  }
+
+  private static List<JsonNode> plannedChanges(final String body) throws Exception {
+    final var changes = JSON.readTree(body).get("plannedChanges");
+    assertThat(changes).as("response carries a plan: %s", body).isNotNull();
+    return StreamSupport.stream(changes.spliterator(), false).toList();
+  }
+
+  private static String basicAuth(final String user, final String password) {
+    return "Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes());
+  }
+
+  private CamundaClient newClient(final String tenantId) {
+    return TENANTS
+        .newClientBuilder(cluster.availableGateway(), tenantId)
+        .preferRestOverGrpc(true)
+        .defaultRequestTimeout(REQUEST_TIMEOUT)
+        .build();
+  }
+
+  /**
+   * Sends the mode change until the cluster accepts it.
+   *
+   * <p>A change is rejected with {@code 409} while another one is still pending, and commands start
+   * failing as soon as the partitions stop — which is before the change that stopped them has
+   * completed. Waiting for the pending change to clear would be the deterministic alternative, but
+   * a change targeting a non-default physical tenant is not observable: the topology API projects
+   * {@code pendingChanges} from the global configuration and the default partition group only
+   * ({@code CurrentClusterConfiguration#toLegacyDefault}), so a plan scoped to another tenant's
+   * group never appears there. Retry until the platform exposes per-group change status.
+   */
+  private void awaitModeChangeAccepted(final String mode, final String physicalTenantId) {
+    Awaitility.await("the cluster accepts the mode change")
+        .atMost(TRANSITION_TIMEOUT)
+        .untilAsserted(
+            () -> {
+              final var response = changeMode(mode, physicalTenantId);
+              assertThat(response.statusCode())
+                  .as("mode change rejected: %s", response.body())
+                  .isEqualTo(HttpURLConnection.HTTP_OK);
+            });
+  }
+
+  // The mode change is acknowledged once accepted, so the partitions may still be transitioning.
+  private static void awaitCommandsRejected(final CamundaClient client, final String processId) {
+    Awaitility.await("recovering tenant stops accepting commands")
+        .atMost(TRANSITION_TIMEOUT)
+        .untilAsserted(
+            () ->
+                assertThatThrownBy(() -> createInstance(client, processId))
+                    .as("a recovering tenant has no partition that can process a command")
+                    .isInstanceOf(Exception.class));
+  }
+
+  private static void awaitCommandsAccepted(final CamundaClient client, final String processId) {
+    Awaitility.await("tenant handed back to processing accepts commands again")
+        .atMost(TRANSITION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(() -> assertThat(createInstance(client, processId)).isPositive());
+  }
+
+  private static void deployProcess(final CamundaClient client, final String processId) {
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess(processId).startEvent().endEvent().done();
+    Awaitility.await("process deployed to the tenant's partitions")
+        .atMost(Duration.ofSeconds(60))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        client
+                            .newDeployResourceCommand()
+                            .addProcessModel(model, processId + ".bpmn")
+                            .send()
+                            .join()
+                            .getProcesses())
+                    .isNotEmpty());
+  }
+
+  private static long createInstance(final CamundaClient client, final String processId) {
+    return client
+        .newCreateInstanceCommand()
+        .bpmnProcessId(processId)
+        .latestVersion()
+        .send()
+        .join()
+        .getProcessInstanceKey();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterAdminPhysicalTenantModeChangeIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterAdminPhysicalTenantModeChangeIT.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.Base64;
+import org.agrona.CloseHelper;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Proves that the cluster-admin mode change ({@code PATCH /cluster/v2/mode}) transitions a single
+ * physical tenant's partition group while every other tenant keeps processing. That isolation is
+ * the whole point of scoping the endpoint by {@code physicalTenantId}: one tenant's secondary
+ * storage can be restored without stopping the rest of the cluster.
+ *
+ * <p>Complements {@code ClusterAdminModeChangeIT}, which covers the endpoint's authentication and
+ * request validation on a single-tenant broker, and {@code NewModelManagementApiEndpointsTest},
+ * which covers the same isolation at the cluster configuration level with stubbed executors. This
+ * test is the only place where the real broker-side {@code PartitionModeHandler} of a non-default
+ * tenant is exercised.
+ */
+@ZeebeIntegration
+final class ClusterAdminPhysicalTenantModeChangeIT {
+
+  private static final String TENANT_B = "tenantb";
+  private static final String CLUSTER_ADMIN_USER = "cluster-operator";
+  private static final String CLUSTER_ADMIN_PASSWORD = "cluster-secret";
+  private static final Duration TRANSITION_TIMEOUT = Duration.ofSeconds(60);
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_B, Storage.none())
+          .build();
+
+  // The data plane is left unauthenticated so the tenant clients need no credentials; the
+  // cluster-admin chain is independent of that and still requires these basic-auth credentials.
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private static final TestStandaloneBroker BROKER =
+      TENANTS.configure(
+          new TestStandaloneBroker()
+              .withUnauthenticatedAccess()
+              .withProperty(
+                  "camunda.security.cluster-admin.basic.users[0].name", CLUSTER_ADMIN_USER)
+              .withProperty(
+                  "camunda.security.cluster-admin.basic.users[0].password",
+                  CLUSTER_ADMIN_PASSWORD));
+
+  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
+  private static CamundaClient defaultTenantClient;
+  private static CamundaClient tenantBClient;
+
+  @BeforeAll
+  static void start() {
+    BROKER.start();
+    defaultTenantClient = newClient(PhysicalTenantsITHelper.DEFAULT_TENANT_ID);
+    tenantBClient = newClient(TENANT_B);
+  }
+
+  @AfterAll
+  static void close() {
+    CloseHelper.quietCloseAll(defaultTenantClient, tenantBClient);
+  }
+
+  @Test
+  void shouldRecoverOneTenantWhileTheOtherKeepsProcessing() throws Exception {
+    // given — both physical tenants are processing commands on their own partition group
+    final String defaultProcessId = "mode-change-default";
+    final String tenantBProcessId = "mode-change-tenantb";
+    deployProcess(defaultTenantClient, defaultProcessId);
+    deployProcess(tenantBClient, tenantBProcessId);
+    assertThat(createInstance(defaultTenantClient, defaultProcessId)).isPositive();
+    assertThat(createInstance(tenantBClient, tenantBProcessId)).isPositive();
+
+    // when — the cluster admin moves only tenant B into recovery
+    final var recoveringResponse = changeMode(TENANT_B, "RECOVERING");
+    assertThat(recoveringResponse.statusCode())
+        .as("mode change rejected: %s", recoveringResponse.body())
+        .isEqualTo(HttpURLConnection.HTTP_OK);
+
+    // then — tenant B stops accepting commands; the default tenant keeps processing on its own
+    // group
+    awaitCommandsRejected(tenantBClient, tenantBProcessId);
+    assertThat(createInstance(defaultTenantClient, defaultProcessId)).isPositive();
+
+    // and — the transition is reversible, so the tenant can be handed back to processing
+    awaitModeChangeAccepted(TENANT_B, "PROCESSING");
+    awaitCommandsAccepted(tenantBClient, tenantBProcessId);
+  }
+
+  private static HttpResponse<String> changeMode(final String physicalTenantId, final String mode)
+      throws Exception {
+    final URI uri =
+        URI.create(
+            "%scluster/v2/mode?mode=%s&physicalTenantId=%s"
+                .formatted(BROKER.restAddress(), mode, physicalTenantId));
+    final HttpRequest request =
+        HttpRequest.newBuilder(uri)
+            .header("Authorization", basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD))
+            .method("PATCH", BodyPublishers.noBody())
+            .build();
+    return HTTP_CLIENT.send(request, BodyHandlers.ofString());
+  }
+
+  private static String basicAuth(final String user, final String password) {
+    return "Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes());
+  }
+
+  private static CamundaClient newClient(final String tenantId) {
+    return TENANTS
+        .newClientBuilder(BROKER, tenantId)
+        .preferRestOverGrpc(true)
+        .defaultRequestTimeout(REQUEST_TIMEOUT)
+        .build();
+  }
+
+  /**
+   * Sends the mode change until the cluster accepts it.
+   *
+   * <p>A change is rejected with {@code 409} while another one is still pending, and commands start
+   * failing as soon as the partitions stop — which is before the change that stopped them has
+   * completed. Waiting for the pending change to clear would be the deterministic alternative, but
+   * a change targeting a non-default physical tenant is not observable: the topology API projects
+   * {@code pendingChanges} from the global configuration and the default partition group only
+   * ({@code CurrentClusterConfiguration#toLegacyDefault}), so a plan scoped to another tenant's
+   * group never appears there. Retry until the platform exposes per-group change status.
+   */
+  private static void awaitModeChangeAccepted(final String physicalTenantId, final String mode) {
+    Awaitility.await("the cluster accepts the mode change")
+        .atMost(TRANSITION_TIMEOUT)
+        .untilAsserted(
+            () -> {
+              final var response = changeMode(physicalTenantId, mode);
+              assertThat(response.statusCode())
+                  .as("mode change rejected: %s", response.body())
+                  .isEqualTo(HttpURLConnection.HTTP_OK);
+            });
+  }
+
+  // The mode change is acknowledged once accepted, so the partitions may still be transitioning.
+  private static void awaitCommandsRejected(final CamundaClient client, final String processId) {
+    Awaitility.await("recovering tenant stops accepting commands")
+        .atMost(TRANSITION_TIMEOUT)
+        .untilAsserted(
+            () ->
+                assertThatThrownBy(() -> createInstance(client, processId))
+                    .as("a recovering tenant has no partition that can process a command")
+                    .isInstanceOf(Exception.class));
+  }
+
+  private static void awaitCommandsAccepted(final CamundaClient client, final String processId) {
+    Awaitility.await("tenant handed back to processing accepts commands again")
+        .atMost(TRANSITION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(() -> assertThat(createInstance(client, processId)).isPositive());
+  }
+
+  private static void deployProcess(final CamundaClient client, final String processId) {
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess(processId).startEvent().endEvent().done();
+    Awaitility.await("process deployed to the tenant's partitions")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        client
+                            .newDeployResourceCommand()
+                            .addProcessModel(model, processId + ".bpmn")
+                            .send()
+                            .join()
+                            .getProcesses())
+                    .isNotEmpty());
+  }
+
+  private static long createInstance(final CamundaClient client, final String processId) {
+    return client
+        .newCreateInstanceCommand()
+        .bpmnProcessId(processId)
+        .latestVersion()
+        .send()
+        .join()
+        .getProcessInstanceKey();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantModeChangeApiInteropIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantModeChangeApiInteropIT.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.Base64;
+import org.agrona.CloseHelper;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ThrowingRunnable;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the two mode-change APIs are interchangeable on the same physical tenant: a
+ * transition started through the tenant-scoped {@code PATCH /physical-tenants/{id}/v2/mode} can be
+ * reverted through the cluster-admin {@code PATCH /cluster/v2/mode}, and the other way round.
+ */
+@ZeebeIntegration
+final class PhysicalTenantModeChangeApiInteropIT {
+
+  private static final String TENANT_B = "tenantb";
+  private static final String CLUSTER_ADMIN_USER = "cluster-operator";
+  private static final String CLUSTER_ADMIN_PASSWORD = "cluster-secret";
+  private static final Duration TRANSITION_TIMEOUT = Duration.ofSeconds(60);
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_B, Storage.none())
+          .build();
+
+  // The data plane is unauthenticated so the tenant-scoped endpoint needs no credentials of its
+  // own; the cluster-admin chain is independent of that and still requires these.
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private static final TestStandaloneBroker BROKER =
+      TENANTS.configure(
+          new TestStandaloneBroker()
+              .withUnauthenticatedAccess()
+              .withProperty(
+                  "camunda.security.cluster-admin.basic.users[0].name", CLUSTER_ADMIN_USER)
+              .withProperty(
+                  "camunda.security.cluster-admin.basic.users[0].password",
+                  CLUSTER_ADMIN_PASSWORD));
+
+  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
+  private static CamundaClient tenantBClient;
+
+  @BeforeAll
+  static void start() {
+    BROKER.start();
+    tenantBClient =
+        TENANTS
+            .newClientBuilder(BROKER, TENANT_B)
+            .preferRestOverGrpc(true)
+            .defaultRequestTimeout(REQUEST_TIMEOUT)
+            .build();
+  }
+
+  @AfterAll
+  static void close() {
+    CloseHelper.quietCloseAll(tenantBClient);
+  }
+
+  @Test
+  void shouldRevertTenantScopedRecoveryWithTheClusterAdminApi() throws Exception {
+    // given — the tenant is processing and its own API puts it into recovery
+    final String processId = "interop-tenant-first";
+    deployProcess(processId);
+    awaitAccepted(() -> tenantModeChange("RECOVERING"));
+    awaitCommandsRejected(processId);
+
+    // when — the cluster admin reverts a transition it did not start
+    awaitAccepted(() -> clusterAdminModeChange("PROCESSING"));
+
+    // then — the tenant processes again, so the cluster-admin API planned against the same
+    // partition group the tenant-scoped API had transitioned
+    awaitCommandsAccepted(processId);
+  }
+
+  @Test
+  void shouldRevertClusterAdminRecoveryWithTheTenantScopedApi() throws Exception {
+    // given — the tenant is processing and the cluster admin puts it into recovery
+    final String processId = "interop-cluster-admin-first";
+    deployProcess(processId);
+    awaitAccepted(() -> clusterAdminModeChange("RECOVERING"));
+    awaitCommandsRejected(processId);
+
+    // when — the tenant's own API reverts it. The endpoint stays reachable while its partitions are
+    // inactive, because the mode change is served from the cluster configuration rather than from
+    // the tenant's own partitions.
+    awaitAccepted(() -> tenantModeChange("PROCESSING"));
+
+    // then
+    awaitCommandsAccepted(processId);
+  }
+
+  /**
+   * {@code PATCH /physical-tenants/<id>/v2/mode} — the per-tenant, authorization-checked API.
+   *
+   * <p>The tenant is put in the path explicitly rather than reusing {@code
+   * InProcessRestoreTestUtil#changeMode}: that helper derives the URL from the client's configured
+   * REST address, which for a {@link PhysicalTenantsITHelper} client is the bare gateway root (the
+   * client applies the tenant prefix per request). It would therefore address the <em>default</em>
+   * tenant and return 200 while leaving this one untouched.
+   */
+  private static void tenantModeChange(final String mode) throws Exception {
+    patchAndAssertAccepted(
+        "%sphysical-tenants/%s/v2/mode?mode=%s".formatted(BROKER.restAddress(), TENANT_B, mode),
+        null);
+  }
+
+  /** {@code PATCH /cluster/v2/mode} — the cluster-wide API, authenticated as a cluster admin. */
+  private static void clusterAdminModeChange(final String mode) throws Exception {
+    patchAndAssertAccepted(
+        "%scluster/v2/mode?mode=%s&physicalTenantId=%s"
+            .formatted(BROKER.restAddress(), mode, TENANT_B),
+        "Basic "
+            + Base64.getEncoder()
+                .encodeToString((CLUSTER_ADMIN_USER + ":" + CLUSTER_ADMIN_PASSWORD).getBytes()));
+  }
+
+  private static void patchAndAssertAccepted(final String uri, final String authorizationHeader)
+      throws Exception {
+    final HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(uri));
+    if (authorizationHeader != null) {
+      builder.header("Authorization", authorizationHeader);
+    }
+    final var response =
+        HTTP_CLIENT.send(
+            builder.method("PATCH", BodyPublishers.noBody()).build(), BodyHandlers.ofString());
+    assertThat(response.statusCode())
+        .describedAs("mode change REST response: %s", response.body())
+        .isEqualTo(HttpURLConnection.HTTP_OK);
+  }
+
+  /**
+   * Sends a mode change until the cluster accepts it.
+   *
+   * <p>TODO: This is required now since the topology response is not tenant aware and does not
+   * include the change plan for non default tenant
+   */
+  private static void awaitAccepted(final ThrowingRunnable modeChange) {
+    Awaitility.await("the cluster accepts the mode change")
+        .atMost(TRANSITION_TIMEOUT)
+        .untilAsserted(modeChange);
+  }
+
+  private static void awaitCommandsRejected(final String processId) {
+    Awaitility.await("the recovering tenant stops accepting commands")
+        .atMost(TRANSITION_TIMEOUT)
+        .untilAsserted(
+            () ->
+                assertThatThrownBy(() -> createInstance(processId))
+                    .as("a recovering tenant has no partition that can process a command")
+                    .isInstanceOf(Exception.class));
+  }
+
+  private static void awaitCommandsAccepted(final String processId) {
+    Awaitility.await("the tenant accepts commands again")
+        .atMost(TRANSITION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(() -> assertThat(createInstance(processId)).isPositive());
+  }
+
+  private static void deployProcess(final String processId) {
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess(processId).startEvent().endEvent().done();
+    Awaitility.await("process deployed to the tenant's partitions")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        tenantBClient
+                            .newDeployResourceCommand()
+                            .addProcessModel(model, processId + ".bpmn")
+                            .send()
+                            .join()
+                            .getProcesses())
+                    .isNotEmpty());
+  }
+
+  private static long createInstance(final String processId) {
+    return tenantBClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId(processId)
+        .latestVersion()
+        .send()
+        .join()
+        .getProcessInstanceKey();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Enable the ClusterAdmin role to perform mode changes on a single tenant or cluster wide. Introduces the `/cluster/v2/mode` endpoint with the optional parameter of the `physicalTenantId`.

Includes refactoring of `ModeChangeRequest` so that `Optional<String> tenantId` is passed throughout the dynamic config change to avoid null checks.

In `ClusterAdminBasicSecurityConfiguration` the security context has been adjusted due to requests not making it into the cluster. Rationale by Claude, will require cross checking with the Identity team:

```
Why it's needed. The cluster-admin endpoints return CompletableFuture, so Spring MVC processes them as async: the request is dispatched twice, and the security chain runs on both passes. On the ASYNC pass, BasicAuthenticationFilter does not re-run — it extends OncePerRequestFilter, whose shouldNotFilterAsyncDispatch() is true — but AuthorizationFilter does. So the second pass has no filter to re-read the Authorization header, and asks the repository for the context instead. NullSecurityContextRepository stores nothing, so it finds none and rejects.

A/B tested on an identical broker, only that line differing:

┌───────────────────────────────────────────┬───────────────────────────────────────────────────────────────────────┬──────────┐
│                repository                 │                       valid cluster-admin creds                       │ no creds │
├───────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────┼──────────┤
│ NullSecurityContextRepository             │ 401 — "An Authentication object was not found in the SecurityContext" │ 401      │
├───────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────┼──────────┤
│ RequestAttributeSecurityContextRepository │ 200 + plan                                                            │ 401      │
└───────────────────────────────────────────┴───────────────────────────────────────────────────────────────────────┴──────────┘

The endpoint was simply unreachable with correct credentials.

Why it doesn't weaken statelessness. The name is the point: the context goes in a ServletRequest attribute, not an HttpSession. That map is created and discarded with a single HTTP request, and the ASYNC dispatch is the same request — exactly the window that needs covering. Measured, not assumed:

set-cookie=[]          ← no session created
cookieOnlyReplay=401   ← nothing replayable carries authentication

sessionCreationPolicy(STATELESS) is untouched, and the original reason the repository is set explicitly still holds — STATELESS only installs one if none was set already (SessionManagementConfigurer's if (repo == null) guard). The isolation guarantee in the class javadoc — a webapp session cookie can never authenticate /cluster/v2/** — is intact. This is also Spring Security's documented recommendation for stateless applications, and ClusterAdminOidcSecurityConfiguration already uses it at the same spot, so the two chains now agree.

Alternatives, and why not:

1. Drop ASYNC from the security filter's dispatcher types (spring.security.filter.dispatcher-types=REQUEST,ERROR) — global; unhooks authorization from async dispatch for every chain in the app, including the webapp ones. Far bigger blast radius than the problem.
2. Make the endpoint synchronous — blocks a Tomcat thread for a full cluster-configuration round trip; the CompletableFuture return is deliberate.
3. Subclass BasicAuthenticationFilter with setShouldNotFilterAsyncDispatch(false) so it re-authenticates from the header on the async pass — works, but adds custom security code that re-parses credentials twice per request to avoid a one-line standard repository.
```


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #59535
