### PR TITLE
ci: deny pull_request_target trigger due to security risks

### DIFF
--- a/.github/conftest-gha-best-practices.rego
+++ b/.github/conftest-gha-best-practices.rego
@@ -77,6 +77,23 @@ deny[msg] {
         [concat(", ", get_jobs_with_cihealth_but_no_checkout(input.jobs))])
 }
 
+deny[msg] {
+    # This rule forbids usage of the "pull_request_target" trigger, which runs
+    # in the context of the base branch and has access to secrets. Using it with
+    # a checkout of the PR's code is a common source of secret exfiltration and
+    # code injection vulnerabilities via forks. Prefer the "pull_request" trigger.
+    # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+
+    is_pull_request_target_trigger
+
+    # exempted: "Pull Request Labeler" only runs the trusted actions/labeler
+    # action (no checkout of PR code, no secret exposure beyond the labelling
+    # API), which is the documented safe use of pull_request_target
+    input.name != "Pull Request Labeler"
+
+    msg := "This GitHub Actions workflow uses the 'pull_request_target' trigger which is forbidden due to security risks with forks! Use 'pull_request' instead."
+}
+
 warn[msg] {
     # This rule warns in situations where no "secrets: inherit" is passed on
     # calling other workflows as this is usually an oversight that prevents
@@ -89,6 +106,23 @@ warn[msg] {
 }
 
 ###########################   RULE HELPERS   ##################################
+
+# Detects whether the workflow uses the "pull_request_target" trigger across
+# any of the three YAML forms GHA accepts.
+# The "on" key gets transformed by conftest into "true" due to some legacy
+# YAML standards, see https://stackoverflow.com/q/42283732/2148786
+is_pull_request_target_trigger {
+    # object form
+    input["true"]["pull_request_target"]
+}
+is_pull_request_target_trigger {
+    # array form
+    input["true"][_] == "pull_request_target"
+}
+is_pull_request_target_trigger {
+    # string form
+    input["true"] == "pull_request_target"
+}
 
 get_jobs_with_setupnodecaching(jobInput) = jobs_with_setupnodecaching {
     jobs_with_setupnodecaching := { job_id |

--- a/docs/monorepo-docs/ci.md
+++ b/docs/monorepo-docs/ci.md
@@ -496,6 +496,12 @@ Every GHA workflow job is given a `GITHUB_TOKEN` environment variable with a val
 
 **Best Practice:** All GHA workflow jobs must request only actually required [permissions on the `GITHUB_TOKEN`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token). Set `permissions: {}` by default and add what is needed.
 
+### Avoid `pull_request_target` trigger
+
+This [GHA trigger](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) disables safeguards that combined with other factors can lead to compromise of CI, repository and secret integrity.
+
+For this reason we avoid using this trigger to minimize the attack surface and security risks.
+
 ### Usage of Third Party GitHub Actions
 
 GitHub Actions has a [large ecosystem of existing useful actions](https://github.com/marketplace) from GitHub and third parties such as other companies and individuals. While reusing existing actions avoids code duplication and maintenance effort for Camunda, it increases the _attack surface_ should any of those actions be hacked to perform malicious tasks.


### PR DESCRIPTION
## Description

This pull request introduces a new security policy to the CI/CD pipeline by forbidding the use of the `pull_request_target` trigger in GitHub Actions workflows, due to its associated security risks. It also updates the documentation to explain this best practice and the reasoning behind it.

**Security Policy Enforcement:**

* [`.github/conftest-gha-best-practices.rego`](diffhunk://#diff-3c56c1ca11f95c99a01a7a9c77aeb95aabbd5c404c98089acd49bad5f85f4d08R80-R98): Added a Rego policy rule that denies workflows using the `pull_request_target` trigger, except for the trusted "Pull Request Labeler" workflow, to prevent potential secret exfiltration and code injection vulnerabilities.

**Documentation Updates:**

* [`docs/monorepo-docs/ci.md`](diffhunk://#diff-9645fbc8fa9e55a1d4a6f3e442d00b777f77702342610afed8b87bd64be4cd11R499-R504): Added a new section explaining the risks of the `pull_request_target` trigger and clarified that its use is forbidden to minimize the attack surface and security risks.

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

None
