### PR TITLE
ci: load-test: label Renovate PR with area/load-tests

### DIFF
--- a/.ci/scripts/renovate-assignments.py
+++ b/.ci/scripts/renovate-assignments.py
@@ -19,8 +19,9 @@ DELAYED_OPTION_ID = "47fc9ee4"  # "Delayed" option ID
 
 TEAM_SLUGS = {
     "area/backend": "monorepo-backend-engineers",
+    "area/build": "monorepo-devops-engineers",
     "area/frontend": "monorepo-frontend-engineers",
-    "area/build": "monorepo-devops-engineers"
+    "area/load-tests": "reliability-testing",
 }
 
 # Polling parameters

--- a/.github/renovate/team-reliability-testing.json5
+++ b/.github/renovate/team-reliability-testing.json5
@@ -33,6 +33,12 @@
     // globally enabled in .github/renovate.json5.
 
     {
+      // Fit into .ci/scripts/renovate-assignments.py
+      matchFileNames: ["load-tests/**"],
+      addLabels: ["area/load-tests"]
+    },
+
+    {
       // Simplify the commit message when updating the Camunda Platform Helm Chart for load tests
       matchDepNames: [
         "camunda/camunda-platform-helm",


### PR DESCRIPTION
## Description

This fits into the `.ci/scripts/renovate-assignments.py` repository infrastructure.

Discussed on Slack with @cmur2 in https://camunda.slack.com/archives/C07N9H8FSSW/p1786017689422089?thread_ts=1785845773.648929&cid=C07N9H8FSSW

Note that @camunda/reliability-testing already [has code ownership](https://github.com/camunda/camunda/blob/be1b0dd27a87efcb096e122c39f8cb6a3bb7b9d4/CODEOWNERS#L132) on the `load-tests/**` folder, so this mostly adds the label.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
