### PR TITLE
Scope exporter delete to an optional physical tenant

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
@@ -68,7 +68,7 @@ public class ExportersEndpoint {
       @RequestParam(defaultValue = "false") final boolean dryRun) {
 
     return requestSender
-        .deleteExporter(new ExporterDeleteRequest(exporterId, dryRun))
+        .deleteExporter(new ExporterDeleteRequest(exporterId, Optional.empty(), dryRun))
         .handle(ClusterApiUtils::mapOperationResponse);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -153,7 +153,11 @@ public sealed interface ClusterConfigurationManagementRequest {
       String exporterId, Optional<String> physicalTenantId, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
-  record ExporterDeleteRequest(String exporterId, boolean dryRun)
+  /**
+   * Delete an exporter on all partitions of the given physical tenant. If no physicalTenantId is
+   * provided, it applies to all tenants.
+   */
+  record ExporterDeleteRequest(String exporterId, Optional<String> physicalTenantId, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
   record ExporterEnableRequest(String exporterId, Optional<String> initializeFrom, boolean dryRun)

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -248,7 +248,8 @@ public final class ClusterConfigurationManagementRequestsHandler
       final ExporterDeleteRequest exporterDeleteRequest) {
     return handleRequest(
         exporterDeleteRequest.dryRun(),
-        new ExporterDeleteRequestTransformer(exporterDeleteRequest.exporterId()));
+        new ExporterDeleteRequestTransformer(
+            exporterDeleteRequest.exporterId(), exporterDeleteRequest.physicalTenantId()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterDeleteRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterDeleteRequestTransformer.java
@@ -7,34 +7,122 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
+/**
+ * Deletes an exporter, either for a single physical tenant or, when none is given, for every
+ * physical tenant that currently has it pending deletion (CONFIG_NOT_FOUND). Exporter configuration
+ * is per physical tenant, so an exporter id may not exist in every tenant; If any tenant (and
+ * partitions within a tenant) has the exporter, but not in {@link State#CONFIG_NOT_FOUND} the whole
+ * request is rejected.
+ */
 public final class ExporterDeleteRequestTransformer implements ConfigurationChangeRequest {
 
   private final String exporterId;
+  private final Optional<String> physicalTenantId;
 
   public ExporterDeleteRequestTransformer(final String exporterId) {
+    this(exporterId, Optional.empty());
+  }
 
+  public ExporterDeleteRequestTransformer(
+      final String exporterId, final Optional<String> physicalTenantId) {
     this.exporterId = exporterId;
+    this.physicalTenantId = physicalTenantId;
   }
 
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration clusterConfiguration) {
-    final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
-    for (final var member : clusterConfiguration.members().entrySet()) {
-      final var memberId = member.getKey();
-      for (final var partitions : member.getValue().partitions().entrySet()) {
-        final var partitionId = partitions.getKey();
-        operations.add(new PartitionDeleteExporterOperation(memberId, partitionId, exporterId));
+    throw new UnsupportedOperationException(
+        "ExporterDeleteRequestTransformer builds its change plan via "
+            + "phases(CurrentClusterConfiguration); the new-model coordinator path never calls "
+            + "operations(ClusterConfiguration)");
+  }
+
+  @Override
+  public Either<Exception, List<Phase>> phases(
+      final CurrentClusterConfiguration clusterConfiguration) {
+    if (physicalTenantId.isPresent()
+        && !clusterConfiguration.hasPartitionGroup(physicalTenantId.get())) {
+      return Either.left(
+          new NotFound(
+              "Expected to delete exporter '%s' for physical tenant '%s', but the physical tenant does not exist"
+                  .formatted(exporterId, physicalTenantId.get())));
+    }
+
+    final List<String> groupIds =
+        physicalTenantId
+            .map(List::of)
+            .orElseGet(() -> List.copyOf(clusterConfiguration.partitionGroups().keySet()));
+
+    final Map<String, List<PartitionGroupOperation>> groupOperations = new LinkedHashMap<>();
+    for (final var groupId : groupIds) {
+      if (cannotDelete(Objects.requireNonNull(clusterConfiguration.partitionGroup(groupId)))) {
+        return Either.left(
+            new InvalidRequest(
+                "Expected to delete exporter '%s' for physical tenant '%s', but the exporter is still configured. Delete the exporter from the application configuration first."
+                    .formatted(exporterId, physicalTenantId.orElse("all tenants"))));
+      }
+      final var operations =
+          deleteOperationsFor(Objects.requireNonNull(clusterConfiguration.partitionGroup(groupId)));
+      if (!operations.isEmpty()) {
+        groupOperations.put(groupId, operations);
       }
     }
-    return Either.right(operations);
+
+    if (groupOperations.isEmpty()) {
+      return Either.left(
+          new NotFound(
+              "Expected to delete exporter '%s' for physical tenant '%s', but no matching exporters were found"
+                  .formatted(exporterId, physicalTenantId.orElse("all tenants"))));
+    }
+    return Either.right(List.of(new PartitionGroupParallelPhase(groupOperations)));
+  }
+
+  private List<PartitionGroupOperation> deleteOperationsFor(
+      final PartitionGroupConfiguration group) {
+    final List<PartitionGroupOperation> operations = new ArrayList<>();
+    for (final var member : group.members().entrySet()) {
+      final var memberId = member.getKey();
+      for (final var partition : member.getValue().partitions().entrySet()) {
+        final var partitionId = partition.getKey();
+        final var hasExporter =
+            partition.getValue().config().exporting().exporters().containsKey(exporterId);
+        if (hasExporter) {
+          operations.add(new PartitionDeleteExporterOperation(memberId, partitionId, exporterId));
+        }
+      }
+    }
+    return operations;
+  }
+
+  // returns true if at least one partition has the exporter in a state other than CONFIG_NOT_FOUND
+  private boolean cannotDelete(final PartitionGroupConfiguration group) {
+    return group.members().values().stream()
+        .flatMap(member -> member.partitions().values().stream())
+        .anyMatch(
+            partition -> {
+              final var exporterState = partition.config().exporting().exporters().get(exporterId);
+              return exporterState != null && exporterState.state() != State.CONFIG_NOT_FOUND;
+            });
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1080,11 +1080,14 @@ public class ProtoBufSerializer
 
   @Override
   public byte[] encodeExporterDeleteRequest(final ExporterDeleteRequest exporterDeleteRequest) {
-    return Requests.ExporterDeleteRequest.newBuilder()
-        .setExporterId(exporterDeleteRequest.exporterId())
-        .setDryRun(exporterDeleteRequest.dryRun())
-        .build()
-        .toByteArray();
+    final var builder =
+        Requests.ExporterDeleteRequest.newBuilder()
+            .setExporterId(exporterDeleteRequest.exporterId())
+            .setDryRun(exporterDeleteRequest.dryRun());
+
+    exporterDeleteRequest.physicalTenantId().ifPresent(builder::setPhysicalTenantId);
+
+    return builder.build().toByteArray();
   }
 
   @Override
@@ -1319,8 +1322,14 @@ public class ProtoBufSerializer
   public ExporterDeleteRequest decodeExporterDeleteRequest(final byte[] encodedRequest) {
     try {
       final var exporterDeleteRequest = Requests.ExporterDeleteRequest.parseFrom(encodedRequest);
+      final Optional<String> physicalTenantId =
+          exporterDeleteRequest.hasPhysicalTenantId()
+              ? Optional.of(exporterDeleteRequest.getPhysicalTenantId())
+              : Optional.empty();
       return new ExporterDeleteRequest(
-          exporterDeleteRequest.getExporterId(), exporterDeleteRequest.getDryRun());
+          exporterDeleteRequest.getExporterId(),
+          physicalTenantId,
+          exporterDeleteRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -109,6 +109,9 @@ message ExporterDisableRequest {
 message ExporterDeleteRequest {
   string exporterId = 1;
   bool dryRun = 2;
+  // When physicalTenantId is set, the exporter will be deleted only for that tenant.
+  // If not set, the exporter will be deleted for all tenants.
+  optional string physicalTenantId = 3;
 }
 
 message ExporterEnableRequest {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
@@ -438,7 +438,9 @@ final class NewModelManagementApiEndpointsTest {
 
     // when
     final var response =
-        handler.deleteExporter(new ExporterDeleteRequest(exporterId, false)).join();
+        handler
+            .deleteExporter(new ExporterDeleteRequest(exporterId, Optional.empty(), false))
+            .join();
 
     // then
     assertThat(response.legacyResponse().plannedChanges())

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTestBase.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTestBase.java
@@ -757,15 +757,17 @@ abstract class ClusterConfigurationManagementApiTestBase {
 
   @Test
   void shouldDeleteExporter() {
-    // given
+    // given — the exporter is in CONFIG_NOT_FOUND, the state a delete requires
     final String exporterId = "exporterId";
     final var request =
-        new ClusterConfigurationManagementRequest.ExporterDeleteRequest(exporterId, false);
+        new ClusterConfigurationManagementRequest.ExporterDeleteRequest(
+            exporterId, Optional.empty(), false);
     final var partitionConfigWithExporter =
         new DynamicPartitionConfig(
             new ExportingConfig(
                 ExportingState.EXPORTING,
-                Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
+                Map.of(
+                    exporterId, new ExporterState(1, State.CONFIG_NOT_FOUND, Optional.empty()))));
     final var configurationWithExporter =
         initialTopology.updateMember(
             memberFactory.apply(0),

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDeleteRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDeleteRequestTransformerTest.java
@@ -10,15 +10,21 @@ package io.camunda.zeebe.dynamic.config.api;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.Map;
 import java.util.Optional;
@@ -26,39 +32,163 @@ import org.junit.jupiter.api.Test;
 
 final class ExporterDeleteRequestTransformerTest {
 
-  final String exporterId = "exporterA";
+  private static final String EXPORTER_ID = "exporterA";
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+
   private final MemberId id0 = MemberId.from("0");
   private final MemberId id1 = MemberId.from("1");
-  private final DynamicPartitionConfig config =
+
+  private final DynamicPartitionConfig configPendingDeletion =
       new DynamicPartitionConfig(
           new ExportingConfig(
               ExportingState.EXPORTING,
-              Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
+              Map.of(EXPORTER_ID, new ExporterState(1, State.CONFIG_NOT_FOUND, Optional.empty()))));
+
+  private final DynamicPartitionConfig configWithoutExporter =
+      new DynamicPartitionConfig(new ExportingConfig(ExportingState.EXPORTING, Map.of()));
+
+  private final DynamicPartitionConfig configWithEnabledExporter =
+      new DynamicPartitionConfig(
+          new ExportingConfig(
+              ExportingState.EXPORTING,
+              Map.of(EXPORTER_ID, new ExporterState(1, State.ENABLED, Optional.empty()))));
 
   @Test
-  void shouldGenerateOperationForAllPartitionsAndMembers() {
+  void shouldGenerateOperationsForAllPhysicalTenantsWhenNoneIsGiven() {
     // given
-    final var transformer = new ExporterDeleteRequestTransformer(exporterId);
-
+    final var transformer = new ExporterDeleteRequestTransformer(EXPORTER_ID);
     final var clusterConfiguration =
-        ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, config)))
-            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(2, config)))
-            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, config)))
-            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, config)));
+        withPartitionGroups(
+            Map.of(
+                TENANT_A, groupWithMembers(configPendingDeletion),
+                TENANT_B, groupWithMembers(configPendingDeletion)));
 
     // when
-    final var result = transformer.operations(clusterConfiguration);
+    final var result = transformer.phases(clusterConfiguration);
 
     // then
     EitherAssert.assertThat(result).isRight();
-    assertThat(result.get())
-        .containsExactlyInAnyOrder(
-            new PartitionDeleteExporterOperation(id0, 1, exporterId),
-            new PartitionDeleteExporterOperation(id0, 2, exporterId),
-            new PartitionDeleteExporterOperation(id1, 2, exporterId),
-            new PartitionDeleteExporterOperation(id1, 1, exporterId));
+    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    assertThat(phase.groupOperations())
+        .containsOnlyKeys(TENANT_A, TENANT_B)
+        .allSatisfy(
+            (groupId, operations) ->
+                assertThat(operations)
+                    .containsExactlyInAnyOrder(
+                        new PartitionDeleteExporterOperation(id0, 1, EXPORTER_ID),
+                        new PartitionDeleteExporterOperation(id1, 1, EXPORTER_ID)));
+  }
+
+  @Test
+  void shouldSkipPhysicalTenantsThatDoNotHaveTheExporterPendingDeletion() {
+    // given
+    final var transformer = new ExporterDeleteRequestTransformer(EXPORTER_ID);
+    final var clusterConfiguration =
+        withPartitionGroups(
+            Map.of(
+                TENANT_A, groupWithMembers(configPendingDeletion),
+                TENANT_B, groupWithMembers(configWithoutExporter)));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    assertThat(phase.groupOperations()).containsOnlyKeys(TENANT_A);
+  }
+
+  @Test
+  void shouldRejectIfTheExporterIsNotInConfigNotFoundState() {
+    // given
+    final var transformer = new ExporterDeleteRequestTransformer(EXPORTER_ID);
+    final var clusterConfiguration =
+        withPartitionGroups(Map.of(TENANT_A, groupWithMembers(configWithEnabledExporter)));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft()).isInstanceOf(InvalidRequest.class);
+  }
+
+  @Test
+  void shouldGenerateOperationsOnlyForTheGivenPhysicalTenant() {
+    // given
+    final var transformer =
+        new ExporterDeleteRequestTransformer(EXPORTER_ID, Optional.of(TENANT_A));
+    final var clusterConfiguration =
+        withPartitionGroups(
+            Map.of(
+                TENANT_A, groupWithMembers(configPendingDeletion),
+                TENANT_B, groupWithMembers(configPendingDeletion)));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    assertThat(phase.groupOperations())
+        .containsOnlyKeys(TENANT_A)
+        .hasEntrySatisfying(
+            TENANT_A,
+            operations ->
+                assertThat(operations)
+                    .containsExactlyInAnyOrder(
+                        new PartitionDeleteExporterOperation(id0, 1, EXPORTER_ID),
+                        new PartitionDeleteExporterOperation(id1, 1, EXPORTER_ID)));
+  }
+
+  @Test
+  void shouldFailWhenNoPhysicalTenantHasTheExporterPendingDeletion() {
+    // given
+    final var transformer = new ExporterDeleteRequestTransformer(EXPORTER_ID);
+    final var clusterConfiguration =
+        withPartitionGroups(Map.of(TENANT_A, groupWithMembers(configWithoutExporter)));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(NotFound.class)
+        .hasMessageContaining("no matching exporters were found");
+  }
+
+  @Test
+  void shouldRejectAnUnknownPhysicalTenantId() {
+    // given
+    final var transformer =
+        new ExporterDeleteRequestTransformer(EXPORTER_ID, Optional.of("unknowntenant"));
+    final var clusterConfiguration =
+        withPartitionGroups(Map.of(TENANT_A, groupWithMembers(configPendingDeletion)));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft()).isInstanceOf(NotFound.class);
+  }
+
+  private PartitionGroupConfiguration groupWithMembers(final DynamicPartitionConfig config) {
+    return PartitionGroupConfiguration.empty(PartitionGroupConfiguration.INITIAL_VERSION)
+        .addMember(
+            id0, BrokerPartitionState.initialize(Map.of(1, PartitionState.active(1, config))))
+        .addMember(
+            id1, BrokerPartitionState.initialize(Map.of(1, PartitionState.active(1, config))));
+  }
+
+  private CurrentClusterConfiguration withPartitionGroups(
+      final Map<String, PartitionGroupConfiguration> partitionGroups) {
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        GlobalConfiguration.init(),
+        partitionGroups,
+        PhasedChangeState.empty());
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -226,7 +226,22 @@ final class ProtoBufSerializerTest {
   @Test
   void shouldEncodeAndDecodeExporterDeleteRequest() {
     // given
-    final var exporterDeleteRequest = new ExporterDeleteRequest("expId", false);
+    final var exporterDeleteRequest =
+        new ExporterDeleteRequest("expId", Optional.of("tenanta"), false);
+
+    // when
+    final var encodedRequest =
+        protoBufSerializer.encodeExporterDeleteRequest(exporterDeleteRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeExporterDeleteRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(exporterDeleteRequest);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeExporterDeleteRequestWithoutPhysicalTenantId() {
+    // given
+    final var exporterDeleteRequest = new ExporterDeleteRequest("expId", Optional.empty(), false);
 
     // when
     final var encodedRequest =


### PR DESCRIPTION
## Summary
Stacked on #59587 — same pattern applied to exporter delete instead of disable.

- `ExporterDeleteRequestTransformer` now accepts an optional physical tenant id: when given, delete operations are generated only for that tenant's partitions; when absent, it fans out to every tenant. Returns `NotFound` when nothing in scope qualifies, and rejects an unknown tenant id outright. Reject the request if the exporter is not in CONFIG_NOT_FOUND.
- The transformer now overrides `ConfigurationChangeRequest.phases()` (the new multi-partition-group model) instead of the legacy `operations()`, which the new-model coordinator path never calls.
- Threaded the optional tenant id through the wire protocol: added `optional string physicalTenantId` to the `ExporterDeleteRequest` proto message and updated `ProtoBufSerializer` encode/decode and `ClusterConfigurationManagementRequestsHandler` accordingly.
- Fixed `shouldDeleteExporter` in `ClusterConfigurationManagementApiTestBase`, which had the exporter in `ENABLED` state instead of `CONFIG_NOT_FOUND` — the fake coordinator never exercised the real applier so the mismatch was latent until the transformer started filtering by that state.

REST/actuator exposure of the new parameter (`ExportersEndpoint`) is left for follow-up work; it currently passes `Optional.empty()`.

part of #59575.