### PR TITLE
refactor: build ResourceAccessProvider from a scope repository, not AuthorizationChecker

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
@@ -18,12 +18,11 @@ import io.camunda.search.clients.auth.DocumentBasedResourceAccessController;
 import io.camunda.search.clients.auth.ResourceAccessDelegatingController;
 import io.camunda.search.clients.reader.PhysicalTenantSearchClientReaders;
 import io.camunda.search.clients.reader.SearchClientReaders;
-import io.camunda.security.core.authz.AuthorizationChecker;
-import io.camunda.security.core.authz.DisabledResourceAccessProvider;
 import io.camunda.security.core.authz.ResourceAccessController;
 import io.camunda.security.core.authz.ResourceAccessProvider;
 import io.camunda.security.core.authz.TenantAccessProvider;
-import io.camunda.security.impl.AuthorizationCheckerFactory;
+import io.camunda.security.core.port.out.AuthorizationScopeRepositoryPort;
+import io.camunda.security.impl.SearchAuthorizationScopeRepository;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import java.util.LinkedHashMap;
@@ -41,10 +40,10 @@ public class ResourceAccessControllerConfiguration {
 
   @Bean
   public ResourceAccessProvider resourceAccessProvider(
-      final CamundaSecurityLibraryProperties cslProperties, final AuthorizationChecker checker) {
-    return cslProperties.getAuthorizations().isEnabled()
-        ? new DefaultResourceAccessProvider(checker)
-        : new DisabledResourceAccessProvider();
+      final CamundaSecurityLibraryProperties cslProperties,
+      final AuthorizationScopeRepositoryPort scopeRepository) {
+    return DefaultResourceAccessProvider.forScopeRepository(
+        scopeRepository, cslProperties.getAuthorizations().isEnabled());
   }
 
   @Bean
@@ -114,10 +113,10 @@ public class ResourceAccessControllerConfiguration {
   private static ResourceAccessProvider resourceAccessProviderFor(
       final SearchClientReaders searchClientReaders,
       final CamundaSecurityLibraryProperties cslProps) {
-    final var checker = AuthorizationCheckerFactory.forPhysicalTenant(searchClientReaders);
-    return cslProps.getAuthorizations().isEnabled()
-        ? new DefaultResourceAccessProvider(checker)
-        : new DisabledResourceAccessProvider();
+    final var scopeRepository =
+        new SearchAuthorizationScopeRepository(searchClientReaders.authorizationReader());
+    return DefaultResourceAccessProvider.forScopeRepository(
+        scopeRepository, cslProps.getAuthorizations().isEnabled());
   }
 
   private static PhysicalTenantResourceAccessControllers buildPerTenantControllers(

--- a/dist/src/main/java/io/camunda/application/commons/security/AuthorizationCheckerProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/AuthorizationCheckerProviderConfiguration.java
@@ -25,9 +25,7 @@ import org.springframework.context.annotation.Configuration;
  * default-tenant-pinned {@link AuthorizationChecker} bean is always present here, while the
  * per-tenant checkers are derived only when {@link PhysicalTenantSearchClientReaders} exists (i.e.
  * secondary storage is enabled). Each per-tenant checker is built through {@link
- * AuthorizationCheckerFactory}.
- *
- * <p>This is the only remaining consumer of {@link AuthorizationCheckerFactory}: it exists so
+ * AuthorizationCheckerFactory} — the only remaining consumer of that factory, since it exists so
  * {@code CamundaServicesConfiguration} can hand a raw {@link AuthorizationChecker} to services
  * ({@code DocumentServices}, {@code SecretServices}) that query it directly, bypassing the {@code
  * ResourceAccessController}/data-plane path. {@code ResourceAccessControllerConfiguration} no

--- a/dist/src/main/java/io/camunda/application/commons/security/AuthorizationCheckerProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/AuthorizationCheckerProviderConfiguration.java
@@ -20,12 +20,12 @@ import org.springframework.context.annotation.Configuration;
 /**
  * Builds the single {@link AuthorizationCheckerProvider} injected into the service registry.
  *
- * <p>Gated on the same condition as its consumers ({@code CamundaServicesConfiguration} and {@code
- * WebAppAuthorizationCheckPortConfiguration}) rather than on secondary storage, so it constructs in
- * every storage mode: the required, default-tenant-pinned {@link AuthorizationChecker} bean is
- * always present here, while the per-tenant checkers are derived only when {@link
- * PhysicalTenantSearchClientReaders} exists (i.e. secondary storage is enabled). Each per-tenant
- * checker is built through {@link AuthorizationCheckerFactory}.
+ * <p>Gated on the same condition as its only consumer ({@code CamundaServicesConfiguration}) rather
+ * than on secondary storage, so it constructs in every storage mode: the required,
+ * default-tenant-pinned {@link AuthorizationChecker} bean is always present here, while the
+ * per-tenant checkers are derived only when {@link PhysicalTenantSearchClientReaders} exists (i.e.
+ * secondary storage is enabled). Each per-tenant checker is built through {@link
+ * AuthorizationCheckerFactory}.
  *
  * <p>This is the only remaining consumer of {@link AuthorizationCheckerFactory}: it exists so
  * {@code CamundaServicesConfiguration} can hand a raw {@link AuthorizationChecker} to services

--- a/dist/src/main/java/io/camunda/application/commons/security/AuthorizationCheckerProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/AuthorizationCheckerProviderConfiguration.java
@@ -20,12 +20,12 @@ import org.springframework.context.annotation.Configuration;
 /**
  * Builds the single {@link AuthorizationCheckerProvider} injected into the service registry.
  *
- * <p>Gated on the same condition as its only consumer ({@link
- * io.camunda.application.commons.service.CamundaServicesConfiguration}) rather than on secondary
- * storage, so it constructs in every storage mode: the required, default-tenant-pinned {@link
- * AuthorizationChecker} bean is always present here, while the per-tenant checkers are derived only
- * when {@link PhysicalTenantSearchClientReaders} exists (i.e. secondary storage is enabled). Each
- * per-tenant checker is built through {@link AuthorizationCheckerFactory}.
+ * <p>Gated on the same condition as its consumers ({@code CamundaServicesConfiguration} and {@code
+ * WebAppAuthorizationCheckPortConfiguration}) rather than on secondary storage, so it constructs in
+ * every storage mode: the required, default-tenant-pinned {@link AuthorizationChecker} bean is
+ * always present here, while the per-tenant checkers are derived only when {@link
+ * PhysicalTenantSearchClientReaders} exists (i.e. secondary storage is enabled). Each per-tenant
+ * checker is built through {@link AuthorizationCheckerFactory}.
  *
  * <p>This is the only remaining consumer of {@link AuthorizationCheckerFactory}: it exists so
  * {@code CamundaServicesConfiguration} can hand a raw {@link AuthorizationChecker} to services

--- a/dist/src/main/java/io/camunda/application/commons/security/AuthorizationCheckerProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/AuthorizationCheckerProviderConfiguration.java
@@ -25,9 +25,15 @@ import org.springframework.context.annotation.Configuration;
  * storage, so it constructs in every storage mode: the required, default-tenant-pinned {@link
  * AuthorizationChecker} bean is always present here, while the per-tenant checkers are derived only
  * when {@link PhysicalTenantSearchClientReaders} exists (i.e. secondary storage is enabled). Each
- * per-tenant checker is built through {@link AuthorizationCheckerFactory}, the same factory {@link
- * io.camunda.application.commons.search.ResourceAccessControllerConfiguration} uses, so the two
- * checker-construction sites stay in sync.
+ * per-tenant checker is built through {@link AuthorizationCheckerFactory}.
+ *
+ * <p>This is the only remaining consumer of {@link AuthorizationCheckerFactory}: it exists so
+ * {@code CamundaServicesConfiguration} can hand a raw {@link AuthorizationChecker} to services
+ * ({@code DocumentServices}, {@code SecretServices}) that query it directly, bypassing the {@code
+ * ResourceAccessController}/data-plane path. {@code ResourceAccessControllerConfiguration} no
+ * longer shares this factory — it builds its {@code ResourceAccessProvider}s via {@code
+ * DefaultResourceAccessProvider.forScopeRepository(...)} instead, which depends only on the {@code
+ * AuthorizationScopeRepositoryPort} outbound port.
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnAnyHttpGatewayEnabled

--- a/dist/src/main/java/io/camunda/application/commons/security/TenantAwareAuthorizationCheckPort.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/TenantAwareAuthorizationCheckPort.java
@@ -7,67 +7,68 @@
  */
 package io.camunda.application.commons.security;
 
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.security.api.context.TokenClaimsAuthenticationResolver;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.api.model.Either;
 import io.camunda.security.api.model.authz.AuthorizationRejection;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.api.model.authz.PermissionType;
 import io.camunda.security.core.auth.RequiredAuthorization;
-import io.camunda.security.core.authz.AuthorizationChecker;
-import io.camunda.security.core.authz.AuthorizationService;
-import io.camunda.security.core.authz.LazyTokenClaimsConverter;
-import io.camunda.security.core.authz.PropertyAuthorizationEvaluatorRegistry;
+import io.camunda.security.core.authz.ScopedAuthorizationCheckPortFactory.ScopedAuthorizationCheckPorts;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.spring.utils.PhysicalTenantContext;
 import java.util.List;
 import java.util.Map;
 
 /**
- * {@link AuthorizationCheckPort} that resolves the {@link AuthorizationChecker} for the physical
- * tenant of the current request via {@link AuthorizationCheckerProvider} before delegating to a
- * per-call {@link AuthorizationService}, and additionally grants COMPONENT/ACCESS on {@code admin}
- * to any principal holding the legacy {@code identity} component grant.
+ * {@link AuthorizationCheckPort} that resolves the per-physical-tenant {@link
+ * AuthorizationCheckPort} assembled by {@link
+ * io.camunda.security.core.authz.ScopedAuthorizationCheckPortFactory} for the physical tenant of
+ * the current request, and additionally grants COMPONENT/ACCESS on {@code admin} to any principal
+ * holding the legacy {@code identity} component grant.
  *
  * <p>The {@code identity}-to-{@code admin} alias exists because the Identity web app was renamed to
  * Admin; hosts with pre-existing {@code identity} component grants must keep working against the
  * {@code admin} component id without a data migration. It replaces the legacy {@code
  * IdentityToAdminComponentAliasAdapter} (issue #399).
+ *
+ * <p>{@code hasPerTenantScopes} distinguishes the two wiring shapes: when secondary storage is
+ * disabled, {@code checkPorts} was assembled from a single {@code default}-keyed entry and every
+ * request — regardless of what {@link PhysicalTenantContext#currentOrNull()} returns, typically
+ * {@code null} — resolves to it; when per-tenant scopes exist, the physical tenant id is passed
+ * through unchanged (including {@code null}) so an unstamped request fails hard rather than
+ * silently resolving against the default tenant's storage.
  */
 final class TenantAwareAuthorizationCheckPort implements AuthorizationCheckPort {
 
   private static final String COMPONENT_ADMIN = "admin";
   private static final String COMPONENT_IDENTITY_LEGACY_ALIAS = "identity";
 
-  private final AuthorizationCheckerProvider authorizationCheckerProvider;
-  private final PropertyAuthorizationEvaluatorRegistry propertyEvaluatorRegistry;
-  private final boolean authorizationEnabled;
-  private final boolean multiTenancyChecksEnabled;
-  private final LazyTokenClaimsConverter claimsConverter;
+  private final ScopedAuthorizationCheckPorts checkPorts;
+  private final boolean hasPerTenantScopes;
+  private final TokenClaimsAuthenticationResolver claimsResolver;
 
   TenantAwareAuthorizationCheckPort(
-      final AuthorizationCheckerProvider authorizationCheckerProvider,
-      final PropertyAuthorizationEvaluatorRegistry propertyEvaluatorRegistry,
-      final boolean authorizationEnabled,
-      final boolean multiTenancyChecksEnabled,
-      final LazyTokenClaimsConverter claimsConverter) {
-    this.authorizationCheckerProvider = authorizationCheckerProvider;
-    this.propertyEvaluatorRegistry = propertyEvaluatorRegistry;
-    this.authorizationEnabled = authorizationEnabled;
-    this.multiTenancyChecksEnabled = multiTenancyChecksEnabled;
-    this.claimsConverter = claimsConverter;
+      final ScopedAuthorizationCheckPorts checkPorts,
+      final boolean hasPerTenantScopes,
+      final TokenClaimsAuthenticationResolver claimsResolver) {
+    this.checkPorts = checkPorts;
+    this.hasPerTenantScopes = hasPerTenantScopes;
+    this.claimsResolver = claimsResolver;
   }
 
   @Override
   public <T> Either<AuthorizationRejection, Void> check(
       final CamundaAuthentication authentication, final RequiredAuthorization<T> authorization) {
-    final AuthorizationService authorizationService = authorizationServiceForCurrentTenant();
+    final AuthorizationCheckPort checkPort = checkPortForCurrentScope();
     final Either<AuthorizationRejection, Void> result =
-        authorizationService.check(authentication, authorization);
+        checkPort.check(authentication, authorization);
     if (result.isRight() || !isComponentAdminAccess(authorization)) {
       return result;
     }
     final Either<AuthorizationRejection, Void> aliasResult =
-        authorizationService.check(authentication, withIdentityAlias(authorization));
+        checkPort.check(authentication, withIdentityAlias(authorization));
     // If both checks fail, return the original rejection: it names the requested "admin"
     // component, whereas aliasResult's would reference the internal "identity" alias.
     return aliasResult.isRight() ? aliasResult : result;
@@ -76,7 +77,7 @@ final class TenantAwareAuthorizationCheckPort implements AuthorizationCheckPort 
   @Override
   public <T> Either<AuthorizationRejection, Void> check(
       final Map<String, Object> claims, final RequiredAuthorization<T> authorization) {
-    return check(claimsConverter.convert(claims), authorization);
+    return check(claimsResolver.resolve(claims), authorization);
   }
 
   @Override
@@ -84,18 +85,14 @@ final class TenantAwareAuthorizationCheckPort implements AuthorizationCheckPort 
       final CamundaAuthentication authentication,
       final RequiredAuthorization<T> authorization,
       final T resource) {
-    return authorizationServiceForCurrentTenant().check(authentication, authorization, resource);
+    return checkPortForCurrentScope().check(authentication, authorization, resource);
   }
 
-  private AuthorizationService authorizationServiceForCurrentTenant() {
-    final AuthorizationChecker checker =
-        authorizationCheckerProvider.withPhysicalTenant(PhysicalTenantContext.currentOrNull());
-    return new AuthorizationService(
-        checker,
-        propertyEvaluatorRegistry,
-        authorizationEnabled,
-        multiTenancyChecksEnabled,
-        claimsConverter);
+  private AuthorizationCheckPort checkPortForCurrentScope() {
+    if (!hasPerTenantScopes) {
+      return checkPorts.forScope(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    }
+    return checkPorts.forScope(PhysicalTenantContext.currentOrNull());
   }
 
   private static <T> boolean isComponentAdminAccess(final RequiredAuthorization<T> authorization) {

--- a/dist/src/main/java/io/camunda/application/commons/security/WebAppAuthorizationCheckPortConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/WebAppAuthorizationCheckPortConfiguration.java
@@ -82,6 +82,15 @@ public class WebAppAuthorizationCheckPortConfiguration {
         hasPerTenantScopes
             ? perTenantScopeRepositories(physicalTenantSearchClientReaders.get())
             : Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, defaultScopeRepository);
+    if (hasPerTenantScopes && scopeRepositoriesByScope.isEmpty()) {
+      throw new IllegalStateException(
+          "PhysicalTenantSearchClientReaders is present but declares no physical tenants; "
+              + "expected PhysicalTenantResolver to always synthesize a '"
+              + PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID
+              + "' entry. This indicates a broken invariant between PhysicalTenantResolver and "
+              + "this bean -- every authorization check, including default-tenant ones, would "
+              + "otherwise fail hard per request instead of at startup.");
+    }
     final var checkPorts =
         ScopedAuthorizationCheckPortFactory.create(
             scopeRepositoriesByScope,

--- a/dist/src/main/java/io/camunda/application/commons/security/WebAppAuthorizationCheckPortConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/WebAppAuthorizationCheckPortConfiguration.java
@@ -8,14 +8,21 @@
 package io.camunda.application.commons.security;
 
 import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabled;
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.search.clients.reader.PhysicalTenantSearchClientReaders;
 import io.camunda.security.api.context.PropertyAuthorizationEvaluator;
 import io.camunda.security.core.authz.LazyTokenClaimsConverter;
-import io.camunda.security.core.authz.PropertyAuthorizationEvaluatorRegistry;
+import io.camunda.security.core.authz.ScopedAuthorizationCheckPortFactory;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
+import io.camunda.security.core.port.out.AuthorizationScopeRepositoryPort;
 import io.camunda.security.core.port.out.MembershipPort;
 import io.camunda.security.core.port.out.MembershipQuery;
+import io.camunda.security.impl.SearchAuthorizationScopeRepository;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -25,11 +32,11 @@ import org.springframework.context.annotation.Configuration;
  * Builds the webapp-facing {@link AuthorizationCheckPort}, replacing the legacy {@code
  * ResourcePermissionPort}/{@code AuthorizationRepositoryPort} trio (issue #399).
  *
- * <p>Gated on the same condition as {@link AuthorizationCheckerProviderConfiguration}, the
- * collaborator whose per-tenant checkers vary with secondary storage, rather than on secondary
- * storage itself: with secondary storage disabled there is exactly one authorization source and
- * {@link AuthorizationCheckerProvider#withPhysicalTenant(String)} resolves every tenant to it, so
- * this bean constructs and behaves correctly in every storage mode.
+ * <p>Gated on the same condition as {@link AuthorizationScopeRepositoryConfiguration}'s root {@link
+ * AuthorizationScopeRepositoryPort} bean (unconditional), rather than on secondary storage itself:
+ * with secondary storage disabled there is exactly one authorization source and this bean seeds a
+ * single {@code default}-keyed scope so every request resolves to it, so this bean constructs and
+ * behaves correctly in every storage mode.
  *
  * <p>{@code @ConditionalOnMissingBean(AuthorizationCheckPort.class)} lets this user configuration
  * win the race against {@code camunda-security-library}'s own default {@code
@@ -38,7 +45,7 @@ import org.springframework.context.annotation.Configuration;
  * {@code @ImportAutoConfiguration}-imported configuration, per Spring Boot's ordering guarantee.
  * That CSL default builds a single {@code AuthorizationService} from a single {@code
  * AuthorizationChecker} bean, with no per-physical-tenant fan-out, so it cannot serve this repo's
- * requirement of one {@code AuthorizationService} per physical tenant; this bean is the required
+ * requirement of one {@code AuthorizationCheckPort} per physical tenant; this bean is the required
  * override, not a redundant duplicate.
  *
  * <p>{@link LazyTokenClaimsConverter} and {@link MembershipPort} are only registered as beans under
@@ -59,16 +66,44 @@ public class WebAppAuthorizationCheckPortConfiguration {
   @Bean
   @ConditionalOnMissingBean(AuthorizationCheckPort.class)
   public AuthorizationCheckPort authorizationCheckPort(
-      final AuthorizationCheckerProvider authorizationCheckerProvider,
+      final AuthorizationScopeRepositoryPort defaultScopeRepository,
+      final Optional<PhysicalTenantSearchClientReaders> physicalTenantSearchClientReaders,
       final List<PropertyAuthorizationEvaluator<?>> propertyAuthorizationEvaluators,
       final CamundaSecurityLibraryProperties securityProperties,
       final ObjectProvider<LazyTokenClaimsConverter> claimsConverter) {
-    return new TenantAwareAuthorizationCheckPort(
-        authorizationCheckerProvider,
-        new PropertyAuthorizationEvaluatorRegistry(propertyAuthorizationEvaluators),
-        securityProperties.getAuthorizations().isEnabled(),
-        securityProperties.getMultiTenancy().isChecksEnabled(),
-        claimsConverter.getIfAvailable(() -> defaultClaimsConverter(securityProperties)));
+    final var resolver =
+        claimsConverter.getIfAvailable(() -> defaultClaimsConverter(securityProperties));
+    // Equivalent to "the map would be empty" (the condition AuthorizationCheckerProvider used):
+    // PhysicalTenantResolver always synthesizes a "default" entry when none is explicitly
+    // configured, so whenever PhysicalTenantSearchClientReaders exists at all, its map is
+    // guaranteed non-empty.
+    final boolean hasPerTenantScopes = physicalTenantSearchClientReaders.isPresent();
+    final Map<String, AuthorizationScopeRepositoryPort> scopeRepositoriesByScope =
+        hasPerTenantScopes
+            ? perTenantScopeRepositories(physicalTenantSearchClientReaders.get())
+            : Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, defaultScopeRepository);
+    final var checkPorts =
+        ScopedAuthorizationCheckPortFactory.create(
+            scopeRepositoriesByScope,
+            resolver,
+            propertyAuthorizationEvaluators,
+            securityProperties.getAuthorizations().isEnabled(),
+            securityProperties.getMultiTenancy().isChecksEnabled());
+    return new TenantAwareAuthorizationCheckPort(checkPorts, hasPerTenantScopes, resolver);
+  }
+
+  private static Map<String, AuthorizationScopeRepositoryPort> perTenantScopeRepositories(
+      final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders) {
+    final Map<String, AuthorizationScopeRepositoryPort> scopeRepositories = new LinkedHashMap<>();
+    physicalTenantSearchClientReaders
+        .readersByPhysicalTenant()
+        .forEach(
+            (tenantId, searchClientReaders) ->
+                scopeRepositories.put(
+                    tenantId,
+                    new SearchAuthorizationScopeRepository(
+                        searchClientReaders.authorizationReader())));
+    return Map.copyOf(scopeRepositories);
   }
 
   /**

--- a/dist/src/test/java/io/camunda/application/commons/search/ResourceAccessControllerConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/ResourceAccessControllerConfigurationTest.java
@@ -20,11 +20,11 @@ import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.search.clients.reader.AuthorizationReader;
 import io.camunda.search.clients.reader.PhysicalTenantSearchClientReaders;
 import io.camunda.search.clients.reader.SearchClientReaders;
-import io.camunda.security.core.authz.AuthorizationChecker;
 import io.camunda.security.core.authz.DefaultTenantAccessProvider;
 import io.camunda.security.core.authz.DisabledTenantAccessProvider;
 import io.camunda.security.core.authz.ResourceAccessController;
 import io.camunda.security.core.authz.TenantAccessProvider;
+import io.camunda.security.core.port.out.AuthorizationScopeRepositoryPort;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import java.util.Map;
 import org.junit.jupiter.api.Nested;
@@ -49,14 +49,15 @@ public class ResourceAccessControllerConfigurationTest {
             CamundaSecurityConfiguration.class,
             UnifiedConfiguration.class,
             UnifiedConfigurationHelper.class)
-        .withBean(AuthorizationChecker.class, () -> mock(AuthorizationChecker.class))
+        .withBean(
+            AuthorizationScopeRepositoryPort.class,
+            () -> mock(AuthorizationScopeRepositoryPort.class))
         .withBean(PhysicalTenantSearchClientReaders.class, () -> defaultPtReaders)
         .withBean(PhysicalTenantSecurityProperties.class, () -> defaultPtSecProps)
         // make REST gateway condition pass
         .withPropertyValues(
             "zeebe.broker.gateway.enable=true",
             "camunda.rest.enabled=true",
-            // avoid needing AuthorizationChecker by disabling authorizations
             "camunda.security.authorizations.enabled=false");
   }
 
@@ -147,7 +148,9 @@ public class ResourceAccessControllerConfigurationTest {
               CamundaSecurityConfiguration.class,
               UnifiedConfiguration.class,
               UnifiedConfigurationHelper.class)
-          .withBean(AuthorizationChecker.class, () -> mock(AuthorizationChecker.class))
+          .withBean(
+              AuthorizationScopeRepositoryPort.class,
+              () -> mock(AuthorizationScopeRepositoryPort.class))
           .withBean(PhysicalTenantSearchClientReaders.class, () -> ptReaders)
           .withBean(PhysicalTenantSecurityProperties.class, () -> ptSecProps)
           .withPropertyValues(

--- a/dist/src/test/java/io/camunda/application/commons/security/TenantAwareAuthorizationCheckPortTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/TenantAwareAuthorizationCheckPortTest.java
@@ -8,23 +8,26 @@
 package io.camunda.application.commons.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.security.api.context.TokenClaimsAuthenticationResolver;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.api.model.Either;
 import io.camunda.security.api.model.authz.AuthorizationRejection;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.api.model.authz.PermissionType;
 import io.camunda.security.core.auth.RequiredAuthorization;
-import io.camunda.security.core.authz.AuthorizationChecker;
-import io.camunda.security.core.authz.LazyTokenClaimsConverter;
-import io.camunda.security.core.authz.PropertyAuthorizationEvaluatorRegistry;
+import io.camunda.security.core.authz.ScopedAuthorizationCheckPortFactory;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
+import io.camunda.security.core.port.out.AuthorizationScopeRepositoryPort;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -36,26 +39,40 @@ class TenantAwareAuthorizationCheckPortTest {
   private static final String COMPONENT_IDENTITY_LEGACY_ALIAS = "identity";
   private static final String COMPONENT_OPERATE = "operate";
 
-  private final AuthorizationChecker authorizationChecker = mock(AuthorizationChecker.class);
-  private final LazyTokenClaimsConverter claimsConverter = mock(LazyTokenClaimsConverter.class);
-  private final AuthorizationCheckPort authorizationCheckPort =
-      new TenantAwareAuthorizationCheckPort(
-          new AuthorizationCheckerProvider(authorizationChecker, Map.of()),
-          new PropertyAuthorizationEvaluatorRegistry(List.of()),
-          true,
-          false,
-          claimsConverter);
+  private final AuthorizationScopeRepositoryPort scopeRepository =
+      mock(AuthorizationScopeRepositoryPort.class);
+  private final TokenClaimsAuthenticationResolver claimsResolver =
+      mock(TokenClaimsAuthenticationResolver.class);
+  private final AuthorizationCheckPort authorizationCheckPort = noPerTenantScopesCheckPort();
   private final CamundaAuthentication authentication =
       CamundaAuthentication.of(b -> b.user("alice"));
+
+  /**
+   * A no-per-tenant-scopes port, backed by a single {@code default}-keyed scope. Used by every test
+   * below that exercises {@link TenantAwareAuthorizationCheckPort}'s own delegation/alias logic,
+   * not the per-tenant resolution itself — see {@link
+   * #shouldFailHardWhenPerTenantScopesConfiguredButNoPhysicalTenantResolved} for that.
+   */
+  private AuthorizationCheckPort noPerTenantScopesCheckPort() {
+    final var checkPorts =
+        ScopedAuthorizationCheckPortFactory.create(
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, scopeRepository),
+            claimsResolver,
+            List.of(),
+            true,
+            false);
+    return new TenantAwareAuthorizationCheckPort(checkPorts, false, claimsResolver);
+  }
 
   @Test
   void shouldGrantAdminComponentAccessViaLegacyIdentityAlias() {
     // given: principal lacks the admin COMPONENT/ACCESS grant but holds the legacy identity one
-    when(authorizationChecker.isAuthorized(any(), any(), any())).thenReturn(false);
-    when(authorizationChecker.isAuthorized(
+    when(scopeRepository.hasAuthorizedScope(any(), any(), any(), anyList())).thenReturn(false);
+    when(scopeRepository.hasAuthorizedScope(
             any(),
             any(),
-            argThat(auth -> auth.resourceIds().contains(COMPONENT_IDENTITY_LEGACY_ALIAS))))
+            any(),
+            argThat(ids -> ids != null && ids.contains(COMPONENT_IDENTITY_LEGACY_ALIAS))))
         .thenReturn(true);
 
     // when
@@ -69,7 +86,7 @@ class TenantAwareAuthorizationCheckPortTest {
   @Test
   void shouldDenyAdminComponentAccessWhenNeitherAdminNorIdentityGranted() {
     // given
-    when(authorizationChecker.isAuthorized(any(), any(), any())).thenReturn(false);
+    when(scopeRepository.hasAuthorizedScope(any(), any(), any(), anyList())).thenReturn(false);
 
     // when
     final Either<AuthorizationRejection, Void> result =
@@ -86,11 +103,12 @@ class TenantAwareAuthorizationCheckPortTest {
   @Test
   void shouldNotApplyIdentityAliasToOtherComponents() {
     // given: the alias only maps identity -> admin; other components must not benefit from it
-    when(authorizationChecker.isAuthorized(any(), any(), any())).thenReturn(false);
-    when(authorizationChecker.isAuthorized(
+    when(scopeRepository.hasAuthorizedScope(any(), any(), any(), anyList())).thenReturn(false);
+    when(scopeRepository.hasAuthorizedScope(
             any(),
             any(),
-            argThat(auth -> auth.resourceIds().contains(COMPONENT_IDENTITY_LEGACY_ALIAS))))
+            any(),
+            argThat(ids -> ids != null && ids.contains(COMPONENT_IDENTITY_LEGACY_ALIAS))))
         .thenReturn(true);
 
     // when
@@ -104,7 +122,7 @@ class TenantAwareAuthorizationCheckPortTest {
   @Test
   void shouldPassThroughDirectAdminGrantWithoutConsultingAlias() {
     // given
-    when(authorizationChecker.isAuthorized(any(), any(), any())).thenReturn(true);
+    when(scopeRepository.hasAuthorizedScope(any(), any(), any(), anyList())).thenReturn(true);
 
     // when
     final Either<AuthorizationRejection, Void> result =
@@ -115,11 +133,11 @@ class TenantAwareAuthorizationCheckPortTest {
   }
 
   @Test
-  void shouldDelegateClaimsBasedCheckThroughConverter() {
+  void shouldDelegateClaimsBasedCheckThroughResolver() {
     // given
     final Map<String, Object> claims = Map.of("sub", "alice");
-    when(claimsConverter.convert(claims)).thenReturn(authentication);
-    when(authorizationChecker.isAuthorized(any(), any(), any())).thenReturn(true);
+    when(claimsResolver.resolve(claims)).thenReturn(authentication);
+    when(scopeRepository.hasAuthorizedScope(any(), any(), any(), anyList())).thenReturn(true);
 
     // when
     final Either<AuthorizationRejection, Void> result =
@@ -127,7 +145,7 @@ class TenantAwareAuthorizationCheckPortTest {
 
     // then
     assertThat(result.isRight()).isTrue();
-    verify(claimsConverter).convert(claims);
+    verify(claimsResolver).resolve(claims);
   }
 
   @Test
@@ -141,7 +159,7 @@ class TenantAwareAuthorizationCheckPortTest {
                     b.resourceType(AuthorizationResourceType.COMPONENT)
                         .permissionType(PermissionType.ACCESS))
             .withResourcePropertyNames(Set.of("owner"));
-    when(authorizationChecker.retrieveAuthorizedPropertyScopes(any(), any(), any()))
+    when(scopeRepository.findAuthorizedPropertyScopes(any(), any(), any(), any()))
         .thenReturn(List.of());
 
     // when
@@ -150,19 +168,18 @@ class TenantAwareAuthorizationCheckPortTest {
 
     // then: denied (no matching granted property scope), and the RBAC/alias path was never touched
     assertThat(result.isLeft()).isTrue();
-    verify(authorizationChecker, never()).isAuthorized(any(), any(), any());
+    verify(scopeRepository, never()).hasAuthorizedScope(any(), any(), any(), anyList());
   }
 
   @Test
   void shouldPreserveOtherResourceIdsWhenApplyingIdentityAlias() {
     // given: a multi-id requirement (admin + operate); only the legacy identity alias is granted
-    when(authorizationChecker.isAuthorized(any(), any(), any())).thenReturn(false);
-    when(authorizationChecker.isAuthorized(
-            argThat(
-                scope ->
-                    scope != null && COMPONENT_IDENTITY_LEGACY_ALIAS.equals(scope.getResourceId())),
+    when(scopeRepository.hasAuthorizedScope(any(), any(), any(), anyList())).thenReturn(false);
+    when(scopeRepository.hasAuthorizedScope(
             any(),
-            any()))
+            any(),
+            any(),
+            argThat(ids -> ids != null && ids.contains(COMPONENT_IDENTITY_LEGACY_ALIAS))))
         .thenReturn(true);
 
     // when
@@ -180,18 +197,15 @@ class TenantAwareAuthorizationCheckPortTest {
   @Test
   void shouldGrantAccessViaAliasWhenAllOtherResourceIdsAreAlsoGranted() {
     // given: a multi-id requirement (admin + operate); identity alias and operate are both granted
-    when(authorizationChecker.isAuthorized(any(), any(), any())).thenReturn(false);
-    when(authorizationChecker.isAuthorized(
-            argThat(
-                scope ->
-                    scope != null && COMPONENT_IDENTITY_LEGACY_ALIAS.equals(scope.getResourceId())),
+    when(scopeRepository.hasAuthorizedScope(any(), any(), any(), anyList())).thenReturn(false);
+    when(scopeRepository.hasAuthorizedScope(
             any(),
-            any()))
+            any(),
+            any(),
+            argThat(ids -> ids != null && ids.contains(COMPONENT_IDENTITY_LEGACY_ALIAS))))
         .thenReturn(true);
-    when(authorizationChecker.isAuthorized(
-            argThat(scope -> scope != null && COMPONENT_OPERATE.equals(scope.getResourceId())),
-            any(),
-            any()))
+    when(scopeRepository.hasAuthorizedScope(
+            any(), any(), any(), argThat(ids -> ids != null && ids.contains(COMPONENT_OPERATE))))
         .thenReturn(true);
 
     // when
@@ -203,6 +217,39 @@ class TenantAwareAuthorizationCheckPortTest {
 
     // then
     assertThat(result.isRight()).isTrue();
+  }
+
+  @Test
+  void
+      shouldResolveToTheSingleDefaultScopeRegardlessOfPhysicalTenantContextWhenNoPerTenantScopesConfigured() {
+    // given — hasPerTenantScopes=false always resolves the seeded default entry; this test runs
+    // outside any request scope or propagated tenant (PhysicalTenantContext.currentOrNull() would
+    // return null here), yet the check still succeeds because that context is never consulted
+    when(scopeRepository.hasAuthorizedScope(any(), any(), any(), anyList())).thenReturn(true);
+
+    // when
+    final Either<AuthorizationRejection, Void> result =
+        authorizationCheckPort.check(authentication, componentAccess(COMPONENT_OPERATE));
+
+    // then
+    assertThat(result.isRight()).isTrue();
+  }
+
+  @Test
+  void shouldFailHardWhenPerTenantScopesConfiguredButNoPhysicalTenantResolved() {
+    // given — per-tenant scopes exist (keyed by physical tenant id, not "default"), and this test
+    // runs outside any request scope or propagated tenant, so
+    // PhysicalTenantContext.currentOrNull() returns null
+    final var checkPorts =
+        ScopedAuthorizationCheckPortFactory.create(
+            Map.of("tenant-a", scopeRepository), claimsResolver, List.of(), true, false);
+    final AuthorizationCheckPort perTenantPort =
+        new TenantAwareAuthorizationCheckPort(checkPorts, true, claimsResolver);
+
+    // when / then — CSL's fail-hard forScope(null) surfaces rather than silently resolving against
+    // tenant-a's storage, which would break tenant isolation for an unstamped request
+    assertThatIllegalStateException()
+        .isThrownBy(() -> perTenantPort.check(authentication, componentAccess(COMPONENT_ADMIN)));
   }
 
   private static RequiredAuthorization<Void> componentAccess(final String resourceId) {

--- a/dist/src/test/java/io/camunda/application/commons/security/WebAppAuthorizationCheckPortConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/WebAppAuthorizationCheckPortConfigurationTest.java
@@ -59,9 +59,7 @@ class WebAppAuthorizationCheckPortConfigurationTest {
 
     // when / then
     runner
-        .withUserConfiguration(
-            AuthorizationCheckerProviderConfiguration.class,
-            WebAppAuthorizationCheckPortConfiguration.class)
+        .withUserConfiguration(WebAppAuthorizationCheckPortConfiguration.class)
         .run(
             ctx -> {
               assertThat(ctx).hasSingleBean(AuthorizationCheckPort.class);
@@ -89,9 +87,7 @@ class WebAppAuthorizationCheckPortConfigurationTest {
         .withConfiguration(
             AutoConfigurations.of(
                 AuthorizationCheckerConfiguration.class, AuthorizationConfiguration.class))
-        .withUserConfiguration(
-            AuthorizationCheckerProviderConfiguration.class,
-            WebAppAuthorizationCheckPortConfiguration.class)
+        .withUserConfiguration(WebAppAuthorizationCheckPortConfiguration.class)
         .run(
             ctx -> {
               assertThat(ctx).hasSingleBean(AuthorizationCheckPort.class);
@@ -129,9 +125,7 @@ class WebAppAuthorizationCheckPortConfigurationTest {
         .withConfiguration(
             AutoConfigurations.of(
                 AuthorizationCheckerConfiguration.class, AuthorizationConfiguration.class))
-        .withUserConfiguration(
-            AuthorizationCheckerProviderConfiguration.class,
-            WebAppAuthorizationCheckPortConfiguration.class)
+        .withUserConfiguration(WebAppAuthorizationCheckPortConfiguration.class)
         .run(
             ctx -> {
               assertThat(ctx).hasSingleBean(AuthorizationCheckPort.class);
@@ -187,9 +181,7 @@ class WebAppAuthorizationCheckPortConfigurationTest {
         .withConfiguration(
             AutoConfigurations.of(
                 AuthorizationCheckerConfiguration.class, AuthorizationConfiguration.class))
-        .withUserConfiguration(
-            AuthorizationCheckerProviderConfiguration.class,
-            WebAppAuthorizationCheckPortConfiguration.class)
+        .withUserConfiguration(WebAppAuthorizationCheckPortConfiguration.class)
         .run(
             ctx -> {
               assertThat(ctx).hasSingleBean(AuthorizationCheckPort.class);

--- a/dist/src/test/java/io/camunda/application/commons/security/WebAppAuthorizationCheckPortConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/WebAppAuthorizationCheckPortConfigurationTest.java
@@ -8,8 +8,11 @@
 package io.camunda.application.commons.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.Mockito.mock;
 
+import io.camunda.search.clients.reader.PhysicalTenantSearchClientReaders;
+import io.camunda.search.clients.reader.SearchClientReaders;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.api.model.authz.PermissionType;
@@ -22,6 +25,7 @@ import io.camunda.security.core.port.out.MembershipPort;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.security.spring.authz.AuthorizationCheckerConfiguration;
 import io.camunda.security.spring.authz.AuthorizationConfiguration;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
@@ -159,5 +163,49 @@ class WebAppAuthorizationCheckPortConfigurationTest {
           assertThat(ctx.getBean(AuthorizationCheckPort.class))
               .isInstanceOf(AuthorizationService.class);
         });
+  }
+
+  @Test
+  void shouldFailHardWhenPerTenantScopesConfiguredButNoPhysicalTenantResolved() {
+    // given: a PhysicalTenantSearchClientReaders bean is present, so this bean wires one scope per
+    // physical tenant instead of the single "default" entry -- and this test runs outside any
+    // request scope or propagated tenant, so PhysicalTenantContext.currentOrNull() returns null
+    final var readersStub = mock(SearchClientReaders.class);
+    final var perTenantReaders =
+        new PhysicalTenantSearchClientReaders(Map.of("tenant-a", readersStub));
+
+    // when / then: CSL's fail-hard forScope(null) surfaces rather than silently resolving against
+    // tenant-a's storage, proving this bean method actually wires the per-tenant branch (not just
+    // the single-default-entry one every other test in this class exercises)
+    new WebApplicationContextRunner()
+        .withBean(
+            AuthorizationScopeRepositoryPort.class,
+            () -> mock(AuthorizationScopeRepositoryPort.class))
+        .withBean(PhysicalTenantSearchClientReaders.class, () -> perTenantReaders)
+        .withBean(MembershipPort.class, () -> mock(MembershipPort.class))
+        .withBean(CamundaSecurityLibraryProperties.class, CamundaSecurityLibraryProperties::new)
+        .withConfiguration(
+            AutoConfigurations.of(
+                AuthorizationCheckerConfiguration.class, AuthorizationConfiguration.class))
+        .withUserConfiguration(
+            AuthorizationCheckerProviderConfiguration.class,
+            WebAppAuthorizationCheckPortConfiguration.class)
+        .run(
+            ctx -> {
+              assertThat(ctx).hasSingleBean(AuthorizationCheckPort.class);
+              final AuthorizationCheckPort port = ctx.getBean(AuthorizationCheckPort.class);
+
+              final RequiredAuthorization<Void> authorization =
+                  RequiredAuthorization.<Void>of(
+                          b ->
+                              b.resourceType(AuthorizationResourceType.COMPONENT)
+                                  .permissionType(PermissionType.ACCESS))
+                      .withResourceId("operate");
+              assertThatIllegalStateException()
+                  .isThrownBy(
+                      () ->
+                          port.check(
+                              CamundaAuthentication.of(b -> b.user("alice")), authorization));
+            });
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/security/WebAppAuthorizationCheckPortConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/WebAppAuthorizationCheckPortConfigurationTest.java
@@ -200,4 +200,39 @@ class WebAppAuthorizationCheckPortConfigurationTest {
                               CamundaAuthentication.of(b -> b.user("alice")), authorization));
             });
   }
+
+  @Test
+  void shouldFailFastAtStartupWhenPerTenantScopesReportedButNoTenantsDeclared() {
+    // given: a PhysicalTenantSearchClientReaders bean is present but backed by an empty map --
+    // simulating a broken PhysicalTenantResolver invariant (it is expected to always synthesize a
+    // "default" entry, see PhysicalTenantResolverTest), which this bean has no way to verify itself
+    final var emptyReaders = new PhysicalTenantSearchClientReaders(Map.of());
+
+    // when / then: construction fails loudly at startup instead of leaving every authorization
+    // check -- including default-tenant ones -- to fail hard on every subsequent request
+    new WebApplicationContextRunner()
+        .withBean(
+            AuthorizationScopeRepositoryPort.class,
+            () -> mock(AuthorizationScopeRepositoryPort.class))
+        .withBean(PhysicalTenantSearchClientReaders.class, () -> emptyReaders)
+        .withBean(MembershipPort.class, () -> mock(MembershipPort.class))
+        .withBean(CamundaSecurityLibraryProperties.class, CamundaSecurityLibraryProperties::new)
+        .withConfiguration(
+            AutoConfigurations.of(
+                AuthorizationCheckerConfiguration.class, AuthorizationConfiguration.class))
+        .withUserConfiguration(WebAppAuthorizationCheckPortConfiguration.class)
+        .run(
+            ctx -> {
+              assertThat(ctx).hasFailed();
+              assertThat(ctx.getStartupFailure())
+                  .hasRootCauseInstanceOf(IllegalStateException.class)
+                  .hasRootCauseMessage(
+                      "PhysicalTenantSearchClientReaders is present but declares no physical "
+                          + "tenants; expected PhysicalTenantResolver to always synthesize a "
+                          + "'default' entry. This indicates a broken invariant between "
+                          + "PhysicalTenantResolver and this bean -- every authorization check, "
+                          + "including default-tenant ones, would otherwise fail hard per request "
+                          + "instead of at startup.");
+            });
+  }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.bouncycastle>1.85</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha63</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha64</version.camunda-security-library>
     <version.checkstyle>13.9.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultResourceAccessProvider.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultResourceAccessProvider.java
@@ -16,8 +16,10 @@ import io.camunda.security.api.model.authz.AuthorizationResourceMatcher;
 import io.camunda.security.api.model.authz.AuthorizationScope;
 import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.security.core.authz.AuthorizationChecker;
+import io.camunda.security.core.authz.DisabledResourceAccessProvider;
 import io.camunda.security.core.authz.ResourceAccess;
 import io.camunda.security.core.authz.ResourceAccessProvider;
+import io.camunda.security.core.port.out.AuthorizationScopeRepositoryPort;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -34,6 +36,22 @@ public class DefaultResourceAccessProvider implements ResourceAccessProvider {
   public DefaultResourceAccessProvider(final AuthorizationChecker authorizationChecker) {
     this.authorizationChecker = authorizationChecker;
     this.propertyMatcherRegistry = new ResourcePropertyMatcherRegistry();
+  }
+
+  /**
+   * Builds a {@link ResourceAccessProvider} for a single authorization scope (for example, one
+   * physical tenant) from its {@link AuthorizationScopeRepositoryPort}, or a {@link
+   * DisabledResourceAccessProvider} when {@code authorizationEnabled} is {@code false}.
+   *
+   * <p>Lets callers depend on the {@link AuthorizationScopeRepositoryPort} outbound port instead of
+   * naming {@link AuthorizationChecker} directly, and consolidates the enabled/disabled branch that
+   * would otherwise be duplicated at every call site building a per-scope provider.
+   */
+  public static ResourceAccessProvider forScopeRepository(
+      final AuthorizationScopeRepositoryPort scopeRepository, final boolean authorizationEnabled) {
+    return authorizationEnabled
+        ? new DefaultResourceAccessProvider(new AuthorizationChecker(scopeRepository))
+        : new DisabledResourceAccessProvider();
   }
 
   @Override

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DefaultResourceAccessProviderTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DefaultResourceAccessProviderTest.java
@@ -516,12 +516,20 @@ class DefaultResourceAccessProviderTest {
   void forScopeRepositoryShouldBuildDefaultProviderWhenAuthorizationsEnabled() {
     // given
     final var scopeRepository = mock(AuthorizationScopeRepositoryPort.class);
+    final var authentication = CamundaAuthentication.of(a -> a.user("foo"));
+    final var authorization =
+        RequiredAuthorization.of(a -> a.processDefinition().readProcessDefinition());
+    when(scopeRepository.findAuthorizedScopes(any(), any(), any()))
+        .thenReturn(List.of(AuthorizationScope.of("bar")));
 
     // when
     final var provider = DefaultResourceAccessProvider.forScopeRepository(scopeRepository, true);
+    final var result = provider.resolveResourceAccess(authentication, authorization);
 
     // then
     assertThat(provider).isInstanceOf(DefaultResourceAccessProvider.class);
+    assertThat(result.allowed()).isTrue();
+    assertThat(result.authorization().resourceIds()).containsExactly("bar");
   }
 
   @Test

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DefaultResourceAccessProviderTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DefaultResourceAccessProviderTest.java
@@ -21,6 +21,8 @@ import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.api.model.authz.AuthorizationScope;
 import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.security.core.authz.AuthorizationChecker;
+import io.camunda.security.core.authz.DisabledResourceAccessProvider;
+import io.camunda.security.core.port.out.AuthorizationScopeRepositoryPort;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -508,6 +510,30 @@ class DefaultResourceAccessProviderTest {
     assertThat(result.allowed()).isFalse();
     assertThat(result.wildcard()).isFalse();
     assertThat(result.authorization()).isEqualTo(authorization);
+  }
+
+  @Test
+  void forScopeRepositoryShouldBuildDefaultProviderWhenAuthorizationsEnabled() {
+    // given
+    final var scopeRepository = mock(AuthorizationScopeRepositoryPort.class);
+
+    // when
+    final var provider = DefaultResourceAccessProvider.forScopeRepository(scopeRepository, true);
+
+    // then
+    assertThat(provider).isInstanceOf(DefaultResourceAccessProvider.class);
+  }
+
+  @Test
+  void forScopeRepositoryShouldBuildDisabledProviderWhenAuthorizationsDisabled() {
+    // given
+    final var scopeRepository = mock(AuthorizationScopeRepositoryPort.class);
+
+    // when
+    final var provider = DefaultResourceAccessProvider.forScopeRepository(scopeRepository, false);
+
+    // then
+    assertThat(provider).isInstanceOf(DisabledResourceAccessProvider.class);
   }
 
   private UserTaskEntity createUserTask(final String assignee) {

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DefaultResourceAccessProviderTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DefaultResourceAccessProviderTest.java
@@ -513,7 +513,7 @@ class DefaultResourceAccessProviderTest {
   }
 
   @Test
-  void forScopeRepositoryShouldBuildDefaultProviderWhenAuthorizationsEnabled() {
+  void shouldBuildDefaultProviderForScopeRepositoryWhenAuthorizationsEnabled() {
     // given
     final var scopeRepository = mock(AuthorizationScopeRepositoryPort.class);
     final var authentication = CamundaAuthentication.of(a -> a.user("foo"));
@@ -533,7 +533,7 @@ class DefaultResourceAccessProviderTest {
   }
 
   @Test
-  void forScopeRepositoryShouldBuildDisabledProviderWhenAuthorizationsDisabled() {
+  void shouldBuildDisabledProviderForScopeRepositoryWhenAuthorizationsDisabled() {
     // given
     final var scopeRepository = mock(AuthorizationScopeRepositoryPort.class);
 

--- a/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationCheckerFactory.java
+++ b/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationCheckerFactory.java
@@ -14,9 +14,13 @@ import io.camunda.security.core.authz.AuthorizationChecker;
  * Builds the {@link AuthorizationChecker} for a single physical tenant from that tenant's own
  * {@link SearchClientReaders}, wrapping the tenant's {@link SearchAuthorizationScopeRepository}.
  *
- * <p>Kept as a shared static factory so every per-tenant checker-construction site in the
- * application wiring layer builds the checker the same way, since those consumers are gated by
- * different Spring conditions and can't simply share a bean.
+ * <p>Used by {@code AuthorizationCheckerProviderConfiguration} to build the raw {@link
+ * AuthorizationChecker} that {@code CamundaServicesConfiguration} hands to services ({@code
+ * DocumentServices}, {@code SecretServices}) that query it directly, bypassing the {@code
+ * ResourceAccessController}/data-plane path. {@code ResourceAccessControllerConfiguration} no
+ * longer uses this factory — its {@code ResourceAccessProvider}s are built from an {@link
+ * io.camunda.security.core.port.out.AuthorizationScopeRepositoryPort} instead, via {@code
+ * DefaultResourceAccessProvider.forScopeRepository(...)}.
  */
 public final class AuthorizationCheckerFactory {
 


### PR DESCRIPTION
## Summary

Part of implementing https://github.com/camunda/camunda-security-library/issues/596 — split across two repos/PRs (see that issue and camunda-security-library PR https://github.com/camunda/camunda-security-library/pull/602).

Two related pieces, both replacing direct construction/naming of CSL-internal `AuthorizationChecker` in application wiring with CSL's outbound-port-based factories:

1. **`ResourceAccessProvider` construction** (search + dist): `ResourceAccessControllerConfiguration`'s root `resourceAccessProvider` bean and its per-physical-tenant fan-out each constructed an `AuthorizationChecker` directly to build a `DefaultResourceAccessProvider`, duplicating the same `enabled ? Default : Disabled` branch three times.
   - Added `DefaultResourceAccessProvider.forScopeRepository(AuthorizationScopeRepositoryPort, boolean authorizationEnabled)` (search module), building the provider from the outbound port instead.
   - `ResourceAccessControllerConfiguration` (root bean + per-tenant fan-out) adopts it, dropping its `AuthorizationChecker` import.
   - `AuthorizationCheckerFactory`/`AuthorizationCheckerProvider` are unchanged in behavior — both stay, still needed by `AuthorizationCheckerProviderConfiguration` → `CamundaServicesConfiguration`'s `DocumentServices`/`SecretServices` path, which legitimately needs the raw `AuthorizationChecker`. Their Javadoc is corrected: `AuthorizationCheckerFactory` now has exactly one caller, not two.

2. **`TenantAwareAuthorizationCheckPort`** (dist): now built from CSL's `ScopedAuthorizationCheckPortFactory` instead of constructing an `AuthorizationService` per call from an `AuthorizationChecker` resolved via `AuthorizationCheckerProvider`. Requires bumping `camunda-security-library` to `0.1.0-alpha64` (first release containing `ScopedAuthorizationCheckPortFactory`, delivered by camunda-security-library#602). `WebAppAuthorizationCheckPortConfiguration` now wires one `AuthorizationScopeRepositoryPort` per physical tenant (or a single `default`-keyed one when secondary storage is disabled) and hands the map to the factory once at startup; `TenantAwareAuthorizationCheckPort` resolves the current tenant's `AuthorizationCheckPort` from that map per request. The two isolation modes `AuthorizationCheckerProvider` had are preserved: with no per-tenant scopes, every request (including unstamped ones) resolves to the single default entry; with per-tenant scopes configured, an unresolved physical tenant fails hard rather than silently falling back to another tenant's storage.

## Test plan

- [x] `./mvnw install -Dquickly -T1C` — full-repo cross-module build, green
- [x] `./mvnw verify -pl search/search-client-query-transformer -Dtest=DefaultResourceAccessProviderTest -DskipITs -DskipTests=false -Dquickly` — 20/20 green (incl. 2 new tests for the factory)
- [x] `./mvnw verify -pl dist -Dtest=ResourceAccessControllerConfigurationTest,TenantAwareAuthorizationCheckPortTest,WebAppAuthorizationCheckPortConfigurationTest -DskipITs -DskipTests=false -Dquickly` — mocks updated to `AuthorizationScopeRepositoryPort`/`ScopedAuthorizationCheckPortFactory`; 10/10 and 5/5 green. **Note on `ResourceAccessControllerConfigurationTest`:** it reports `Tests run: 0` under its own class name in the Surefire summary — this is a known Surefire + JUnit 5 `@Nested`-class reporting artifact (`usePhrasedTestSuiteClassName=true` in `parent/pom.xml` files an outer class's results under its `@Nested` inner class's report when a class mixes both), not a real skip: the underlying `TEST-*$PhysicalTenantResourceAccessControllersBean.xml` report shows all 8 tests (5 outer + 3 nested) ran and passed. Pre-existing across the repo, unrelated to this diff.
- [x] `./mvnw license:format spotless:apply` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
