### PR TITLE
Add CONFIGURATION agent-history role and thread its fields through secondary storage

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/AgentInstanceHistoryRole.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/AgentInstanceHistoryRole.java
@@ -20,5 +20,6 @@ public enum AgentInstanceHistoryRole {
   USER,
   ASSISTANT,
   TOOL_RESULT,
+  CONFIGURATION,
   UNKNOWN_ENUM_VALUE
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/AgentInstanceHistory.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/AgentInstanceHistory.java
@@ -49,4 +49,22 @@ public interface AgentInstanceHistory {
   AgentInstanceHistoryCommitStatus getCommitStatus();
 
   OffsetDateTime getProducedAt();
+
+  /** Returns the client-supplied identifier this item was created with, or empty if none. */
+  String getHistoryItemId();
+
+  /** Returns the tools available to the agent as of this entry. CONFIGURATION items only. */
+  List<AgentInstance.Tool> getTools();
+
+  /** Returns the LLM model identifier as of this entry, or {@code null} for other roles. */
+  String getModel();
+
+  /** Returns the LLM provider as of this entry, or {@code null} for other roles. */
+  String getProvider();
+
+  /** Returns the operational limits as of this entry. CONFIGURATION items only. */
+  AgentInstance.Limits getLimits();
+
+  /** Returns the system prompt, as content blocks, as of this entry. CONFIGURATION items only. */
+  List<AgentInstanceHistoryContent> getSystemPrompt();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceHistoryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceHistoryImpl.java
@@ -23,6 +23,7 @@ import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
 import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryCommitStatus;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.client.api.search.response.AgentInstance;
 import io.camunda.client.api.search.response.AgentInstanceHistory;
 import io.camunda.client.impl.response.DocumentReferenceResponseImpl;
 import io.camunda.client.impl.util.EnumUtil;
@@ -30,10 +31,12 @@ import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.AgentInstanceDocumentContent;
 import io.camunda.client.protocol.rest.AgentInstanceHistoryItemMetrics;
 import io.camunda.client.protocol.rest.AgentInstanceHistoryItemResult;
+import io.camunda.client.protocol.rest.AgentInstanceLimits;
 import io.camunda.client.protocol.rest.AgentInstanceMessageContent;
 import io.camunda.client.protocol.rest.AgentInstanceObjectContent;
 import io.camunda.client.protocol.rest.AgentInstanceTextContent;
 import io.camunda.client.protocol.rest.AgentInstanceToolCall;
+import io.camunda.client.protocol.rest.AgentTool;
 import io.camunda.client.protocol.rest.DocumentReference;
 import java.time.OffsetDateTime;
 import java.util.Collections;
@@ -55,6 +58,12 @@ public class AgentInstanceHistoryImpl implements AgentInstanceHistory {
   private final AgentInstanceHistoryMetrics metrics;
   private final AgentInstanceHistoryCommitStatus commitStatus;
   private final OffsetDateTime producedAt;
+  private final String historyItemId;
+  private final List<AgentInstance.Tool> tools;
+  private final String model;
+  private final String provider;
+  private final AgentInstance.Limits limits;
+  private final List<AgentInstanceHistoryContent> systemPrompt;
 
   public AgentInstanceHistoryImpl(final AgentInstanceHistoryItemResult result) {
     historyItemKey = Long.parseLong(result.getHistoryItemKey());
@@ -80,6 +89,20 @@ public class AgentInstanceHistoryImpl implements AgentInstanceHistory {
     commitStatus =
         EnumUtil.convert(result.getCommitStatus(), AgentInstanceHistoryCommitStatus.class);
     producedAt = ParseUtil.parseOffsetDateTimeOrNull(result.getProducedAt());
+    historyItemId = result.getHistoryItemId();
+    tools =
+        result.getTools() != null
+            ? result.getTools().stream().map(ToolImpl::new).collect(Collectors.toList())
+            : Collections.emptyList();
+    model = result.getModel();
+    provider = result.getProvider();
+    limits = result.getLimits() != null ? new LimitsImpl(result.getLimits()) : null;
+    systemPrompt =
+        result.getSystemPrompt() != null
+            ? result.getSystemPrompt().stream()
+                .map(AgentInstanceHistoryImpl::toContent)
+                .collect(Collectors.toList())
+            : Collections.emptyList();
   }
 
   @Override
@@ -142,6 +165,36 @@ public class AgentInstanceHistoryImpl implements AgentInstanceHistory {
     return producedAt;
   }
 
+  @Override
+  public String getHistoryItemId() {
+    return historyItemId;
+  }
+
+  @Override
+  public List<AgentInstance.Tool> getTools() {
+    return tools;
+  }
+
+  @Override
+  public String getModel() {
+    return model;
+  }
+
+  @Override
+  public String getProvider() {
+    return provider;
+  }
+
+  @Override
+  public AgentInstance.Limits getLimits() {
+    return limits;
+  }
+
+  @Override
+  public List<AgentInstanceHistoryContent> getSystemPrompt() {
+    return systemPrompt;
+  }
+
   private static AgentInstanceHistoryContent toContent(final AgentInstanceMessageContent proto) {
     if (proto instanceof AgentInstanceTextContent) {
       return new TextContent(((AgentInstanceTextContent) proto).getText());
@@ -174,5 +227,61 @@ public class AgentInstanceHistoryImpl implements AgentInstanceHistory {
         .inputTokens(proto.getInputTokens())
         .outputTokens(proto.getOutputTokens())
         .durationMs(proto.getDurationMs());
+  }
+
+  private static class LimitsImpl implements AgentInstance.Limits {
+
+    private final int maxModelCalls;
+    private final int maxToolCalls;
+    private final long maxTokens;
+
+    LimitsImpl(final AgentInstanceLimits proto) {
+      maxModelCalls = proto.getMaxModelCalls();
+      maxToolCalls = proto.getMaxToolCalls();
+      maxTokens = proto.getMaxTokens();
+    }
+
+    @Override
+    public int getMaxModelCalls() {
+      return maxModelCalls;
+    }
+
+    @Override
+    public int getMaxToolCalls() {
+      return maxToolCalls;
+    }
+
+    @Override
+    public long getMaxTokens() {
+      return maxTokens;
+    }
+  }
+
+  private static class ToolImpl implements AgentInstance.Tool {
+
+    private final String name;
+    private final String description;
+    private final String elementId;
+
+    ToolImpl(final AgentTool proto) {
+      name = proto.getName();
+      description = proto.getDescription();
+      elementId = proto.getElementId();
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public String getDescription() {
+      return description;
+    }
+
+    @Override
+    public String getElementId() {
+      return elementId;
+    }
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceHistoryTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceHistoryTest.java
@@ -39,10 +39,12 @@ import io.camunda.client.protocol.rest.AgentInstanceHistoryRoleEnum;
 import io.camunda.client.protocol.rest.AgentInstanceHistorySearchQuery;
 import io.camunda.client.protocol.rest.AgentInstanceHistorySearchQueryResult;
 import io.camunda.client.protocol.rest.AgentInstanceHistorySearchQuerySortRequest;
+import io.camunda.client.protocol.rest.AgentInstanceLimits;
 import io.camunda.client.protocol.rest.AgentInstanceMessageContent;
 import io.camunda.client.protocol.rest.AgentInstanceObjectContent;
 import io.camunda.client.protocol.rest.AgentInstanceTextContent;
 import io.camunda.client.protocol.rest.AgentInstanceToolCall;
+import io.camunda.client.protocol.rest.AgentTool;
 import io.camunda.client.protocol.rest.DocumentReference;
 import io.camunda.client.protocol.rest.SearchQueryPageResponse;
 import io.camunda.client.protocol.rest.SortOrderEnum;
@@ -282,7 +284,20 @@ class SearchAgentInstanceHistoryTest extends ClientRestTest {
             .content(
                 Collections.singletonList(
                     (AgentInstanceMessageContent)
-                        new AgentInstanceTextContent().contentType("TEXT").text("hello")));
+                        new AgentInstanceTextContent().contentType("TEXT").text("hello")))
+            .historyItemId("history-item-1")
+            .tools(
+                Collections.singletonList(
+                    new AgentTool().name("search").description("Searches the web")))
+            .model("gpt-4o")
+            .provider("openai")
+            .limits(new AgentInstanceLimits().maxTokens(1000L).maxModelCalls(10).maxToolCalls(5))
+            .systemPrompt(
+                Collections.singletonList(
+                    (AgentInstanceMessageContent)
+                        new AgentInstanceTextContent()
+                            .contentType("TEXT")
+                            .text("You are a helpful assistant.")));
 
     gatewayService.onAgentInstanceHistorySearchRequest(
         AGENT_INSTANCE_KEY,
@@ -337,6 +352,27 @@ class SearchAgentInstanceHistoryTest extends ClientRestTest {
           softly.assertThat(content.getContentType()).as("contentType").isEqualTo("TEXT");
           softly.assertThat(content).as("content is TextContent").isInstanceOf(TextContent.class);
           softly.assertThat(((TextContent) content).getText()).as("text").isEqualTo("hello");
+
+          softly
+              .assertThat(item.getHistoryItemId())
+              .as("historyItemId")
+              .isEqualTo("history-item-1");
+          softly.assertThat(item.getTools()).as("tools").hasSize(1);
+          softly.assertThat(item.getTools().get(0).getName()).as("tool name").isEqualTo("search");
+          softly
+              .assertThat(item.getTools().get(0).getDescription())
+              .as("tool description")
+              .isEqualTo("Searches the web");
+          softly.assertThat(item.getModel()).as("model").isEqualTo("gpt-4o");
+          softly.assertThat(item.getProvider()).as("provider").isEqualTo("openai");
+          softly.assertThat(item.getLimits().getMaxTokens()).as("maxTokens").isEqualTo(1000L);
+          softly.assertThat(item.getLimits().getMaxModelCalls()).as("maxModelCalls").isEqualTo(10);
+          softly.assertThat(item.getLimits().getMaxToolCalls()).as("maxToolCalls").isEqualTo(5);
+          softly.assertThat(item.getSystemPrompt()).as("systemPrompt").hasSize(1);
+          softly
+              .assertThat(((TextContent) item.getSystemPrompt().get(0)).getText())
+              .as("systemPrompt text")
+              .isEqualTo("You are a helpful assistant.");
         });
   }
 

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -479,6 +479,14 @@
       <column name="DURATION_MS" type="BIGINT"/>
       <column name="CONTENT" type="CLOB"/>
       <column name="TOOL_CALLS" type="CLOB"/>
+      <column name="HISTORY_ITEM_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="TOOLS" type="CLOB"/>
+      <column name="MODEL" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PROVIDER" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="MAX_TOKENS" type="BIGINT"/>
+      <column name="MAX_MODEL_CALLS" type="INTEGER"/>
+      <column name="MAX_TOOL_CALLS" type="INTEGER"/>
+      <column name="SYSTEM_PROMPT" type="CLOB"/>
     </createTable>
 
     <modifySql dbms="mariadb,mysql">
@@ -541,100 +549,6 @@
       <column name="TENANT_ID"/>
     </createIndex>
   </changeSet>
-
-  <changeSet id="add_agent_history_history_item_id_column" author="camunda">
-    <preConditions onFail="MARK_RAN">
-      <not>
-        <columnExists tableName="${prefix}AGENT_HISTORY" columnName="HISTORY_ITEM_ID"/>
-      </not>
-    </preConditions>
-    <addColumn tableName="${prefix}AGENT_HISTORY">
-      <column name="HISTORY_ITEM_ID" type="NVARCHAR(${userCharColumnSize})"/>
-    </addColumn>
-  </changeSet>
-
-  <changeSet id="add_agent_history_tools_column" author="camunda">
-    <preConditions onFail="MARK_RAN">
-      <not>
-        <columnExists tableName="${prefix}AGENT_HISTORY" columnName="TOOLS"/>
-      </not>
-    </preConditions>
-    <addColumn tableName="${prefix}AGENT_HISTORY">
-      <column name="TOOLS" type="CLOB"/>
-    </addColumn>
-  </changeSet>
-
-  <changeSet id="add_agent_history_model_column" author="camunda">
-    <preConditions onFail="MARK_RAN">
-      <not>
-        <columnExists tableName="${prefix}AGENT_HISTORY" columnName="MODEL"/>
-      </not>
-    </preConditions>
-    <addColumn tableName="${prefix}AGENT_HISTORY">
-      <column name="MODEL" type="NVARCHAR(${userCharColumnSize})"/>
-    </addColumn>
-  </changeSet>
-
-  <changeSet id="add_agent_history_provider_column" author="camunda">
-    <preConditions onFail="MARK_RAN">
-      <not>
-        <columnExists tableName="${prefix}AGENT_HISTORY" columnName="PROVIDER"/>
-      </not>
-    </preConditions>
-    <addColumn tableName="${prefix}AGENT_HISTORY">
-      <column name="PROVIDER" type="NVARCHAR(${userCharColumnSize})"/>
-    </addColumn>
-  </changeSet>
-
-  <changeSet id="add_agent_history_max_tokens_column" author="camunda">
-    <preConditions onFail="MARK_RAN">
-      <not>
-        <columnExists tableName="${prefix}AGENT_HISTORY" columnName="MAX_TOKENS"/>
-      </not>
-    </preConditions>
-    <addColumn tableName="${prefix}AGENT_HISTORY">
-      <column name="MAX_TOKENS" type="BIGINT"/>
-    </addColumn>
-  </changeSet>
-
-  <changeSet id="add_agent_history_max_model_calls_column" author="camunda">
-    <preConditions onFail="MARK_RAN">
-      <not>
-        <columnExists tableName="${prefix}AGENT_HISTORY" columnName="MAX_MODEL_CALLS"/>
-      </not>
-    </preConditions>
-    <addColumn tableName="${prefix}AGENT_HISTORY">
-      <column name="MAX_MODEL_CALLS" type="INTEGER"/>
-    </addColumn>
-  </changeSet>
-
-  <changeSet id="add_agent_history_max_tool_calls_column" author="camunda">
-    <preConditions onFail="MARK_RAN">
-      <not>
-        <columnExists tableName="${prefix}AGENT_HISTORY" columnName="MAX_TOOL_CALLS"/>
-      </not>
-    </preConditions>
-    <addColumn tableName="${prefix}AGENT_HISTORY">
-      <column name="MAX_TOOL_CALLS" type="INTEGER"/>
-    </addColumn>
-  </changeSet>
-
-  <changeSet id="add_agent_history_system_prompt_column" author="camunda">
-    <preConditions onFail="MARK_RAN">
-      <not>
-        <columnExists tableName="${prefix}AGENT_HISTORY" columnName="SYSTEM_PROMPT"/>
-      </not>
-    </preConditions>
-    <addColumn tableName="${prefix}AGENT_HISTORY">
-      <column name="SYSTEM_PROMPT" type="CLOB"/>
-    </addColumn>
-  </changeSet>
-
-
-
-
-
-
 
   <changeSet id="create_wait_state_keyset_index" author="camunda">
     <preConditions onFail="MARK_RAN">

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -542,6 +542,100 @@
     </createIndex>
   </changeSet>
 
+  <changeSet id="add_agent_history_history_item_id_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}AGENT_HISTORY" columnName="HISTORY_ITEM_ID"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}AGENT_HISTORY">
+      <column name="HISTORY_ITEM_ID" type="NVARCHAR(${userCharColumnSize})"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="add_agent_history_tools_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}AGENT_HISTORY" columnName="TOOLS"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}AGENT_HISTORY">
+      <column name="TOOLS" type="CLOB"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="add_agent_history_model_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}AGENT_HISTORY" columnName="MODEL"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}AGENT_HISTORY">
+      <column name="MODEL" type="NVARCHAR(${userCharColumnSize})"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="add_agent_history_provider_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}AGENT_HISTORY" columnName="PROVIDER"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}AGENT_HISTORY">
+      <column name="PROVIDER" type="NVARCHAR(${userCharColumnSize})"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="add_agent_history_max_tokens_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}AGENT_HISTORY" columnName="MAX_TOKENS"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}AGENT_HISTORY">
+      <column name="MAX_TOKENS" type="BIGINT"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="add_agent_history_max_model_calls_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}AGENT_HISTORY" columnName="MAX_MODEL_CALLS"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}AGENT_HISTORY">
+      <column name="MAX_MODEL_CALLS" type="INTEGER"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="add_agent_history_max_tool_calls_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}AGENT_HISTORY" columnName="MAX_TOOL_CALLS"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}AGENT_HISTORY">
+      <column name="MAX_TOOL_CALLS" type="INTEGER"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="add_agent_history_system_prompt_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}AGENT_HISTORY" columnName="SYSTEM_PROMPT"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}AGENT_HISTORY">
+      <column name="SYSTEM_PROMPT" type="CLOB"/>
+    </addColumn>
+  </changeSet>
+
+
+
+
+
+
+
   <changeSet id="create_wait_state_keyset_index" author="camunda">
     <preConditions onFail="MARK_RAN">
       <not>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapper.java
@@ -11,6 +11,7 @@ import static io.camunda.db.rdbms.read.NullSafeStrings.nullToEmpty;
 
 import io.camunda.db.rdbms.write.domain.AgentHistoryDbModel;
 import io.camunda.search.entities.AgentInstanceHistoryEntity;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.Limits;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.Metrics;
 import java.util.List;
 
@@ -24,6 +25,7 @@ public class AgentHistoryEntityMapper {
     final var toolCallValues = dbModel.toolCallValues();
     return new AgentInstanceHistoryEntity(
         dbModel.agentHistoryKey(),
+        nullToEmpty(dbModel.historyItemId()),
         dbModel.agentInstanceKey(),
         dbModel.elementInstanceKey(),
         dbModel.processInstanceKey(),
@@ -37,6 +39,11 @@ public class AgentHistoryEntityMapper {
         contentItems != null ? contentItems : List.of(),
         toolCallValues != null ? toolCallValues : List.of(),
         toMetrics(dbModel.inputTokens(), dbModel.outputTokens(), dbModel.durationMs()),
+        dbModel.toolValues(),
+        dbModel.model(),
+        dbModel.provider(),
+        toLimits(dbModel.maxTokens(), dbModel.maxModelCalls(), dbModel.maxToolCalls()),
+        dbModel.systemPromptItems(),
         dbModel.commitStatus(),
         dbModel.producedAt());
   }
@@ -52,5 +59,17 @@ public class AgentHistoryEntityMapper {
       return null;
     }
     return new Metrics(inputTokens, outputTokens, durationMs);
+  }
+
+  /**
+   * Defaults any null individual field to {@code -1} ("no limit configured"), the same sentinel
+   * {@code AgentInstanceLimits} uses.
+   */
+  private static Limits toLimits(
+      final Long maxTokens, final Integer maxModelCalls, final Integer maxToolCalls) {
+    return new Limits(
+        maxTokens != null ? maxTokens : -1L,
+        maxModelCalls != null ? maxModelCalls : -1,
+        maxToolCalls != null ? maxToolCalls : -1);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModel.java
@@ -15,6 +15,7 @@ import io.camunda.db.rdbms.write.util.TruncateUtil;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryRole;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.Tool;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.ToolCall;
 import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
@@ -45,7 +46,15 @@ public record AgentHistoryDbModel(
     Long outputTokens,
     Long durationMs,
     String content,
-    String toolCalls)
+    String toolCalls,
+    String historyItemId,
+    String tools,
+    String model,
+    String provider,
+    Long maxTokens,
+    Integer maxModelCalls,
+    Integer maxToolCalls,
+    String systemPrompt)
     implements Copyable<AgentHistoryDbModel> {
 
   private static final Logger LOG = LoggerFactory.getLogger(AgentHistoryDbModel.class);
@@ -59,9 +68,16 @@ public record AgentHistoryDbModel(
     return copyFunction.apply(toBuilder()).build();
   }
 
-  public AgentHistoryDbModel truncateJobLease(final int sizeLimit, final Integer byteLimit) {
+  public AgentHistoryDbModel truncate(final int sizeLimit, final Integer byteLimit) {
     final var truncatedJobLease = TruncateUtil.truncateValue(jobLease, sizeLimit, byteLimit);
-    if (Objects.equals(truncatedJobLease, jobLease)) {
+    final var truncatedHistoryItemId =
+        TruncateUtil.truncateValue(historyItemId, sizeLimit, byteLimit);
+    final var truncatedModel = TruncateUtil.truncateValue(model, sizeLimit, byteLimit);
+    final var truncatedProvider = TruncateUtil.truncateValue(provider, sizeLimit, byteLimit);
+    if (Objects.equals(truncatedJobLease, jobLease)
+        && Objects.equals(truncatedHistoryItemId, historyItemId)
+        && Objects.equals(truncatedModel, model)
+        && Objects.equals(truncatedProvider, provider)) {
       return this;
     }
 
@@ -85,7 +101,15 @@ public record AgentHistoryDbModel(
         outputTokens,
         durationMs,
         content,
-        toolCalls);
+        toolCalls,
+        truncatedHistoryItemId,
+        tools,
+        truncatedModel,
+        truncatedProvider,
+        maxTokens,
+        maxModelCalls,
+        maxToolCalls,
+        systemPrompt);
   }
 
   /**
@@ -108,6 +132,17 @@ public record AgentHistoryDbModel(
       return null;
     }
     return deserializeToolCallValues(toolCalls);
+  }
+
+  /**
+   * Returns the structured tool list of a CONFIGURATION item, deserializing the JSON form on every
+   * call. Returns an empty list, not null, when this item didn't touch the tool list.
+   */
+  public List<Tool> toolValues() {
+    if (tools == null || tools.isEmpty()) {
+      return List.of();
+    }
+    return deserializeTools(tools);
   }
 
   private static List<ContentItem> deserializeContentItems(final String json) {
@@ -154,8 +189,30 @@ public record AgentHistoryDbModel(
     }
   }
 
+  private static List<Tool> deserializeTools(final String json) {
+    try {
+      return MAPPER.readValue(json, new TypeReference<>() {});
+    } catch (final JsonProcessingException e) {
+      LOG.error("Failed to deserialize agent history tools", e);
+      return Collections.emptyList();
+    }
+  }
+
+  private static String serializeTools(final List<Tool> toolValues) {
+    if (toolValues == null || toolValues.isEmpty()) {
+      return null;
+    }
+
+    try {
+      return MAPPER.writeValueAsString(toolValues);
+    } catch (final JsonProcessingException e) {
+      LOG.error("Failed to serialize agent history tools", e);
+      return null;
+    }
+  }
+
   public Builder toBuilder() {
-    return new Builder(content, toolCalls)
+    return new Builder(content, toolCalls, tools, systemPrompt)
         .agentHistoryKey(agentHistoryKey)
         .agentInstanceKey(agentInstanceKey)
         .elementInstanceKey(elementInstanceKey)
@@ -173,7 +230,25 @@ public record AgentHistoryDbModel(
         .producedAt(producedAt)
         .inputTokens(inputTokens)
         .outputTokens(outputTokens)
-        .durationMs(durationMs);
+        .durationMs(durationMs)
+        .historyItemId(historyItemId)
+        .model(model)
+        .provider(provider)
+        .maxTokens(maxTokens)
+        .maxModelCalls(maxModelCalls)
+        .maxToolCalls(maxToolCalls);
+  }
+
+  /**
+   * Returns the structured system-prompt content list of a CONFIGURATION item, deserializing the
+   * JSON form on every call. Returns an empty list, not null, when this item didn't touch the
+   * system prompt.
+   */
+  public List<ContentItem> systemPromptItems() {
+    if (systemPrompt == null || systemPrompt.isEmpty()) {
+      return List.of();
+    }
+    return deserializeContentItems(systemPrompt);
   }
 
   public static class Builder implements ObjectBuilder<AgentHistoryDbModel> {
@@ -198,17 +273,32 @@ public record AgentHistoryDbModel(
     private Long durationMs;
     private String content;
     private String toolCalls;
+    private String historyItemId;
+    private String tools;
+    private String model;
+    private String provider;
+    private Long maxTokens;
+    private Integer maxModelCalls;
+    private Integer maxToolCalls;
+    private String systemPrompt;
 
     public Builder() {}
 
     // Seeds the raw serialized column values for toBuilder()/copy(), so a copy that never
-    // touches contentItems()/toolCallValues() carries the original JSON through unparsed instead
-    // of round-tripping it through Jackson. Package-private, not a public setter: a second
-    // public setter aliasing the same fields as contentItems(List)/toolCallValues(List) would
-    // let callers silently drop a write (e.g. builder.content(x).contentItems(y) loses x).
-    Builder(final String content, final String toolCalls) {
+    // touches contentItems()/toolCallValues()/toolValues()/systemPromptItems() carries the
+    // original JSON through unparsed instead of round-tripping it through Jackson.
+    // Package-private, not a public setter: a second public setter aliasing the same fields as
+    // contentItems(List)/toolCallValues(List)/toolValues(List)/systemPromptItems(List) would let
+    // callers silently drop a write (e.g. builder.content(x).contentItems(y) loses x).
+    Builder(
+        final String content,
+        final String toolCalls,
+        final String tools,
+        final String systemPrompt) {
       this.content = content;
       this.toolCalls = toolCalls;
+      this.tools = tools;
+      this.systemPrompt = systemPrompt;
     }
 
     public Builder agentHistoryKey(final long agentHistoryKey) {
@@ -311,6 +401,46 @@ public record AgentHistoryDbModel(
       return this;
     }
 
+    public Builder historyItemId(final String historyItemId) {
+      this.historyItemId = historyItemId;
+      return this;
+    }
+
+    public Builder toolValues(final List<Tool> toolValues) {
+      tools = serializeTools(toolValues);
+      return this;
+    }
+
+    public Builder model(final String model) {
+      this.model = model;
+      return this;
+    }
+
+    public Builder provider(final String provider) {
+      this.provider = provider;
+      return this;
+    }
+
+    public Builder maxTokens(final Long maxTokens) {
+      this.maxTokens = maxTokens;
+      return this;
+    }
+
+    public Builder maxModelCalls(final Integer maxModelCalls) {
+      this.maxModelCalls = maxModelCalls;
+      return this;
+    }
+
+    public Builder maxToolCalls(final Integer maxToolCalls) {
+      this.maxToolCalls = maxToolCalls;
+      return this;
+    }
+
+    public Builder systemPromptItems(final List<ContentItem> systemPromptItems) {
+      systemPrompt = serializeContentItems(systemPromptItems);
+      return this;
+    }
+
     @Override
     public AgentHistoryDbModel build() {
       return new AgentHistoryDbModel(
@@ -333,7 +463,15 @@ public record AgentHistoryDbModel(
           outputTokens,
           durationMs,
           content,
-          toolCalls);
+          toolCalls,
+          historyItemId,
+          tools,
+          model,
+          provider,
+          maxTokens,
+          maxModelCalls,
+          maxToolCalls,
+          systemPrompt);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentHistoryWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentHistoryWriter.java
@@ -31,7 +31,7 @@ public class AgentHistoryWriter extends ProcessInstanceDependant implements Rdbm
 
   public void create(final AgentHistoryDbModel model) {
     final var truncated =
-        model.truncateJobLease(
+        model.truncate(
             vendorDatabaseProperties.userCharColumnSize(),
             vendorDatabaseProperties.charColumnMaxBytes());
     executionQueue.executeInQueue(

--- a/db/rdbms/src/main/resources/mapper/AgentHistoryMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AgentHistoryMapper.xml
@@ -35,7 +35,15 @@
       OUTPUT_TOKENS,
       DURATION_MS,
       CONTENT,
-      TOOL_CALLS
+      TOOL_CALLS,
+      HISTORY_ITEM_ID,
+      TOOLS,
+      MODEL,
+      PROVIDER,
+      MAX_TOKENS,
+      MAX_MODEL_CALLS,
+      MAX_TOOL_CALLS,
+      SYSTEM_PROMPT
     )
     VALUES (
       #{agentHistoryKey},
@@ -57,7 +65,15 @@
       #{outputTokens},
       #{durationMs},
       #{content, jdbcType=CLOB},
-      #{toolCalls, jdbcType=CLOB}
+      #{toolCalls, jdbcType=CLOB},
+      #{historyItemId},
+      #{tools, jdbcType=CLOB},
+      #{model},
+      #{provider},
+      #{maxTokens},
+      #{maxModelCalls},
+      #{maxToolCalls},
+      #{systemPrompt, jdbcType=CLOB}
     )
   </insert>
 
@@ -82,9 +98,11 @@
   <!-- ===== READ operations ===== -->
 
   <!--
-    CONTENT and TOOL_CALLS are JSON CLOBs. They are mapped to the raw String properties on
-    AgentHistoryDbModel; AgentHistoryDbModel.contentItems() and toolCallValues() then deserialize
-    them lazily on first access.
+    CONTENT, TOOL_CALLS, TOOLS and SYSTEM_PROMPT are JSON CLOBs. They are mapped to the raw String
+    properties on AgentHistoryDbModel; AgentHistoryDbModel.contentItems(), toolCallValues(),
+    toolValues() and systemPromptItems() then deserialize them lazily on first access.
+    HISTORY_ITEM_ID/MODEL/PROVIDER/MAX_TOKENS/MAX_MODEL_CALLS/MAX_TOOL_CALLS/SYSTEM_PROMPT are
+    CONFIGURATION-only fields; NULL means this item didn't touch the corresponding field.
   -->
   <resultMap id="searchResultMap" type="io.camunda.db.rdbms.write.domain.AgentHistoryDbModel">
     <constructor>
@@ -112,6 +130,14 @@
       <arg column="DURATION_MS" javaType="java.lang.Long" name="durationMs"/>
       <arg column="CONTENT" javaType="java.lang.String" name="content"/>
       <arg column="TOOL_CALLS" javaType="java.lang.String" name="toolCalls"/>
+      <arg column="HISTORY_ITEM_ID" javaType="java.lang.String" name="historyItemId"/>
+      <arg column="TOOLS" javaType="java.lang.String" name="tools"/>
+      <arg column="MODEL" javaType="java.lang.String" name="model"/>
+      <arg column="PROVIDER" javaType="java.lang.String" name="provider"/>
+      <arg column="MAX_TOKENS" javaType="java.lang.Long" name="maxTokens"/>
+      <arg column="MAX_MODEL_CALLS" javaType="java.lang.Integer" name="maxModelCalls"/>
+      <arg column="MAX_TOOL_CALLS" javaType="java.lang.Integer" name="maxToolCalls"/>
+      <arg column="SYSTEM_PROMPT" javaType="java.lang.String" name="systemPrompt"/>
     </constructor>
   </resultMap>
 
@@ -140,7 +166,15 @@
           ah.OUTPUT_TOKENS,
           ah.DURATION_MS,
           ah.CONTENT,
-          ah.TOOL_CALLS
+          ah.TOOL_CALLS,
+          ah.HISTORY_ITEM_ID,
+          ah.TOOLS,
+          ah.MODEL,
+          ah.PROVIDER,
+          ah.MAX_TOKENS,
+          ah.MAX_MODEL_CALLS,
+          ah.MAX_TOOL_CALLS,
+          ah.SYSTEM_PROMPT
         FROM ${prefix}AGENT_HISTORY ah
         <include refid="io.camunda.db.rdbms.sql.AgentHistoryMapper.searchAndAuthFilter"/>
       ) filtered

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapperTest.java
@@ -15,6 +15,8 @@ import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistor
 import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryRole;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem.ContentType;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.Limits;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.Tool;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.ToolCall;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -51,11 +53,22 @@ class AgentHistoryEntityMapperTest {
                 List.of(new ContentItem(ContentType.TEXT, "Hello from assistant", null, null)))
             .toolCallValues(
                 List.of(new ToolCall("tc-1", "myTool", "Task_1", Map.of("key", "value"))))
+            .historyItemId("history-item-1")
+            .toolValues(List.of(new Tool("search", "Searches the web", "Task_2")))
+            .model("gpt-4o")
+            .provider("openai")
+            .maxTokens(1000L)
+            .maxModelCalls(10)
+            .maxToolCalls(5)
+            .systemPromptItems(
+                List.of(
+                    new ContentItem(ContentType.TEXT, "You are a helpful assistant.", null, null)))
             .build();
 
     final AgentInstanceHistoryEntity entity = AgentHistoryEntityMapper.toEntity(dbModel);
 
     assertThat(entity.historyItemKey()).isEqualTo(100L);
+    assertThat(entity.historyItemId()).isEqualTo("history-item-1");
     assertThat(entity.agentInstanceKey()).isEqualTo(200L);
     assertThat(entity.elementInstanceKey()).isEqualTo(300L);
     assertThat(entity.processInstanceKey()).isEqualTo(400L);
@@ -77,6 +90,61 @@ class AgentHistoryEntityMapperTest {
     assertThat(entity.toolCalls()).hasSize(1);
     assertThat(entity.toolCalls().get(0).toolCallId()).isEqualTo("tc-1");
     assertThat(entity.toolCalls().get(0).toolName()).isEqualTo("myTool");
+    assertThat(entity.tools()).hasSize(1);
+    assertThat(entity.tools().get(0).name()).isEqualTo("search");
+    assertThat(entity.model()).isEqualTo("gpt-4o");
+    assertThat(entity.provider()).isEqualTo("openai");
+    assertThat(entity.limits()).isNotNull();
+    assertThat(entity.limits().maxTokens()).isEqualTo(1000L);
+    assertThat(entity.limits().maxModelCalls()).isEqualTo(10);
+    assertThat(entity.limits().maxToolCalls()).isEqualTo(5);
+    assertThat(entity.systemPrompt()).hasSize(1);
+    assertThat(entity.systemPrompt().get(0).contentType()).isEqualTo(ContentType.TEXT);
+    assertThat(entity.systemPrompt().get(0).text()).isEqualTo("You are a helpful assistant.");
+  }
+
+  @Test
+  void shouldMapNullHistoryItemIdToEmptyString() {
+    // given — historyItemId is only carried by CONFIGURATION-triggering paths; other items leave
+    // it unset on the DB model
+    final var dbModel = minimalDbModel(45L).historyItemId(null).build();
+
+    // when
+    final AgentInstanceHistoryEntity entity = AgentHistoryEntityMapper.toEntity(dbModel);
+
+    // then
+    assertThat(entity.historyItemId()).isEmpty();
+  }
+
+  @Test
+  void shouldMapEmptyToolsAndSystemPromptAndSentinelLimitsWhenUntouched() {
+    // given — a CONFIGURATION item (or non-CONFIGURATION item) that didn't touch these fields
+    final var dbModel = minimalDbModel(46L).build();
+
+    // when
+    final AgentInstanceHistoryEntity entity = AgentHistoryEntityMapper.toEntity(dbModel);
+
+    // then
+    assertThat(entity.tools()).isEmpty();
+    assertThat(entity.model()).isNull();
+    assertThat(entity.provider()).isNull();
+    assertThat(entity.limits()).isEqualTo(new Limits(-1, -1, -1));
+    assertThat(entity.systemPrompt()).isEmpty();
+  }
+
+  @Test
+  void shouldDefaultMissingLimitsSubFieldsToNegativeOneWhenLimitsTouched() {
+    // given — only maxTokens was touched; maxModelCalls/maxToolCalls left null on the DB row
+    final var dbModel = minimalDbModel(47L).maxTokens(500L).build();
+
+    // when
+    final AgentInstanceHistoryEntity entity = AgentHistoryEntityMapper.toEntity(dbModel);
+
+    // then
+    assertThat(entity.limits()).isNotNull();
+    assertThat(entity.limits().maxTokens()).isEqualTo(500L);
+    assertThat(entity.limits().maxModelCalls()).isEqualTo(-1);
+    assertThat(entity.limits().maxToolCalls()).isEqualTo(-1);
   }
 
   @Test

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModelTest.java
@@ -13,6 +13,7 @@ import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem.ContentType;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.DocumentMetadata;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.DocumentReference;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.Tool;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.ToolCall;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -39,7 +40,10 @@ class AgentHistoryDbModelTest {
     // given — simulate a model hydrated from the DB: only the JSON form is populated
     final var model =
         new AgentHistoryDbModel.Builder(
-                "[{\"contentType\":\"TEXT\",\"text\":\"hello\",\"documentReference\":null}]", null)
+                "[{\"contentType\":\"TEXT\",\"text\":\"hello\",\"documentReference\":null}]",
+                null,
+                null,
+                null)
             .build();
 
     // when
@@ -70,7 +74,9 @@ class AgentHistoryDbModelTest {
     final var model =
         new AgentHistoryDbModel.Builder(
                 null,
-                "[{\"toolCallId\":\"call-1\",\"toolName\":\"myTool\",\"elementId\":\"el-1\"}]")
+                "[{\"toolCallId\":\"call-1\",\"toolName\":\"myTool\",\"elementId\":\"el-1\"}]",
+                null,
+                null)
             .build();
 
     // when
@@ -143,5 +149,144 @@ class AgentHistoryDbModelTest {
     assertThat(model.toolCallValues())
         .isEqualTo(model.toolCallValues())
         .isNotSameAs(model.toolCallValues());
+  }
+
+  @Test
+  void shouldSerializeToolsToJson() {
+    // given — CONFIGURATION-only tool list
+    final var tool = new Tool("search", "Searches the web", "Task_1");
+
+    // when
+    final var model = new AgentHistoryDbModel.Builder().toolValues(List.of(tool)).build();
+
+    // then — serialized CLOB field is populated and contains the tool name
+    assertThat(model.toolValues()).containsExactly(tool);
+    assertThat(model.tools()).contains("\"name\":\"search\"");
+  }
+
+  @Test
+  void shouldDeserializeToolsFromJson() {
+    // given — simulate a model hydrated from the DB: only the JSON form is populated
+    final var model =
+        new AgentHistoryDbModel.Builder(
+                null,
+                null,
+                "[{\"name\":\"search\",\"description\":\"Searches the web\",\"elementId\":\"Task_1\"}]",
+                null)
+            .build();
+
+    // when
+    final List<Tool> deserialized = model.toolValues();
+
+    // then
+    assertThat(deserialized).hasSize(1);
+    assertThat(deserialized.getFirst().name()).isEqualTo("search");
+    assertThat(deserialized.getFirst().description()).isEqualTo("Searches the web");
+    assertThat(deserialized.getFirst().elementId()).isEqualTo("Task_1");
+  }
+
+  @Test
+  void shouldReturnNullForNullOrEmptyToolsList() {
+    // given — empty list passed to builder
+    final var modelWithEmptyTools = new AgentHistoryDbModel.Builder().toolValues(List.of()).build();
+
+    // then — empty list serializes to null JSON (not "[]"), so the CLOB column is null, but
+    // toolValues() still returns an empty list, never null
+    assertThat(modelWithEmptyTools.tools()).isNull();
+    assertThat(modelWithEmptyTools.toolValues()).isEmpty();
+
+    // given — null list passed to builder
+    final var modelWithNullTools = new AgentHistoryDbModel.Builder().toolValues(null).build();
+
+    // then — null list also results in null JSON (not "[]")
+    assertThat(modelWithNullTools.tools()).isNull();
+    assertThat(modelWithNullTools.toolValues()).isEmpty();
+  }
+
+  @Test
+  void shouldSetAndGetHistoryItemIdModelProviderAndLimits() {
+    // given / when
+    final var model =
+        new AgentHistoryDbModel.Builder()
+            .historyItemId("history-item-1")
+            .model("gpt-4o")
+            .provider("openai")
+            .maxTokens(1000L)
+            .maxModelCalls(10)
+            .maxToolCalls(5)
+            .build();
+
+    // then
+    assertThat(model.historyItemId()).isEqualTo("history-item-1");
+    assertThat(model.model()).isEqualTo("gpt-4o");
+    assertThat(model.provider()).isEqualTo("openai");
+    assertThat(model.maxTokens()).isEqualTo(1000L);
+    assertThat(model.maxModelCalls()).isEqualTo(10);
+    assertThat(model.maxToolCalls()).isEqualTo(5);
+  }
+
+  @Test
+  void shouldSerializeSystemPromptToJson() {
+    // given — CONFIGURATION-only system prompt content
+    final var item = new ContentItem(ContentType.TEXT, "You are a helpful assistant.", null, null);
+
+    // when
+    final var model = new AgentHistoryDbModel.Builder().systemPromptItems(List.of(item)).build();
+
+    // then — serialized CLOB field is populated and contains the prompt text
+    assertThat(model.systemPromptItems()).containsExactly(item);
+    assertThat(model.systemPrompt()).contains("\"text\":\"You are a helpful assistant.\"");
+  }
+
+  @Test
+  void shouldDeserializeSystemPromptFromJson() {
+    // given — simulate a model hydrated from the DB: only the JSON form is populated
+    final var model =
+        new AgentHistoryDbModel.Builder(
+                null,
+                null,
+                null,
+                "[{\"contentType\":\"TEXT\",\"text\":\"You are a helpful assistant.\",\"documentReference\":null}]")
+            .build();
+
+    // when
+    final List<ContentItem> deserialized = model.systemPromptItems();
+
+    // then
+    assertThat(deserialized).hasSize(1);
+    assertThat(deserialized.getFirst().contentType()).isEqualTo(ContentType.TEXT);
+    assertThat(deserialized.getFirst().text()).isEqualTo("You are a helpful assistant.");
+  }
+
+  @Test
+  void shouldReturnNullForNullOrEmptySystemPrompt() {
+    // given — empty list passed to builder
+    final var modelWithEmptySystemPrompt =
+        new AgentHistoryDbModel.Builder().systemPromptItems(List.of()).build();
+
+    // then — empty list serializes to null JSON (not "[]"), so the CLOB column is null, but
+    // systemPromptItems() still returns an empty list, never null
+    assertThat(modelWithEmptySystemPrompt.systemPrompt()).isNull();
+    assertThat(modelWithEmptySystemPrompt.systemPromptItems()).isEmpty();
+
+    // given — null list passed to builder
+    final var modelWithNullSystemPrompt =
+        new AgentHistoryDbModel.Builder().systemPromptItems(null).build();
+
+    // then — null list also results in null JSON (not "[]")
+    assertThat(modelWithNullSystemPrompt.systemPrompt()).isNull();
+    assertThat(modelWithNullSystemPrompt.systemPromptItems()).isEmpty();
+  }
+
+  @Test
+  void shouldDeriveSystemPromptFreshOnEveryCall() {
+    // given
+    final var item = new ContentItem(ContentType.TEXT, "hello", null, null);
+    final var model = new AgentHistoryDbModel.Builder().systemPromptItems(List.of(item)).build();
+
+    // then — equal content, but freshly deserialized each time (no cache)
+    assertThat(model.systemPromptItems())
+        .isEqualTo(model.systemPromptItems())
+        .isNotSameAs(model.systemPromptItems());
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -185,6 +185,7 @@ public class AgentInstanceMapper {
       case USER -> AgentHistoryRole.USER;
       case ASSISTANT -> AgentHistoryRole.ASSISTANT;
       case TOOL_RESULT -> AgentHistoryRole.TOOL_RESULT;
+      case CONFIGURATION -> AgentHistoryRole.CONFIGURATION;
     };
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -252,6 +252,7 @@ public class AgentInstanceMapper {
       case USER -> AgentHistoryRole.USER;
       case ASSISTANT -> AgentHistoryRole.ASSISTANT;
       case TOOL_RESULT -> AgentHistoryRole.TOOL_RESULT;
+      case CONFIGURATION -> AgentHistoryRole.CONFIGURATION;
     };
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -2221,6 +2221,30 @@ public final class SearchQueryResponseMapper {
               .build();
     }
 
+    final var tools =
+        entity.tools().stream()
+            .map(
+                t ->
+                    AgentTool.Builder.create()
+                        .name(t.name())
+                        .description(t.description())
+                        .elementId(t.elementId())
+                        .build())
+            .toList();
+
+    final var l = entity.limits();
+    final var limits =
+        AgentInstanceLimits.Builder.create()
+            .maxModelCalls(l.maxModelCalls())
+            .maxTokens(l.maxTokens())
+            .maxToolCalls(l.maxToolCalls())
+            .build();
+
+    final var systemPrompt =
+        entity.systemPrompt().stream()
+            .map(SearchQueryResponseMapper::toAgentInstanceMessageContent)
+            .toList();
+
     return AgentInstanceHistoryItemResult.Builder.create()
         .historyItemKey(keyToString(entity.historyItemKey()))
         .agentInstanceKey(keyToString(entity.agentInstanceKey()))
@@ -2234,6 +2258,12 @@ public final class SearchQueryResponseMapper {
         .metrics(metrics)
         .commitStatus(AgentInstanceHistoryCommitStatusEnum.fromValue(entity.commitStatus().name()))
         .producedAt(formatDate(entity.producedAt()))
+        .historyItemId(entity.historyItemId())
+        .tools(tools)
+        .model(entity.model())
+        .provider(entity.provider())
+        .limits(limits)
+        .systemPrompt(systemPrompt)
         .build();
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -2247,6 +2247,7 @@ public final class SearchQueryResponseMapper {
 
     return AgentInstanceHistoryItemResult.Builder.create()
         .historyItemKey(keyToString(entity.historyItemKey()))
+        .historyItemId(entity.historyItemId())
         .agentInstanceKey(keyToString(entity.agentInstanceKey()))
         .elementInstanceKey(keyToString(entity.elementInstanceKey()))
         .jobKey(keyToString(entity.jobKey()))
@@ -2258,7 +2259,6 @@ public final class SearchQueryResponseMapper {
         .metrics(metrics)
         .commitStatus(AgentInstanceHistoryCommitStatusEnum.fromValue(entity.commitStatus().name()))
         .producedAt(formatDate(entity.producedAt()))
-        .historyItemId(entity.historyItemId())
         .tools(tools)
         .model(entity.model())
         .provider(entity.provider())

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -29,7 +29,9 @@ import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem.ContentType;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.DocumentMetadata;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.DocumentReference;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.Limits;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.Metrics;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.Tool;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.ToolCall;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.AuditLogEntity.AuditLogActorType;
@@ -1404,6 +1406,7 @@ class SearchQueryResponseMapperTest {
 
       // then
       assertThat(result.getHistoryItemKey()).isEqualTo("100");
+      assertThat(result.getHistoryItemId()).isEqualTo("history-item-1");
       assertThat(result.getAgentInstanceKey()).isEqualTo("200");
       assertThat(result.getElementInstanceKey()).isEqualTo("300");
       assertThat(result.getJobKey()).isEqualTo("600");
@@ -1642,6 +1645,95 @@ class SearchQueryResponseMapperTest {
       assertThat(result.getMetrics().getInputTokens()).isEqualTo(100L);
       assertThat(result.getMetrics().getOutputTokens()).isEqualTo(200L);
       assertThat(result.getMetrics().getDurationMs()).isNull();
+    }
+
+    @Test
+    void shouldMapConfigurationFields() {
+      // given — a CONFIGURATION item that touched tools/model/provider/limits/systemPrompt
+      final var entity =
+          new AgentInstanceHistoryEntity(
+              1L,
+              "history-item-1",
+              2L,
+              3L,
+              4L,
+              5L,
+              "",
+              "<default>",
+              6L,
+              "",
+              1,
+              AgentInstanceHistoryRole.CONFIGURATION,
+              List.of(),
+              List.of(),
+              null,
+              List.of(new Tool("search", "Searches the web", "Task_1")),
+              "gpt-4o",
+              "openai",
+              new Limits(1000L, 10, 5),
+              List.of(
+                  new ContentItem(ContentType.TEXT, "You are a helpful assistant.", null, null)),
+              AgentInstanceHistoryCommitStatus.COMMITTED,
+              OffsetDateTime.now());
+
+      // when
+      final var result = SearchQueryResponseMapper.toAgentHistoryItemResult(entity);
+
+      // then
+      assertThat(result.getHistoryItemId()).isEqualTo("history-item-1");
+      assertThat(result.getRole().getValue()).isEqualTo("CONFIGURATION");
+      assertThat(result.getTools()).hasSize(1);
+      assertThat(result.getTools().get(0).getName()).isEqualTo("search");
+      assertThat(result.getTools().get(0).getDescription()).isEqualTo("Searches the web");
+      assertThat(result.getTools().get(0).getElementId()).isEqualTo("Task_1");
+      assertThat(result.getModel()).isEqualTo("gpt-4o");
+      assertThat(result.getProvider()).isEqualTo("openai");
+      assertThat(result.getLimits().getMaxTokens()).isEqualTo(1000L);
+      assertThat(result.getLimits().getMaxModelCalls()).isEqualTo(10);
+      assertThat(result.getLimits().getMaxToolCalls()).isEqualTo(5);
+      assertThat(result.getSystemPrompt()).hasSize(1);
+      assertThat(result.getSystemPrompt().get(0).getContentType()).isEqualTo("TEXT");
+    }
+
+    @Test
+    void shouldMapEmptyToolsAndSystemPromptAndSentinelLimitsWhenUntouched() {
+      // given — a non-CONFIGURATION item; tools/model/provider/limits/systemPrompt are untouched
+      final var entity =
+          new AgentInstanceHistoryEntity(
+              1L,
+              "history-item-1",
+              2L,
+              3L,
+              4L,
+              5L,
+              "",
+              "<default>",
+              6L,
+              "",
+              1,
+              AgentInstanceHistoryRole.USER,
+              List.of(),
+              List.of(),
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              AgentInstanceHistoryCommitStatus.COMMITTED,
+              OffsetDateTime.now());
+
+      // when
+      final var result = SearchQueryResponseMapper.toAgentHistoryItemResult(entity);
+
+      // then
+      assertThat(result.getTools()).isEmpty();
+      assertThat(result.getModel()).isNull();
+      assertThat(result.getProvider()).isNull();
+      assertThat(result.getLimits().getMaxTokens()).isEqualTo(-1L);
+      assertThat(result.getLimits().getMaxModelCalls()).isEqualTo(-1);
+      assertThat(result.getLimits().getMaxToolCalls()).isEqualTo(-1);
+      assertThat(result.getSystemPrompt()).isEmpty();
     }
   }
 }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -1377,6 +1377,7 @@ class SearchQueryResponseMapperTest {
       final var entity =
           new AgentInstanceHistoryEntity(
               100L,
+              "history-item-1",
               200L,
               300L,
               400L,
@@ -1390,6 +1391,11 @@ class SearchQueryResponseMapperTest {
               List.of(new ContentItem(ContentType.TEXT, "Hello", null, null)),
               List.of(),
               new Metrics(10L, 20L, 30L),
+              null,
+              null,
+              null,
+              null,
+              null,
               AgentInstanceHistoryCommitStatus.COMMITTED,
               producedAt);
 
@@ -1421,6 +1427,7 @@ class SearchQueryResponseMapperTest {
       final var entity =
           new AgentInstanceHistoryEntity(
               1L,
+              "history-item-1",
               2L,
               3L,
               4L,
@@ -1434,6 +1441,11 @@ class SearchQueryResponseMapperTest {
               List.of(new ContentItem(ContentType.DOCUMENT, null, docRef, null)),
               List.of(),
               new Metrics(0L, 0L, 0L),
+              null,
+              null,
+              null,
+              null,
+              null,
               AgentInstanceHistoryCommitStatus.PENDING,
               OffsetDateTime.now());
 
@@ -1453,6 +1465,7 @@ class SearchQueryResponseMapperTest {
       final var entity =
           new AgentInstanceHistoryEntity(
               1L,
+              "history-item-1",
               2L,
               3L,
               4L,
@@ -1466,6 +1479,11 @@ class SearchQueryResponseMapperTest {
               null,
               null,
               new Metrics(0L, 0L, 0L),
+              null,
+              null,
+              null,
+              null,
+              null,
               AgentInstanceHistoryCommitStatus.DISCARDED,
               OffsetDateTime.now());
 
@@ -1484,6 +1502,7 @@ class SearchQueryResponseMapperTest {
       final var entity =
           new AgentInstanceHistoryEntity(
               1L,
+              "history-item-1",
               2L,
               3L,
               4L,
@@ -1497,6 +1516,11 @@ class SearchQueryResponseMapperTest {
               List.of(),
               List.of(toolCall),
               new Metrics(5L, 10L, 100L),
+              null,
+              null,
+              null,
+              null,
+              null,
               AgentInstanceHistoryCommitStatus.COMMITTED,
               OffsetDateTime.now());
 
@@ -1516,6 +1540,7 @@ class SearchQueryResponseMapperTest {
       final var entity =
           new AgentInstanceHistoryEntity(
               42L,
+              "history-item-1",
               7L,
               8L,
               9L,
@@ -1529,6 +1554,11 @@ class SearchQueryResponseMapperTest {
               List.of(),
               List.of(),
               new Metrics(0L, 0L, 0L),
+              null,
+              null,
+              null,
+              null,
+              null,
               AgentInstanceHistoryCommitStatus.COMMITTED,
               OffsetDateTime.now());
       final var queryResult = new SearchQueryResult<>(1L, false, List.of(entity), null, null);
@@ -1547,6 +1577,7 @@ class SearchQueryResponseMapperTest {
       final var entity =
           new AgentInstanceHistoryEntity(
               1L,
+              "history-item-1",
               2L,
               3L,
               4L,
@@ -1559,6 +1590,11 @@ class SearchQueryResponseMapperTest {
               AgentInstanceHistoryRole.USER,
               List.of(),
               List.of(),
+              null,
+              null,
+              null,
+              null,
+              null,
               null,
               AgentInstanceHistoryCommitStatus.COMMITTED,
               OffsetDateTime.now());
@@ -1576,6 +1612,7 @@ class SearchQueryResponseMapperTest {
       final var entity =
           new AgentInstanceHistoryEntity(
               1L,
+              "history-item-1",
               2L,
               3L,
               4L,
@@ -1589,6 +1626,11 @@ class SearchQueryResponseMapperTest {
               List.of(),
               List.of(),
               new Metrics(100L, 200L, null),
+              null,
+              null,
+              null,
+              null,
+              null,
               AgentInstanceHistoryCommitStatus.COMMITTED,
               OffsetDateTime.now());
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformer.java
@@ -15,13 +15,18 @@ import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem.ContentType;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.DocumentMetadata;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.DocumentReference;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.Limits;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.Metrics;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.Tool;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.ToolCall;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryContentValue;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryEmbeddedToolCallValue;
+import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryLimitsValue;
+import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryToolValue;
 import io.camunda.webapps.schema.entities.document.DocumentReferenceEntity;
 import java.util.List;
+import java.util.Objects;
 
 public class AgentHistoryEntityTransformer
     implements ServiceTransformer<AgentHistoryEntity, AgentInstanceHistoryEntity> {
@@ -30,6 +35,7 @@ public class AgentHistoryEntityTransformer
   public AgentInstanceHistoryEntity apply(final AgentHistoryEntity source) {
     return new AgentInstanceHistoryEntity(
         source.getKey(),
+        Objects.requireNonNullElse(source.getHistoryItemId(), ""),
         source.getAgentInstanceKey(),
         source.getElementInstanceKey(),
         source.getProcessInstanceKey(),
@@ -43,6 +49,11 @@ public class AgentHistoryEntityTransformer
         toContent(source.getContent()),
         toToolCalls(source.getToolCalls()),
         toMetrics(source.getInputTokens(), source.getOutputTokens(), source.getDurationMs()),
+        toTools(source.getTools()),
+        source.getModel(),
+        source.getProvider(),
+        toLimits(source.getLimits()),
+        toSystemPrompt(source.getSystemPrompt()),
         toCommitStatus(source.getCommitStatus()),
         source.getProducedAt());
   }
@@ -123,5 +134,33 @@ public class AgentHistoryEntityTransformer
       return null;
     }
     return new Metrics(inputTokens, outputTokens, durationMs);
+  }
+
+  /** The tools available to the agent, as of this entry. CONFIGURATION items only. */
+  private static List<Tool> toTools(final List<AgentHistoryToolValue> tools) {
+    if (tools == null) {
+      return List.of();
+    }
+    return tools.stream().map(t -> new Tool(t.name(), t.description(), t.elementId())).toList();
+  }
+
+  /**
+   * The operational limits, as of this entry. CONFIGURATION items only. {@code -1} on any field
+   * means "no limit configured".
+   */
+  private static Limits toLimits(final AgentHistoryLimitsValue limits) {
+    if (limits == null) {
+      return new Limits(-1, -1, -1);
+    }
+    return new Limits(limits.maxTokens(), limits.maxModelCalls(), limits.maxToolCalls());
+  }
+
+  /** The system prompt, as content blocks, as of this entry. CONFIGURATION items only. */
+  private static List<ContentItem> toSystemPrompt(
+      final List<AgentHistoryContentValue> systemPrompt) {
+    if (systemPrompt == null) {
+      return List.of();
+    }
+    return systemPrompt.stream().map(AgentHistoryEntityTransformer::toContentItem).toList();
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformer.java
@@ -53,6 +53,7 @@ public class AgentHistoryEntityTransformer
       case USER -> AgentInstanceHistoryRole.USER;
       case ASSISTANT -> AgentInstanceHistoryRole.ASSISTANT;
       case TOOL_RESULT -> AgentInstanceHistoryRole.TOOL_RESULT;
+      case CONFIGURATION -> AgentInstanceHistoryRole.CONFIGURATION;
     };
   }
 

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformerTest.java
@@ -13,10 +13,13 @@ import io.camunda.search.entities.AgentInstanceHistoryEntity;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryRole;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem.ContentType;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.Limits;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryCommitStatus;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryContentValue;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryEmbeddedToolCallValue;
+import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryLimitsValue;
+import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryToolValue;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryRole;
 import io.camunda.webapps.schema.entities.document.DocumentReferenceEntity;
 import io.camunda.webapps.schema.entities.document.DocumentReferenceMetadataEntity;
@@ -46,6 +49,7 @@ class AgentHistoryEntityTransformerTest {
     source.setJobKey(500L);
     source.setJobLease("lease-token");
     source.setLoopIteration(3);
+    source.setHistoryItemId("history-item-1");
     source.setRole(AgentHistoryRole.ASSISTANT);
     source.setCommitStatus(AgentHistoryCommitStatus.COMMITTED);
     source.setProducedAt(OffsetDateTime.parse("2024-06-01T12:00:00Z"));
@@ -70,6 +74,7 @@ class AgentHistoryEntityTransformerTest {
 
     // then
     assertThat(result.historyItemKey()).isEqualTo(100L);
+    assertThat(result.historyItemId()).isEqualTo("history-item-1");
     assertThat(result.agentInstanceKey()).isEqualTo(50L);
     assertThat(result.elementInstanceKey()).isEqualTo(200L);
     assertThat(result.processInstanceKey()).isEqualTo(300L);
@@ -245,5 +250,54 @@ class AgentHistoryEntityTransformerTest {
     assertThat(result.metrics().inputTokens()).isEqualTo(100L);
     assertThat(result.metrics().outputTokens()).isEqualTo(200L);
     assertThat(result.metrics().durationMs()).isNull();
+  }
+
+  @Test
+  void shouldMapConfigurationFields() {
+    // given — a CONFIGURATION item that touched tools/model/provider/limits/systemPrompt
+    final var source = buildSource();
+    source.setRole(AgentHistoryRole.CONFIGURATION);
+    source.setTools(List.of(new AgentHistoryToolValue("search", "Searches the web", "Task_1")));
+    source.setModel("gpt-4o");
+    source.setProvider("openai");
+    source.setLimits(new AgentHistoryLimitsValue(1000L, 10, 5));
+    source.setSystemPrompt(List.of(AgentHistoryContentValue.text("You are a helpful assistant.")));
+
+    // when
+    final AgentInstanceHistoryEntity result = transformer.apply(source);
+
+    // then
+    assertThat(result.role()).isEqualTo(AgentInstanceHistoryRole.CONFIGURATION);
+    assertThat(result.tools()).hasSize(1);
+    assertThat(result.tools().get(0).name()).isEqualTo("search");
+    assertThat(result.tools().get(0).description()).isEqualTo("Searches the web");
+    assertThat(result.tools().get(0).elementId()).isEqualTo("Task_1");
+    assertThat(result.model()).isEqualTo("gpt-4o");
+    assertThat(result.provider()).isEqualTo("openai");
+    assertThat(result.limits()).isNotNull();
+    assertThat(result.limits().maxTokens()).isEqualTo(1000L);
+    assertThat(result.limits().maxModelCalls()).isEqualTo(10);
+    assertThat(result.limits().maxToolCalls()).isEqualTo(5);
+    assertThat(result.systemPrompt()).hasSize(1);
+    assertThat(result.systemPrompt().get(0).contentType()).isEqualTo(ContentType.TEXT);
+    assertThat(result.systemPrompt().get(0).text()).isEqualTo("You are a helpful assistant.");
+  }
+
+  @Test
+  void shouldMapEmptyToolsAndSystemPromptAndSentinelLimitsWhenUntouched() {
+    // given — source has no tools/model/provider/limits/systemPrompt set (the default for
+    // non-CONFIGURATION items, and for CONFIGURATION items that didn't touch these particular
+    // fields)
+    final var source = buildSource();
+
+    // when
+    final AgentInstanceHistoryEntity result = transformer.apply(source);
+
+    // then
+    assertThat(result.tools()).isEmpty();
+    assertThat(result.model()).isNull();
+    assertThat(result.provider()).isNull();
+    assertThat(result.limits()).isEqualTo(new Limits(-1, -1, -1));
+    assertThat(result.systemPrompt()).isEmpty();
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceHistoryEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceHistoryEntity.java
@@ -63,7 +63,8 @@ public record AgentInstanceHistoryEntity(
   public enum AgentInstanceHistoryRole {
     USER,
     ASSISTANT,
-    TOOL_RESULT
+    TOOL_RESULT,
+    CONFIGURATION
   }
 
   public enum AgentInstanceHistoryCommitStatus {

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceHistoryEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceHistoryEntity.java
@@ -24,6 +24,7 @@ import org.jspecify.annotations.Nullable;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record AgentInstanceHistoryEntity(
     Long historyItemKey,
+    String historyItemId,
     Long agentInstanceKey,
     Long elementInstanceKey,
     Long processInstanceKey,
@@ -37,12 +38,18 @@ public record AgentInstanceHistoryEntity(
     List<ContentItem> content,
     List<ToolCall> toolCalls,
     @Nullable Metrics metrics,
+    List<Tool> tools,
+    @Nullable String model,
+    @Nullable String provider,
+    Limits limits,
+    List<ContentItem> systemPrompt,
     AgentInstanceHistoryCommitStatus commitStatus,
     OffsetDateTime producedAt)
     implements TenantOwnedEntity {
 
   public AgentInstanceHistoryEntity {
     Objects.requireNonNull(historyItemKey, "historyItemKey");
+    Objects.requireNonNull(historyItemId, "historyItemId");
     Objects.requireNonNull(agentInstanceKey, "agentInstanceKey");
     Objects.requireNonNull(elementInstanceKey, "elementInstanceKey");
     Objects.requireNonNull(processInstanceKey, "processInstanceKey");
@@ -58,6 +65,9 @@ public record AgentInstanceHistoryEntity(
     // Mutable lists required — readers may hydrate by calling .add()
     content = content != null ? new ArrayList<>(content) : new ArrayList<>();
     toolCalls = toolCalls != null ? new ArrayList<>(toolCalls) : new ArrayList<>();
+    tools = tools != null ? new ArrayList<>(tools) : new ArrayList<>();
+    systemPrompt = systemPrompt != null ? new ArrayList<>(systemPrompt) : new ArrayList<>();
+    limits = limits != null ? limits : new Limits(-1, -1, -1);
   }
 
   public enum AgentInstanceHistoryRole {
@@ -146,4 +156,20 @@ public record AgentInstanceHistoryEntity(
   @JsonIgnoreProperties(ignoreUnknown = true)
   public record Metrics(
       @Nullable Long inputTokens, @Nullable Long outputTokens, @Nullable Long durationMs) {}
+
+  /** A tool made available to the agent by a CONFIGURATION item. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record Tool(String name, @Nullable String description, @Nullable String elementId) {
+    public Tool {
+      Objects.requireNonNull(name, "name");
+    }
+  }
+
+  /**
+   * The limits set by a CONFIGURATION item. {@code -1} on any field means "no limit configured" for
+   * that dimension — same convention as {@link
+   * io.camunda.search.entities.AgentInstanceEntity.AgentInstanceLimits}.
+   */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record Limits(long maxTokens, int maxModelCalls, int maxToolCalls) {}
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryEntity.java
@@ -92,6 +92,38 @@ public final class AgentHistoryEntity
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private List<AgentHistoryEmbeddedToolCallValue> toolCalls;
 
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String historyItemId;
+
+  /**
+   * CONFIGURATION items only — empty when this item didn't touch the tool list. May still be null
+   * for documents exported before this field existed.
+   */
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private List<AgentHistoryToolValue> tools;
+
+  /** CONFIGURATION items only — null if this item didn't touch the model. */
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String model;
+
+  /** CONFIGURATION items only — null if this item didn't touch the provider. */
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String provider;
+
+  /**
+   * CONFIGURATION items only — the {@code -1} sentinel ("no limit configured") when this item
+   * didn't touch the limits. May still be null for documents exported before this field existed.
+   */
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private AgentHistoryLimitsValue limits;
+
+  /**
+   * CONFIGURATION items only — empty when this item didn't touch the system prompt. May still be
+   * null for documents exported before this field existed.
+   */
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private List<AgentHistoryContentValue> systemPrompt;
+
   @Override
   public String getId() {
     return id;
@@ -286,6 +318,60 @@ public final class AgentHistoryEntity
     return this;
   }
 
+  public String getHistoryItemId() {
+    return historyItemId;
+  }
+
+  public AgentHistoryEntity setHistoryItemId(final String historyItemId) {
+    this.historyItemId = historyItemId;
+    return this;
+  }
+
+  public List<AgentHistoryToolValue> getTools() {
+    return tools;
+  }
+
+  public AgentHistoryEntity setTools(final List<AgentHistoryToolValue> tools) {
+    this.tools = tools;
+    return this;
+  }
+
+  public String getModel() {
+    return model;
+  }
+
+  public AgentHistoryEntity setModel(final String model) {
+    this.model = model;
+    return this;
+  }
+
+  public String getProvider() {
+    return provider;
+  }
+
+  public AgentHistoryEntity setProvider(final String provider) {
+    this.provider = provider;
+    return this;
+  }
+
+  public AgentHistoryLimitsValue getLimits() {
+    return limits;
+  }
+
+  public AgentHistoryEntity setLimits(final AgentHistoryLimitsValue limits) {
+    this.limits = limits;
+    return this;
+  }
+
+  public List<AgentHistoryContentValue> getSystemPrompt() {
+    return systemPrompt;
+  }
+
+  public AgentHistoryEntity setSystemPrompt(final List<AgentHistoryContentValue> systemPrompt) {
+    this.systemPrompt = systemPrompt;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -424,4 +510,13 @@ public final class AgentHistoryEntity
   /** A tool call embedded in a history entry. */
   public record AgentHistoryEmbeddedToolCallValue(
       String toolCallId, String toolName, String elementId, Map<String, Object> arguments) {}
+
+  /** A tool made available to the agent by a CONFIGURATION history entry. */
+  public record AgentHistoryToolValue(String name, String description, String elementId) {}
+
+  /**
+   * The limits carried by a CONFIGURATION history entry. {@code -1} on any field means "no limit
+   * configured" for that dimension, same convention as {@code AgentInstanceEntity}'s limits fields.
+   */
+  public record AgentHistoryLimitsValue(long maxTokens, int maxModelCalls, int maxToolCalls) {}
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryEntity.java
@@ -95,10 +95,7 @@ public final class AgentHistoryEntity
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private String historyItemId;
 
-  /**
-   * CONFIGURATION items only — empty when this item didn't touch the tool list. May still be null
-   * for documents exported before this field existed.
-   */
+  /** CONFIGURATION items only — empty when this item didn't touch the tool list. */
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private List<AgentHistoryToolValue> tools;
 
@@ -112,15 +109,12 @@ public final class AgentHistoryEntity
 
   /**
    * CONFIGURATION items only — the {@code -1} sentinel ("no limit configured") when this item
-   * didn't touch the limits. May still be null for documents exported before this field existed.
+   * didn't touch the limits.
    */
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private AgentHistoryLimitsValue limits;
 
-  /**
-   * CONFIGURATION items only — empty when this item didn't touch the system prompt. May still be
-   * null for documents exported before this field existed.
-   */
+  /** CONFIGURATION items only — empty when this item didn't touch the system prompt. */
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private List<AgentHistoryContentValue> systemPrompt;
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryRole.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryRole.java
@@ -11,5 +11,6 @@ package io.camunda.webapps.schema.entities.agenthistory;
 public enum AgentHistoryRole {
   USER,
   ASSISTANT,
-  TOOL_RESULT
+  TOOL_RESULT,
+  CONFIGURATION
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-agent-history.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-agent-history.json
@@ -160,6 +160,125 @@
             "enabled": false
           }
         }
+      },
+      "historyItemId": {
+        "type": "keyword"
+      },
+      "tools": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "keyword",
+            "index": false,
+            "doc_values": false
+          },
+          "description": {
+            "type": "text",
+            "index": false
+          },
+          "elementId": {
+            "type": "keyword",
+            "index": false,
+            "doc_values": false
+          }
+        }
+      },
+      "model": {
+        "type": "keyword"
+      },
+      "provider": {
+        "type": "keyword"
+      },
+      "limits": {
+        "type": "object",
+        "properties": {
+          "maxTokens": {
+            "type": "long"
+          },
+          "maxModelCalls": {
+            "type": "integer"
+          },
+          "maxToolCalls": {
+            "type": "integer"
+          }
+        }
+      },
+      "systemPrompt": {
+        "type": "object",
+        "properties": {
+          "contentType": {
+            "type": "keyword",
+            "index": false,
+            "doc_values": false
+          },
+          "text": {
+            "type": "text",
+            "index": false
+          },
+          "documentReference": {
+            "type": "object",
+            "properties": {
+              "documentId": {
+                "type": "keyword",
+                "index": false,
+                "doc_values": false
+              },
+              "storeId": {
+                "type": "keyword",
+                "index": false,
+                "doc_values": false
+              },
+              "contentHash": {
+                "type": "keyword",
+                "index": false,
+                "doc_values": false
+              },
+              "metadata": {
+                "type": "object",
+                "properties": {
+                  "contentType": {
+                    "type": "keyword",
+                    "index": false,
+                    "doc_values": false
+                  },
+                  "fileName": {
+                    "type": "keyword",
+                    "index": false,
+                    "doc_values": false
+                  },
+                  "expiresAt": {
+                    "type": "date",
+                    "format": "date_time || epoch_millis",
+                    "index": false
+                  },
+                  "size": {
+                    "type": "long",
+                    "index": false,
+                    "doc_values": false
+                  },
+                  "processDefinitionId": {
+                    "type": "keyword",
+                    "index": false,
+                    "doc_values": false
+                  },
+                  "processInstanceKey": {
+                    "type": "long",
+                    "index": false,
+                    "doc_values": false
+                  },
+                  "customProperties": {
+                    "type": "object",
+                    "enabled": false
+                  }
+                }
+              }
+            }
+          },
+          "object": {
+            "type": "object",
+            "enabled": false
+          }
+        }
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-agent-history.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-agent-history.json
@@ -160,6 +160,125 @@
             "enabled": false
           }
         }
+      },
+      "historyItemId": {
+        "type": "keyword"
+      },
+      "tools": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "keyword",
+            "index": false,
+            "doc_values": false
+          },
+          "description": {
+            "type": "text",
+            "index": false
+          },
+          "elementId": {
+            "type": "keyword",
+            "index": false,
+            "doc_values": false
+          }
+        }
+      },
+      "model": {
+        "type": "keyword"
+      },
+      "provider": {
+        "type": "keyword"
+      },
+      "limits": {
+        "type": "object",
+        "properties": {
+          "maxTokens": {
+            "type": "long"
+          },
+          "maxModelCalls": {
+            "type": "integer"
+          },
+          "maxToolCalls": {
+            "type": "integer"
+          }
+        }
+      },
+      "systemPrompt": {
+        "type": "object",
+        "properties": {
+          "contentType": {
+            "type": "keyword",
+            "index": false,
+            "doc_values": false
+          },
+          "text": {
+            "type": "text",
+            "index": false
+          },
+          "documentReference": {
+            "type": "object",
+            "properties": {
+              "documentId": {
+                "type": "keyword",
+                "index": false,
+                "doc_values": false
+              },
+              "storeId": {
+                "type": "keyword",
+                "index": false,
+                "doc_values": false
+              },
+              "contentHash": {
+                "type": "keyword",
+                "index": false,
+                "doc_values": false
+              },
+              "metadata": {
+                "type": "object",
+                "properties": {
+                  "contentType": {
+                    "type": "keyword",
+                    "index": false,
+                    "doc_values": false
+                  },
+                  "fileName": {
+                    "type": "keyword",
+                    "index": false,
+                    "doc_values": false
+                  },
+                  "expiresAt": {
+                    "type": "date",
+                    "format": "date_time || epoch_millis",
+                    "index": false
+                  },
+                  "size": {
+                    "type": "long",
+                    "index": false,
+                    "doc_values": false
+                  },
+                  "processDefinitionId": {
+                    "type": "keyword",
+                    "index": false,
+                    "doc_values": false
+                  },
+                  "processInstanceKey": {
+                    "type": "long",
+                    "index": false,
+                    "doc_values": false
+                  },
+                  "customProperties": {
+                    "type": "object",
+                    "enabled": false
+                  }
+                }
+              }
+            }
+          },
+          "object": {
+            "type": "object",
+            "enabled": false
+          }
+        }
       }
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
@@ -15,6 +15,8 @@ import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryCommitStatus;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryContentValue;
+import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryLimitsValue;
+import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryToolValue;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryRole;
 import io.camunda.webapps.schema.entities.document.DocumentReferenceEntity;
 import io.camunda.webapps.schema.entities.document.DocumentReferenceMetadataEntity;
@@ -24,6 +26,8 @@ import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue.AgentHistoryEmbeddedToolCallValue;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue.AgentHistoryMessageContentValue;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue.AgentInstanceLimitsValue;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue.AgentInstanceToolValue;
 import io.camunda.zeebe.protocol.record.value.DocumentReferenceValue;
 import io.camunda.zeebe.util.DateUtil;
 import java.time.Instant;
@@ -35,16 +39,13 @@ import java.util.Set;
  * CamundaExporter handler for {@code AGENT_HISTORY} records.
  *
  * <ul>
- *   <li>{@code CREATED}: full upsert — all entity fields are populated from the record value,
- *       including {@code content}, {@code toolCalls}, {@code inputTokens}, {@code outputTokens},
- *       {@code durationMs} and {@code producedAt}.
+ *   <li>{@code CREATED}: full upsert — every entity field is populated from the record value.
  *   <li>{@code COMMITTED} / {@code DISCARDED}: the engine only retains identity fields once an item
- *       is committed/discarded, so the record value's {@code content}, {@code toolCalls},
- *       token/duration metrics and {@code producedAt} are trimmed and must not be applied to the
- *       entity — {@code updateEntity()} leaves those 6 fields untouched, updating only {@code
- *       commitStatus} and the other identity fields. {@code flush()} additionally passes only
- *       {@code Map.of(COMMIT_STATUS, ...)} as updateFields so only {@code commitStatus} is written
- *       to the existing document.
+ *       is committed/discarded, so the record value's non-identity fields are trimmed and must not
+ *       be applied to the entity — {@code updateEntity()} leaves those fields untouched, updating
+ *       only {@code commitStatus} and the other identity fields. {@code flush()} additionally
+ *       passes only {@code Map.of(COMMIT_STATUS, ...)} as updateFields so only {@code commitStatus}
+ *       is written to the existing document.
  * </ul>
  */
 public class AgentHistoryHandler
@@ -108,7 +109,10 @@ public class AgentHistoryHandler
         .setCommitStatus(mapCommitStatusFromIntent(intent));
 
     // Guarded to CREATED only: ExporterBatchWriter shares one mutable entity across a batch, so a
-    // same-batch COMMITTED/DISCARDED call would otherwise clobber these with its trimmed values.
+    // same-batch COMMITTED/DISCARDED call would otherwise clobber these with its trimmed values —
+    // AgentHistoryCreatedApplier in primary storage doesn't retain these fields past CREATED
+    // either (see that class), so COMMITTED/DISCARDED events carry them as empty/default rather
+    // than the original CREATED values; guarding to CREATED avoids clobbering.
     if (intent == AgentHistoryIntent.CREATED) {
       entity
           .setProducedAt(
@@ -119,7 +123,13 @@ public class AgentHistoryHandler
           .setOutputTokens(ExporterUtil.nullIfNegative(value.getMetrics().getOutputTokens()))
           .setDurationMs(ExporterUtil.nullIfNegative(value.getMetrics().getDurationMs()))
           .setContent(mapContent(value.getContent()))
-          .setToolCalls(mapToolCalls(value.getToolCalls()));
+          .setToolCalls(mapToolCalls(value.getToolCalls()))
+          .setHistoryItemId(ExporterUtil.emptyToNull(value.getHistoryItemId()))
+          .setTools(mapTools(value.getTools()))
+          .setModel(ExporterUtil.emptyToNull(value.getModel()))
+          .setProvider(ExporterUtil.emptyToNull(value.getProvider()))
+          .setLimits(mapLimits(value.getLimits()))
+          .setSystemPrompt(mapSystemPrompt(value.getSystemPrompt()));
     }
   }
 
@@ -221,5 +231,42 @@ public class AgentHistoryHandler
                     ExporterUtil.emptyToNull(t.getElementId()),
                     t.getArguments()))
         .toList();
+  }
+
+  /** The tools available to the agent, as of this entry. CONFIGURATION items only. */
+  private static List<AgentHistoryToolValue> mapTools(
+      final List<? extends AgentInstanceToolValue> tools) {
+    if (tools == null || tools.isEmpty()) {
+      return List.of();
+    }
+    return tools.stream()
+        .map(
+            t ->
+                new AgentHistoryToolValue(
+                    t.getName(),
+                    ExporterUtil.emptyToNull(t.getDescription()),
+                    ExporterUtil.emptyToNull(t.getElementId())))
+        .toList();
+  }
+
+  /**
+   * The operational limits, as of this entry. CONFIGURATION items only. {@code -1} on any field
+   * means "no limit configured".
+   */
+  private static AgentHistoryLimitsValue mapLimits(final AgentInstanceLimitsValue limits) {
+    if (limits == null) {
+      return new AgentHistoryLimitsValue(-1L, -1, -1);
+    }
+    return new AgentHistoryLimitsValue(
+        limits.getMaxTokens(), limits.getMaxModelCalls(), limits.getMaxToolCalls());
+  }
+
+  /** The system prompt, as content blocks, as of this entry. CONFIGURATION items only. */
+  private static List<AgentHistoryContentValue> mapSystemPrompt(
+      final List<? extends AgentHistoryMessageContentValue> systemPrompt) {
+    if (systemPrompt == null || systemPrompt.isEmpty()) {
+      return List.of();
+    }
+    return mapContent(systemPrompt);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
@@ -143,6 +143,7 @@ public class AgentHistoryHandler
       case USER -> AgentHistoryRole.USER;
       case ASSISTANT -> AgentHistoryRole.ASSISTANT;
       case TOOL_RESULT -> AgentHistoryRole.TOOL_RESULT;
+      case CONFIGURATION -> AgentHistoryRole.CONFIGURATION;
       // should never happen — protocol UNSPECIFIED is always overwritten before export
       case UNSPECIFIED ->
           throw new IllegalStateException(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
@@ -22,6 +22,8 @@ import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryContentType;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryContentValue;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryEmbeddedToolCallValue;
+import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryLimitsValue;
+import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryToolValue;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryRole;
 import io.camunda.webapps.schema.entities.document.DocumentReferenceEntity;
 import io.camunda.webapps.schema.entities.document.DocumentReferenceMetadataEntity;
@@ -33,6 +35,8 @@ import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryEmbeddedToolC
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryMessageContentValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryMetricsValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentInstanceLimitsValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentInstanceToolValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableDocumentReferenceMetadataValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableDocumentReferenceValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
@@ -188,6 +192,85 @@ final class AgentHistoryHandlerTest {
                 "tc-1", "search", "searchElement", Map.of("query", "weather")));
   }
 
+  @Test
+  void shouldPopulateConfigurationFieldsForCreatedIntent() {
+    // given — a CONFIGURATION item that touched
+    // historyItemId/tools/model/provider/limits/systemPrompt
+    final var recordValue =
+        ImmutableAgentHistoryRecordValue.builder()
+            .from(buildMinimalRecordValue(50L, 3))
+            .withRole(io.camunda.zeebe.protocol.record.value.AgentHistoryRole.CONFIGURATION)
+            .withHistoryItemId("history-item-1")
+            .withTools(
+                List.of(
+                    ImmutableAgentInstanceToolValue.builder()
+                        .withName("search")
+                        .withDescription("Searches the web")
+                        .withElementId("Task_1")
+                        .build()))
+            .withModel("gpt-4o")
+            .withProvider("openai")
+            .withLimits(
+                ImmutableAgentInstanceLimitsValue.builder()
+                    .withMaxTokens(1000L)
+                    .withMaxModelCalls(10)
+                    .withMaxToolCalls(5)
+                    .build())
+            .withSystemPrompt(
+                List.of(
+                    ImmutableAgentHistoryMessageContentValue.builder()
+                        .withContentType(
+                            io.camunda.zeebe.protocol.record.value.AgentHistoryContentType.TEXT)
+                        .withText("You are a helpful assistant.")
+                        .withObject(Map.of())
+                        .build()))
+            .build();
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r -> r.withIntent(AgentHistoryIntent.CREATED).withKey(101L).withValue(recordValue));
+    final var entity = new AgentHistoryEntity().setId("101");
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getRole()).isEqualTo(AgentHistoryRole.CONFIGURATION);
+    assertThat(entity.getHistoryItemId()).isEqualTo("history-item-1");
+    assertThat(entity.getTools())
+        .containsExactly(new AgentHistoryToolValue("search", "Searches the web", "Task_1"));
+    assertThat(entity.getModel()).isEqualTo("gpt-4o");
+    assertThat(entity.getProvider()).isEqualTo("openai");
+    assertThat(entity.getLimits()).isEqualTo(new AgentHistoryLimitsValue(1000L, 10, 5));
+    assertThat(entity.getSystemPrompt())
+        .containsExactly(
+            new AgentHistoryContentValue(
+                AgentHistoryContentType.TEXT, "You are a helpful assistant.", null, null));
+  }
+
+  @Test
+  void shouldMapUntouchedConfigurationFields() {
+    // given — a non-CONFIGURATION item (protocol defaults: empty historyItemId/tools/model/
+    // provider/systemPrompt, all-sentinel limits)
+    final var recordValue = buildMinimalRecordValue(50L, 3);
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r -> r.withIntent(AgentHistoryIntent.CREATED).withKey(102L).withValue(recordValue));
+    final var entity = new AgentHistoryEntity().setId("102");
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getHistoryItemId()).isNull();
+    assertThat(entity.getTools()).isEmpty();
+    assertThat(entity.getModel()).isNull();
+    assertThat(entity.getProvider()).isNull();
+    assertThat(entity.getLimits()).isEqualTo(new AgentHistoryLimitsValue(-1L, -1, -1));
+    assertThat(entity.getSystemPrompt()).isEmpty();
+  }
+
   @ParameterizedTest(name = "[{index}] Terminal ''{0}'' event must not clobber CREATED content")
   @EnumSource(
       value = AgentHistoryIntent.class,
@@ -229,6 +312,30 @@ final class AgentHistoryHandlerTest {
                         .withElementId("searchElement")
                         .withArguments(Map.of("query", "weather"))
                         .build()))
+            .withHistoryItemId("history-item-1")
+            .withTools(
+                List.of(
+                    ImmutableAgentInstanceToolValue.builder()
+                        .withName("search")
+                        .withDescription("Searches the web")
+                        .withElementId("Task_1")
+                        .build()))
+            .withModel("gpt-4o")
+            .withProvider("openai")
+            .withLimits(
+                ImmutableAgentInstanceLimitsValue.builder()
+                    .withMaxTokens(1000L)
+                    .withMaxModelCalls(10)
+                    .withMaxToolCalls(5)
+                    .build())
+            .withSystemPrompt(
+                List.of(
+                    ImmutableAgentHistoryMessageContentValue.builder()
+                        .withContentType(
+                            io.camunda.zeebe.protocol.record.value.AgentHistoryContentType.TEXT)
+                        .withText("You are a helpful assistant.")
+                        .withObject(Map.of())
+                        .build()))
             .build();
 
     final Record<AgentHistoryRecordValue> createdRecord =
@@ -266,6 +373,17 @@ final class AgentHistoryHandlerTest {
                                     .build())
                             .withContent(List.of())
                             .withToolCalls(List.of())
+                            .withHistoryItemId("")
+                            .withTools(List.of())
+                            .withModel("")
+                            .withProvider("")
+                            .withLimits(
+                                ImmutableAgentInstanceLimitsValue.builder()
+                                    .withMaxTokens(-1L)
+                                    .withMaxModelCalls(-1)
+                                    .withMaxToolCalls(-1)
+                                    .build())
+                            .withSystemPrompt(List.of())
                             .build()));
 
     underTest.updateEntity(trimmedRecord, entity);
@@ -315,6 +433,32 @@ final class AgentHistoryHandlerTest {
               .assertThat(entity.getCommitStatus())
               .as("commitStatus must reflect the terminal event that was actually applied")
               .isEqualTo(expectedStatus);
+          softly
+              .assertThat(entity.getHistoryItemId())
+              .as("historyItemId must still hold the original CREATED value")
+              .isEqualTo("history-item-1");
+          softly
+              .assertThat(entity.getTools())
+              .as("tools must still hold the original CREATED tool list")
+              .containsExactly(new AgentHistoryToolValue("search", "Searches the web", "Task_1"));
+          softly
+              .assertThat(entity.getModel())
+              .as("model must still hold the original CREATED value")
+              .isEqualTo("gpt-4o");
+          softly
+              .assertThat(entity.getProvider())
+              .as("provider must still hold the original CREATED value")
+              .isEqualTo("openai");
+          softly
+              .assertThat(entity.getLimits())
+              .as("limits must still hold the original CREATED value")
+              .isEqualTo(new AgentHistoryLimitsValue(1000L, 10, 5));
+          softly
+              .assertThat(entity.getSystemPrompt())
+              .as("systemPrompt must still hold the original CREATED value")
+              .containsExactly(
+                  new AgentHistoryContentValue(
+                      AgentHistoryContentType.TEXT, "You are a helpful assistant.", null, null));
         });
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandler.java
@@ -95,6 +95,7 @@ public class AgentHistoryExportHandler implements RdbmsExportHandler<AgentHistor
       case USER -> AgentInstanceHistoryRole.USER;
       case ASSISTANT -> AgentInstanceHistoryRole.ASSISTANT;
       case TOOL_RESULT -> AgentInstanceHistoryRole.TOOL_RESULT;
+      case CONFIGURATION -> AgentInstanceHistoryRole.CONFIGURATION;
       case UNSPECIFIED ->
           throw new IllegalStateException(
               "should never happen — protocol UNSPECIFIED is always overwritten before export");

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandler.java
@@ -128,22 +128,19 @@ public class AgentHistoryExportHandler implements RdbmsExportHandler<AgentHistor
   }
 
   /**
-   * The operational limits, as of this entry. CONFIGURATION items only. Leaves the three DB columns
-   * null (rather than writing {@code -1} literally) when none of the sub-fields are configured —
-   * {@link io.camunda.db.rdbms.read.mapper.AgentHistoryEntityMapper} defaults each back to {@code
-   * -1} on read.
+   * The operational limits, as of this entry. CONFIGURATION items only. Leaves a DB column null
+   * (rather than writing {@code -1} literally) when its sub-field isn't configured, independently
+   * per sub-field — {@link io.camunda.db.rdbms.read.mapper.AgentHistoryEntityMapper} defaults each
+   * back to {@code -1} on read.
    */
   private static void applyLimits(final Builder builder, final AgentInstanceLimitsValue limits) {
-    if (limits == null
-        || (limits.getMaxTokens() < 0
-            && limits.getMaxModelCalls() < 0
-            && limits.getMaxToolCalls() < 0)) {
+    if (limits == null) {
       return;
     }
     builder
-        .maxTokens(limits.getMaxTokens())
-        .maxModelCalls(limits.getMaxModelCalls())
-        .maxToolCalls(limits.getMaxToolCalls());
+        .maxTokens(ExportUtil.nullIfNegative(limits.getMaxTokens()))
+        .maxModelCalls(ExportUtil.nullIfNegative(limits.getMaxModelCalls()))
+        .maxToolCalls(ExportUtil.nullIfNegative(limits.getMaxToolCalls()));
   }
 
   /** The system prompt, as content blocks, as of this entry. CONFIGURATION items only. */

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandler.java
@@ -19,12 +19,15 @@ import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem.ContentType;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.DocumentMetadata;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.DocumentReference;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.Tool;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.ToolCall;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue.AgentHistoryEmbeddedToolCallValue;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue.AgentHistoryMessageContentValue;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue.AgentInstanceLimitsValue;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue.AgentInstanceToolValue;
 import io.camunda.zeebe.protocol.record.value.DocumentReferenceValue;
 import java.time.Instant;
 import java.util.List;
@@ -65,28 +68,35 @@ public class AgentHistoryExportHandler implements RdbmsExportHandler<AgentHistor
     final long producedAtMillis =
         value.getProducedAt() > 0 ? value.getProducedAt() : record.getTimestamp();
 
-    return new Builder()
-        .agentHistoryKey(record.getKey())
-        .agentInstanceKey(value.getAgentInstanceKey())
-        .elementInstanceKey(value.getElementInstanceKey())
-        .processInstanceKey(value.getProcessInstanceKey())
-        .rootProcessInstanceKey(value.getRootProcessInstanceKey())
-        .processDefinitionId(value.getBpmnProcessId())
-        .processDefinitionKey(value.getProcessDefinitionKey())
-        .tenantId(value.getTenantId())
-        .partitionId(record.getPartitionId())
-        .jobKey(value.getJobKey())
-        .jobLease(value.getJobLease())
-        .loopIteration(value.getLoopIteration())
-        .role(mapRole(value.getRole()))
-        .commitStatus(mapCommitStatus(intent))
-        .producedAt(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(producedAtMillis)))
-        .inputTokens(ExportUtil.nullIfNegative(value.getMetrics().getInputTokens()))
-        .outputTokens(ExportUtil.nullIfNegative(value.getMetrics().getOutputTokens()))
-        .durationMs(ExportUtil.nullIfNegative(value.getMetrics().getDurationMs()))
-        .contentItems(mapContent(value.getContent()))
-        .toolCallValues(mapToolCalls(value.getToolCalls()))
-        .build();
+    final var builder =
+        new Builder()
+            .agentHistoryKey(record.getKey())
+            .agentInstanceKey(value.getAgentInstanceKey())
+            .elementInstanceKey(value.getElementInstanceKey())
+            .processInstanceKey(value.getProcessInstanceKey())
+            .rootProcessInstanceKey(value.getRootProcessInstanceKey())
+            .processDefinitionId(value.getBpmnProcessId())
+            .processDefinitionKey(value.getProcessDefinitionKey())
+            .tenantId(value.getTenantId())
+            .partitionId(record.getPartitionId())
+            .jobKey(value.getJobKey())
+            .jobLease(value.getJobLease())
+            .loopIteration(value.getLoopIteration())
+            .role(mapRole(value.getRole()))
+            .commitStatus(mapCommitStatus(intent))
+            .producedAt(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(producedAtMillis)))
+            .inputTokens(ExportUtil.nullIfNegative(value.getMetrics().getInputTokens()))
+            .outputTokens(ExportUtil.nullIfNegative(value.getMetrics().getOutputTokens()))
+            .durationMs(ExportUtil.nullIfNegative(value.getMetrics().getDurationMs()))
+            .contentItems(mapContent(value.getContent()))
+            .toolCallValues(mapToolCalls(value.getToolCalls()))
+            .historyItemId(ExportUtil.emptyToNull(value.getHistoryItemId()))
+            .toolValues(mapTools(value.getTools()))
+            .model(ExportUtil.emptyToNull(value.getModel()))
+            .provider(ExportUtil.emptyToNull(value.getProvider()))
+            .systemPromptItems(mapSystemPrompt(value.getSystemPrompt()));
+    applyLimits(builder, value.getLimits());
+    return builder.build();
   }
 
   private static AgentInstanceHistoryRole mapRole(
@@ -100,6 +110,49 @@ public class AgentHistoryExportHandler implements RdbmsExportHandler<AgentHistor
           throw new IllegalStateException(
               "should never happen — protocol UNSPECIFIED is always overwritten before export");
     };
+  }
+
+  /** The tools available to the agent, as of this entry. CONFIGURATION items only. */
+  private static List<Tool> mapTools(final List<? extends AgentInstanceToolValue> tools) {
+    if (tools == null || tools.isEmpty()) {
+      return List.of();
+    }
+    return tools.stream()
+        .map(
+            t ->
+                new Tool(
+                    t.getName(),
+                    ExportUtil.emptyToNull(t.getDescription()),
+                    ExportUtil.emptyToNull(t.getElementId())))
+        .toList();
+  }
+
+  /**
+   * The operational limits, as of this entry. CONFIGURATION items only. Leaves the three DB columns
+   * null (rather than writing {@code -1} literally) when none of the sub-fields are configured —
+   * {@link io.camunda.db.rdbms.read.mapper.AgentHistoryEntityMapper} defaults each back to {@code
+   * -1} on read.
+   */
+  private static void applyLimits(final Builder builder, final AgentInstanceLimitsValue limits) {
+    if (limits == null
+        || (limits.getMaxTokens() < 0
+            && limits.getMaxModelCalls() < 0
+            && limits.getMaxToolCalls() < 0)) {
+      return;
+    }
+    builder
+        .maxTokens(limits.getMaxTokens())
+        .maxModelCalls(limits.getMaxModelCalls())
+        .maxToolCalls(limits.getMaxToolCalls());
+  }
+
+  /** The system prompt, as content blocks, as of this entry. CONFIGURATION items only. */
+  private static List<ContentItem> mapSystemPrompt(
+      final List<? extends AgentHistoryMessageContentValue> systemPrompt) {
+    if (systemPrompt == null || systemPrompt.isEmpty()) {
+      return List.of();
+    }
+    return mapContent(systemPrompt);
   }
 
   private static AgentInstanceHistoryCommitStatus mapCommitStatus(final AgentHistoryIntent intent) {

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/utils/ExportUtil.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/utils/ExportUtil.java
@@ -85,4 +85,15 @@ public class ExportUtil {
   public static Long nullIfNegative(final long value) {
     return value < 0 ? null : value;
   }
+
+  /**
+   * Returns {@code null} when {@code value} is negative (i.e., the protocol sentinel for "not
+   * set"), otherwise returns the boxed value.
+   *
+   * <p>Treats {@code 0} as a valid explicit value — callers that use it must not conflate zero with
+   * "absent".
+   */
+  public static Integer nullIfNegative(final int value) {
+    return value < 0 ? null : value;
+  }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandlerTest.java
@@ -634,6 +634,38 @@ class AgentHistoryExportHandlerTest {
   }
 
   @Test
+  void shouldMapPartiallyConfiguredLimitsIndependently() {
+    // given — a CONFIGURATION item that only set maxTokens, leaving maxModelCalls/maxToolCalls at
+    // the protocol sentinel (-1)
+    final var recordValue =
+        ImmutableAgentHistoryRecordValue.builder()
+            .from(buildRecordValue())
+            .withRole(AgentHistoryRole.CONFIGURATION)
+            .withLimits(
+                ImmutableAgentInstanceLimitsValue.builder()
+                    .withMaxTokens(1000L)
+                    .withMaxModelCalls(-1)
+                    .withMaxToolCalls(-1)
+                    .build())
+            .build();
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r -> r.withIntent(AgentHistoryIntent.CREATED).withKey(66L).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then — the configured field is stored as-is; the untouched ones stay null (not -1), same as
+    // a fully-untouched item
+    verify(writer).create(modelCaptor.capture());
+    final var model = modelCaptor.getValue();
+    assertThat(model.maxTokens()).isEqualTo(1000L);
+    assertThat(model.maxModelCalls()).isNull();
+    assertThat(model.maxToolCalls()).isNull();
+  }
+
+  @Test
   void shouldMapUnsetMetricsToNull() {
     // given — -1L is the protocol sentinel meaning "metrics not provided"
     final var recordValue =

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandlerTest.java
@@ -27,6 +27,8 @@ import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryEmbeddedToolC
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryMessageContentValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryMetricsValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentInstanceLimitsValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentInstanceToolValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableDocumentReferenceMetadataValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableDocumentReferenceValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
@@ -542,6 +544,93 @@ class AgentHistoryExportHandlerTest {
     assertThat(mappedItem.text()).isNull();
     assertThat(mappedItem.documentReference()).isNull();
     assertThat(mappedItem.object()).isEqualTo(arrayValue);
+  }
+
+  @Test
+  void shouldMapConfigurationFields() {
+    // given — a CONFIGURATION item that touched
+    // historyItemId/tools/model/provider/limits/systemPrompt
+    final var recordValue =
+        ImmutableAgentHistoryRecordValue.builder()
+            .from(buildRecordValue())
+            .withRole(AgentHistoryRole.CONFIGURATION)
+            .withHistoryItemId("history-item-1")
+            .withTools(
+                List.of(
+                    ImmutableAgentInstanceToolValue.builder()
+                        .withName("search")
+                        .withDescription("Searches the web")
+                        .withElementId("Task_1")
+                        .build()))
+            .withModel("gpt-4o")
+            .withProvider("openai")
+            .withLimits(
+                ImmutableAgentInstanceLimitsValue.builder()
+                    .withMaxTokens(1000L)
+                    .withMaxModelCalls(10)
+                    .withMaxToolCalls(5)
+                    .build())
+            .withSystemPrompt(
+                List.of(
+                    ImmutableAgentHistoryMessageContentValue.builder()
+                        .withContentType(AgentHistoryContentType.TEXT)
+                        .withText("You are a helpful assistant.")
+                        .build()))
+            .build();
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r -> r.withIntent(AgentHistoryIntent.CREATED).withKey(64L).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).create(modelCaptor.capture());
+    final var model = modelCaptor.getValue();
+    assertThat(model.historyItemId()).isEqualTo("history-item-1");
+    assertThat(model.toolValues()).hasSize(1);
+    assertThat(model.toolValues().getFirst().name()).isEqualTo("search");
+    assertThat(model.toolValues().getFirst().description()).isEqualTo("Searches the web");
+    assertThat(model.toolValues().getFirst().elementId()).isEqualTo("Task_1");
+    assertThat(model.model()).isEqualTo("gpt-4o");
+    assertThat(model.provider()).isEqualTo("openai");
+    assertThat(model.maxTokens()).isEqualTo(1000L);
+    assertThat(model.maxModelCalls()).isEqualTo(10);
+    assertThat(model.maxToolCalls()).isEqualTo(5);
+    assertThat(model.systemPromptItems()).hasSize(1);
+    assertThat(model.systemPromptItems().getFirst().text())
+        .isEqualTo("You are a helpful assistant.");
+  }
+
+  @Test
+  void shouldMapUntouchedConfigurationFields() {
+    // given — a non-CONFIGURATION item (protocol defaults: empty historyItemId/tools/model/
+    // provider/systemPrompt, all-sentinel limits)
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r ->
+                r.withIntent(AgentHistoryIntent.CREATED)
+                    .withKey(65L)
+                    .withValue(buildRecordValue()));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).create(modelCaptor.capture());
+    final var model = modelCaptor.getValue();
+    assertThat(model.historyItemId()).isNull();
+    assertThat(model.toolValues()).isEmpty();
+    assertThat(model.model()).isNull();
+    assertThat(model.provider()).isNull();
+    // the three DB columns stay null (not -1) — a storage-only optimization; the read mapper
+    // defaults them back to -1 (AgentHistoryEntityMapper.toLimits())
+    assertThat(model.maxTokens()).isNull();
+    assertThat(model.maxModelCalls()).isNull();
+    assertThat(model.maxToolCalls()).isNull();
+    assertThat(model.systemPromptItems()).isEmpty();
   }
 
   @Test

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -943,6 +943,12 @@ components:
         - metrics
         - commitStatus
         - producedAt
+        - historyItemId
+        - tools
+        - model
+        - provider
+        - limits
+        - systemPrompt
       properties:
         historyItemKey:
           description: The unique key for this history item. Stable and sortable by creation order.
@@ -999,6 +1005,42 @@ components:
           description: The connector-side timestamp of when this message was produced.
           type: string
           format: date-time
+        historyItemId:
+          description: |
+            The client-supplied identifier this item was created with. Empty for items that don't
+            carry one.
+          type: string
+        tools:
+          description: |
+            The complete list of tools available to the agent as of this entry. CONFIGURATION
+            items only; empty for other roles.
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentTool'
+        model:
+          description: |
+            The LLM model identifier as of this entry. CONFIGURATION items only; null for other
+            roles.
+          type: string
+          nullable: true
+        provider:
+          description: |
+            The LLM provider as of this entry. CONFIGURATION items only; null for other roles.
+          type: string
+          nullable: true
+        limits:
+          description: |
+            The operational limits as of this entry. CONFIGURATION items only; -1 on any field
+            means "no limit configured" for other roles.
+          allOf:
+            - $ref: '#/components/schemas/AgentInstanceLimits'
+        systemPrompt:
+          description: |
+            The system prompt, as content blocks, as of this entry. CONFIGURATION items only;
+            empty for other roles.
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentInstanceMessageContent'
     AgentInstanceHistoryRoleEnum:
       description: The role of a history item in the agent conversation.
       type: string

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -1054,6 +1054,7 @@ components:
       type: object
       required:
         - historyItemKey
+        - historyItemId
         - agentInstanceKey
         - elementInstanceKey
         - jobKey
@@ -1065,7 +1066,6 @@ components:
         - metrics
         - commitStatus
         - producedAt
-        - historyItemId
         - tools
         - model
         - provider
@@ -1076,6 +1076,11 @@ components:
           description: The unique key for this history item. Stable and sortable by creation order.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/AgentHistoryItemKey'
+        historyItemId:
+          description: |
+            The client-supplied identifier this item was created with. Empty for items that don't
+            carry one.
+          type: string
         agentInstanceKey:
           description: The key of the agent instance this item belongs to.
           allOf:
@@ -1125,11 +1130,6 @@ components:
           description: The agent-side timestamp of when this message was produced.
           type: string
           format: date-time
-        historyItemId:
-          description: |
-            The client-supplied identifier this item was created with. Empty for items that don't
-            carry one.
-          type: string
         tools:
           description: |
             The complete list of tools available to the agent as of this entry. CONFIGURATION

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -1126,6 +1126,7 @@ components:
         - USER
         - ASSISTANT
         - TOOL_RESULT
+        - CONFIGURATION
 
     AgentInstanceHistoryCommitStatusEnum:
       description: |

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -1006,6 +1006,7 @@ components:
         - USER
         - ASSISTANT
         - TOOL_RESULT
+        - CONFIGURATION
 
     AgentInstanceHistoryCommitStatusEnum:
       description: |

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -1065,6 +1065,12 @@ components:
         - metrics
         - commitStatus
         - producedAt
+        - historyItemId
+        - tools
+        - model
+        - provider
+        - limits
+        - systemPrompt
       properties:
         historyItemKey:
           description: The unique key for this history item. Stable and sortable by creation order.
@@ -1119,6 +1125,42 @@ components:
           description: The agent-side timestamp of when this message was produced.
           type: string
           format: date-time
+        historyItemId:
+          description: |
+            The client-supplied identifier this item was created with. Empty for items that don't
+            carry one.
+          type: string
+        tools:
+          description: |
+            The complete list of tools available to the agent as of this entry. CONFIGURATION
+            items only; empty for other roles.
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentTool'
+        model:
+          description: |
+            The LLM model identifier as of this entry. CONFIGURATION items only; null for other
+            roles.
+          type: string
+          nullable: true
+        provider:
+          description: |
+            The LLM provider as of this entry. CONFIGURATION items only; null for other roles.
+          type: string
+          nullable: true
+        limits:
+          description: |
+            The operational limits as of this entry. CONFIGURATION items only; -1 on any field
+            means "no limit configured" for other roles.
+          allOf:
+            - $ref: '#/components/schemas/AgentInstanceLimits'
+        systemPrompt:
+          description: |
+            The system prompt, as content blocks, as of this entry. CONFIGURATION items only;
+            empty for other roles.
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentInstanceMessageContent'
     AgentInstanceHistoryRoleEnum:
       description: The role of a history item in the agent conversation.
       type: string

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceHistorySearchControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceHistorySearchControllerTest.java
@@ -51,8 +51,8 @@ class AgentInstanceHistorySearchControllerTest extends RestControllerTest {
 
   private static final AgentInstanceHistoryEntity HISTORY_ENTITY =
       new AgentInstanceHistoryEntity(
-          HISTORY_ITEM_ID,
           HISTORY_ITEM_KEY,
+          HISTORY_ITEM_ID,
           AGENT_INSTANCE_KEY,
           ELEMENT_INSTANCE_KEY,
           9007199254741001L,
@@ -83,6 +83,7 @@ class AgentInstanceHistorySearchControllerTest extends RestControllerTest {
         "items": [
           {
             "historyItemKey": "%d",
+            "historyItemId": "%s",
             "agentInstanceKey": "%d",
             "elementInstanceKey": "%d",
             "jobKey": "%d",
@@ -92,6 +93,11 @@ class AgentInstanceHistorySearchControllerTest extends RestControllerTest {
             "content": [{ "contentType": "TEXT", "text": "Hello agent" }],
             "toolCalls": [],
             "metrics": { "inputTokens": 10, "outputTokens": 20, "durationMs": 100 },
+            "tools": [],
+            "model": null,
+            "provider": null,
+            "limits": { "maxTokens": -1, "maxModelCalls": -1, "maxToolCalls": -1 },
+            "systemPrompt": [],
             "commitStatus": "COMMITTED",
             "producedAt": "2025-01-01T10:00:00.000Z"
           }
@@ -104,7 +110,8 @@ class AgentInstanceHistorySearchControllerTest extends RestControllerTest {
         }
       }
       """
-          .formatted(HISTORY_ITEM_KEY, AGENT_INSTANCE_KEY, ELEMENT_INSTANCE_KEY, JOB_KEY);
+          .formatted(
+              HISTORY_ITEM_KEY, HISTORY_ITEM_ID, AGENT_INSTANCE_KEY, ELEMENT_INSTANCE_KEY, JOB_KEY);
 
   @MockitoBean private AgentInstanceServices agentInstanceServices;
   @MockitoBean private AgentHistoryServices agentHistoryServices;
@@ -256,8 +263,8 @@ class AgentInstanceHistorySearchControllerTest extends RestControllerTest {
     // given — entity with metrics == null (history item created without metrics)
     final var entityNoMetrics =
         new AgentInstanceHistoryEntity(
-            HISTORY_ITEM_ID,
             HISTORY_ITEM_KEY,
+            HISTORY_ITEM_ID,
             AGENT_INSTANCE_KEY,
             ELEMENT_INSTANCE_KEY,
             9007199254741001L,
@@ -300,5 +307,69 @@ class AgentInstanceHistorySearchControllerTest extends RestControllerTest {
         .expectBody()
         .jsonPath("$.items[0].metrics")
         .isEqualTo(null);
+  }
+
+  @Test
+  void shouldSearchAgentHistoryWithConfigurationFields() {
+    // given — a CONFIGURATION item that touched tools/model/provider/limits
+    final var configurationEntity =
+        new AgentInstanceHistoryEntity(
+            HISTORY_ITEM_KEY,
+            HISTORY_ITEM_ID,
+            AGENT_INSTANCE_KEY,
+            ELEMENT_INSTANCE_KEY,
+            9007199254741001L,
+            9007199254740992L,
+            "myProcess",
+            "<default>",
+            JOB_KEY,
+            "job-lease-1",
+            1,
+            AgentInstanceHistoryRole.CONFIGURATION,
+            List.of(),
+            List.of(),
+            null,
+            List.of(new AgentInstanceHistoryEntity.Tool("search", "Searches the web", "Task_1")),
+            "gpt-4o",
+            "openai",
+            new AgentInstanceHistoryEntity.Limits(1000L, 10, 5),
+            null,
+            AgentInstanceHistoryCommitStatus.COMMITTED,
+            PRODUCED_AT);
+
+    when(agentHistoryServices.search(any(AgentInstanceHistoryQuery.class), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<AgentInstanceHistoryEntity>()
+                .total(1)
+                .startCursor("f")
+                .endCursor("v")
+                .items(List.of(configurationEntity))
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri(HISTORY_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            {
+              "items": [
+                {
+                  "role": "CONFIGURATION",
+                  "tools": [{ "name": "search", "description": "Searches the web", "elementId": "Task_1" }],
+                  "model": "gpt-4o",
+                  "provider": "openai",
+                  "limits": { "maxTokens": 1000, "maxModelCalls": 10, "maxToolCalls": 5 }
+                }
+              ]
+            }
+            """,
+            JsonCompareMode.LENIENT);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceHistorySearchControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceHistorySearchControllerTest.java
@@ -47,8 +47,11 @@ class AgentInstanceHistorySearchControllerTest extends RestControllerTest {
   private static final OffsetDateTime PRODUCED_AT =
       OffsetDateTime.parse("2025-01-01T10:00:00+00:00");
 
+  private static final String HISTORY_ITEM_ID = "history-item-1";
+
   private static final AgentInstanceHistoryEntity HISTORY_ENTITY =
       new AgentInstanceHistoryEntity(
+          HISTORY_ITEM_ID,
           HISTORY_ITEM_KEY,
           AGENT_INSTANCE_KEY,
           ELEMENT_INSTANCE_KEY,
@@ -63,6 +66,11 @@ class AgentInstanceHistorySearchControllerTest extends RestControllerTest {
           List.of(new ContentItem(ContentType.TEXT, "Hello agent", null, null)),
           List.of(),
           new Metrics(10L, 20L, 100L),
+          null,
+          null,
+          null,
+          null,
+          null,
           AgentInstanceHistoryCommitStatus.COMMITTED,
           PRODUCED_AT);
 
@@ -248,6 +256,7 @@ class AgentInstanceHistorySearchControllerTest extends RestControllerTest {
     // given — entity with metrics == null (history item created without metrics)
     final var entityNoMetrics =
         new AgentInstanceHistoryEntity(
+            HISTORY_ITEM_ID,
             HISTORY_ITEM_KEY,
             AGENT_INSTANCE_KEY,
             ELEMENT_INSTANCE_KEY,
@@ -261,6 +270,11 @@ class AgentInstanceHistorySearchControllerTest extends RestControllerTest {
             AgentInstanceHistoryRole.USER,
             List.of(new ContentItem(ContentType.TEXT, "Hello agent", null, null)),
             List.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
             null,
             AgentInstanceHistoryCommitStatus.COMMITTED,
             PRODUCED_AT);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
@@ -32,10 +32,10 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   public static final String ATTR_METRICS = "metrics";
   public static final String ATTR_TOOLS = "tools";
 
-  // Derived from a future configuration-change history entry kind on the output side (see #58794
-  // for that entry kind and #58791 for the engine processing that merges them in), never from a
-  // request-level changedAttributes entry — these are not part of ALLOWED_ATTRIBUTES in
-  // AgentInstanceUpdateProcessor, only of the output-side merge order.
+  // Derived from the CONFIGURATION history entry kind on the output side, once the engine
+  // processing that merges them in lands (see #58791) — never from a request-level
+  // changedAttributes entry. Not part of ALLOWED_ATTRIBUTES in AgentInstanceUpdateProcessor, only
+  // of the output-side merge order.
   public static final String ATTR_SYSTEM_PROMPT = "systemPrompt";
   public static final String ATTR_MODEL = "model";
   public static final String ATTR_PROVIDER = "provider";

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
@@ -88,10 +88,8 @@ public interface AgentHistoryRecordValue extends RecordValue, TenantOwned, Proce
   List<AgentHistoryMessageContentValue> getContent();
 
   /**
-   * Returns the system prompt, as content blocks, as of this entry. Reserved for a future
-   * configuration-change entry kind (see #58794); unused until that lands. An empty list does not
-   * by itself mean the system prompt wasn't touched — it may also mean the prompt was explicitly
-   * cleared; check {@link #getChangedAttributes()} to tell the two apart.
+   * Returns the system prompt, as content blocks, as of this entry. Populated by CONFIGURATION
+   * items; empty for other roles.
    */
   List<AgentHistoryMessageContentValue> getSystemPrompt();
 
@@ -105,35 +103,33 @@ public interface AgentHistoryRecordValue extends RecordValue, TenantOwned, Proce
   String getHistoryItemId();
 
   /**
-   * Returns the complete list of tools available to the agent as of this entry. Reserved for a
-   * future configuration-change entry kind (see #58794); unused until that lands. An empty list
-   * does not by itself mean the tool list wasn't touched — it may also mean the tools were
-   * explicitly cleared; check {@link #getChangedAttributes()} to tell the two apart.
+   * Returns the complete list of tools available to the agent as of this entry. Populated by
+   * CONFIGURATION items; empty for other roles.
    */
   List<AgentInstanceRecordValue.AgentInstanceToolValue> getTools();
 
   /**
-   * Returns the LLM model identifier as of this entry. Reserved for a future configuration-change
-   * entry kind (see #58794); empty until that lands.
+   * Returns the LLM model identifier as of this entry. Populated by CONFIGURATION items; empty for
+   * other roles.
    */
   String getModel();
 
   /**
-   * Returns the LLM provider as of this entry. Reserved for a future configuration-change entry
-   * kind (see #58794); empty until that lands.
+   * Returns the LLM provider as of this entry. Populated by CONFIGURATION items; empty for other
+   * roles.
    */
   String getProvider();
 
   /**
-   * Returns the operational limits as of this entry. Reserved for a future configuration-change
-   * entry kind (see #58794); unused until that lands.
+   * Returns the operational limits as of this entry. Populated by CONFIGURATION items; unused for
+   * other roles.
    */
   AgentInstanceRecordValue.AgentInstanceLimitsValue getLimits();
 
   /**
    * Returns the names of attributes this entry intends to update, or the names of the attributes
-   * that were actually updated; empty otherwise. Reserved for a future configuration-change entry
-   * kind (see #58794); unused until that lands.
+   * that were actually updated; empty otherwise. Reserved for CONFIGURATION items once the engine
+   * processing that populates it lands (see #58791); unused until then.
    */
   List<String> getChangedAttributes();
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
@@ -86,10 +86,8 @@ public interface AgentHistoryRecordValue extends RecordValue, TenantOwned, Proce
   List<AgentHistoryMessageContentValue> getContent();
 
   /**
-   * Returns the system prompt, as content blocks, as of this entry. Reserved for a future
-   * configuration-change entry kind (see #58794); unused until that lands. An empty list does not
-   * by itself mean the system prompt wasn't touched — it may also mean the prompt was explicitly
-   * cleared; check {@link #getChangedAttributes()} to tell the two apart.
+   * Returns the system prompt, as content blocks, as of this entry. Populated by CONFIGURATION
+   * items; empty for other roles.
    */
   List<AgentHistoryMessageContentValue> getSystemPrompt();
 
@@ -103,35 +101,33 @@ public interface AgentHistoryRecordValue extends RecordValue, TenantOwned, Proce
   String getHistoryItemId();
 
   /**
-   * Returns the complete list of tools available to the agent as of this entry. Reserved for a
-   * future configuration-change entry kind (see #58794); unused until that lands. An empty list
-   * does not by itself mean the tool list wasn't touched — it may also mean the tools were
-   * explicitly cleared; check {@link #getChangedAttributes()} to tell the two apart.
+   * Returns the complete list of tools available to the agent as of this entry. Populated by
+   * CONFIGURATION items; empty for other roles.
    */
   List<AgentInstanceRecordValue.AgentInstanceToolValue> getTools();
 
   /**
-   * Returns the LLM model identifier as of this entry. Reserved for a future configuration-change
-   * entry kind (see #58794); empty until that lands.
+   * Returns the LLM model identifier as of this entry. Populated by CONFIGURATION items; empty for
+   * other roles.
    */
   String getModel();
 
   /**
-   * Returns the LLM provider as of this entry. Reserved for a future configuration-change entry
-   * kind (see #58794); empty until that lands.
+   * Returns the LLM provider as of this entry. Populated by CONFIGURATION items; empty for other
+   * roles.
    */
   String getProvider();
 
   /**
-   * Returns the operational limits as of this entry. Reserved for a future configuration-change
-   * entry kind (see #58794); unused until that lands.
+   * Returns the operational limits as of this entry. Populated by CONFIGURATION items; unused for
+   * other roles.
    */
   AgentInstanceRecordValue.AgentInstanceLimitsValue getLimits();
 
   /**
    * Returns the names of attributes this entry intends to update, or the names of the attributes
-   * that were actually updated; empty otherwise. Reserved for a future configuration-change entry
-   * kind (see #58794); unused until that lands.
+   * that were actually updated; empty otherwise. Reserved for CONFIGURATION items once the engine
+   * processing that populates it lands (see #58791); unused until then.
    */
   List<String> getChangedAttributes();
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRole.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRole.java
@@ -19,5 +19,6 @@ public enum AgentHistoryRole {
   USER,
   ASSISTANT,
   TOOL_RESULT,
+  CONFIGURATION,
   UNSPECIFIED
 }


### PR DESCRIPTION
## Summary

Adds `AgentHistoryRole.CONFIGURATION` at every layer (protocol, webapps-schema, search-domain, REST, Java client) and threads its associated fields — `historyItemId`/`systemPrompt`/`tools`/`model`/`provider`/`limits` — through the `camunda-exporter` and `rdbms-exporter` handlers into ES/OS and RDBMS secondary storage, and back out again through the search API and Java client.

This also makes the two `AgentHistory*Handler` role-mapping switches (and two more discovered along the way, in `search-client-query-transformer` and `gateway-mapping-http`) exhaustive over the new role.

## What's included

- `AgentHistoryRole.CONFIGURATION` added at the protocol, webapps-schema, search-domain, REST (`agent-instances.yaml`), and Java client layers.
- `historyItemId`/`systemPrompt`/`tools`/`model`/`provider`/`limits` threaded through `camunda-exporter`'s `AgentHistoryHandler` and `rdbms-exporter`'s `AgentHistoryExportHandler`, their webapps-schema/search-domain entities, ES/OS index templates, and RDBMS DbModel/mapper/schema.
- `AgentInstanceHistoryItemResult` REST response schema extended with all of the above, so a `CONFIGURATION` item's fields are visible via the search API and Java client, not just in storage.
- Four exhaustive role-mapping `switch` statements updated: `AgentHistoryHandler` (camunda-exporter), `AgentHistoryExportHandler` (rdbms-exporter), `AgentHistoryEntityTransformer` (search-client-query-transformer), `AgentInstanceMapper` (gateway-mapping-http).
- Truncation logic on `AgentHistoryDbModel` unified from two field-group methods into a single generic `truncate()`.

## What's explicitly out of scope

- Engine/effect processing for `CONFIGURATION` items (`AgentHistoryBatchProcessor` and friends) — #58791.
- A REST/client batch-create endpoint for embedded history items — #58793. The existing single-item `createAgentInstanceHistoryItem` endpoint accepts `CONFIGURATION` as a role today; it doesn't yet accept the CONFIGURATION-only fields on create, since that's the batch endpoint's job.
- `AgentInstance`/search-result optimistic-apply-with-rollback sync for `CONFIGURATION` fields — #58797.
- Threading `reasoningTokenCount`/`cacheCreationTokenCount`/`cacheReadTokenCount` through secondary storage for `AGENT_HISTORY` and `AGENT_INSTANCE`. This was found alongside the CONFIGURATION work (an unrelated gap in the same exporter-handler files) and is split out into #59627, based on top of this branch.

## Test plan

- [x] `zeebe/protocol-impl`: `AgentHistoryRecordTest`, `JsonSerializableToJsonTest` — protocol enum/field additions round-trip correctly.
- [x] `zeebe/exporters/camunda-exporter`: `AgentHistoryHandlerTest` — new fields mapped onto the webapps-schema entity, role switch exhaustive.
- [x] `zeebe/exporters/rdbms-exporter`: `AgentHistoryExportHandlerTest` — new fields mapped onto the RDBMS DbModel, role switch exhaustive.
- [x] `db/rdbms`: `AgentHistoryDbModelTest`, `AgentHistoryEntityMapperTest`, `AgentHistoryDbReaderTest`, `AgentHistoryWriterTest` — DbModel round-trips, read mapper, writer.
- [x] `search/search-client-query-transformer`: `AgentHistoryEntityTransformerTest` — ES/OS-entity-to-search-domain-entity mapping, role switch exhaustive.
- [x] `gateways/gateway-mapping-http`: `SearchQueryResponseMapperTest` — REST response mapping for the new fields, including a dedicated `shouldMapConfigurationFields` case.
- [x] `zeebe/gateway-rest`: `AgentInstanceHistorySearchControllerTest`, `AgentInstanceControllerTest` — end-to-end controller behavior against the updated schema.
- [x] `historyItemId` null→`""` coercion follows the same pattern as #56496's `jobLease` fix.
- [ ] Manual smoke test (create a CONFIGURATION item via the REST API, confirm it round-trips through search).

## Related issues
Closes #58794