### PR TITLE
ci: dispatch a fix agent for chart-caused Helm install failures

### DIFF
--- a/.github/scripts/alwaysgreen/classify.py
+++ b/.github/scripts/alwaysgreen/classify.py
@@ -106,9 +106,10 @@ SURFACE_HELM_CLEANUP = "helm-cleanup"
 SURFACE_BUILD = "build"
 SURFACE_CI_INFRA = "ci-infra"
 
-#: Surfaces the first increment dispatches. Everything else is recorded and
-#: reported but not handed to the agent yet.
-DISPATCHABLE_SURFACES = frozenset({SURFACE_SM_E2E, SURFACE_SAAS_E2E})
+#: Surfaces dispatched to the agent. Everything else is recorded and reported but not
+#: handed over. helm-install is gated further by helm_install_verdict: the failure has
+#: to look like the chart rather than the cluster.
+DISPATCHABLE_SURFACES = frozenset({SURFACE_SM_E2E, SURFACE_SAAS_E2E, SURFACE_HELM_INSTALL})
 
 #: A pure propagator: it fails whenever the reusable helm workflow failed and
 #: carries no independent signal.
@@ -228,6 +229,64 @@ def saas_surface_from_counts(counts: SpecCounts, *, has_artifacts: bool) -> str:
     if counts.setup_failed == counts.failed:
         return SURFACE_SAAS_PROVISIONING
     return SURFACE_SAAS_E2E
+
+
+# ---------------------------------------------------------------------------
+# Helm install: chart problem or cluster problem?
+# ---------------------------------------------------------------------------
+
+HELM_ACTIONABLE = "actionable"
+HELM_INFRASTRUCTURE = "infrastructure"
+
+#: A failing install is worth an agent only when something points at the chart or its
+#: values. Every helm-install failure sampled on main and stable/8.8 in 2026-07/08 was
+#: the cluster failing to place or attach the workload instead, so the default is to
+#: withhold: dispatching there costs an agent run and can only produce a guess.
+_HELM_CONFIG_MARKERS = (
+    "INSTALLATION FAILED",
+    "UPGRADE FAILED",
+    "YAML parse error",
+    "error validating data",
+    "error converting YAML",
+    "CreateContainerConfigError",
+    "CrashLoopBackOff",
+    "Back-off restarting failed container",
+    "couldn't find key",
+    "is invalid:",
+)
+
+#: Only used to explain the verdict; the decision does not depend on them, so an
+#: unseen infrastructure shape still withholds rather than dispatching.
+_HELM_INFRA_MARKERS = (
+    "FailedScheduling",
+    "Insufficient cpu",
+    "Insufficient memory",
+    "untolerated taint",
+    "node affinity/selector",
+    "Multi-Attach error",
+    "FailedAttachVolume",
+    "ImagePullBackOff",
+    "ErrImagePull",
+    "TLS handshake timeout",
+    "context deadline exceeded",
+)
+
+
+def helm_install_verdict(log_text: str) -> tuple[str, str]:
+    """Classify a failed Helm install from its job log.
+
+    Returns (verdict, detail). A chart marker wins over an infrastructure one: a values
+    bug can crash a pod that the scheduler also complained about, and the chart reading
+    is the one an agent can act on.
+    """
+    text = log_text or ""
+    for marker in _HELM_CONFIG_MARKERS:
+        if marker in text:
+            return HELM_ACTIONABLE, marker
+    for marker in _HELM_INFRA_MARKERS:
+        if marker in text:
+            return HELM_INFRASTRUCTURE, marker
+    return HELM_INFRASTRUCTURE, "no chart-level failure signal"
 
 
 # ---------------------------------------------------------------------------

--- a/.github/scripts/alwaysgreen/classify.py
+++ b/.github/scripts/alwaysgreen/classify.py
@@ -245,6 +245,9 @@ HELM_INFRASTRUCTURE = "infrastructure"
 _HELM_CONFIG_MARKERS = (
     "INSTALLATION FAILED",
     "UPGRADE FAILED",
+    # helm install prefixes schema errors with INSTALLATION FAILED, but template and
+    # dry-run print the bare message, so match that too.
+    "values don't meet the specifications",
     "YAML parse error",
     "error validating data",
     "error converting YAML",

--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -67,6 +67,20 @@ def gh_json_ex(args: list[str], default) -> tuple[object, str]:
         return default, "invalid json"
 
 
+def gh_text_ex(args: list[str]) -> tuple[str | None, str]:
+    """Run a gh command expecting plain text. Returns (text, error_text).
+
+    Job logs are large, so the timeout is longer than the JSON helper's; None means the
+    call failed and the caller must not treat an empty log as "nothing was wrong".
+    """
+    try:
+        return subprocess.run(
+            ["gh", *args], capture_output=True, text=True, timeout=300, check=True
+        ).stdout, ""
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        return None, (getattr(exc, "stderr", "") or str(exc)).strip()
+
+
 def gh_json(args: list[str], default):
     """Run a gh command expecting JSON on stdout. Returns `default` on any failure."""
     value, _ = gh_json_ex(args, default)
@@ -342,6 +356,20 @@ def resolve_blame(head_sha: str) -> classify.Blame:
 # ---------------------------------------------------------------------------
 
 
+def job_log(job_id: str) -> str:
+    """Raw log of one job, empty when it cannot be read.
+
+    A helm-install failure has no report artifact: the evidence is the job log and the
+    diagnostics dump. Unreadable logs fall through to the withhold default rather than
+    dispatching blind.
+    """
+    out, err = gh_text_ex(["api", f"repos/{REPO}/actions/jobs/{job_id}/logs"])
+    if out is None:
+        log(f"::warning::could not read log for job {job_id}: {err.strip()[:200]}")
+        return ""
+    return out
+
+
 def build_candidates(run_id: str, base_ref: str, workdir: Path):
     candidates: list[planning.Candidate] = []
     noise: list[tuple[str, str]] = []
@@ -366,6 +394,19 @@ def build_candidates(run_id: str, base_ref: str, workdir: Path):
             candidates.append(sm_candidates(run_id, base_ref, name, workdir))
         elif surface == classify.SURFACE_SAAS_E2E:
             candidates.append(saas_candidate(run_id, base_ref, name, workdir))
+        elif surface == classify.SURFACE_HELM_INSTALL:
+            verdict, detail = classify.helm_install_verdict(job_log(str(job.get("id") or "")))
+            log(f"helm-install verdict: {verdict} ({detail})")
+            if verdict != classify.HELM_ACTIONABLE:
+                noise.append((classify.job_leaf_name(name), f"helm-{verdict}: {detail}"))
+                continue
+            candidates.append(
+                planning.Candidate(
+                    base_ref=base_ref, surface=surface, job_name=name, job_level=True,
+                    evidence_run_url=f"https://github.com/{REPO}/actions/runs/{run_id}",
+                    evidence_repo=REPO,
+                )
+            )
         else:
             candidates.append(
                 planning.Candidate(

--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -356,17 +356,19 @@ def resolve_blame(head_sha: str) -> classify.Blame:
 # ---------------------------------------------------------------------------
 
 
-def job_log(job_id: str) -> str:
-    """Raw log of one job, empty when it cannot be read.
+def job_log(job_id: str) -> str | None:
+    """Raw log of one job, or None when it could not be read.
 
     A helm-install failure has no report artifact: the evidence is the job log and the
-    diagnostics dump. Unreadable logs fall through to the withhold default rather than
-    dispatching blind.
+    diagnostics dump. None is kept distinct from an empty log so an unreadable one is
+    reported as such instead of looking like a log that simply carried no markers.
+
+    The job-level endpoint returns plain text; the run-level one returns a zip.
     """
     out, err = gh_text_ex(["api", f"repos/{REPO}/actions/jobs/{job_id}/logs"])
     if out is None:
         log(f"::warning::could not read log for job {job_id}: {err.strip()[:200]}")
-        return ""
+        return None
     return out
 
 
@@ -395,7 +397,12 @@ def build_candidates(run_id: str, base_ref: str, workdir: Path):
         elif surface == classify.SURFACE_SAAS_E2E:
             candidates.append(saas_candidate(run_id, base_ref, name, workdir))
         elif surface == classify.SURFACE_HELM_INSTALL:
-            verdict, detail = classify.helm_install_verdict(job_log(str(job.get("id") or "")))
+            text = job_log(str(job.get("id") or ""))
+            if text is None:
+                noise.append((classify.job_leaf_name(name), "helm-unreadable-log"))
+                log("helm-install: log unreadable, withholding")
+                continue
+            verdict, detail = classify.helm_install_verdict(text)
             log(f"helm-install verdict: {verdict} ({detail})")
             if verdict != classify.HELM_ACTIONABLE:
                 noise.append((classify.job_leaf_name(name), f"helm-{verdict}: {detail}"))

--- a/.github/scripts/alwaysgreen/test_classify.py
+++ b/.github/scripts/alwaysgreen/test_classify.py
@@ -110,11 +110,13 @@ def test_helm_install_and_cleanup_are_distinct_surfaces():
     )
 
 
-def test_only_e2e_surfaces_dispatch_in_first_increment():
+def test_dispatchable_surfaces():
     assert classify.SURFACE_SM_E2E in classify.DISPATCHABLE_SURFACES
     assert classify.SURFACE_SAAS_E2E in classify.DISPATCHABLE_SURFACES
-    assert classify.SURFACE_HELM_INSTALL not in classify.DISPATCHABLE_SURFACES
+    # Dispatchable, but gated further by helm_install_verdict.
+    assert classify.SURFACE_HELM_INSTALL in classify.DISPATCHABLE_SURFACES
     assert classify.SURFACE_BUILD not in classify.DISPATCHABLE_SURFACES
+    assert classify.SURFACE_HELM_CLEANUP not in classify.DISPATCHABLE_SURFACES
 
 
 # ---------------------------------------------------------------------------
@@ -479,3 +481,54 @@ def test_normalised_ref_makes_fingerprints_stable_across_queue_runs():
         "main", "sm-smoke-e2e", "tests/SM-8.10/smoke-tests.spec.ts", "t"
     )
     assert a == b == direct
+
+# ---------------------------------------------------------------------------
+# Helm install verdict
+# ---------------------------------------------------------------------------
+
+
+def test_helm_scheduling_failure_is_infrastructure():
+    # Shape taken from run 31103675147, where 0/39 nodes could take the pod.
+    log = (
+        "Warning  FailedScheduling  20m  default-scheduler  0/39 nodes are available: "
+        "1 Insufficient cpu, 34 node(s) had untolerated taint(s), 4 node(s) didn't "
+        "match Pod's node affinity/selector."
+    )
+    verdict, detail = classify.helm_install_verdict(log)
+    assert verdict == classify.HELM_INFRASTRUCTURE
+    assert detail == "FailedScheduling"
+
+
+def test_helm_volume_attach_failure_is_infrastructure():
+    log = 'Multi-Attach error for volume "pvc-8e24" Volume is already exclusively attached'
+    verdict, _ = classify.helm_install_verdict(log)
+    assert verdict == classify.HELM_INFRASTRUCTURE
+
+
+def test_helm_values_error_is_actionable():
+    log = "Error: INSTALLATION FAILED: values don't meet the specifications of the schema"
+    verdict, detail = classify.helm_install_verdict(log)
+    assert verdict == classify.HELM_ACTIONABLE
+    assert detail == "INSTALLATION FAILED"
+
+
+def test_helm_crashloop_is_actionable():
+    verdict, _ = classify.helm_install_verdict("identity  0/1  CrashLoopBackOff  5")
+    assert verdict == classify.HELM_ACTIONABLE
+
+
+def test_helm_chart_marker_wins_over_scheduling_noise():
+    # A values bug can crash a pod the scheduler also complained about; the chart
+    # reading is the one an agent can act on.
+    log = "Warning FailedScheduling 0/39 nodes are available\nError: UPGRADE FAILED: template"
+    verdict, detail = classify.helm_install_verdict(log)
+    assert verdict == classify.HELM_ACTIONABLE
+    assert detail == "UPGRADE FAILED"
+
+
+def test_helm_unreadable_log_withholds():
+    # gh failures yield an empty string; that must not read as "nothing was wrong".
+    verdict, detail = classify.helm_install_verdict("")
+    assert verdict == classify.HELM_INFRASTRUCTURE
+    assert detail == "no chart-level failure signal"
+

--- a/.github/scripts/alwaysgreen/test_classify.py
+++ b/.github/scripts/alwaysgreen/test_classify.py
@@ -512,6 +512,16 @@ def test_helm_values_error_is_actionable():
     assert detail == "INSTALLATION FAILED"
 
 
+def test_helm_schema_error_without_install_prefix_is_actionable():
+    # helm template and dry-run print the bare message; only install prefixes it with
+    # INSTALLATION FAILED. Verified locally against camunda-platform-8.10.
+    log = ("Error: values don't meet the specifications of the schema(s) in the "
+           "following chart(s):\ncamunda-platform:\n- global.multitenancy.enabled: "
+           "Invalid type. Expected: boolean, given: string")
+    verdict, _ = classify.helm_install_verdict(log)
+    assert verdict == classify.HELM_ACTIONABLE
+
+
 def test_helm_crashloop_is_actionable():
     verdict, _ = classify.helm_install_verdict("identity  0/1  CrashLoopBackOff  5")
     assert verdict == classify.HELM_ACTIONABLE

--- a/.github/scripts/alwaysgreen/test_plan.py
+++ b/.github/scripts/alwaysgreen/test_plan.py
@@ -41,9 +41,16 @@ def test_dispatchable_surface_with_specs_is_dispatched():
 
 
 def test_non_dispatchable_surface_is_recorded_not_dispatched():
-    result = _plan([_cand(surface=classify.SURFACE_HELM_INSTALL)])
+    result = _plan([_cand(surface=classify.SURFACE_BUILD)])
     assert result.dispatches == []
     assert result.suppressed[0].reason == plan.SUPPRESSED_NOT_DISPATCHABLE
+
+
+def test_helm_install_reaches_the_agent():
+    # Whether a helm-install failure is worth an agent is decided earlier, by
+    # helm_install_verdict in discover; anything that gets here is already actionable.
+    result = _plan([_cand(surface=classify.SURFACE_HELM_INSTALL, specs=[], job_level=True)])
+    assert len(result.dispatches) == 1
 
 
 def test_in_flight_agent_blocks_the_same_surface():

--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -114,7 +114,7 @@ jobs:
             *) echo "::error::unsupported base_ref '$BASE_REF'"; exit 1 ;;
           esac
           case "$SURFACE" in
-            sm-smoke-e2e|saas-smoke-e2e) ;;
+            sm-smoke-e2e|saas-smoke-e2e|helm-install) ;;
             *) echo "::error::unsupported surface '$SURFACE'"; exit 1 ;;
           esac
           # main carries the next unreleased minor; stable/X.Y carries X.Y. Bump this

--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -183,7 +183,7 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           exportEnv: false
           secrets: |
-            secret/data/products/qa/ci/common CLAUDE_API_KEY | ANTHROPIC_API_KEY ;
+            secret/data/products/qa/ci/common ALWAYS_GREEN_ANTHROPIC_API_KEY | ANTHROPIC_API_KEY ;
             secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
             secret/data/products/qa/ci/common GH_TOKEN | GH_PAT ;
 

--- a/docs/alwaysgreen/FIX-AGENT.md
+++ b/docs/alwaysgreen/FIX-AGENT.md
@@ -140,6 +140,31 @@ effect only once that package is published. Say so in the PR body: until then th
 stays red and the same failure will be re-dispatched unless your PR carries the coverage
 block.
 
+## When the surface is helm-install
+
+There is no Playwright report: the install never got far enough to run tests. Your evidence
+is the failing job's log (`gh api repos/camunda/camunda/actions/jobs/<id>/logs`, or
+`gh run view <run> --log-failed`) and the `diagnostics-e2e*` dump in
+`/tmp/alwaysgreen-artifacts/`, which holds the pod list, events and component logs.
+
+Triage has already withheld the cluster-side failures — scheduling, capacity, volume
+attach, image pull — so a dispatch means something in the log pointed at the chart or its
+values: an `INSTALLATION FAILED`, a rejected value, a `CrashLoopBackOff`, a missing key.
+Start from that marker rather than re-reading the whole log.
+
+Which component failed to become ready decides the repo. A chart-side cause — a values
+default, a template, Keycloak or Identity wiring, a probe or resource setting — belongs in
+`camunda-platform-helm` under the chart directory named in your prompt. A component that is
+configured correctly and still crashes on startup is a product bug, and belongs in
+`camunda`. Say which of the two you concluded, and why, in the PR body.
+
+`camunda-platform-helm` has no release branches: the version is the directory, so the PR
+targets that repo's default branch. Chart goldens are generated — regenerate them with the
+repo's `make` targets rather than hand-editing, or the PR will be rejected on review.
+
+If the log points at neither — the install simply timed out with healthy pods — that is the
+cluster, not the chart. Write `not-determined` rather than inventing a values change.
+
 ## Where fixes go
 
 |                       Diagnosis                       |           Repository           |                  Path                   |

--- a/docs/alwaysgreen/FIX-AGENT.md
+++ b/docs/alwaysgreen/FIX-AGENT.md
@@ -143,7 +143,8 @@ block.
 ## When the surface is helm-install
 
 There is no Playwright report: the install never got far enough to run tests. Your evidence
-is the failing job's log (`gh api repos/camunda/camunda/actions/jobs/<id>/logs`, or
+is the failing job's log (`gh api repos/camunda/camunda/actions/jobs/<id>/logs` — the
+job-level endpoint returns plain text, unlike the run-level one which returns a zip — or
 `gh run view <run> --log-failed`) and the `diagnostics-e2e*` dump in
 `/tmp/alwaysgreen-artifacts/`, which holds the pod list, events and component logs.
 


### PR DESCRIPTION
## Description

Closes the epic's *"Fix the Helm chart/deploy config, if that's the cause"* item. `helm-install`
failures were classified and then dropped: [run 31103675147](https://github.com/camunda/camunda/actions/runs/31103675147)
produced `dispatches=0 suppressed=1 surface-not-in-increment` and no agent, on any branch.

## Why it is not just adding the surface to the list

Every `helm-install` failure I could find was the **cluster**, not the chart:

| Run | Branch | What actually failed |
|---|---|---|
| [31103675147](https://github.com/camunda/camunda/actions/runs/31103675147) | `main` | `FailedScheduling … 0/39 nodes: Insufficient cpu, untolerated taints`; `Multi-Attach error for volume` |
| [30651262832](https://github.com/camunda/camunda/actions/runs/30651262832) | `main` | `FailedScheduling` ×22, `Insufficient cpu`, `context deadline exceeded` |
| [30647334883](https://github.com/camunda/camunda/actions/runs/30647334883) | `main` | `FailedScheduling` ×42, `context deadline exceeded` |
| [30647308043](https://github.com/camunda/camunda/actions/runs/30647308043) | `stable/8.8` | `FailedScheduling` ×124, `context deadline exceeded` |

Zero chart bugs in the sample. Making the surface dispatchable on its own would spend an agent
run on every one of these to conclude nothing.

## What this does

`helm-install` becomes dispatchable **behind a verdict** read from the failing job's log:

- a chart marker — `INSTALLATION FAILED`, `UPGRADE FAILED`, a rejected value, `CrashLoopBackOff`,
  `CreateContainerConfigError`, `couldn't find key` — dispatches
- anything else is recorded as noise, naming the marker that decided it, so the summary explains
  itself without opening the run

Three deliberate choices:

- **The default withholds.** An infrastructure shape nobody has seen yet does not leak through.
- **An unreadable log withholds too.** `gh` failing must not read as "nothing was wrong".
- **A chart marker beats a scheduling one.** A values bug can crash a pod the scheduler also
  complained about, and the chart reading is the one an agent can act on.

The manual gains the diagnosis path for this surface: there is no Playwright report, so the
evidence is the job log plus the `diagnostics-e2e` dump, and the component that failed to become
ready decides between `camunda-platform-helm` (values, templates, wiring, probes) and `camunda`
(a component that is configured correctly and still crashes). It also records that the helm repo
has no release branches — the version is the chart directory — and that goldens must be
regenerated rather than hand-edited.

## Verification

- Unit tests over the real log shapes above: scheduling → infrastructure, volume attach →
  infrastructure, values error → actionable, `CrashLoopBackOff` → actionable, chart marker wins
  over scheduling noise, empty log → withhold.
- Full `.github/scripts/alwaysgreen` suite: **77 tests, 0 failures**.
- Two existing tests asserted the old "only e2e surfaces dispatch" behaviour and were updated —
  they were asserting exactly what this changes.
- **Not yet exercised end to end.** No chart-caused failure exists to replay, and the four real
  ones are all infrastructure. A deliberate broken chart value on a test branch is the way to
  confirm the dispatch path, and I can run that if you want it before merge.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Part of camunda/team-test-automation#138. No backport labels: the classifier lives only on `main`,
so this applies to every branch at once.
