### PR TITLE
fix: reject over-long entity names before they reach the index

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/providers/OptimizeExceptionMapper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/providers/OptimizeExceptionMapper.java
@@ -18,6 +18,7 @@ import io.camunda.optimize.service.exceptions.OptimizeImportDefinitionDoesNotExi
 import io.camunda.optimize.service.exceptions.OptimizeImportDescriptionNotValidException;
 import io.camunda.optimize.service.exceptions.OptimizeImportForbiddenException;
 import io.camunda.optimize.service.exceptions.OptimizeImportIncorrectIndexVersionException;
+import io.camunda.optimize.service.exceptions.OptimizeImportNameNotValidException;
 import io.camunda.optimize.service.exceptions.OptimizeUserOrGroupIdNotFoundException;
 import io.camunda.optimize.service.exceptions.conflict.OptimizeConflictException;
 import org.slf4j.Logger;
@@ -49,6 +50,24 @@ public class OptimizeExceptionMapper {
 
   private ErrorResponseDto getDescriptionNotValidResponseDto(
       final OptimizeImportDescriptionNotValidException exception) {
+    final String errorCode = exception.getErrorCode();
+    final String errorMessage =
+        localizationService.getDefaultLocaleMessageForApiErrorCode(errorCode);
+    final String detailedErrorMessage = exception.getMessage();
+    return new ErrorResponseDto(errorCode, errorMessage, detailedErrorMessage);
+  }
+
+  @ExceptionHandler(OptimizeImportNameNotValidException.class)
+  public ResponseEntity<ErrorResponseDto> handleImportNameNotValidException(
+      final OptimizeImportNameNotValidException exception) {
+    LOG.info("Mapping OptimizeImportNameNotValidException");
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+        .body(getNameNotValidResponseDto(exception));
+  }
+
+  private ErrorResponseDto getNameNotValidResponseDto(
+      final OptimizeImportNameNotValidException exception) {
     final String errorCode = exception.getErrorCode();
     final String errorMessage =
         localizationService.getDefaultLocaleMessageForApiErrorCode(errorCode);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/UIConfigurationService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/UIConfigurationService.java
@@ -19,6 +19,7 @@ import io.camunda.optimize.rest.cloud.CloudSaasMetaInfoService;
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
 import io.camunda.optimize.service.metadata.OptimizeVersionService;
 import io.camunda.optimize.service.tenant.TenantService;
+import io.camunda.optimize.service.util.ValidationHelper;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.OptimizeProfile;
 import java.time.OffsetDateTime;
@@ -81,6 +82,9 @@ public class UIConfigurationService {
     uiConfigurationDto.setOptimizeProfile(optimizeProfile);
     uiConfigurationDto.setExportCsvLimit(
         configurationService.getCsvConfiguration().getExportCsvLimit());
+    uiConfigurationDto.setEntityNameMaxLength(
+        Optional.ofNullable(configurationService.getEntityConfiguration().getNameMaxLength())
+            .orElse(ValidationHelper.DEFAULT_MAX_ENTITY_NAME_LENGTH));
     uiConfigurationDto.setMaxNumDataSourcesForReport(
         configurationService.getUiConfiguration().getMaxNumDataSourcesForReport());
     uiConfigurationDto.setOptimizeDatabase(ConfigurationService.getDatabaseType(environment));

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/alert/AlertService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/alert/AlertService.java
@@ -420,6 +420,10 @@ public class AlertService implements ReportReferencingService {
 
     ValidationHelper.ensureNotEmpty(REPORT, report);
 
+    ValidationHelper.validateEntityName(
+        "Alert",
+        toCreate.getName(),
+        configurationService.getEntityConfiguration().getNameMaxLength());
     ValidationHelper.ensureNotEmpty(THRESHOLD_OPERATOR, toCreate.getThresholdOperator());
     ValidationHelper.ensureNotNull(CHECK_INTERVAL, toCreate.getCheckInterval());
     ValidationHelper.ensureNotEmpty(INTERVAL_UNIT, toCreate.getCheckInterval().getUnit());

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/collection/CollectionService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/collection/CollectionService.java
@@ -29,6 +29,8 @@ import io.camunda.optimize.service.relations.CollectionRelationService;
 import io.camunda.optimize.service.security.AuthorizedCollectionService;
 import io.camunda.optimize.service.security.util.LocalDateUtil;
 import io.camunda.optimize.service.util.IdGenerator;
+import io.camunda.optimize.service.util.ValidationHelper;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -46,6 +48,7 @@ public class CollectionService {
   private final CollectionWriter collectionWriter;
   private final CollectionReader collectionReader;
   private final AbstractIdentityService identityService;
+  private final ConfigurationService configurationService;
 
   public CollectionService(
       final AuthorizedCollectionService authorizedCollectionService,
@@ -53,17 +56,27 @@ public class CollectionService {
       final CollectionEntityService collectionEntityService,
       final CollectionWriter collectionWriter,
       final CollectionReader collectionReader,
-      final AbstractIdentityService identityService) {
+      final AbstractIdentityService identityService,
+      final ConfigurationService configurationService) {
     this.authorizedCollectionService = authorizedCollectionService;
     this.collectionRelationService = collectionRelationService;
     this.collectionEntityService = collectionEntityService;
     this.collectionWriter = collectionWriter;
     this.collectionReader = collectionReader;
     this.identityService = identityService;
+    this.configurationService = configurationService;
   }
 
   public List<CollectionDefinitionDto> getAllCollections() {
     return collectionReader.getAllCollections();
+  }
+
+  public void validateCollectionName(final String collectionName) {
+    ValidationHelper.validateEntityName("Collection", collectionName, getNameMaxLength());
+  }
+
+  private Integer getNameMaxLength() {
+    return configurationService.getEntityConfiguration().getNameMaxLength();
   }
 
   public IdResponseDto createNewCollectionAndReturnId(
@@ -72,6 +85,7 @@ public class CollectionService {
     if (!identityService.getEnabledAuthorizations().contains(AuthorizationType.ENTITY_EDITOR)) {
       throw new ForbiddenException("User is not an authorized entity editor");
     }
+    validateCollectionName(partialCollectionDefinitionDto.getName());
     return collectionWriter.createNewCollectionAndReturnId(userId, partialCollectionDefinitionDto);
   }
 
@@ -80,6 +94,7 @@ public class CollectionService {
       final PartialCollectionDefinitionRequestDto partialCollectionDefinitionDto,
       final String presetId,
       final boolean automaticallyCreated) {
+    validateCollectionName(partialCollectionDefinitionDto.getName());
     try {
       return Optional.of(
           collectionWriter.createNewCollectionAndReturnId(
@@ -117,6 +132,8 @@ public class CollectionService {
       final PartialCollectionDefinitionRequestDto collectionUpdate) {
     authorizedCollectionService.getAuthorizedCollectionAndVerifyUserAuthorizedToManageOrFail(
         userId, collectionId);
+
+    validateCollectionName(collectionUpdate.getName());
 
     final CollectionDefinitionUpdateDto updateDto = new CollectionDefinitionUpdateDto();
     updateDto.setName(collectionUpdate.getName());
@@ -175,18 +192,25 @@ public class CollectionService {
 
   public IdResponseDto copyCollection(
       final String userId, final String collectionId, final String newCollectionName) {
+    validateCollectionName(newCollectionName);
     final AuthorizedCollectionDefinitionDto oldCollection =
         authorizedCollectionService.getAuthorizedCollectionAndVerifyUserAuthorizedToManageOrFail(
             userId, collectionId);
+
+    final String copyName =
+        newCollectionName != null
+            ? newCollectionName
+            // clamped rather than rejected: Optimize generates this from a stored name, so the user
+            // cannot correct it
+            : ValidationHelper.clampGeneratedEntityName(
+                oldCollection.getDefinitionDto().getName() + " – Copy", getNameMaxLength());
 
     final CollectionDefinitionDto newCollection =
         new CollectionDefinitionDto(
             oldCollection.getDefinitionDto().getData(),
             OffsetDateTime.now(),
             IdGenerator.getNextId(),
-            newCollectionName != null
-                ? newCollectionName
-                : oldCollection.getDefinitionDto().getName() + " – Copy",
+            copyName,
             OffsetDateTime.now(),
             userId,
             userId);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/collection/CollectionService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/collection/CollectionService.java
@@ -71,7 +71,7 @@ public class CollectionService {
     return collectionReader.getAllCollections();
   }
 
-  public void validateCollectionName(final String collectionName) {
+  private void validateCollectionName(final String collectionName) {
     ValidationHelper.validateEntityName("Collection", collectionName, getNameMaxLength());
   }
 
@@ -192,10 +192,10 @@ public class CollectionService {
 
   public IdResponseDto copyCollection(
       final String userId, final String collectionId, final String newCollectionName) {
-    validateCollectionName(newCollectionName);
     final AuthorizedCollectionDefinitionDto oldCollection =
         authorizedCollectionService.getAuthorizedCollectionAndVerifyUserAuthorizedToManageOrFail(
             userId, collectionId);
+    validateCollectionName(newCollectionName);
 
     final String copyName =
         newCollectionName != null

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/DashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/DashboardService.java
@@ -194,9 +194,9 @@ public class DashboardService implements ReportReferencingService, CollectionRef
 
   public IdResponseDto copyDashboard(
       final String dashboardId, final String userId, final String name) {
-    validateDashboardName(name);
     final AuthorizedDashboardDefinitionResponseDto authorizedDashboard =
         getDashboardDefinition(dashboardId, userId);
+    validateDashboardName(name);
     final DashboardDefinitionRestDto dashboardDefinition = authorizedDashboard.getDefinitionDto();
 
     final String newDashboardName = name != null ? name : dashboardDefinition.getName() + " – Copy";

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/DashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/DashboardService.java
@@ -51,6 +51,8 @@ import io.camunda.optimize.service.report.ReportService;
 import io.camunda.optimize.service.security.AuthorizedCollectionService;
 import io.camunda.optimize.service.security.util.LocalDateUtil;
 import io.camunda.optimize.service.util.IdGenerator;
+import io.camunda.optimize.service.util.ValidationHelper;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.variable.ProcessVariableService;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -82,6 +84,7 @@ public class DashboardService implements ReportReferencingService, CollectionRef
   private final AbstractIdentityService identityService;
   private final ReportReader reportReader;
   private final DashboardRelationService dashboardRelationService;
+  private final ConfigurationService configurationService;
 
   public DashboardService(
       final DashboardWriter dashboardWriter,
@@ -91,7 +94,8 @@ public class DashboardService implements ReportReferencingService, CollectionRef
       final AuthorizedCollectionService collectionService,
       final AbstractIdentityService identityService,
       final ReportReader reportReader,
-      final DashboardRelationService dashboardRelationService) {
+      final DashboardRelationService dashboardRelationService,
+      final ConfigurationService configurationService) {
     this.dashboardWriter = dashboardWriter;
     this.dashboardReader = dashboardReader;
     this.processVariableService = processVariableService;
@@ -100,6 +104,7 @@ public class DashboardService implements ReportReferencingService, CollectionRef
     this.identityService = identityService;
     this.reportReader = reportReader;
     this.dashboardRelationService = dashboardRelationService;
+    this.configurationService = configurationService;
   }
 
   @Override
@@ -182,12 +187,14 @@ public class DashboardService implements ReportReferencingService, CollectionRef
     collectionService.verifyUserAuthorizedToEditCollectionResources(
         userId, dashboardDefinitionDto.getCollectionId());
     validateEntityEditorAuthorization(dashboardDefinitionDto.getCollectionId());
+    validateDashboardName(dashboardDefinitionDto.getName());
     validateDashboardFilters(userId, dashboardDefinitionDto);
     return dashboardWriter.createNewDashboard(userId, dashboardDefinitionDto);
   }
 
   public IdResponseDto copyDashboard(
       final String dashboardId, final String userId, final String name) {
+    validateDashboardName(name);
     final AuthorizedDashboardDefinitionResponseDto authorizedDashboard =
         getDashboardDefinition(dashboardId, userId);
     final DashboardDefinitionRestDto dashboardDefinition = authorizedDashboard.getDefinitionDto();
@@ -268,9 +275,12 @@ public class DashboardService implements ReportReferencingService, CollectionRef
     }
 
     final String newDashboardName = name != null ? name : dashboardDefinition.getName() + " – Copy";
+    // clamped rather than rejected: this may be Optimize's own " – Copy" variant of a stored name,
+    // which the user cannot correct
     final DashboardDefinitionRestDto newDashboardDefinitionDto = new DashboardDefinitionRestDto();
     newDashboardDefinitionDto.setCollectionId(collectionId);
-    newDashboardDefinitionDto.setName(newDashboardName);
+    newDashboardDefinitionDto.setName(
+        ValidationHelper.clampGeneratedEntityName(newDashboardName, getNameMaxLength()));
     newDashboardDefinitionDto.setDescription(dashboardDefinition.getDescription());
     newDashboardDefinitionDto.setTiles(newDashboardReports);
     newDashboardDefinitionDto.setAvailableFilters(dashboardDefinition.getAvailableFilters());
@@ -287,6 +297,14 @@ public class DashboardService implements ReportReferencingService, CollectionRef
             "Dashboard descriptions cannot be non-null and empty");
       }
     }
+  }
+
+  public void validateDashboardName(final String dashboardName) {
+    ValidationHelper.validateEntityName("Dashboard", dashboardName, getNameMaxLength());
+  }
+
+  private Integer getNameMaxLength() {
+    return configurationService.getEntityConfiguration().getNameMaxLength();
   }
 
   private void removeVariableFiltersFromDashboardsIfUnavailable(
@@ -446,6 +464,7 @@ public class DashboardService implements ReportReferencingService, CollectionRef
         convertToUpdateDtoWithModifier(updatedDashboard, userId);
     final String dashboardCollectionId =
         dashboardWithEditAuthorization.getDefinitionDto().getCollectionId();
+    validateDashboardName(updatedDashboard.getName());
     validateDashboardFilters(userId, updatedDashboard);
     updateDto
         .getTiles()

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/entities/dashboard/DashboardImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/entities/dashboard/DashboardImportService.java
@@ -73,6 +73,7 @@ public class DashboardImportService {
     dashboardsToImport.forEach(
         exportedDto -> {
           dashboardService.validateDashboardDescription(exportedDto.getDescription());
+          dashboardService.validateDashboardName(exportedDto.getName());
           validateDashboardFiltersOrFail(userId, exportedDto);
         });
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/entities/report/ReportImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/entities/report/ReportImportService.java
@@ -42,6 +42,7 @@ import io.camunda.optimize.service.exceptions.OptimizeImportDefinitionDoesNotExi
 import io.camunda.optimize.service.exceptions.OptimizeImportDescriptionNotValidException;
 import io.camunda.optimize.service.exceptions.OptimizeImportForbiddenException;
 import io.camunda.optimize.service.exceptions.OptimizeImportIncorrectIndexVersionException;
+import io.camunda.optimize.service.exceptions.OptimizeImportNameNotValidException;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.exceptions.OptimizeValidationException;
 import io.camunda.optimize.service.exceptions.conflict.OptimizeNonDefinitionScopeCompliantException;
@@ -130,6 +131,7 @@ public class ReportImportService {
     final Set<ConflictedItemDto> definitionsNotInScope = new HashSet<>();
     final Set<ConflictedItemDto> tenantsNotInScope = new HashSet<>();
     final Set<String> invalidReportIds = new HashSet<>();
+    final Set<String> invalidReportNameIds = new HashSet<>();
 
     reportsToImport.forEach(
         reportExportDto -> {
@@ -147,6 +149,8 @@ public class ReportImportService {
             tenantsNotInScope.addAll(e.getConflictedItems());
           } catch (final OptimizeImportDescriptionNotValidException e) {
             invalidReportIds.addAll(e.getInvalidEntityIds());
+          } catch (final OptimizeImportNameNotValidException e) {
+            invalidReportNameIds.addAll(e.getInvalidEntityIds());
           }
         });
 
@@ -181,6 +185,10 @@ public class ReportImportService {
 
     if (!invalidReportIds.isEmpty()) {
       throw new OptimizeImportDescriptionNotValidException(invalidReportIds);
+    }
+
+    if (!invalidReportNameIds.isEmpty()) {
+      throw new OptimizeImportNameNotValidException(invalidReportNameIds);
     }
   }
 
@@ -391,7 +399,11 @@ public class ReportImportService {
     } catch (final OptimizeValidationException ex) {
       throw new OptimizeImportDescriptionNotValidException(Set.of(reportToImport.getId()));
     }
-    reportService.validateReportName(reportToImport.getName());
+    try {
+      reportService.validateReportName(reportToImport.getName());
+    } catch (final OptimizeValidationException ex) {
+      throw new OptimizeImportNameNotValidException(Set.of(reportToImport.getId()));
+    }
     switch (reportToImport.getExportEntityType()) {
       case SINGLE_PROCESS_REPORT:
         final SingleProcessReportDefinitionExportDto processExport =

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/entities/report/ReportImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/entities/report/ReportImportService.java
@@ -391,6 +391,7 @@ public class ReportImportService {
     } catch (final OptimizeValidationException ex) {
       throw new OptimizeImportDescriptionNotValidException(Set.of(reportToImport.getId()));
     }
+    reportService.validateReportName(reportToImport.getName());
     switch (reportToImport.getExportEntityType()) {
       case SINGLE_PROCESS_REPORT:
         final SingleProcessReportDefinitionExportDto processExport =

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/exceptions/OptimizeImportNameNotValidException.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/exceptions/OptimizeImportNameNotValidException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.exceptions;
+
+import java.util.Set;
+
+@SuppressWarnings("squid:MaximumInheritanceDepth")
+public class OptimizeImportNameNotValidException extends OptimizeValidationException {
+
+  public static final String ERROR_CODE = "importNameInvalid";
+
+  private final Set<String> invalidEntityIds;
+
+  public OptimizeImportNameNotValidException(final Set<String> invalidEntityIds) {
+    super(
+        "Could not apply action due to invalid names. Names must be null or not exceed the configured maximum "
+            + "length. Invalid entities: "
+            + invalidEntityIds);
+    this.invalidEntityIds = invalidEntityIds;
+  }
+
+  @Override
+  public String getErrorCode() {
+    return ERROR_CODE;
+  }
+
+  public Set<String> getInvalidEntityIds() {
+    return invalidEntityIds;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/report/ReportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/report/ReportService.java
@@ -62,6 +62,7 @@ import io.camunda.optimize.service.security.AuthorizedCollectionService;
 import io.camunda.optimize.service.security.ReportAuthorizationService;
 import io.camunda.optimize.service.util.DefinitionVersionHandlingUtil;
 import io.camunda.optimize.service.util.ValidationHelper;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.util.SuppressionConstants;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -94,6 +95,7 @@ public class ReportService implements CollectionReferencingService {
   private final AuthorizedCollectionService collectionService;
   private final AbstractIdentityService identityService;
   private final DefinitionService defintionService;
+  private final ConfigurationService configurationService;
 
   public ReportService(
       final ReportWriter reportWriter,
@@ -102,7 +104,8 @@ public class ReportService implements CollectionReferencingService {
       final ReportRelationService reportRelationService,
       final AuthorizedCollectionService collectionService,
       final AbstractIdentityService identityService,
-      final DefinitionService defintionService) {
+      final DefinitionService defintionService,
+      final ConfigurationService configurationService) {
     this.reportWriter = reportWriter;
     this.reportReader = reportReader;
     this.reportAuthorizationService = reportAuthorizationService;
@@ -110,6 +113,7 @@ public class ReportService implements CollectionReferencingService {
     this.collectionService = collectionService;
     this.identityService = identityService;
     this.defintionService = defintionService;
+    this.configurationService = configurationService;
   }
 
   private static void copyDefinitionMetaDataToUpdate(
@@ -147,6 +151,7 @@ public class ReportService implements CollectionReferencingService {
       final String userId, final SingleDecisionReportDefinitionRequestDto definitionDto) {
     ensureCompliesWithCollectionScope(userId, definitionDto.getCollectionId(), definitionDto);
     validateReportDescription(definitionDto.getDescription());
+    validateReportName(definitionDto.getName());
     return createReport(
         userId,
         definitionDto,
@@ -158,6 +163,7 @@ public class ReportService implements CollectionReferencingService {
       final String userId, final SingleProcessReportDefinitionRequestDto definitionDto) {
     ensureCompliesWithCollectionScope(userId, definitionDto.getCollectionId(), definitionDto);
     validateReportDescription(definitionDto.getDescription());
+    validateReportName(definitionDto.getName());
     Optional.ofNullable(definitionDto.getData())
         .ifPresent(
             data -> {
@@ -177,6 +183,7 @@ public class ReportService implements CollectionReferencingService {
   public IdResponseDto createNewCombinedProcessReport(
       final String userId, final CombinedReportDefinitionRequestDto combinedReportDefinitionDto) {
     validateReportDescription(combinedReportDefinitionDto.getDescription());
+    validateReportName(combinedReportDefinitionDto.getName());
     verifyValidReportCombination(
         userId,
         combinedReportDefinitionDto.getCollectionId(),
@@ -197,6 +204,7 @@ public class ReportService implements CollectionReferencingService {
 
   public IdResponseDto copyReport(
       final String reportId, final String userId, final String newReportName) {
+    validateReportName(newReportName);
     final AuthorizedReportDefinitionResponseDto authorizedReportDefinition =
         getReportDefinition(reportId, userId);
     final ReportDefinitionDto oldReportDefinition = authorizedReportDefinition.getDefinitionDto();
@@ -210,6 +218,7 @@ public class ReportService implements CollectionReferencingService {
       final String userId,
       final String collectionId,
       final String newReportName) {
+    validateReportName(newReportName);
     return copyAndMoveReport(reportId, userId, collectionId, newReportName, new HashMap<>());
   }
 
@@ -378,6 +387,7 @@ public class ReportService implements CollectionReferencingService {
       final CombinedReportDefinitionRequestDto updatedReport) {
     ValidationHelper.ensureNotNull("data", updatedReport.getData());
     validateReportDescription(updatedReport.getDescription());
+    validateReportName(updatedReport.getName());
 
     final ReportDefinitionDto currentReportVersion =
         getReportDefinition(combinedReportId, userId).getDefinitionDto();
@@ -403,6 +413,7 @@ public class ReportService implements CollectionReferencingService {
     ValidationHelper.ensureNotNull("data", updatedReport.getData());
     ValidationHelper.validateProcessFilters(updatedReport.getData().getFilter());
     validateReportDescription(updatedReport.getDescription());
+    validateReportName(updatedReport.getName());
     Optional.ofNullable(updatedReport.getData().getConfiguration())
         .ifPresent(
             config -> ValidationHelper.validateAggregationTypes(config.getAggregationTypes()));
@@ -443,6 +454,7 @@ public class ReportService implements CollectionReferencingService {
       final boolean force) {
     ValidationHelper.ensureNotNull("data", updatedReport.getData());
     validateReportDescription(updatedReport.getDescription());
+    validateReportName(updatedReport.getName());
     final SingleDecisionReportDefinitionRequestDto currentReportVersion =
         getSingleDecisionReportDefinition(reportId, userId);
     getReportWithEditAuthorization(userId, currentReportVersion);
@@ -628,6 +640,14 @@ public class ReportService implements CollectionReferencingService {
     }
   }
 
+  public void validateReportName(final String reportName) {
+    ValidationHelper.validateEntityName("Report", reportName, getNameMaxLength());
+  }
+
+  private Integer getNameMaxLength() {
+    return configurationService.getEntityConfiguration().getNameMaxLength();
+  }
+
   public Optional<String> updateReportDefinitionXmlIfRequiredAndReturn(
       final ReportDefinitionDto reportDefinition) {
     // we only need to validate that the stored XML is still up to date for heatmap reports on the
@@ -675,6 +695,10 @@ public class ReportService implements CollectionReferencingService {
       final boolean keepSubReportNames) {
     final String oldCollectionId = originalReportDefinition.getCollectionId();
     validateEntityEditorAuthorization(oldCollectionId);
+    // clamped rather than rejected: by this point the name may be Optimize's own " – Copy" variant
+    // or an existing stored name, neither of which the user can correct
+    final String newName =
+        ValidationHelper.clampGeneratedEntityName(newReportName, getNameMaxLength());
 
     if (!originalReportDefinition.isCombined()) {
       switch (originalReportDefinition.getReportType()) {
@@ -686,7 +710,7 @@ public class ReportService implements CollectionReferencingService {
           return reportWriter.createNewSingleProcessReport(
               userId,
               singleProcessReportDefinitionDto.getData(),
-              newReportName,
+              newName,
               originalReportDefinition.getDescription(),
               newCollectionId);
         case DECISION:
@@ -697,7 +721,7 @@ public class ReportService implements CollectionReferencingService {
           return reportWriter.createNewSingleDecisionReport(
               userId,
               singleDecisionReportDefinitionDto.getData(),
-              newReportName,
+              newName,
               originalReportDefinition.getDescription(),
               newCollectionId);
         default:
@@ -709,7 +733,7 @@ public class ReportService implements CollectionReferencingService {
           (CombinedReportDefinitionRequestDto) originalReportDefinition;
       return copyAndMoveCombinedReport(
           userId,
-          newReportName,
+          newName,
           newCollectionId,
           oldCollectionId,
           combinedReportDefinition,

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/report/ReportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/report/ReportService.java
@@ -204,9 +204,9 @@ public class ReportService implements CollectionReferencingService {
 
   public IdResponseDto copyReport(
       final String reportId, final String userId, final String newReportName) {
-    validateReportName(newReportName);
     final AuthorizedReportDefinitionResponseDto authorizedReportDefinition =
         getReportDefinition(reportId, userId);
+    validateReportName(newReportName);
     final ReportDefinitionDto oldReportDefinition = authorizedReportDefinition.getDefinitionDto();
 
     return copyAndMoveReport(
@@ -218,6 +218,8 @@ public class ReportService implements CollectionReferencingService {
       final String userId,
       final String collectionId,
       final String newReportName) {
+    // authorize first, so the name check cannot answer whether the report exists
+    getReportDefinition(reportId, userId);
     validateReportName(newReportName);
     return copyAndMoveReport(reportId, userId, collectionId, newReportName, new HashMap<>());
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/util/ValidationHelper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/util/ValidationHelper.java
@@ -56,24 +56,16 @@ import org.slf4j.LoggerFactory;
 public final class ValidationHelper {
 
   /**
-   * Largest name length that always fits the ~32,766 byte Elasticsearch/OpenSearch term limit,
-   * since UTF-8 uses at most 4 bytes per character. Used when {@code entity.nameMaxLength} is not
-   * set.
+   * Mirrors {@code EngineConfiguration.DEFAULT_MAX_NAME_FIELD_LENGTH} in the orchestration cluster.
    */
-  public static final int DEFAULT_MAX_ENTITY_NAME_LENGTH = 8191;
+  public static final int DEFAULT_MAX_ENTITY_NAME_LENGTH = 32 * 1024;
 
   protected static final Logger LOG = LoggerFactory.getLogger(ValidationHelper.class);
 
   private ValidationHelper() {}
 
   /**
-   * Validates the length of a user-provided entity name on the write path. A {@code null} name is
-   * accepted, as entities without a name fall back to a default one when persisted.
-   *
-   * @param entityLabel the capitalised entity type used in the error message, e.g. {@code "Report"}
-   * @param name the name to validate, may be {@code null}
-   * @param maxLength the configured limit, or {@code null} to use {@link
-   *     #DEFAULT_MAX_ENTITY_NAME_LENGTH}
+   * A {@code null} name is accepted, as unnamed entities fall back to a default name when saved.
    */
   public static void validateEntityName(
       final String entityLabel, final String name, final Integer maxLength) {
@@ -85,17 +77,25 @@ public final class ValidationHelper {
   }
 
   /**
-   * Shortens a name Optimize generates itself, such as the name of a copy, so that it satisfies the
-   * configured limit. Generated names are clamped rather than rejected, because the user did not
-   * supply them and so cannot correct them.
+   * Names Optimize generates itself are clamped, as the user cannot correct what they didn't type.
    */
   public static String clampGeneratedEntityName(final String name, final Integer maxLength) {
     final int limit = resolveMaxNameLength(maxLength);
-    return name != null && name.length() > limit ? name.substring(0, limit) : name;
+    if (name == null || name.length() <= limit) {
+      return name;
+    }
+    // drop the whole character when the cut would land between the halves of a surrogate pair
+    final int end =
+        Character.isHighSurrogate(name.charAt(limit - 1))
+                && Character.isLowSurrogate(name.charAt(limit))
+            ? limit - 1
+            : limit;
+    return name.substring(0, end);
   }
 
+  /** Falls back to the default when the limit is unset or misconfigured to a non-positive value. */
   private static int resolveMaxNameLength(final Integer maxLength) {
-    return maxLength != null ? maxLength : DEFAULT_MAX_ENTITY_NAME_LENGTH;
+    return maxLength != null && maxLength > 0 ? maxLength : DEFAULT_MAX_ENTITY_NAME_LENGTH;
   }
 
   public static void validate(final BranchAnalysisRequestDto dto) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/util/ValidationHelper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/util/ValidationHelper.java
@@ -55,9 +55,48 @@ import org.slf4j.LoggerFactory;
 
 public final class ValidationHelper {
 
+  /**
+   * Largest name length that always fits the ~32,766 byte Elasticsearch/OpenSearch term limit,
+   * since UTF-8 uses at most 4 bytes per character. Used when {@code entity.nameMaxLength} is not
+   * set.
+   */
+  public static final int DEFAULT_MAX_ENTITY_NAME_LENGTH = 8191;
+
   protected static final Logger LOG = LoggerFactory.getLogger(ValidationHelper.class);
 
   private ValidationHelper() {}
+
+  /**
+   * Validates the length of a user-provided entity name on the write path. A {@code null} name is
+   * accepted, as entities without a name fall back to a default one when persisted.
+   *
+   * @param entityLabel the capitalised entity type used in the error message, e.g. {@code "Report"}
+   * @param name the name to validate, may be {@code null}
+   * @param maxLength the configured limit, or {@code null} to use {@link
+   *     #DEFAULT_MAX_ENTITY_NAME_LENGTH}
+   */
+  public static void validateEntityName(
+      final String entityLabel, final String name, final Integer maxLength) {
+    final int limit = resolveMaxNameLength(maxLength);
+    if (name != null && name.length() > limit) {
+      throw new OptimizeValidationException(
+          String.format("%s names cannot be greater than %d characters", entityLabel, limit));
+    }
+  }
+
+  /**
+   * Shortens a name Optimize generates itself, such as the name of a copy, so that it satisfies the
+   * configured limit. Generated names are clamped rather than rejected, because the user did not
+   * supply them and so cannot correct them.
+   */
+  public static String clampGeneratedEntityName(final String name, final Integer maxLength) {
+    final int limit = resolveMaxNameLength(maxLength);
+    return name != null && name.length() > limit ? name.substring(0, limit) : name;
+  }
+
+  private static int resolveMaxNameLength(final Integer maxLength) {
+    return maxLength != null ? maxLength : DEFAULT_MAX_ENTITY_NAME_LENGTH;
+  }
 
   public static void validate(final BranchAnalysisRequestDto dto) {
     ensureNotEmpty("gateway activity id", dto.getGateway());

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -1526,6 +1526,7 @@
     "importDefinitionForbidden": "Import fehlgeschlagen, weil Ihnen die Befugnis für eine oder mehrere Definitionen, auf denen die zu importierende Entität basiert, fehlt.",
     "importFileInvalid": "Import fehlgeschlagen, weil die ausgewählte Datei ungültig ist. Es können nur von Optimize exportierte JSON-Dateien importiert werden.",
     "importDescriptionInvalid": "Importierung ist fehlgeschlagen weil die gegebene Beschreibung fehlerhaft ist. Die Beschreibung muss entweder null oder nicht größer als 400 Charaktere sein.",
+    "importNameInvalid": "Importierung ist fehlgeschlagen weil der gegebene Name fehlerhaft ist. Der Name muss entweder null sein oder darf die konfigurierte maximale Namenslänge nicht überschreiten.",
     "invalidAlertEmailAddresses": "Benutzer mit den folgenden Email-Addressen können keine Alarme empfange: {invalidAlertEmails}",
     "payloadTooLarge": "Die Anforderungslast ist zu groß.",
     "reportNotSupportedForOpenSearch": "Dieser Berichtstyp wird derzeit nicht für OpenSearch unterstützt."

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -1526,6 +1526,7 @@
     "importDefinitionForbidden": "Import failed because you are not authorized to access some of the required definitions for the imported entity.",
     "importFileInvalid": "Import failed because the provided file was invalid. Only JSON files exported from Optimize can be imported.",
     "importDescriptionInvalid": "Import failed because the provided description was invalid. Must be null or not greater than 400 characters.",
+    "importNameInvalid": "Import failed because the provided name was invalid. Must be null or not exceed the configured maximum name length.",
     "invalidAlertEmailAddresses": "Users with the following email addresses are not available for receiving alerts: {invalidAlertEmails}",
     "payloadTooLarge": "The request payload is too large.",
     "reportNotSupportedForOpenSearch": "This type of report is currently not supported for OpenSearch."

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/collection/CollectionServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/collection/CollectionServiceTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.query.IdResponseDto;
+import io.camunda.optimize.dto.optimize.query.collection.CollectionDefinitionDto;
+import io.camunda.optimize.dto.optimize.query.collection.PartialCollectionDefinitionRequestDto;
+import io.camunda.optimize.dto.optimize.rest.AuthorizationType;
+import io.camunda.optimize.dto.optimize.rest.AuthorizedCollectionDefinitionDto;
+import io.camunda.optimize.service.db.reader.CollectionReader;
+import io.camunda.optimize.service.db.writer.CollectionWriter;
+import io.camunda.optimize.service.exceptions.OptimizeValidationException;
+import io.camunda.optimize.service.identity.AbstractIdentityService;
+import io.camunda.optimize.service.relations.CollectionRelationService;
+import io.camunda.optimize.service.security.AuthorizedCollectionService;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.EntityConfiguration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class CollectionServiceTest {
+
+  private static final String USER_ID = "demo";
+  private static final int CONFIGURED_LIMIT = 256;
+  private static final String COLLECTION_ID = "collectionId";
+
+  @Mock private AuthorizedCollectionService authorizedCollectionService;
+  @Mock private CollectionRelationService collectionRelationService;
+  @Mock private CollectionEntityService collectionEntityService;
+  @Mock private CollectionWriter collectionWriter;
+  @Mock private CollectionReader collectionReader;
+  @Mock private AbstractIdentityService identityService;
+  @Mock private ConfigurationService configurationService;
+
+  @InjectMocks private CollectionService collectionService;
+
+  @BeforeEach
+  void setUp() {
+    final EntityConfiguration entityConfiguration = new EntityConfiguration();
+    entityConfiguration.setNameMaxLength(CONFIGURED_LIMIT);
+    when(configurationService.getEntityConfiguration()).thenReturn(entityConfiguration);
+    when(identityService.getEnabledAuthorizations())
+        .thenReturn(List.of(AuthorizationType.ENTITY_EDITOR));
+  }
+
+  @Test
+  void shouldRejectCreatingCollectionWithNameExceedingConfiguredLimit() {
+    // given
+    final var request = new PartialCollectionDefinitionRequestDto("a".repeat(CONFIGURED_LIMIT + 1));
+
+    // when
+    final var thrown =
+        assertThatExceptionOfType(OptimizeValidationException.class)
+            .isThrownBy(() -> collectionService.createNewCollectionAndReturnId(USER_ID, request));
+
+    // then
+    thrown.withMessage("Collection names cannot be greater than 256 characters");
+    verifyNoInteractions(collectionWriter);
+  }
+
+  @Test
+  void shouldAcceptCreatingCollectionWithNameAtExactlyConfiguredLimit() {
+    // given
+    when(collectionWriter.createNewCollectionAndReturnId(anyString(), any()))
+        .thenReturn(new IdResponseDto("id"));
+    final var request = new PartialCollectionDefinitionRequestDto("a".repeat(CONFIGURED_LIMIT));
+
+    // when
+    final var result = collectionService.createNewCollectionAndReturnId(USER_ID, request);
+
+    // then
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldRejectUpdatingCollectionWithNameExceedingConfiguredLimit() {
+    // given
+    final var request = new PartialCollectionDefinitionRequestDto("a".repeat(CONFIGURED_LIMIT + 1));
+
+    // when
+    final var thrown =
+        assertThatExceptionOfType(OptimizeValidationException.class)
+            .isThrownBy(
+                () -> collectionService.updatePartialCollection(USER_ID, COLLECTION_ID, request));
+
+    // then
+    thrown.withMessage("Collection names cannot be greater than 256 characters");
+    verify(collectionWriter, never()).updateCollection(any(), anyString());
+  }
+
+  @Test
+  void shouldClampRatherThanRejectGeneratedCopyNameThatOverflowsTheLimit() {
+    // given a source name at exactly the limit, so the appended " – Copy" suffix would overflow it
+    givenStoredCollection("a".repeat(CONFIGURED_LIMIT));
+
+    // when no name is supplied, so Optimize generates one
+    collectionService.copyCollection(USER_ID, COLLECTION_ID, null);
+
+    // then the copy is created with a clamped name rather than rejected
+    assertThat(capturedCreatedCollectionName()).hasSize(CONFIGURED_LIMIT);
+  }
+
+  @Test
+  void shouldAllowCopyingCollectionWhoseStoredNamePredatesTheLimit() {
+    // given an existing collection saved before the limit existed
+    givenStoredCollection("a".repeat(20_000));
+
+    // when
+    collectionService.copyCollection(USER_ID, COLLECTION_ID, null);
+
+    // then the copy still succeeds, clamped to the configured limit
+    assertThat(capturedCreatedCollectionName()).hasSize(CONFIGURED_LIMIT);
+  }
+
+  @Test
+  void shouldRejectUserSuppliedCopyNameExceedingConfiguredLimit() {
+    // given
+    givenStoredCollection("short name");
+
+    // when
+    final var thrown =
+        assertThatExceptionOfType(OptimizeValidationException.class)
+            .isThrownBy(
+                () ->
+                    collectionService.copyCollection(
+                        USER_ID, COLLECTION_ID, "a".repeat(CONFIGURED_LIMIT + 1)));
+
+    // then
+    thrown.withMessage("Collection names cannot be greater than 256 characters");
+    verify(collectionWriter, never()).createNewCollection(any());
+  }
+
+  @Test
+  void shouldNotValidateNameOnRead() {
+    // given an already stored collection whose name predates the limit
+    when(collectionReader.getCollection(COLLECTION_ID))
+        .thenReturn(Optional.of(collectionWithName("a".repeat(20_000))));
+
+    // when
+    final var result = collectionService.getCollectionDefinition(COLLECTION_ID);
+
+    // then
+    assertThat(result.getName()).hasSize(20_000);
+  }
+
+  private String capturedCreatedCollectionName() {
+    final var created = ArgumentCaptor.forClass(CollectionDefinitionDto.class);
+    verify(collectionWriter).createNewCollection(created.capture());
+    return created.getValue().getName();
+  }
+
+  private void givenStoredCollection(final String name) {
+    final var stored = collectionWithName(name);
+    when(authorizedCollectionService.getAuthorizedCollectionAndVerifyUserAuthorizedToManageOrFail(
+            USER_ID, COLLECTION_ID))
+        .thenReturn(new AuthorizedCollectionDefinitionDto(stored));
+    when(collectionReader.getCollection(COLLECTION_ID)).thenReturn(Optional.of(stored));
+  }
+
+  private CollectionDefinitionDto collectionWithName(final String name) {
+    return new CollectionDefinitionDto(
+        null, OffsetDateTime.now(), COLLECTION_ID, name, OffsetDateTime.now(), USER_ID, USER_ID);
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/report/ReportServiceConflictTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/report/ReportServiceConflictTest.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service.report;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -27,6 +28,8 @@ import io.camunda.optimize.service.identity.AbstractIdentityService;
 import io.camunda.optimize.service.relations.ReportRelationService;
 import io.camunda.optimize.service.security.AuthorizedCollectionService;
 import io.camunda.optimize.service.security.ReportAuthorizationService;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.EntityConfiguration;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -53,6 +56,8 @@ public class ReportServiceConflictTest {
 
   @Mock DefinitionService definitionService;
 
+  @Mock ConfigurationService configurationService;
+
   private ReportService underTest;
 
   @BeforeEach
@@ -65,7 +70,11 @@ public class ReportServiceConflictTest {
             reportRelationService,
             collectionService,
             abstractIdentityService,
-            definitionService);
+            definitionService,
+            configurationService);
+    lenient()
+        .when(configurationService.getEntityConfiguration())
+        .thenReturn(new EntityConfiguration());
     when(abstractIdentityService.getEnabledAuthorizations())
         .thenReturn(List.of(AuthorizationType.values()));
   }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/util/ValidationHelperTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/util/ValidationHelperTest.java
@@ -104,7 +104,7 @@ public class ValidationHelperTest {
     // then
     Assertions.assertThat(thrown)
         .isInstanceOf(OptimizeValidationException.class)
-        .hasMessageContaining("Report names cannot be greater than 8191 characters");
+        .hasMessageContaining("Report names cannot be greater than 32768 characters");
   }
 
   @Test
@@ -157,6 +157,43 @@ public class ValidationHelperTest {
 
     // then
     Assertions.assertThat(clamped).hasSize(256);
+  }
+
+  @Test
+  void shouldNotSplitSurrogatePairWhenClamping() {
+    // given a name where the limit falls exactly between the two halves of a surrogate pair
+    final String emoji = "\uD83D\uDE00";
+    final String generated = "a" + emoji.repeat(10);
+
+    // when
+    final String clamped = ValidationHelper.clampGeneratedEntityName(generated, 2);
+
+    // then the trailing half-character is dropped rather than persisted as invalid Unicode
+    Assertions.assertThat(clamped).isEqualTo("a");
+  }
+
+  @Test
+  void shouldKeepWholeSurrogatePairWhenClampingLandsAfterIt() {
+    // given
+    final String emoji = "\uD83D\uDE00";
+    final String generated = emoji.repeat(10);
+
+    // when the limit falls on a pair boundary rather than inside a pair
+    final String clamped = ValidationHelper.clampGeneratedEntityName(generated, 4);
+
+    // then
+    Assertions.assertThat(clamped).isEqualTo(emoji.repeat(2));
+  }
+
+  @Test
+  void shouldFallBackToDefaultWhenConfiguredLimitIsNotPositive() {
+    // given a misconfigured limit that would otherwise reject every name and break clamping
+    final String name = "a".repeat(300);
+
+    // then
+    ValidationHelper.validateEntityName("Report", name, 0);
+    ValidationHelper.validateEntityName("Report", name, -1);
+    Assertions.assertThat(ValidationHelper.clampGeneratedEntityName(name, 0)).isEqualTo(name);
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/util/ValidationHelperTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/util/ValidationHelperTest.java
@@ -93,6 +93,83 @@ public class ValidationHelperTest {
   }
 
   @Test
+  void shouldRejectEntityNameExceedingMaxLength() {
+    // given
+    final String name = "a".repeat(ValidationHelper.DEFAULT_MAX_ENTITY_NAME_LENGTH + 1);
+
+    // when
+    final Throwable thrown =
+        Assertions.catchThrowable(() -> ValidationHelper.validateEntityName("Report", name, null));
+
+    // then
+    Assertions.assertThat(thrown)
+        .isInstanceOf(OptimizeValidationException.class)
+        .hasMessageContaining("Report names cannot be greater than 8191 characters");
+  }
+
+  @Test
+  void shouldAcceptEntityNameAtExactlyMaxLength() {
+    // given
+    final String name = "a".repeat(ValidationHelper.DEFAULT_MAX_ENTITY_NAME_LENGTH);
+
+    // then
+    ValidationHelper.validateEntityName("Report", name, null);
+  }
+
+  @Test
+  void shouldAcceptNullEntityNameSoDefaultNamesStillApply() {
+    // then
+    ValidationHelper.validateEntityName("Dashboard", null, null);
+  }
+
+  @Test
+  void shouldEnforceConfiguredLimitInsteadOfDefault() {
+    // given
+    final String name = "a".repeat(257);
+
+    // when
+    final Throwable thrown =
+        Assertions.catchThrowable(
+            () -> ValidationHelper.validateEntityName("Collection", name, 256));
+
+    // then
+    Assertions.assertThat(thrown)
+        .isInstanceOf(OptimizeValidationException.class)
+        .hasMessageContaining("Collection names cannot be greater than 256 characters");
+  }
+
+  @Test
+  void shouldCountCharactersNotUtf8Bytes() {
+    // given a name of 4-byte characters that is within the character limit but not the byte limit
+    final String name = "\uD83D\uDE00".repeat(100);
+
+    // then
+    ValidationHelper.validateEntityName("Report", name, 256);
+  }
+
+  @Test
+  void shouldClampGeneratedNameToConfiguredLimit() {
+    // given
+    final String generated = "a".repeat(300);
+
+    // when
+    final String clamped = ValidationHelper.clampGeneratedEntityName(generated, 256);
+
+    // then
+    Assertions.assertThat(clamped).hasSize(256);
+  }
+
+  @Test
+  void shouldLeaveGeneratedNameWithinLimitUntouched() {
+    // given
+    final String generated = "a".repeat(100);
+
+    // then
+    Assertions.assertThat(ValidationHelper.clampGeneratedEntityName(generated, 256))
+        .isEqualTo(generated);
+  }
+
+  @Test
   void shouldValidateFiltersCorrectly() {
     // given
     final ProcessFilterDto<DateFilterDataDto<?>> validFilter = new InstanceStartDateFilterDto();

--- a/optimize/client/src/__mocks__/config.js
+++ b/optimize/client/src/__mocks__/config.js
@@ -8,6 +8,7 @@
 
 export const isEmailEnabled = () => true;
 export const isSharingEnabled = () => true;
+export const getEntityNameMaxLength = () => 32768;
 export const getOptimizeVersion = () => '2.7.0';
 export const getHeader = () => ({
   textColor: 'dark', // or "light"

--- a/optimize/client/src/components/Home/modals/CollectionModal.tsx
+++ b/optimize/client/src/components/Home/modals/CollectionModal.tsx
@@ -6,11 +6,12 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {ReactNode, useState} from 'react';
+import {ReactNode, useEffect, useState} from 'react';
 import {useHistory} from 'react-router-dom';
 import {Button, Form, TextInput} from '@carbon/react';
 
 import {Modal} from 'components';
+import {getEntityNameMaxLength} from 'config';
 import {t} from 'translation';
 import {showError} from 'notifications';
 import {addSources} from 'services';
@@ -42,8 +43,13 @@ export function CollectionModal({
   const [loading, setLoading] = useState(false);
   const [redirect, setRedirect] = useState<string | null>(null);
   const [displaySourcesModal, setDisplaySourcesModal] = useState(false);
+  const [nameMaxLength, setNameMaxLength] = useState<number>();
   const {mightFail} = useErrorHandling();
   const history = useHistory();
+
+  useEffect(() => {
+    getEntityNameMaxLength().then(setNameMaxLength);
+  }, []);
 
   const confirm = () => {
     if (!name || loading) {
@@ -95,6 +101,7 @@ export function CollectionModal({
               onChange={({target: {value}}) => setName(value)}
               disabled={loading}
               autoComplete="off"
+              maxLength={nameMaxLength}
               data-modal-primary-focus
             />
           </Form>

--- a/optimize/client/src/components/Home/modals/CopyAlertModal.tsx
+++ b/optimize/client/src/components/Home/modals/CopyAlertModal.tsx
@@ -6,10 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import {Button, Form, TextInput} from '@carbon/react';
 
 import {Modal} from 'components';
+import {getEntityNameMaxLength} from 'config';
 import {t} from 'translation';
 
 interface CopyAlertModalProps {
@@ -24,6 +25,11 @@ export default function CopyAlertModal({
   onConfirm,
 }: CopyAlertModalProps) {
   const [name, setName] = useState(initialAlertName + ' (' + t('common.copyLabel') + ')');
+  const [nameMaxLength, setNameMaxLength] = useState<number>();
+
+  useEffect(() => {
+    getEntityNameMaxLength().then(setNameMaxLength);
+  }, []);
 
   return (
     <Modal open onClose={onClose}>
@@ -35,6 +41,7 @@ export default function CopyAlertModal({
             labelText={t('home.copy.inputLabel')}
             value={name}
             autoComplete="off"
+            maxLength={nameMaxLength}
             onChange={({target: {value}}) => setName(value)}
             data-modal-primary-focus
           />

--- a/optimize/client/src/components/Home/modals/CopyModal.tsx
+++ b/optimize/client/src/components/Home/modals/CopyModal.tsx
@@ -6,10 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {MouseEvent, useState} from 'react';
+import {MouseEvent, useEffect, useState} from 'react';
 import {Button, TextInput, Form, Checkbox, Stack} from '@carbon/react';
 
 import {Modal} from 'components';
+import {getEntityNameMaxLength} from 'config';
 import {t} from 'translation';
 import {EntityListEntity} from 'types';
 
@@ -34,6 +35,11 @@ export default function CopyModal({
   const [moving, setMoving] = useState(false);
   const [collection, setCollection] = useState<EntityListEntity | CollectionsHome | null>(null);
   const [gotoNew, setGotoNew] = useState(true);
+  const [nameMaxLength, setNameMaxLength] = useState<number>();
+
+  useEffect(() => {
+    getEntityNameMaxLength().then(setNameMaxLength);
+  }, []);
 
   const handleConfirm = () => {
     if (name && (!moving || collection)) {
@@ -58,6 +64,7 @@ export default function CopyModal({
               labelText={t('home.copy.inputLabel')}
               value={name}
               autoComplete="off"
+              maxLength={nameMaxLength}
               onChange={({target: {value}}) => setName(value)}
               helperText={isCollection() && t('home.copy.copyCollectionInfo')}
             />

--- a/optimize/client/src/modules/components/AlertModal/AlertModal.js
+++ b/optimize/client/src/modules/components/AlertModal/AlertModal.js
@@ -22,7 +22,7 @@ import {
 
 import {Modal, Select} from 'components';
 import {formatters, evaluateReport, getReportResult} from 'services';
-import {isEmailEnabled} from 'config';
+import {isEmailEnabled, getEntityNameMaxLength} from 'config';
 import {t} from 'translation';
 import {withDocs, withErrorHandling} from 'HOC';
 import {showError} from 'notifications';
@@ -69,6 +69,7 @@ export class AlertModal extends React.Component {
 
     this.setState({
       emailNotificationIsEnabled: await isEmailEnabled(),
+      nameMaxLength: await getEntityNameMaxLength(),
     });
   };
 
@@ -231,6 +232,7 @@ export class AlertModal extends React.Component {
       reminder,
       fixNotification,
       emailNotificationIsEnabled,
+      nameMaxLength,
       invalid,
       validEmails,
       report,
@@ -267,6 +269,7 @@ export class AlertModal extends React.Component {
                     value={name}
                     onChange={({target: {value}}) => this.setState({name: value})}
                     autoComplete="off"
+                    maxLength={nameMaxLength}
                   />
                   <ComboBox
                     id="report"

--- a/optimize/client/src/modules/components/AlertModal/AlertModal.test.js
+++ b/optimize/client/src/modules/components/AlertModal/AlertModal.test.js
@@ -17,6 +17,7 @@ import ThresholdInput from './ThresholdInput';
 
 jest.mock('config', () => ({
   isEmailEnabled: jest.fn().mockReturnValue(true),
+  getEntityNameMaxLength: jest.fn().mockResolvedValue(256),
   getOptimizeVersion: jest.fn().mockReturnValue('2.7.0'),
 }));
 

--- a/optimize/client/src/modules/components/EntityNameForm/EntityNameForm.test.tsx
+++ b/optimize/client/src/modules/components/EntityNameForm/EntityNameForm.test.tsx
@@ -9,6 +9,7 @@
 import {shallow} from 'enzyme';
 
 import {TextInput} from '@carbon/react';
+import {runAllEffects} from '__mocks__/react';
 
 import EntityNameForm from './EntityNameForm';
 
@@ -17,6 +18,10 @@ jest.mock('hooks', () => ({
     mightFail: (promise: Promise<unknown>, cb: ((response: unknown) => unknown) | undefined) =>
       cb?.(promise),
   }),
+}));
+
+jest.mock('config', () => ({
+  getEntityNameMaxLength: jest.fn().mockResolvedValue(256),
 }));
 
 const props = {
@@ -32,6 +37,14 @@ it('should provide name edit input', () => {
   const node = shallow(<EntityNameForm {...props} />);
 
   expect(node.find(TextInput)).toExist();
+});
+
+it('should cap the name input at the configured server limit', async () => {
+  const node = shallow(<EntityNameForm {...props} />);
+
+  await runAllEffects();
+
+  expect(node.find(TextInput).prop('maxLength')).toBe(256);
 });
 
 it('should provide a link to view mode', () => {

--- a/optimize/client/src/modules/components/EntityNameForm/EntityNameForm.test.tsx
+++ b/optimize/client/src/modules/components/EntityNameForm/EntityNameForm.test.tsx
@@ -42,7 +42,9 @@ it('should provide name edit input', () => {
 it('should cap the name input at the configured server limit', async () => {
   const node = shallow(<EntityNameForm {...props} />);
 
-  await runAllEffects();
+  runAllEffects();
+  await flushPromises();
+  node.update();
 
   expect(node.find(TextInput).prop('maxLength')).toBe(256);
 });

--- a/optimize/client/src/modules/components/EntityNameForm/EntityNameForm.tsx
+++ b/optimize/client/src/modules/components/EntityNameForm/EntityNameForm.tsx
@@ -6,12 +6,13 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {ChangeEventHandler, ReactNode, useState} from 'react';
+import {ChangeEventHandler, ReactNode, useEffect, useState} from 'react';
 import {Link} from 'react-router-dom';
 import {Button, TextInput} from '@carbon/react';
 import {Error, Save} from '@carbon/icons-react';
 
 import {EntityDescription} from 'components';
+import {getEntityNameMaxLength} from 'config';
 import {useErrorHandling} from 'hooks';
 import {t} from 'translation';
 
@@ -41,7 +42,12 @@ export default function EntityNameForm({
   children,
 }: EntityNameFormProps) {
   const [loading, setLoading] = useState(false);
+  const [nameMaxLength, setNameMaxLength] = useState<number>();
   const {mightFail} = useErrorHandling();
+
+  useEffect(() => {
+    getEntityNameMaxLength().then(setNameMaxLength);
+  }, []);
 
   const homeLink = entity === 'Process' ? '../' : '../../';
 
@@ -58,6 +64,7 @@ export default function EntityNameForm({
             labelText={t(`common.entity.namePlaceholder.${entity}`).toString()}
             placeholder={t(`common.entity.namePlaceholder.${entity}`).toString()}
             autoComplete="off"
+            maxLength={nameMaxLength}
           />
         </div>
         {onDescriptionChange && (

--- a/optimize/client/src/modules/config.tsx
+++ b/optimize/client/src/modules/config.tsx
@@ -47,6 +47,7 @@ export type UiConfig = {
   logoutHidden: boolean;
   cslEnabled: boolean;
   exportCsvLimit: number;
+  entityNameMaxLength: number;
   maxNumDataSourcesForReport: number;
   onboarding: Onboarding;
   notificationsUrl: string;
@@ -120,6 +121,7 @@ export const getOptimizeProfile =
 export const isLogoutHidden = createAccessorFunction<boolean>('logoutHidden');
 export const isCslEnabled = createAccessorFunction<boolean>('cslEnabled');
 export const getExportCsvLimit = createAccessorFunction<number>('exportCsvLimit');
+export const getEntityNameMaxLength = createAccessorFunction<number>('entityNameMaxLength');
 export const getMaxNumDataSourcesForReport = createAccessorFunction<number>(
   'maxNumDataSourcesForReport'
 );

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/ui_configuration/UIConfigurationResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/ui_configuration/UIConfigurationResponseDto.java
@@ -29,6 +29,7 @@ public class UIConfigurationResponseDto {
   private boolean cslEnabled;
   private int maxNumDataSourcesForReport;
   private Integer exportCsvLimit;
+  private Integer entityNameMaxLength;
   private DatabaseType optimizeDatabase;
   private boolean validLicense;
   private String licenseType;
@@ -204,6 +205,14 @@ public class UIConfigurationResponseDto {
 
   public void setExportCsvLimit(final Integer exportCsvLimit) {
     this.exportCsvLimit = exportCsvLimit;
+  }
+
+  public Integer getEntityNameMaxLength() {
+    return entityNameMaxLength;
+  }
+
+  public void setEntityNameMaxLength(final Integer entityNameMaxLength) {
+    this.entityNameMaxLength = entityNameMaxLength;
   }
 
   public DatabaseType getOptimizeDatabase() {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/EntityConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/EntityConfiguration.java
@@ -20,6 +20,8 @@ public class EntityConfiguration {
 
   private Boolean createOnStartup;
 
+  private Integer nameMaxLength;
+
   public EntityConfiguration() {}
 
   public AuthorizedUserType getAuthorizedUserType() {
@@ -47,13 +49,21 @@ public class EntityConfiguration {
     this.createOnStartup = createOnStartup;
   }
 
+  public Integer getNameMaxLength() {
+    return nameMaxLength;
+  }
+
+  public void setNameMaxLength(final Integer nameMaxLength) {
+    this.nameMaxLength = nameMaxLength;
+  }
+
   protected boolean canEqual(final Object other) {
     return other instanceof EntityConfiguration;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(authorizedUserType, kpiRefreshInterval, createOnStartup);
+    return Objects.hash(authorizedUserType, kpiRefreshInterval, createOnStartup, nameMaxLength);
   }
 
   @Override
@@ -67,7 +77,8 @@ public class EntityConfiguration {
     final EntityConfiguration that = (EntityConfiguration) o;
     return Objects.equals(authorizedUserType, that.authorizedUserType)
         && Objects.equals(kpiRefreshInterval, that.kpiRefreshInterval)
-        && Objects.equals(createOnStartup, that.createOnStartup);
+        && Objects.equals(createOnStartup, that.createOnStartup)
+        && Objects.equals(nameMaxLength, that.nameMaxLength);
   }
 
   @Override
@@ -78,6 +89,8 @@ public class EntityConfiguration {
         + getKpiRefreshInterval()
         + ", createOnStartup="
         + getCreateOnStartup()
+        + ", nameMaxLength="
+        + getNameMaxLength()
         + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -572,6 +572,13 @@ entity:
   kpiRefreshInterval: 600
   # flag to determine whether this Optimize instance should (re)create management entities on startup
   createOnStartup: ${CAMUNDA_OPTIMIZE_ENTITY_CREATE_ON_STARTUP:true}
+  # Maximum number of characters allowed in the name of a report, collection, dashboard or alert.
+  # Names longer than this are rejected with a validation error when created or updated.
+  # The default is the largest value that always fits the Elasticsearch/OpenSearch term limit of
+  # 32766 bytes, since UTF-8 uses at most 4 bytes per character (32766 / 4 = 8191). Raising it above
+  # this can make names fail at index time; lower it to enforce a stricter naming policy.
+  # Existing entities with longer names are unaffected and remain readable.
+  nameMaxLength: ${CAMUNDA_OPTIMIZE_ENTITY_NAME_MAX_LENGTH:8191}
 
 export:
   csv:

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -573,12 +573,10 @@ entity:
   # flag to determine whether this Optimize instance should (re)create management entities on startup
   createOnStartup: ${CAMUNDA_OPTIMIZE_ENTITY_CREATE_ON_STARTUP:true}
   # Maximum number of characters allowed in the name of a report, collection, dashboard or alert.
-  # Names longer than this are rejected with a validation error when created or updated.
-  # The default is the largest value that always fits the Elasticsearch/OpenSearch term limit of
-  # 32766 bytes, since UTF-8 uses at most 4 bytes per character (32766 / 4 = 8191). Raising it above
-  # this can make names fail at index time; lower it to enforce a stricter naming policy.
-  # Existing entities with longer names are unaffected and remain readable.
-  nameMaxLength: ${CAMUNDA_OPTIMIZE_ENTITY_NAME_MAX_LENGTH:8191}
+  # Matches the orchestration cluster's equivalent limit for name fields. Note that a name well below
+  # this can still be too large to index, as Elasticsearch/OpenSearch cap a term at 32766 bytes and a
+  # character takes up to 3 bytes in UTF-8. Existing longer names remain readable.
+  nameMaxLength: ${CAMUNDA_OPTIMIZE_ENTITY_NAME_MAX_LENGTH:32768}
 
 export:
   csv:


### PR DESCRIPTION
> [!IMPORTANT]
> **Correction (2026-08-13).** The description below claims this change "rejects with HTTP 400". That is
> wrong, and it was never verified before merging.
>
> The validation itself works — the request is rejected with the right message — but Optimize has no
> `@ExceptionHandler` for `OptimizeValidationException` on `main`, `stable/8.9` and `stable/8.8`, so it
> falls through to the catch-all `@ExceptionHandler(Throwable.class)` in `GenericExceptionMapper` and is
> returned as **HTTP 500 `serverError`**. Consequently the "so they can correct them" rationale under
> *Rejecting vs clamping* did not hold either: the user sees a generic internal error, not the limit.
>
> This is not a regression introduced here — the mapping was lost in the Dec 2024 JAX-RS→Spring
> migration and affects every validation error in Optimize. This change simply made it reachable. The
> tests listed under *Testing* could not have caught it: they assert the thrown exception at the service
> layer, never the HTTP status.
>
> The 8.7 backport (#59746) is **not** affected and does return 400, since that branch predates the
> migration.
>
> Tracked in #60047.

---

## Description

Optimize accepted arbitrarily long names for reports, collections, dashboards and alerts. The name is indexed into an Elasticsearch/OpenSearch `keyword` field with **no `ignore_above`**, so the only effective ceiling was the Lucene maximum term length of ~32,766 bytes. Names past that ceiling were accepted by the API and then failed at index time with an unhandled error — the user saw an internal error instead of a validation message.

This PR validates name length on the write path and rejects with HTTP 400.

### How it works

A single validator in `ValidationHelper` (`validateEntityName` + `clampGeneratedEntityName`), wired into every write path:

| Area | Sites |
| --- | --- |
| `ReportService` | 3 create + 3 update, plus the shared `copyAndMoveReport` choke point |
| `DashboardService` | create, update, `copyAndMoveDashboard` |
| `CollectionService` | create, create-with-preset-id, update, copy |
| Import | `ReportImportService`, `DashboardImportService` |
| Alerts | `AlertService.validateAlert` |
| Frontend | `maxLength` on the name input in `EntityNameForm` |

### Design decisions

**Limit: 32768 characters by default, configurable.** New `entity.nameMaxLength` property, overridable via `CAMUNDA_OPTIMIZE_ENTITY_NAME_MAX_LENGTH`. The default mirrors `EngineConfiguration.DEFAULT_MAX_NAME_FIELD_LENGTH` in the orchestration cluster, which makes the equivalent limit configurable and caps names at the storage ceiling rather than at a product-chosen length (see #37952).

**Why default to the storage ceiling rather than a small display-oriented value.** It keeps this a pure bug fix — it only rejects names that already failed, so no currently-working entity starts failing and no migration is needed. Deployments that want a stricter naming policy can lower the limit, which is what the configuration option is for.

**Rejecting vs clamping.** Names the *user* supplies are rejected, so they can correct them. Names *Optimize generates itself* — the `" – Copy"` variant of an existing name, or a sub-report name carried over during a dashboard copy — are clamped instead. Rejecting those would let a stricter configured limit block copying an entity whose stored name predates the limit, which the user has no way to fix.

**Write path only, never on read.** Entities already stored with a longer name keep loading. Import rejects rather than truncates, since truncation would corrupt user data and could collide names.

**System-generated entities are unaffected.** Management, instant preview and agentic control dashboards write through the writer rather than the service. Verified the longest name in the bundled instant-preview templates is 43 characters.

**The limit is published through the UI configuration endpoint** so the name input caps typing at whatever the server enforces. That is a usability affordance only — the server check is the enforcement point.

### Testing

- New `CollectionServiceTest` (7 tests) covering the boundary, the copy-suffix overflow, the user-supplied-vs-generated split, and a **read-path regression** proving a stored 20,000-character name still loads.
- `ValidationHelperTest` extended (14 tests) covering the configured limit, the default, null names, character-vs-byte counting, and clamping.
- Full Optimize backend suite green (846 tests). Frontend `EntityNameForm` tests green.

### Not included

`ignore_above` on the Optimize `name` mapping — the mapping-level safety net the orchestration cluster has and Optimize lacks. It would need an index version bump and reindex, which is the wrong blast radius for a backportable bug fix. Worth a separate follow-up.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #59384

