### PR TITLE
refactor: adopt CSL scoped check-port factory in TenantAwareAuthorizationCheckPort

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/security/TenantAwareAuthorizationCheckPort.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/TenantAwareAuthorizationCheckPort.java
@@ -7,67 +7,68 @@
  */
 package io.camunda.application.commons.security;
 
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.security.api.context.TokenClaimsAuthenticationResolver;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.api.model.Either;
 import io.camunda.security.api.model.authz.AuthorizationRejection;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.api.model.authz.PermissionType;
 import io.camunda.security.core.auth.RequiredAuthorization;
-import io.camunda.security.core.authz.AuthorizationChecker;
-import io.camunda.security.core.authz.AuthorizationService;
-import io.camunda.security.core.authz.LazyTokenClaimsConverter;
-import io.camunda.security.core.authz.PropertyAuthorizationEvaluatorRegistry;
+import io.camunda.security.core.authz.ScopedAuthorizationCheckPortFactory.ScopedAuthorizationCheckPorts;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.spring.utils.PhysicalTenantContext;
 import java.util.List;
 import java.util.Map;
 
 /**
- * {@link AuthorizationCheckPort} that resolves the {@link AuthorizationChecker} for the physical
- * tenant of the current request via {@link AuthorizationCheckerProvider} before delegating to a
- * per-call {@link AuthorizationService}, and additionally grants COMPONENT/ACCESS on {@code admin}
- * to any principal holding the legacy {@code identity} component grant.
+ * {@link AuthorizationCheckPort} that resolves the per-physical-tenant {@link
+ * AuthorizationCheckPort} assembled by {@link
+ * io.camunda.security.core.authz.ScopedAuthorizationCheckPortFactory} for the physical tenant of
+ * the current request, and additionally grants COMPONENT/ACCESS on {@code admin} to any principal
+ * holding the legacy {@code identity} component grant.
  *
  * <p>The {@code identity}-to-{@code admin} alias exists because the Identity web app was renamed to
  * Admin; hosts with pre-existing {@code identity} component grants must keep working against the
  * {@code admin} component id without a data migration. It replaces the legacy {@code
  * IdentityToAdminComponentAliasAdapter} (issue #399).
+ *
+ * <p>{@code hasPerTenantScopes} distinguishes the two wiring shapes: when secondary storage is
+ * disabled, {@code checkPorts} was assembled from a single {@code default}-keyed entry and every
+ * request — regardless of what {@link PhysicalTenantContext#currentOrNull()} returns, typically
+ * {@code null} — resolves to it; when per-tenant scopes exist, the physical tenant id is passed
+ * through unchanged (including {@code null}) so an unstamped request fails hard rather than
+ * silently resolving against the default tenant's storage.
  */
 final class TenantAwareAuthorizationCheckPort implements AuthorizationCheckPort {
 
   private static final String COMPONENT_ADMIN = "admin";
   private static final String COMPONENT_IDENTITY_LEGACY_ALIAS = "identity";
 
-  private final AuthorizationCheckerProvider authorizationCheckerProvider;
-  private final PropertyAuthorizationEvaluatorRegistry propertyEvaluatorRegistry;
-  private final boolean authorizationEnabled;
-  private final boolean multiTenancyChecksEnabled;
-  private final LazyTokenClaimsConverter claimsConverter;
+  private final ScopedAuthorizationCheckPorts checkPorts;
+  private final boolean hasPerTenantScopes;
+  private final TokenClaimsAuthenticationResolver claimsResolver;
 
   TenantAwareAuthorizationCheckPort(
-      final AuthorizationCheckerProvider authorizationCheckerProvider,
-      final PropertyAuthorizationEvaluatorRegistry propertyEvaluatorRegistry,
-      final boolean authorizationEnabled,
-      final boolean multiTenancyChecksEnabled,
-      final LazyTokenClaimsConverter claimsConverter) {
-    this.authorizationCheckerProvider = authorizationCheckerProvider;
-    this.propertyEvaluatorRegistry = propertyEvaluatorRegistry;
-    this.authorizationEnabled = authorizationEnabled;
-    this.multiTenancyChecksEnabled = multiTenancyChecksEnabled;
-    this.claimsConverter = claimsConverter;
+      final ScopedAuthorizationCheckPorts checkPorts,
+      final boolean hasPerTenantScopes,
+      final TokenClaimsAuthenticationResolver claimsResolver) {
+    this.checkPorts = checkPorts;
+    this.hasPerTenantScopes = hasPerTenantScopes;
+    this.claimsResolver = claimsResolver;
   }
 
   @Override
   public <T> Either<AuthorizationRejection, Void> check(
       final CamundaAuthentication authentication, final RequiredAuthorization<T> authorization) {
-    final AuthorizationService authorizationService = authorizationServiceForCurrentTenant();
+    final AuthorizationCheckPort checkPort = checkPortForCurrentScope();
     final Either<AuthorizationRejection, Void> result =
-        authorizationService.check(authentication, authorization);
+        checkPort.check(authentication, authorization);
     if (result.isRight() || !isComponentAdminAccess(authorization)) {
       return result;
     }
     final Either<AuthorizationRejection, Void> aliasResult =
-        authorizationService.check(authentication, withIdentityAlias(authorization));
+        checkPort.check(authentication, withIdentityAlias(authorization));
     // If both checks fail, return the original rejection: it names the requested "admin"
     // component, whereas aliasResult's would reference the internal "identity" alias.
     return aliasResult.isRight() ? aliasResult : result;
@@ -76,7 +77,7 @@ final class TenantAwareAuthorizationCheckPort implements AuthorizationCheckPort 
   @Override
   public <T> Either<AuthorizationRejection, Void> check(
       final Map<String, Object> claims, final RequiredAuthorization<T> authorization) {
-    return check(claimsConverter.convert(claims), authorization);
+    return check(claimsResolver.resolve(claims), authorization);
   }
 
   @Override
@@ -84,18 +85,14 @@ final class TenantAwareAuthorizationCheckPort implements AuthorizationCheckPort 
       final CamundaAuthentication authentication,
       final RequiredAuthorization<T> authorization,
       final T resource) {
-    return authorizationServiceForCurrentTenant().check(authentication, authorization, resource);
+    return checkPortForCurrentScope().check(authentication, authorization, resource);
   }
 
-  private AuthorizationService authorizationServiceForCurrentTenant() {
-    final AuthorizationChecker checker =
-        authorizationCheckerProvider.withPhysicalTenant(PhysicalTenantContext.currentOrNull());
-    return new AuthorizationService(
-        checker,
-        propertyEvaluatorRegistry,
-        authorizationEnabled,
-        multiTenancyChecksEnabled,
-        claimsConverter);
+  private AuthorizationCheckPort checkPortForCurrentScope() {
+    if (!hasPerTenantScopes) {
+      return checkPorts.forScope(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    }
+    return checkPorts.forScope(PhysicalTenantContext.currentOrNull());
   }
 
   private static <T> boolean isComponentAdminAccess(final RequiredAuthorization<T> authorization) {

--- a/dist/src/main/java/io/camunda/application/commons/security/WebAppAuthorizationCheckPortConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/WebAppAuthorizationCheckPortConfiguration.java
@@ -8,14 +8,21 @@
 package io.camunda.application.commons.security;
 
 import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabled;
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.search.clients.reader.PhysicalTenantSearchClientReaders;
 import io.camunda.security.api.context.PropertyAuthorizationEvaluator;
 import io.camunda.security.core.authz.LazyTokenClaimsConverter;
-import io.camunda.security.core.authz.PropertyAuthorizationEvaluatorRegistry;
+import io.camunda.security.core.authz.ScopedAuthorizationCheckPortFactory;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
+import io.camunda.security.core.port.out.AuthorizationScopeRepositoryPort;
 import io.camunda.security.core.port.out.MembershipPort;
 import io.camunda.security.core.port.out.MembershipQuery;
+import io.camunda.security.impl.SearchAuthorizationScopeRepository;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -25,11 +32,11 @@ import org.springframework.context.annotation.Configuration;
  * Builds the webapp-facing {@link AuthorizationCheckPort}, replacing the legacy {@code
  * ResourcePermissionPort}/{@code AuthorizationRepositoryPort} trio (issue #399).
  *
- * <p>Gated on the same condition as {@link AuthorizationCheckerProviderConfiguration}, the
- * collaborator whose per-tenant checkers vary with secondary storage, rather than on secondary
- * storage itself: with secondary storage disabled there is exactly one authorization source and
- * {@link AuthorizationCheckerProvider#withPhysicalTenant(String)} resolves every tenant to it, so
- * this bean constructs and behaves correctly in every storage mode.
+ * <p>Gated on the same condition as {@link AuthorizationScopeRepositoryConfiguration}'s root {@link
+ * AuthorizationScopeRepositoryPort} bean (unconditional), rather than on secondary storage itself:
+ * with secondary storage disabled there is exactly one authorization source and this bean seeds a
+ * single {@code default}-keyed scope so every request resolves to it, so this bean constructs and
+ * behaves correctly in every storage mode.
  *
  * <p>{@code @ConditionalOnMissingBean(AuthorizationCheckPort.class)} lets this user configuration
  * win the race against {@code camunda-security-library}'s own default {@code
@@ -38,7 +45,7 @@ import org.springframework.context.annotation.Configuration;
  * {@code @ImportAutoConfiguration}-imported configuration, per Spring Boot's ordering guarantee.
  * That CSL default builds a single {@code AuthorizationService} from a single {@code
  * AuthorizationChecker} bean, with no per-physical-tenant fan-out, so it cannot serve this repo's
- * requirement of one {@code AuthorizationService} per physical tenant; this bean is the required
+ * requirement of one {@code AuthorizationCheckPort} per physical tenant; this bean is the required
  * override, not a redundant duplicate.
  *
  * <p>{@link LazyTokenClaimsConverter} and {@link MembershipPort} are only registered as beans under
@@ -59,16 +66,44 @@ public class WebAppAuthorizationCheckPortConfiguration {
   @Bean
   @ConditionalOnMissingBean(AuthorizationCheckPort.class)
   public AuthorizationCheckPort authorizationCheckPort(
-      final AuthorizationCheckerProvider authorizationCheckerProvider,
+      final AuthorizationScopeRepositoryPort defaultScopeRepository,
+      final Optional<PhysicalTenantSearchClientReaders> physicalTenantSearchClientReaders,
       final List<PropertyAuthorizationEvaluator<?>> propertyAuthorizationEvaluators,
       final CamundaSecurityLibraryProperties securityProperties,
       final ObjectProvider<LazyTokenClaimsConverter> claimsConverter) {
-    return new TenantAwareAuthorizationCheckPort(
-        authorizationCheckerProvider,
-        new PropertyAuthorizationEvaluatorRegistry(propertyAuthorizationEvaluators),
-        securityProperties.getAuthorizations().isEnabled(),
-        securityProperties.getMultiTenancy().isChecksEnabled(),
-        claimsConverter.getIfAvailable(() -> defaultClaimsConverter(securityProperties)));
+    final var resolver =
+        claimsConverter.getIfAvailable(() -> defaultClaimsConverter(securityProperties));
+    // Equivalent to "the map would be empty" (the condition AuthorizationCheckerProvider used):
+    // PhysicalTenantResolver always synthesizes a "default" entry when none is explicitly
+    // configured, so whenever PhysicalTenantSearchClientReaders exists at all, its map is
+    // guaranteed non-empty.
+    final boolean hasPerTenantScopes = physicalTenantSearchClientReaders.isPresent();
+    final Map<String, AuthorizationScopeRepositoryPort> scopeRepositoriesByScope =
+        hasPerTenantScopes
+            ? perTenantScopeRepositories(physicalTenantSearchClientReaders.get())
+            : Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, defaultScopeRepository);
+    final var checkPorts =
+        ScopedAuthorizationCheckPortFactory.create(
+            scopeRepositoriesByScope,
+            resolver,
+            propertyAuthorizationEvaluators,
+            securityProperties.getAuthorizations().isEnabled(),
+            securityProperties.getMultiTenancy().isChecksEnabled());
+    return new TenantAwareAuthorizationCheckPort(checkPorts, hasPerTenantScopes, resolver);
+  }
+
+  private static Map<String, AuthorizationScopeRepositoryPort> perTenantScopeRepositories(
+      final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders) {
+    final Map<String, AuthorizationScopeRepositoryPort> scopeRepositories = new LinkedHashMap<>();
+    physicalTenantSearchClientReaders
+        .readersByPhysicalTenant()
+        .forEach(
+            (tenantId, searchClientReaders) ->
+                scopeRepositories.put(
+                    tenantId,
+                    new SearchAuthorizationScopeRepository(
+                        searchClientReaders.authorizationReader())));
+    return Map.copyOf(scopeRepositories);
   }
 
   /**

--- a/dist/src/test/java/io/camunda/application/commons/security/TenantAwareAuthorizationCheckPortTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/TenantAwareAuthorizationCheckPortTest.java
@@ -8,23 +8,26 @@
 package io.camunda.application.commons.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.security.api.context.TokenClaimsAuthenticationResolver;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.api.model.Either;
 import io.camunda.security.api.model.authz.AuthorizationRejection;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.api.model.authz.PermissionType;
 import io.camunda.security.core.auth.RequiredAuthorization;
-import io.camunda.security.core.authz.AuthorizationChecker;
-import io.camunda.security.core.authz.LazyTokenClaimsConverter;
-import io.camunda.security.core.authz.PropertyAuthorizationEvaluatorRegistry;
+import io.camunda.security.core.authz.ScopedAuthorizationCheckPortFactory;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
+import io.camunda.security.core.port.out.AuthorizationScopeRepositoryPort;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -36,26 +39,40 @@ class TenantAwareAuthorizationCheckPortTest {
   private static final String COMPONENT_IDENTITY_LEGACY_ALIAS = "identity";
   private static final String COMPONENT_OPERATE = "operate";
 
-  private final AuthorizationChecker authorizationChecker = mock(AuthorizationChecker.class);
-  private final LazyTokenClaimsConverter claimsConverter = mock(LazyTokenClaimsConverter.class);
-  private final AuthorizationCheckPort authorizationCheckPort =
-      new TenantAwareAuthorizationCheckPort(
-          new AuthorizationCheckerProvider(authorizationChecker, Map.of()),
-          new PropertyAuthorizationEvaluatorRegistry(List.of()),
-          true,
-          false,
-          claimsConverter);
+  private final AuthorizationScopeRepositoryPort scopeRepository =
+      mock(AuthorizationScopeRepositoryPort.class);
+  private final TokenClaimsAuthenticationResolver claimsResolver =
+      mock(TokenClaimsAuthenticationResolver.class);
+  private final AuthorizationCheckPort authorizationCheckPort = noPerTenantScopesCheckPort();
   private final CamundaAuthentication authentication =
       CamundaAuthentication.of(b -> b.user("alice"));
+
+  /**
+   * A no-per-tenant-scopes port, backed by a single {@code default}-keyed scope. Used by every test
+   * below that exercises {@link TenantAwareAuthorizationCheckPort}'s own delegation/alias logic,
+   * not the per-tenant resolution itself — see {@link
+   * #shouldFailHardWhenPerTenantScopesConfiguredButNoPhysicalTenantResolved} for that.
+   */
+  private AuthorizationCheckPort noPerTenantScopesCheckPort() {
+    final var checkPorts =
+        ScopedAuthorizationCheckPortFactory.create(
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, scopeRepository),
+            claimsResolver,
+            List.of(),
+            true,
+            false);
+    return new TenantAwareAuthorizationCheckPort(checkPorts, false, claimsResolver);
+  }
 
   @Test
   void shouldGrantAdminComponentAccessViaLegacyIdentityAlias() {
     // given: principal lacks the admin COMPONENT/ACCESS grant but holds the legacy identity one
-    when(authorizationChecker.isAuthorized(any(), any(), any())).thenReturn(false);
-    when(authorizationChecker.isAuthorized(
+    when(scopeRepository.hasAuthorizedScope(any(), any(), any(), anyList())).thenReturn(false);
+    when(scopeRepository.hasAuthorizedScope(
             any(),
             any(),
-            argThat(auth -> auth.resourceIds().contains(COMPONENT_IDENTITY_LEGACY_ALIAS))))
+            any(),
+            argThat(ids -> ids != null && ids.contains(COMPONENT_IDENTITY_LEGACY_ALIAS))))
         .thenReturn(true);
 
     // when
@@ -69,7 +86,7 @@ class TenantAwareAuthorizationCheckPortTest {
   @Test
   void shouldDenyAdminComponentAccessWhenNeitherAdminNorIdentityGranted() {
     // given
-    when(authorizationChecker.isAuthorized(any(), any(), any())).thenReturn(false);
+    when(scopeRepository.hasAuthorizedScope(any(), any(), any(), anyList())).thenReturn(false);
 
     // when
     final Either<AuthorizationRejection, Void> result =
@@ -86,11 +103,12 @@ class TenantAwareAuthorizationCheckPortTest {
   @Test
   void shouldNotApplyIdentityAliasToOtherComponents() {
     // given: the alias only maps identity -> admin; other components must not benefit from it
-    when(authorizationChecker.isAuthorized(any(), any(), any())).thenReturn(false);
-    when(authorizationChecker.isAuthorized(
+    when(scopeRepository.hasAuthorizedScope(any(), any(), any(), anyList())).thenReturn(false);
+    when(scopeRepository.hasAuthorizedScope(
             any(),
             any(),
-            argThat(auth -> auth.resourceIds().contains(COMPONENT_IDENTITY_LEGACY_ALIAS))))
+            any(),
+            argThat(ids -> ids != null && ids.contains(COMPONENT_IDENTITY_LEGACY_ALIAS))))
         .thenReturn(true);
 
     // when
@@ -104,7 +122,7 @@ class TenantAwareAuthorizationCheckPortTest {
   @Test
   void shouldPassThroughDirectAdminGrantWithoutConsultingAlias() {
     // given
-    when(authorizationChecker.isAuthorized(any(), any(), any())).thenReturn(true);
+    when(scopeRepository.hasAuthorizedScope(any(), any(), any(), anyList())).thenReturn(true);
 
     // when
     final Either<AuthorizationRejection, Void> result =
@@ -115,11 +133,11 @@ class TenantAwareAuthorizationCheckPortTest {
   }
 
   @Test
-  void shouldDelegateClaimsBasedCheckThroughConverter() {
+  void shouldDelegateClaimsBasedCheckThroughResolver() {
     // given
     final Map<String, Object> claims = Map.of("sub", "alice");
-    when(claimsConverter.convert(claims)).thenReturn(authentication);
-    when(authorizationChecker.isAuthorized(any(), any(), any())).thenReturn(true);
+    when(claimsResolver.resolve(claims)).thenReturn(authentication);
+    when(scopeRepository.hasAuthorizedScope(any(), any(), any(), anyList())).thenReturn(true);
 
     // when
     final Either<AuthorizationRejection, Void> result =
@@ -127,7 +145,7 @@ class TenantAwareAuthorizationCheckPortTest {
 
     // then
     assertThat(result.isRight()).isTrue();
-    verify(claimsConverter).convert(claims);
+    verify(claimsResolver).resolve(claims);
   }
 
   @Test
@@ -141,7 +159,7 @@ class TenantAwareAuthorizationCheckPortTest {
                     b.resourceType(AuthorizationResourceType.COMPONENT)
                         .permissionType(PermissionType.ACCESS))
             .withResourcePropertyNames(Set.of("owner"));
-    when(authorizationChecker.retrieveAuthorizedPropertyScopes(any(), any(), any()))
+    when(scopeRepository.findAuthorizedPropertyScopes(any(), any(), any(), any()))
         .thenReturn(List.of());
 
     // when
@@ -150,19 +168,18 @@ class TenantAwareAuthorizationCheckPortTest {
 
     // then: denied (no matching granted property scope), and the RBAC/alias path was never touched
     assertThat(result.isLeft()).isTrue();
-    verify(authorizationChecker, never()).isAuthorized(any(), any(), any());
+    verify(scopeRepository, never()).hasAuthorizedScope(any(), any(), any(), anyList());
   }
 
   @Test
   void shouldPreserveOtherResourceIdsWhenApplyingIdentityAlias() {
     // given: a multi-id requirement (admin + operate); only the legacy identity alias is granted
-    when(authorizationChecker.isAuthorized(any(), any(), any())).thenReturn(false);
-    when(authorizationChecker.isAuthorized(
-            argThat(
-                scope ->
-                    scope != null && COMPONENT_IDENTITY_LEGACY_ALIAS.equals(scope.getResourceId())),
+    when(scopeRepository.hasAuthorizedScope(any(), any(), any(), anyList())).thenReturn(false);
+    when(scopeRepository.hasAuthorizedScope(
             any(),
-            any()))
+            any(),
+            any(),
+            argThat(ids -> ids != null && ids.contains(COMPONENT_IDENTITY_LEGACY_ALIAS))))
         .thenReturn(true);
 
     // when
@@ -180,18 +197,15 @@ class TenantAwareAuthorizationCheckPortTest {
   @Test
   void shouldGrantAccessViaAliasWhenAllOtherResourceIdsAreAlsoGranted() {
     // given: a multi-id requirement (admin + operate); identity alias and operate are both granted
-    when(authorizationChecker.isAuthorized(any(), any(), any())).thenReturn(false);
-    when(authorizationChecker.isAuthorized(
-            argThat(
-                scope ->
-                    scope != null && COMPONENT_IDENTITY_LEGACY_ALIAS.equals(scope.getResourceId())),
+    when(scopeRepository.hasAuthorizedScope(any(), any(), any(), anyList())).thenReturn(false);
+    when(scopeRepository.hasAuthorizedScope(
             any(),
-            any()))
+            any(),
+            any(),
+            argThat(ids -> ids != null && ids.contains(COMPONENT_IDENTITY_LEGACY_ALIAS))))
         .thenReturn(true);
-    when(authorizationChecker.isAuthorized(
-            argThat(scope -> scope != null && COMPONENT_OPERATE.equals(scope.getResourceId())),
-            any(),
-            any()))
+    when(scopeRepository.hasAuthorizedScope(
+            any(), any(), any(), argThat(ids -> ids != null && ids.contains(COMPONENT_OPERATE))))
         .thenReturn(true);
 
     // when
@@ -203,6 +217,39 @@ class TenantAwareAuthorizationCheckPortTest {
 
     // then
     assertThat(result.isRight()).isTrue();
+  }
+
+  @Test
+  void
+      shouldResolveToTheSingleDefaultScopeRegardlessOfPhysicalTenantContextWhenNoPerTenantScopesConfigured() {
+    // given — hasPerTenantScopes=false always resolves the seeded default entry; this test runs
+    // outside any request scope or propagated tenant (PhysicalTenantContext.currentOrNull() would
+    // return null here), yet the check still succeeds because that context is never consulted
+    when(scopeRepository.hasAuthorizedScope(any(), any(), any(), anyList())).thenReturn(true);
+
+    // when
+    final Either<AuthorizationRejection, Void> result =
+        authorizationCheckPort.check(authentication, componentAccess(COMPONENT_OPERATE));
+
+    // then
+    assertThat(result.isRight()).isTrue();
+  }
+
+  @Test
+  void shouldFailHardWhenPerTenantScopesConfiguredButNoPhysicalTenantResolved() {
+    // given — per-tenant scopes exist (keyed by physical tenant id, not "default"), and this test
+    // runs outside any request scope or propagated tenant, so
+    // PhysicalTenantContext.currentOrNull() returns null
+    final var checkPorts =
+        ScopedAuthorizationCheckPortFactory.create(
+            Map.of("tenant-a", scopeRepository), claimsResolver, List.of(), true, false);
+    final AuthorizationCheckPort perTenantPort =
+        new TenantAwareAuthorizationCheckPort(checkPorts, true, claimsResolver);
+
+    // when / then — CSL's fail-hard forScope(null) surfaces rather than silently resolving against
+    // tenant-a's storage, which would break tenant isolation for an unstamped request
+    assertThatIllegalStateException()
+        .isThrownBy(() -> perTenantPort.check(authentication, componentAccess(COMPONENT_ADMIN)));
   }
 
   private static RequiredAuthorization<Void> componentAccess(final String resourceId) {

--- a/dist/src/test/java/io/camunda/application/commons/security/WebAppAuthorizationCheckPortConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/WebAppAuthorizationCheckPortConfigurationTest.java
@@ -8,8 +8,11 @@
 package io.camunda.application.commons.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.Mockito.mock;
 
+import io.camunda.search.clients.reader.PhysicalTenantSearchClientReaders;
+import io.camunda.search.clients.reader.SearchClientReaders;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.api.model.authz.PermissionType;
@@ -22,6 +25,7 @@ import io.camunda.security.core.port.out.MembershipPort;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.security.spring.authz.AuthorizationCheckerConfiguration;
 import io.camunda.security.spring.authz.AuthorizationConfiguration;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
@@ -159,5 +163,49 @@ class WebAppAuthorizationCheckPortConfigurationTest {
           assertThat(ctx.getBean(AuthorizationCheckPort.class))
               .isInstanceOf(AuthorizationService.class);
         });
+  }
+
+  @Test
+  void shouldFailHardWhenPerTenantScopesConfiguredButNoPhysicalTenantResolved() {
+    // given: a PhysicalTenantSearchClientReaders bean is present, so this bean wires one scope per
+    // physical tenant instead of the single "default" entry -- and this test runs outside any
+    // request scope or propagated tenant, so PhysicalTenantContext.currentOrNull() returns null
+    final var readersStub = mock(SearchClientReaders.class);
+    final var perTenantReaders =
+        new PhysicalTenantSearchClientReaders(Map.of("tenant-a", readersStub));
+
+    // when / then: CSL's fail-hard forScope(null) surfaces rather than silently resolving against
+    // tenant-a's storage, proving this bean method actually wires the per-tenant branch (not just
+    // the single-default-entry one every other test in this class exercises)
+    new WebApplicationContextRunner()
+        .withBean(
+            AuthorizationScopeRepositoryPort.class,
+            () -> mock(AuthorizationScopeRepositoryPort.class))
+        .withBean(PhysicalTenantSearchClientReaders.class, () -> perTenantReaders)
+        .withBean(MembershipPort.class, () -> mock(MembershipPort.class))
+        .withBean(CamundaSecurityLibraryProperties.class, CamundaSecurityLibraryProperties::new)
+        .withConfiguration(
+            AutoConfigurations.of(
+                AuthorizationCheckerConfiguration.class, AuthorizationConfiguration.class))
+        .withUserConfiguration(
+            AuthorizationCheckerProviderConfiguration.class,
+            WebAppAuthorizationCheckPortConfiguration.class)
+        .run(
+            ctx -> {
+              assertThat(ctx).hasSingleBean(AuthorizationCheckPort.class);
+              final AuthorizationCheckPort port = ctx.getBean(AuthorizationCheckPort.class);
+
+              final RequiredAuthorization<Void> authorization =
+                  RequiredAuthorization.<Void>of(
+                          b ->
+                              b.resourceType(AuthorizationResourceType.COMPONENT)
+                                  .permissionType(PermissionType.ACCESS))
+                      .withResourceId("operate");
+              assertThatIllegalStateException()
+                  .isThrownBy(
+                      () ->
+                          port.check(
+                              CamundaAuthentication.of(b -> b.user("alice")), authorization));
+            });
   }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.bouncycastle>1.85</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha63</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha64</version.camunda-security-library>
     <version.checkstyle>13.9.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>


### PR DESCRIPTION
## Why

Follow-up to #59594 (2b) implementing the remaining half of
[camunda-security-library#596](https://github.com/camunda/camunda-security-library/issues/596):
`TenantAwareAuthorizationCheckPort` still builds a new `AuthorizationService` on every
single check call, naming CSL's core-internal `AuthorizationChecker`/`AuthorizationService`
directly instead of depending on CSL's ports.

## Status: blocked, not mergeable yet — expect CI to be red

**Does not compile against the currently pinned `camunda-security-library` version
(`0.1.0-alpha63`)** — it depends on `ScopedAuthorizationCheckPortFactory`, a new class
introduced in [camunda-security-library#602](https://github.com/camunda/camunda-security-library/pull/602),
which is not yet released. This PR exists to preserve the work and make it reviewable in
context; it is not ready to merge, and CI is expected to fail until it is unblocked.

**To unblock:**
1. Get CSL PR #602 merged and released as a new `0.1.0-alphaNN`.
2. Bump `version.camunda-security-library` in `parent/pom.xml` on this branch to that version.
3. Update `TenantAwareAuthorizationCheckPortTest` and
   `WebAppAuthorizationCheckPortConfigurationTest` for the new constructor shapes — **not done
   yet**; only production code was adopted here. Needs the no-physical-tenant/physical-tenant ×
   null-scope-key behavior matrix (see commit message) covered explicitly.
4. Re-run `./mvnw install -Dquickly -T1C` then the module test suite before marking ready for
   review.

Verified locally (not via Maven — the repo's `branch-scoped-local-repository` extension defeats
manual jar-syncing against an unreleased CSL SNAPSHOT) by direct `javac` compilation against a
locally-built CSL `0.1.0-SNAPSHOT`, confirming both files compile against the shape CSL PR #602
introduces.

## What changed

- `TenantAwareAuthorizationCheckPort`: drops `AuthorizationCheckerProvider`, the property
  evaluator registry, both authorization flags, and the claims converter; now holds CSL's
  `ScopedAuthorizationCheckPorts` and looks up the current scope's port via `forScope(...)`
  instead of constructing a fresh `AuthorizationService` per check.
- `WebAppAuthorizationCheckPortConfiguration`: builds the per-scope
  `AuthorizationScopeRepositoryPort` map (one entry per physical tenant, or a single `default`
  entry when no per-tenant search readers are configured) and assembles it via
  `ScopedAuthorizationCheckPortFactory.create(...)`.

Preserves the two isolation modes the previous `AuthorizationCheckerProvider.withPhysicalTenant`
had: no per-tenant scopes configured → any lookup key including `null` resolves to the single
default entry; per-tenant scopes configured → exact match required, `null` fails hard (via CSL's
`forScope`, which now guards against `null` throwing a bare `NullPointerException` instead of the
intended `IllegalStateException` — fixed in CSL PR #602).

Part of [camunda-security-library#596](https://github.com/camunda/camunda-security-library/issues/596)
(together with #59594). CSL side: [camunda-security-library#602](https://github.com/camunda/camunda-security-library/pull/602).