### PR TITLE
Drop request-level loopIteration from AgentInstanceRecord

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDto.java
@@ -32,7 +32,6 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
   private String tenantId;
   private long jobKey = -1L;
   private String jobLease;
-  private int loopIteration;
   private AgentInstanceStatus status;
   private AgentDefinitionValueDto definition = new AgentDefinitionValueDto();
   private AgentMetricsValueDto metrics = new AgentMetricsValueDto();
@@ -155,15 +154,6 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
     this.jobLease = jobLease;
   }
 
-  @Override
-  public int getLoopIteration() {
-    return loopIteration;
-  }
-
-  public void setLoopIteration(final int loopIteration) {
-    this.loopIteration = loopIteration;
-  }
-
   // Not tracked — Optimize's import doesn't need the embedded history batch, only the
   // instance-level fields above.
   @Override
@@ -245,7 +235,6 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
         tenantId,
         jobKey,
         jobLease,
-        loopIteration,
         status,
         definition,
         metrics,
@@ -266,7 +255,6 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
         && processDefinitionKey == that.processDefinitionKey
         && processDefinitionVersion == that.processDefinitionVersion
         && jobKey == that.jobKey
-        && loopIteration == that.loopIteration
         && Objects.equals(elementInstanceKeys, that.elementInstanceKeys)
         && Objects.equals(elementId, that.elementId)
         && Objects.equals(bpmnProcessId, that.bpmnProcessId)
@@ -301,8 +289,6 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
         + jobKey
         + ", jobLease="
         + jobLease
-        + ", loopIteration="
-        + loopIteration
         + ", status="
         + status
         + ", definition="
@@ -330,7 +316,6 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
     public static final String tenantId = "tenantId";
     public static final String jobKey = "jobKey";
     public static final String jobLease = "jobLease";
-    public static final String loopIteration = "loopIteration";
     public static final String status = "status";
     public static final String definition = "definition";
     public static final String metrics = "metrics";

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-template.json
@@ -128,9 +128,6 @@
             "jobLease": {
               "type": "keyword"
             },
-            "loopIteration": {
-              "type": "integer"
-            },
             "history": {
               "properties": {
                 "agentHistoryKey": {

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-template.json
@@ -134,9 +134,6 @@
             "jobLease": {
               "type": "keyword"
             },
-            "loopIteration": {
-              "type": "integer"
-            },
             "history": {
               "properties": {
                 "agentHistoryKey": {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
@@ -72,12 +72,11 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
       new ArrayProperty<>("changedAttributes", StringValue::new);
   private final LongProperty jobKeyProp = new LongProperty("jobKey", -1L);
   private final StringProperty jobLeaseProp = new StringProperty("jobLease", "");
-  private final IntegerProperty loopIterationProp = new IntegerProperty("loopIteration", 0);
   private final ArrayProperty<AgentHistoryRecord> historyProp =
       new ArrayProperty<>("history", AgentHistoryRecord::new);
 
   public AgentInstanceRecord() {
-    super(22);
+    super(21);
     declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(elementInstanceKeysProp)
@@ -98,7 +97,6 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
         .declareProperty(changedAttributesProp)
         .declareProperty(jobKeyProp)
         .declareProperty(jobLeaseProp)
-        .declareProperty(loopIterationProp)
         .declareProperty(historyProp);
   }
 
@@ -289,16 +287,6 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord setJobLease(final String jobLease) {
     jobLeaseProp.setValue(jobLease);
-    return this;
-  }
-
-  @Override
-  public int getLoopIteration() {
-    return loopIterationProp.getValue();
-  }
-
-  public AgentInstanceRecord setLoopIteration(final int loopIteration) {
-    loopIterationProp.setValue(loopIteration);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -5279,7 +5279,6 @@ final class JsonSerializableToJsonTest {
           "changedAttributes": ["status", "metrics"],
           "jobKey": -1,
           "jobLease": "",
-          "loopIteration": 0,
           "history": [],
           "storageOrdinalKey": 11
         }
@@ -5309,7 +5308,6 @@ final class JsonSerializableToJsonTest {
           "changedAttributes": [],
           "jobKey": -1,
           "jobLease": "",
-          "loopIteration": 0,
           "history": [],
           "storageOrdinalKey": 0
         }
@@ -5345,7 +5343,6 @@ final class JsonSerializableToJsonTest {
                   new AgentInstanceRecord()
                       .setJobKey(2251799813685252L)
                       .setJobLease("job-lease-abc123")
-                      .setLoopIteration(3)
                       .setHistory(List.of(item));
               return record;
             },
@@ -5370,7 +5367,6 @@ final class JsonSerializableToJsonTest {
           "changedAttributes": [],
           "jobKey": 2251799813685252,
           "jobLease": "job-lease-abc123",
-          "loopIteration": 3,
           "history": [
             {
               "agentHistoryKey": -1,

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
@@ -324,17 +324,13 @@ final class AgentInstanceRecordTest {
     final AgentInstanceRecord record = new AgentInstanceRecord();
     assertThat(record.getJobKey()).isEqualTo(-1L);
     assertThat(record.getJobLease()).isEmpty();
-    assertThat(record.getLoopIteration()).isZero();
   }
 
   @Test
   void shouldRoundTripJobFieldsViaMsgPack() {
     // given
     final AgentInstanceRecord original =
-        new AgentInstanceRecord()
-            .setJobKey(2251799813685300L)
-            .setJobLease("job-lease-xyz789")
-            .setLoopIteration(4);
+        new AgentInstanceRecord().setJobKey(2251799813685300L).setJobLease("job-lease-xyz789");
 
     // when
     final AgentInstanceRecord copy = new AgentInstanceRecord();
@@ -343,7 +339,6 @@ final class AgentInstanceRecordTest {
     // then
     assertThat(copy.getJobKey()).isEqualTo(2251799813685300L);
     assertThat(copy.getJobLease()).isEqualTo("job-lease-xyz789");
-    assertThat(copy.getLoopIteration()).isEqualTo(4);
   }
 
   @Test

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
@@ -72,12 +72,11 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
       new ArrayProperty<>("changedAttributes", StringValue::new);
   private final LongProperty jobKeyProp = new LongProperty("jobKey", -1L);
   private final StringProperty jobLeaseProp = new StringProperty("jobLease", "");
-  private final IntegerProperty loopIterationProp = new IntegerProperty("loopIteration", 0);
   private final ArrayProperty<AgentHistoryRecord> historyProp =
       new ArrayProperty<>("history", AgentHistoryRecord::new);
 
   public AgentInstanceRecord() {
-    super(22);
+    super(21);
     declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(elementInstanceKeysProp)
@@ -98,7 +97,6 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
         .declareProperty(changedAttributesProp)
         .declareProperty(jobKeyProp)
         .declareProperty(jobLeaseProp)
-        .declareProperty(loopIterationProp)
         .declareProperty(historyProp);
   }
 
@@ -289,16 +287,6 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord setJobLease(final String jobLease) {
     jobLeaseProp.setValue(jobLease);
-    return this;
-  }
-
-  @Override
-  public int getLoopIteration() {
-    return loopIterationProp.getValue();
-  }
-
-  public AgentInstanceRecord setLoopIteration(final int loopIteration) {
-    loopIterationProp.setValue(loopIteration);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
@@ -128,12 +128,6 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
   String getJobLease();
 
   /**
-   * @return the loopIteration this command belongs to; a loopIteration is one pass through the
-   *     agent feedback loop: one LLM call, its tool dispatches, and their results
-   */
-  int getLoopIteration();
-
-  /**
    * @return the batch of history items carried by this command, each reusing the same shape as a
    *     persisted {@code AgentHistoryRecord} entry
    */


### PR DESCRIPTION
## Summary

`#58790` shipped `jobKey`/`jobLease`/`loopIteration` as request-level fields on `AgentInstanceRecord` (merged, #59477). Resolved 2026-08-07 in https://camunda.slack.com/archives/C0AH08C7UA2/p1786034995344059: a single job worker activation can span more than one loop iteration (the connectors team's `pause_turn` case — one activation covering both iteration 2 and 3), which a single request-level value can't express.

`loopIteration` already exists per item on `AgentHistoryRecord` (from the job-lease work, `#54844`/`#54846`), so this is a pure removal, not a migration: drops the redundant, insufficient request-level copy from `AgentInstanceRecord`, its protocol interface, and both ES/OS `zeebe-record-agent-instance-template.json` files. `jobKey`/`jobLease` are unaffected and stay request-level — one worker holding one activation genuinely submits the whole batch under a single lease.

## Test plan

- [x] `AgentInstanceRecordTest` — 26 tests, 0 failures
- [x] `JsonSerializableToJsonTest` — 135 tests, 0 failures
- [x] `RecordGoldenFilesTest` — 119 tests, 0 failures (golden file regenerated to match)
- [x] `spotless:apply license:format` — clean, no diff
- [x] License headers on touched files verified unchanged (`zeebe/protocol` Apache-2.0, `zeebe/protocol-impl` Camunda License 1.0)
- [x] Repo-wide grep confirms the per-item `loopIteration` on `AgentHistoryRecord`/`AgentHistoryEntity`/RDBMS/ES/OS is untouched