### PR TITLE
ci: raise stale backport PR threshold from 6 to 24 hours

### DIFF
--- a/.github/workflows/stale-backport-tracker.yml
+++ b/.github/workflows/stale-backport-tracker.yml
@@ -35,7 +35,7 @@ on:
       stale_hours_threshold:
         description: 'Hours after which a backport PR is considered stale'
         required: false
-        default: '6'
+        default: '24'
         type: string
       slack_channel_id:
         description: 'Slack channel ID to post the report to. Required for manual runs — the default #top-monorepo-ci channel is only used by the scheduled cron trigger.'
@@ -67,7 +67,7 @@ on:
       stale_hours_threshold:
         description: 'Hours after which a backport PR is considered stale'
         required: false
-        default: '6'
+        default: '24'
         type: string
       slack_channel_id:
         description: 'Slack channel ID to post the report to. Required when notify_slack is true — the default #top-monorepo-ci channel is only used by the scheduled cron trigger.'
@@ -117,7 +117,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
           REPOSITORIES: "camunda/camunda,camunda/zeebe-process-test"
-          STALE_HOURS_THRESHOLD: ${{ inputs.stale_hours_threshold || '6' }}
+          STALE_HOURS_THRESHOLD: ${{ inputs.stale_hours_threshold || '24' }}
           TARGET_BRANCH: ${{ inputs.target_branch || '' }}
         run: |
           chmod +x .ci/scripts/stale-backport-scripts/collect-stale-backports.sh


### PR DESCRIPTION
Raises the stale-backport-tracker's default staleness threshold from 6 hours to 24 hours, across all three places it's configured (workflow_dispatch default, workflow_call default, runtime fallback).

6 hours was too aggressive relative to normal review turnaround, flagging backport PRs as stale before authors had a reasonable chance to act.

🤖 Generated with [Claude Code](https://claude.com/claude-code)