### PR TITLE
fix: restore x-properties-added-in-version coverage on Authorization schemas

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
@@ -306,6 +306,11 @@ components:
           allOf:
             - $ref: '#/components/schemas/AuthorizationFilter'
           description: The authorization search filters.
+      x-properties-added-in-version:
+        - propertyName: "sort"
+          addedInVersion: "8.8"
+        - propertyName: "filter"
+          addedInVersion: "8.8"
 
     AuthorizationFilter:
       description: Authorization search filter.
@@ -372,6 +377,18 @@ components:
             - $ref: '#/components/schemas/AuthorizationKey'
           description: The key of the authorization.
       x-properties-added-in-version:
+        - propertyName: "ownerId"
+          addedInVersion: "8.8"
+        - propertyName: "ownerType"
+          addedInVersion: "8.8"
+        - propertyName: "resourceType"
+          addedInVersion: "8.8"
+        - propertyName: "resourceId"
+          addedInVersion: "8.8"
+        - propertyName: "permissionTypes"
+          addedInVersion: "8.8"
+        - propertyName: "authorizationKey"
+          addedInVersion: "8.8"
         - propertyName: resourcePropertyName
           addedInVersion: "8.9"
 
@@ -387,6 +404,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AuthorizationResult'
+      x-properties-added-in-version:
+        - propertyName: "items"
+          addedInVersion: "8.8"
 
     AuthorizationCreateResult:
       x-semantic-provider:


### PR DESCRIPTION
## Summary
- PR #58987 added `POST /authentication/me/authorizations/search` (`x-added-in-version: "8.10"`), reusing the existing 8.8-introduced `AuthorizationResult`, `AuthorizationSearchQuery`, and `AuthorizationSearchResult` schemas from `authorizations.yaml`.
- Per the annotation verifier's shared-schema suppression rule (Rule 3 in `.github/scripts/x-added-in-version-check/README.md`), a shared schema's properties only skip explicit annotation when every consuming endpoint's own intro version matches the schema's earliest intro version. Adding the 8.10 consumer broke that match, so the base properties on all three schemas now need explicit `x-properties-added-in-version: "8.8"` entries.
- This went unnoticed at review time because the PR-time equivalent of this check (`openapi-x-added-in-version-check` in `ci.yml`) is currently disabled, as a mitigation for the unrelated backport-drift issue #58872. The nightly scheduled verifier still runs and caught the drift: https://github.com/camunda/camunda/actions/runs/31151039399

Closes #59624

## Test plan
- [x] `node .github/scripts/x-added-in-version-check/verify-specs.mjs` → "All checks passed!" (exit 0), was 9 `MISSING_X_PROPERTIES_ADDED_IN_VERSION` errors
- [x] `spectral lint zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml --ruleset zeebe/gateway-protocol/.spectral.yaml` → 0 errors, 0 hints
- [x] Diff scoped to the 3 affected schemas only (20 lines, 1 file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)