### PR TITLE
fix: remove obsolete Docker versions from C8Run

### DIFF
--- a/c8run/.env
+++ b/c8run/.env
@@ -1,8 +1,6 @@
 ELASTICSEARCH_VERSION=8.13.4
 CAMUNDA_RELEASE_TAG=8.7.35
 CAMUNDA_VERSION=8.7.36
-# docker images moved to a shortened tag, override compose with this value when using --docker
-CAMUNDA_DOCKER_VERSION=8.7.35
 CONNECTORS_VERSION=8.7.23
 COMPOSE_TAG=8.7
 COMPOSE_EXTRACTED_FOLDER=docker-compose-8.7

--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -78,7 +78,6 @@ func runDockerCommand(composeExtractedFolder string, args ...string) error {
 	composeCmd := exec.Command("docker", append([]string{"compose"}, args...)...)
 	composeCmd.Stdout = os.Stdout
 	composeCmd.Stderr = os.Stderr
-	composeCmd.Env = dockerCommandEnv(os.Environ())
 
 	err = composeCmd.Run()
 	if err != nil {
@@ -96,27 +95,6 @@ func runDockerCommand(composeExtractedFolder string, args ...string) error {
 func usage(exitcode int) {
 	fmt.Printf("Usage: %s [command] [options]\nCommands:\n  start\n  stop\n", os.Args[0])
 	os.Exit(exitcode)
-}
-
-func dockerCommandEnv(baseEnv []string) []string {
-	dockerVersion := strings.TrimSpace(os.Getenv("CAMUNDA_DOCKER_VERSION"))
-	if dockerVersion == "" {
-		return baseEnv
-	}
-
-	env := append([]string(nil), baseEnv...)
-	return overrideEnvVar(env, "CAMUNDA_VERSION", dockerVersion)
-}
-
-func overrideEnvVar(env []string, key, value string) []string {
-	prefix := key + "="
-	for i := range env {
-		if strings.HasPrefix(env[i], prefix) {
-			env[i] = prefix + value
-			return env
-		}
-	}
-	return append(env, prefix+value)
 }
 
 func getBaseCommand() (string, error) {

--- a/c8run/cmd/c8run/main_test.go
+++ b/c8run/cmd/c8run/main_test.go
@@ -78,32 +78,3 @@ func TestCamundaCmdDifferentPort(t *testing.T) {
 	assert.Contains(t, javaOptsEnvVar, "-Dserver.port=8087")
 
 }
-
-func TestDockerCommandEnvOverridesVersion(t *testing.T) {
-	t.Setenv("CAMUNDA_DOCKER_VERSION", "8.7.99")
-	base := []string{"CAMUNDA_VERSION=8.7.23", "FOO=bar"}
-
-	result := dockerCommandEnv(base)
-
-	assert.Contains(t, result, "CAMUNDA_VERSION=8.7.99")
-	assert.Equal(t, []string{"CAMUNDA_VERSION=8.7.23", "FOO=bar"}, base)
-}
-
-func TestDockerCommandEnvAddsVersionWhenMissing(t *testing.T) {
-	t.Setenv("CAMUNDA_DOCKER_VERSION", "8.7.99")
-	base := []string{"FOO=bar"}
-
-	result := dockerCommandEnv(base)
-
-	assert.Contains(t, result, "CAMUNDA_VERSION=8.7.99")
-	assert.Equal(t, []string{"FOO=bar"}, base)
-}
-
-func TestDockerCommandEnvNoOverrideWithoutDockerVersion(t *testing.T) {
-	t.Setenv("CAMUNDA_DOCKER_VERSION", "")
-	base := []string{"CAMUNDA_VERSION=8.7.23"}
-
-	result := dockerCommandEnv(base)
-
-	assert.Equal(t, base, result)
-}


### PR DESCRIPTION
## Description

Remove the committed `CAMUNDA_DOCKER_VERSION` pin and its runtime rewrite from C8Run 8.7.

The 8.7 Compose distribution selects Zeebe, Operate, and Tasklist through component-specific version variables, so rewriting `CAMUNDA_VERSION` has no effect. Keeping the duplicate pin nevertheless allows it to drift from the C8Run release and obscures which Compose matrix is authoritative.

The coordinated E2E workflow change supplies the component-specific snapshot tags directly when the Docker nightly starts C8Run.

Validation:

- `go test ./...`
- `go vet ./...`
- `go build -o /tmp/c8run-59578-8-7 ./cmd/c8run`
- `git diff --check`

The required full Maven baseline could not resolve three private HeroDevs Spring BOMs because local Artifactory requests returned `401`; the standalone C8Run checks above are green.

## Related issues

Part of #59578
