### PR TITLE
fix: deliver signal thrown while moving a token via batch modification

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnSignalBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnSignalBehavior.java
@@ -18,8 +18,11 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWr
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo.AuthDataFormat;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
+import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import org.agrona.DirectBuffer;
@@ -80,6 +83,19 @@ public final class BpmnSignalBehavior {
     signalRecord.setSignalName(signalName).setVariables(variables).setTenantId(tenantId);
 
     final var key = keyGenerator.nextKey();
-    commandWriter.appendFollowUpCommand(key, SignalIntent.BROADCAST, signalRecord);
+    // A signal broadcast triggered by a throw event is an internal side-effect of process
+    // execution, not a user-initiated broadcast, so it must not be subjected to the
+    // CREATE_PROCESS_INSTANCE / UPDATE_PROCESS_INSTANCE authorization check in
+    // SignalBroadcastProcessor. It is normally treated as internal via isInternalCommand(), but a
+    // command processed within a batch operation propagates its batchOperationReference to every
+    // follow-up command, which makes the follow-up non-internal. Marking the follow-up as
+    // PRE_AUTHORIZED keeps it exempt from the user authorization check regardless of the inherited
+    // batchOperationReference.
+    final var authInfo = new AuthInfo().setFormat(AuthDataFormat.PRE_AUTHORIZED);
+    commandWriter.appendFollowUpCommand(
+        key,
+        SignalIntent.BROADCAST,
+        signalRecord,
+        FollowUpCommandMetadata.of(builder -> builder.authInfo(authInfo)));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -84,7 +84,9 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
     final long eventKey = keyGenerator.nextKey();
     final var signalRecord = command.getValue();
 
-    final var isAuthNeeded = !command.isInternalCommand();
+    final var isAuthNeeded =
+        !command.isInternalCommand()
+            && command.getAuthInfo().getFormat() != AuthDataFormat.PRE_AUTHORIZED;
 
     // Check tenant authorization if not an internal command
     if (isAuthNeeded) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchMoveTokenToGatewaySignalAuthTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchMoveTokenToGatewaySignalAuthTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.auth.Authorization;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+/**
+ * Regression test on stable/8.8, exercising the REAL batch-operation move path.
+ *
+ * <p>This test drives {@link
+ * io.camunda.zeebe.engine.processing.batchoperation.handlers.ModifyProcessInstanceBatchOperationExecutor}
+ * via {@link AbstractBatchOperationTest#createNewModifyProcessInstanceBatchOperation} — the exact
+ * code path used by Operate's process-list "move" (batch) feature. The executor expands the move
+ * into a {@code MODIFY} command carrying a {@code batchOperationReference} and the acting user's
+ * {@code claims}.
+ *
+ * <p>Topology: exclusive split -&gt; user task {@code Activity_1sgi1dh} -&gt; exclusive JOIN {@code
+ * Gateway_0zrxxs9} -&gt; intermediate signal-throw {@code Event_15l5ajp} -&gt; user task -&gt; end,
+ * plus a signal-start receiver process {@code Process_0a5la8z}. Moving the token onto the join
+ * gateway auto-proceeds through the gateway and the signal throw, which broadcasts the signal and
+ * must start the receiver.
+ *
+ * <p><b>Before the fix:</b> the signal broadcast emitted by the moved token inherited the MODIFY's
+ * {@code batchOperationReference}, so it was classified as a user command and re-authorized with a
+ * {@code CREATE_PROCESS_INSTANCE} check against an empty principal (no claims are propagated to the
+ * follow-up). The check always failed, raising a {@code PROCESSING_ERROR} that rolled back the
+ * whole modification: the token was not moved and no signal was broadcast, yet the batch reported
+ * COMPLETED.
+ *
+ * <p><b>After the fix:</b> a signal broadcast triggered by process execution (a throw event) is
+ * marked {@code PRE_AUTHORIZED}, so it is exempt from the user authorization check regardless of
+ * the inherited {@code batchOperationReference}. The move now completes, the signal is broadcast,
+ * and the receiver process instance is created — matching the single-instance move behaviour.
+ */
+public final class BatchMoveTokenToGatewaySignalAuthTest extends AbstractBatchOperationTest {
+
+  private static final String SENDER_ID = "Process_nbgivsr";
+  private static final String RECEIVER_ID = "Process_0a5la8z";
+  private static final String SIGNAL_NAME = "Demo_Signal_Subprozess_StartEvent";
+  private static final String SOURCE_ELEMENT = "Activity_1sgi1dh"; // first user task
+  private static final String TARGET_GATEWAY = "Gateway_0zrxxs9"; // exclusive join gateway
+
+  private static BpmnModelInstance sender() {
+    return Bpmn.createExecutableProcess(SENDER_ID)
+        .startEvent()
+        .exclusiveGateway("Gateway_131fii5")
+        .sequenceFlowId("flow_ja")
+        .conditionExpression("=haltpunkt=\"Ja\"")
+        .userTask(SOURCE_ELEMENT)
+        .zeebeUserTask()
+        .exclusiveGateway(TARGET_GATEWAY)
+        .intermediateThrowEvent("Event_15l5ajp", t -> t.signal(SIGNAL_NAME))
+        .userTask("Activity_0ckjnwl")
+        .zeebeUserTask()
+        .endEvent()
+        .moveToNode("Gateway_131fii5")
+        .sequenceFlowId("flow_nein")
+        .conditionExpression("=haltpunkt=\"Nein\"")
+        .connectTo(TARGET_GATEWAY)
+        .done();
+  }
+
+  private static BpmnModelInstance receiver() {
+    return Bpmn.createExecutableProcess(RECEIVER_ID)
+        .startEvent("signalStart")
+        .signal(SIGNAL_NAME)
+        .endEvent()
+        .done();
+  }
+
+  private long deployAndAdvanceToSourceUserTask() {
+    engine.deployment().withXmlResource(sender()).withXmlResource(receiver()).deploy();
+
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(SENDER_ID)
+            .withVariable("haltpunkt", "Ja")
+            .create();
+
+    // wait for the source (native) user task to exist
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId(SOURCE_ELEMENT)
+        .getFirst();
+    return processInstanceKey;
+  }
+
+  private List<Record<?>> runBatchMoveAndCollectRecords(
+      final long processInstanceKey, final Map<String, Object> claims) {
+    final long batchOperationKey =
+        createNewModifyProcessInstanceBatchOperation(
+            Set.of(processInstanceKey), SOURCE_ELEMENT, TARGET_GATEWAY, claims);
+
+    RecordingExporter.batchOperationLifecycleRecords()
+        .withBatchOperationKey(batchOperationKey)
+        .withIntent(BatchOperationIntent.COMPLETED)
+        .getFirst();
+
+    return RecordingExporter.records()
+        .limit(r -> r.getIntent() == BatchOperationIntent.COMPLETED)
+        .collect(Collectors.toList());
+  }
+
+  private static boolean modified(final List<Record<?>> records) {
+    return records.stream()
+        .anyMatch(
+            r ->
+                r.getValueType() == ValueType.PROCESS_INSTANCE_MODIFICATION
+                    && r.getIntent() == ProcessInstanceModificationIntent.MODIFIED);
+  }
+
+  private static boolean signalBroadcast(final List<Record<?>> records) {
+    return records.stream()
+        .anyMatch(
+            r -> r.getValueType() == ValueType.SIGNAL && r.getIntent() == SignalIntent.BROADCASTED);
+  }
+
+  private static Record<?> modifyRejection(final List<Record<?>> records) {
+    return records.stream()
+        .filter(
+            r ->
+                r.getValueType() == ValueType.PROCESS_INSTANCE_MODIFICATION
+                    && r.getRecordType() == RecordType.COMMAND_REJECTION
+                    && r.getIntent() == ProcessInstanceModificationIntent.MODIFY)
+        .findFirst()
+        .orElse(null);
+  }
+
+  /**
+   * Proves the fix: a batch move onto a join gateway whose downstream throw event broadcasts a
+   * signal that starts another process is no longer rejected — even though the acting user has no
+   * {@code CREATE_PROCESS_INSTANCE} permission on the receiver. The modification is applied, the
+   * signal is broadcast and the receiver instance is created.
+   */
+  @Test
+  public void shouldBroadcastSignalAndMoveTokenViaBatchWhenSignalStartIsReached() {
+    // given
+    final long processInstanceKey = deployAndAdvanceToSourceUserTask();
+
+    // when: the batch MODIFY carries the acting user's claims (mirrors Operate's batch move)
+    final Map<String, Object> userClaims =
+        Map.of(Authorization.AUTHORIZED_USERNAME, DEFAULT_USER.getUsername());
+    final var records = runBatchMoveAndCollectRecords(processInstanceKey, userClaims);
+
+    // then: the modification is NOT rejected (the execution-triggered signal is pre-authorized)
+    assertThat(modifyRejection(records))
+        .describedAs("the batch MODIFY is no longer rejected by the signal-start auth check")
+        .isNull();
+
+    // and: the token is moved and the signal is broadcast
+    assertThat(modified(records))
+        .describedAs("the modification is applied, so a MODIFIED event is emitted")
+        .isTrue();
+    assertThat(signalBroadcast(records)).describedAs("the downstream signal is broadcast").isTrue();
+
+    // and: the receiver signal-start process instance is created
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withBpmnProcessId(RECEIVER_ID)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .describedAs("the signal-start receiver process instance is created")
+        .isTrue();
+  }
+}


### PR DESCRIPTION
## Description

Moving a process token via Operate's **batch** (process-list) "Move" onto an element that auto-proceeds to an intermediate signal-throw event (e.g. a join gateway) silently failed on 8.8: the signal was never broadcast, the downstream signal-start subprocess never started, and the token was not moved — yet the batch operation reported **COMPLETED**. The **single-instance** move (Operate detail view) of the exact same change worked.

## Root cause

The batch move writes a `MODIFY` command carrying a `batchOperationReference`. While it is processed, the moved token proceeds through the gateway to the throw event, which emits a `SignalIntent.BROADCAST` follow-up. `BufferedProcessingResultBuilder` stamps every follow-up with the source command's `batchOperationReference` but **not** its authorization claims, so the broadcast inherits the reference with **no principal**. `TypedRecord.isInternalCommand()` classifies a command as internal only when it has no request metadata **and** no `batchOperationReference`, so the inherited reference makes the broadcast non-internal, and `SignalBroadcastProcessor` runs a `CREATE_PROCESS_INSTANCE` check for the signal-start receiver **against an empty principal**. The check fails unconditionally (no user grant can satisfy it), raising a `PROCESSING_ERROR` that rolls back the whole modification. The single-instance move has no `batchOperationReference`, stays internal, and is never checked.

## Fix

A signal broadcast triggered by a throw event is an internal side-effect of process execution, not a user-initiated broadcast, so it must not be subjected to that check. This PR marks the execution-triggered broadcast follow-up as `PRE_AUTHORIZED` (the `authInfo` survives follow-up buffering, unlike the batch reference which is unconditionally overwritten) and honors `PRE_AUTHORIZED` in `SignalBroadcastProcessor.processNewCommand`, mirroring the existing distributed-command handling.

### Alternatives considered
- **Change `isInternalCommand()` semantics** to ignore `batchOperationReference` — rejected: that predicate is used broadly (jobs, messages, …), so it would weaken authorization on other batch-originated follow-ups.
- **Strip the inherited `batchOperationReference` on the follow-up** — not possible at the `BpmnSignalBehavior` level: `BufferedProcessingResultBuilder` unconditionally re-stamps it onto every follow-up.

## Scope of the change

`BpmnSignalBehavior.broadcastNewSignal` has exactly two callers — the **signal intermediate throw event** and the **signal end event**. Both now emit their broadcast as `PRE_AUTHORIZED`. The signal **end event** had the identical latent bug (a token reaching it during a batch-referenced command would fail the same check) and is fixed symmetrically. For all normal (non-batch) execution these broadcasts were already internal, so the flag is inert there; the only observable behavioral change is that execution-triggered signals during batch-referenced processing are no longer wrongly rejected.

## Security

Scoped to signals emitted by **execution**: the user-facing `BroadcastSignal` API still carries request metadata and claims, is never `PRE_AUTHORIZED`, and remains fully authorized. The existing `SignalBroadcastAuthorizationTest` (unauthorized user is rejected) still passes.

## Testing

- New `BatchMoveTokenToGatewaySignalAuthTest` reproduces the scenario via the **real batch executor** and asserts the move now succeeds (MODIFIED, signal BROADCASTED, receiver instance created) with no `PROCESSING_ERROR`.
- `SignalBroadcastAuthorizationTest` (public-API auth guard) remains green — the fix does not weaken user-facing authorization.
- Full signal-related suite: 103 tests, 0 failures.

## Notes

- 8.9+ is unaffected (the batch-modification path was reworked there); this is an 8.8-only fix.

## Links

- Closes #59509
