### PR TITLE
test: add e2e coverage for POST /v2/authentication/me/authorizations/search

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/index.ts
@@ -770,6 +770,7 @@ export function validateResponseShape<
     configPath?: string;
     throw?: boolean;
     record?: boolean | {label?: string};
+    truncateValidationErrors?: boolean;
   },
 ) {
   // Cast to base signature (method/status widened to string) for internal call.
@@ -797,6 +798,7 @@ export function validateResponse<
     configPath?: string;
     throw?: boolean;
     record?: boolean | {label?: string};
+    truncateValidationErrors?: boolean;
   },
 ) {
   return _baseValidateResponse(spec, response, options);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/index.ts
@@ -54,6 +54,11 @@ export const RESPONSE_INDEX = {
       '200': 1,
     },
   },
+  '/authentication/me/authorizations/search': {
+    POST: {
+      '200': 1,
+    },
+  },
   '/authorizations': {
     POST: {
       '201': 1,
@@ -65,6 +70,29 @@ export const RESPONSE_INDEX = {
     },
   },
   '/authorizations/{authorizationKey}': {
+    GET: {
+      '200': 1,
+    },
+  },
+  '/backups/runtime': {
+    GET: {
+      '200': 1,
+    },
+    POST: {
+      '202': 1,
+    },
+  },
+  '/backups/runtime/state': {
+    GET: {
+      '200': 1,
+    },
+  },
+  '/backups/runtime/state/sync': {
+    POST: {
+      '200': 1,
+    },
+  },
+  '/backups/runtime/{backupId}': {
     GET: {
       '200': 1,
     },
@@ -203,6 +231,11 @@ export const RESPONSE_INDEX = {
   },
   '/element-instances/{elementInstanceKey}/incidents/search': {
     POST: {
+      '200': 1,
+    },
+  },
+  '/exporting': {
+    GET: {
       '200': 1,
     },
   },
@@ -548,6 +581,16 @@ export const RESPONSE_INDEX = {
       '200': 1,
     },
   },
+  '/secrets/resolve': {
+    POST: {
+      '200': 1,
+    },
+  },
+  '/secrets/list': {
+    POST: {
+      '200': 1,
+    },
+  },
   '/setup/user': {
     POST: {
       '201': 1,
@@ -556,6 +599,12 @@ export const RESPONSE_INDEX = {
   '/signals/broadcast': {
     POST: {
       '200': 1,
+    },
+  },
+  '/cluster/v2/status': {
+    GET: {
+      '200': 1,
+      '503': 1,
     },
   },
   '/system/usage-metrics': {
@@ -622,6 +671,9 @@ export const RESPONSE_INDEX = {
     },
   },
   '/restore': {
+    GET: {
+      '200': 1,
+    },
     POST: {
       '202': 1,
     },
@@ -718,7 +770,6 @@ export function validateResponseShape<
     configPath?: string;
     throw?: boolean;
     record?: boolean | {label?: string};
-    truncateValidationErrors?: boolean;
   },
 ) {
   // Cast to base signature (method/status widened to string) for internal call.
@@ -746,7 +797,6 @@ export function validateResponse<
     configPath?: string;
     throw?: boolean;
     record?: boolean | {label?: string};
-    truncateValidationErrors?: boolean;
   },
 ) {
   return _baseValidateResponse(spec, response, options);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
     "sourceRepo": "https://github.com/camunda/camunda",
-    "commit": "3e39a2d98dab6eb07cb4438d17915c291744c7a2",
-    "generatedAt": "2026-08-06T12:39:23.040Z",
+    "commit": "be1b0dd27a87efcb096e122c39f8cb6a3bb7b9d4",
+    "generatedAt": "2026-08-06T14:03:11.013Z",
     "specPath": "zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml",
     "specSha256": "b33f0519714cde6ee3c35e929a034227b50537cd23ca0c140509f21b6c680865"
   },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
@@ -2,7 +2,7 @@
   "metadata": {
     "sourceRepo": "https://github.com/camunda/camunda",
     "commit": "be1b0dd27a87efcb096e122c39f8cb6a3bb7b9d4",
-    "generatedAt": "2026-08-06T14:03:11.013Z",
+    "generatedAt": "2026-08-06T15:26:01.012Z",
     "specPath": "zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml",
     "specSha256": "b33f0519714cde6ee3c35e929a034227b50537cd23ca0c140509f21b6c680865"
   },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authentication-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authentication-api-tests.spec.ts
@@ -18,11 +18,15 @@ import {
 import {validateResponse} from '../../../json-body-assertions';
 import {defaultAssertionOptions} from '../../../utils/constants';
 import {
+  cleanupAuthorizations,
   createComponentAuthorization,
   createGroupAndStoreResponseFields,
   createRole,
   createTenant,
+  createUser,
   createUsersAndStoreResponseFields,
+  expectAuthorizationCanBeFound,
+  verifyAuthorizationFields,
 } from '@requestHelpers';
 import {
   authenticationRequiredFields,
@@ -235,5 +239,159 @@ test.describe.parallel('Authentication API Tests', () => {
       const json = await res.json();
       assertEqualsForKeys(json, expectedBody, authenticationRequiredFields);
     }).toPass(defaultAssertionOptions);
+  });
+});
+
+test.describe.parallel('Search Own Authorizations API Tests', () => {
+  const authorizationKeysToCleanup: string[] = [];
+  const usernamesToCleanup: string[] = [];
+
+  test.afterAll(async ({request}) => {
+    await cleanupAuthorizations(request, authorizationKeysToCleanup);
+    await cleanupUsers(request, usernamesToCleanup);
+  });
+
+  test('Search Own Authorizations Returns Direct Grant', async ({request}) => {
+    const user = await createUser(request);
+    usernamesToCleanup.push(user.username);
+
+    const authorizationKey = await createComponentAuthorization(request, {
+      ownerId: user.username,
+      ownerType: 'USER',
+      resourceId: '*',
+      resourceType: 'CLUSTER_VARIABLE',
+      permissionTypes: ['READ'],
+    });
+    authorizationKeysToCleanup.push(authorizationKey);
+    await expectAuthorizationCanBeFound(request, authorizationKey);
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/authentication/me/authorizations/search'),
+        {
+          headers: jsonHeaders(encode(`${user.username}:${user.password}`)),
+          data: {},
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/authentication/me/authorizations/search',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      const item = json.items.find(
+        (it: {authorizationKey: string}) =>
+          it.authorizationKey === authorizationKey,
+      );
+      expect(item).toBeDefined();
+      verifyAuthorizationFields(item, {
+        ownerId: user.username,
+        ownerType: 'USER',
+        resourceId: '*',
+        resourceType: 'CLUSTER_VARIABLE',
+        permissionTypes: ['READ'],
+        authorizationKey,
+      });
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Own Authorizations Filtered By Resource Type Excludes Others', async ({
+    request,
+  }) => {
+    const user = await createUser(request);
+    usernamesToCleanup.push(user.username);
+
+    const matchingKey = await createComponentAuthorization(request, {
+      ownerId: user.username,
+      ownerType: 'USER',
+      resourceId: '*',
+      resourceType: 'CLUSTER_VARIABLE',
+      permissionTypes: ['READ'],
+    });
+    const otherKey = await createComponentAuthorization(request, {
+      ownerId: user.username,
+      ownerType: 'USER',
+      resourceId: '*',
+      resourceType: 'MESSAGE',
+      permissionTypes: ['READ'],
+    });
+    authorizationKeysToCleanup.push(matchingKey, otherKey);
+    await expectAuthorizationCanBeFound(request, matchingKey);
+    await expectAuthorizationCanBeFound(request, otherKey);
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/authentication/me/authorizations/search'),
+        {
+          headers: jsonHeaders(encode(`${user.username}:${user.password}`)),
+          data: {filter: {resourceType: 'CLUSTER_VARIABLE'}},
+        },
+      );
+      await assertStatusCode(res, 200);
+      const json = await res.json();
+      expect(
+        json.items.some(
+          (it: {authorizationKey: string}) =>
+            it.authorizationKey === matchingKey,
+        ),
+      ).toBe(true);
+      expect(
+        json.items.some(
+          (it: {authorizationKey: string}) => it.authorizationKey === otherKey,
+        ),
+      ).toBe(false);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Own Authorizations Never Leaks Another Users Grants', async ({
+    request,
+  }) => {
+    const caller = await createUser(request);
+    const stranger = await createUser(request);
+    usernamesToCleanup.push(caller.username, stranger.username);
+
+    const strangerKey = await createComponentAuthorization(request, {
+      ownerId: stranger.username,
+      ownerType: 'USER',
+      resourceId: '*',
+      resourceType: 'CLUSTER_VARIABLE',
+      permissionTypes: ['READ'],
+    });
+    authorizationKeysToCleanup.push(strangerKey);
+    await expectAuthorizationCanBeFound(request, strangerKey);
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/authentication/me/authorizations/search'),
+        {
+          headers: jsonHeaders(encode(`${caller.username}:${caller.password}`)),
+          data: {filter: {ownerId: stranger.username, ownerType: 'USER'}},
+        },
+      );
+      await assertStatusCode(res, 200);
+      const json = await res.json();
+      expect(
+        json.items.some(
+          (it: {authorizationKey: string}) =>
+            it.authorizationKey === strangerKey,
+        ),
+      ).toBe(false);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  // eslint-disable-next-line playwright/expect-expect
+  test('Search Own Authorizations Unauthorized', async ({request}) => {
+    const res = await request.post(
+      buildUrl('/authentication/me/authorizations/search'),
+      {
+        headers: {'Content-Type': 'application/json'},
+        data: {},
+      },
+    );
+    await assertUnauthorizedRequest(res);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authentication-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authentication-api-tests.spec.ts
@@ -354,6 +354,15 @@ test.describe.parallel('Search Own Authorizations API Tests', () => {
     const stranger = await createUser(request);
     usernamesToCleanup.push(caller.username, stranger.username);
 
+    // Both grants are identical apart from their owner, so the only thing that
+    // can keep the stranger's out of the caller's results is owner scoping.
+    const callerKey = await createComponentAuthorization(request, {
+      ownerId: caller.username,
+      ownerType: 'USER',
+      resourceId: '*',
+      resourceType: 'CLUSTER_VARIABLE',
+      permissionTypes: ['READ'],
+    });
     const strangerKey = await createComponentAuthorization(request, {
       ownerId: stranger.username,
       ownerType: 'USER',
@@ -361,10 +370,31 @@ test.describe.parallel('Search Own Authorizations API Tests', () => {
       resourceType: 'CLUSTER_VARIABLE',
       permissionTypes: ['READ'],
     });
-    authorizationKeysToCleanup.push(strangerKey);
+    authorizationKeysToCleanup.push(callerKey, strangerKey);
+    await expectAuthorizationCanBeFound(request, callerKey);
     await expectAuthorizationCanBeFound(request, strangerKey);
 
-    await expect(async () => {
+    await test.step('Own grant is returned, stranger grant is not', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/authentication/me/authorizations/search'),
+          {
+            headers: jsonHeaders(
+              encode(`${caller.username}:${caller.password}`),
+            ),
+            data: {},
+          },
+        );
+        await assertStatusCode(res, 200);
+        const keys = (await res.json()).items.map(
+          (it: {authorizationKey: string}) => it.authorizationKey,
+        );
+        expect(keys).toContain(callerKey);
+        expect(keys).not.toContain(strangerKey);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Filtering by the stranger as owner returns nothing', async () => {
       const res = await request.post(
         buildUrl('/authentication/me/authorizations/search'),
         {
@@ -373,14 +403,8 @@ test.describe.parallel('Search Own Authorizations API Tests', () => {
         },
       );
       await assertStatusCode(res, 200);
-      const json = await res.json();
-      expect(
-        json.items.some(
-          (it: {authorizationKey: string}) =>
-            it.authorizationKey === strangerKey,
-        ),
-      ).toBe(false);
-    }).toPass(defaultAssertionOptions);
+      expect((await res.json()).items).toEqual([]);
+    });
   });
 
   // eslint-disable-next-line playwright/expect-expect

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authentication-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authentication-api-tests.spec.ts
@@ -245,10 +245,24 @@ test.describe.parallel('Authentication API Tests', () => {
 test.describe.parallel('Search Own Authorizations API Tests', () => {
   const authorizationKeysToCleanup: string[] = [];
   const usernamesToCleanup: string[] = [];
+  const groupIdsToCleanup: string[] = [];
+  const roleIdsToCleanup: string[] = [];
 
   test.afterAll(async ({request}) => {
     await cleanupAuthorizations(request, authorizationKeysToCleanup);
     await cleanupUsers(request, usernamesToCleanup);
+    await Promise.allSettled([
+      ...groupIdsToCleanup.map((groupId) =>
+        request.delete(buildUrl('/groups/{groupId}', {groupId}), {
+          headers: jsonHeaders(),
+        }),
+      ),
+      ...roleIdsToCleanup.map((roleId) =>
+        request.delete(buildUrl('/roles/{roleId}', {roleId}), {
+          headers: jsonHeaders(),
+        }),
+      ),
+    ]);
   });
 
   test('Search Own Authorizations Returns Direct Grant', async ({request}) => {
@@ -312,6 +326,7 @@ test.describe.parallel('Search Own Authorizations API Tests', () => {
       resourceType: 'CLUSTER_VARIABLE',
       permissionTypes: ['READ'],
     });
+    authorizationKeysToCleanup.push(matchingKey);
     const otherKey = await createComponentAuthorization(request, {
       ownerId: user.username,
       ownerType: 'USER',
@@ -319,7 +334,7 @@ test.describe.parallel('Search Own Authorizations API Tests', () => {
       resourceType: 'MESSAGE',
       permissionTypes: ['READ'],
     });
-    authorizationKeysToCleanup.push(matchingKey, otherKey);
+    authorizationKeysToCleanup.push(otherKey);
     await expectAuthorizationCanBeFound(request, matchingKey);
     await expectAuthorizationCanBeFound(request, otherKey);
 
@@ -332,27 +347,29 @@ test.describe.parallel('Search Own Authorizations API Tests', () => {
         },
       );
       await assertStatusCode(res, 200);
-      const json = await res.json();
-      expect(
-        json.items.some(
-          (it: {authorizationKey: string}) =>
-            it.authorizationKey === matchingKey,
-        ),
-      ).toBe(true);
-      expect(
-        json.items.some(
-          (it: {authorizationKey: string}) => it.authorizationKey === otherKey,
-        ),
-      ).toBe(false);
+      await validateResponse(
+        {
+          path: '/authentication/me/authorizations/search',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const keys = (await res.json()).items.map(
+        (it: {authorizationKey: string}) => it.authorizationKey,
+      );
+      expect(keys).toContain(matchingKey);
+      expect(keys).not.toContain(otherKey);
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search Own Authorizations Never Leaks Another Users Grants', async ({
+  test("Search Own Authorizations Never Leaks Another User's Grants", async ({
     request,
   }) => {
     const caller = await createUser(request);
+    usernamesToCleanup.push(caller.username);
     const stranger = await createUser(request);
-    usernamesToCleanup.push(caller.username, stranger.username);
+    usernamesToCleanup.push(stranger.username);
 
     // Both grants are identical apart from their owner, so the only thing that
     // can keep the stranger's out of the caller's results is owner scoping.
@@ -363,6 +380,7 @@ test.describe.parallel('Search Own Authorizations API Tests', () => {
       resourceType: 'CLUSTER_VARIABLE',
       permissionTypes: ['READ'],
     });
+    authorizationKeysToCleanup.push(callerKey);
     const strangerKey = await createComponentAuthorization(request, {
       ownerId: stranger.username,
       ownerType: 'USER',
@@ -370,7 +388,7 @@ test.describe.parallel('Search Own Authorizations API Tests', () => {
       resourceType: 'CLUSTER_VARIABLE',
       permissionTypes: ['READ'],
     });
-    authorizationKeysToCleanup.push(callerKey, strangerKey);
+    authorizationKeysToCleanup.push(strangerKey);
     await expectAuthorizationCanBeFound(request, callerKey);
     await expectAuthorizationCanBeFound(request, strangerKey);
 
@@ -386,6 +404,14 @@ test.describe.parallel('Search Own Authorizations API Tests', () => {
           },
         );
         await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: '/authentication/me/authorizations/search',
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
         const keys = (await res.json()).items.map(
           (it: {authorizationKey: string}) => it.authorizationKey,
         );
@@ -405,6 +431,168 @@ test.describe.parallel('Search Own Authorizations API Tests', () => {
       await assertStatusCode(res, 200);
       expect((await res.json()).items).toEqual([]);
     });
+  });
+
+  test('Search Own Authorizations Returns Grants Inherited Via Group And Role', async ({
+    request,
+  }) => {
+    const user = await createUser(request);
+    usernamesToCleanup.push(user.username);
+
+    const state: Record<string, unknown> = {};
+    await createGroupAndStoreResponseFields(request, 1, state, 'Inherited');
+    const groupId = state['groupIdInherited1'] as string;
+    groupIdsToCleanup.push(groupId);
+    await createRole(request, state, 'Inherited');
+    const roleId = state['roleIdInherited'] as string;
+    roleIdsToCleanup.push(roleId);
+
+    await test.step('Assign the user to the group and the role', async () => {
+      await expect(async () => {
+        const res = await request.put(
+          buildUrl('/groups/{groupId}/users/{username}', {
+            groupId,
+            username: user.username,
+          }),
+          {headers: jsonHeaders()},
+        );
+        await assertStatusCode(res, 204);
+      }).toPass(defaultAssertionOptions);
+
+      await expect(async () => {
+        const res = await request.put(
+          buildUrl('/roles/{roleId}/users/{username}', {
+            roleId,
+            username: user.username,
+          }),
+          {headers: jsonHeaders()},
+        );
+        await assertStatusCode(res, 204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    // Neither grant names the user as owner, so they can only surface through
+    // the group/role membership traversal rather than a direct owner match.
+    const groupOwnedKey = await createComponentAuthorization(request, {
+      ownerId: groupId,
+      ownerType: 'GROUP',
+      resourceId: '*',
+      resourceType: 'CLUSTER_VARIABLE',
+      permissionTypes: ['READ'],
+    });
+    authorizationKeysToCleanup.push(groupOwnedKey);
+    const roleOwnedKey = await createComponentAuthorization(request, {
+      ownerId: roleId,
+      ownerType: 'ROLE',
+      resourceId: '*',
+      resourceType: 'MESSAGE',
+      permissionTypes: ['READ'],
+    });
+    authorizationKeysToCleanup.push(roleOwnedKey);
+    await expectAuthorizationCanBeFound(request, groupOwnedKey);
+    await expectAuthorizationCanBeFound(request, roleOwnedKey);
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/authentication/me/authorizations/search'),
+        {
+          headers: jsonHeaders(encode(`${user.username}:${user.password}`)),
+          data: {},
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/authentication/me/authorizations/search',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const items = (await res.json()).items;
+      const byKey = (key: string) =>
+        items.find((it: {authorizationKey: string}) => {
+          return it.authorizationKey === key;
+        });
+
+      expect(byKey(groupOwnedKey)).toBeDefined();
+      verifyAuthorizationFields(byKey(groupOwnedKey), {
+        ownerId: groupId,
+        ownerType: 'GROUP',
+        resourceId: '*',
+        resourceType: 'CLUSTER_VARIABLE',
+        permissionTypes: ['READ'],
+        authorizationKey: groupOwnedKey,
+      });
+
+      expect(byKey(roleOwnedKey)).toBeDefined();
+      verifyAuthorizationFields(byKey(roleOwnedKey), {
+        ownerId: roleId,
+        ownerType: 'ROLE',
+        resourceId: '*',
+        resourceType: 'MESSAGE',
+        permissionTypes: ['READ'],
+        authorizationKey: roleOwnedKey,
+      });
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Own Authorizations Filters Inherited Grants By Resource Type', async ({
+    request,
+  }) => {
+    const user = await createUser(request);
+    usernamesToCleanup.push(user.username);
+
+    const state: Record<string, unknown> = {};
+    await createGroupAndStoreResponseFields(request, 1, state, 'Filtered');
+    const groupId = state['groupIdFiltered1'] as string;
+    groupIdsToCleanup.push(groupId);
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/groups/{groupId}/users/{username}', {
+          groupId,
+          username: user.username,
+        }),
+        {headers: jsonHeaders()},
+      );
+      await assertStatusCode(res, 204);
+    }).toPass(defaultAssertionOptions);
+
+    const matchingKey = await createComponentAuthorization(request, {
+      ownerId: groupId,
+      ownerType: 'GROUP',
+      resourceId: '*',
+      resourceType: 'CLUSTER_VARIABLE',
+      permissionTypes: ['READ'],
+    });
+    authorizationKeysToCleanup.push(matchingKey);
+    const otherKey = await createComponentAuthorization(request, {
+      ownerId: groupId,
+      ownerType: 'GROUP',
+      resourceId: '*',
+      resourceType: 'MESSAGE',
+      permissionTypes: ['READ'],
+    });
+    authorizationKeysToCleanup.push(otherKey);
+    await expectAuthorizationCanBeFound(request, matchingKey);
+    await expectAuthorizationCanBeFound(request, otherKey);
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/authentication/me/authorizations/search'),
+        {
+          headers: jsonHeaders(encode(`${user.username}:${user.password}`)),
+          data: {filter: {resourceType: 'CLUSTER_VARIABLE'}},
+        },
+      );
+      await assertStatusCode(res, 200);
+      const keys = (await res.json()).items.map(
+        (it: {authorizationKey: string}) => it.authorizationKey,
+      );
+      expect(keys).toContain(matchingKey);
+      expect(keys).not.toContain(otherKey);
+    }).toPass(defaultAssertionOptions);
   });
 
   // eslint-disable-next-line playwright/expect-expect


### PR DESCRIPTION
## Summary

- Adds Playwright coverage in the C8 orchestration cluster e2e suite for `POST /v2/authentication/me/authorizations/search`, added by camunda/camunda#55892 (PR #58987). That PR shipped with acceptance-test coverage only (`qa/acceptance-tests`); this suite had zero coverage for the new endpoint, unlike its sibling `GET /v2/authentication/me`.
- New tests: direct-grant happy path, `resourceType` filtering, owner-scope escalation safety (a foreign `ownerId`/`ownerType` filter never leaks another user's grants), and the unauthorized case.
- Regenerates `json-body-assertions/_generated/*` (via `npm run responses:regenerate`) so OpenAPI schema validation covers the new endpoint's response shape.

Closes #59588

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [x] Ran the new + existing tests in `tests/api/v2/authentication-api-tests.spec.ts` against a freshly-pulled `camunda/camunda:SNAPSHOT` (post-merge of #58987) with ES as secondary storage — 8/8 passed, no regressions on the old endpoint's tests