### PR TITLE
ci: skip GCS build-cache upload/restore for fork PRs

### DIFF
--- a/.github/workflows/ci-build-distball-reusable.yml
+++ b/.github/workflows/ci-build-distball-reusable.yml
@@ -34,6 +34,9 @@ jobs:
       - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1
+      - name: Check for fork
+        id: is-fork
+        uses: ./.github/actions/is-fork
       - uses: ./.github/actions/setup-build
         with:
           maven-cache-key-modifier: build-shared
@@ -101,6 +104,9 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - name: Upload distball to GCS
+        # gcloud is only installed/authenticated when gcs-build-cache-auth ran, which is
+        # itself skipped for fork PRs (no Vault access) -- see gcs-build-cache-auth/action.yml.
+        if: steps.is-fork.outputs.is-fork != 'true'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         # SA lacks storage.buckets.get, so gcloud's parallel-composite precheck fails; disable it.
         env:
@@ -115,6 +121,8 @@ jobs:
             gcloud storage cp "${{ steps.build-zeebe.outputs.distball }}" \
               "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/$(basename "${{ steps.build-zeebe.outputs.distball }}")"
       - name: Upload SNAPSHOTs to GCS
+        # Same fork-PR guard as "Upload distball to GCS" above.
+        if: steps.is-fork.outputs.is-fork != 'true'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
           CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_ENABLED: "False"

--- a/.github/workflows/ci-build-distball-reusable.yml
+++ b/.github/workflows/ci-build-distball-reusable.yml
@@ -34,6 +34,9 @@ jobs:
       - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1
+      - name: Check for fork
+        id: is-fork
+        uses: ./.github/actions/is-fork
       - uses: ./.github/actions/setup-build
         with:
           maven-cache-key-modifier: build-shared
@@ -101,6 +104,9 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - name: Upload distball to GCS
+        # gcloud is only installed/authenticated when gcs-build-cache-auth ran, which is
+        # itself skipped for fork PRs (no Vault access) -- see gcs-build-cache-auth/action.yml.
+        if: steps.is-fork.outputs.is-fork != 'true'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         # SA lacks storage.buckets.get, so gcloud's parallel-composite precheck fails; disable it.
         env:
@@ -115,6 +121,8 @@ jobs:
             gcloud storage cp "${{ steps.build-zeebe.outputs.distball }}" \
               "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/$(basename "${{ steps.build-zeebe.outputs.distball }}")"
       - name: Upload SNAPSHOTs to GCS
+        # Same fork-PR guard as "Upload distball to GCS" above.
+        if: steps.is-fork.outputs.is-fork != 'true'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
           CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_ENABLED: "False"

--- a/.github/workflows/ci-build-distball-reusable.yml
+++ b/.github/workflows/ci-build-distball-reusable.yml
@@ -104,8 +104,9 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - name: Upload distball to GCS
-        # gcloud is only installed/authenticated when gcs-build-cache-auth ran, which is
-        # itself skipped for fork PRs (no Vault access) -- see gcs-build-cache-auth/action.yml.
+        # gcs-build-cache-auth runs unconditionally, but its internal Vault/WIF/setup-gcloud
+        # steps no-op on fork PRs (no Vault access -- see gcs-build-cache-auth/action.yml),
+        # so gcloud is never installed. Guard this step the same way.
         if: steps.is-fork.outputs.is-fork != 'true'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         # SA lacks storage.buckets.get, so gcloud's parallel-composite precheck fails; disable it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2588,7 +2588,9 @@ jobs:
       - zeebe-ci
       - zeebe-unit-tests
     env:
-      SHOULD_CLEANUP_GCS: ${{ needs.build-distball.result == 'success' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+      # Fork PRs never authenticate to GCS (no Vault access), so there's nothing to clean up
+      # there -- exclude them explicitly instead of relying on the run/echo fallback below.
+      SHOULD_CLEANUP_GCS: ${{ needs.build-distball.result == 'success' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && github.event.pull_request.head.repo.fork != true }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1072,7 +1072,9 @@ jobs:
       database-image-version: "${{ matrix.database-image-version }}"
       database-name: "${{ matrix.database-name }}"
       it-database-type: "${{ matrix.it-database-type }}"
-      use-shared-distball: true
+      # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
+      # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
+      use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
 
   history-tests:
     name: "History Integration Tests / ${{ matrix.name }}"
@@ -1097,7 +1099,9 @@ jobs:
       test-type: "history-tests"
       test-type-label: "History"
       runs-on: "gcp-perf-core-8-default"
-      use-shared-distball: true
+      # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
+      # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
+      use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
 
   identity-tests:
     name: "Identity Integration Tests / ${{ matrix.name }}"
@@ -1121,7 +1125,9 @@ jobs:
       maven-profiles: "identity-tests"
       test-type: "identity-tests"
       test-type-label: "Identity"
-      use-shared-distball: true
+      # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
+      # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
+      use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
 
   physical-tenant-acceptance-tests:
     name: "Physical Tenant Acceptance Tests / ${{ matrix.database-name }}"
@@ -1167,7 +1173,9 @@ jobs:
       test-type: "physical-tenant-acceptance-tests"
       test-type-label: "Physical Tenant Acceptance"
       test-suite-name: "acceptance"
-      use-shared-distball: true
+      # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
+      # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
+      use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
 
   physical-tenant-identity-tests:
     name: "Physical Tenant Acceptance Tests / Identity / ${{ matrix.database-name }}"
@@ -1205,7 +1213,9 @@ jobs:
       test-type: "physical-tenant-identity-tests"
       test-type-label: "Physical Tenant Acceptance Identity"
       test-suite-name: "identity"
-      use-shared-distball: true
+      # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
+      # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
+      use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
 
   physical-tenant-history-tests:
     name: "Physical Tenant Acceptance Tests / History / ${{ matrix.database-name }}"
@@ -1243,7 +1253,9 @@ jobs:
       test-type: "physical-tenant-history-tests"
       test-type-label: "Physical Tenant Acceptance History"
       test-suite-name: "history"
-      use-shared-distball: true
+      # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
+      # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
+      use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
 
   rdbms-integration-tests:
     if: needs.detect-changes.outputs.rdbms-integration-tests == 'true'
@@ -1266,6 +1278,9 @@ jobs:
       - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1
+      - name: Check for fork
+        id: is-fork
+        uses: ./.github/actions/is-fork
       # Consume the shared distball's io.camunda SNAPSHOTs instead of a ~15 min reactor build.
       # This job runs on a self-hosted gcp-perf runner where the artifact API is throughput-capped,
       # so restore-shared-m2 pulls from GCS (same-region, non-billable). RDBMS ITs run in-process
@@ -1282,6 +1297,7 @@ jobs:
       # Timed out here directly (not via setup-build) so a Vault/WIF hang fails fast instead
       # of silently eating the whole job timeout-minutes budget -- see INC-6820.
       - name: Authenticate to GCS build-cache
+        if: steps.is-fork.outputs.is-fork != 'true'
         timeout-minutes: 3
         uses: ./.github/actions/gcs-build-cache-auth
         with:
@@ -1289,6 +1305,14 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - uses: ./.github/actions/restore-shared-m2
+        if: steps.is-fork.outputs.is-fork != 'true'
+      # Fork PRs can't authenticate to GCS (no Vault access), so build the SNAPSHOTs locally
+      # instead of restoring them -- same fallback the database/webapp-UT reusable workflows
+      # use for their standalone (non-ci.yml) callers.
+      - uses: ./.github/actions/build-zeebe
+        if: steps.is-fork.outputs.is-fork == 'true'
+        with:
+          maven-extra-args: -T1C -PskipFrontendBuild
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       # Run integration tests with RDBMS database
@@ -1363,6 +1387,9 @@ jobs:
       - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1
+      - name: Check for fork
+        id: is-fork
+        uses: ./.github/actions/is-fork
       - name: Generate cache key with current hour
         if: matrix.group == 'qa-update'
         id: cache-key
@@ -1395,6 +1422,7 @@ jobs:
       # Timed out here directly (not via setup-build) so a Vault/WIF hang fails fast instead
       # of silently eating the whole job timeout-minutes budget -- see INC-6820.
       - name: Authenticate to GCS build-cache
+        if: steps.is-fork.outputs.is-fork != 'true'
         timeout-minutes: 3
         uses: ./.github/actions/gcs-build-cache-auth
         with:
@@ -1403,9 +1431,11 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       # Download the shared distball tarball; restore-shared-m2 below handles the SNAPSHOTs.
       - name: Create dist/target
+        if: steps.is-fork.outputs.is-fork != 'true'
         shell: bash
         run: mkdir -p dist/target
       - name: Download distball from GCS
+        if: steps.is-fork.outputs.is-fork != 'true'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           max_attempts: 5
@@ -1416,6 +1446,15 @@ jobs:
       # Restore the io.camunda SNAPSHOTs archived by build-distball for `mvn verify` below
       # (the GHA Maven cache doesn't carry locally-installed SNAPSHOTs between jobs).
       - uses: ./.github/actions/restore-shared-m2
+        if: steps.is-fork.outputs.is-fork != 'true'
+      # Fork PRs can't authenticate to GCS (no Vault access), so build the distball + SNAPSHOTs
+      # locally instead of restoring them -- same fallback the database/webapp-UT reusable
+      # workflows use for their standalone (non-ci.yml) callers. Produces dist/target/*.tar.gz,
+      # same as "Download distball from GCS" above, so build-platform-docker below is unchanged.
+      - uses: ./.github/actions/build-zeebe
+        if: steps.is-fork.outputs.is-fork == 'true'
+        with:
+          maven-extra-args: -T1C -PskipFrontendBuild
       - uses: ./.github/actions/build-platform-docker
         if: ${{ matrix.docker-file != '' }}
         with:
@@ -2108,7 +2147,9 @@ jobs:
     with:
       runFeTests: ${{ needs.detect-changes.outputs.tasklist-frontend-changes  == 'true' }}
       runBeTests: ${{ needs.detect-changes.outputs.tasklist-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-changes == 'true' }}
-      use-shared-distball: true
+      # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
+      # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
+      use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
 
   operate-ci:
     if: needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true'
@@ -2122,7 +2163,9 @@ jobs:
     with:
       runFeTests: ${{ needs.detect-changes.outputs.operate-frontend-changes == 'true' }}
       runBeTests: ${{ needs.detect-changes.outputs.operate-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-changes == 'true'}}
-      use-shared-distball: true
+      # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
+      # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
+      use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
 
   optimize-ci:
     if: ${{ needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true' || needs.detect-changes.outputs.optimize-dockerfile-changes == 'true' }}
@@ -2137,7 +2180,9 @@ jobs:
       runFeTests: ${{ needs.detect-changes.outputs.optimize-frontend-changes == 'true' }}
       runBeTests: ${{ needs.detect-changes.outputs.optimize-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-changes == 'true' }}
       runDockerfileChecks: ${{ needs.detect-changes.outputs.optimize-dockerfile-changes == 'true' }}
-      use-shared-distball: true
+      # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
+      # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
+      use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
 
   zeebe-ci:
     if: needs.detect-changes.outputs.zeebe-changes == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1072,7 +1072,9 @@ jobs:
       database-image-version: "${{ matrix.database-image-version }}"
       database-name: "${{ matrix.database-name }}"
       it-database-type: "${{ matrix.it-database-type }}"
-      use-shared-distball: true
+      # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
+      # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
+      use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
 
   history-tests:
     name: "History Integration Tests / ${{ matrix.name }}"
@@ -1097,7 +1099,9 @@ jobs:
       test-type: "history-tests"
       test-type-label: "History"
       runs-on: "gcp-perf-core-8-default"
-      use-shared-distball: true
+      # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
+      # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
+      use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
 
   identity-tests:
     name: "Identity Integration Tests / ${{ matrix.name }}"
@@ -1121,7 +1125,9 @@ jobs:
       maven-profiles: "identity-tests"
       test-type: "identity-tests"
       test-type-label: "Identity"
-      use-shared-distball: true
+      # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
+      # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
+      use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
 
   physical-tenant-acceptance-tests:
     name: "Physical Tenant Acceptance Tests / ${{ matrix.database-name }}"
@@ -1167,7 +1173,9 @@ jobs:
       test-type: "physical-tenant-acceptance-tests"
       test-type-label: "Physical Tenant Acceptance"
       test-suite-name: "acceptance"
-      use-shared-distball: true
+      # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
+      # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
+      use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
 
   physical-tenant-identity-tests:
     name: "Physical Tenant Acceptance Tests / Identity / ${{ matrix.database-name }}"
@@ -1205,7 +1213,9 @@ jobs:
       test-type: "physical-tenant-identity-tests"
       test-type-label: "Physical Tenant Acceptance Identity"
       test-suite-name: "identity"
-      use-shared-distball: true
+      # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
+      # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
+      use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
 
   physical-tenant-history-tests:
     name: "Physical Tenant Acceptance Tests / History / ${{ matrix.database-name }}"
@@ -1243,7 +1253,9 @@ jobs:
       test-type: "physical-tenant-history-tests"
       test-type-label: "Physical Tenant Acceptance History"
       test-suite-name: "history"
-      use-shared-distball: true
+      # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
+      # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
+      use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
 
   rdbms-integration-tests:
     if: needs.detect-changes.outputs.rdbms-integration-tests == 'true'
@@ -1266,6 +1278,9 @@ jobs:
       - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1
+      - name: Check for fork
+        id: is-fork
+        uses: ./.github/actions/is-fork
       # Consume the shared distball's io.camunda SNAPSHOTs instead of a ~15 min reactor build.
       # This job runs on a self-hosted gcp-perf runner where the artifact API is throughput-capped,
       # so restore-shared-m2 pulls from GCS (same-region, non-billable). RDBMS ITs run in-process
@@ -1282,6 +1297,7 @@ jobs:
       # Timed out here directly (not via setup-build) so a Vault/WIF hang fails fast instead
       # of silently eating the whole job timeout-minutes budget -- see INC-6820.
       - name: Authenticate to GCS build-cache
+        if: steps.is-fork.outputs.is-fork != 'true'
         timeout-minutes: 3
         uses: ./.github/actions/gcs-build-cache-auth
         with:
@@ -1289,6 +1305,14 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - uses: ./.github/actions/restore-shared-m2
+        if: steps.is-fork.outputs.is-fork != 'true'
+      # Fork PRs can't authenticate to GCS (no Vault access), so build the SNAPSHOTs locally
+      # instead of restoring them -- same fallback the database/webapp-UT reusable workflows
+      # use for their standalone (non-ci.yml) callers.
+      - uses: ./.github/actions/build-zeebe
+        if: steps.is-fork.outputs.is-fork == 'true'
+        with:
+          maven-extra-args: -T1C -PskipFrontendBuild
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       # Run integration tests with RDBMS database
@@ -1363,6 +1387,9 @@ jobs:
       - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1
+      - name: Check for fork
+        id: is-fork
+        uses: ./.github/actions/is-fork
       - name: Generate cache key with current hour
         if: matrix.group == 'qa-update'
         id: cache-key
@@ -1395,6 +1422,7 @@ jobs:
       # Timed out here directly (not via setup-build) so a Vault/WIF hang fails fast instead
       # of silently eating the whole job timeout-minutes budget -- see INC-6820.
       - name: Authenticate to GCS build-cache
+        if: steps.is-fork.outputs.is-fork != 'true'
         timeout-minutes: 3
         uses: ./.github/actions/gcs-build-cache-auth
         with:
@@ -1403,9 +1431,11 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       # Download the shared distball tarball; restore-shared-m2 below handles the SNAPSHOTs.
       - name: Create dist/target
+        if: steps.is-fork.outputs.is-fork != 'true'
         shell: bash
         run: mkdir -p dist/target
       - name: Download distball from GCS
+        if: steps.is-fork.outputs.is-fork != 'true'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           max_attempts: 5
@@ -1416,6 +1446,15 @@ jobs:
       # Restore the io.camunda SNAPSHOTs archived by build-distball for `mvn verify` below
       # (the GHA Maven cache doesn't carry locally-installed SNAPSHOTs between jobs).
       - uses: ./.github/actions/restore-shared-m2
+        if: steps.is-fork.outputs.is-fork != 'true'
+      # Fork PRs can't authenticate to GCS (no Vault access), so build the distball + SNAPSHOTs
+      # locally instead of restoring them -- same fallback the database/webapp-UT reusable
+      # workflows use for their standalone (non-ci.yml) callers. Produces dist/target/*.tar.gz,
+      # same as "Download distball from GCS" above, so build-platform-docker below is unchanged.
+      - uses: ./.github/actions/build-zeebe
+        if: steps.is-fork.outputs.is-fork == 'true'
+        with:
+          maven-extra-args: -T1C -PskipFrontendBuild
       - uses: ./.github/actions/build-platform-docker
         if: ${{ matrix.docker-file != '' }}
         with:
@@ -2108,7 +2147,9 @@ jobs:
     with:
       runFeTests: ${{ needs.detect-changes.outputs.tasklist-frontend-changes  == 'true' }}
       runBeTests: ${{ needs.detect-changes.outputs.tasklist-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-changes == 'true' }}
-      use-shared-distball: true
+      # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
+      # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
+      use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
 
   operate-ci:
     if: needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true'
@@ -2122,7 +2163,9 @@ jobs:
     with:
       runFeTests: ${{ needs.detect-changes.outputs.operate-frontend-changes == 'true' }}
       runBeTests: ${{ needs.detect-changes.outputs.operate-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-changes == 'true'}}
-      use-shared-distball: true
+      # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
+      # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
+      use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
 
   optimize-ci:
     if: ${{ needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true' || needs.detect-changes.outputs.optimize-dockerfile-changes == 'true' }}
@@ -2137,7 +2180,9 @@ jobs:
       runFeTests: ${{ needs.detect-changes.outputs.optimize-frontend-changes == 'true' }}
       runBeTests: ${{ needs.detect-changes.outputs.optimize-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-changes == 'true' }}
       runDockerfileChecks: ${{ needs.detect-changes.outputs.optimize-dockerfile-changes == 'true' }}
-      use-shared-distball: true
+      # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
+      # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
+      use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
 
   zeebe-ci:
     if: needs.detect-changes.outputs.zeebe-changes == 'true'


### PR DESCRIPTION

## Description

`gcs-build-cache-auth` (#56514) skips Vault/WIF auth for fork PRs — correct, no Vault access, matches `setup-build`'s existing DockerHub/Harbor/Minimus fork guard. But nothing downstream skipped the `gcloud` calls that depend on that auth. On a fork PR, `gcloud` is never installed, so those calls fail hard instead of degrading gracefully:

- `build-distball`'s `Upload distball to GCS` / `Upload SNAPSHOTs to GCS` steps ran unconditionally, retried 5x by `nick-fields/retry`, then failed with `gcloud: command not found` (exit 127). Since nearly every downstream job `needs: build-distball`, this failed the whole CI run for any external-contributor PR touching Java code.
- The database/history/identity/webapp-UT reusable-workflow callers in `ci.yml` hardcode `use-shared-distball: true` — same gap in `restore-shared-m2`, currently masked only because `build-distball` fails first.
- `integration-tests` and `rdbms-integration-tests` call `gcs-build-cache-auth` and download/restore the shared distball directly, with no fallback at all — same gap, same masking.

This has silently blocked every external-contributor PR touching Java code since #56514 merged (2026-07-07). Reported in Slack on 2026-07-24 for PR #58518, escalated, stalled 2 weeks, never fixed or ticketed. Also hit by #56066. See #59647 for full history (Slack thread link included there).

## Changes

- `ci-build-distball-reusable.yml`: add an `is-fork` check step (same composite already used inside `setup-build`/`gcs-build-cache-auth`) and guard `Upload distball to GCS` / `Upload SNAPSHOTs to GCS` with `if: steps.is-fork.outputs.is-fork != 'true'` — same explicit-gate convention as `setup-build`'s DockerHub/Harbor/Minimus logins.
- `ci.yml`, 9 reusable-workflow callers (database/history/identity/physical-tenant ITs, operate/tasklist/optimize CI): `use-shared-distball: true` becomes `use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}`. Fork PRs now take each reusable workflow's existing `build-zeebe` fallback (already used today by standalone callers like `zeebe-rdbms-integration-tests`) instead of attempting the GCS-authenticated restore. No new mechanism — reuses the fallback #56514 already built.
- `ci.yml`, `integration-tests` and `rdbms-integration-tests`: these had no existing fallback, so add one — gate `Authenticate to GCS build-cache` / `Download distball from GCS` / `restore-shared-m2` behind the same `is-fork` check, and build the distball (or just the m2 SNAPSHOTs, for rdbms — no Docker image needed there) locally via `build-zeebe` when `is-fork` is true. Mirrors the database-reusable workflow's own fallback for its standalone callers.

## Validation

- `actionlint` + `conftest` clean on both changed files (only pre-existing self-hosted-runner-label warnings, unrelated to this diff).
- Verified locally with `act` against temporary harnesses mirroring the new conditional logic (not committed — kept untracked): fork-PR event payload → all GCS steps skipped, fallback runs, `use-shared-distball=false`; same-repo-PR payload → GCS steps run, fallback skipped, `use-shared-distball=true`. Confirmed for `build-distball`, `integration-tests`, and `rdbms-integration-tests`.
- Real build-zeebe/Vault/GCS paths themselves are unchanged by this PR (not exercised locally — need a real self-hosted-runner CI run); only the new conditional routing was act-tested.

## Checklist

- [x] Enable backports when necessary — recommend `backport stable/8.9` (CI-reliability fix, matches #56514's own backport labels; `stable/8.8` doesn't have this file).
- [ ] N/A — no E2E test suite changes

## Related issues

closes #59647