### PR TITLE
feat: add unified config for evaluateBoundaryEventCorrelationKeyInActivityScope

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Processing.java
+++ b/configuration/src/main/java/io/camunda/configuration/Processing.java
@@ -26,6 +26,8 @@ public class Processing {
   private static final boolean DEFAULT_ENABLE_ASYNC_TIMER_DUEDATE_CHECKER = false;
   private static final boolean DEFAULT_ENABLE_STRAIGHTTHROUGH_PROCESSING_LOOP_DETECTOR = true;
   private static final boolean DEFAULT_ENABLE_MESSAGE_BODY_ON_EXPIRED = false;
+  private static final boolean DEFAULT_EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE =
+      true;
 
   private static final int DEFAULT_MAX_RECOVERABLE_RETRIES = 1000;
 
@@ -52,6 +54,10 @@ public class Processing {
           Set.of("zeebe.broker.experimental.features.enableStraightThroughProcessingLoopDetector");
   private static final Set<String> LEGACY_FEATURES_ENABLE_MESSAGE_BODY_ON_EXPIRED_PROPERTIES =
       Set.of("zeebe.broker.experimental.features.enableMessageBodyOnExpired");
+  private static final Set<String>
+      LEGACY_FEATURES_EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE_PROPERTIES =
+          Set.of(
+              "zeebe.broker.experimental.features.evaluateBoundaryEventCorrelationKeyInActivityScope");
 
   /**
    * Configure flow control for user requests. This setting takes precedence over the backpressure
@@ -150,6 +156,16 @@ public class Processing {
    * default value is false, meaning message bodies will not be appended unless explicitly enabled.
    */
   private boolean enableMessageBodyOnExpired = DEFAULT_ENABLE_MESSAGE_BODY_ON_EXPIRED;
+
+  /**
+   * Controls the scope used to evaluate the {@code correlationKey} expression of a message boundary
+   * event. When enabled (default), the expression is evaluated in the activity's own (element
+   * instance) scope, consistent with timer duration, message name, and signal name expressions.
+   * When disabled, restores the previous behavior where the expression is evaluated in the flow
+   * scope instead.
+   */
+  private boolean evaluateBoundaryEventCorrelationKeyInActivityScope =
+      DEFAULT_EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE;
 
   /**
    * Sets the maximum number of recoverable retries for state update and replay operations. When the
@@ -295,6 +311,21 @@ public class Processing {
 
   public void setEnableMessageBodyOnExpired(final boolean enableMessageBodyOnExpired) {
     this.enableMessageBodyOnExpired = enableMessageBodyOnExpired;
+  }
+
+  public boolean isEvaluateBoundaryEventCorrelationKeyInActivityScope() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".evaluate-boundary-event-correlation-key-in-activity-scope",
+        evaluateBoundaryEventCorrelationKeyInActivityScope,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_FEATURES_EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE_PROPERTIES);
+  }
+
+  public void setEvaluateBoundaryEventCorrelationKeyInActivityScope(
+      final boolean evaluateBoundaryEventCorrelationKeyInActivityScope) {
+    this.evaluateBoundaryEventCorrelationKeyInActivityScope =
+        evaluateBoundaryEventCorrelationKeyInActivityScope;
   }
 
   public int getMaxRecoverableRetries() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -247,6 +247,11 @@ public class BrokerBasedPropertiesOverride {
         .getExperimental()
         .getFeatures()
         .setEnableMessageBodyOnExpired(processing.isEnableMessageBodyOnExpired());
+    override
+        .getExperimental()
+        .getFeatures()
+        .setEvaluateBoundaryEventCorrelationKeyInActivityScope(
+            processing.isEvaluateBoundaryEventCorrelationKeyInActivityScope());
 
     populateFromEngine(override, camunda);
   }

--- a/configuration/src/test/java/io/camunda/configuration/ProcessingPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ProcessingPropertiesTest.java
@@ -65,6 +65,8 @@ public class ProcessingPropertiesTest {
             + EXPECTED_ENABLE_STRAIGHTTHROUGH_PROCESSING_LOOP_DETECTOR,
         "camunda.processing.enable-message-body-on-expired="
             + EXPECTED_ENABLE_MESSAGE_BODY_ON_EXPIRED,
+        "camunda.processing.evaluate-boundary-event-correlation-key-in-activity-scope="
+            + EXPECTED_CONFIGURED_EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE,
         "camunda.processing.max-recoverable-retries=" + EXPECTED_MAX_RECOVERABLE_RETRIES
       })
   class WithOnlyUnifiedConfigSet {
@@ -105,7 +107,7 @@ public class ProcessingPropertiesTest {
               EXPECTED_ENABLE_MESSAGE_BODY_ON_EXPIRED,
               FeatureFlagsCfg::isEnableMessageBodyOnExpired)
           .returns(
-              EXPECTED_DEFAULT_EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE,
+              EXPECTED_CONFIGURED_EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE,
               FeatureFlagsCfg::isEvaluateBoundaryEventCorrelationKeyInActivityScope);
     }
   }
@@ -194,6 +196,8 @@ public class ProcessingPropertiesTest {
             + EXPECTED_ENABLE_STRAIGHTTHROUGH_PROCESSING_LOOP_DETECTOR,
         "camunda.processing.enable-message-body-on-expired="
             + EXPECTED_ENABLE_MESSAGE_BODY_ON_EXPIRED,
+        "camunda.processing.evaluate-boundary-event-correlation-key-in-activity-scope="
+            + EXPECTED_DEFAULT_EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE,
         "camunda.processing.max-recoverable-retries=" + EXPECTED_MAX_RECOVERABLE_RETRIES,
 
         // legacy
@@ -248,7 +252,7 @@ public class ProcessingPropertiesTest {
               EXPECTED_ENABLE_MESSAGE_BODY_ON_EXPIRED,
               FeatureFlagsCfg::isEnableMessageBodyOnExpired)
           .returns(
-              EXPECTED_CONFIGURED_EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE,
+              EXPECTED_DEFAULT_EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE,
               FeatureFlagsCfg::isEvaluateBoundaryEventCorrelationKeyInActivityScope);
     }
   }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -301,6 +301,7 @@ processing.engine.secrets.retry-max-attempts
 processing.engine.secrets.retry-max-delay
 processing.engine.usage-metrics.export-interval
 processing.engine.validators.results-output-max-size
+processing.evaluate-boundary-event-correlation-key-in-activity-scope
 processing.flow-control.request.aimd.backoff-ratio
 processing.flow-control.request.aimd.initial-limit
 processing.flow-control.request.aimd.max-limit


### PR DESCRIPTION
## Description

Wires `camunda.processing.evaluate-boundary-event-correlation-key-in-activity-scope` (env var `CAMUNDA_PROCESSING_EVALUATEBOUNDARYEVENTCORRELATIONKEYINACTIVITYSCOPE`) as a direct mapping for the legacy `zeebe.broker.experimental.features.evaluateBoundaryEventCorrelationKeyInActivityScope` flag, following the exact same pattern as the other `experimental.features.*` flags in `FeatureFlagsCfg` (e.g. `enableMessageBodyOnExpired` → `camunda.processing.enable-message-body-on-expired`).

Closes #57698, unblocks camunda/camunda-docs#9384.

## Changes

- **`configuration/src/main/java/io/camunda/configuration/Processing.java`**: adds constant (`true`), legacy-property set, field, getter (using `validateLegacyConfigurationUnsafe` / `BackwardsCompatibilityMode.SUPPORTED`), and setter.
- **`configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java`**: wires the unified value into `populateFromProcessing` → `FeatureFlagsCfg`.
- **`configuration/src/test/java/io/camunda/configuration/ProcessingPropertiesTest.java`**: fills pre-existing test stubs — `WithOnlyUnifiedConfigSet` now explicitly exercises the binding, `WithNewAndLegacySet` now exercises "unified wins over legacy".

## Note on backport

The same change is needed on `stable/8.9` with default `false` (the flag ships disabled by default there per camunda/camunda#57700). I'll open a separate PR once this lands, or it can be done as a `backport stable/8.9` label if the diff applies cleanly.