### PR TITLE
pg/backup-acceptance-retry

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/PartitionBackupStatus.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/PartitionBackupStatus.java
@@ -72,7 +72,7 @@ public record PartitionBackupStatus(
     return new PartitionBackupStatus(
         response.getPartitionId(),
         BackupStatusCode.FAILED,
-        Optional.of(response.getFailureReason()),
+        Optional.ofNullable(response.getFailureReason()),
         Optional.ofNullable(response.getCreatedAt()),
         Optional.ofNullable(response.getLastUpdated()),
         Optional.ofNullable(response.getSnapshotId()),

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -243,7 +243,7 @@ class BackupApiRequestHandlerTest {
         .returns("test", BackupStatusResponse::getBrokerVersion)
         .returns(createdAt.toString(), BackupStatusResponse::getCreatedAt)
         .returns(lastModified.toString(), BackupStatusResponse::getLastUpdated)
-        .matches(response -> response.getFailureReason().isEmpty());
+        .matches(response -> response.getFailureReason() == null);
   }
 
   @Test

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupStatusResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupStatusResponse.java
@@ -153,7 +153,7 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
   }
 
   public String getFailureReason() {
-    return failureReason;
+    return failureReason.isEmpty() ? null : failureReason;
   }
 
   public BackupStatusResponse setFailureReason(final String failureReason) {

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
@@ -326,7 +326,7 @@ public interface BackupCompatibilityAcceptance {
   private boolean shouldRetryBackupDueToSnapshot(final BackupInfo status, final int retryCount) {
     return status.getState() == StateCode.FAILED
         && status.getFailureReason() != null
-        && status.getFailureReason().contains("Cannot find a snapshot that can be included")
+        && status.getFailureReason().contains("No valid snapshots found for backup")
         && retryCount < MAX_BACKUP_RETRIES;
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Attempt to address flakiness of `GcsBackupCompatibilityIT.shouldRestoreBackupWhenSnapshotContainsCheckpointFromPreviousVersion` as reported by our CI tracking tools.

Snapshot retrying was skipped due to the usage of a wrong message in the failure correlation.
## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
