### PR TITLE
feat: bump operate zod schemas to 0.0.87 for DRAINING state

### DIFF
--- a/operate/client/e2e-playwright/docs-screenshots/variables-and-incidents.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/variables-and-incidents.spec.ts
@@ -28,6 +28,7 @@ test.describe('variables and incidents', () => {
       mockProcessesResponses({
         processDefinitions: [
           {
+            state: 'ACTIVE',
             processDefinitionId: 'order-process',
             version: 1,
             name: 'order-process',

--- a/operate/client/e2e-playwright/mocks/processes.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processes.mocks.ts
@@ -227,6 +227,7 @@ function mockResponses({
 
 const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813685249',
     name: 'Always completing process',
     version: 1,
@@ -237,6 +238,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813685430',
     name: 'Big variable process',
     version: 1,
@@ -247,6 +249,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686145',
     name: 'Call Activity Process',
     version: 1,
@@ -257,6 +260,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686130',
     name: 'DMN invoice',
     version: 1,
@@ -267,6 +271,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686159',
     name: 'Data store process',
     version: 1,
@@ -277,6 +282,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686151',
     name: 'Error Process',
     version: 1,
@@ -287,6 +293,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813687212',
     name: 'Escalation events',
     version: 2,
@@ -297,6 +304,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686163',
     name: 'Escalation events',
     version: 1,
@@ -307,6 +315,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686147',
     name: 'Event Subprocess Process',
     version: 1,
@@ -317,6 +326,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813687203',
     name: 'Event based gateway with timer start',
     version: 2,
@@ -327,6 +337,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686134',
     name: 'Event based gateway with message start',
     version: 1,
@@ -337,6 +348,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813687190',
     name: 'Flight registration',
     version: 2,
@@ -347,6 +359,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686118',
     name: 'Flight registration',
     version: 1,
@@ -357,6 +370,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686168',
     name: 'Inclusive gateway',
     version: 1,
@@ -367,6 +381,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813685251',
     name: 'Input Output Mapping Test',
     version: 1,
@@ -377,6 +392,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686161',
     name: 'Link events process',
     version: 1,
@@ -387,6 +403,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813687192',
     name: 'Multi-Instance Process',
     version: 2,
@@ -397,6 +414,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686120',
     name: 'Sequential Multi-Instance Process',
     version: 1,
@@ -407,6 +425,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686137',
     name: 'Nested subprocesses',
     version: 1,
@@ -417,6 +436,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813685301',
     name: 'Only Incidents Process',
     version: 2,
@@ -427,6 +447,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813685257',
     name: 'Only Incidents Process',
     version: 1,
@@ -437,6 +458,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686114',
     name: 'Order process',
     version: 1,
@@ -447,6 +469,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686165',
     name: 'Signal event',
     version: 1,
@@ -457,6 +480,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686155',
     name: 'Terminate End Event',
     version: 1,
@@ -467,6 +491,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813687198',
     name: 'Timer process',
     version: 2,
@@ -477,6 +502,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686143',
     name: 'Timer process',
     version: 1,
@@ -487,6 +513,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813685364',
     name: 'Without Incidents Process',
     version: 2,
@@ -497,6 +524,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813685350',
     name: 'Without Incidents Process',
     version: 1,
@@ -507,6 +535,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813685255',
     name: 'Without Instances Process',
     version: 2,
@@ -517,6 +546,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813685253',
     name: 'Without Instances Process',
     version: 1,
@@ -527,6 +557,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686157',
     name: 'undefined-task',
     version: 1,
@@ -537,6 +568,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686149',
     name: null,
     version: 1,
@@ -547,6 +579,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813687891',
     name: null,
     version: 2,
@@ -557,6 +590,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813687210',
     name: 'Called Process',
     version: 1,
@@ -567,6 +601,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813687889',
     name: null,
     version: 3,
@@ -577,6 +612,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813687201',
     name: null,
     version: 2,
@@ -587,6 +623,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686132',
     name: null,
     version: 1,
@@ -597,6 +634,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686153',
     name: null,
     version: 1,
@@ -607,6 +645,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686124',
     name: null,
     version: 1,
@@ -617,6 +656,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686126',
     name: null,
     version: 1,
@@ -627,6 +667,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813687206',
     name: null,
     version: 2,
@@ -637,6 +678,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686139',
     name: null,
     version: 1,
@@ -647,6 +689,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686116',
     name: null,
     version: 1,
@@ -657,6 +700,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686122',
     name: null,
     version: 1,
@@ -667,6 +711,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686128',
     name: null,
     version: 1,
@@ -677,6 +722,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813687208',
     name: null,
     version: 2,
@@ -687,6 +733,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686141',
     name: null,
     version: 1,
@@ -697,6 +744,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686133',
     name: 'Lots Of Tasks',
     version: 1,
@@ -707,6 +755,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] = [
     hasStartForm: false,
   },
   {
+    state: 'ACTIVE',
     processDefinitionKey: '2251799813686146',
     name: 'Lots Of Tasks',
     version: 2,
@@ -1926,6 +1975,7 @@ const mockProcessInstancesWithOperationError: QueryProcessInstancesResponseBody 
 const mockOrderProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] =
   [
     {
+      state: 'ACTIVE',
       processDefinitionKey: '2251799813686115',
       name: 'Order process',
       version: 2,
@@ -1936,6 +1986,7 @@ const mockOrderProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] 
       hasStartForm: false,
     },
     {
+      state: 'ACTIVE',
       processDefinitionKey: '2251799813686114',
       name: 'Order process',
       version: 1,
@@ -2049,6 +2100,7 @@ const mockAhspProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] =
       hasStartForm: false,
       resourceName: null,
       versionTag: null,
+      state: 'ACTIVE',
     },
     {
       processDefinitionId: 'migration-ahsp-process_v2',
@@ -2059,6 +2111,7 @@ const mockAhspProcessDefinitions: QueryProcessDefinitionsResponseBody['items'] =
       hasStartForm: false,
       resourceName: null,
       versionTag: null,
+      state: 'ACTIVE',
     },
   ];
 

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.12.1",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.86",
+        "@camunda/camunda-api-zod-schemas": "0.0.87",
         "@camunda/camunda-composite-components": "0.25.2",
         "@carbon/elements": "11.94.0",
         "@carbon/react": "1.112.0",
@@ -498,9 +498,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.86",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.86.tgz",
-      "integrity": "sha512-ucjf0OZP/xWjyqd1COeNRXqAC0lkp/caRaxgDTpO8iA1nhNsGIxFWnWxulhV82ZEDmU5DZlJbDP5GuIWPwwfGw==",
+      "version": "0.0.87",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.87.tgz",
+      "integrity": "sha512-Z46n48+QsneVZDeP+nWR0tcJ71Bo7kj+uCKTDRr1AWtjQTfWTU64/QzKxsqyZOnthIeQwnKOZup7q8kkneiTiA==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.12.1",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.86",
+    "@camunda/camunda-api-zod-schemas": "0.0.87",
     "@camunda/camunda-composite-components": "0.25.2",
     "@carbon/elements": "11.94.0",
     "@carbon/react": "1.112.0",

--- a/operate/client/src/App/OperationsLog/Filters/index.test.tsx
+++ b/operate/client/src/App/OperationsLog/Filters/index.test.tsx
@@ -38,6 +38,7 @@ describe('OperationsLog Filters', () => {
     mockSearchProcessDefinitions().withSuccess({
       items: [
         {
+          state: 'ACTIVE',
           processDefinitionKey: '123',
           processDefinitionId: 'process1',
           name: 'Process 1',
@@ -48,6 +49,7 @@ describe('OperationsLog Filters', () => {
           versionTag: null,
         },
         {
+          state: 'ACTIVE',
           processDefinitionKey: '456',
           processDefinitionId: 'process2',
           name: 'Process 2',
@@ -177,6 +179,7 @@ describe('OperationsLog Filters', () => {
     mockSearchProcessDefinitions().withSuccess({
       items: [
         {
+          state: 'ACTIVE',
           processDefinitionKey: '123',
           processDefinitionId: 'process1',
           name: 'Process 1',
@@ -187,6 +190,7 @@ describe('OperationsLog Filters', () => {
           versionTag: null,
         },
         {
+          state: 'ACTIVE',
           processDefinitionKey: '456',
           processDefinitionId: 'process2',
           name: 'Process 2',

--- a/operate/client/src/App/OperationsLog/InstancesTable/index.test.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/index.test.tsx
@@ -47,6 +47,7 @@ describe('OperationsLog InstancesTable', () => {
     mockSearchProcessDefinitions().withSuccess(
       searchResult([
         {
+          state: 'ACTIVE',
           processDefinitionKey: '123456',
           processDefinitionId: 'process1',
           name: 'Test Process',

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/ProcessInstanceOperations.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/ProcessInstanceOperations.tsx
@@ -133,6 +133,7 @@ const ProcessInstanceOperations: React.FC<Props> = ({
 
   const enterMigrationMode = () => {
     processInstanceMigrationStore.setSourceProcessDefinition({
+      state: 'ACTIVE',
       processDefinitionKey: processInstance.processDefinitionKey,
       processDefinitionId: processInstance.processDefinitionId,
       version: processInstance.processDefinitionVersion,

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/tests/index.test.tsx
@@ -317,6 +317,7 @@ describe('InstanceHeader', () => {
         tenantId: mockInstance.tenantId,
         resourceName: null,
         hasStartForm: false,
+        state: 'ACTIVE',
       },
     );
 

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/DiagramHeader/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/DiagramHeader/index.test.tsx
@@ -27,6 +27,7 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
 const singleVersionSelection: ProcessDefinitionSelection = {
   kind: 'single-version',
   definition: {
+    state: 'ACTIVE',
     processDefinitionId: 'MyProcess',
     processDefinitionKey: '123',
     name: 'My Process',

--- a/operate/client/src/modules/testUtils.tsx
+++ b/operate/client/src/modules/testUtils.tsx
@@ -102,6 +102,7 @@ const createProcessDefinition = (
   options: Partial<ProcessDefinition> = {},
 ): ProcessDefinition => {
   return {
+    state: 'ACTIVE',
     name: 'Big variable process',
     processDefinitionId: 'bigVarProcess',
     processDefinitionKey: '2223894723423800',
@@ -146,6 +147,7 @@ const createUser = (options: Partial<CurrentUser> = {}): CurrentUser => ({
 const mockProcessDefinitions: QueryProcessDefinitionsResponseBody =
   searchResult([
     {
+      state: 'ACTIVE',
       name: 'New demo process',
       processDefinitionId: 'demoProcess',
       processDefinitionKey: 'demoProcess3',
@@ -156,6 +158,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody =
       hasStartForm: false,
     },
     {
+      state: 'ACTIVE',
       name: 'Demo process',
       processDefinitionId: 'demoProcess',
       processDefinitionKey: 'demoProcess2',
@@ -166,6 +169,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody =
       hasStartForm: false,
     },
     {
+      state: 'ACTIVE',
       name: 'Demo process',
       processDefinitionId: 'demoProcess',
       processDefinitionKey: 'demoProcess1',
@@ -176,6 +180,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody =
       hasStartForm: false,
     },
     {
+      state: 'ACTIVE',
       name: null,
       processDefinitionId: 'eventBasedGatewayProcess',
       processDefinitionKey: '2251799813696866',
@@ -186,6 +191,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody =
       hasStartForm: false,
     },
     {
+      state: 'ACTIVE',
       name: 'Event based gateway with message start',
       processDefinitionId: 'eventBasedGatewayProcess',
       processDefinitionKey: '2251799813685911',
@@ -196,6 +202,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody =
       hasStartForm: false,
     },
     {
+      state: 'ACTIVE',
       name: 'Big variable process',
       processDefinitionId: 'bigVarProcess',
       processDefinitionKey: '2251799813685892',
@@ -206,6 +213,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody =
       hasStartForm: false,
     },
     {
+      state: 'ACTIVE',
       name: 'Big variable process',
       processDefinitionId: 'bigVarProcess',
       processDefinitionKey: '2251799813685893',
@@ -216,6 +224,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody =
       hasStartForm: false,
     },
     {
+      state: 'ACTIVE',
       name: 'Big variable process',
       processDefinitionId: 'bigVarProcess',
       processDefinitionKey: '2251799813685894',
@@ -226,6 +235,7 @@ const mockProcessDefinitions: QueryProcessDefinitionsResponseBody =
       hasStartForm: false,
     },
     {
+      state: 'ACTIVE',
       name: 'Order',
       processDefinitionId: 'orderProcess',
       processDefinitionKey: 'orderProcess1',

--- a/operate/client/src/modules/utils/getDiagramNameByProcessDefinition.test.ts
+++ b/operate/client/src/modules/utils/getDiagramNameByProcessDefinition.test.ts
@@ -20,6 +20,7 @@ describe('getDiagramNameByProcessDefinition', () => {
       hasStartForm: false,
       resourceName: null,
       versionTag: null,
+      state: 'ACTIVE',
     } satisfies ProcessDefinition;
     expect(getDiagramNameByProcessDefinition(definition)).toBe(
       'order-process_v5',
@@ -36,6 +37,7 @@ describe('getDiagramNameByProcessDefinition', () => {
       hasStartForm: false,
       resourceName: null,
       versionTag: null,
+      state: 'ACTIVE',
     } satisfies ProcessDefinition;
     expect(getDiagramNameByProcessDefinition(definition)).toBe(
       'fallback-id_v2',


### PR DESCRIPTION
## Description

The DRAINING process-definition state added in the preceding commits is released in @camunda/camunda-api-zod-schemas 0.0.87. Operate still pinned the previous 0.0.86, so it could not consume the new state.

Bump the dependency in operate/client to 0.0.87 to match the released schema. The lockfile version, resolved URL, and integrity were updated to the published 0.0.87 artifact.

## Related issues

closes https://github.com/camunda/camunda/issues/56987
