### PR TITLE
Prevent Operate frontend unit-test heap exhaustion

### DIFF
--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -149,7 +149,7 @@ jobs:
       - run: npm run test -- --no-file-parallelism --maxWorkers 1 --reporter=blob --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         name: Unit & Integration tests
         env:
-          NODE_OPTIONS: --max-old-space-size=8192
+          NODE_OPTIONS: --max-old-space-size=12288
       - name: Upload blob report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary

- raise the Operate Vitest worker old-space ceiling from 8 GiB to 12 GiB
- keep the existing single-worker execution, sharding, and job timeout unchanged

## Why

The failures in [shard 4/6](https://github.com/camunda/camunda/actions/runs/31021953677/job/92363086914) and [shard 3/6](https://github.com/camunda/camunda/actions/runs/31024198304/job/92370101906) reached the configured 8 GiB V8 heap limit while runner memory remained around 42%. The logs also confirm that `NODE_OPTIONS` reached the Vitest process, so propagation is not the problem.

Giving the worker 12 GiB of old-space headroom uses the runner memory already available and addresses the observed failure without weakening the timeout or increasing test concurrency.

## Validation

- `actionlint -ignore 'label ".+" is unknown' .github/workflows/ci-operate.yml`
- `conftest test --rego-version v0 -o github --policy .github .github/workflows/*.yml`
- `./mvnw spotless:apply -T1C`
- `./mvnw install -Dquickly -T1C`
- reviewed with GPT-5.6 Sol; no findings

<details>
<summary>Local act assessment</summary>

- workflow: `.github/workflows/ci-operate.yml`
- tier: 3
- non-applicability rationale: the changed behavior is the real Node/Vitest heap ceiling under peak allocation on a self-hosted runner; local `act` execution cannot reproduce or validate that memory characteristic with useful confidence
- act-scenarios: not required
- harness: removed because mocked or local-runner execution would provide insufficient signal

</details>

Closes #59641
