### PR TITLE
Scope exporter disable to an optional physical tenant

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
@@ -44,7 +44,7 @@ public class ExportersEndpoint {
       @RequestParam(defaultValue = "false") final boolean dryRun) {
 
     return requestSender
-        .disableExporter(new ExporterDisableRequest(exporterId, dryRun))
+        .disableExporter(new ExporterDisableRequest(exporterId, Optional.empty(), dryRun))
         .handle(ClusterApiUtils::mapOperationResponse);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -145,7 +145,12 @@ public sealed interface ClusterConfigurationManagementRequest {
   record UpdateZonePrioritiesRequest(List<String> zoneOrder, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
-  record ExporterDisableRequest(String exporterId, boolean dryRun)
+  /**
+   * Disable an exporter on all partitions of the given physical tenant. If no physicalTenantId is
+   * provided, it applies to all tenants.
+   */
+  record ExporterDisableRequest(
+      String exporterId, Optional<String> physicalTenantId, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
   record ExporterDeleteRequest(String exporterId, boolean dryRun)

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -239,7 +239,8 @@ public final class ClusterConfigurationManagementRequestsHandler
       final ExporterDisableRequest exporterDisableRequest) {
     return handleRequest(
         exporterDisableRequest.dryRun(),
-        new ExporterDisableRequestTransformer(exporterDisableRequest.exporterId()));
+        new ExporterDisableRequestTransformer(
+            exporterDisableRequest.exporterId(), exporterDisableRequest.physicalTenantId()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformer.java
@@ -7,34 +7,103 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
+/**
+ * Disables an exporter, either for a single physical tenant or, when none is given, for every
+ * physical tenant that currently has it configured. Exporter configuration is per physical tenant,
+ * so an exporter id may not exist in every tenant; tenants (and partitions within a tenant) that do
+ * not have it configured are silently skipped rather than failing the whole request.
+ */
 public final class ExporterDisableRequestTransformer implements ConfigurationChangeRequest {
 
   private final String exporterId;
+  private final Optional<String> physicalTenantId;
 
   public ExporterDisableRequestTransformer(final String exporterId) {
+    this(exporterId, Optional.empty());
+  }
 
+  public ExporterDisableRequestTransformer(
+      final String exporterId, final Optional<String> physicalTenantId) {
     this.exporterId = exporterId;
+    this.physicalTenantId = physicalTenantId;
   }
 
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration clusterConfiguration) {
-    final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
-    for (final var member : clusterConfiguration.members().entrySet()) {
-      final var memberId = member.getKey();
-      for (final var partitions : member.getValue().partitions().entrySet()) {
-        final var partitionId = partitions.getKey();
-        operations.add(new PartitionDisableExporterOperation(memberId, partitionId, exporterId));
+    throw new UnsupportedOperationException(
+        "ExporterDisableRequestTransformer builds its change plan via "
+            + "phases(CurrentClusterConfiguration); the new-model coordinator path never calls "
+            + "operations(ClusterConfiguration)");
+  }
+
+  @Override
+  public Either<Exception, List<Phase>> phases(
+      final CurrentClusterConfiguration clusterConfiguration) {
+    if (physicalTenantId.isPresent()
+        && !clusterConfiguration.hasPartitionGroup(physicalTenantId.get())) {
+      return Either.left(
+          new NotFound(
+              "Expected to disable exporter '%s' for physical tenant '%s', but the physical tenant does not exist"
+                  .formatted(exporterId, physicalTenantId.get())));
+    }
+
+    final List<String> groupIds =
+        physicalTenantId
+            .<List<String>>map(List::of)
+            .orElseGet(() -> List.copyOf(clusterConfiguration.partitionGroups().keySet()));
+
+    final Map<String, List<PartitionGroupOperation>> groupOperations = new LinkedHashMap<>();
+    for (final var groupId : groupIds) {
+      final var operations =
+          disableOperationsFor(
+              Objects.requireNonNull(clusterConfiguration.partitionGroup(groupId)));
+      if (!operations.isEmpty()) {
+        groupOperations.put(groupId, operations);
       }
     }
-    return Either.right(operations);
+
+    if (groupOperations.isEmpty()) {
+      return Either.left(
+          new InvalidRequest(
+              "Expected to disable exporter '%s' for physical tenant '%s', but no matching exporters were found"
+                  .formatted(exporterId, physicalTenantId.orElse("all tenants"))));
+    }
+    return Either.right(List.of(new PartitionGroupParallelPhase(groupOperations)));
+  }
+
+  private List<PartitionGroupOperation> disableOperationsFor(
+      final PartitionGroupConfiguration group) {
+    final List<PartitionGroupOperation> operations = new ArrayList<>();
+    for (final var member : group.members().entrySet()) {
+      final var memberId = member.getKey();
+      for (final var partition : member.getValue().partitions().entrySet()) {
+        final var partitionId = partition.getKey();
+        final var hasExporter =
+            partition.getValue().config().exporting().exporters().containsKey(exporterId);
+        if (hasExporter) {
+          operations.add(new PartitionDisableExporterOperation(memberId, partitionId, exporterId));
+        }
+      }
+    }
+    return operations;
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformer.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
@@ -83,7 +83,7 @@ public final class ExporterDisableRequestTransformer implements ConfigurationCha
 
     if (groupOperations.isEmpty()) {
       return Either.left(
-          new InvalidRequest(
+          new NotFound(
               "Expected to disable exporter '%s' for physical tenant '%s', but no matching exporters were found"
                   .formatted(exporterId, physicalTenantId.orElse("all tenants"))));
     }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1068,11 +1068,14 @@ public class ProtoBufSerializer
 
   @Override
   public byte[] encodeExporterDisableRequest(final ExporterDisableRequest exporterDisableRequest) {
-    return Requests.ExporterDisableRequest.newBuilder()
-        .setExporterId(exporterDisableRequest.exporterId())
-        .setDryRun(exporterDisableRequest.dryRun())
-        .build()
-        .toByteArray();
+    final var builder =
+        Requests.ExporterDisableRequest.newBuilder()
+            .setExporterId(exporterDisableRequest.exporterId())
+            .setDryRun(exporterDisableRequest.dryRun());
+
+    exporterDisableRequest.physicalTenantId().ifPresent(builder::setPhysicalTenantId);
+
+    return builder.build().toByteArray();
   }
 
   @Override
@@ -1299,8 +1302,14 @@ public class ProtoBufSerializer
   public ExporterDisableRequest decodeExporterDisableRequest(final byte[] encodedRequest) {
     try {
       final var exporterDisableRequest = Requests.ExporterDisableRequest.parseFrom(encodedRequest);
+      final Optional<String> physicalTenantId =
+          exporterDisableRequest.hasPhysicalTenantId()
+              ? Optional.of(exporterDisableRequest.getPhysicalTenantId())
+              : Optional.empty();
       return new ExporterDisableRequest(
-          exporterDisableRequest.getExporterId(), exporterDisableRequest.getDryRun());
+          exporterDisableRequest.getExporterId(),
+          physicalTenantId,
+          exporterDisableRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -101,6 +101,9 @@ message ReassignAllPartitionsRequest {
 message ExporterDisableRequest {
   string exporterId = 1;
   bool dryRun = 2;
+  // When physicalTenantId is set, the exporter will be disabled only for that tenant.
+  // If not set, the exporter will be disabled for all tenants.
+  optional string physicalTenantId = 3;
 }
 
 message ExporterDeleteRequest {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
@@ -378,7 +378,9 @@ final class NewModelManagementApiEndpointsTest {
 
     // when
     final var response =
-        handler.disableExporter(new ExporterDisableRequest(exporterId, false)).join();
+        handler
+            .disableExporter(new ExporterDisableRequest(exporterId, Optional.empty(), false))
+            .join();
 
     // then
     assertThat(response.legacyResponse().plannedChanges())
@@ -401,7 +403,7 @@ final class NewModelManagementApiEndpointsTest {
                 m -> m.addPartition(1, PartitionState.active(1, partitionConfigWithExporter))));
 
     // when
-    handler.disableExporter(new ExporterDisableRequest(exporterId, false)).join();
+    handler.disableExporter(new ExporterDisableRequest(exporterId, Optional.empty(), false)).join();
 
     // then — the plan is applied on the local member and completes
     final var config = manager.getMultiConfiguration().join();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTestBase.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTestBase.java
@@ -733,7 +733,8 @@ abstract class ClusterConfigurationManagementApiTestBase {
     // given
     final String exporterId = "exporterId";
     final var request =
-        new ClusterConfigurationManagementRequest.ExporterDisableRequest(exporterId, false);
+        new ClusterConfigurationManagementRequest.ExporterDisableRequest(
+            exporterId, Optional.empty(), false);
     final var partitionConfigWithExporter =
         new DynamicPartitionConfig(
             new ExportingConfig(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformerTest.java
@@ -10,15 +10,19 @@ package io.camunda.zeebe.dynamic.config.api;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.Map;
 import java.util.Optional;
@@ -26,39 +30,142 @@ import org.junit.jupiter.api.Test;
 
 final class ExporterDisableRequestTransformerTest {
 
-  final String exporterId = "exporterA";
+  private static final String EXPORTER_ID = "exporterA";
+  private static final String TENANT_A = "tenant-a";
+  private static final String TENANT_B = "tenant-b";
+
   private final MemberId id0 = MemberId.from("0");
   private final MemberId id1 = MemberId.from("1");
-  private final DynamicPartitionConfig config =
+
+  private final DynamicPartitionConfig configWithExporter =
       new DynamicPartitionConfig(
           new ExportingConfig(
               ExportingState.EXPORTING,
-              Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
+              Map.of(EXPORTER_ID, new ExporterState(1, State.ENABLED, Optional.empty()))));
+
+  private final DynamicPartitionConfig configWithoutExporter =
+      new DynamicPartitionConfig(new ExportingConfig(ExportingState.EXPORTING, Map.of()));
 
   @Test
-  void shouldGenerateOperationForAllPartitionsAndMembers() {
+  void shouldGenerateOperationsForAllPhysicalTenantsWhenNoneIsGiven() {
     // given
-    final var transformer = new ExporterDisableRequestTransformer(exporterId);
-
+    final var transformer = new ExporterDisableRequestTransformer(EXPORTER_ID);
     final var clusterConfiguration =
-        ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, config)))
-            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(2, config)))
-            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, config)))
-            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, config)));
+        withPartitionGroups(
+            Map.of(
+                TENANT_A, groupWithMembers(configWithExporter),
+                TENANT_B, groupWithMembers(configWithExporter)));
 
     // when
-    final var result = transformer.operations(clusterConfiguration);
+    final var result = transformer.phases(clusterConfiguration);
 
     // then
     EitherAssert.assertThat(result).isRight();
-    assertThat(result.get())
-        .containsExactlyInAnyOrder(
-            new PartitionDisableExporterOperation(id0, 1, exporterId),
-            new PartitionDisableExporterOperation(id0, 2, exporterId),
-            new PartitionDisableExporterOperation(id1, 2, exporterId),
-            new PartitionDisableExporterOperation(id1, 1, exporterId));
+    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    assertThat(phase.groupOperations())
+        .containsOnlyKeys(TENANT_A, TENANT_B)
+        .allSatisfy(
+            (groupId, operations) ->
+                assertThat(operations)
+                    .containsExactlyInAnyOrder(
+                        new PartitionDisableExporterOperation(id0, 1, EXPORTER_ID),
+                        new PartitionDisableExporterOperation(id1, 1, EXPORTER_ID)));
+  }
+
+  @Test
+  void shouldSkipPhysicalTenantsThatDoNotHaveTheExporterConfigured() {
+    // given
+    final var transformer = new ExporterDisableRequestTransformer(EXPORTER_ID);
+    final var clusterConfiguration =
+        withPartitionGroups(
+            Map.of(
+                TENANT_A, groupWithMembers(configWithExporter),
+                TENANT_B, groupWithMembers(configWithoutExporter)));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    assertThat(phase.groupOperations()).containsOnlyKeys(TENANT_A);
+  }
+
+  @Test
+  void shouldGenerateOperationsOnlyForTheGivenPhysicalTenant() {
+    // given
+    final var transformer =
+        new ExporterDisableRequestTransformer(EXPORTER_ID, Optional.of(TENANT_A));
+    final var clusterConfiguration =
+        withPartitionGroups(
+            Map.of(
+                TENANT_A, groupWithMembers(configWithExporter),
+                TENANT_B, groupWithMembers(configWithExporter)));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    assertThat(phase.groupOperations())
+        .containsOnlyKeys(TENANT_A)
+        .hasEntrySatisfying(
+            TENANT_A,
+            operations ->
+                assertThat(operations)
+                    .containsExactlyInAnyOrder(
+                        new PartitionDisableExporterOperation(id0, 1, EXPORTER_ID),
+                        new PartitionDisableExporterOperation(id1, 1, EXPORTER_ID)));
+  }
+
+  @Test
+  void shouldReturnEmptyPhasesWhenNoPhysicalTenantHasTheExporterConfigured() {
+    // given
+    final var transformer = new ExporterDisableRequestTransformer(EXPORTER_ID);
+    final var clusterConfiguration =
+        withPartitionGroups(Map.of(TENANT_A, groupWithMembers(configWithoutExporter)));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get()).isEmpty();
+  }
+
+  @Test
+  void shouldRejectAnUnknownPhysicalTenantId() {
+    // given
+    final var transformer =
+        new ExporterDisableRequestTransformer(EXPORTER_ID, Optional.of("unknown-tenant"));
+    final var clusterConfiguration =
+        withPartitionGroups(Map.of(TENANT_A, groupWithMembers(configWithExporter)));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(NotFound.class)
+        .hasMessageContaining("unknown-tenant");
+  }
+
+  private PartitionGroupConfiguration groupWithMembers(final DynamicPartitionConfig config) {
+    return PartitionGroupConfiguration.empty(PartitionGroupConfiguration.INITIAL_VERSION)
+        .addMember(
+            id0, BrokerPartitionState.initialize(Map.of(1, PartitionState.active(1, config))))
+        .addMember(
+            id1, BrokerPartitionState.initialize(Map.of(1, PartitionState.active(1, config))));
+  }
+
+  private CurrentClusterConfiguration withPartitionGroups(
+      final Map<String, PartitionGroupConfiguration> partitionGroups) {
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        GlobalConfiguration.init(),
+        partitionGroups,
+        PhasedChangeState.empty());
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformerTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.dynamic.config.api;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
@@ -120,7 +121,7 @@ final class ExporterDisableRequestTransformerTest {
   }
 
   @Test
-  void shouldReturnEmptyPhasesWhenNoPhysicalTenantHasTheExporterConfigured() {
+  void shouldFailWhenNoPhysicalTenantHasTheExporterConfigured() {
     // given
     final var transformer = new ExporterDisableRequestTransformer(EXPORTER_ID);
     final var clusterConfiguration =
@@ -130,8 +131,10 @@ final class ExporterDisableRequestTransformerTest {
     final var result = transformer.phases(clusterConfiguration);
 
     // then
-    EitherAssert.assertThat(result).isRight();
-    assertThat(result.get()).isEmpty();
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(NotFound.class)
+        .hasMessageContaining("no matching exporters were found");
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RecordingChangeCoordinator.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RecordingChangeCoordinator.java
@@ -12,8 +12,12 @@ import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
+import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,7 +38,7 @@ final class RecordingChangeCoordinator implements ConfigurationChangeCoordinator
   @Override
   public ActorFuture<ConfigurationChangeResult> applyOperations(
       final ConfigurationChangeRequest request) {
-    final var operationsEither = request.operations(currentTopology);
+    final var operationsEither = resolveOperations(request);
     if (operationsEither.isLeft()) {
       return TestActorFuture.failedFuture(operationsEither.getLeft());
     }
@@ -70,5 +74,33 @@ final class RecordingChangeCoordinator implements ConfigurationChangeCoordinator
 
   public List<ClusterConfigurationChangeOperation> getLastAppliedOperation() {
     return lastAppliedOperation;
+  }
+
+  /**
+   * Requests that only implement {@code phases()} (the new multi-partition-group model) have no
+   * meaningful {@code operations(ClusterConfiguration)}; fall back to {@code phases()} on a
+   * fromLegacy projection of the test's legacy topology in that case.
+   */
+  private Either<Exception, List<ClusterConfigurationChangeOperation>> resolveOperations(
+      final ConfigurationChangeRequest request) {
+    try {
+      return request.operations(currentTopology);
+    } catch (final UnsupportedOperationException requestIsPhasesOnly) {
+      return request
+          .phases(CurrentClusterConfiguration.fromLegacy(currentTopology))
+          .map(RecordingChangeCoordinator::flattenPhases);
+    }
+  }
+
+  private static List<ClusterConfigurationChangeOperation> flattenPhases(final List<Phase> phases) {
+    final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
+    for (final var phase : phases) {
+      switch (phase) {
+        case final GlobalPhase globalPhase -> operations.addAll(globalPhase.operations());
+        case final PartitionGroupParallelPhase parallelPhase ->
+            parallelPhase.groupOperations().values().forEach(operations::addAll);
+      }
+    }
+    return operations;
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -182,7 +182,22 @@ final class ProtoBufSerializerTest {
   @Test
   void shouldEncodeAndDecodeExporterDisableRequest() {
     // given
-    final var exporterDisableRequest = new ExporterDisableRequest("expId", false);
+    final var exporterDisableRequest =
+        new ExporterDisableRequest("expId", Optional.of("tenant-a"), false);
+
+    // when
+    final var encodedRequest =
+        protoBufSerializer.encodeExporterDisableRequest(exporterDisableRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeExporterDisableRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(exporterDisableRequest);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeExporterDisableRequestWithoutPhysicalTenantId() {
+    // given
+    final var exporterDisableRequest = new ExporterDisableRequest("expId", Optional.empty(), false);
 
     // when
     final var encodedRequest =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ExportersEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ExportersEndpointIT.java
@@ -116,7 +116,7 @@ final class ExportersEndpointIT {
         .isInstanceOf(FeignException.class)
         .asInstanceOf(InstanceOfAssertFactories.type(FeignException.class))
         .extracting(FeignException::status)
-        .isEqualTo(400);
+        .isEqualTo(404);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- `ExporterDisableRequestTransformer` now accepts an optional physical tenant id: when given, disable operations are generated only for that tenant's partitions; when absent, it fans out to every tenant, skipping tenants/partitions that don't have the exporter configured instead of failing.
- The transformer now overrides `ConfigurationChangeRequest.phases()` (the new multi-partition-group model) instead of the legacy `operations()`, which the new-model coordinator path never calls.
- Threaded the optional tenant id through the wire protocol: added `optional string physicalTenantId` to the `ExporterDisableRequest` proto message and updated `ProtoBufSerializer` encode/decode and `ClusterConfigurationManagementRequestsHandler` accordingly.

REST/actuator exposure of the new parameter (`ExportersEndpoint`) is left for follow-up work; it currently passes `Optional.empty()`.

part of #59575.
