### PR TITLE
ci: run AlwaysGreen triage for stable/8.7 failures

### DIFF
--- a/.github/actions/post-failure-feedback/action.yml
+++ b/.github/actions/post-failure-feedback/action.yml
@@ -72,10 +72,22 @@ inputs:
     required: false
     default: ""
 
+outputs:
+  slack_ts:
+    description: >
+      Timestamp of the Slack message that was posted, so a later job can reply in its
+      thread instead of starting a second top-level message. Empty when Slack was
+      skipped or the post failed.
+    value: ${{ steps.feedback.outputs.slack_ts }}
+  slack_channel:
+    description: "Channel id the message was posted to. Empty when nothing was posted."
+    value: ${{ steps.feedback.outputs.slack_channel }}
+
 runs:
   using: composite
   steps:
     - name: Render & post failure feedback
+      id: feedback
       shell: bash
       env:
         FB_CATEGORY: ${{ inputs.failure_category }}

--- a/.github/actions/post-failure-feedback/feedback.mjs
+++ b/.github/actions/post-failure-feedback/feedback.mjs
@@ -282,7 +282,7 @@ async function postSlack(m) {
     if (!j.ok) throw new Error(j.error || 'unknown');
     console.log(`[feedback] posted to Slack ${channel} (ts=${j.ts})`);
     await setStepOutput('slack_ts', j.ts);
-    await setStepOutput('slack_channel', j.channel || channel);
+    await setStepOutput('slack_channel', j.channel);
   } catch (e) {
     console.error(`[feedback] Slack post failed: ${e.message || e}`);
   }

--- a/.github/actions/post-failure-feedback/feedback.mjs
+++ b/.github/actions/post-failure-feedback/feedback.mjs
@@ -237,6 +237,18 @@ async function resolveDraft(m) {
   }
 }
 
+// Publishes the posted message's identity so a later job in the same run can reply in
+// its thread instead of opening a second top-level message for the same failure.
+async function setStepOutput(name, value) {
+  const file = process.env.GITHUB_OUTPUT;
+  if (!file || !value) return;
+  try {
+    await appendFile(file, `${name}=${value}\n`);
+  } catch (e) {
+    console.error(`[feedback] could not write output ${name}: ${e.message || e}`);
+  }
+}
+
 async function postSlack(m) {
   const channel = env('FB_SLACK_CHANNEL');
   const token = env('SLACK_BOT_TOKEN');
@@ -268,7 +280,9 @@ async function postSlack(m) {
     });
     const j = await res.json();
     if (!j.ok) throw new Error(j.error || 'unknown');
-    console.log(`[feedback] posted to Slack ${channel}`);
+    console.log(`[feedback] posted to Slack ${channel} (ts=${j.ts})`);
+    await setStepOutput('slack_ts', j.ts);
+    await setStepOutput('slack_channel', j.channel || channel);
   } catch (e) {
     console.error(`[feedback] Slack post failed: ${e.message || e}`);
   }

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -737,6 +737,11 @@ jobs:
     permissions:
       contents: read
       actions: read
+    # Surfaced so alwaysgreen-triage can reply in the feedback message's thread rather
+    # than opening a second top-level message for the same failure.
+    outputs:
+      slack_ts: ${{ steps.feedback.outputs.slack_ts }}
+      slack_channel: ${{ steps.feedback.outputs.slack_channel }}
     steps:
       - run: |
           # shellcheck disable=SC2242
@@ -802,6 +807,7 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
       - name: Post AlwaysGreen failure feedback
+        id: feedback
         if: failure()
         continue-on-error: true
         uses: ./.github/actions/post-failure-feedback
@@ -1314,3 +1320,40 @@ jobs:
           retention-days: 5
 
 
+  # Final job: hand a failed run to the triage agent. github.run_id here is this run,
+  # so the classifier reads this run's own artifacts. The triage workflow and the fix
+  # agent live only on main; base_ref carries the branch so the fix targets stable/8.7.
+  #
+  # `continue-on-error` is not available on a job that calls a reusable workflow, so
+  # alwaysgreen-triage.yml keeps its own fallible steps continue-on-error instead.
+  alwaysgreen-triage:
+    name: AlwaysGreen triage and fix dispatch
+    needs:
+      - should-run
+      - preflight
+      - build-operate-frontend
+      - build-tasklist-frontend
+      - build-identity-frontend
+      - build-and-push-images
+      - format-identifier
+      - helm-deploy-status
+      - trigger-saas-e2e
+    # Unfinished work is expected to fail: dispatching a fix agent at a draft PR wastes
+    # an agent run and can open a PR against a moving target. No-op until a
+    # pull_request trigger is added — merge_group is never a draft and push carries no
+    # PR. Mirrors the gate on main (#59386).
+    if: ${{ always() && contains(needs.*.result, 'failure')
+            && !github.event.pull_request.draft }}
+    uses: camunda/camunda/.github/workflows/alwaysgreen-triage.yml@main
+    secrets: inherit
+    with:
+      # On a merge_group run this is gh-readonly-queue/<base>/pr-<n>-<sha> rather than the
+      # target branch. Triage normalises it (classify.normalise_base_ref) before anything
+      # derives from it, because the ref is part of every fingerprint and a per-PR value
+      # would defeat dedupe.
+      base_ref: ${{ github.ref_name }}
+      chart_version: ${{ inputs.helmRepositoryDirName || 'camunda-platform-8.7' }}
+      # Empty when the helm stage did not fail, or Slack was unavailable; triage then
+      # posts its own parent message instead of threading.
+      parent_slack_ts: ${{ needs.helm-deploy-status.outputs.slack_ts }}
+      parent_slack_channel: ${{ needs.helm-deploy-status.outputs.slack_channel }}


### PR DESCRIPTION
## Description

Wires AlwaysGreen triage into `stable/8.7`, identical to camunda/camunda#59388 for `stable/8.9`.
A failed run hands itself to the triage agent, which classifies the failure and dispatches a fix
agent against this branch.

The triage workflow and the fix agent live only on `main`. This branch carries just the caller and
passes `base_ref`, which is what makes the fix target `stable/8.7` and resolve the 8.7 suite and
chart directories rather than main's.

Also: `post-failure-feedback` now publishes the Slack message it posted, so triage replies in that
thread instead of opening a second top-level message for the same failure. And the draft gate
matches `main` (camunda/camunda#59386) — a draft PR's failure should not spend an agent run on a
moving target. That gate is a no-op until a `pull_request` trigger exists, since `merge_group` is
never a draft and `push` carries no PR; it lives in the caller, so each branch needs its own copy.

## Verification

The change is byte-identical to camunda/camunda#59388 apart from the version string and the image job name, which is `build-and-push-images` on this branch rather than `build-and-push`. I diffed the two changesets against each other to confirm that.

`actionlint -shellcheck=shellcheck` reports only the pre-existing `gcp-perf-core-8-default` runner-label
finding, unchanged from this branch's baseline. `node --check` passes on `feedback.mjs`, and both
YAML files parse.

The chain itself was verified end to end on 8.9 lineage — triage classified the failure, resolved
`VERSION 8.9 / SUITE SM-8.9 / CHART camunda-platform-8.9`, and the agent opened its PR against the
failing branch rather than `main`.

## Merge order

Behind camunda/camunda#59541 and camunda/camunda#59388. #59541 is the blocker: without it triage
cannot run at all when called from a stable branch, because a reusable workflow's checkout follows
the caller and this branch has none of the tooling.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Part of camunda/team-test-automation#138 — same wiring for every supported stable branch.
