### PR TITLE
style: reformat zeebe record classes to align with auto-format

### DIFF
--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
@@ -144,22 +144,17 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   }
 
   @Override
+  public String getBpmnProcessId() {
+    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  @Override
   public long getProcessDefinitionKey() {
     return processDefinitionKeyProp.getValue();
   }
 
   public AgentHistoryRecord setProcessDefinitionKey(final long processDefinitionKey) {
     processDefinitionKeyProp.setValue(processDefinitionKey);
-    return this;
-  }
-
-  @Override
-  public String getBpmnProcessId() {
-    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
-  }
-
-  public AgentHistoryRecord setBpmnProcessId(final String bpmnProcessId) {
-    bpmnProcessIdProp.setValue(bpmnProcessId);
     return this;
   }
 
@@ -244,11 +239,6 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
     return this;
   }
 
-  public AgentHistoryRecord addContent(final AgentHistoryMessageContent content) {
-    contentProp.add().copy(content);
-    return this;
-  }
-
   @Override
   public List<AgentHistoryMessageContentValue> getSystemPrompt() {
     return systemPromptProp.stream()
@@ -269,11 +259,6 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
         systemPromptProp.add().copy(item);
       }
     }
-    return this;
-  }
-
-  public AgentHistoryRecord addSystemPrompt(final AgentHistoryMessageContent block) {
-    systemPromptProp.add().copy(block);
     return this;
   }
 
@@ -298,18 +283,9 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
     return this;
   }
 
-  public AgentHistoryRecord addToolCall(final AgentHistoryEmbeddedToolCall toolCall) {
-    toolCallsProp.add().copy(toolCall);
-    return this;
-  }
-
   @Override
   public AgentHistoryMetrics getMetrics() {
     return metricsProp.getValue();
-  }
-
-  public AgentHistoryRecord ignoreLease() {
-    return setJobLease(JobRecord.EMPTY_LEASE);
   }
 
   @Override
@@ -386,11 +362,6 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
     return this;
   }
 
-  public AgentHistoryRecord addChangedAttribute(final String attribute) {
-    changedAttributesProp.add().wrap(BufferUtil.wrapString(attribute));
-    return this;
-  }
-
   @Override
   public boolean isDuplicate() {
     return isDuplicateProp.getValue();
@@ -398,6 +369,35 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
 
   public AgentHistoryRecord setDuplicate(final boolean duplicate) {
     isDuplicateProp.setValue(duplicate);
+    return this;
+  }
+
+  public AgentHistoryRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  public AgentHistoryRecord addContent(final AgentHistoryMessageContent content) {
+    contentProp.add().copy(content);
+    return this;
+  }
+
+  public AgentHistoryRecord addSystemPrompt(final AgentHistoryMessageContent block) {
+    systemPromptProp.add().copy(block);
+    return this;
+  }
+
+  public AgentHistoryRecord addToolCall(final AgentHistoryEmbeddedToolCall toolCall) {
+    toolCallsProp.add().copy(toolCall);
+    return this;
+  }
+
+  public AgentHistoryRecord ignoreLease() {
+    return setJobLease(JobRecord.EMPTY_LEASE);
+  }
+
+  public AgentHistoryRecord addChangedAttribute(final String attribute) {
+    changedAttributesProp.add().wrap(BufferUtil.wrapString(attribute));
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
@@ -133,11 +133,6 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
     return this;
   }
 
-  public AgentInstanceRecord addElementInstanceKey(final long elementInstanceKey) {
-    elementInstanceKeysProp.add().setValue(elementInstanceKey);
-    return this;
-  }
-
   @Override
   public String getElementId() {
     return BufferUtil.bufferAsString(elementIdProp.getValue());
@@ -159,6 +154,11 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   }
 
   @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  @Override
   public String getBpmnProcessId() {
     return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
   }
@@ -175,16 +175,6 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord setProcessDefinitionKey(final long processDefinitionKey) {
     processDefinitionKeyProp.setValue(processDefinitionKey);
-    return this;
-  }
-
-  @Override
-  public long getRootProcessInstanceKey() {
-    return rootProcessInstanceKeyProp.getValue();
-  }
-
-  public AgentInstanceRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
-    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 
@@ -280,11 +270,6 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
     return this;
   }
 
-  public AgentInstanceRecord addChangedAttribute(final String attribute) {
-    changedAttributesProp.add().wrap(BufferUtil.wrapString(attribute));
-    return this;
-  }
-
   @Override
   public long getJobKey() {
     return jobKeyProp.getValue();
@@ -327,6 +312,21 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
         historyProp.add().copyFrom(item);
       }
     }
+    return this;
+  }
+
+  public AgentInstanceRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  public AgentInstanceRecord addElementInstanceKey(final long elementInstanceKey) {
+    elementInstanceKeysProp.add().setValue(elementInstanceKey);
+    return this;
+  }
+
+  public AgentInstanceRecord addChangedAttribute(final String attribute) {
+    changedAttributesProp.add().wrap(BufferUtil.wrapString(attribute));
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
@@ -287,15 +287,15 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
     return this;
   }
 
-  @JsonIgnore
-  public DirectBuffer getBusinessIdBuffer() {
-    return businessIdProp.getValue();
-  }
-
   public DecisionEvaluationRecord setEvaluationFailureMessage(
       final String evaluationFailureMessage) {
     evaluationFailureMessageProp.setValue(evaluationFailureMessage);
     return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProp.getValue();
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
@@ -125,13 +125,8 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
   }
 
   @Override
-  public String getBpmnProcessId() {
-    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
-  }
-
-  public IncidentRecord setBpmnProcessId(final DirectBuffer directBuffer) {
-    bpmnProcessIdProp.setValue(directBuffer, 0, directBuffer.capacity());
-    return this;
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
   }
 
   @Override
@@ -142,11 +137,6 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
   public IncidentRecord setProcessDefinitionKey(final long processDefinitionKey) {
     processDefinitionKeyProp.setValue(processDefinitionKey);
     return this;
-  }
-
-  @Override
-  public long getProcessInstanceKey() {
-    return processInstanceKeyProp.getValue();
   }
 
   @Override
@@ -164,8 +154,13 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
     return elementInstanceKeyProp.getValue();
   }
 
-  public IncidentRecord setElementInstanceKey(final long elementInstanceKey) {
-    elementInstanceKeyProp.setValue(elementInstanceKey);
+  @Override
+  public String getBpmnProcessId() {
+    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  public IncidentRecord setBpmnProcessId(final DirectBuffer directBuffer) {
+    bpmnProcessIdProp.setValue(directBuffer, 0, directBuffer.capacity());
     return this;
   }
 
@@ -249,6 +244,11 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
 
   public IncidentRecord setJobKey(final long jobKey) {
     jobKeyProp.setValue(jobKey);
+    return this;
+  }
+
+  public IncidentRecord setElementInstanceKey(final long elementInstanceKey) {
+    elementInstanceKeyProp.setValue(elementInstanceKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -331,6 +331,31 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     return rootProcessInstanceKeyProp.getValue();
   }
 
+  public JobRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  public JobRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public JobRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  @Override
+  public String getLeaseToken() {
+    return bufferAsString(leaseTokenProp.getValue());
+  }
+
   @Override
   public String getBpmnProcessId() {
     return bufferAsString(bpmnProcessIdProp.getValue());
@@ -410,6 +435,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   }
 
   @Override
+  public boolean isJobToUserTaskMigration() {
+    return isJobToUserTaskMigrationProp.getValue();
+  }
+
+  @Override
   public List<JobSecretReferenceValue> getSecretReferences() {
     // detach copies so the returned list stays valid if this record is reused or reset later
     return secretReferencesProp.stream()
@@ -434,40 +464,6 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     return this;
   }
 
-  /**
-   * Direct access to the secret reference elements, without the detached copies of {@link
-   * #getSecretReferences()}. The elements stay owned by this record; do not hold on to them.
-   */
-  @JsonIgnore
-  public ValueArray<JobSecretReference> secretReferences() {
-    return secretReferencesProp;
-  }
-
-  @JsonIgnore
-  public boolean hasSecretReferences() {
-    return !secretReferencesProp.isEmpty();
-  }
-
-  public JobRecord addSecretReference(
-      final String storeId, final String secretReference, final String path) {
-    secretReferencesProp
-        .add()
-        .setStoreId(storeId)
-        .setSecretReference(secretReference)
-        .setPath(path);
-    return this;
-  }
-
-  public JobRecord resetSecretReferences() {
-    secretReferencesProp.reset();
-    return this;
-  }
-
-  @Override
-  public boolean isJobToUserTaskMigration() {
-    return isJobToUserTaskMigrationProp.getValue();
-  }
-
   public JobRecord setProcessDefinitionVersion(final int version) {
     processDefinitionVersionProp.setValue(version);
     return this;
@@ -483,49 +479,9 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     return this;
   }
 
-  public JobRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
-    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
-    return this;
-  }
-
-  @Override
-  public String getBusinessId() {
-    return bufferAsString(businessIdProp.getValue());
-  }
-
-  public JobRecord setBusinessId(final String businessId) {
-    businessIdProp.setValue(businessId);
-    return this;
-  }
-
-  public JobRecord setBusinessId(final DirectBuffer businessId) {
-    businessIdProp.setValue(businessId);
-    return this;
-  }
-
-  @JsonIgnore
-  public DirectBuffer getBusinessIdBuffer() {
-    return businessIdProp.getValue();
-  }
-
-  @Override
-  public String getLeaseToken() {
-    return bufferAsString(leaseTokenProp.getValue());
-  }
-
-  @JsonIgnore
-  public boolean hasLeaseToken() {
-    return !getLeaseToken().isEmpty();
-  }
-
   public JobRecord setLeaseToken(final String leaseToken) {
     leaseTokenProp.setValue(leaseToken);
     return this;
-  }
-
-  @JsonIgnore
-  public DirectBuffer getLeaseTokenBuffer() {
-    return leaseTokenProp.getValue();
   }
 
   public JobRecord setElementInstanceKey(final long elementInstanceKey) {
@@ -612,6 +568,50 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public JobRecord setType(final DirectBuffer buf) {
     return setType(buf, 0, buf.capacity());
+  }
+
+  /**
+   * Direct access to the secret reference elements, without the detached copies of {@link
+   * #getSecretReferences()}. The elements stay owned by this record; do not hold on to them.
+   */
+  @JsonIgnore
+  public ValueArray<JobSecretReference> secretReferences() {
+    return secretReferencesProp;
+  }
+
+  @JsonIgnore
+  public boolean hasSecretReferences() {
+    return !secretReferencesProp.isEmpty();
+  }
+
+  public JobRecord addSecretReference(
+      final String storeId, final String secretReference, final String path) {
+    secretReferencesProp
+        .add()
+        .setStoreId(storeId)
+        .setSecretReference(secretReference)
+        .setPath(path);
+    return this;
+  }
+
+  public JobRecord resetSecretReferences() {
+    secretReferencesProp.reset();
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public boolean hasLeaseToken() {
+    return !getLeaseToken().isEmpty();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getLeaseTokenBuffer() {
+    return leaseTokenProp.getValue();
   }
 
   public JobRecord setListenerEventType(final JobListenerEventType jobListenerEventType) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageCorrelationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageCorrelationRecord.java
@@ -112,6 +112,21 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  public MessageCorrelationRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public MessageCorrelationRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
   public MessageCorrelationRecord setRequestId(final long requestId) {
     requestIdProp.setValue(requestId);
     return this;
@@ -182,23 +197,8 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
     return this;
   }
 
-  @Override
-  public String getBusinessId() {
-    return bufferAsString(businessIdProp.getValue());
-  }
-
   @JsonIgnore
   public DirectBuffer getBusinessIdBuffer() {
     return businessIdProp.getValue();
-  }
-
-  public MessageCorrelationRecord setBusinessId(final String businessId) {
-    businessIdProp.setValue(businessId);
-    return this;
-  }
-
-  public MessageCorrelationRecord setBusinessId(final DirectBuffer businessId) {
-    businessIdProp.setValue(businessId);
-    return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
@@ -160,6 +160,56 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  public MessageSubscriptionRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public MessageSubscriptionRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  @Override
+  public String getElementId() {
+    return bufferAsString(elementIdProp.getValue());
+  }
+
+  public MessageSubscriptionRecord setElementId(final DirectBuffer elementId) {
+    elementIdProp.setValue(elementId);
+    return this;
+  }
+
+  public MessageSubscriptionRecord setElementId(final String elementId) {
+    elementIdProp.setValue(elementId);
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setRootProcessInstanceKey(final long key) {
+    rootProcessInstanceKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public BpmnElementType getElementType() {
+    return elementTypeProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setElementType(final BpmnElementType elementType) {
+    elementTypeProp.setValue(elementType);
+    return this;
+  }
+
   public MessageSubscriptionRecord setMessageKey(final long messageKey) {
     messageKeyProp.setValue(messageKey);
     return this;
@@ -220,63 +270,13 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
-  @Override
-  public String getBusinessId() {
-    return bufferAsString(businessIdProp.getValue());
-  }
-
   @JsonIgnore
   public DirectBuffer getBusinessIdBuffer() {
     return businessIdProp.getValue();
   }
 
-  public MessageSubscriptionRecord setBusinessId(final String businessId) {
-    businessIdProp.setValue(businessId);
-    return this;
-  }
-
-  public MessageSubscriptionRecord setBusinessId(final DirectBuffer businessId) {
-    businessIdProp.setValue(businessId);
-    return this;
-  }
-
-  @Override
-  public String getElementId() {
-    return bufferAsString(elementIdProp.getValue());
-  }
-
   @JsonIgnore
   public DirectBuffer getElementIdBuffer() {
     return elementIdProp.getValue();
-  }
-
-  public MessageSubscriptionRecord setElementId(final DirectBuffer elementId) {
-    elementIdProp.setValue(elementId);
-    return this;
-  }
-
-  public MessageSubscriptionRecord setElementId(final String elementId) {
-    elementIdProp.setValue(elementId);
-    return this;
-  }
-
-  @Override
-  public long getRootProcessInstanceKey() {
-    return rootProcessInstanceKeyProp.getValue();
-  }
-
-  public MessageSubscriptionRecord setRootProcessInstanceKey(final long key) {
-    rootProcessInstanceKeyProp.setValue(key);
-    return this;
-  }
-
-  @Override
-  public BpmnElementType getElementType() {
-    return elementTypeProp.getValue();
-  }
-
-  public MessageSubscriptionRecord setElementType(final BpmnElementType elementType) {
-    elementTypeProp.setValue(elementType);
-    return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
@@ -220,6 +220,31 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public String getBusinessId() {
+    return BufferUtil.bufferAsString(businessIdProp.getValue());
+  }
+
+  public ProcessMessageSubscriptionRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public ProcessMessageSubscriptionRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  @Override
+  public BpmnElementType getElementType() {
+    return elementTypeProp.getValue();
+  }
+
+  public ProcessMessageSubscriptionRecord setElementType(final BpmnElementType elementType) {
+    elementTypeProp.setValue(elementType);
+    return this;
+  }
+
   public ProcessMessageSubscriptionRecord setElementId(final DirectBuffer elementId) {
     elementIdProp.setValue(elementId);
     return this;
@@ -260,33 +285,8 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
-  @Override
-  public String getBusinessId() {
-    return BufferUtil.bufferAsString(businessIdProp.getValue());
-  }
-
   @JsonIgnore
   public DirectBuffer getBusinessIdBuffer() {
     return businessIdProp.getValue();
-  }
-
-  public ProcessMessageSubscriptionRecord setBusinessId(final String businessId) {
-    businessIdProp.setValue(businessId);
-    return this;
-  }
-
-  public ProcessMessageSubscriptionRecord setBusinessId(final DirectBuffer businessId) {
-    businessIdProp.setValue(businessId);
-    return this;
-  }
-
-  @Override
-  public BpmnElementType getElementType() {
-    return elementTypeProp.getValue();
-  }
-
-  public ProcessMessageSubscriptionRecord setElementType(final BpmnElementType elementType) {
-    elementTypeProp.setValue(elementType);
-    return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryRecord.golden
@@ -144,22 +144,17 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   }
 
   @Override
+  public String getBpmnProcessId() {
+    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  @Override
   public long getProcessDefinitionKey() {
     return processDefinitionKeyProp.getValue();
   }
 
   public AgentHistoryRecord setProcessDefinitionKey(final long processDefinitionKey) {
     processDefinitionKeyProp.setValue(processDefinitionKey);
-    return this;
-  }
-
-  @Override
-  public String getBpmnProcessId() {
-    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
-  }
-
-  public AgentHistoryRecord setBpmnProcessId(final String bpmnProcessId) {
-    bpmnProcessIdProp.setValue(bpmnProcessId);
     return this;
   }
 
@@ -244,11 +239,6 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
     return this;
   }
 
-  public AgentHistoryRecord addContent(final AgentHistoryMessageContent content) {
-    contentProp.add().copy(content);
-    return this;
-  }
-
   @Override
   public List<AgentHistoryMessageContentValue> getSystemPrompt() {
     return systemPromptProp.stream()
@@ -269,11 +259,6 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
         systemPromptProp.add().copy(item);
       }
     }
-    return this;
-  }
-
-  public AgentHistoryRecord addSystemPrompt(final AgentHistoryMessageContent block) {
-    systemPromptProp.add().copy(block);
     return this;
   }
 
@@ -298,18 +283,9 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
     return this;
   }
 
-  public AgentHistoryRecord addToolCall(final AgentHistoryEmbeddedToolCall toolCall) {
-    toolCallsProp.add().copy(toolCall);
-    return this;
-  }
-
   @Override
   public AgentHistoryMetrics getMetrics() {
     return metricsProp.getValue();
-  }
-
-  public AgentHistoryRecord ignoreLease() {
-    return setJobLease(JobRecord.EMPTY_LEASE);
   }
 
   @Override
@@ -386,11 +362,6 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
     return this;
   }
 
-  public AgentHistoryRecord addChangedAttribute(final String attribute) {
-    changedAttributesProp.add().wrap(BufferUtil.wrapString(attribute));
-    return this;
-  }
-
   @Override
   public boolean isDuplicate() {
     return isDuplicateProp.getValue();
@@ -398,6 +369,35 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
 
   public AgentHistoryRecord setDuplicate(final boolean duplicate) {
     isDuplicateProp.setValue(duplicate);
+    return this;
+  }
+
+  public AgentHistoryRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  public AgentHistoryRecord addContent(final AgentHistoryMessageContent content) {
+    contentProp.add().copy(content);
+    return this;
+  }
+
+  public AgentHistoryRecord addSystemPrompt(final AgentHistoryMessageContent block) {
+    systemPromptProp.add().copy(block);
+    return this;
+  }
+
+  public AgentHistoryRecord addToolCall(final AgentHistoryEmbeddedToolCall toolCall) {
+    toolCallsProp.add().copy(toolCall);
+    return this;
+  }
+
+  public AgentHistoryRecord ignoreLease() {
+    return setJobLease(JobRecord.EMPTY_LEASE);
+  }
+
+  public AgentHistoryRecord addChangedAttribute(final String attribute) {
+    changedAttributesProp.add().wrap(BufferUtil.wrapString(attribute));
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
@@ -32,10 +32,10 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   public static final String ATTR_METRICS = "metrics";
   public static final String ATTR_TOOLS = "tools";
 
-  // Derived from CONFIGURATION-role history items on the output side (see #58791 for the engine
-  // processing that merges them in), never from a request-level changedAttributes entry — these
-  // are not part of ALLOWED_ATTRIBUTES in AgentInstanceUpdateProcessor, only of the output-side
-  // merge order.
+  // Derived from a future configuration-change history entry kind on the output side (see #58794
+  // for that entry kind and #58791 for the engine processing that merges them in), never from a
+  // request-level changedAttributes entry — these are not part of ALLOWED_ATTRIBUTES in
+  // AgentInstanceUpdateProcessor, only of the output-side merge order.
   public static final String ATTR_SYSTEM_PROMPT = "systemPrompt";
   public static final String ATTR_MODEL = "model";
   public static final String ATTR_PROVIDER = "provider";
@@ -133,11 +133,6 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
     return this;
   }
 
-  public AgentInstanceRecord addElementInstanceKey(final long elementInstanceKey) {
-    elementInstanceKeysProp.add().setValue(elementInstanceKey);
-    return this;
-  }
-
   @Override
   public String getElementId() {
     return BufferUtil.bufferAsString(elementIdProp.getValue());
@@ -159,6 +154,11 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   }
 
   @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  @Override
   public String getBpmnProcessId() {
     return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
   }
@@ -175,16 +175,6 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord setProcessDefinitionKey(final long processDefinitionKey) {
     processDefinitionKeyProp.setValue(processDefinitionKey);
-    return this;
-  }
-
-  @Override
-  public long getRootProcessInstanceKey() {
-    return rootProcessInstanceKeyProp.getValue();
-  }
-
-  public AgentInstanceRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
-    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 
@@ -280,11 +270,6 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
     return this;
   }
 
-  public AgentInstanceRecord addChangedAttribute(final String attribute) {
-    changedAttributesProp.add().wrap(BufferUtil.wrapString(attribute));
-    return this;
-  }
-
   @Override
   public long getJobKey() {
     return jobKeyProp.getValue();
@@ -327,6 +312,21 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
         historyProp.add().copyFrom(item);
       }
     }
+    return this;
+  }
+
+  public AgentInstanceRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  public AgentInstanceRecord addElementInstanceKey(final long elementInstanceKey) {
+    elementInstanceKeysProp.add().setValue(elementInstanceKey);
+    return this;
+  }
+
+  public AgentInstanceRecord addChangedAttribute(final String attribute) {
+    changedAttributesProp.add().wrap(BufferUtil.wrapString(attribute));
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationCreationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationCreationRecord.golden
@@ -20,7 +20,7 @@ import io.camunda.zeebe.protocol.impl.record.value.NestedRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
-import io.camunda.zeebe.protocol.record.value.BatchOperationJobUpdatePlanValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue.BatchOperationJobUpdatePlanValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import java.util.Collection;
 import java.util.List;

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationJobUpdatePlan.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationJobUpdatePlan.golden
@@ -80,6 +80,9 @@ public final class BatchOperationJobUpdatePlan extends ObjectValue
 
   public BatchOperationJobUpdatePlan wrap(final BatchOperationJobUpdatePlanValue record) {
     changedAttributesProp.reset();
+    retriesProp.reset();
+    timeoutProp.reset();
+    priorityProp.reset();
     setRetries(record.getRetries());
     setTimeout(record.getTimeout());
     setPriority(record.getPriority());

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CommandDistributionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CommandDistributionRecord.golden
@@ -28,6 +28,7 @@ import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperation
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
@@ -69,6 +70,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   // You'll need to register any of the records value's that you want to distribute
   static {
     RECORDS_BY_TYPE.put(ValueType.DEPLOYMENT, DeploymentRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.PROCESS, ProcessRecord::new);
     RECORDS_BY_TYPE.put(ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionRecord::new);
     RECORDS_BY_TYPE.put(ValueType.RESOURCE_DELETION, ResourceDeletionRecord::new);
     RECORDS_BY_TYPE.put(ValueType.SIGNAL, SignalRecord::new);

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ConditionalStartedProcessInstance.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ConditionalStartedProcessInstance.golden
@@ -41,7 +41,8 @@ public final class ConditionalStartedProcessInstance extends ObjectValue
     return processDefinitionKeyProp.getValue();
   }
 
-  public ConditionalStartedProcessInstance setProcessDefinitionKey(final long processDefinitionKey) {
+  public ConditionalStartedProcessInstance setProcessDefinitionKey(
+      final long processDefinitionKey) {
     processDefinitionKeyProp.setValue(processDefinitionKey);
     return this;
   }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ConditionalSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ConditionalSubscriptionRecord.golden
@@ -224,13 +224,19 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
-  public ConditionalSubscriptionRecord setCatchEventId(final DirectBuffer catchEventId) {
-    catchEventIdProp.setValue(catchEventId);
+  @Override
+  public BpmnElementType getElementType() {
+    return elementTypeProp.getValue();
+  }
+
+  public ConditionalSubscriptionRecord setElementType(final BpmnElementType elementType) {
+    elementTypeProp.setValue(elementType);
     return this;
   }
 
-  public String getBpmnProcessId() {
-    return bufferAsString(bpmnProcessIdProp.getValue());
+  public ConditionalSubscriptionRecord setCatchEventId(final DirectBuffer catchEventId) {
+    catchEventIdProp.setValue(catchEventId);
+    return this;
   }
 
   public ConditionalSubscriptionRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
@@ -260,21 +266,6 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
 
   public ConditionalSubscriptionRecord setRootProcessInstanceKey(final long key) {
     rootProcessInstanceKeyProp.setValue(key);
-    return this;
-  }
-
-  @Override
-  public String getElementId() {
-    return getCatchEventId();
-  }
-
-  @Override
-  public BpmnElementType getElementType() {
-    return elementTypeProp.getValue();
-  }
-
-  public ConditionalSubscriptionRecord setElementType(final BpmnElementType elementType) {
-    elementTypeProp.setValue(elementType);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/DecisionEvaluationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/DecisionEvaluationRecord.golden
@@ -287,15 +287,15 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
     return this;
   }
 
-  @JsonIgnore
-  public DirectBuffer getBusinessIdBuffer() {
-    return businessIdProp.getValue();
-  }
-
   public DecisionEvaluationRecord setEvaluationFailureMessage(
       final String evaluationFailureMessage) {
     evaluationFailureMessageProp.setValue(evaluationFailureMessage);
     return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProp.getValue();
   }
 
   @Override

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/DecisionRequirementsRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/DecisionRequirementsRecord.golden
@@ -142,6 +142,16 @@ public final class DecisionRequirementsRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public long getDeploymentKey() {
+    return deploymentKeyProp.getValue();
+  }
+
+  public DecisionRequirementsRecord setDeploymentKey(final long deploymentKey) {
+    deploymentKeyProp.setValue(deploymentKey);
+    return this;
+  }
+
   @JsonIgnore
   public DirectBuffer getDecisionRequirementsIdBuffer() {
     return decisionRequirementsIdProp.getValue();
@@ -179,16 +189,6 @@ public final class DecisionRequirementsRecord extends UnifiedRecordValue
 
   public DecisionRequirementsRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
-    return this;
-  }
-
-  @Override
-  public long getDeploymentKey() {
-    return deploymentKeyProp.getValue();
-  }
-
-  public DecisionRequirementsRecord setDeploymentKey(final long deploymentKey) {
-    deploymentKeyProp.setValue(deploymentKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/DeploymentRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/DeploymentRecord.golden
@@ -222,35 +222,34 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
     return this;
   }
 
-  public boolean hasBpmnResources() {
-    return getResources().stream()
-        .map(io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource::getResourceName)
-        .anyMatch(x -> x.endsWith(".bpmn") || x.endsWith(".xml"));
-  }
-
-  public boolean hasDmnResources() {
-    return getResources().stream()
-        .map(io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource::getResourceName)
-        .anyMatch(x -> x.endsWith(".dmn"));
-  }
-
-  public boolean hasForms() {
-    return getResources().stream()
-        .map(io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource::getResourceName)
-        .anyMatch(x -> x.endsWith(".form"));
-  }
-
-  public boolean hasResources() {
-    return getResources().stream()
-        .map(io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource::getResourceName)
-        .anyMatch(x -> x.endsWith(".rpa"));
-  }
-
+  /**
+   * Returns {@code true} if every metadata entry in this deployment record has its {@code
+   * duplicate} flag set, {@code false} if at least one entry is marked as new or changed. The
+   * duplicate flag is set during metadata creation by the individual resource transformers.
+   */
   public boolean hasDuplicatesOnly() {
     return processesMetadata().stream().allMatch(ProcessMetadata::isDuplicate)
         && decisionRequirementsMetadata().stream()
             .allMatch(DecisionRequirementsMetadataValue::isDuplicate)
         && formMetadata().stream().allMatch(FormMetadataValue::isDuplicate)
         && resourceMetadata().stream().allMatch(ResourceMetadataValue::isDuplicate);
+  }
+
+  /**
+   * Returns the resource name (filename) of the DRG that contains the given decision. Decisions
+   * don't carry their own resource name — they belong to a decision requirements graph (DRG), and
+   * the DRG carries the resource name.
+   *
+   * @param decision the decision metadata to look up
+   * @return the resource name of the parent DRG, or {@code null} if not found
+   */
+  @JsonIgnore
+  public String getResourceNameForDecision(final DecisionRecordValue decision) {
+    for (final var drg : decisionRequirementsMetadataProp) {
+      if (drg.getDecisionRequirementsKey() == decision.getDecisionRequirementsKey()) {
+        return drg.getResourceName();
+      }
+    }
+    return null;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/GlobalListenerBatchRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/GlobalListenerBatchRecord.golden
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerType;
 import java.util.List;
 import java.util.Set;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 public final class GlobalListenerBatchRecord extends UnifiedRecordValue
@@ -86,26 +87,17 @@ public final class GlobalListenerBatchRecord extends UnifiedRecordValue
    * the batch and the listeners.
    */
   public boolean isSameConfiguration(final GlobalListenerBatchRecord other) {
+    final UnaryOperator<GlobalListenerRecord> makeComparable =
+        listener -> {
+          final GlobalListenerRecord copy = new GlobalListenerRecord();
+          copy.copyFrom(listener);
+          copy.setGlobalListenerKey(-1L); // ignore keys when comparing listeners
+          return copy;
+        };
     final Set<GlobalListenerRecord> thisListeners =
-        listenersProp.stream()
-            .map(
-                listener -> {
-                  final GlobalListenerRecord copy = new GlobalListenerRecord();
-                  copy.copyFrom(listener);
-                  copy.setGlobalListenerKey(-1L); // ignore keys when comparing listeners
-                  return copy;
-                })
-            .collect(Collectors.toSet());
+        listenersProp.stream().map(makeComparable).collect(Collectors.toSet());
     final Set<GlobalListenerRecord> otherListeners =
-        other.listenersProp.stream()
-            .map(
-                listener -> {
-                  final GlobalListenerRecord copy = new GlobalListenerRecord();
-                  copy.copyFrom(listener);
-                  copy.setGlobalListenerKey(-1L); // ignore keys when comparing listeners
-                  return copy;
-                })
-            .collect(Collectors.toSet());
+        other.listenersProp.stream().map(makeComparable).collect(Collectors.toSet());
     return thisListeners.equals(otherListeners);
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/GlobalListenerRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/GlobalListenerRecord.golden
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.globallistener;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
@@ -23,7 +24,9 @@ import io.camunda.zeebe.protocol.record.value.GlobalListenerType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public final class GlobalListenerRecord extends UnifiedRecordValue
@@ -42,6 +45,11 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
           .reversed()
           .thenComparing(GlobalListenerRecord::getId);
 
+  public static final String ALL_EVENT_TYPES = "all";
+  // Set of all possible task listener event types as strings, to be used while validating records
+  public static final Set<String> TASK_LISTENER_EVENT_TYPES =
+      Stream.of(ZeebeTaskListenerEventType.values()).map(Enum::name).collect(Collectors.toSet());
+
   private final LongProperty globalListenerKeyProp = new LongProperty("globalListenerKey", -1L);
   private final StringProperty idProp = new StringProperty("id", "");
   private final StringProperty typeProp = new StringProperty("type", "");
@@ -51,9 +59,9 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
   private final BooleanProperty afterNonGlobalProp = new BooleanProperty("afterNonGlobal", false);
   private final IntegerProperty priorityProp = new IntegerProperty("priority", DEFAULT_PRIORITY);
   private final EnumProperty<GlobalListenerSource> sourceProp =
-      new EnumProperty<>("source", GlobalListenerSource.class, GlobalListenerSource.CONFIGURATION);
+      new EnumProperty<>("source", GlobalListenerSource.class, DEFAULT_SOURCE);
   private final EnumProperty<GlobalListenerType> listenerTypeProp =
-      new EnumProperty<>("listenerType", GlobalListenerType.class, GlobalListenerType.USER_TASK);
+      new EnumProperty<>("listenerType", GlobalListenerType.class, DEFAULT_LISTENER_TYPE);
 
   private final LongProperty configKeyProp = new LongProperty("configKey", -1L);
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/IdentitySetupRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/IdentitySetupRecord.golden
@@ -158,8 +158,8 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
     return this;
   }
 
-  public IdentitySetupRecord addGroupMember(final GroupRecord role) {
-    groupMembersProp.add().copyFrom(role);
+  public IdentitySetupRecord addGroupMember(final GroupRecord groupMember) {
+    groupMembersProp.add().copyFrom(groupMember);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/IncidentRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/IncidentRecord.golden
@@ -125,13 +125,8 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
   }
 
   @Override
-  public String getBpmnProcessId() {
-    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
-  }
-
-  public IncidentRecord setBpmnProcessId(final DirectBuffer directBuffer) {
-    bpmnProcessIdProp.setValue(directBuffer, 0, directBuffer.capacity());
-    return this;
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
   }
 
   @Override
@@ -142,11 +137,6 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
   public IncidentRecord setProcessDefinitionKey(final long processDefinitionKey) {
     processDefinitionKeyProp.setValue(processDefinitionKey);
     return this;
-  }
-
-  @Override
-  public long getProcessInstanceKey() {
-    return processInstanceKeyProp.getValue();
   }
 
   @Override
@@ -164,8 +154,13 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
     return elementInstanceKeyProp.getValue();
   }
 
-  public IncidentRecord setElementInstanceKey(final long elementInstanceKey) {
-    elementInstanceKeyProp.setValue(elementInstanceKey);
+  @Override
+  public String getBpmnProcessId() {
+    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  public IncidentRecord setBpmnProcessId(final DirectBuffer directBuffer) {
+    bpmnProcessIdProp.setValue(directBuffer, 0, directBuffer.capacity());
     return this;
   }
 
@@ -249,6 +244,11 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
 
   public IncidentRecord setJobKey(final long jobKey) {
     jobKeyProp.setValue(jobKey);
+    return this;
+  }
+
+  public IncidentRecord setElementInstanceKey(final long elementInstanceKey) {
+    elementInstanceKeyProp.setValue(elementInstanceKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobMetrics.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobMetrics.golden
@@ -59,8 +59,15 @@ public final class JobMetrics extends ObjectValue implements JobMetricsValue {
   }
 
   @Override
-  public List<StatusMetricValue> getStatusMetrics() {
+  public List<StatusMetricsValue> getStatusMetrics() {
     return statusMetricsProperty.stream().collect(Collectors.toList());
+  }
+
+  public JobMetrics setStatusMetrics(final List<StatusMetricsValue> statusMetrics) {
+    statusMetricsProperty.reset();
+    statusMetrics.forEach(
+        statusMetricsValue -> statusMetricsProperty.add().wrap(statusMetricsValue));
+    return this;
   }
 
   public JobMetrics setWorkerNameIndex(final int workerNameIndex) {
@@ -73,12 +80,6 @@ public final class JobMetrics extends ObjectValue implements JobMetricsValue {
     setTenantIdIndex(value.getTenantIdIndex());
     setWorkerNameIndex(value.getWorkerNameIndex());
     setStatusMetrics(value.getStatusMetrics());
-    return this;
-  }
-
-  public JobMetricsValue setStatusMetrics(final List<StatusMetricValue> statusMetrics) {
-    statusMetricsProperty.reset();
-    statusMetrics.forEach(statusMetricsValue -> statusMetricsProperty.add().wrap(statusMetricsValue));
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobMetricsBatchRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobMetricsBatchRecord.golden
@@ -16,7 +16,6 @@ import io.camunda.zeebe.protocol.record.value.JobMetricsBatchRecordValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -109,7 +108,7 @@ public final class JobMetricsBatchRecord extends UnifiedRecordValue
     return this;
   }
 
-  public JobMetricsBatchRecord setEncodedStrings(final Set<String> encodedStrings) {
+  public JobMetricsBatchRecord setEncodedStrings(final List<String> encodedStrings) {
     encodedStringsProperty.reset();
     encodedStrings.forEach(str -> encodedStringsProperty.add().wrap(BufferUtil.wrapString(str)));
     return this;

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
@@ -23,6 +23,7 @@ import io.camunda.zeebe.msgpack.property.PackedProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
 import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -330,6 +331,31 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     return rootProcessInstanceKeyProp.getValue();
   }
 
+  public JobRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  public JobRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public JobRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  @Override
+  public String getLeaseToken() {
+    return bufferAsString(leaseTokenProp.getValue());
+  }
+
   @Override
   public String getBpmnProcessId() {
     return bufferAsString(bpmnProcessIdProp.getValue());
@@ -409,8 +435,13 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   }
 
   @Override
+  public boolean isJobToUserTaskMigration() {
+    return isJobToUserTaskMigrationProp.getValue();
+  }
+
+  @Override
   public List<JobSecretReferenceValue> getSecretReferences() {
-    // copy each element while iterating the ArrayProperty because the inner values are reused
+    // detach copies so the returned list stays valid if this record is reused or reset later
     return secretReferencesProp.stream()
         .map(
             element -> {
@@ -421,7 +452,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .toList();
   }
 
-  public JobRecord setSecretReferences(final List<JobSecretReferenceValue> secretReferences) {
+  public JobRecord setSecretReferences(
+      final List<? extends JobSecretReferenceValue> secretReferences) {
     secretReferencesProp.reset();
     if (secretReferences != null) {
       secretReferences.forEach(
@@ -430,26 +462,6 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
                   reference.getStoreId(), reference.getSecretReference(), reference.getPath()));
     }
     return this;
-  }
-
-  public JobRecord addSecretReference(
-      final String storeId, final String secretReference, final String path) {
-    secretReferencesProp
-        .add()
-        .setStoreId(storeId)
-        .setSecretReference(secretReference)
-        .setPath(path);
-    return this;
-  }
-
-  public JobRecord resetSecretReferences() {
-    secretReferencesProp.reset();
-    return this;
-  }
-
-  @Override
-  public boolean isJobToUserTaskMigration() {
-    return isJobToUserTaskMigrationProp.getValue();
   }
 
   public JobRecord setProcessDefinitionVersion(final int version) {
@@ -467,44 +479,9 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     return this;
   }
 
-  public JobRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
-    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
-    return this;
-  }
-
-  @Override
-  public String getBusinessId() {
-    return bufferAsString(businessIdProp.getValue());
-  }
-
-  public JobRecord setBusinessId(final String businessId) {
-    businessIdProp.setValue(businessId);
-    return this;
-  }
-
-  public JobRecord setBusinessId(final DirectBuffer businessId) {
-    businessIdProp.setValue(businessId);
-    return this;
-  }
-
-  @JsonIgnore
-  public DirectBuffer getBusinessIdBuffer() {
-    return businessIdProp.getValue();
-  }
-
-  @Override
-  public String getLeaseToken() {
-    return bufferAsString(leaseTokenProp.getValue());
-  }
-
   public JobRecord setLeaseToken(final String leaseToken) {
     leaseTokenProp.setValue(leaseToken);
     return this;
-  }
-
-  @JsonIgnore
-  public DirectBuffer getLeaseTokenBuffer() {
-    return leaseTokenProp.getValue();
   }
 
   public JobRecord setElementInstanceKey(final long elementInstanceKey) {
@@ -591,6 +568,50 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public JobRecord setType(final DirectBuffer buf) {
     return setType(buf, 0, buf.capacity());
+  }
+
+  /**
+   * Direct access to the secret reference elements, without the detached copies of {@link
+   * #getSecretReferences()}. The elements stay owned by this record; do not hold on to them.
+   */
+  @JsonIgnore
+  public ValueArray<JobSecretReference> secretReferences() {
+    return secretReferencesProp;
+  }
+
+  @JsonIgnore
+  public boolean hasSecretReferences() {
+    return !secretReferencesProp.isEmpty();
+  }
+
+  public JobRecord addSecretReference(
+      final String storeId, final String secretReference, final String path) {
+    secretReferencesProp
+        .add()
+        .setStoreId(storeId)
+        .setSecretReference(secretReference)
+        .setPath(path);
+    return this;
+  }
+
+  public JobRecord resetSecretReferences() {
+    secretReferencesProp.reset();
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public boolean hasLeaseToken() {
+    return !getLeaseToken().isEmpty();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getLeaseTokenBuffer() {
+    return leaseTokenProp.getValue();
   }
 
   public JobRecord setListenerEventType(final JobListenerEventType jobListenerEventType) {

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageCorrelationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageCorrelationRecord.golden
@@ -112,6 +112,21 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  public MessageCorrelationRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public MessageCorrelationRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
   public MessageCorrelationRecord setRequestId(final long requestId) {
     requestIdProp.setValue(requestId);
     return this;
@@ -182,23 +197,8 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
     return this;
   }
 
-  @Override
-  public String getBusinessId() {
-    return bufferAsString(businessIdProp.getValue());
-  }
-
   @JsonIgnore
   public DirectBuffer getBusinessIdBuffer() {
     return businessIdProp.getValue();
-  }
-
-  public MessageCorrelationRecord setBusinessId(final String businessId) {
-    businessIdProp.setValue(businessId);
-    return this;
-  }
-
-  public MessageCorrelationRecord setBusinessId(final DirectBuffer businessId) {
-    businessIdProp.setValue(businessId);
-    return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageRecord.golden
@@ -186,7 +186,6 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
     return businessIdProp.getValue();
   }
 
-
   public MessageRecord setBusinessId(final String businessId) {
     businessIdProp.setValue(businessId);
     return this;

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageStartCorrelationKeyLockReleaseRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageStartCorrelationKeyLockReleaseRecord.golden
@@ -23,7 +23,15 @@ import java.util.List;
  * on a single partition in isolation: {@code P_K} sends a {@code QUERY} batching one {@link
  * MessageStartLockReleaseHolder holder} per lock entry to {@code P_B} (derived from each holder's
  * instance key); {@code P_B} replies {@code RELEASE} back to {@code P_K} (derived from {@link
- * #requestKeyProp the request key}) with the single gone holder.
+ * #requestKeyProp the request key}) with the single gone holder. On the {@code PUSHED} path {@code
+ * P_B} builds the same {@code RELEASE} itself, from the holder-origin entry, the moment the holder
+ * completes — so the release also flows without a preceding {@code QUERY}.
+ *
+ * <p>The {@link #requestKeyProp request key} is purely a partition-addressing envelope: the {@code
+ * RELEASE} is routed to the partition its bits encode. On the query path {@code P_K} stamps it so
+ * the reply comes back to itself; on the push path {@code P_B} synthesizes it from the buffered
+ * message key's partition bits to address {@code P_K}. It is never a request-correlation id and
+ * never an event key.
  */
 public final class MessageStartCorrelationKeyLockReleaseRecord extends UnifiedRecordValue
     implements MessageStartCorrelationKeyLockReleaseRecordValue {

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageSubscriptionRecord.golden
@@ -160,6 +160,56 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  public MessageSubscriptionRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public MessageSubscriptionRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  @Override
+  public String getElementId() {
+    return bufferAsString(elementIdProp.getValue());
+  }
+
+  public MessageSubscriptionRecord setElementId(final DirectBuffer elementId) {
+    elementIdProp.setValue(elementId);
+    return this;
+  }
+
+  public MessageSubscriptionRecord setElementId(final String elementId) {
+    elementIdProp.setValue(elementId);
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setRootProcessInstanceKey(final long key) {
+    rootProcessInstanceKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public BpmnElementType getElementType() {
+    return elementTypeProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setElementType(final BpmnElementType elementType) {
+    elementTypeProp.setValue(elementType);
+    return this;
+  }
+
   public MessageSubscriptionRecord setMessageKey(final long messageKey) {
     messageKeyProp.setValue(messageKey);
     return this;
@@ -220,63 +270,13 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
-  @Override
-  public String getBusinessId() {
-    return bufferAsString(businessIdProp.getValue());
-  }
-
   @JsonIgnore
   public DirectBuffer getBusinessIdBuffer() {
     return businessIdProp.getValue();
   }
 
-  public MessageSubscriptionRecord setBusinessId(final String businessId) {
-    businessIdProp.setValue(businessId);
-    return this;
-  }
-
-  public MessageSubscriptionRecord setBusinessId(final DirectBuffer businessId) {
-    businessIdProp.setValue(businessId);
-    return this;
-  }
-
-  @Override
-  public String getElementId() {
-    return bufferAsString(elementIdProp.getValue());
-  }
-
   @JsonIgnore
   public DirectBuffer getElementIdBuffer() {
     return elementIdProp.getValue();
-  }
-
-  public MessageSubscriptionRecord setElementId(final DirectBuffer elementId) {
-    elementIdProp.setValue(elementId);
-    return this;
-  }
-
-  public MessageSubscriptionRecord setElementId(final String elementId) {
-    elementIdProp.setValue(elementId);
-    return this;
-  }
-
-  @Override
-  public long getRootProcessInstanceKey() {
-    return rootProcessInstanceKeyProp.getValue();
-  }
-
-  public MessageSubscriptionRecord setRootProcessInstanceKey(final long key) {
-    rootProcessInstanceKeyProp.setValue(key);
-    return this;
-  }
-
-  @Override
-  public BpmnElementType getElementType() {
-    return elementTypeProp.getValue();
-  }
-
-  public MessageSubscriptionRecord setElementType(final BpmnElementType elementType) {
-    elementTypeProp.setValue(elementType);
-    return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceBusinessIdRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceBusinessIdRecord.golden
@@ -19,7 +19,7 @@ import io.camunda.zeebe.protocol.record.value.TenantOwned;
 public final class ProcessInstanceBusinessIdRecord extends UnifiedRecordValue
     implements ProcessInstanceBusinessIdRecordValue {
 
-  public static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   // Static StringValue keys to avoid memory waste
   private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
@@ -30,7 +30,7 @@ public final class ProcessInstanceBusinessIdRecord extends UnifiedRecordValue
   private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
 
   private final LongProperty processInstanceKeyProperty =
-      new LongProperty(PROCESS_INSTANCE_KEY_KEY);
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1);
   private final StringProperty businessIdProperty = new StringProperty(BUSINESS_ID_KEY, "");
   private final StringProperty tenantIdProperty =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceCreationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceCreationRecord.golden
@@ -195,6 +195,10 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
     return this;
   }
 
+  public boolean hasBusinessId() {
+    return businessIdProperty.getValue().capacity() > 0;
+  }
+
   @JsonIgnore
   public boolean hasStartInstructions() {
     return !startInstructionsProperty.isEmpty();
@@ -231,6 +235,10 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
 
   public ArrayProperty<ProcessInstanceCreationStartInstruction> startInstructions() {
     return startInstructionsProperty;
+  }
+
+  public ArrayProperty<ProcessInstanceCreationRuntimeInstruction> runtimeInstructions() {
+    return runtimeInstructionsProperty;
   }
 
   public ProcessInstanceCreationRecord addStartInstructions(

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceMigrationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceMigrationRecord.golden
@@ -124,6 +124,16 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public String getBpmnProcessId() {
+    return bufferAsString(bpmnProcessIdProperty.getValue());
+  }
+
+  public ProcessInstanceMigrationRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProperty.setValue(bpmnProcessId);
+    return this;
+  }
+
   /** Returns true if this record has mapping instructions, otherwise false. */
   @JsonIgnore
   public boolean hasMappingInstructions() {
@@ -143,16 +153,6 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
 
   public ProcessInstanceMigrationRecord setTenantId(final String tenantId) {
     tenantIdProperty.setValue(tenantId);
-    return this;
-  }
-
-  @Override
-  public String getBpmnProcessId() {
-    return bufferAsString(bpmnProcessIdProperty.getValue());
-  }
-
-  public ProcessInstanceMigrationRecord setBpmnProcessId(final String bpmnProcessId) {
-    bpmnProcessIdProperty.setValue(bpmnProcessId);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceRecord.golden
@@ -163,18 +163,13 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   }
 
   @Override
-  public long getProcessDefinitionKey() {
-    return processDefinitionKeyProp.getValue();
-  }
-
-  @Override
   public long getProcessInstanceKey() {
     return processInstanceKeyProp.getValue();
   }
 
-  public ProcessInstanceRecord setProcessInstanceKey(final long processInstanceKey) {
-    processInstanceKeyProp.setValue(processInstanceKey);
-    return this;
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKeyProp.getValue();
   }
 
   @Override
@@ -219,13 +214,14 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
 
   @Override
   public List<List<Long>> getElementInstancePath() {
-    final var elementInstancePath = new ArrayList<List<Long>>();
-    elementInstancePathProp.forEach(
-        pe -> {
-          final var pathEntry = new ArrayList<Long>();
-          pe.forEach(e -> pathEntry.add(e.getValue()));
-          elementInstancePath.add(pathEntry);
-        });
+    final var elementInstancePath = new ArrayList<List<Long>>(elementInstancePathProp.size());
+    for (final var pe : elementInstancePathProp) {
+      final var pathEntry = new ArrayList<Long>(pe.size());
+      for (final var e : pe) {
+        pathEntry.add(e.getValue());
+      }
+      elementInstancePath.add(pathEntry);
+    }
     return elementInstancePath;
   }
 
@@ -291,6 +287,21 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  public ProcessInstanceRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public ProcessInstanceRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
   public ProcessInstanceRecord setParentProcessInstanceKey(final long parentProcessInstanceKey) {
     parentProcessInstanceKeyProp.setValue(parentProcessInstanceKey);
     return this;
@@ -317,6 +328,11 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
 
   public ProcessInstanceRecord setProcessDefinitionKey(final long processDefinitionKey) {
     processDefinitionKeyProp.setValue(processDefinitionKey);
+    return this;
+  }
+
+  public ProcessInstanceRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProp.setValue(processInstanceKey);
     return this;
   }
 
@@ -350,7 +366,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     return this;
   }
 
-  public boolean hasParentProcess() {
+  public boolean hasParentProcessInstance() {
     return getParentProcessInstanceKey() != -1L;
   }
 
@@ -367,21 +383,6 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
 
   public ProcessInstanceRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
-    return this;
-  }
-
-  @Override
-  public String getBusinessId() {
-    return bufferAsString(businessIdProp.getValue());
-  }
-
-  public ProcessInstanceRecord setBusinessId(final String businessId) {
-    businessIdProp.setValue(businessId);
-    return this;
-  }
-
-  public ProcessInstanceRecord setBusinessId(final DirectBuffer businessId) {
-    businessIdProp.setValue(businessId);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMessageSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMessageSubscriptionRecord.golden
@@ -220,6 +220,31 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public String getBusinessId() {
+    return BufferUtil.bufferAsString(businessIdProp.getValue());
+  }
+
+  public ProcessMessageSubscriptionRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public ProcessMessageSubscriptionRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  @Override
+  public BpmnElementType getElementType() {
+    return elementTypeProp.getValue();
+  }
+
+  public ProcessMessageSubscriptionRecord setElementType(final BpmnElementType elementType) {
+    elementTypeProp.setValue(elementType);
+    return this;
+  }
+
   public ProcessMessageSubscriptionRecord setElementId(final DirectBuffer elementId) {
     elementIdProp.setValue(elementId);
     return this;
@@ -260,33 +285,8 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
-  @Override
-  public String getBusinessId() {
-    return BufferUtil.bufferAsString(businessIdProp.getValue());
-  }
-
   @JsonIgnore
   public DirectBuffer getBusinessIdBuffer() {
     return businessIdProp.getValue();
-  }
-
-  public ProcessMessageSubscriptionRecord setBusinessId(final String businessId) {
-    businessIdProp.setValue(businessId);
-    return this;
-  }
-
-  public ProcessMessageSubscriptionRecord setBusinessId(final DirectBuffer businessId) {
-    businessIdProp.setValue(businessId);
-    return this;
-  }
-
-  @Override
-  public BpmnElementType getElementType() {
-    return elementTypeProp.getValue();
-  }
-
-  public ProcessMessageSubscriptionRecord setElementType(final BpmnElementType elementType) {
-    elementTypeProp.setValue(elementType);
-    return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessRecord.golden
@@ -257,12 +257,10 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   }
 
   /**
-   * Whether the history of this process definition's instances must be deleted once the definition
-   * is gone. Carried on the {@code DRAINING} event so it can be persisted with the draining
-   * definition, and carried back on the {@code DELETE_COMPLETE} drain report so the deployment
-   * partition knows whether to delete the history when the definition has drained cluster-wide.
-   *
-   * <p>Excluded from JSON export — engine-internal coordination not exposed to external consumers.
+   * Whether the instances' history must be deleted once the definition is gone cluster-wide.
+   * Carried on {@code DRAINING} to be persisted with the draining definition, then back on the
+   * {@code DELETE_COMPLETE} drain report so the deployment partition knows whether to delete it.
+   * Excluded from JSON export — engine-internal coordination.
    */
   @JsonIgnore
   public boolean isDeleteHistory() {

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ResourceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ResourceRecord.golden
@@ -159,6 +159,11 @@ public class ResourceRecord extends UnifiedRecordValue implements Resource {
     return resourceIdProp.getValue();
   }
 
+  @JsonIgnore
+  public DirectBuffer getResourceBuffer() {
+    return resourceProp.getValue();
+  }
+
   @Override
   @JsonIgnore
   public int getLength() {
@@ -184,6 +189,12 @@ public class ResourceRecord extends UnifiedRecordValue implements Resource {
   @Override
   public String getResourceProp() {
     return bufferAsString(resourceProp.getValue());
+  }
+
+  @Override
+  @JsonIgnore
+  public byte[] getResourceBytes() {
+    return BufferUtil.bufferAsArray(resourceProp.getValue());
   }
 
   public ResourceRecord setResource(final DirectBuffer resource) {

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/StatusMetrics.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/StatusMetrics.golden
@@ -12,7 +12,7 @@ import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.protocol.record.value.JobMetricsBatchRecordValue.StatusMetricsValue;
 
-public final class StatusMetrics extends ObjectValue implements StatusMetricValue {
+public final class StatusMetrics extends ObjectValue implements StatusMetricsValue {
 
   private final IntegerProperty countProperty = new IntegerProperty("count", -1);
   private final LongProperty lastUpdatedAtProperty = new LongProperty("lastUpdatedAt", -1L);
@@ -43,7 +43,7 @@ public final class StatusMetrics extends ObjectValue implements StatusMetricValu
     return this;
   }
 
-  public void wrap(final StatusMetricValue statusMetricsValue) {
+  public void wrap(final StatusMetricsValue statusMetricsValue) {
     setCount(statusMetricsValue.getCount());
     setLastUpdatedAt(statusMetricsValue.getLastUpdatedAt());
   }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/UnifiedRecordValue.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/UnifiedRecordValue.golden
@@ -10,7 +10,88 @@ package io.camunda.zeebe.protocol.impl.record;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.AsyncRequestRecord;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRuleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationInitializationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationPartitionLifecycleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
+import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.conditional.ConditionalEvaluationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.conditional.ConditionalSubscriptionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentDistributionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceReexportRecord;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
+import io.camunda.zeebe.protocol.impl.record.value.escalation.EscalationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.expression.ExpressionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
+import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
+import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.jobmetrics.JobMetricsBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartCorrelationKeyLockReleaseRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessInstanceRequestRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.metrics.UsageMetricRecord;
+import io.camunda.zeebe.protocol.impl.record.value.multiinstance.MultiInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBusinessIdRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.RuntimeInstructionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
+import io.camunda.zeebe.protocol.impl.record.value.signal.SignalSubscriptionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
+import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
+import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.variable.VariableRecord;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class UnifiedRecordValue extends UnpackedObject implements RecordValue {
 
@@ -45,5 +126,133 @@ public class UnifiedRecordValue extends UnpackedObject implements RecordValue {
   @Override
   public String toJson() {
     return MsgPackConverter.convertJsonSerializableObjectToJson(this);
+  }
+
+  /**
+   * NOTE: this is different from {@link CommandDistributionRecord#getValueType()} or {@link
+   * AsyncRequestRecord#getValueType()} as that is referring to the value they are wrapping
+   *
+   * <p>It needs to be a different method, otherwise those methods will be ignored in the json.
+   *
+   * @return the valueType associated to this record
+   */
+  @JsonIgnore
+  public ValueType valueType() {
+    return ClassToValueType.MAP.get(getClass());
+  }
+
+  public static Stream<UnifiedRecordValue> allRecords() {
+    return Arrays.stream(ValueType.values())
+        .map(UnifiedRecordValue::fromValueType)
+        .filter(Objects::nonNull);
+  }
+
+  public static EnumMap<ValueType, UnifiedRecordValue> allRecordsMap() {
+    return new EnumMap<>(
+        UnifiedRecordValue.allRecords()
+            .collect(Collectors.toMap(UnifiedRecordValue::valueType, Function.identity())));
+  }
+
+  public static UnifiedRecordValue fromValueType(final ValueType valueType) {
+    return switch (valueType) {
+      case ValueType.DEPLOYMENT -> new DeploymentRecord();
+      case ValueType.JOB -> new JobRecord();
+      case ValueType.PROCESS_INSTANCE -> new ProcessInstanceRecord();
+      case ValueType.MESSAGE -> new MessageRecord();
+      case ValueType.MESSAGE_BATCH -> new MessageBatchRecord();
+      case ValueType.PROCESS_MESSAGE_SUBSCRIPTION -> new ProcessMessageSubscriptionRecord();
+      case ValueType.JOB_BATCH -> new JobBatchRecord();
+      case ValueType.INCIDENT -> new IncidentRecord();
+      case ValueType.TIMER -> new TimerRecord();
+      case ValueType.MESSAGE_START_EVENT_SUBSCRIPTION -> new MessageStartEventSubscriptionRecord();
+      case ValueType.MESSAGE_START_PROCESS_INSTANCE_REQUEST ->
+          new MessageStartProcessInstanceRequestRecord();
+      case ValueType.MESSAGE_START_CORRELATION_KEY_LOCK_RELEASE ->
+          new MessageStartCorrelationKeyLockReleaseRecord();
+      case ValueType.VARIABLE -> new VariableRecord();
+      case ValueType.VARIABLE_DOCUMENT -> new VariableDocumentRecord();
+      case ValueType.CLUSTER_VARIABLE -> new ClusterVariableRecord();
+      case ValueType.PROCESS_INSTANCE_CREATION -> new ProcessInstanceCreationRecord();
+      case ValueType.ERROR -> new ErrorRecord();
+      case ValueType.PROCESS_INSTANCE_RESULT -> new ProcessInstanceResultRecord();
+      case ValueType.PROCESS -> new ProcessRecord();
+      case ValueType.DEPLOYMENT_DISTRIBUTION -> new DeploymentDistributionRecord();
+      case ValueType.PROCESS_EVENT -> new ProcessEventRecord();
+      case ValueType.DECISION -> new DecisionRecord();
+      case ValueType.DECISION_REQUIREMENTS -> new DecisionRequirementsRecord();
+      case ValueType.DECISION_EVALUATION -> new DecisionEvaluationRecord();
+      case ValueType.PROCESS_INSTANCE_MODIFICATION -> new ProcessInstanceModificationRecord();
+      case ValueType.ESCALATION -> new EscalationRecord();
+      case ValueType.SIGNAL_SUBSCRIPTION -> new SignalSubscriptionRecord();
+      case ValueType.SIGNAL -> new SignalRecord();
+      case ValueType.COMMAND_DISTRIBUTION -> new CommandDistributionRecord();
+      case ValueType.PROCESS_INSTANCE_BATCH -> new ProcessInstanceBatchRecord();
+      case ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND ->
+          new ProcessInstanceBufferedCommandRecord();
+      case ValueType.PROCESS_INSTANCE_BUSINESS_ID -> new ProcessInstanceBusinessIdRecord();
+      case ValueType.RESOURCE_DELETION -> new ResourceDeletionRecord();
+      case ValueType.FORM -> new FormRecord();
+      case ValueType.USER_TASK -> new UserTaskRecord();
+      case ValueType.PROCESS_INSTANCE_MIGRATION -> new ProcessInstanceMigrationRecord();
+      case ValueType.BATCH_OPERATION_EXECUTION -> new BatchOperationExecutionRecord();
+      case ValueType.BATCH_OPERATION_CHUNK -> new BatchOperationChunkRecord();
+      case ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION -> new AdHocSubProcessInstructionRecord();
+      case ValueType.COMPENSATION_SUBSCRIPTION -> new CompensationSubscriptionRecord();
+      case ValueType.MESSAGE_CORRELATION -> new MessageCorrelationRecord();
+      case ValueType.USER -> new UserRecord();
+      case ValueType.CLOCK -> new ClockRecord();
+      case ValueType.AUTHORIZATION -> new AuthorizationRecord();
+      case ValueType.ROLE -> new RoleRecord();
+      case ValueType.TENANT -> new TenantRecord();
+      case ValueType.RESOURCE_REEXPORT -> new ResourceReexportRecord();
+      case ValueType.SCALE -> new ScaleRecord();
+      case ValueType.GROUP -> new GroupRecord();
+      case ValueType.MAPPING_RULE -> new MappingRuleRecord();
+      case ValueType.IDENTITY_SETUP -> new IdentitySetupRecord();
+      case ValueType.RESOURCE -> new ResourceRecord();
+      case ValueType.BATCH_OPERATION_CREATION -> new BatchOperationCreationRecord();
+      case ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT ->
+          new BatchOperationLifecycleManagementRecord();
+      case ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE ->
+          new BatchOperationPartitionLifecycleRecord();
+      case ValueType.ASYNC_REQUEST -> new AsyncRequestRecord();
+      case ValueType.USAGE_METRIC -> new UsageMetricRecord();
+      case ValueType.HISTORY_DELETION -> new HistoryDeletionRecord();
+      case ValueType.CONDITIONAL_SUBSCRIPTION -> new ConditionalSubscriptionRecord();
+      case ValueType.CONDITIONAL_EVALUATION -> new ConditionalEvaluationRecord();
+      case ValueType.EXPRESSION -> new ExpressionRecord();
+      case ValueType.MULTI_INSTANCE -> new MultiInstanceRecord();
+      case ValueType.RUNTIME_INSTRUCTION -> new RuntimeInstructionRecord();
+      case ValueType.BATCH_OPERATION_INITIALIZATION -> new BatchOperationInitializationRecord();
+      case ValueType.CHECKPOINT -> new CheckpointRecord();
+      case ValueType.MESSAGE_SUBSCRIPTION -> new MessageSubscriptionRecord();
+      case ValueType.GLOBAL_LISTENER_BATCH -> new GlobalListenerBatchRecord();
+      case ValueType.JOB_METRICS_BATCH -> new JobMetricsBatchRecord();
+      case ValueType.GLOBAL_LISTENER -> new GlobalListenerRecord();
+      case ValueType.AGENT_HISTORY -> new AgentHistoryRecord();
+      case ValueType.AGENT_INSTANCE -> new AgentInstanceRecord();
+      case ValueType.SECRET_REFERENCE -> new SecretReferenceRecord();
+      case ValueType.SBE_UNKNOWN -> null;
+      case ValueType.NULL_VAL -> null;
+    };
+  }
+
+  /**
+   * Because of how java static initializers works, it need to be in a separate class: /* inside the
+   * static{} block we use {@link UnifiedRecordValue#fromValueType} from the outer class
+   */
+  private static final class ClassToValueType {
+    private static final Map<Class<? extends RecordValue>, ValueType> MAP = new HashMap<>();
+
+    static {
+      Arrays.stream(ValueType.values())
+          .forEach(
+              v -> {
+                final var record = fromValueType(v);
+                if (record != null) {
+                  MAP.put(record.getClass(), v);
+                }
+              });
+    }
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/UserRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/UserRecord.golden
@@ -69,6 +69,9 @@ public final class UserRecord extends UnifiedRecordValue implements UserRecordVa
   }
 
   public UserRecord setName(final String name) {
+    if (name == null) {
+      return this;
+    }
     nameProp.setValue(name);
     return this;
   }
@@ -84,6 +87,9 @@ public final class UserRecord extends UnifiedRecordValue implements UserRecordVa
   }
 
   public UserRecord setEmail(final String email) {
+    if (email == null) {
+      return this;
+    }
     emailProp.setValue(email);
     return this;
   }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/VariableRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/VariableRecord.golden
@@ -51,6 +51,12 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   private final ObjectProperty<VariableSourceRecord> sourceProp =
       new ObjectProperty<>(SOURCE_KEY, new VariableSourceRecord());
 
+  /**
+   * Cached JSON representation of the value. Lazily computed on first call to {@link #getValue()}
+   * and invalidated when the underlying value changes via {@link #setValue} or {@link #wrap}.
+   */
+  private String cachedJsonValue;
+
   public VariableRecord() {
     super(9);
     declareProperty(nameProp)
@@ -65,13 +71,29 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   }
 
   @Override
+  public void reset() {
+    super.reset();
+    cachedJsonValue = null;
+  }
+
+  @Override
   public String getName() {
     return BufferUtil.bufferAsString(nameProp.getValue());
   }
 
   @Override
   public String getValue() {
-    return MsgPackConverter.convertToJson(valueProp.getValue());
+    if (cachedJsonValue == null) {
+      cachedJsonValue = MsgPackConverter.convertToJson(valueProp.getValue());
+    }
+    return cachedJsonValue;
+  }
+
+  // Internal accessor used by MetricsExporter for size-based metrics; not part of
+  // VariableRecordValue and excluded from JSON serialization.
+  @JsonIgnore
+  public int getValueLength() {
+    return valueProp.getValue().capacity();
   }
 
   @Override
@@ -136,6 +158,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
 
   public VariableRecord setValue(final DirectBuffer value) {
     valueProp.setValue(value);
+    cachedJsonValue = null;
     return this;
   }
 
@@ -146,6 +169,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
 
   public VariableRecord setValue(final DirectBuffer value, final int offset, final int length) {
     valueProp.setValue(value, offset, length);
+    cachedJsonValue = null;
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/VariableSourceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/VariableSourceRecord.golden
@@ -15,10 +15,10 @@ import io.camunda.zeebe.protocol.record.value.VariableSourceValue;
 
 public class VariableSourceRecord extends UnifiedRecordValue implements VariableSourceValue {
 
-  public static final VariableSourceRecord API =
-      new VariableSourceRecord().setType(VariableOperationType.API);
-  public static final VariableSourceRecord NONE =
-      new VariableSourceRecord().setType(VariableOperationType.UNKNOWN);
+  //  public static final VariableSourceRecord API =
+  //      new VariableSourceRecord().setType(VariableOperationType.API);
+  //  public static final VariableSourceRecord NONE =
+  //      new VariableSourceRecord().setType(VariableOperationType.UNKNOWN);
 
   private static final StringValue TYPE_KEY = new StringValue("type");
 
@@ -43,5 +43,13 @@ public class VariableSourceRecord extends UnifiedRecordValue implements Variable
 
   public void wrap(final VariableSourceRecord variableSourceRecord) {
     setType(variableSourceRecord.getType());
+  }
+
+  public static VariableSourceRecord api() {
+    return new VariableSourceRecord().setType(VariableOperationType.API);
+  }
+
+  public static VariableSourceRecord none() {
+    return new VariableSourceRecord().setType(VariableOperationType.UNKNOWN);
   }
 }


### PR DESCRIPTION
## Description

Reformatting the classes so later changes are easier to review.

Also mass updating the golden files, as they appeared not to be exact copies of the Java files anymore.  Again this should make future changes easier to review as there won't be a bunch of random stuff appearing in the golden files.

## Related issues

refs #57154
