### PR TITLE
Scope exporter enable to an optional physical tenant

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
@@ -58,6 +58,7 @@ public class ExportersEndpoint {
             new ExporterEnableRequest(
                 exporterId,
                 Optional.ofNullable(initializeInfo).map(InitializationInfo::initializeFrom),
+                Optional.empty(),
                 dryRun))
         .handle(ClusterApiUtils::mapOperationResponse);
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -160,7 +160,15 @@ public sealed interface ClusterConfigurationManagementRequest {
   record ExporterDeleteRequest(String exporterId, Optional<String> physicalTenantId, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
-  record ExporterEnableRequest(String exporterId, Optional<String> initializeFrom, boolean dryRun)
+  /**
+   * Enable an exporter on all partitions of the given physical tenant. If no physicalTenantId is
+   * provided, it applies to all tenants.
+   */
+  record ExporterEnableRequest(
+      String exporterId,
+      Optional<String> initializeFrom,
+      Optional<String> physicalTenantId,
+      boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
   record ExportingStateChangeRequest(ExportingState state, boolean dryRun)

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -258,7 +258,9 @@ public final class ClusterConfigurationManagementRequestsHandler
     return handleRequest(
         enableRequest.dryRun(),
         new ExporterEnableRequestTransformer(
-            enableRequest.exporterId(), enableRequest.initializeFrom()));
+            enableRequest.exporterId(),
+            enableRequest.initializeFrom(),
+            enableRequest.physicalTenantId()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterEnableRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterEnableRequestTransformer.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.Co
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
-import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
@@ -29,8 +28,7 @@ import java.util.Optional;
 /**
  * Enables an exporter, either for a single physical tenant or, when none is given, for every
  * physical tenant. Unlike disable and delete, an exporter does not need to already exist on a
- * partition to be enabled there; tenants/partitions where it is already {@link State#ENABLED} are
- * silently skipped rather than failing the whole request.
+ * partition to be enabled there.
  */
 final class ExporterEnableRequestTransformer implements ConfigurationChangeRequest {
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterEnableRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterEnableRequestTransformer.java
@@ -7,39 +7,99 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
+/**
+ * Enables an exporter, either for a single physical tenant or, when none is given, for every
+ * physical tenant. Unlike disable and delete, an exporter does not need to already exist on a
+ * partition to be enabled there; tenants/partitions where it is already {@link State#ENABLED} are
+ * silently skipped rather than failing the whole request.
+ */
 final class ExporterEnableRequestTransformer implements ConfigurationChangeRequest {
 
   private final String exporterId;
   private final Optional<String> initializeFrom;
+  private final Optional<String> physicalTenantId;
 
   public ExporterEnableRequestTransformer(
       final String exporterId, final Optional<String> initializeFrom) {
+    this(exporterId, initializeFrom, Optional.empty());
+  }
+
+  public ExporterEnableRequestTransformer(
+      final String exporterId,
+      final Optional<String> initializeFrom,
+      final Optional<String> physicalTenantId) {
     this.exporterId = exporterId;
     this.initializeFrom = initializeFrom;
+    this.physicalTenantId = physicalTenantId;
   }
 
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration clusterConfiguration) {
-    final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
-    for (final var member : clusterConfiguration.members().entrySet()) {
+    throw new UnsupportedOperationException(
+        "ExporterEnableRequestTransformer builds its change plan via "
+            + "phases(CurrentClusterConfiguration); the new-model coordinator path never calls "
+            + "operations(ClusterConfiguration)");
+  }
+
+  @Override
+  public Either<Exception, List<Phase>> phases(
+      final CurrentClusterConfiguration clusterConfiguration) {
+    if (physicalTenantId.isPresent()
+        && !clusterConfiguration.hasPartitionGroup(physicalTenantId.get())) {
+      return Either.left(
+          new NotFound(
+              "Expected to enable exporter '%s' for physical tenant '%s', but the physical tenant does not exist"
+                  .formatted(exporterId, physicalTenantId.get())));
+    }
+
+    final List<String> groupIds =
+        physicalTenantId
+            .map(List::of)
+            .orElseGet(() -> List.copyOf(clusterConfiguration.partitionGroups().keySet()));
+
+    final Map<String, List<PartitionGroupOperation>> groupOperations = new LinkedHashMap<>();
+    for (final var groupId : groupIds) {
+      final var operations =
+          enableOperationsFor(Objects.requireNonNull(clusterConfiguration.partitionGroup(groupId)));
+      if (!operations.isEmpty()) {
+        groupOperations.put(groupId, operations);
+      }
+    }
+    return Either.right(List.of(new PartitionGroupParallelPhase(groupOperations)));
+  }
+
+  private List<PartitionGroupOperation> enableOperationsFor(
+      final PartitionGroupConfiguration group) {
+    final List<PartitionGroupOperation> operations = new ArrayList<>();
+    for (final var member : group.members().entrySet()) {
       final var memberId = member.getKey();
-      for (final var partitions : member.getValue().partitions().entrySet()) {
-        final var partitionId = partitions.getKey();
+      for (final var partition : member.getValue().partitions().entrySet()) {
+        final var partitionId = partition.getKey();
         operations.add(
             new PartitionEnableExporterOperation(
                 memberId, partitionId, exporterId, initializeFrom));
       }
     }
-    return Either.right(operations);
+    return operations;
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionEnableExporterApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionEnableExporterApplier.java
@@ -100,6 +100,15 @@ public final class PartitionEnableExporterApplier
                   .formatted(exporterId)));
     }
 
+    if (partitionHasExporter
+        && exportersInPartition.get(exporterId).state() == State.CONFIG_NOT_FOUND) {
+      return Either.left(
+          new IllegalStateException(
+              String.format(
+                  "Expected to enable exporter, but the exporter '%s' is not configured in broker '%s'",
+                  exporterId, memberId)));
+    }
+
     if (partitionHasExporter) {
       // Increment by one when re-enabling the exporter so that the ExporterDirector can verify
       // whether the runtime state has the latest state. This is useful when the operation is

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1098,6 +1098,7 @@ public class ProtoBufSerializer
             .setDryRun(exporterEnableRequest.dryRun());
 
     exporterEnableRequest.initializeFrom().ifPresent(builder::setInitializeFrom);
+    exporterEnableRequest.physicalTenantId().ifPresent(builder::setPhysicalTenantId);
 
     return builder.build().toByteArray();
   }
@@ -1343,8 +1344,15 @@ public class ProtoBufSerializer
           exporterEnableRequest.hasInitializeFrom()
               ? Optional.of(exporterEnableRequest.getInitializeFrom())
               : Optional.empty();
+      final Optional<String> physicalTenantId =
+          exporterEnableRequest.hasPhysicalTenantId()
+              ? Optional.of(exporterEnableRequest.getPhysicalTenantId())
+              : Optional.empty();
       return new ExporterEnableRequest(
-          exporterEnableRequest.getExporterId(), initializeFrom, exporterEnableRequest.getDryRun());
+          exporterEnableRequest.getExporterId(),
+          initializeFrom,
+          physicalTenantId,
+          exporterEnableRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -118,6 +118,9 @@ message ExporterEnableRequest {
   string exporterId = 1;
   optional string initializeFrom = 2;
   bool dryRun = 3;
+  // When physicalTenantId is set, the exporter will be enabled only for that tenant.
+  // If not set, the exporter will be enabled for all tenants.
+  optional string physicalTenantId = 4;
 }
 
 enum Mode {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
@@ -464,7 +464,8 @@ final class NewModelManagementApiEndpointsTest {
     // when
     final var response =
         handler
-            .enableExporter(new ExporterEnableRequest(exporterId, Optional.empty(), false))
+            .enableExporter(
+                new ExporterEnableRequest(exporterId, Optional.empty(), Optional.empty(), false))
             .join();
 
     // then

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTestBase.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTestBase.java
@@ -789,7 +789,7 @@ abstract class ClusterConfigurationManagementApiTestBase {
     final String exporterId = "exporterId";
     final var request =
         new ClusterConfigurationManagementRequest.ExporterEnableRequest(
-            exporterId, Optional.empty(), false);
+            exporterId, Optional.empty(), Optional.empty(), false);
     final var partitionConfigWithExporter =
         new DynamicPartitionConfig(
             new ExportingConfig(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterEnableRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterEnableRequestTransformerTest.java
@@ -10,15 +10,20 @@ package io.camunda.zeebe.dynamic.config.api;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.Map;
 import java.util.Optional;
@@ -26,40 +31,133 @@ import org.junit.jupiter.api.Test;
 
 final class ExporterEnableRequestTransformerTest {
 
-  final String exporterId = "exporterA";
+  private static final String EXPORTER_ID = "exporterA";
+  private static final String TENANT_A = "tenant-a";
+  private static final String TENANT_B = "tenant-b";
+
   private final MemberId id0 = MemberId.from("0");
   private final MemberId id1 = MemberId.from("1");
-  private final DynamicPartitionConfig config =
+
+  private final DynamicPartitionConfig configWithDisabledExporter =
       new DynamicPartitionConfig(
           new ExportingConfig(
               ExportingState.EXPORTING,
-              Map.of(exporterId, new ExporterState(1, State.DISABLED, Optional.empty()))));
+              Map.of(EXPORTER_ID, new ExporterState(1, State.DISABLED, Optional.empty()))));
+
+  private final DynamicPartitionConfig configWithEnabledExporter =
+      new DynamicPartitionConfig(
+          new ExportingConfig(
+              ExportingState.EXPORTING,
+              Map.of(EXPORTER_ID, new ExporterState(1, State.ENABLED, Optional.empty()))));
+
+  private final DynamicPartitionConfig configWithoutExporter =
+      new DynamicPartitionConfig(new ExportingConfig(ExportingState.EXPORTING, Map.of()));
 
   @Test
-  void shouldGenerateOperationForAllPartitionsAndMembers() {
+  void shouldGenerateOperationsForAllPhysicalTenantsWhenNoneIsGiven() {
     // given
-    final Optional<String> initializeFrom = Optional.empty();
-    final var transformer = new ExporterEnableRequestTransformer(exporterId, initializeFrom);
-
+    final var transformer = new ExporterEnableRequestTransformer(EXPORTER_ID, Optional.empty());
     final var clusterConfiguration =
-        ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, config)))
-            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(2, config)))
-            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, config)))
-            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, config)));
+        withPartitionGroups(
+            Map.of(
+                TENANT_A, groupWithMembers(configWithDisabledExporter),
+                TENANT_B, groupWithMembers(configWithDisabledExporter)));
 
     // when
-    final var result = transformer.operations(clusterConfiguration);
+    final var result = transformer.phases(clusterConfiguration);
 
     // then
     EitherAssert.assertThat(result).isRight();
-    assertThat(result.get())
-        .containsExactlyInAnyOrder(
-            new PartitionEnableExporterOperation(id0, 1, exporterId, initializeFrom),
-            new PartitionEnableExporterOperation(id0, 2, exporterId, initializeFrom),
-            new PartitionEnableExporterOperation(id1, 2, exporterId, initializeFrom),
-            new PartitionEnableExporterOperation(id1, 1, exporterId, initializeFrom));
+    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    assertThat(phase.groupOperations())
+        .containsOnlyKeys(TENANT_A, TENANT_B)
+        .allSatisfy(
+            (groupId, operations) ->
+                assertThat(operations)
+                    .containsExactlyInAnyOrder(
+                        new PartitionEnableExporterOperation(id0, 1, EXPORTER_ID, Optional.empty()),
+                        new PartitionEnableExporterOperation(
+                            id1, 1, EXPORTER_ID, Optional.empty())));
+  }
+
+  @Test
+  void shouldGenerateOperationsForATenantThatHasNeverConfiguredTheExporter() {
+    // given — enable does not require the exporter to already exist on the partition
+    final var transformer = new ExporterEnableRequestTransformer(EXPORTER_ID, Optional.empty());
+    final var clusterConfiguration =
+        withPartitionGroups(Map.of(TENANT_A, groupWithMembers(configWithoutExporter)));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    assertThat(phase.groupOperations()).containsOnlyKeys(TENANT_A);
+  }
+
+  @Test
+  void shouldGenerateOperationsOnlyForTheGivenPhysicalTenant() {
+    // given
+    final var transformer =
+        new ExporterEnableRequestTransformer(EXPORTER_ID, Optional.empty(), Optional.of(TENANT_A));
+    final var clusterConfiguration =
+        withPartitionGroups(
+            Map.of(
+                TENANT_A, groupWithMembers(configWithDisabledExporter),
+                TENANT_B, groupWithMembers(configWithDisabledExporter)));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    assertThat(phase.groupOperations())
+        .containsOnlyKeys(TENANT_A)
+        .hasEntrySatisfying(
+            TENANT_A,
+            operations ->
+                assertThat(operations)
+                    .containsExactlyInAnyOrder(
+                        new PartitionEnableExporterOperation(id0, 1, EXPORTER_ID, Optional.empty()),
+                        new PartitionEnableExporterOperation(
+                            id1, 1, EXPORTER_ID, Optional.empty())));
+  }
+
+  @Test
+  void shouldRejectAnUnknownPhysicalTenantId() {
+    // given
+    final var transformer =
+        new ExporterEnableRequestTransformer(
+            EXPORTER_ID, Optional.empty(), Optional.of("unknown-tenant"));
+    final var clusterConfiguration =
+        withPartitionGroups(Map.of(TENANT_A, groupWithMembers(configWithDisabledExporter)));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(NotFound.class)
+        .hasMessageContaining("unknown-tenant");
+  }
+
+  private PartitionGroupConfiguration groupWithMembers(final DynamicPartitionConfig config) {
+    return PartitionGroupConfiguration.empty(PartitionGroupConfiguration.INITIAL_VERSION)
+        .addMember(
+            id0, BrokerPartitionState.initialize(Map.of(1, PartitionState.active(1, config))))
+        .addMember(
+            id1, BrokerPartitionState.initialize(Map.of(1, PartitionState.active(1, config))));
+  }
+
+  private CurrentClusterConfiguration withPartitionGroups(
+      final Map<String, PartitionGroupConfiguration> partitionGroups) {
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        GlobalConfiguration.init(),
+        partitionGroups,
+        PhasedChangeState.empty());
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionEnableExporterApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionEnableExporterApplierTest.java
@@ -144,6 +144,30 @@ final class PartitionEnableExporterApplierTest {
   }
 
   @Test
+  void shouldRejectIfExporterIsNotConfigured() {
+    // given
+    final String exporterId = "exporterA";
+    final var config =
+        DynamicPartitionConfig.init()
+            .updateExporting(c -> c.addExporters(Set.of(exporterId)))
+            .updateExporting(c -> c.withConfigNotFoundFor(Set.of(exporterId)));
+    final var group =
+        groupWithMembers(Map.of(memberId, brokerWith(Map.of(1, PartitionState.active(1, config)))));
+
+    // when
+    final var result =
+        new PartitionEnableExporterApplier(
+                memberId, 1, exporterId, Optional.empty(), partitionChangeExecutor)
+            .init(globalConfigurationWithMember, group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("is not configured");
+  }
+
+  @Test
   void shouldExecuteEnableExporterCallbackForNewExporter() {
     // given
     final var config = DynamicPartitionConfig.init();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -256,7 +256,22 @@ final class ProtoBufSerializerTest {
   void shouldEncodeAndDecodeExporterEnableRequest() {
     // given
     final var exporterEnableRequest =
-        new ExporterEnableRequest("expId", Optional.of("expId2"), false);
+        new ExporterEnableRequest("expId", Optional.of("expId2"), Optional.of("tenant-a"), false);
+
+    // when
+    final var encodedRequest =
+        protoBufSerializer.encodeExporterEnableRequest(exporterEnableRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeExporterEnableRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(exporterEnableRequest);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeExporterEnableRequestWithoutPhysicalTenantId() {
+    // given
+    final var exporterEnableRequest =
+        new ExporterEnableRequest("expId", Optional.empty(), Optional.empty(), false);
 
     // when
     final var encodedRequest =


### PR DESCRIPTION
## Summary
Stacked on #59598 — same pattern applied to exporter enable instead of delete.

- `ExporterEnableRequestTransformer` now accepts an optional physical tenant id: when given, enable operations are generated only for that tenant's partitions; when absent, it fans out to every tenant. Unlike disable/delete, an exporter does not need to already exist on a partition to be enabled there. Returns `NotFound` for an unknown tenant id.
- The transformer now overrides `ConfigurationChangeRequest.phases()` (the new multi-partition-group model) instead of the legacy `operations()`, which the new-model coordinator path never calls.
- Threaded the optional tenant id through the wire protocol: added `optional string physicalTenantId` to the `ExporterEnableRequest` proto message and updated `ProtoBufSerializer` encode/decode and `ClusterConfigurationManagementRequestsHandler` accordingly.

REST/actuator exposure of the new parameter (`ExportersEndpoint`) is left for follow-up work; it currently passes `Optional.empty()`.

closes #59575. 