### PR TITLE
fix: prevent stale Docker versions in C8Run

### DIFF
--- a/c8run/.env
+++ b/c8run/.env
@@ -1,8 +1,6 @@
 ELASTICSEARCH_VERSION=8.17.3
 # this is the version of camunda/ zeebe
 CAMUNDA_VERSION=8.8.33
-# docker images moved to a shortened tag, override compose with this value when using --docker
-CAMUNDA_DOCKER_VERSION=8.8.31
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
 CONNECTORS_VERSION=8.8.15
 # version of docker compose artifact (used for --docker option)

--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -66,7 +66,6 @@ func runDockerCommand(composeExtractedFolder string, args ...string) error {
 	composeCmd := exec.Command("docker", append([]string{"compose"}, args...)...)
 	composeCmd.Stdout = os.Stdout
 	composeCmd.Stderr = os.Stderr
-	composeCmd.Env = dockerCommandEnv(os.Environ())
 
 	err = composeCmd.Run()
 	if err != nil {
@@ -79,27 +78,6 @@ func runDockerCommand(composeExtractedFolder string, args ...string) error {
 	}
 
 	return nil
-}
-
-func dockerCommandEnv(baseEnv []string) []string {
-	dockerVersion := strings.TrimSpace(os.Getenv("CAMUNDA_DOCKER_VERSION"))
-	if dockerVersion == "" {
-		return baseEnv
-	}
-
-	env := append([]string(nil), baseEnv...)
-	return overrideEnvVar(env, "CAMUNDA_VERSION", dockerVersion)
-}
-
-func overrideEnvVar(env []string, key, value string) []string {
-	prefix := key + "="
-	for i := range env {
-		if strings.HasPrefix(env[i], prefix) {
-			env[i] = prefix + value
-			return env
-		}
-	}
-	return append(env, prefix+value)
 }
 
 func usage(exitcode int) {

--- a/c8run/cmd/c8run/main_test.go
+++ b/c8run/cmd/c8run/main_test.go
@@ -117,32 +117,3 @@ func TestCamundaCmdPassword(t *testing.T) {
 	}
 	assert.Contains(t, javaOptsEnvVar, "-Dcamunda.security.initialization.users[0].password=changeme")
 }
-
-func TestDockerCommandEnvOverridesVersion(t *testing.T) {
-	t.Setenv("CAMUNDA_DOCKER_VERSION", "8.9-SNAPSHOT")
-	base := []string{"CAMUNDA_VERSION=8.9.0-SNAPSHOT", "FOO=bar"}
-
-	result := dockerCommandEnv(base)
-
-	assert.Contains(t, result, "CAMUNDA_VERSION=8.9-SNAPSHOT")
-	assert.Equal(t, []string{"CAMUNDA_VERSION=8.9.0-SNAPSHOT", "FOO=bar"}, base)
-}
-
-func TestDockerCommandEnvAddsVersionWhenMissing(t *testing.T) {
-	t.Setenv("CAMUNDA_DOCKER_VERSION", "8.9-SNAPSHOT")
-	base := []string{"FOO=bar"}
-
-	result := dockerCommandEnv(base)
-
-	assert.Contains(t, result, "CAMUNDA_VERSION=8.9-SNAPSHOT")
-	assert.Equal(t, []string{"FOO=bar"}, base)
-}
-
-func TestDockerCommandEnvNoOverrideWithoutDockerVersion(t *testing.T) {
-	t.Setenv("CAMUNDA_DOCKER_VERSION", "")
-	base := []string{"CAMUNDA_VERSION=8.9.0-SNAPSHOT"}
-
-	result := dockerCommandEnv(base)
-
-	assert.Equal(t, base, result)
-}


### PR DESCRIPTION
## Description

Remove the committed `CAMUNDA_DOCKER_VERSION` pin and its runtime rewrite from C8Run 8.8.

The 8.8.34 release candidate retained `CAMUNDA_DOCKER_VERSION=8.8.31`, so Docker startup replaced the Camunda 8.8.34 image from the validated Compose matrix with 8.8.31. Connectors 8.8.16 then remained unhealthy in the Harbor release test.

Docker Compose now inherits the synchronized `CAMUNDA_VERSION` directly. The coordinated E2E workflow change supplies shortened snapshot tags only for nightly Docker startup.

Validation:

- `go test ./...`
- `go vet ./...`
- `go build -o /tmp/c8run-59578-8-8 ./cmd/c8run`
- `git diff --check`

The required full Maven baseline could not resolve three private HeroDevs Spring BOMs because local Artifactory requests returned `401`; the standalone C8Run checks above are green.

## Related issues

Part of #59578
