### PR TITLE
feat: add business-value-overview index for precomputed L0 rollup

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/BusinessValueOverviewRepository.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/BusinessValueOverviewRepository.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import java.util.List;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+
+public interface BusinessValueOverviewRepository {
+
+  String ID_SEPARATOR = "::";
+
+  void bulkUpsert(List<BusinessValueOverviewDto> rows, boolean refreshImmediately);
+
+  Optional<BusinessValueOverviewDto> getByKey(
+      String tenantId, String processDefinitionKey, MetricRange metricRange);
+
+  List<BusinessValueOverviewDto> readByRange(MetricRange metricRange);
+
+  static String documentId(
+      final String tenantId, final String processDefinitionKey, final MetricRange metricRange) {
+    if (StringUtils.isBlank(tenantId)) {
+      throw new IllegalArgumentException(
+          "tenantId must not be null or blank on a business-value overview row");
+    }
+    if (StringUtils.isBlank(processDefinitionKey)) {
+      throw new IllegalArgumentException(
+          "processDefinitionKey must not be null or blank on a business-value overview row");
+    }
+    if (metricRange == null) {
+      throw new IllegalArgumentException(
+          "metricRange must not be null on a business-value overview row");
+    }
+    return tenantId + ID_SEPARATOR + processDefinitionKey + ID_SEPARATOR + metricRange.getId();
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepository.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepository.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.service.db.repository;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
 import java.util.List;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 
 public interface BusinessValueTargetRepository {
 
@@ -22,12 +23,13 @@ public interface BusinessValueTargetRepository {
   List<BusinessValueTargetDto> scanAll();
 
   static String documentId(final String tenantId, final String processDefinitionKey) {
-    if (tenantId == null) {
-      throw new IllegalArgumentException("tenantId must not be null on a business-value target");
-    }
-    if (processDefinitionKey == null) {
+    if (StringUtils.isBlank(tenantId)) {
       throw new IllegalArgumentException(
-          "processDefinitionKey must not be null on a business-value target");
+          "tenantId must not be null or blank on a business-value target");
+    }
+    if (StringUtils.isBlank(processDefinitionKey)) {
+      throw new IllegalArgumentException(
+          "processDefinitionKey must not be null or blank on a business-value target");
     }
     return tenantId + ID_SEPARATOR + processDefinitionKey;
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/BusinessValueOverviewRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/BusinessValueOverviewRepositoryES.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository.es;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.BUSINESS_VALUE_OVERVIEW_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
+
+import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.db.es.builders.OptimizeGetRequestBuilderES;
+import io.camunda.optimize.service.db.es.builders.OptimizeIndexOperationBuilderES;
+import io.camunda.optimize.service.db.es.builders.OptimizeSearchRequestBuilderES;
+import io.camunda.optimize.service.db.es.reader.ElasticsearchReaderUtil;
+import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
+import io.camunda.optimize.service.db.schema.index.BusinessValueOverviewIndex;
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(ElasticSearchCondition.class)
+public class BusinessValueOverviewRepositoryES implements BusinessValueOverviewRepository {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(BusinessValueOverviewRepositoryES.class);
+
+  private final OptimizeElasticsearchClient esClient;
+  private final ObjectMapper objectMapper;
+
+  public BusinessValueOverviewRepositoryES(
+      final OptimizeElasticsearchClient esClient, final ObjectMapper objectMapper) {
+    this.esClient = esClient;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public void bulkUpsert(
+      final List<BusinessValueOverviewDto> rows, final boolean refreshImmediately) {
+    if (rows == null || rows.isEmpty()) {
+      return;
+    }
+    final BulkRequest bulkRequest =
+        BulkRequest.of(
+            b -> {
+              if (refreshImmediately) {
+                b.refresh(Refresh.True);
+              }
+              rows.forEach(
+                  row ->
+                      b.operations(
+                          op ->
+                              op.index(
+                                  OptimizeIndexOperationBuilderES.of(
+                                      i ->
+                                          i.optimizeIndex(
+                                                  esClient, BUSINESS_VALUE_OVERVIEW_INDEX_NAME)
+                                              .id(
+                                                  BusinessValueOverviewRepository.documentId(
+                                                      row.getTenantId(),
+                                                      row.getProcessDefinitionKey(),
+                                                      row.getMetricRange()))
+                                              .document(row)))));
+              return b;
+            });
+    esClient.doBulkRequest(bulkRequest, BUSINESS_VALUE_OVERVIEW_INDEX_NAME, false);
+  }
+
+  @Override
+  public Optional<BusinessValueOverviewDto> getByKey(
+      final String tenantId, final String processDefinitionKey, final MetricRange metricRange) {
+    final String documentId =
+        BusinessValueOverviewRepository.documentId(tenantId, processDefinitionKey, metricRange);
+    try {
+      final var response =
+          esClient.get(
+              OptimizeGetRequestBuilderES.of(
+                  g ->
+                      g.optimizeIndex(esClient, BUSINESS_VALUE_OVERVIEW_INDEX_NAME).id(documentId)),
+              BusinessValueOverviewDto.class);
+      return response.found() ? Optional.ofNullable(response.source()) : Optional.empty();
+    } catch (final IOException e) {
+      final String errorMessage =
+          String.format("Could not read business-value overview row for id [%s].", documentId);
+      LOG.error(errorMessage, e);
+      throw new OptimizeRuntimeException(errorMessage, e);
+    }
+  }
+
+  @Override
+  public List<BusinessValueOverviewDto> readByRange(final MetricRange metricRange) {
+    if (metricRange == null) {
+      throw new IllegalArgumentException("metricRange must not be null");
+    }
+    final SearchRequest searchRequest =
+        OptimizeSearchRequestBuilderES.of(
+            b ->
+                b.optimizeIndex(esClient, BUSINESS_VALUE_OVERVIEW_INDEX_NAME)
+                    .query(
+                        q ->
+                            q.term(
+                                t ->
+                                    t.field(BusinessValueOverviewIndex.METRIC_RANGE)
+                                        .value(metricRange.getId())))
+                    .size(LIST_FETCH_LIMIT));
+    final SearchResponse<BusinessValueOverviewDto> response;
+    try {
+      response = esClient.search(searchRequest, BusinessValueOverviewDto.class);
+    } catch (final IOException e) {
+      final String errorMessage =
+          String.format(
+              "Could not read business-value overview rows for range [%s].", metricRange.getId());
+      LOG.error(errorMessage, e);
+      throw new OptimizeRuntimeException(errorMessage, e);
+    }
+    final List<BusinessValueOverviewDto> rows =
+        ElasticsearchReaderUtil.mapHits(
+            response.hits(), BusinessValueOverviewDto.class, objectMapper);
+    if (rows.size() >= LIST_FETCH_LIMIT) {
+      throw new OptimizeRuntimeException(
+          String.format(
+              "business-value overview readByRange returned %d rows for range [%s], "
+                  + "hitting the LIST_FETCH_LIMIT cap. Pagination must be introduced before "
+                  + "the read path can rely on complete results.",
+              rows.size(), metricRange.getId()));
+    }
+    return rows;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/BusinessValueOverviewRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/BusinessValueOverviewRepositoryES.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository.es;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.BUSINESS_VALUE_OVERVIEW_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
+
+import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.db.es.builders.OptimizeGetRequestBuilderES;
+import io.camunda.optimize.service.db.es.builders.OptimizeIndexOperationBuilderES;
+import io.camunda.optimize.service.db.es.builders.OptimizeSearchRequestBuilderES;
+import io.camunda.optimize.service.db.es.reader.ElasticsearchReaderUtil;
+import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
+import io.camunda.optimize.service.db.schema.index.BusinessValueOverviewIndex;
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(ElasticSearchCondition.class)
+public class BusinessValueOverviewRepositoryES implements BusinessValueOverviewRepository {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(BusinessValueOverviewRepositoryES.class);
+
+  private final OptimizeElasticsearchClient esClient;
+  private final ObjectMapper objectMapper;
+
+  public BusinessValueOverviewRepositoryES(
+      final OptimizeElasticsearchClient esClient, final ObjectMapper objectMapper) {
+    this.esClient = esClient;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public void bulkUpsert(
+      final List<BusinessValueOverviewDto> rows, final boolean refreshImmediately) {
+    if (rows == null || rows.isEmpty()) {
+      return;
+    }
+    final BulkRequest bulkRequest =
+        BulkRequest.of(
+            b -> {
+              if (refreshImmediately) {
+                b.refresh(Refresh.True);
+              }
+              rows.forEach(
+                  row ->
+                      b.operations(
+                          op ->
+                              op.index(
+                                  OptimizeIndexOperationBuilderES.of(
+                                      i ->
+                                          i.optimizeIndex(
+                                                  esClient, BUSINESS_VALUE_OVERVIEW_INDEX_NAME)
+                                              .id(
+                                                  BusinessValueOverviewRepository.documentId(
+                                                      row.getTenantId(),
+                                                      row.getProcessDefinitionKey(),
+                                                      row.getMetricRange()))
+                                              .document(row)))));
+              return b;
+            });
+    esClient.doBulkRequest(bulkRequest, BUSINESS_VALUE_OVERVIEW_INDEX_NAME, false);
+  }
+
+  @Override
+  public Optional<BusinessValueOverviewDto> getByKey(
+      final String tenantId, final String processDefinitionKey, final MetricRange metricRange) {
+    final String documentId =
+        BusinessValueOverviewRepository.documentId(tenantId, processDefinitionKey, metricRange);
+    try {
+      final var response =
+          esClient.get(
+              OptimizeGetRequestBuilderES.of(
+                  g ->
+                      g.optimizeIndex(esClient, BUSINESS_VALUE_OVERVIEW_INDEX_NAME).id(documentId)),
+              BusinessValueOverviewDto.class);
+      return response.found() ? Optional.ofNullable(response.source()) : Optional.empty();
+    } catch (final IOException e) {
+      final String errorMessage =
+          String.format("Could not read business-value overview row for id [%s].", documentId);
+      LOG.error(errorMessage, e);
+      throw new OptimizeRuntimeException(errorMessage, e);
+    }
+  }
+
+  @Override
+  public List<BusinessValueOverviewDto> readByRange(final MetricRange metricRange) {
+    if (metricRange == null) {
+      throw new IllegalArgumentException("metricRange must not be null");
+    }
+    final SearchRequest searchRequest =
+        OptimizeSearchRequestBuilderES.of(
+            b ->
+                b.optimizeIndex(esClient, BUSINESS_VALUE_OVERVIEW_INDEX_NAME)
+                    .query(
+                        q ->
+                            q.term(
+                                t ->
+                                    t.field(BusinessValueOverviewIndex.METRIC_RANGE)
+                                        .value(metricRange.getId())))
+                    .size(LIST_FETCH_LIMIT));
+    final SearchResponse<BusinessValueOverviewDto> response;
+    try {
+      response = esClient.search(searchRequest, BusinessValueOverviewDto.class);
+    } catch (final IOException e) {
+      final String errorMessage =
+          String.format(
+              "Could not read business-value overview rows for range [%s].", metricRange.getId());
+      LOG.error(errorMessage, e);
+      throw new OptimizeRuntimeException(errorMessage, e);
+    }
+    return ElasticsearchReaderUtil.mapHits(
+        response.hits(), BusinessValueOverviewDto.class, objectMapper);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/BusinessValueOverviewRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/BusinessValueOverviewRepositoryOS.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository.os;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.BUSINESS_VALUE_OVERVIEW_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
+import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.term;
+import static java.lang.String.format;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
+import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
+import io.camunda.optimize.service.db.schema.OptimizeIndexNameService;
+import io.camunda.optimize.service.db.schema.index.BusinessValueOverviewIndex;
+import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.List;
+import java.util.Optional;
+import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.GetRequest;
+import org.opensearch.client.opensearch.core.GetResponse;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.opensearch.client.opensearch.core.bulk.IndexOperation;
+import org.slf4j.Logger;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(OpenSearchCondition.class)
+public class BusinessValueOverviewRepositoryOS implements BusinessValueOverviewRepository {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(BusinessValueOverviewRepositoryOS.class);
+
+  private final OptimizeOpenSearchClient osClient;
+  private final OptimizeIndexNameService indexNameService;
+
+  public BusinessValueOverviewRepositoryOS(
+      final OptimizeOpenSearchClient osClient, final OptimizeIndexNameService indexNameService) {
+    this.osClient = osClient;
+    this.indexNameService = indexNameService;
+  }
+
+  @Override
+  public void bulkUpsert(
+      final List<BusinessValueOverviewDto> rows, final boolean refreshImmediately) {
+    if (rows == null || rows.isEmpty()) {
+      return;
+    }
+    final String indexAlias =
+        indexNameService.getOptimizeIndexAliasForIndex(BUSINESS_VALUE_OVERVIEW_INDEX_NAME);
+    final List<BulkOperation> operations =
+        rows.stream()
+            .map(
+                row ->
+                    new BulkOperation.Builder()
+                        .index(
+                            new IndexOperation.Builder<BusinessValueOverviewDto>()
+                                .index(indexAlias)
+                                .id(
+                                    BusinessValueOverviewRepository.documentId(
+                                        row.getTenantId(),
+                                        row.getProcessDefinitionKey(),
+                                        row.getMetricRange()))
+                                .document(row)
+                                .build())
+                        .build())
+            .toList();
+    osClient.doBulkRequest(
+        refreshImmediately
+            ? () -> new BulkRequest.Builder().refresh(Refresh.True)
+            : BulkRequest.Builder::new,
+        operations,
+        BUSINESS_VALUE_OVERVIEW_INDEX_NAME,
+        false);
+  }
+
+  @Override
+  public Optional<BusinessValueOverviewDto> getByKey(
+      final String tenantId, final String processDefinitionKey, final MetricRange metricRange) {
+    final String documentId =
+        BusinessValueOverviewRepository.documentId(tenantId, processDefinitionKey, metricRange);
+    final GetRequest.Builder requestBuilder =
+        new GetRequest.Builder()
+            .index(
+                indexNameService.getOptimizeIndexAliasForIndex(BUSINESS_VALUE_OVERVIEW_INDEX_NAME))
+            .id(documentId);
+
+    final String errorMessage =
+        format("Could not read business-value overview row for id [%s].", documentId);
+    final GetResponse<BusinessValueOverviewDto> response =
+        osClient.get(requestBuilder, BusinessValueOverviewDto.class, errorMessage);
+    return response.found() ? Optional.ofNullable(response.source()) : Optional.empty();
+  }
+
+  @Override
+  public List<BusinessValueOverviewDto> readByRange(final MetricRange metricRange) {
+    if (metricRange == null) {
+      throw new IllegalArgumentException("metricRange must not be null");
+    }
+    final SearchRequest.Builder requestBuilder =
+        new SearchRequest.Builder()
+            .index(
+                indexNameService.getOptimizeIndexAliasForIndex(BUSINESS_VALUE_OVERVIEW_INDEX_NAME))
+            .query(term(BusinessValueOverviewIndex.METRIC_RANGE, metricRange.getId()))
+            .size(LIST_FETCH_LIMIT);
+    return osClient.searchValues(requestBuilder, BusinessValueOverviewDto.class);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/BusinessValueOverviewRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/BusinessValueOverviewRepositoryOS.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository.os;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.BUSINESS_VALUE_OVERVIEW_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
+import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.term;
+import static java.lang.String.format;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
+import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
+import io.camunda.optimize.service.db.schema.OptimizeIndexNameService;
+import io.camunda.optimize.service.db.schema.index.BusinessValueOverviewIndex;
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.List;
+import java.util.Optional;
+import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.GetRequest;
+import org.opensearch.client.opensearch.core.GetResponse;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.opensearch.client.opensearch.core.bulk.IndexOperation;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(OpenSearchCondition.class)
+public class BusinessValueOverviewRepositoryOS implements BusinessValueOverviewRepository {
+
+  private final OptimizeOpenSearchClient osClient;
+  private final OptimizeIndexNameService indexNameService;
+
+  public BusinessValueOverviewRepositoryOS(
+      final OptimizeOpenSearchClient osClient, final OptimizeIndexNameService indexNameService) {
+    this.osClient = osClient;
+    this.indexNameService = indexNameService;
+  }
+
+  @Override
+  public void bulkUpsert(
+      final List<BusinessValueOverviewDto> rows, final boolean refreshImmediately) {
+    if (rows == null || rows.isEmpty()) {
+      return;
+    }
+    final String indexAlias =
+        indexNameService.getOptimizeIndexAliasForIndex(BUSINESS_VALUE_OVERVIEW_INDEX_NAME);
+    final List<BulkOperation> operations =
+        rows.stream()
+            .map(
+                row ->
+                    new BulkOperation.Builder()
+                        .index(
+                            new IndexOperation.Builder<BusinessValueOverviewDto>()
+                                .index(indexAlias)
+                                .id(
+                                    BusinessValueOverviewRepository.documentId(
+                                        row.getTenantId(),
+                                        row.getProcessDefinitionKey(),
+                                        row.getMetricRange()))
+                                .document(row)
+                                .build())
+                        .build())
+            .toList();
+    osClient.doBulkRequest(
+        refreshImmediately
+            ? () -> new BulkRequest.Builder().refresh(Refresh.True)
+            : BulkRequest.Builder::new,
+        operations,
+        BUSINESS_VALUE_OVERVIEW_INDEX_NAME,
+        false);
+  }
+
+  @Override
+  public Optional<BusinessValueOverviewDto> getByKey(
+      final String tenantId, final String processDefinitionKey, final MetricRange metricRange) {
+    final String documentId =
+        BusinessValueOverviewRepository.documentId(tenantId, processDefinitionKey, metricRange);
+    final GetRequest.Builder requestBuilder =
+        new GetRequest.Builder()
+            .index(
+                indexNameService.getOptimizeIndexAliasForIndex(BUSINESS_VALUE_OVERVIEW_INDEX_NAME))
+            .id(documentId);
+
+    final String errorMessage =
+        format("Could not read business-value overview row for id [%s].", documentId);
+    final GetResponse<BusinessValueOverviewDto> response =
+        osClient.get(requestBuilder, BusinessValueOverviewDto.class, errorMessage);
+    return response.found() ? Optional.ofNullable(response.source()) : Optional.empty();
+  }
+
+  @Override
+  public List<BusinessValueOverviewDto> readByRange(final MetricRange metricRange) {
+    if (metricRange == null) {
+      throw new IllegalArgumentException("metricRange must not be null");
+    }
+    final SearchRequest.Builder requestBuilder =
+        new SearchRequest.Builder()
+            .index(
+                indexNameService.getOptimizeIndexAliasForIndex(BUSINESS_VALUE_OVERVIEW_INDEX_NAME))
+            .query(term(BusinessValueOverviewIndex.METRIC_RANGE, metricRange.getId()))
+            .size(LIST_FETCH_LIMIT);
+    final List<BusinessValueOverviewDto> rows =
+        osClient.searchValues(requestBuilder, BusinessValueOverviewDto.class);
+    if (rows.size() >= LIST_FETCH_LIMIT) {
+      throw new OptimizeRuntimeException(
+          format(
+              "business-value overview readByRange returned %d rows for range [%s], "
+                  + "hitting the LIST_FETCH_LIMIT cap. Pagination must be introduced before "
+                  + "the read path can rely on complete results.",
+              rows.size(), metricRange.getId()));
+    }
+    return rows;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/BusinessValueOverviewWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/BusinessValueOverviewWriter.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.writer;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.AutomationRateBlock;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.CycleTimeBlock;
+import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BusinessValueOverviewWriter {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(BusinessValueOverviewWriter.class);
+
+  private final BusinessValueOverviewRepository repository;
+
+  public BusinessValueOverviewWriter(final BusinessValueOverviewRepository repository) {
+    this.repository = repository;
+  }
+
+  public void bulkUpsertFromScheduler(final List<BusinessValueOverviewDto> rows) {
+    validateAll(rows);
+    LOG.debug("Upserting [{}] business-value overview rows from scheduler", rows.size());
+    repository.bulkUpsert(rows, false);
+  }
+
+  public void bulkUpsertFromTargetWrite(final List<BusinessValueOverviewDto> rows) {
+    validateAll(rows);
+    LOG.debug("Upserting [{}] business-value overview rows from target write", rows.size());
+    repository.bulkUpsert(rows, true);
+  }
+
+  private void validateAll(final List<BusinessValueOverviewDto> rows) {
+    if (rows == null) {
+      throw new IllegalArgumentException("rows must not be null");
+    }
+    for (final BusinessValueOverviewDto row : rows) {
+      validate(row);
+    }
+  }
+
+  private void validate(final BusinessValueOverviewDto row) {
+    if (row == null) {
+      throw new IllegalArgumentException("business-value overview row must not be null");
+    }
+    if (StringUtils.isBlank(row.getTenantId())) {
+      throw new IllegalArgumentException(
+          "tenantId must not be null or blank on a business-value overview row");
+    }
+    if (StringUtils.isBlank(row.getProcessDefinitionKey())) {
+      throw new IllegalArgumentException(
+          "processDefinitionKey must not be null or blank on a business-value overview row");
+    }
+    if (row.getMetricRange() == null) {
+      throw new IllegalArgumentException(
+          "metricRange must not be null on a business-value overview row");
+    }
+    if (row.getLastComputedAt() == null) {
+      throw new IllegalArgumentException(
+          "lastComputedAt must not be null on a business-value overview row");
+    }
+
+    final int expectedTargetsSet =
+        countNonNullTarget(row.getCycleTime()) + countNonNullTarget(row.getAutomationRate());
+    if (row.getTargetsSet() != expectedTargetsSet) {
+      throw new IllegalArgumentException(
+          "targetsSet ["
+              + row.getTargetsSet()
+              + "] does not match the number of non-null targets ["
+              + expectedTargetsSet
+              + "]");
+    }
+    if (row.isHasAnyTarget() != (expectedTargetsSet > 0)) {
+      throw new IllegalArgumentException(
+          "hasAnyTarget ["
+              + row.isHasAnyTarget()
+              + "] is inconsistent with targetsSet ["
+              + expectedTargetsSet
+              + "]");
+    }
+
+    final int expectedTargetsMet = countMet(row.getCycleTime()) + countMet(row.getAutomationRate());
+    if (row.getTargetsMet() != expectedTargetsMet) {
+      throw new IllegalArgumentException(
+          "targetsMet ["
+              + row.getTargetsMet()
+              + "] does not match the number of met targets ["
+              + expectedTargetsMet
+              + "]");
+    }
+
+    validateBlockInvariant(
+        "cycleTime",
+        row.getCycleTime() == null ? null : row.getCycleTime().getValue(),
+        row.getCycleTime() == null ? null : row.getCycleTime().getTarget(),
+        row.getCycleTime() == null ? null : row.getCycleTime().getMet());
+    validateBlockInvariant(
+        "automationRate",
+        row.getAutomationRate() == null ? null : row.getAutomationRate().getValue(),
+        row.getAutomationRate() == null ? null : row.getAutomationRate().getTarget(),
+        row.getAutomationRate() == null ? null : row.getAutomationRate().getMet());
+  }
+
+  private static int countNonNullTarget(final CycleTimeBlock block) {
+    return block != null && block.getTarget() != null ? 1 : 0;
+  }
+
+  private static int countNonNullTarget(final AutomationRateBlock block) {
+    return block != null && block.getTarget() != null ? 1 : 0;
+  }
+
+  private static int countMet(final CycleTimeBlock block) {
+    return block != null && Boolean.TRUE.equals(block.getMet()) ? 1 : 0;
+  }
+
+  private static int countMet(final AutomationRateBlock block) {
+    return block != null && Boolean.TRUE.equals(block.getMet()) ? 1 : 0;
+  }
+
+  private static void validateBlockInvariant(
+      final String kpi, final Object value, final Object target, final Boolean met) {
+    final boolean unset = value == null || target == null;
+    if (unset && met != null) {
+      throw new IllegalArgumentException(kpi + ".met must be null when value or target is null");
+    }
+    if (!unset && met == null) {
+      throw new IllegalArgumentException(
+          kpi + ".met must be non-null when value and target are both non-null");
+    }
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/BusinessValueOverviewWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/BusinessValueOverviewWriter.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.writer;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.AutomationRateBlock;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.CycleTimeBlock;
+import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BusinessValueOverviewWriter {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(BusinessValueOverviewWriter.class);
+
+  private final BusinessValueOverviewRepository repository;
+
+  public BusinessValueOverviewWriter(final BusinessValueOverviewRepository repository) {
+    this.repository = repository;
+  }
+
+  public void bulkUpsertFromScheduler(final List<BusinessValueOverviewDto> rows) {
+    validateAll(rows);
+    LOG.debug("Upserting [{}] business-value overview rows from scheduler", rowCount(rows));
+    repository.bulkUpsert(rows, false);
+  }
+
+  public void bulkUpsertFromTargetWrite(final List<BusinessValueOverviewDto> rows) {
+    validateAll(rows);
+    LOG.debug("Upserting [{}] business-value overview rows from target write", rowCount(rows));
+    repository.bulkUpsert(rows, true);
+  }
+
+  private static int rowCount(final List<BusinessValueOverviewDto> rows) {
+    return rows == null ? 0 : rows.size();
+  }
+
+  private void validateAll(final List<BusinessValueOverviewDto> rows) {
+    if (rows == null) {
+      throw new IllegalArgumentException("rows must not be null");
+    }
+    for (final BusinessValueOverviewDto row : rows) {
+      validate(row);
+    }
+  }
+
+  private void validate(final BusinessValueOverviewDto row) {
+    if (row == null) {
+      throw new IllegalArgumentException("business-value overview row must not be null");
+    }
+    if (StringUtils.isBlank(row.getTenantId())) {
+      throw new IllegalArgumentException(
+          "tenantId must not be null or blank on a business-value overview row");
+    }
+    if (StringUtils.isBlank(row.getProcessDefinitionKey())) {
+      throw new IllegalArgumentException(
+          "processDefinitionKey must not be null or blank on a business-value overview row");
+    }
+    if (row.getMetricRange() == null) {
+      throw new IllegalArgumentException(
+          "metricRange must not be null on a business-value overview row");
+    }
+    if (row.getLastComputedAt() == null) {
+      throw new IllegalArgumentException(
+          "lastComputedAt must not be null on a business-value overview row");
+    }
+
+    final int expectedTargetsSet =
+        countNonNullTarget(row.getCycleTime()) + countNonNullTarget(row.getAutomationRate());
+    if (row.getTargetsSet() != expectedTargetsSet) {
+      throw new IllegalArgumentException(
+          "targetsSet ["
+              + row.getTargetsSet()
+              + "] does not match the number of non-null targets ["
+              + expectedTargetsSet
+              + "]");
+    }
+    if (row.isHasAnyTarget() != (expectedTargetsSet > 0)) {
+      throw new IllegalArgumentException(
+          "hasAnyTarget ["
+              + row.isHasAnyTarget()
+              + "] is inconsistent with targetsSet ["
+              + expectedTargetsSet
+              + "]");
+    }
+
+    final int expectedTargetsMet = countMet(row.getCycleTime()) + countMet(row.getAutomationRate());
+    if (row.getTargetsMet() != expectedTargetsMet) {
+      throw new IllegalArgumentException(
+          "targetsMet ["
+              + row.getTargetsMet()
+              + "] does not match the number of met targets ["
+              + expectedTargetsMet
+              + "]");
+    }
+    if (row.getTargetsMet() > row.getTargetsSet()) {
+      throw new IllegalArgumentException(
+          "targetsMet ["
+              + row.getTargetsMet()
+              + "] cannot exceed targetsSet ["
+              + row.getTargetsSet()
+              + "]");
+    }
+
+    validateBlockInvariant(
+        "cycleTime",
+        row.getCycleTime() == null ? null : row.getCycleTime().getValue(),
+        row.getCycleTime() == null ? null : row.getCycleTime().getTarget(),
+        row.getCycleTime() == null ? null : row.getCycleTime().getMet());
+    validateBlockInvariant(
+        "automationRate",
+        row.getAutomationRate() == null ? null : row.getAutomationRate().getValue(),
+        row.getAutomationRate() == null ? null : row.getAutomationRate().getTarget(),
+        row.getAutomationRate() == null ? null : row.getAutomationRate().getMet());
+  }
+
+  private static int countNonNullTarget(final CycleTimeBlock block) {
+    return block != null && block.getTarget() != null ? 1 : 0;
+  }
+
+  private static int countNonNullTarget(final AutomationRateBlock block) {
+    return block != null && block.getTarget() != null ? 1 : 0;
+  }
+
+  private static int countMet(final CycleTimeBlock block) {
+    return block != null && Boolean.TRUE.equals(block.getMet()) ? 1 : 0;
+  }
+
+  private static int countMet(final AutomationRateBlock block) {
+    return block != null && Boolean.TRUE.equals(block.getMet()) ? 1 : 0;
+  }
+
+  private static void validateBlockInvariant(
+      final String kpi, final Object value, final Object target, final Boolean met) {
+    final boolean unset = value == null || target == null;
+    if (unset && met != null) {
+      throw new IllegalArgumentException(kpi + ".met must be null when value or target is null");
+    }
+    if (!unset && met == null) {
+      throw new IllegalArgumentException(
+          kpi + ".met must be non-null when value and target are both non-null");
+    }
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/BusinessValueOverviewRepositoryTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/BusinessValueOverviewRepositoryTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.AutomationRateBlock;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.CycleTimeBlock;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.service.util.importing.ZeebeConstants;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+class BusinessValueOverviewRepositoryTest {
+
+  @Test
+  void shouldCombineTenantProcessKeyAndRangeIntoDocumentId() {
+    assertThat(
+            BusinessValueOverviewRepository.documentId(
+                ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID,
+                "invoice-automation",
+                MetricRange.THIRTY_DAYS))
+        .isEqualTo(ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID + "::invoice-automation::30d");
+  }
+
+  @Test
+  void shouldReturnDifferentDocumentIdsForDifferentRanges() {
+    final String a =
+        BusinessValueOverviewRepository.documentId(
+            ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID, "invoice-automation", MetricRange.SEVEN_DAYS);
+    final String b =
+        BusinessValueOverviewRepository.documentId(
+            ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID, "invoice-automation", MetricRange.THIRTY_DAYS);
+    assertThat(a).isNotEqualTo(b);
+  }
+
+  @Test
+  void shouldReturnDifferentDocumentIdsForDifferentTenants() {
+    final String a =
+        BusinessValueOverviewRepository.documentId(
+            "tenant-a", "invoice-automation", MetricRange.THIRTY_DAYS);
+    final String b =
+        BusinessValueOverviewRepository.documentId(
+            "tenant-b", "invoice-automation", MetricRange.THIRTY_DAYS);
+    assertThat(a).isNotEqualTo(b);
+  }
+
+  @Test
+  void shouldRejectNullTenant() {
+    assertThatThrownBy(
+            () ->
+                BusinessValueOverviewRepository.documentId(
+                    null, "any-key", MetricRange.THIRTY_DAYS))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId");
+  }
+
+  @Test
+  void shouldRejectNullProcessKey() {
+    assertThatThrownBy(
+            () ->
+                BusinessValueOverviewRepository.documentId(
+                    ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID, null, MetricRange.THIRTY_DAYS))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("processDefinitionKey");
+  }
+
+  @Test
+  void shouldRejectNullRange() {
+    assertThatThrownBy(
+            () ->
+                BusinessValueOverviewRepository.documentId(
+                    ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID, "any-key", null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("metricRange");
+  }
+
+  @Test
+  void shouldMapEachMetricRangeIdToItsEnumConstant() {
+    assertThat(MetricRange.fromId("7d")).isEqualTo(MetricRange.SEVEN_DAYS);
+    assertThat(MetricRange.fromId("30d")).isEqualTo(MetricRange.THIRTY_DAYS);
+    assertThat(MetricRange.fromId("3m")).isEqualTo(MetricRange.THREE_MONTHS);
+    assertThat(MetricRange.fromId("6m")).isEqualTo(MetricRange.SIX_MONTHS);
+  }
+
+  @Test
+  void shouldRejectUnknownMetricRangeId() {
+    assertThatThrownBy(() -> MetricRange.fromId("12m"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("12m");
+  }
+
+  @Test
+  void shouldSerializeMetricRangeAsIdString() throws Exception {
+    // guards the ES storage/query alignment: docs are stored with the id string, term queries
+    // filter on it
+    final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+    final BusinessValueOverviewDto dto =
+        new BusinessValueOverviewDto(
+            ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID,
+            "invoice-automation",
+            "Invoice Automation",
+            MetricRange.THIRTY_DAYS,
+            OffsetDateTime.parse("2026-08-05T04:00:15Z"),
+            new CycleTimeBlock(1L, 2L, true),
+            new AutomationRateBlock(72.4, 85, false),
+            true,
+            2,
+            1);
+
+    final String json = mapper.writeValueAsString(dto);
+
+    assertThat(json).contains("\"metricRange\":\"30d\"");
+    assertThat(json).doesNotContain("THIRTY_DAYS");
+
+    final BusinessValueOverviewDto roundTripped =
+        mapper.readValue(json, BusinessValueOverviewDto.class);
+    assertThat(roundTripped.getMetricRange()).isEqualTo(MetricRange.THIRTY_DAYS);
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepositoryTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepositoryTest.java
@@ -46,4 +46,21 @@ class BusinessValueTargetRepositoryTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("processDefinitionKey");
   }
+
+  @Test
+  void shouldRejectBlankTenant() {
+    assertThatThrownBy(() -> BusinessValueTargetRepository.documentId("   ", "any-key"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId");
+  }
+
+  @Test
+  void shouldRejectBlankProcessKey() {
+    assertThatThrownBy(
+            () ->
+                BusinessValueTargetRepository.documentId(
+                    ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID, "   "))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("processDefinitionKey");
+  }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/writer/BusinessValueOverviewWriterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/writer/BusinessValueOverviewWriterTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.writer;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.AutomationRateBlock;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.CycleTimeBlock;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
+import io.camunda.optimize.service.util.importing.ZeebeConstants;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BusinessValueOverviewWriterTest {
+
+  private BusinessValueOverviewRepository repository;
+  private BusinessValueOverviewWriter writer;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(BusinessValueOverviewRepository.class);
+    writer = new BusinessValueOverviewWriter(repository);
+  }
+
+  @Test
+  void shouldForwardSchedulerUpsertWithoutForcedRefresh() {
+    // given
+    final List<BusinessValueOverviewDto> rows = List.of(validRow());
+
+    // when
+    writer.bulkUpsertFromScheduler(rows);
+
+    // then
+    verify(repository).bulkUpsert(rows, false);
+  }
+
+  @Test
+  void shouldForwardTargetWriteUpsertWithForcedRefresh() {
+    // given
+    final List<BusinessValueOverviewDto> rows = List.of(validRow());
+
+    // when
+    writer.bulkUpsertFromTargetWrite(rows);
+
+    // then
+    verify(repository).bulkUpsert(rows, true);
+  }
+
+  @Test
+  void shouldAcceptEmptyRowList() {
+    // given
+    final List<BusinessValueOverviewDto> empty = List.of();
+
+    // when
+    writer.bulkUpsertFromScheduler(empty);
+
+    // then
+    verify(repository).bulkUpsert(empty, false);
+  }
+
+  @Test
+  void shouldRejectNullRowList() {
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("rows");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectNullRowInList() {
+    // guards the per-element null check inside validateAll; the "null list" case above only
+    // covers the outer guard
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(Arrays.asList(validRow(), null)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("row must not be null");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectRowMissingTenantId() {
+    // given
+    final BusinessValueOverviewDto row = validRow();
+    row.setTenantId(null);
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectRowWithBlankTenantId() {
+    // given a whitespace-only tenantId — nonsensical, would produce a garbage composite doc id
+    final BusinessValueOverviewDto row = validRow();
+    row.setTenantId("   ");
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectRowMissingProcessDefinitionKey() {
+    // given
+    final BusinessValueOverviewDto row = validRow();
+    row.setProcessDefinitionKey("");
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("processDefinitionKey");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectRowMissingMetricRange() {
+    // given
+    final BusinessValueOverviewDto row = validRow();
+    row.setMetricRange(null);
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("metricRange");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectRowMissingLastComputedAt() {
+    // given
+    final BusinessValueOverviewDto row = validRow();
+    row.setLastComputedAt(null);
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("lastComputedAt");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectInconsistentTargetsSet() {
+    // given a row that claims 2 targets set but only 1 target is actually non-null
+    final BusinessValueOverviewDto row = validRow();
+    row.setAutomationRate(new AutomationRateBlock(null, null, null));
+    row.setTargetsSet(2);
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("targetsSet");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectHasAnyTargetInconsistentWithTargetsSet() {
+    // given a row that has no targets but hasAnyTarget=true
+    final BusinessValueOverviewDto row = validRow();
+    row.setCycleTime(new CycleTimeBlock(14_472_000L, null, null));
+    row.setAutomationRate(new AutomationRateBlock(72.4, null, null));
+    row.setTargetsSet(0);
+    row.setTargetsMet(0);
+    row.setHasAnyTarget(true);
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("hasAnyTarget");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectTargetsMetExceedingTargetsSet() {
+    // given a row where targetsMet > targetsSet — impossible by definition
+    final BusinessValueOverviewDto row = validRow();
+    row.setTargetsMet(3);
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("targetsMet");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectMetSetWhenValueOrTargetIsNull() {
+    // given a KPI block with null value but a non-null met flag; other counts kept consistent so
+    // the block-invariant check is what fires
+    final BusinessValueOverviewDto row = validRow();
+    row.setCycleTime(new CycleTimeBlock(null, 11_520_000L, true));
+    row.setAutomationRate(null);
+    row.setHasAnyTarget(true);
+    row.setTargetsSet(1);
+    row.setTargetsMet(1);
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("cycleTime.met");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectMetNullWhenValueAndTargetAreBothSet() {
+    // given a KPI block with both value and target but no met verdict; counts kept consistent so
+    // the block-invariant check is what fires
+    final BusinessValueOverviewDto row = validRow();
+    row.setAutomationRate(new AutomationRateBlock(72.4, 85, null));
+    row.setTargetsMet(0);
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("automationRate.met");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldAcceptRowWithNoTargetsSet() {
+    // given an empty-targets row (both blocks null) — valid on first scheduler tick
+    final BusinessValueOverviewDto row = validRow();
+    row.setCycleTime(null);
+    row.setAutomationRate(null);
+    row.setHasAnyTarget(false);
+    row.setTargetsSet(0);
+    row.setTargetsMet(0);
+
+    // when
+    writer.bulkUpsertFromScheduler(List.of(row));
+
+    // then
+    verify(repository).bulkUpsert(List.of(row), false);
+  }
+
+  private BusinessValueOverviewDto validRow() {
+    return new BusinessValueOverviewDto(
+        ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID,
+        "invoice-automation",
+        "Invoice Automation",
+        MetricRange.THIRTY_DAYS,
+        OffsetDateTime.parse("2026-08-05T04:00:15Z"),
+        new CycleTimeBlock(14_472_000L, 11_520_000L, false),
+        new AutomationRateBlock(72.4, 85, false),
+        true,
+        2,
+        0);
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/writer/BusinessValueOverviewWriterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/writer/BusinessValueOverviewWriterTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.writer;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.AutomationRateBlock;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.CycleTimeBlock;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
+import io.camunda.optimize.service.util.importing.ZeebeConstants;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BusinessValueOverviewWriterTest {
+
+  private BusinessValueOverviewRepository repository;
+  private BusinessValueOverviewWriter writer;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(BusinessValueOverviewRepository.class);
+    writer = new BusinessValueOverviewWriter(repository);
+  }
+
+  @Test
+  void shouldForwardSchedulerUpsertWithoutForcedRefresh() {
+    // given
+    final List<BusinessValueOverviewDto> rows = List.of(validRow());
+
+    // when
+    writer.bulkUpsertFromScheduler(rows);
+
+    // then
+    verify(repository).bulkUpsert(rows, false);
+  }
+
+  @Test
+  void shouldForwardTargetWriteUpsertWithForcedRefresh() {
+    // given
+    final List<BusinessValueOverviewDto> rows = List.of(validRow());
+
+    // when
+    writer.bulkUpsertFromTargetWrite(rows);
+
+    // then
+    verify(repository).bulkUpsert(rows, true);
+  }
+
+  @Test
+  void shouldAcceptEmptyRowList() {
+    // given
+    final List<BusinessValueOverviewDto> empty = List.of();
+
+    // when
+    writer.bulkUpsertFromScheduler(empty);
+
+    // then
+    verify(repository).bulkUpsert(empty, false);
+  }
+
+  @Test
+  void shouldRejectNullRowList() {
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("rows");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectRowMissingTenantId() {
+    // given
+    final BusinessValueOverviewDto row = validRow();
+    row.setTenantId(null);
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectRowWithBlankTenantId() {
+    // given a whitespace-only tenantId — nonsensical, would produce a garbage composite doc id
+    final BusinessValueOverviewDto row = validRow();
+    row.setTenantId("   ");
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectRowMissingProcessDefinitionKey() {
+    // given
+    final BusinessValueOverviewDto row = validRow();
+    row.setProcessDefinitionKey("");
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("processDefinitionKey");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectRowMissingMetricRange() {
+    // given
+    final BusinessValueOverviewDto row = validRow();
+    row.setMetricRange(null);
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("metricRange");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectRowMissingLastComputedAt() {
+    // given
+    final BusinessValueOverviewDto row = validRow();
+    row.setLastComputedAt(null);
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("lastComputedAt");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectInconsistentTargetsSet() {
+    // given a row that claims 2 targets set but only 1 target is actually non-null
+    final BusinessValueOverviewDto row = validRow();
+    row.setAutomationRate(new AutomationRateBlock(null, null, null));
+    row.setTargetsSet(2);
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("targetsSet");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectHasAnyTargetInconsistentWithTargetsSet() {
+    // given a row that has no targets but hasAnyTarget=true
+    final BusinessValueOverviewDto row = validRow();
+    row.setCycleTime(new CycleTimeBlock(14_472_000L, null, null));
+    row.setAutomationRate(new AutomationRateBlock(72.4, null, null));
+    row.setTargetsSet(0);
+    row.setTargetsMet(0);
+    row.setHasAnyTarget(true);
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("hasAnyTarget");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectTargetsMetExceedingTargetsSet() {
+    // given a row where targetsMet > targetsSet — impossible by definition
+    final BusinessValueOverviewDto row = validRow();
+    row.setTargetsMet(3);
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("targetsMet");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectMetSetWhenValueOrTargetIsNull() {
+    // given a KPI block with null value but a non-null met flag; other counts kept consistent so
+    // the block-invariant check is what fires
+    final BusinessValueOverviewDto row = validRow();
+    row.setCycleTime(new CycleTimeBlock(null, 11_520_000L, true));
+    row.setAutomationRate(null);
+    row.setHasAnyTarget(true);
+    row.setTargetsSet(1);
+    row.setTargetsMet(1);
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("cycleTime.met");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldRejectMetNullWhenValueAndTargetAreBothSet() {
+    // given a KPI block with both value and target but no met verdict; counts kept consistent so
+    // the block-invariant check is what fires
+    final BusinessValueOverviewDto row = validRow();
+    row.setAutomationRate(new AutomationRateBlock(72.4, 85, null));
+    row.setTargetsMet(0);
+
+    // when + then
+    assertThatThrownBy(() -> writer.bulkUpsertFromScheduler(List.of(row)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("automationRate.met");
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldAcceptRowWithNoTargetsSet() {
+    // given an empty-targets row (both blocks null) — valid on first scheduler tick
+    final BusinessValueOverviewDto row = validRow();
+    row.setCycleTime(null);
+    row.setAutomationRate(null);
+    row.setHasAnyTarget(false);
+    row.setTargetsSet(0);
+    row.setTargetsMet(0);
+
+    // when
+    writer.bulkUpsertFromScheduler(List.of(row));
+
+    // then
+    verify(repository).bulkUpsert(List.of(row), false);
+  }
+
+  private BusinessValueOverviewDto validRow() {
+    return new BusinessValueOverviewDto(
+        ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID,
+        "invoice-automation",
+        "Invoice Automation",
+        MetricRange.THIRTY_DAYS,
+        OffsetDateTime.parse("2026-08-05T04:00:15Z"),
+        new CycleTimeBlock(14_472_000L, 11_520_000L, false),
+        new AutomationRateBlock(72.4, 85, false),
+        true,
+        2,
+        0);
+  }
+}

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/Upgrade89to810PlanFactory.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/Upgrade89to810PlanFactory.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.upgrade.plan.factories;
 
+import io.camunda.optimize.service.db.es.schema.index.BusinessValueOverviewIndexES;
 import io.camunda.optimize.service.db.es.schema.index.BusinessValueTargetIndexES;
 import io.camunda.optimize.upgrade.plan.UpgradeExecutionDependencies;
 import io.camunda.optimize.upgrade.plan.UpgradePlan;
@@ -21,6 +22,7 @@ public class Upgrade89to810PlanFactory implements UpgradePlanFactory {
         .fromVersion("8.9")
         .toVersion("8.10.0")
         .addUpgradeStep(new CreateIndexStep(new BusinessValueTargetIndexES()))
+        .addUpgradeStep(new CreateIndexStep(new BusinessValueOverviewIndexES()))
         .build();
   }
 }

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/plan/factories/Upgrade89to810PlanFactoryIT.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/plan/factories/Upgrade89to810PlanFactoryIT.java
@@ -9,7 +9,9 @@ package io.camunda.optimize.upgrade.plan.factories;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.optimize.service.db.es.schema.index.BusinessValueOverviewIndexES;
 import io.camunda.optimize.service.db.es.schema.index.BusinessValueTargetIndexES;
+import io.camunda.optimize.service.db.os.schema.index.BusinessValueOverviewIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.BusinessValueTargetIndexOS;
 import io.camunda.optimize.service.db.schema.IndexMappingCreator;
 import io.camunda.optimize.upgrade.AbstractUpgradeIT;
@@ -17,8 +19,9 @@ import io.camunda.optimize.upgrade.plan.UpgradePlan;
 import org.junit.jupiter.api.Test;
 
 /**
- * Verifies that {@link Upgrade89to810PlanFactory} creates the {@code business-value-target} index
- * on an 8.9 cluster, so upgraded and fresh-install schemas stay in parity.
+ * Verifies that {@link Upgrade89to810PlanFactory} creates the {@code business-value-target} and
+ * {@code business-value-overview} indices on an 8.9 cluster, so upgraded and fresh-install schemas
+ * stay in parity.
  */
 public class Upgrade89to810PlanFactoryIT extends AbstractUpgradeIT {
 
@@ -44,9 +47,34 @@ public class Upgrade89to810PlanFactoryIT extends AbstractUpgradeIT {
         .isNotEmpty();
   }
 
+  @Test
+  public void shouldCreateBusinessValueOverviewIndexOnUpgrade() {
+    // given an 8.9 cluster (schema version is set to the previous minor)
+    setMetadataVersion(FROM_PATCH);
+    final IndexMappingCreator businessValueOverviewIndex = businessValueOverviewIndex();
+    assertThat(getIndicesForMapping(businessValueOverviewIndex))
+        .as("business-value-overview index must not exist before the upgrade runs")
+        .isEmpty();
+
+    // when the 8.9 -> 8.10 upgrade plan runs
+    final UpgradePlan plan = new Upgrade89to810PlanFactory().createUpgradePlan(upgradeDependencies);
+    upgradeProcedure.performUpgrade(plan);
+
+    // then the business-value-overview index exists in the database
+    assertThat(getIndicesForMapping(businessValueOverviewIndex))
+        .as("business-value-overview index must exist after the upgrade runs")
+        .isNotEmpty();
+  }
+
   private IndexMappingCreator businessValueTargetIndex() {
     return isElasticSearchUpgrade()
         ? new BusinessValueTargetIndexES()
         : new BusinessValueTargetIndexOS();
+  }
+
+  private IndexMappingCreator businessValueOverviewIndex() {
+    return isElasticSearchUpgrade()
+        ? new BusinessValueOverviewIndexES()
+        : new BusinessValueOverviewIndexOS();
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/businessvalue/BusinessValueOverviewDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/businessvalue/BusinessValueOverviewDto.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.businessvalue;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.camunda.optimize.dto.optimize.OptimizeDto;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+public class BusinessValueOverviewDto implements OptimizeDto {
+
+  private String tenantId;
+  private String processDefinitionKey;
+  private String processDefinitionName;
+  private MetricRange metricRange;
+  private OffsetDateTime lastComputedAt;
+  private CycleTimeBlock cycleTime;
+  private AutomationRateBlock automationRate;
+  private boolean hasAnyTarget;
+  private int targetsSet;
+  private int targetsMet;
+
+  public BusinessValueOverviewDto() {}
+
+  public BusinessValueOverviewDto(
+      final String tenantId,
+      final String processDefinitionKey,
+      final String processDefinitionName,
+      final MetricRange metricRange,
+      final OffsetDateTime lastComputedAt,
+      final CycleTimeBlock cycleTime,
+      final AutomationRateBlock automationRate,
+      final boolean hasAnyTarget,
+      final int targetsSet,
+      final int targetsMet) {
+    this.tenantId = tenantId;
+    this.processDefinitionKey = processDefinitionKey;
+    this.processDefinitionName = processDefinitionName;
+    this.metricRange = metricRange;
+    this.lastComputedAt = lastComputedAt;
+    this.cycleTime = cycleTime;
+    this.automationRate = automationRate;
+    this.hasAnyTarget = hasAnyTarget;
+    this.targetsSet = targetsSet;
+    this.targetsMet = targetsMet;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public String getProcessDefinitionName() {
+    return processDefinitionName;
+  }
+
+  public void setProcessDefinitionName(final String processDefinitionName) {
+    this.processDefinitionName = processDefinitionName;
+  }
+
+  public MetricRange getMetricRange() {
+    return metricRange;
+  }
+
+  public void setMetricRange(final MetricRange metricRange) {
+    this.metricRange = metricRange;
+  }
+
+  public OffsetDateTime getLastComputedAt() {
+    return lastComputedAt;
+  }
+
+  public void setLastComputedAt(final OffsetDateTime lastComputedAt) {
+    this.lastComputedAt = lastComputedAt;
+  }
+
+  public CycleTimeBlock getCycleTime() {
+    return cycleTime;
+  }
+
+  public void setCycleTime(final CycleTimeBlock cycleTime) {
+    this.cycleTime = cycleTime;
+  }
+
+  public AutomationRateBlock getAutomationRate() {
+    return automationRate;
+  }
+
+  public void setAutomationRate(final AutomationRateBlock automationRate) {
+    this.automationRate = automationRate;
+  }
+
+  public boolean isHasAnyTarget() {
+    return hasAnyTarget;
+  }
+
+  public void setHasAnyTarget(final boolean hasAnyTarget) {
+    this.hasAnyTarget = hasAnyTarget;
+  }
+
+  public int getTargetsSet() {
+    return targetsSet;
+  }
+
+  public void setTargetsSet(final int targetsSet) {
+    this.targetsSet = targetsSet;
+  }
+
+  public int getTargetsMet() {
+    return targetsMet;
+  }
+
+  public void setTargetsMet(final int targetsMet) {
+    this.targetsMet = targetsMet;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BusinessValueOverviewDto that = (BusinessValueOverviewDto) o;
+    return hasAnyTarget == that.hasAnyTarget
+        && targetsSet == that.targetsSet
+        && targetsMet == that.targetsMet
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionName, that.processDefinitionName)
+        && metricRange == that.metricRange
+        && Objects.equals(lastComputedAt, that.lastComputedAt)
+        && Objects.equals(cycleTime, that.cycleTime)
+        && Objects.equals(automationRate, that.automationRate);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        tenantId,
+        processDefinitionKey,
+        processDefinitionName,
+        metricRange,
+        lastComputedAt,
+        cycleTime,
+        automationRate,
+        hasAnyTarget,
+        targetsSet,
+        targetsMet);
+  }
+
+  @Override
+  public String toString() {
+    return "BusinessValueOverviewDto(tenantId="
+        + tenantId
+        + ", processDefinitionKey="
+        + processDefinitionKey
+        + ", processDefinitionName="
+        + processDefinitionName
+        + ", metricRange="
+        + metricRange
+        + ", lastComputedAt="
+        + lastComputedAt
+        + ", cycleTime="
+        + cycleTime
+        + ", automationRate="
+        + automationRate
+        + ", hasAnyTarget="
+        + hasAnyTarget
+        + ", targetsSet="
+        + targetsSet
+        + ", targetsMet="
+        + targetsMet
+        + ")";
+  }
+
+  public enum MetricRange {
+    SEVEN_DAYS("7d"),
+    THIRTY_DAYS("30d"),
+    THREE_MONTHS("3m"),
+    SIX_MONTHS("6m");
+
+    private final String id;
+
+    MetricRange(final String id) {
+      this.id = id;
+    }
+
+    @JsonValue
+    public String getId() {
+      return id;
+    }
+
+    public static MetricRange fromId(final String id) {
+      for (final MetricRange range : values()) {
+        if (range.id.equals(id)) {
+          return range;
+        }
+      }
+      throw new IllegalArgumentException(
+          "Unknown metricRange id [" + id + "]; must be one of: 7d, 30d, 3m, 6m");
+    }
+  }
+
+  public static class CycleTimeBlock {
+
+    private Long value;
+    private Long target;
+    private Boolean met;
+
+    public CycleTimeBlock() {}
+
+    public CycleTimeBlock(final Long value, final Long target, final Boolean met) {
+      this.value = value;
+      this.target = target;
+      this.met = met;
+    }
+
+    public Long getValue() {
+      return value;
+    }
+
+    public void setValue(final Long value) {
+      this.value = value;
+    }
+
+    public Long getTarget() {
+      return target;
+    }
+
+    public void setTarget(final Long target) {
+      this.target = target;
+    }
+
+    public Boolean getMet() {
+      return met;
+    }
+
+    public void setMet(final Boolean met) {
+      this.met = met;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final CycleTimeBlock that = (CycleTimeBlock) o;
+      return Objects.equals(value, that.value)
+          && Objects.equals(target, that.target)
+          && Objects.equals(met, that.met);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(value, target, met);
+    }
+
+    @Override
+    public String toString() {
+      return "CycleTimeBlock(value=" + value + ", target=" + target + ", met=" + met + ")";
+    }
+  }
+
+  public static class AutomationRateBlock {
+
+    private Double value;
+    private Integer target;
+    private Boolean met;
+
+    public AutomationRateBlock() {}
+
+    public AutomationRateBlock(final Double value, final Integer target, final Boolean met) {
+      this.value = value;
+      this.target = target;
+      this.met = met;
+    }
+
+    public Double getValue() {
+      return value;
+    }
+
+    public void setValue(final Double value) {
+      this.value = value;
+    }
+
+    public Integer getTarget() {
+      return target;
+    }
+
+    public void setTarget(final Integer target) {
+      this.target = target;
+    }
+
+    public Boolean getMet() {
+      return met;
+    }
+
+    public void setMet(final Boolean met) {
+      this.met = met;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final AutomationRateBlock that = (AutomationRateBlock) o;
+      return Objects.equals(value, that.value)
+          && Objects.equals(target, that.target)
+          && Objects.equals(met, that.met);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(value, target, met);
+    }
+
+    @Override
+    public String toString() {
+      return "AutomationRateBlock(value=" + value + ", target=" + target + ", met=" + met + ")";
+    }
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
+  public static final class Fields {
+
+    public static final String tenantId = "tenantId";
+    public static final String processDefinitionKey = "processDefinitionKey";
+    public static final String processDefinitionName = "processDefinitionName";
+    public static final String metricRange = "metricRange";
+    public static final String lastComputedAt = "lastComputedAt";
+    public static final String cycleTime = "cycleTime";
+    public static final String automationRate = "automationRate";
+    public static final String hasAnyTarget = "hasAnyTarget";
+    public static final String targetsSet = "targetsSet";
+    public static final String targetsMet = "targetsMet";
+    public static final String value = "value";
+    public static final String target = "target";
+    public static final String met = "met";
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseConstants.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseConstants.java
@@ -51,6 +51,7 @@ public final class DatabaseConstants {
   public static final String VARIABLE_LABEL_INDEX_NAME = "variable-label";
   public static final String PROCESS_OVERVIEW_INDEX_NAME = "process-overview";
   public static final String BUSINESS_VALUE_TARGET_INDEX_NAME = "business-value-target";
+  public static final String BUSINESS_VALUE_OVERVIEW_INDEX_NAME = "business-value-overview";
   public static final String INSTANT_DASHBOARD_INDEX_NAME = "instant-dashboard";
   public static final String ZEEBE_PROCESS_DEFINITION_INDEX_NAME = "process";
   public static final String ZEEBE_PROCESS_INSTANCE_INDEX_NAME = "process-instance";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/ElasticSearchSchemaManager.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/ElasticSearchSchemaManager.java
@@ -24,6 +24,7 @@ import io.camunda.optimize.service.db.es.MappingMetadataUtilES;
 import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
 import io.camunda.optimize.service.db.es.schema.index.AlertIndexES;
 import io.camunda.optimize.service.db.es.schema.index.BusinessKeyIndexES;
+import io.camunda.optimize.service.db.es.schema.index.BusinessValueOverviewIndexES;
 import io.camunda.optimize.service.db.es.schema.index.BusinessValueTargetIndexES;
 import io.camunda.optimize.service.db.es.schema.index.CollectionIndexES;
 import io.camunda.optimize.service.db.es.schema.index.DashboardIndexES;
@@ -380,6 +381,7 @@ public class ElasticSearchSchemaManager
     return Arrays.asList(
         new AlertIndexES(),
         new BusinessKeyIndexES(),
+        new BusinessValueOverviewIndexES(),
         new BusinessValueTargetIndexES(),
         new CollectionIndexES(),
         new DashboardIndexES(),

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/index/BusinessValueOverviewIndexES.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/index/BusinessValueOverviewIndexES.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.schema.index;
+
+import co.elastic.clients.elasticsearch.indices.IndexSettings;
+import io.camunda.optimize.service.db.schema.index.BusinessValueOverviewIndex;
+import java.io.IOException;
+
+public class BusinessValueOverviewIndexES
+    extends BusinessValueOverviewIndex<IndexSettings.Builder> {
+
+  @Override
+  public IndexSettings.Builder addStaticSetting(
+      final String key, final int value, final IndexSettings.Builder builder) throws IOException {
+    return builder.numberOfShards(Integer.toString(value));
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/OpenSearchSchemaManager.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/OpenSearchSchemaManager.java
@@ -22,6 +22,7 @@ import io.camunda.optimize.service.db.os.MappingMetadataUtilOS;
 import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.os.schema.index.AlertIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.BusinessKeyIndexOS;
+import io.camunda.optimize.service.db.os.schema.index.BusinessValueOverviewIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.BusinessValueTargetIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.CollectionIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.DashboardIndexOS;
@@ -551,6 +552,7 @@ public class OpenSearchSchemaManager
     return Arrays.asList(
         new AlertIndexOS(),
         new BusinessKeyIndexOS(),
+        new BusinessValueOverviewIndexOS(),
         new BusinessValueTargetIndexOS(),
         new CollectionIndexOS(),
         new DashboardIndexOS(),

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/index/BusinessValueOverviewIndexOS.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/index/BusinessValueOverviewIndexOS.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.schema.index;
+
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchUtil;
+import io.camunda.optimize.service.db.schema.index.BusinessValueOverviewIndex;
+import org.opensearch.client.opensearch.indices.IndexSettings;
+
+public class BusinessValueOverviewIndexOS
+    extends BusinessValueOverviewIndex<IndexSettings.Builder> {
+
+  @Override
+  public IndexSettings.Builder addStaticSetting(
+      final String key, final int value, final IndexSettings.Builder contentBuilder) {
+    return OptimizeOpenSearchUtil.addStaticSetting(key, value, contentBuilder);
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/IndexLookupUtil.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/IndexLookupUtil.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service.db.schema;
 
 import io.camunda.optimize.service.db.es.schema.index.AlertIndexES;
 import io.camunda.optimize.service.db.es.schema.index.BusinessKeyIndexES;
+import io.camunda.optimize.service.db.es.schema.index.BusinessValueOverviewIndexES;
 import io.camunda.optimize.service.db.es.schema.index.BusinessValueTargetIndexES;
 import io.camunda.optimize.service.db.es.schema.index.CollectionIndexES;
 import io.camunda.optimize.service.db.es.schema.index.DashboardIndexES;
@@ -34,6 +35,7 @@ import io.camunda.optimize.service.db.es.schema.index.report.SingleDecisionRepor
 import io.camunda.optimize.service.db.es.schema.index.report.SingleProcessReportIndexES;
 import io.camunda.optimize.service.db.os.schema.index.AlertIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.BusinessKeyIndexOS;
+import io.camunda.optimize.service.db.os.schema.index.BusinessValueOverviewIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.BusinessValueTargetIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.CollectionIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.DashboardIndexOS;
@@ -113,6 +115,9 @@ public class IndexLookupUtil {
     lookupMap.put(AlertIndexES.class.getSimpleName(), index -> new AlertIndexOS());
     lookupMap.put(BusinessKeyIndexES.class.getSimpleName(), index -> new BusinessKeyIndexOS());
     lookupMap.put(
+        BusinessValueOverviewIndexES.class.getSimpleName(),
+        index -> new BusinessValueOverviewIndexOS());
+    lookupMap.put(
         BusinessValueTargetIndexES.class.getSimpleName(),
         index -> new BusinessValueTargetIndexOS());
     lookupMap.put(CollectionIndexES.class.getSimpleName(), index -> new CollectionIndexOS());
@@ -165,6 +170,9 @@ public class IndexLookupUtil {
     // OpenSearch -> ElasticSearch Index lookup functions
     lookupMap.put(AlertIndexOS.class.getSimpleName(), index -> new AlertIndexES());
     lookupMap.put(BusinessKeyIndexOS.class.getSimpleName(), index -> new BusinessKeyIndexES());
+    lookupMap.put(
+        BusinessValueOverviewIndexOS.class.getSimpleName(),
+        index -> new BusinessValueOverviewIndexES());
     lookupMap.put(
         BusinessValueTargetIndexOS.class.getSimpleName(),
         index -> new BusinessValueTargetIndexES());

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/BusinessValueOverviewIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/BusinessValueOverviewIndex.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.schema.index;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.OPTIMIZE_DATE_FORMAT;
+
+import co.elastic.clients.elasticsearch._types.mapping.Property;
+import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
+import io.camunda.optimize.service.db.DatabaseConstants;
+import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+
+public abstract class BusinessValueOverviewIndex<TBuilder>
+    extends DefaultIndexMappingCreator<TBuilder> {
+
+  public static final int VERSION = 1;
+
+  public static final String TENANT_ID = BusinessValueOverviewDto.Fields.tenantId;
+  public static final String PROCESS_DEFINITION_KEY =
+      BusinessValueOverviewDto.Fields.processDefinitionKey;
+  public static final String PROCESS_DEFINITION_NAME =
+      BusinessValueOverviewDto.Fields.processDefinitionName;
+  public static final String METRIC_RANGE = BusinessValueOverviewDto.Fields.metricRange;
+  public static final String LAST_COMPUTED_AT = BusinessValueOverviewDto.Fields.lastComputedAt;
+  public static final String CYCLE_TIME = BusinessValueOverviewDto.Fields.cycleTime;
+  public static final String AUTOMATION_RATE = BusinessValueOverviewDto.Fields.automationRate;
+  public static final String HAS_ANY_TARGET = BusinessValueOverviewDto.Fields.hasAnyTarget;
+  public static final String TARGETS_SET = BusinessValueOverviewDto.Fields.targetsSet;
+  public static final String TARGETS_MET = BusinessValueOverviewDto.Fields.targetsMet;
+
+  public static final String VALUE = BusinessValueOverviewDto.Fields.value;
+  public static final String TARGET = BusinessValueOverviewDto.Fields.target;
+  public static final String MET = BusinessValueOverviewDto.Fields.met;
+
+  @Override
+  public String getIndexName() {
+    return DatabaseConstants.BUSINESS_VALUE_OVERVIEW_INDEX_NAME;
+  }
+
+  @Override
+  public int getVersion() {
+    return VERSION;
+  }
+
+  @Override
+  public TypeMapping.Builder addProperties(final TypeMapping.Builder builder) {
+    return builder
+        .properties(TENANT_ID, p -> p.keyword(k -> k))
+        .properties(PROCESS_DEFINITION_KEY, p -> p.keyword(k -> k))
+        .properties(PROCESS_DEFINITION_NAME, p -> p.keyword(k -> k))
+        .properties(METRIC_RANGE, p -> p.keyword(k -> k))
+        .properties(LAST_COMPUTED_AT, Property.of(p -> p.date(d -> d.format(OPTIMIZE_DATE_FORMAT))))
+        .properties(
+            CYCLE_TIME,
+            p ->
+                p.object(
+                    o ->
+                        o.properties(VALUE, v -> v.long_(l -> l))
+                            .properties(TARGET, t -> t.long_(l -> l))
+                            .properties(MET, m -> m.boolean_(b -> b))))
+        .properties(
+            AUTOMATION_RATE,
+            p ->
+                p.object(
+                    o ->
+                        o.properties(VALUE, v -> v.double_(d -> d))
+                            .properties(TARGET, t -> t.integer(i -> i))
+                            .properties(MET, m -> m.boolean_(b -> b))))
+        .properties(HAS_ANY_TARGET, p -> p.boolean_(b -> b))
+        .properties(TARGETS_SET, p -> p.integer(i -> i))
+        .properties(TARGETS_MET, p -> p.integer(i -> i));
+  }
+}


### PR DESCRIPTION
Closes camunda/camunda-hub#27019 (M2.3 of the [M2 backend milestone](https://github.com/camunda/camunda-hub/issues/27016)).

## What

Adds the precomputed `business-value-overview` index — schema, dual-backend index classes (ES + OS), repository, writer, and unit tests. No compute or scheduler logic yet; those land in M2.4 and read/write against the primitives introduced here.

Row shape:

```
DOC ID: {tenantId}::{processDefinitionKey}::{metricRange}   // metricRange ∈ 7d | 30d | 3m | 6m
```

Fields: `tenantId`, `processDefinitionKey`, `processDefinitionName`, `metricRange`, `lastComputedAt`, two per-KPI blocks (`cycleTime`, `automationRate`) each `{ value, target, met }`, and denormalized rollup counters (`hasAnyTarget`, `targetsSet`, `targetsMet`). No volume block — volume is metric-only in v1.

Writer exposes two intent-named entry points: `bulkUpsertFromScheduler` (default async refresh) and `bulkUpsertFromTargetWrite` (`Refresh.True`). Repository reads: `getByKey` by composite id, `readByRange` with a term filter on `metricRange`.

Also piggy-backs a small fix on the sibling target-index validators (introduced on the base branch): tightens `tenantId == null` → `StringUtils.isBlank(tenantId)` so whitespace/empty identifiers no longer produce malformed composite doc ids. Reviewed as a separate commit.

## Why

M1 shipped the seeded BVD reports. M2 delivers the target-setting + attainment-rollup primitives that Hub M3 will consume when the FE ships. `/overview` on the read path (M2.6) is a strategic surface — attainment donuts, off-target list — with roughly 30 process definitions × 4 range presets. Evaluating the underlying reports live per request wastes compute and couples read latency to ES cluster health; the design ([Technical Solution](https://docs.google.com/document/d/1R-qBPFTgtg32dqv0UW7febCD6mlABbFQjbHiouRRxhA/edit?tab=t.fiziz17vicu7#heading=h.tgcab4k4bo9x)) precomputes rows once per tick and lets `/overview` sum them in-memory. This PR adds only the storage layer; M2.4 fills in the compute function + tiered scheduler that populate rows, and M2.6 wires the REST handler.

The two-mode writer matches Optimize's own `ProcessOverviewRepository` pattern in production: scheduler ticks don't need forced refresh (freshness bounded by tick interval), but target-write recompute must be `Refresh.True` so the user's next `/overview` reflects their save immediately. `MetricRange` uses `@JsonValue` for the same reason `TargetValueUnit` does — otherwise Jackson serializes enum names and stored docs would be addressable by `"THIRTY_DAYS"` while queries filter on `"30d"`, returning zero results silently.

## How to verify

```bash
# From optimize/
../mvnw license:format spotless:apply -T1C
../mvnw test -pl backend -Dtest='BusinessValueOverviewWriterTest,BusinessValueOverviewRepositoryTest,BusinessValueTargetWriterTest,BusinessValueTargetRepositoryTest' -T1C
../mvnw install -pl backend -am -DskipTests -T1C

# From repo root
./mvnw install -Dquickly -T1C
```

Expected: 48 unit tests green, full-repo compile clean.

Optional manual sanity: start Optimize against an ES cluster and check the new index appears on schema-manager startup —
`curl -s $ES/_cat/indices | grep business-value-overview`. Not gated on this for M2.3.

### Test coverage of the design invariants

- `shouldSerializeMetricRangeAsIdString` — locks the `@JsonValue` alignment; a regression would recreate the silent-zero-result bug.
- `shouldForwardSchedulerUpsertWithoutForcedRefresh` / `shouldForwardTargetWriteUpsertWithForcedRefresh` — cover the two-mode refresh contract.
- `shouldReject{Row,Null,Blank}...` — 8 rejection cases across null / blank identifiers, missing metricRange / lastComputedAt, inconsistent `targetsSet` / `targetsMet` / `hasAnyTarget`, and per-KPI `met` invariants.
- `shouldAcceptRowWithNoTargetsSet` — first-scheduler-tick shape where no targets exist yet.