### PR TITLE
fix: mark process definition deleted on FULLY_DELETED, not DELETED

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -55,8 +55,8 @@ import io.camunda.exporter.handlers.MessageSubscriptionFromMessageStartEventSubs
 import io.camunda.exporter.handlers.MessageSubscriptionFromProcessMessageSubscriptionHandler;
 import io.camunda.exporter.handlers.MigratedVariableHandler;
 import io.camunda.exporter.handlers.PostImporterQueueFromIncidentHandler;
-import io.camunda.exporter.handlers.ProcessDeletedHandler;
 import io.camunda.exporter.handlers.ProcessDrainingHandler;
+import io.camunda.exporter.handlers.ProcessFullyDeletedHandler;
 import io.camunda.exporter.handlers.ProcessHandler;
 import io.camunda.exporter.handlers.ResourceCreatedHandler;
 import io.camunda.exporter.handlers.ResourceDeletedHandler;
@@ -306,7 +306,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(ProcessIndex.class).getFullQualifiedName(),
                 processCache,
                 configuration.getExtensionProperties()),
-            new ProcessDeletedHandler(
+            new ProcessFullyDeletedHandler(
                 indexDescriptors.get(ProcessIndex.class).getFullQualifiedName()),
             new ProcessDrainingHandler(
                 indexDescriptors.get(ProcessIndex.class).getFullQualifiedName()),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -56,8 +56,8 @@ import io.camunda.exporter.handlers.MessageSubscriptionFromMessageStartEventSubs
 import io.camunda.exporter.handlers.MessageSubscriptionFromProcessMessageSubscriptionHandler;
 import io.camunda.exporter.handlers.MigratedVariableHandler;
 import io.camunda.exporter.handlers.PostImporterQueueFromIncidentHandler;
-import io.camunda.exporter.handlers.ProcessDeletedHandler;
 import io.camunda.exporter.handlers.ProcessDrainingHandler;
+import io.camunda.exporter.handlers.ProcessFullyDeletedHandler;
 import io.camunda.exporter.handlers.ProcessHandler;
 import io.camunda.exporter.handlers.ResourceCreatedHandler;
 import io.camunda.exporter.handlers.ResourceDeletedHandler;
@@ -311,7 +311,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(ProcessIndex.class).getFullQualifiedName(),
                 processCache,
                 configuration.getExtensionProperties()),
-            new ProcessDeletedHandler(
+            new ProcessFullyDeletedHandler(
                 indexDescriptors.get(ProcessIndex.class).getFullQualifiedName()),
             new ProcessDrainingHandler(
                 indexDescriptors.get(ProcessIndex.class).getFullQualifiedName()),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessFullyDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessFullyDeletedHandler.java
@@ -20,11 +20,12 @@ import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import java.util.List;
 import java.util.Map;
 
-public class ProcessDeletedHandler implements MainIndexExporterHandler<ProcessEntity, Process> {
+public class ProcessFullyDeletedHandler
+    implements MainIndexExporterHandler<ProcessEntity, Process> {
 
   private final String indexName;
 
-  public ProcessDeletedHandler(final String indexName) {
+  public ProcessFullyDeletedHandler(final String indexName) {
     this.indexName = indexName;
   }
 
@@ -40,7 +41,7 @@ public class ProcessDeletedHandler implements MainIndexExporterHandler<ProcessEn
 
   @Override
   public boolean handlesRecord(final Record<Process> record) {
-    return record.getIntent() == ProcessIntent.DELETED;
+    return record.getIntent() == ProcessIntent.FULLY_DELETED;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessFullyDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessFullyDeletedHandler.java
@@ -20,11 +20,11 @@ import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import java.util.List;
 import java.util.Map;
 
-public class ProcessDeletedHandler implements ExportHandler<ProcessEntity, Process> {
+public class ProcessFullyDeletedHandler implements ExportHandler<ProcessEntity, Process> {
 
   private final String indexName;
 
-  public ProcessDeletedHandler(final String indexName) {
+  public ProcessFullyDeletedHandler(final String indexName) {
     this.indexName = indexName;
   }
 
@@ -40,7 +40,7 @@ public class ProcessDeletedHandler implements ExportHandler<ProcessEntity, Proce
 
   @Override
   public boolean handlesRecord(final Record<Process> record) {
-    return record.getIntent() == ProcessIntent.DELETED;
+    return record.getIntent() == ProcessIntent.FULLY_DELETED;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessFullyDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessFullyDeletedHandlerTest.java
@@ -28,11 +28,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
 
-class ProcessDeletedHandlerTest {
+class ProcessFullyDeletedHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = "test-process";
-  private final ProcessDeletedHandler underTest = new ProcessDeletedHandler(indexName);
+  private final ProcessFullyDeletedHandler underTest = new ProcessFullyDeletedHandler(indexName);
 
   @Test
   void testGetHandledValueType() {
@@ -47,7 +47,7 @@ class ProcessDeletedHandlerTest {
   @ParameterizedTest
   @EnumSource(
       value = ProcessIntent.class,
-      names = {"DELETED"},
+      names = {"FULLY_DELETED"},
       mode = Mode.INCLUDE)
   void shouldHandleRecord(final ProcessIntent intent) {
     // given
@@ -61,7 +61,7 @@ class ProcessDeletedHandlerTest {
   @ParameterizedTest
   @EnumSource(
       value = ProcessIntent.class,
-      names = {"DELETED"},
+      names = {"FULLY_DELETED"},
       mode = Mode.EXCLUDE)
   void shouldNotHandleRecord(final ProcessIntent intent) {
     // given
@@ -83,7 +83,7 @@ class ProcessDeletedHandlerTest {
             .build();
     final Record<Process> record =
         factory.generateRecord(
-            ValueType.PROCESS, r -> r.withIntent(ProcessIntent.DELETED).withValue(value));
+            ValueType.PROCESS, r -> r.withIntent(ProcessIntent.FULLY_DELETED).withValue(value));
 
     // when
     final var ids = underTest.generateIds(record);
@@ -107,7 +107,7 @@ class ProcessDeletedHandlerTest {
   void shouldSetStateDeletedOnUpdateEntity() {
     // given
     final Record<Process> record =
-        factory.generateRecord(ValueType.PROCESS, r -> r.withIntent(ProcessIntent.DELETED));
+        factory.generateRecord(ValueType.PROCESS, r -> r.withIntent(ProcessIntent.FULLY_DELETED));
     final ProcessEntity entity = new ProcessEntity();
 
     // when

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandler.java
@@ -44,12 +44,12 @@ public class ProcessExportHandler implements RdbmsExportHandler<Process> {
     return record.getValueType() == ValueType.PROCESS
         && (record.getIntent() == ProcessIntent.CREATED
             || record.getIntent() == ProcessIntent.DRAINING
-            || record.getIntent() == ProcessIntent.DELETED);
+            || record.getIntent() == ProcessIntent.FULLY_DELETED);
   }
 
   @Override
   public void export(final Record<Process> record) {
-    if (record.getIntent() == ProcessIntent.DELETED) {
+    if (record.getIntent() == ProcessIntent.FULLY_DELETED) {
       processDefinitionWriter.markDeleted(record.getValue().getProcessDefinitionKey());
       return;
     }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandlerTest.java
@@ -41,7 +41,7 @@ class ProcessExportHandlerTest {
   @ParameterizedTest
   @EnumSource(
       value = ProcessIntent.class,
-      names = {"CREATED", "DRAINING", "DELETED"},
+      names = {"CREATED", "DRAINING", "FULLY_DELETED"},
       mode = Mode.INCLUDE)
   void shouldExportHandledIntents(final ProcessIntent intent) {
     // given
@@ -55,7 +55,7 @@ class ProcessExportHandlerTest {
   @ParameterizedTest
   @EnumSource(
       value = ProcessIntent.class,
-      names = {"CREATED", "DRAINING", "DELETED"},
+      names = {"CREATED", "DRAINING", "FULLY_DELETED"},
       mode = Mode.EXCLUDE)
   void shouldNotExportOtherIntents(final ProcessIntent intent) {
     // given
@@ -87,7 +87,7 @@ class ProcessExportHandlerTest {
   }
 
   @Test
-  void shouldMarkDeletedOnDeletedRecord() {
+  void shouldMarkDeletedOnFullyDeletedRecord() {
     // given
     final long processDefinitionKey = 456L;
     final Process value =
@@ -97,7 +97,7 @@ class ProcessExportHandlerTest {
             .build();
     final Record<Process> record =
         factory.generateRecord(
-            ValueType.PROCESS, r -> r.withIntent(ProcessIntent.DELETED).withValue(value));
+            ValueType.PROCESS, r -> r.withIntent(ProcessIntent.FULLY_DELETED).withValue(value));
 
     // when
     underTest.export(record);


### PR DESCRIPTION
## Description

With draining deletion, ProcessIntent.DELETED is written per partition as each partition drains, while the cluster-wide "gone" signal is the aggregated ProcessIntent.FULLY_DELETED emitted once on the deployment partition. Reacting to bare DELETED would flip the definition to DELETED in secondary storage as soon as the first partition drained, contradicting the DRAINING state still true on the other partitions.

Change both exporters to key the DELETED state transition on FULLY_DELETED:

- camunda-exporter: rename ProcessDeletedHandler to ProcessFullyDeletedHandler and react to FULLY_DELETED.
- rdbms-exporter: ProcessExportHandler.canExport/export trigger markDeleted on FULLY_DELETED instead of DELETED.

FULLY_DELETED is emitted for both delete paths — the draining delete and the classic no-active-instances delete, which also finalizes through the per-partition drain reports (ProcessDeleteCompleteProcessor) — so normal deletes still reach DELETED in secondary storage. Verified end-to-end by DeleteProcessDefinitionHistoryIT.shouldMarkProcessDefinitionAsDeletedWhenDeletedWithoutHistory.

The handler is renamed to match the intent it now reacts to.

## Related issues

closes #59460
