### PR TITLE
feat: migrate start process flow to unified webapp

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/process-instances.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/process-instances.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {CreateProcessInstanceResponseBody} from '@camunda/camunda-api-zod-schemas/8.10';
+
+function createProcessInstanceResponse(
+	overrides?: Partial<CreateProcessInstanceResponseBody>,
+): CreateProcessInstanceResponseBody {
+	return {
+		processDefinitionId: 'my-process',
+		processDefinitionVersion: 1,
+		processDefinitionKey: '2251799813685279',
+		processInstanceKey: '2251799813685280',
+		tenantId: '<default>',
+		variables: null,
+		businessId: null,
+		...overrides,
+	};
+}
+
+export {createProcessInstanceResponse};

--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
@@ -24,6 +24,11 @@ const mockQueryProcessDefinitionsEndpoint = createEndpointMock({
 	method: endpoints.queryProcessDefinitions.method,
 });
 
+const mockCreateProcessInstanceEndpoint = createEndpointMock({
+	endpoint: endpoints.createProcessInstance.getUrl(),
+	method: endpoints.createProcessInstance.method,
+});
+
 const mockGetIncidentProcessInstanceStatisticsByErrorEndpoint = createEndpointMock({
 	endpoint: endpoints.getIncidentProcessInstanceStatisticsByError.getUrl(),
 	method: endpoints.getIncidentProcessInstanceStatisticsByError.method,
@@ -171,6 +176,7 @@ export {
 	mockGetAuditLogEndpoint,
 	mockQueryUserTasksEndpoint,
 	mockQueryProcessDefinitionsEndpoint,
+	mockCreateProcessInstanceEndpoint,
 	mockGetProcessDefinitionInstanceStatisticsEndpoint,
 	mockGetIncidentProcessInstanceStatisticsByErrorEndpoint,
 	mockGetProcessDefinitionInstanceVersionStatisticsEndpoint,

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/tasklist/processes.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/tasklist/processes.tsx
@@ -17,6 +17,7 @@ import {tracking} from '#/shared/tracking';
 import {requestErrorSchema} from '#/shared/http/request';
 import {ForbiddenPage} from '#/shared/pages/ForbiddenPage';
 import {GenericErrorPage} from '#/shared/pages/GenericErrorPage';
+import {useStartProcess} from '#/tasklist/modules/processes/useStartProcess';
 
 const HTTP_STATUS_FORBIDDEN = 403;
 
@@ -57,15 +58,14 @@ export const Route = createFileRoute('/_auth/tasklist/processes')({
 	component: function TasklistProcessesRoute() {
 		const search = Route.useSearch();
 		const {data: currentUser} = useSuspenseQuery(queries.getCurrentUser());
-		const {data, error, fetchNextPage, hasNextPage, isFetchingNextPage} = useSuspenseInfiniteQuery({
-			...queries.queryProcessDefinitionsInfinite(getProcessDefinitionsRequestBody(search, currentUser.tenants)),
+		const processDefinitionsRequestBody = getProcessDefinitionsRequestBody(search, currentUser.tenants);
+		const {data, fetchNextPage, hasNextPage, isFetchingNextPage} = useSuspenseInfiniteQuery({
+			...queries.queryProcessDefinitionsInfinite(processDefinitionsRequestBody),
 			refetchInterval: 5000,
 		});
 		const processes = useMemo(() => data.pages.flatMap((page) => page.items), [data]);
-
-		if (error !== null) {
-			throw error;
-		}
+		const selectedTenantId = processDefinitionsRequestBody.filter?.tenantId;
+		const {status, selectedProcessDefinitionKey, isBusy, startProcess} = useStartProcess();
 
 		return (
 			<TasklistProcessesPage
@@ -74,6 +74,10 @@ export const Route = createFileRoute('/_auth/tasklist/processes')({
 				hasNextPage={hasNextPage}
 				isFetchingNextPage={isFetchingNextPage}
 				onLoadMore={() => fetchNextPage()}
+				selectedProcessDefinitionKey={selectedProcessDefinitionKey}
+				startProcessStatus={status}
+				isStartProcessBusy={isBusy}
+				onStartProcess={(process) => startProcess(process, selectedTenantId)}
 			/>
 		);
 	},

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
@@ -22,6 +22,7 @@ import {
 	type CreateDecisionInstancesDeletionBatchOperationRequestBody,
 	type AssignTaskRequestBody,
 	type CompleteTaskRequestBody,
+	type CreateProcessInstanceRequestBody,
 	type QueryUserTaskAuditLogsRequestBody,
 	type QueryAuditLogsRequestBody,
 	type UserTask,
@@ -154,6 +155,14 @@ const endpoints = {
 		new Request(getFullURL(unifiedAPIEndpoints.queryProcessDefinitions.getUrl()), {
 			...BASE_REQUEST_OPTIONS,
 			method: unifiedAPIEndpoints.queryProcessDefinitions.method,
+			body: JSON.stringify(body),
+			headers: {'Content-Type': 'application/json'},
+		}),
+
+	createProcessInstance: (body: CreateProcessInstanceRequestBody) =>
+		new Request(getFullURL(unifiedAPIEndpoints.createProcessInstance.getUrl()), {
+			...BASE_REQUEST_OPTIONS,
+			method: unifiedAPIEndpoints.createProcessInstance.method,
 			body: JSON.stringify(body),
 			headers: {'Content-Type': 'application/json'},
 		}),

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/processes/components/ProcessTile.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/processes/components/ProcessTile.test.tsx
@@ -8,8 +8,9 @@
 
 import {createProcessDefinition} from '#/shared-test-modules/api-mocks/process-definitions';
 import {it} from '#/vitest-modules/test-extend';
-import {describe, expect} from 'vitest';
+import {describe, expect, vi} from 'vitest';
 import {render} from 'vitest-browser-react';
+import {userEvent} from 'vitest/browser';
 import {ProcessTile} from './ProcessTile';
 
 describe('<ProcessTile />', () => {
@@ -17,6 +18,9 @@ describe('<ProcessTile />', () => {
 		const screen = await render(
 			<ProcessTile
 				process={createProcessDefinition({name: 'Invoice review', processDefinitionId: 'invoice-review'})}
+				status="inactive"
+				isStartButtonDisabled={false}
+				onStartProcess={vi.fn()}
 			/>,
 		);
 
@@ -26,7 +30,12 @@ describe('<ProcessTile />', () => {
 
 	it('should use the process-definition ID when the process has no name', async () => {
 		const screen = await render(
-			<ProcessTile process={createProcessDefinition({name: null, processDefinitionId: 'invoice-review'})} />,
+			<ProcessTile
+				process={createProcessDefinition({name: null, processDefinitionId: 'invoice-review'})}
+				status="inactive"
+				isStartButtonDisabled={false}
+				onStartProcess={vi.fn()}
+			/>,
 		);
 
 		await expect.element(screen.getByRole('heading', {name: 'invoice-review'})).toBeVisible();
@@ -35,15 +44,90 @@ describe('<ProcessTile />', () => {
 
 	it('should display whether the process requires form input', async () => {
 		const screen = await render(
-			<ProcessTile process={createProcessDefinition({name: 'Invoice review', hasStartForm: true})} />,
+			<ProcessTile
+				process={createProcessDefinition({name: 'Invoice review', hasStartForm: true})}
+				status="inactive"
+				isStartButtonDisabled={false}
+				onStartProcess={vi.fn()}
+			/>,
 		);
 
 		await expect.element(screen.getByText('Requires form input')).toBeVisible();
 	});
 
 	it('should display the start-process button', async () => {
-		const screen = await render(<ProcessTile process={createProcessDefinition()} />);
+		const screen = await render(
+			<ProcessTile
+				process={createProcessDefinition()}
+				status="inactive"
+				isStartButtonDisabled={false}
+				onStartProcess={vi.fn()}
+			/>,
+		);
 
 		await expect.element(screen.getByRole('button', {name: 'Start process'})).toBeVisible();
+	});
+
+	it('should call onStartProcess when the start-process button is clicked', async () => {
+		const onStartProcess = vi.fn();
+		const screen = await render(
+			<ProcessTile
+				process={createProcessDefinition()}
+				status="inactive"
+				isStartButtonDisabled={false}
+				onStartProcess={onStartProcess}
+			/>,
+		);
+
+		await userEvent.click(screen.getByRole('button', {name: 'Start process'}));
+
+		expect(onStartProcess).toHaveBeenCalledOnce();
+	});
+
+	it('should disable the start-process button', async () => {
+		const screen = await render(
+			<ProcessTile
+				process={createProcessDefinition()}
+				status="inactive"
+				isStartButtonDisabled
+				onStartProcess={vi.fn()}
+			/>,
+		);
+
+		await expect.element(screen.getByRole('button', {name: 'Start process'})).toBeDisabled();
+	});
+
+	it('should display the starting-process status', async () => {
+		const screen = await render(
+			<ProcessTile
+				process={createProcessDefinition()}
+				status="active"
+				isStartButtonDisabled
+				onStartProcess={vi.fn()}
+			/>,
+		);
+
+		await expect.element(screen.getByText('Starting process...')).toBeVisible();
+	});
+
+	it('should display the process-started status', async () => {
+		const screen = await render(
+			<ProcessTile
+				process={createProcessDefinition()}
+				status="finished"
+				isStartButtonDisabled
+				onStartProcess={vi.fn()}
+			/>,
+		);
+
+		await expect.element(screen.getByText('Process started')).toBeVisible();
+	});
+
+	it('should display the process-start-failed status', async () => {
+		const screen = await render(
+			<ProcessTile process={createProcessDefinition()} status="error" isStartButtonDisabled onStartProcess={vi.fn()} />,
+		);
+
+		await expect.element(screen.getByText('Process start failed')).toBeVisible();
 	});
 });

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/processes/components/ProcessTile.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/processes/components/ProcessTile.tsx
@@ -7,18 +7,62 @@
  */
 
 import type {ProcessDefinition} from '@camunda/camunda-api-zod-schemas/8.10';
-import {Button, Stack, Tag} from '@carbon/react';
+import {Stack, Tag} from '@carbon/react';
 import {ArrowRight, List} from '@carbon/react/icons';
+import {t as _t} from 'i18next';
 import {useTranslation} from 'react-i18next';
+import {AsyncActionButton} from '#/tasklist/modules/task-details/components/AsyncActionButton/AsyncActionButton';
+import type {StartProcessStatus} from '#/tasklist/modules/processes/useStartProcess';
 import styles from './ProcessTile.module.scss';
+import {useMemo} from 'react';
 
 type Props = {
 	process: ProcessDefinition;
+	status: StartProcessStatus;
+	isStartButtonDisabled: boolean;
+	onStartProcess: () => void;
 };
 
-function ProcessTile({process}: Props) {
+function getStartProcessStatusDescription(status: StartProcessStatus): string | undefined {
+	if (status === 'active') {
+		return _t('tasklist.processesStartProcessPendingStatusText');
+	}
+
+	if (status === 'finished') {
+		return _t('tasklist.processesStartProcessSuccess');
+	}
+
+	if (status === 'error') {
+		return _t('tasklist.processesStartProcessFailed');
+	}
+
+	return undefined;
+}
+
+const ProcessTile: React.FC<Props> = ({process, status, isStartButtonDisabled, onStartProcess}) => {
 	const {t} = useTranslation();
 	const displayName = process.name ?? process.processDefinitionId;
+	const statusDescription = getStartProcessStatusDescription(status);
+	const buttonProps = useMemo(
+		() =>
+			({
+				type: 'button',
+				kind: 'tertiary',
+				size: 'sm',
+				renderIcon: process.hasStartForm ? ArrowRight : undefined,
+				disabled: isStartButtonDisabled,
+				onClick: onStartProcess,
+			}) as const,
+		[process.hasStartForm, isStartButtonDisabled, onStartProcess],
+	);
+	const inlineLoadingProps = useMemo(
+		() =>
+			({
+				description: statusDescription,
+				'aria-live': status === 'error' || status === 'finished' ? 'assertive' : 'polite',
+			}) as const,
+		[status, statusDescription],
+	);
 
 	return (
 		<div className={styles.container}>
@@ -45,13 +89,13 @@ function ProcessTile({process}: Props) {
 							</li>
 						) : null}
 					</ul>
-					<Button type="button" kind="tertiary" size="sm" renderIcon={process.hasStartForm ? ArrowRight : undefined}>
+					<AsyncActionButton status={status} buttonProps={buttonProps} inlineLoadingProps={inlineLoadingProps}>
 						{t('tasklist.processesTileStartProcessButtonLabel')}
-					</Button>
+					</AsyncActionButton>
 				</div>
 			</Stack>
 		</div>
 	);
-}
+};
 
 export {ProcessTile};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/processes/useStartProcess.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/processes/useStartProcess.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {createActor, waitFor} from 'xstate';
+import {HttpResponse} from 'msw';
+import {afterEach, beforeEach, describe, expect} from 'vitest';
+import {it} from '#/vitest-modules/test-extend';
+import {createProcessDefinition} from '#/shared-test-modules/api-mocks/process-definitions';
+import {createProcessInstanceResponse} from '#/shared-test-modules/api-mocks/process-instances';
+import {createSystemConfiguration} from '#/shared-test-modules/api-mocks/system-configuration';
+import {mockCreateProcessInstanceEndpoint} from '#/shared-test-modules/mock-handlers';
+import {notificationsStore} from '#/shared/notifications/notifications.store';
+import {startProcessMachine} from './useStartProcess';
+
+describe('startProcessMachine', () => {
+	beforeEach(() => {
+		sessionStorage.setItem('clientConfig', JSON.stringify(createSystemConfiguration()));
+	});
+
+	afterEach(() => {
+		notificationsStore.reset();
+		sessionStorage.clear();
+	});
+
+	it('should start a process and reset after displaying the success state', async ({worker}) => {
+		const process = createProcessDefinition();
+		worker.use(
+			mockCreateProcessInstanceEndpoint({
+				successResponse: HttpResponse.json(createProcessInstanceResponse()),
+			}),
+		);
+		const actor = createActor(startProcessMachine).start();
+
+		actor.send({type: 'process.start', process, tenantId: '<default>'});
+
+		await waitFor(actor, (snapshot) => snapshot.matches('Succeeded'));
+		expect(actor.getSnapshot().context.selectedProcess).toEqual(process);
+		expect(notificationsStore.notifications[0]?.title).toBe('Process has started');
+
+		await waitFor(actor, (snapshot) => snapshot.matches('Idle'));
+		expect(actor.getSnapshot().context.selectedProcess).toBeNull();
+		actor.stop();
+	});
+
+	it('should display a failure state and notify the user before resetting', async ({worker}) => {
+		const process = createProcessDefinition({name: 'Invoice review'});
+		worker.use(
+			mockCreateProcessInstanceEndpoint({
+				successResponse: new HttpResponse(null, {status: 500}),
+			}),
+		);
+		const actor = createActor(startProcessMachine).start();
+
+		actor.send({type: 'process.start', process, tenantId: '<default>'});
+
+		await waitFor(actor, (snapshot) => snapshot.matches('Failed'));
+		expect(notificationsStore.notifications).toHaveLength(0);
+
+		await waitFor(actor, (snapshot) => snapshot.matches('Idle'));
+		expect(notificationsStore.notifications[0]?.title).toBe('Process start failed');
+		expect(notificationsStore.notifications[0]?.subtitle).toBe('Invoice review');
+		expect(actor.getSnapshot().context.selectedProcess).toBeNull();
+		actor.stop();
+	});
+
+	it('should display a permission error notification when process start is forbidden', async ({worker}) => {
+		const process = createProcessDefinition({name: 'Invoice review'});
+		worker.use(
+			mockCreateProcessInstanceEndpoint({
+				successResponse: new HttpResponse(null, {status: 403}),
+			}),
+		);
+		const actor = createActor(startProcessMachine).start();
+
+		actor.send({type: 'process.start', process, tenantId: '<default>'});
+
+		await waitFor(actor, (snapshot) => snapshot.matches('Failed'));
+		expect(notificationsStore.notifications).toHaveLength(0);
+
+		await waitFor(actor, (snapshot) => snapshot.matches('Idle'));
+		const notification = notificationsStore.notifications[0];
+		expect(notification?.title).toBe('Process start failed');
+		expect(notification?.subtitle).toBe(
+			"You don't have the necessary permissions. Contact your admin to request access.",
+		);
+		expect(notification?.isDismissable).toBe(true);
+		expect(notification?.subtitle).not.toBe('Invoice review');
+		expect(actor.getSnapshot().context.selectedProcess).toBeNull();
+		expect(actor.getSnapshot().context.failureReason).toBeNull();
+		actor.stop();
+	});
+
+	it('should ignore processes that require a start form', () => {
+		const actor = createActor(startProcessMachine).start();
+
+		actor.send({
+			type: 'process.start',
+			process: createProcessDefinition({hasStartForm: true}),
+			tenantId: '<default>',
+		});
+
+		expect(actor.getSnapshot().matches('Idle')).toBe(true);
+		expect(actor.getSnapshot().context.selectedProcess).toBeNull();
+		actor.stop();
+	});
+
+	it('should ignore another process while a process start is in progress', async ({worker}) => {
+		const selectedProcess = createProcessDefinition({processDefinitionKey: '1'});
+		worker.use(
+			mockCreateProcessInstanceEndpoint({
+				delay: 100,
+				successResponse: HttpResponse.json(createProcessInstanceResponse()),
+			}),
+		);
+		const actor = createActor(startProcessMachine).start();
+
+		actor.send({type: 'process.start', process: selectedProcess, tenantId: '<default>'});
+		actor.send({
+			type: 'process.start',
+			process: createProcessDefinition({processDefinitionKey: '2'}),
+			tenantId: '<default>',
+		});
+
+		expect(actor.getSnapshot().matches('Starting')).toBe(true);
+		expect(actor.getSnapshot().context.selectedProcess).toEqual(selectedProcess);
+		await waitFor(actor, (snapshot) => snapshot.matches('Succeeded'));
+		actor.stop();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/processes/useStartProcess.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/processes/useStartProcess.ts
@@ -1,0 +1,222 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useActorRef, useSelector} from '@xstate/react';
+import {t} from 'i18next';
+import {useCallback} from 'react';
+import {assign, fromPromise, setup, type SnapshotFrom} from 'xstate';
+import type {CreateProcessInstanceResponseBody, ProcessDefinition} from '@camunda/camunda-api-zod-schemas/8.10';
+import {endpoints} from '#/shared/http/endpoints';
+import {request, requestErrorSchema} from '#/shared/http/request';
+import {notificationsStore} from '#/shared/notifications/notifications.store';
+import {getClientConfig} from '#/shared/config/getClientConfig';
+
+const HTTP_STATUS_FORBIDDEN = 403;
+
+type StartProcessStatus = 'inactive' | 'active' | 'finished' | 'error';
+type StartProcessFailureReason = 'forbidden' | 'generic';
+
+type StartProcessContext = {
+	selectedProcess: ProcessDefinition | null;
+	selectedTenantId: string | undefined;
+	failureReason: StartProcessFailureReason | null;
+};
+
+type StartProcessEvent = {
+	type: 'process.start';
+	process: ProcessDefinition;
+	tenantId: string | undefined;
+};
+
+type StartProcessStatusTag = 'status:starting' | 'status:start_succeeded' | 'status:start_failed';
+
+function getStartProcessFailureReason(error: unknown): StartProcessFailureReason {
+	const result = requestErrorSchema.safeParse(error);
+
+	if (
+		result.success &&
+		result.data.variant === 'failed-response' &&
+		result.data.response.status === HTTP_STATUS_FORBIDDEN
+	) {
+		return 'forbidden';
+	}
+
+	return 'generic';
+}
+
+const createProcessInstanceLogic = fromPromise<
+	CreateProcessInstanceResponseBody,
+	{processDefinitionKey: string; tenantId: string | undefined}
+>(async ({input}) => {
+	const {response, error} = await request(endpoints.createProcessInstance(input));
+
+	if (error !== null) {
+		throw error;
+	}
+
+	return response.json();
+});
+
+const startProcessMachine = setup({
+	types: {
+		context: {} as StartProcessContext,
+		events: {} as StartProcessEvent,
+		tags: {} as StartProcessStatusTag,
+	},
+	actors: {
+		createProcessInstance: createProcessInstanceLogic,
+	},
+	guards: {
+		doesNotRequireStartForm: ({event}) => !event.process.hasStartForm,
+	},
+	actions: {
+		selectProcess: assign(({event}) => ({
+			selectedProcess: event.process,
+			selectedTenantId: event.tenantId,
+		})),
+		clearSelectedProcess: assign({
+			selectedProcess: null,
+			selectedTenantId: undefined,
+			failureReason: null,
+		}),
+		setFailureReason: assign((_, params: {error: unknown}) => ({
+			failureReason: getStartProcessFailureReason(params.error),
+		})),
+		notifySuccess: () => {
+			notificationsStore.displayNotification({
+				kind: 'success',
+				title: t('tasklist.processesStartProcessNotificationSuccess'),
+				isDismissable: true,
+			});
+		},
+		notifyFailure: ({context}) => {
+			const process = context.selectedProcess;
+
+			if (process === null) {
+				return;
+			}
+
+			if (context.failureReason === 'forbidden') {
+				notificationsStore.displayNotification({
+					kind: 'error',
+					title: t('tasklist.processesStartProcessFailed'),
+					subtitle: t('tasklist.taskActionForbidden'),
+					isDismissable: true,
+				});
+				return;
+			}
+
+			notificationsStore.displayNotification({
+				kind: 'error',
+				title:
+					getClientConfig().deployment.isMultiTenancyEnabled && context.selectedTenantId === undefined
+						? t('tasklist.processesStartProcessFailedMissingTenant')
+						: t('tasklist.processesStartProcessFailed'),
+				subtitle: process.name ?? process.processDefinitionId,
+				isDismissable: false,
+			});
+		},
+	},
+	delays: {
+		STATUS_RESET_DELAY: 500,
+	},
+}).createMachine({
+	id: 'startProcess',
+	context: {
+		selectedProcess: null,
+		selectedTenantId: undefined,
+		failureReason: null,
+	},
+	initial: 'Idle',
+	states: {
+		Idle: {
+			on: {
+				'process.start': {
+					guard: 'doesNotRequireStartForm',
+					target: 'Starting',
+					actions: 'selectProcess',
+				},
+			},
+		},
+		Starting: {
+			tags: 'status:starting',
+			invoke: {
+				src: 'createProcessInstance',
+				input: ({context}) => ({
+					processDefinitionKey: context.selectedProcess?.processDefinitionKey ?? '',
+					tenantId: context.selectedTenantId,
+				}),
+				onDone: {target: 'Succeeded'},
+				onError: {
+					target: 'Failed',
+					actions: {
+						type: 'setFailureReason',
+						params: ({event}) => ({error: event.error}),
+					},
+				},
+			},
+		},
+		Succeeded: {
+			tags: 'status:start_succeeded',
+			entry: 'notifySuccess',
+			after: {
+				STATUS_RESET_DELAY: {target: 'Idle', actions: 'clearSelectedProcess'},
+			},
+		},
+		Failed: {
+			tags: 'status:start_failed',
+			after: {
+				STATUS_RESET_DELAY: {
+					target: 'Idle',
+					actions: ['notifyFailure', 'clearSelectedProcess'],
+				},
+			},
+		},
+	},
+});
+
+function deriveStartProcessStatus(snapshot: SnapshotFrom<typeof startProcessMachine>): StartProcessStatus {
+	if (snapshot.hasTag('status:starting')) {
+		return 'active';
+	}
+
+	if (snapshot.hasTag('status:start_succeeded')) {
+		return 'finished';
+	}
+
+	if (snapshot.hasTag('status:start_failed')) {
+		return 'error';
+	}
+
+	return 'inactive';
+}
+
+function useStartProcess() {
+	const actorRef = useActorRef(startProcessMachine);
+	const status = useSelector(actorRef, deriveStartProcessStatus);
+	const selectedProcessDefinitionKey = useSelector(
+		actorRef,
+		(snapshot) => snapshot.context.selectedProcess?.processDefinitionKey ?? null,
+	);
+	const startProcess = useCallback(
+		(process: ProcessDefinition, tenantId: string | undefined) => {
+			actorRef.send({type: 'process.start', process, tenantId});
+		},
+		[actorRef],
+	);
+
+	return {
+		status,
+		selectedProcessDefinitionKey,
+		isBusy: status !== 'inactive',
+		startProcess,
+	};
+}
+
+export {startProcessMachine, useStartProcess};
+export type {StartProcessStatus};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/pages/TasklistProcessesPage.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/pages/TasklistProcessesPage.test.tsx
@@ -14,15 +14,8 @@ import {it} from '#/vitest-modules/test-extend';
 import {renderWithRouter} from '#/vitest-modules/render-with-router';
 import {HttpResponse} from 'msw';
 import {afterEach, beforeEach, describe, expect, vi} from 'vitest';
+import {userEvent} from 'vitest/browser';
 import {TasklistProcessesPage} from './TasklistProcessesPage';
-
-const defaultProps = {
-	initialFilterValues: {},
-	processes: [],
-	hasNextPage: false,
-	isFetchingNextPage: false,
-	onLoadMore: vi.fn(),
-};
 
 describe('<TasklistProcessesPage />', () => {
 	beforeEach(() => {
@@ -38,11 +31,18 @@ describe('<TasklistProcessesPage />', () => {
 		const screen = await renderWithRouter(
 			() => (
 				<TasklistProcessesPage
-					{...defaultProps}
+					initialFilterValues={{}}
 					processes={[
 						createProcessDefinition({name: 'Invoice review', processDefinitionKey: '1'}),
 						createProcessDefinition({name: 'Order approval', processDefinitionKey: '2'}),
 					]}
+					hasNextPage={false}
+					isFetchingNextPage={false}
+					onLoadMore={vi.fn()}
+					selectedProcessDefinitionKey={null}
+					startProcessStatus="inactive"
+					isStartProcessBusy={false}
+					onStartProcess={vi.fn()}
 				/>
 			),
 			{path: '/tasklist/processes'},
@@ -54,9 +54,22 @@ describe('<TasklistProcessesPage />', () => {
 
 	it('should display the unpublished-processes empty state', async ({worker}) => {
 		worker.use(mockCurrentUserEndpoint({successResponse: HttpResponse.json(createCurrentUser())}));
-		const screen = await renderWithRouter(() => <TasklistProcessesPage {...defaultProps} />, {
-			path: '/tasklist/processes',
-		});
+		const screen = await renderWithRouter(
+			() => (
+				<TasklistProcessesPage
+					initialFilterValues={{}}
+					processes={[]}
+					hasNextPage={false}
+					isFetchingNextPage={false}
+					onLoadMore={vi.fn()}
+					selectedProcessDefinitionKey={null}
+					startProcessStatus="inactive"
+					isStartProcessBusy={false}
+					onStartProcess={vi.fn()}
+				/>
+			),
+			{path: '/tasklist/processes'},
+		);
 
 		await expect.element(screen.getByRole('heading', {name: 'No published processes yet'})).toBeVisible();
 		await expect.element(screen.getByRole('img')).toBeVisible();
@@ -65,7 +78,19 @@ describe('<TasklistProcessesPage />', () => {
 	it('should display the no-matching-process empty state for a filtered list', async ({worker}) => {
 		worker.use(mockCurrentUserEndpoint({successResponse: HttpResponse.json(createCurrentUser())}));
 		const screen = await renderWithRouter(
-			() => <TasklistProcessesPage {...defaultProps} initialFilterValues={{search: 'missing'}} />,
+			() => (
+				<TasklistProcessesPage
+					initialFilterValues={{search: 'missing'}}
+					processes={[]}
+					hasNextPage={false}
+					isFetchingNextPage={false}
+					onLoadMore={vi.fn()}
+					selectedProcessDefinitionKey={null}
+					startProcessStatus="inactive"
+					isStartProcessBusy={false}
+					onStartProcess={vi.fn()}
+				/>
+			),
 			{path: '/tasklist/processes'},
 		);
 
@@ -76,9 +101,22 @@ describe('<TasklistProcessesPage />', () => {
 
 	it('should link to the process publishing documentation', async ({worker}) => {
 		worker.use(mockCurrentUserEndpoint({successResponse: HttpResponse.json(createCurrentUser())}));
-		const screen = await renderWithRouter(() => <TasklistProcessesPage {...defaultProps} />, {
-			path: '/tasklist/processes',
-		});
+		const screen = await renderWithRouter(
+			() => (
+				<TasklistProcessesPage
+					initialFilterValues={{}}
+					processes={[]}
+					hasNextPage={false}
+					isFetchingNextPage={false}
+					onLoadMore={vi.fn()}
+					selectedProcessDefinitionKey={null}
+					startProcessStatus="inactive"
+					isStartProcessBusy={false}
+					onStartProcess={vi.fn()}
+				/>
+			),
+			{path: '/tasklist/processes'},
+		);
 
 		await expect
 			.element(screen.getByRole('link', {name: 'here'}))
@@ -91,10 +129,102 @@ describe('<TasklistProcessesPage />', () => {
 	it('should display the load-more button when more processes are available', async ({worker}) => {
 		worker.use(mockCurrentUserEndpoint({successResponse: HttpResponse.json(createCurrentUser())}));
 		const screen = await renderWithRouter(
-			() => <TasklistProcessesPage {...defaultProps} processes={[createProcessDefinition()]} hasNextPage />,
+			() => (
+				<TasklistProcessesPage
+					initialFilterValues={{}}
+					processes={[createProcessDefinition()]}
+					hasNextPage
+					isFetchingNextPage={false}
+					onLoadMore={vi.fn()}
+					selectedProcessDefinitionKey={null}
+					startProcessStatus="inactive"
+					isStartProcessBusy={false}
+					onStartProcess={vi.fn()}
+				/>
+			),
 			{path: '/tasklist/processes'},
 		);
 
 		await expect.element(screen.getByRole('button', {name: 'Load more'})).toBeVisible();
+	});
+
+	it('should call onStartProcess with the selected process', async ({worker}) => {
+		worker.use(mockCurrentUserEndpoint({successResponse: HttpResponse.json(createCurrentUser())}));
+		const process = createProcessDefinition({name: 'Invoice review'});
+		const onStartProcess = vi.fn();
+		const screen = await renderWithRouter(
+			() => (
+				<TasklistProcessesPage
+					initialFilterValues={{}}
+					processes={[process]}
+					hasNextPage={false}
+					isFetchingNextPage={false}
+					onLoadMore={vi.fn()}
+					selectedProcessDefinitionKey={null}
+					startProcessStatus="inactive"
+					isStartProcessBusy={false}
+					onStartProcess={onStartProcess}
+				/>
+			),
+			{path: '/tasklist/processes'},
+		);
+
+		await userEvent.click(screen.getByRole('button', {name: 'Start process'}));
+
+		expect(onStartProcess).toHaveBeenCalledWith(process);
+	});
+
+	it('should display the start status only for the selected process', async ({worker}) => {
+		worker.use(mockCurrentUserEndpoint({successResponse: HttpResponse.json(createCurrentUser())}));
+		const screen = await renderWithRouter(
+			() => (
+				<TasklistProcessesPage
+					initialFilterValues={{}}
+					processes={[
+						createProcessDefinition({name: 'Invoice review', processDefinitionKey: '1'}),
+						createProcessDefinition({name: 'Order approval', processDefinitionKey: '2'}),
+					]}
+					hasNextPage={false}
+					isFetchingNextPage={false}
+					onLoadMore={vi.fn()}
+					selectedProcessDefinitionKey="1"
+					startProcessStatus="active"
+					isStartProcessBusy
+					onStartProcess={vi.fn()}
+				/>
+			),
+			{path: '/tasklist/processes'},
+		);
+
+		await expect.element(screen.getByText('Starting process...')).toHaveLength(1);
+		await expect.element(screen.getByRole('button', {name: 'Start process'})).toHaveLength(1);
+	});
+
+	it('should disable all start-process buttons while a process start is busy', async ({worker}) => {
+		worker.use(mockCurrentUserEndpoint({successResponse: HttpResponse.json(createCurrentUser())}));
+		const screen = await renderWithRouter(
+			() => (
+				<TasklistProcessesPage
+					initialFilterValues={{}}
+					processes={[
+						createProcessDefinition({name: 'Invoice review', processDefinitionKey: '1'}),
+						createProcessDefinition({name: 'Order approval', processDefinitionKey: '2'}),
+					]}
+					hasNextPage={false}
+					isFetchingNextPage={false}
+					onLoadMore={vi.fn()}
+					selectedProcessDefinitionKey={null}
+					startProcessStatus="inactive"
+					isStartProcessBusy
+					onStartProcess={vi.fn()}
+				/>
+			),
+			{path: '/tasklist/processes'},
+		);
+
+		const startButtons = screen.getByRole('button', {name: 'Start process'});
+		await expect.element(startButtons).toHaveLength(2);
+		await expect.element(startButtons.first()).toBeDisabled();
+		await expect.element(startButtons.last()).toBeDisabled();
 	});
 });

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/pages/TasklistProcessesPage.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/pages/TasklistProcessesPage.tsx
@@ -9,6 +9,7 @@
 import EmptyMessageImage from '#/tasklist/modules/processes/empty-message-image.svg';
 import {ProcessesFilters} from '#/tasklist/modules/processes/components/ProcessesFilters';
 import {ProcessTile} from '#/tasklist/modules/processes/components/ProcessTile';
+import type {StartProcessStatus} from '#/tasklist/modules/processes/useStartProcess';
 import {C3EmptyState} from '@camunda/camunda-composite-components';
 import {Button, Column, Grid, Layer, Link, Stack} from '@carbon/react';
 import type {ProcessDefinition} from '@camunda/camunda-api-zod-schemas/8.10';
@@ -23,6 +24,10 @@ type Props = {
 	hasNextPage: boolean;
 	isFetchingNextPage: boolean;
 	onLoadMore: () => void;
+	selectedProcessDefinitionKey: string | null;
+	startProcessStatus: StartProcessStatus;
+	isStartProcessBusy: boolean;
+	onStartProcess: (process: ProcessDefinition) => void;
 };
 
 const TasklistProcessesPage: React.FC<Props> = ({
@@ -31,6 +36,10 @@ const TasklistProcessesPage: React.FC<Props> = ({
 	hasNextPage,
 	isFetchingNextPage,
 	onLoadMore,
+	selectedProcessDefinitionKey,
+	startProcessStatus,
+	isStartProcessBusy,
+	onStartProcess,
 }) => {
 	const {t} = useTranslation();
 	const isFiltered = initialFilterValues.search !== undefined && initialFilterValues.search !== '';
@@ -91,7 +100,16 @@ const TasklistProcessesPage: React.FC<Props> = ({
 											lg={5}
 											key={process.processDefinitionKey}
 										>
-											<ProcessTile process={process} />
+											<ProcessTile
+												process={process}
+												status={
+													selectedProcessDefinitionKey === process.processDefinitionKey
+														? startProcessStatus
+														: 'inactive'
+												}
+												isStartButtonDisabled={isStartProcessBusy}
+												onStartProcess={() => onStartProcess(process)}
+											/>
 										</Column>
 									))}
 								</Grid>

--- a/webapp/client/apps/orchestration-cluster-webapp/test/integration/tasklist/tasklist-processes.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/integration/tasklist/tasklist-processes.test.ts
@@ -10,6 +10,7 @@ import {test, expect} from '#/pw-modules/test-extend';
 import {HttpResponse} from 'msw';
 import {
 	mockCurrentUserEndpoint,
+	mockCreateProcessInstanceEndpoint,
 	mockLicenseEndpoint,
 	mockQueryProcessDefinitionsEndpoint,
 	mockQueryUserTasksEndpoint,
@@ -23,6 +24,7 @@ import {
 	createQueryProcessDefinitionsResponse,
 } from '#/shared-test-modules/api-mocks/process-definitions';
 import {createQueryUserTasksResponse} from '#/shared-test-modules/api-mocks/user-tasks';
+import {createProcessInstanceResponse} from '#/shared-test-modules/api-mocks/process-instances';
 import {z} from 'zod';
 
 function createProcessDefinitionsRequestSchema(filter: Record<string, z.ZodType> = {}) {
@@ -52,6 +54,137 @@ test.beforeEach(({network}) => {
 });
 
 test.describe('Tasklist processes page', () => {
+	test('should start a process without a form using the selected tenant', async ({network, tasklistProcessesPage}) => {
+		const processDefinitionKey = '2251799813685279';
+		const tenants = [
+			{tenantId: '<default>', name: 'Default', description: null},
+			{tenantId: 'tenant-a', name: 'Tenant A', description: null},
+		];
+		network.use(
+			mockCurrentUserEndpoint({successResponse: HttpResponse.json(createCurrentUser({tenants}))}),
+			mockQueryProcessDefinitionsEndpoint({
+				schema: createProcessDefinitionsRequestSchema({tenantId: z.literal('tenant-a')}),
+				successResponse: HttpResponse.json(
+					createQueryProcessDefinitionsResponse({
+						items: [
+							createProcessDefinition({
+								name: 'Invoice review',
+								processDefinitionKey,
+								tenantId: 'tenant-a',
+							}),
+						],
+					}),
+				),
+				failureResponse: new HttpResponse(null, {status: 400}),
+			}),
+			mockCreateProcessInstanceEndpoint({
+				schema: z.strictObject({
+					processDefinitionKey: z.literal(processDefinitionKey),
+					tenantId: z.literal('tenant-a'),
+				}),
+				successResponse: HttpResponse.json(createProcessInstanceResponse({processDefinitionKey, tenantId: 'tenant-a'})),
+				failureResponse: new HttpResponse(null, {status: 400}),
+			}),
+		);
+
+		await tasklistProcessesPage.goto('?tenantId=tenant-a');
+		await tasklistProcessesPage.startProcessButton.click();
+
+		await expect(
+			tasklistProcessesPage.header.notifications.getByNotificationTitle('Process has started'),
+		).toBeVisible();
+	});
+
+	test('should notify the user when starting a process fails', async ({network, tasklistProcessesPage}) => {
+		const processDefinitionKey = '2251799813685279';
+		network.use(
+			mockCurrentUserEndpoint({
+				successResponse: HttpResponse.json(
+					createCurrentUser({
+						tenants: [{tenantId: '<default>', name: 'Default', description: null}],
+					}),
+				),
+			}),
+			mockQueryProcessDefinitionsEndpoint({
+				schema: createProcessDefinitionsRequestSchema({tenantId: z.literal('<default>')}),
+				successResponse: HttpResponse.json(
+					createQueryProcessDefinitionsResponse({
+						items: [
+							createProcessDefinition({
+								name: 'Invoice review',
+								processDefinitionKey,
+							}),
+						],
+					}),
+				),
+				failureResponse: new HttpResponse(null, {status: 400}),
+			}),
+			mockCreateProcessInstanceEndpoint({
+				schema: z.strictObject({
+					processDefinitionKey: z.literal(processDefinitionKey),
+					tenantId: z.literal('<default>'),
+				}),
+				successResponse: new HttpResponse(null, {status: 500}),
+				failureResponse: new HttpResponse(null, {status: 400}),
+			}),
+		);
+
+		await tasklistProcessesPage.goto();
+		await tasklistProcessesPage.startProcessButton.click();
+
+		const notification = tasklistProcessesPage.header.notifications.getByNotificationTitle('Process start failed');
+		await expect(notification).toBeVisible();
+		await expect(notification).toContainText('Invoice review');
+	});
+
+	test('should notify the user when they do not have permission to start a process', async ({
+		network,
+		tasklistProcessesPage,
+	}) => {
+		const processDefinitionKey = '2251799813685279';
+		network.use(
+			mockCurrentUserEndpoint({
+				successResponse: HttpResponse.json(
+					createCurrentUser({
+						tenants: [{tenantId: '<default>', name: 'Default', description: null}],
+					}),
+				),
+			}),
+			mockQueryProcessDefinitionsEndpoint({
+				schema: createProcessDefinitionsRequestSchema({tenantId: z.literal('<default>')}),
+				successResponse: HttpResponse.json(
+					createQueryProcessDefinitionsResponse({
+						items: [
+							createProcessDefinition({
+								name: 'Invoice review',
+								processDefinitionKey,
+							}),
+						],
+					}),
+				),
+				failureResponse: new HttpResponse(null, {status: 400}),
+			}),
+			mockCreateProcessInstanceEndpoint({
+				schema: z.strictObject({
+					processDefinitionKey: z.literal(processDefinitionKey),
+					tenantId: z.literal('<default>'),
+				}),
+				successResponse: new HttpResponse(null, {status: 403}),
+				failureResponse: new HttpResponse(null, {status: 400}),
+			}),
+		);
+
+		await tasklistProcessesPage.goto();
+		await tasklistProcessesPage.startProcessButton.click();
+
+		const notification = tasklistProcessesPage.header.notifications.getByNotificationTitle('Process start failed');
+		await expect(notification).toContainText(
+			"You don't have the necessary permissions. Contact your admin to request access.",
+		);
+		await expect(notification).not.toContainText('Invoice review');
+		await expect(tasklistProcessesPage.startProcessButton).toBeEnabled();
+	});
+
 	test('should render Tasklist Processes page with navigation', async ({tasklistProcessesPage}) => {
 		await tasklistProcessesPage.goto();
 
@@ -96,7 +229,7 @@ test.describe('Tasklist processes page', () => {
 		await expect(page.getByText('invoice-review', {exact: true})).toBeVisible();
 		await expect(tasklistProcessesPage.processHeading('order-approval')).toBeVisible();
 		await expect(page.getByText('Requires form input')).toBeVisible();
-		await expect(page.getByRole('button', {name: 'Start process'})).toHaveCount(2);
+		await expect(tasklistProcessesPage.startProcessButton).toHaveCount(2);
 		await expect(tasklistProcessesPage.loadMoreButton).toBeVisible();
 	});
 

--- a/webapp/client/apps/orchestration-cluster-webapp/test/pages/TasklistProcesses.page.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/pages/TasklistProcesses.page.ts
@@ -65,6 +65,10 @@ class TasklistProcessesPage extends BasePage {
 	processHeading(name: string) {
 		return this.page.getByRole('heading', {name});
 	}
+
+	get startProcessButton() {
+		return this.page.getByRole('button', {name: 'Start process'});
+	}
 }
 
 export {TasklistProcessesPage};


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Migrates process start flow to unified webapp

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53954
