### PR TITLE
feat: add suspend/resume API clients and mutation hooks for Operate

### DIFF
--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.12.1",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.87",
+        "@camunda/camunda-api-zod-schemas": "0.0.88",
         "@camunda/camunda-composite-components": "0.25.2",
         "@carbon/elements": "11.94.0",
         "@carbon/react": "1.112.0",
@@ -498,9 +498,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.87",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.87.tgz",
-      "integrity": "sha512-Z46n48+QsneVZDeP+nWR0tcJ71Bo7kj+uCKTDRr1AWtjQTfWTU64/QzKxsqyZOnthIeQwnKOZup7q8kkneiTiA==",
+      "version": "0.0.88",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.88.tgz",
+      "integrity": "sha512-64lGqSG43uv6PdkeZmL7ZOAWZ1EGx+5Z5RUhDczyaMJC05npzeqzRUKLcJJ4Dy8G++3xemLzke25IgNVjdK4/A==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.12.1",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.87",
+    "@camunda/camunda-api-zod-schemas": "0.0.88",
     "@camunda/camunda-composite-components": "0.25.2",
     "@carbon/elements": "11.94.0",
     "@carbon/react": "1.112.0",

--- a/operate/client/src/modules/api/v2/processInstances/resumeProcessInstance.ts
+++ b/operate/client/src/modules/api/v2/processInstances/resumeProcessInstance.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  endpoints,
+  type ProcessInstance,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import {requestWithThrow} from 'modules/request';
+
+const resumeProcessInstance = async (
+  processInstanceKey: ProcessInstance['processInstanceKey'],
+) => {
+  return requestWithThrow<null>({
+    url: endpoints.resumeProcessInstance.getUrl({processInstanceKey}),
+    method: endpoints.resumeProcessInstance.method,
+    responseType: 'none',
+  });
+};
+
+export {resumeProcessInstance};

--- a/operate/client/src/modules/api/v2/processInstances/suspendProcessInstance.ts
+++ b/operate/client/src/modules/api/v2/processInstances/suspendProcessInstance.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  endpoints,
+  type ProcessInstance,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import {requestWithThrow} from 'modules/request';
+
+const suspendProcessInstance = async (
+  processInstanceKey: ProcessInstance['processInstanceKey'],
+) => {
+  return requestWithThrow<null>({
+    url: endpoints.suspendProcessInstance.getUrl({processInstanceKey}),
+    method: endpoints.suspendProcessInstance.method,
+    responseType: 'none',
+  });
+};
+
+export {suspendProcessInstance};

--- a/operate/client/src/modules/mocks/api/v2/processInstances/resumeProcessInstance.ts
+++ b/operate/client/src/modules/mocks/api/v2/processInstances/resumeProcessInstance.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {endpoints} from '@camunda/camunda-api-zod-schemas/8.10';
+import {mockPostRequest} from '../../mockRequest';
+
+const mockResumeProcessInstance = (contextPath = '') =>
+  mockPostRequest(
+    `${contextPath}${endpoints.resumeProcessInstance.getUrl({processInstanceKey: ':processInstanceKey'})}`,
+  );
+
+export {mockResumeProcessInstance};

--- a/operate/client/src/modules/mocks/api/v2/processInstances/suspendProcessInstance.ts
+++ b/operate/client/src/modules/mocks/api/v2/processInstances/suspendProcessInstance.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {endpoints} from '@camunda/camunda-api-zod-schemas/8.10';
+import {mockPostRequest} from '../../mockRequest';
+
+const mockSuspendProcessInstance = (contextPath = '') =>
+  mockPostRequest(
+    `${contextPath}${endpoints.suspendProcessInstance.getUrl({processInstanceKey: ':processInstanceKey'})}`,
+  );
+
+export {mockSuspendProcessInstance};

--- a/operate/client/src/modules/mutations/processInstance/useChangeProcessInstanceState.test.tsx
+++ b/operate/client/src/modules/mutations/processInstance/useChangeProcessInstanceState.test.tsx
@@ -1,0 +1,213 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {renderHook, waitFor} from '@testing-library/react';
+import {QueryClientProvider} from '@tanstack/react-query';
+import type {ReactNode} from 'react';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockSuspendProcessInstance} from 'modules/mocks/api/v2/processInstances/suspendProcessInstance';
+import {mockResumeProcessInstance} from 'modules/mocks/api/v2/processInstances/resumeProcessInstance';
+import {createProcessInstance} from 'modules/testUtils';
+import {queryKeys} from 'modules/queries/queryKeys';
+import {useSuspendProcessInstance} from './useSuspendProcessInstance';
+import {useResumeProcessInstance} from './useResumeProcessInstance';
+
+const processInstanceKey = '2251799813685294';
+
+const createWrapper = () => {
+  const queryClient = getMockQueryClient();
+  const wrapper = ({children}: {children: ReactNode}) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return {queryClient, wrapper};
+};
+
+describe('useChangeProcessInstanceState', () => {
+  it('should suspend a process instance and cache the SUSPENDED result once observed', async () => {
+    mockSuspendProcessInstance().withSuccess(null);
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({processInstanceKey, state: 'SUSPENDED'}),
+    );
+
+    const {queryClient, wrapper} = createWrapper();
+    const {result} = renderHook(
+      () => useSuspendProcessInstance(processInstanceKey),
+      {wrapper},
+    );
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(
+      queryClient.getQueryData(
+        queryKeys.processInstance.get(processInstanceKey),
+      ),
+    ).toEqual(expect.objectContaining({state: 'SUSPENDED'}));
+  });
+
+  it('should resume a process instance and cache the ACTIVE result once observed', async () => {
+    mockResumeProcessInstance().withSuccess(null);
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({processInstanceKey, state: 'ACTIVE'}),
+    );
+
+    const {queryClient, wrapper} = createWrapper();
+    const {result} = renderHook(
+      () => useResumeProcessInstance(processInstanceKey),
+      {wrapper},
+    );
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(
+      queryClient.getQueryData(
+        queryKeys.processInstance.get(processInstanceKey),
+      ),
+    ).toEqual(expect.objectContaining({state: 'ACTIVE'}));
+  });
+
+  it('should treat any non-SUSPENDED state as resumed, including a terminal state', async () => {
+    mockResumeProcessInstance().withSuccess(null);
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({processInstanceKey, state: 'COMPLETED'}),
+    );
+
+    const {queryClient, wrapper} = createWrapper();
+    const {result} = renderHook(
+      () => useResumeProcessInstance(processInstanceKey),
+      {wrapper},
+    );
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(
+      queryClient.getQueryData(
+        queryKeys.processInstance.get(processInstanceKey),
+      ),
+    ).toEqual(expect.objectContaining({state: 'COMPLETED'}));
+  });
+
+  it('should fail without polling when the suspend request itself fails', async () => {
+    const onError = vi.fn();
+    let verificationRequested = false;
+    mockSuspendProcessInstance().withServerError(500);
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({processInstanceKey, state: 'SUSPENDED'}),
+      {
+        mockResolverFn: vi.fn(() => {
+          verificationRequested = true;
+        }),
+      },
+    );
+
+    const {wrapper} = createWrapper();
+    const {result} = renderHook(
+      () => useSuspendProcessInstance(processInstanceKey, {onError}),
+      {wrapper},
+    );
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(verificationRequested).toBe(false);
+  });
+
+  it('should retry verification until the process instance reaches the expected state', async () => {
+    mockSuspendProcessInstance().withSuccess(null);
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({processInstanceKey, state: 'ACTIVE'}),
+    );
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({processInstanceKey, state: 'SUSPENDED'}),
+    );
+
+    const {queryClient, wrapper} = createWrapper();
+    const {result} = renderHook(
+      () => useSuspendProcessInstance(processInstanceKey),
+      {wrapper},
+    );
+
+    result.current.mutate();
+
+    await waitFor(
+      () => {
+        expect(result.current.isSuccess).toBe(true);
+      },
+      {timeout: 5000},
+    );
+
+    expect(
+      queryClient.getQueryData(
+        queryKeys.processInstance.get(processInstanceKey),
+      ),
+    ).toEqual(expect.objectContaining({state: 'SUSPENDED'}));
+  });
+
+  it('should invalidate the process instances list cache on success', async () => {
+    mockSuspendProcessInstance().withSuccess(null);
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({processInstanceKey, state: 'SUSPENDED'}),
+    );
+
+    const {queryClient, wrapper} = createWrapper();
+    const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const {result} = renderHook(
+      () => useSuspendProcessInstance(processInstanceKey),
+      {wrapper},
+    );
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({queryKey: queryKeys.processInstances.base()}),
+    );
+  });
+
+  it('should call onSuccess and onError callbacks', async () => {
+    const onSuccess = vi.fn();
+    mockSuspendProcessInstance().withSuccess(null);
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({processInstanceKey, state: 'SUSPENDED'}),
+    );
+
+    const {wrapper} = createWrapper();
+    const {result} = renderHook(
+      () => useSuspendProcessInstance(processInstanceKey, {onSuccess}),
+      {wrapper},
+    );
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+});

--- a/operate/client/src/modules/mutations/processInstance/useChangeProcessInstanceState.ts
+++ b/operate/client/src/modules/mutations/processInstance/useChangeProcessInstanceState.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import type {
+  ProcessInstance,
+  ProcessInstanceState,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import type {RequestError} from 'modules/request';
+import {fetchProcessInstance} from 'modules/api/v2/processInstances/fetchProcessInstance';
+import {queryKeys} from 'modules/queries/queryKeys';
+
+type StateChangeError = RequestError | Error;
+type StateChangeRequest = (
+  processInstanceKey: ProcessInstance['processInstanceKey'],
+) => Promise<
+  {response: null; error: null} | {response: null; error: RequestError}
+>;
+
+type Options = {
+  onSuccess?: () => void;
+  onError?: (error: StateChangeError) => void;
+};
+
+const useChangeProcessInstanceState = (
+  processInstanceKey: ProcessInstance['processInstanceKey'],
+  expectedState: ProcessInstanceState,
+  request: StateChangeRequest,
+  options?: Options,
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation<null, StateChangeError>({
+    mutationFn: async () => {
+      const {response, error} = await request(processInstanceKey);
+
+      if (error !== null) {
+        throw error;
+      }
+
+      const processInstanceQueryKey =
+        queryKeys.processInstance.get(processInstanceKey);
+      const stateChangeQueryKey = [
+        'processInstanceStateChange',
+        processInstanceKey,
+        expectedState,
+      ];
+      const processInstance = await queryClient.fetchQuery({
+        queryKey: stateChangeQueryKey,
+        queryFn: async () => {
+          const {response: processInstance, error: fetchError} =
+            await fetchProcessInstance(processInstanceKey);
+
+          if (fetchError !== null) {
+            throw fetchError;
+          }
+
+          const hasReachedExpectedState =
+            expectedState === 'ACTIVE'
+              ? processInstance.state !== 'SUSPENDED'
+              : processInstance.state === expectedState;
+
+          if (!hasReachedExpectedState) {
+            throw new Error(
+              `Process instance has not reached ${expectedState} state`,
+            );
+          }
+
+          return processInstance;
+        },
+        retry: 30,
+        retryDelay: 1000,
+        staleTime: 0,
+      });
+
+      queryClient.setQueryData(processInstanceQueryKey, processInstance);
+      queryClient.removeQueries({queryKey: stateChangeQueryKey, exact: true});
+
+      return response;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.processInstances.base(),
+      });
+      options?.onSuccess?.();
+    },
+    onError: options?.onError,
+  });
+};
+
+export {useChangeProcessInstanceState};
+export type {StateChangeError};

--- a/operate/client/src/modules/mutations/processInstance/useResumeProcessInstance.ts
+++ b/operate/client/src/modules/mutations/processInstance/useResumeProcessInstance.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {resumeProcessInstance} from 'modules/api/v2/processInstances/resumeProcessInstance';
+import {
+  useChangeProcessInstanceState,
+  type StateChangeError,
+} from './useChangeProcessInstanceState';
+
+type Options = {
+  onSuccess?: () => void;
+  onError?: (error: StateChangeError) => void;
+};
+
+const useResumeProcessInstance = (
+  processInstanceKey: string,
+  options?: Options,
+) =>
+  useChangeProcessInstanceState(
+    processInstanceKey,
+    'ACTIVE',
+    resumeProcessInstance,
+    options,
+  );
+
+export {useResumeProcessInstance};

--- a/operate/client/src/modules/mutations/processInstance/useSuspendProcessInstance.ts
+++ b/operate/client/src/modules/mutations/processInstance/useSuspendProcessInstance.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {suspendProcessInstance} from 'modules/api/v2/processInstances/suspendProcessInstance';
+import {
+  useChangeProcessInstanceState,
+  type StateChangeError,
+} from './useChangeProcessInstanceState';
+
+type Options = {
+  onSuccess?: () => void;
+  onError?: (error: StateChangeError) => void;
+};
+
+const useSuspendProcessInstance = (
+  processInstanceKey: string,
+  options?: Options,
+) =>
+  useChangeProcessInstanceState(
+    processInstanceKey,
+    'SUSPENDED',
+    suspendProcessInstance,
+    options,
+  );
+
+export {useSuspendProcessInstance};

--- a/operate/client/src/modules/utils/notifications.ts
+++ b/operate/client/src/modules/utils/notifications.ts
@@ -7,6 +7,7 @@
  */
 
 import {notificationsStore} from 'modules/stores/notifications';
+import type {RequestError} from 'modules/request';
 
 const handleMutationError = (options: {
   statusCode: number;
@@ -37,6 +38,19 @@ const handleOperationError = (statusCode?: number) => {
   });
 };
 
+const handleProcessInstanceStateChangeError = (
+  error: RequestError | Error,
+  action: 'suspend' | 'resume',
+) => {
+  const response = error instanceof Error ? null : error.response;
+
+  handleMutationError({
+    statusCode: response?.status ?? 0,
+    title: `Failed to ${action} process instance`,
+    subtitle: error instanceof Error ? error.message : response?.statusText,
+  });
+};
+
 const handleBatchOperationError = (statusCode?: number, title?: string) => {
   if (statusCode === 404) {
     notificationsStore.displayNotification({
@@ -55,4 +69,9 @@ const handleBatchOperationError = (statusCode?: number, title?: string) => {
   });
 };
 
-export {handleOperationError, handleBatchOperationError, handleMutationError};
+export {
+  handleOperationError,
+  handleBatchOperationError,
+  handleMutationError,
+  handleProcessInstanceStateChangeError,
+};

--- a/operate/client/src/modules/utils/processInstance/handleOperationSuccess.ts
+++ b/operate/client/src/modules/utils/processInstance/handleOperationSuccess.ts
@@ -79,6 +79,22 @@ function useHandleOperationSuccess() {
         isDismissable: true,
       });
     }
+
+    if (operationType === 'SUSPEND_PROCESS_INSTANCE') {
+      notificationsStore.displayNotification({
+        kind: 'info',
+        title: 'Instance suspended',
+        isDismissable: true,
+      });
+    }
+
+    if (operationType === 'RESUME_PROCESS_INSTANCE') {
+      notificationsStore.displayNotification({
+        kind: 'info',
+        title: 'Instance resumed',
+        isDismissable: true,
+      });
+    }
   };
 }
 


### PR DESCRIPTION
## What

Second in the series bringing the approved Operate suspend/resume prototype to
production (first was #59592, the schema package).

- Bumps `operate/client`'s `@camunda/camunda-api-zod-schemas` dependency off
  the prototype's local `file:` override to the real published `0.0.88`.
- Fixes the resulting type errors from also picking up the (unrelated,
  already-merged) DRAINING process-definition state change bundled in that
  version range.
- Adds the suspend/resume REST clients, shared mutation hooks
  (`useChangeProcessInstanceState`, `useSuspendProcessInstance`,
  `useResumeProcessInstance`), and shared error/success handlers that the
  detail-view and list-view PRs will build their UI on top of.

No UI changes in this PR — plumbing only.

## Why

Related to #57534, #57535, #57544 — this PR provides the shared foundation
those Operate-side issues need; none of them are closed by this PR alone.

## Verification

- `npm ci`, `ts-check` (full rebuild), `lint:eslint`, `lint:prettier` all
  clean.
- Full `operate/client` test suite: 293 files / 2002 tests passed, 0 failed.
