### PR TITLE
fix: keep sibling fields when input mappings copy a variable field by field

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -89,7 +89,11 @@ public final class BpmnVariableMappingBehavior {
       return Either.right(null);
     }
 
-    final var resultBuilder = new MappingResultBuilder();
+    // the resolver completes a read of a target that earlier nested mappings only partially built,
+    // so its not-yet-mapped properties still resolve against the scope (see MappingResultBuilder)
+    final var resultBuilder =
+        MappingResultBuilder.forInputMappings(
+            name -> variablesState.getVariable(scopeKey, BufferUtil.wrapString(name)));
     // secret references (camunda.secrets.<name>) are resolved to their placeholder string only
     // for input mappings, so a modeled reference survives evaluation instead of nulling
     final var processor =
@@ -159,7 +163,7 @@ public final class BpmnVariableMappingBehavior {
       // it and keep the existing sibling properties: look up the top-level variable in the element
       // scope, then navigate into it along the remaining path segments (null when absent).
       final var resultBuilder =
-          new MappingResultBuilder(
+          MappingResultBuilder.forOutputMappings(
               path ->
                   Optional.ofNullable(
                           variablesState.getVariable(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilder.java
@@ -31,14 +31,17 @@ import org.jspecify.annotations.Nullable;
  * earlier mappings. {@link #toDocument()} returns the accumulated results as a single MsgPack
  * document to be merged into the element's local scope.
  *
- * <p>For input mappings (no-arg constructor), a mapping to a nested target descends into (or
+ * <p>For input mappings ({@link #forInputMappings}), a mapping to a nested target descends into (or
  * creates) intermediate objects; a mapping whose target collides structurally with an earlier one
- * (a value where an object is needed, or vice versa) replaces the earlier entry — last-wins.
+ * (a value where an object is needed, or vice versa) replaces the earlier entry — last-wins. The
+ * accumulated results are never merged with the scope: what {@link #toDocument()} returns fully
+ * replaces the same-named scope variables. A {@link #getVariable} lookup does fall back to the
+ * scope, see there.
  *
- * <p>For output mappings (constructor with a {@code scopeValueResolver}), a nested target instead
- * merges with the existing scope variable at every path level: a level that is absent or holds a
- * plain value is seeded from the current scope value at that path. A non-context scope value
- * poisons the level to null, matching FEEL's {@code context merge(<non-context>, {...})} behavior.
+ * <p>For output mappings ({@link #forOutputMappings}), a nested target instead merges with the
+ * existing scope variable at every path level: a level that is absent or holds a plain value is
+ * seeded from the current scope value at that path. A non-context scope value poisons the level to
+ * null, matching FEEL's {@code context merge(<non-context>, {...})} behavior.
  */
 @NullMarked
 public final class MappingResultBuilder {
@@ -61,23 +64,42 @@ public final class MappingResultBuilder {
 
   private final Function<List<String>, @Nullable DirectBuffer> scopeValueResolver;
 
-  /** Builder for input mappings: nested targets never merge with existing scope values. */
-  public MappingResultBuilder() {
-    this(path -> null);
+  private final Function<String, @Nullable DirectBuffer> scopeVariableResolver;
+
+  private MappingResultBuilder(
+      final Function<List<String>, @Nullable DirectBuffer> scopeValueResolver,
+      final Function<String, @Nullable DirectBuffer> scopeVariableResolver) {
+    this.scopeValueResolver = scopeValueResolver;
+    this.scopeVariableResolver = scopeVariableResolver;
+  }
+
+  /**
+   * Builder for input mappings: nested targets never merge with existing scope values, so the
+   * accumulated document replaces the same-named scope variables outright. The resolver is used
+   * only to complete a {@link #getVariable} lookup of a target that is still being built, see
+   * there.
+   *
+   * @param scopeVariableResolver resolves a top-level variable name to its current scope value, or
+   *     {@code null} when there is none
+   */
+  public static MappingResultBuilder forInputMappings(
+      final Function<String, @Nullable DirectBuffer> scopeVariableResolver) {
+    return new MappingResultBuilder(path -> null, scopeVariableResolver);
   }
 
   /**
    * Builder for output mappings: when a nested target path needs a map at a level that is absent
    * (or currently holds a plain value), the level is seeded from the existing scope value at that
    * path. A non-context scope value poisons the level to null, matching FEEL's {@code context
-   * merge} behavior.
+   * merge} behavior. Because every level is already seeded while accumulating, a {@link
+   * #getVariable} lookup needs no further scope fallback.
    *
    * @param scopeValueResolver resolves a target-path prefix to the current scope value at that
    *     path, or {@code null} when there is none; invoked only when a level must be (re)created
    */
-  public MappingResultBuilder(
+  public static MappingResultBuilder forOutputMappings(
       final Function<List<String>, @Nullable DirectBuffer> scopeValueResolver) {
-    this.scopeValueResolver = scopeValueResolver;
+    return new MappingResultBuilder(scopeValueResolver, name -> null);
   }
 
   /**
@@ -101,6 +123,12 @@ public final class MappingResultBuilder {
    * has produced it yet. Nested structures are serialized to a MsgPack document on lookup. A
    * poisoned top-level entry returns a NIL buffer (not Java {@code null}, which would let the
    * caller fall back to the scope lookup instead of seeing the poisoned null).
+   *
+   * <p>A variable that only nested targets have contributed to so far is still under construction:
+   * the properties no mapping has produced yet are completed from the scope value, so that a later
+   * mapping reading one of them resolves it up the scope chain instead of dead-ending on the
+   * partial object (see {@link #withScopeFallback}). A variable a mapping produced as a whole is
+   * complete and shadows the scope value outright.
    */
   public @Nullable DirectBuffer getVariable(final String name) {
     final var entry = entries.get(name);
@@ -111,8 +139,45 @@ public final class MappingResultBuilder {
     } else if (entry instanceof final DirectBuffer value) {
       return value;
     } else {
-      return serialize(asNestedMap(entry));
+      return serialize(withScopeFallback(asNestedMap(entry), scopeVariableResolver.apply(name)));
     }
+  }
+
+  /**
+   * Returns the still-under-construction {@code partial} completed with the properties of {@code
+   * scopeValue} that no mapping has produced yet, so a read of one of them defers up the scope
+   * chain like any other variable lookup.
+   *
+   * <p>Mapped properties win over the scope, and a property both sides hold as an object is
+   * completed recursively — otherwise the dead-end would just move one level down. Only the
+   * accumulated results are ever applied to the scope ({@link #toDocument} does not use this), so
+   * completing a read does not turn a nested input target into a merge.
+   *
+   * <p>{@code scopeValue} that is absent or not an object leaves the partial untouched: there is no
+   * object to resolve the remaining properties against.
+   */
+  private static Map<String, Object> withScopeFallback(
+      final Map<String, Object> partial, final @Nullable DirectBuffer scopeValue) {
+    if (scopeValue == null
+        || scopeValue.capacity() == 0
+        || !MsgPackCodes.isMap(scopeValue.getByte(0))) {
+      return partial;
+    }
+    final var completed = deserializeTopLevel(scopeValue);
+    partial.forEach(
+        (key, value) -> {
+          if (value instanceof Map<?, ?>) {
+            final var scopeProperty = completed.get(key);
+            completed.put(
+                key,
+                withScopeFallback(
+                    asNestedMap(value),
+                    scopeProperty instanceof final DirectBuffer buffer ? buffer : null));
+          } else {
+            completed.put(key, value);
+          }
+        });
+    return completed;
   }
 
   /** Returns all accumulated results as a single MsgPack document (a map). */

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilderTest.java
@@ -16,11 +16,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.agrona.DirectBuffer;
 import org.junit.jupiter.api.Test;
 
 final class MappingResultBuilderTest {
 
-  private final MappingResultBuilder builder = new MappingResultBuilder();
+  private final MappingResultBuilder builder = MappingResultBuilder.forInputMappings(name -> null);
 
   @Test
   void shouldBuildEmptyDocument() {
@@ -138,10 +139,102 @@ final class MappingResultBuilderTest {
   }
 
   @Test
+  void shouldCompletePartialTargetFromScopeValueOnLookup() {
+    // given: scope has foo = {'bar': 9, 'baz': 2}, and a nested target has produced foo.bar
+    final var builder = inputBuilder(Map.of("foo", asMsgPack("{'bar': 9, 'baz': 2}")));
+    builder.put(List.of("foo", "bar"), asMsgPack("1"));
+
+    // when + then: 'baz' was not mapped, so it still resolves against the scope value
+    assertEquality(builder.getVariable("foo"), "{'bar': 1, 'baz': 2}");
+  }
+
+  @Test
+  void shouldNotApplyTheScopeValueToTheDocument() {
+    // given: completing a lookup must not turn a nested input target into a merge - input mappings
+    // overwrite the scope variable outright
+    final var builder = inputBuilder(Map.of("foo", asMsgPack("{'bar': 9, 'baz': 2}")));
+    builder.put(List.of("foo", "bar"), asMsgPack("1"));
+
+    // when: the lookup that completes from the scope happens before the document is built
+    builder.getVariable("foo");
+
+    // then: 'baz' is absent - only the mapped property is applied
+    assertEquality(builder.toDocument(), "{'foo': {'bar': 1}}");
+  }
+
+  @Test
+  void shouldCompletePartialTargetAtEveryNestingLevelOnLookup() {
+    // given: without recursion the dead end would just move one level down
+    final var builder =
+        inputBuilder(Map.of("foo", asMsgPack("{'bar': {'x': 9, 'y': 2}, 'other': 3}")));
+    builder.put(List.of("foo", "bar", "x"), asMsgPack("1"));
+
+    // when + then
+    assertEquality(builder.getVariable("foo"), "{'bar': {'x': 1, 'y': 2}, 'other': 3}");
+  }
+
+  @Test
+  void shouldPreferMappedPropertyOverScopeValueOnLookup() {
+    // given
+    final var builder = inputBuilder(Map.of("foo", asMsgPack("{'bar': 9}")));
+    builder.put(List.of("foo", "bar"), asMsgPack("1"));
+
+    // when + then: the just-mapped value wins, the scope only fills the gaps
+    assertEquality(builder.getVariable("foo"), "{'bar': 1}");
+  }
+
+  @Test
+  void shouldNotCompleteCompletedTargetFromScopeValue() {
+    // given: a mapping produced 'foo' as a whole, so it is complete rather than under construction
+    final var builder = inputBuilder(Map.of("foo", asMsgPack("{'bar': 9, 'baz': 2}")));
+    builder.put(List.of("foo"), asMsgPack("{'bar': 1}"));
+
+    // when + then: it shadows the scope value outright
+    assertEquality(builder.getVariable("foo"), "{'bar': 1}");
+  }
+
+  @Test
+  void shouldNotCompletePartialTargetFromNonObjectScopeValue() {
+    // given: scope has foo = 5 - there is no object to resolve the remaining properties against
+    final var builder = inputBuilder(Map.of("foo", asMsgPack("5")));
+    builder.put(List.of("foo", "bar"), asMsgPack("1"));
+
+    // when + then: no poisoning either - that is output-mapping behaviour
+    assertEquality(builder.getVariable("foo"), "{'bar': 1}");
+    assertEquality(builder.toDocument(), "{'foo': {'bar': 1}}");
+  }
+
+  @Test
+  void shouldNotCompletePartialTargetFromNilScopeValue() {
+    // given
+    final var builder = inputBuilder(Map.of("foo", asMsgPack("null")));
+    builder.put(List.of("foo", "bar"), asMsgPack("1"));
+
+    // when + then
+    assertEquality(builder.getVariable("foo"), "{'bar': 1}");
+  }
+
+  @Test
+  void shouldNotCompletePartialTargetOfOutputBuilderOnLookup() {
+    // given: an output builder already seeds every level while accumulating, so a lookup needs no
+    // further fallback
+    final var builder =
+        MappingResultBuilder.forOutputMappings(
+            path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
+
+    // when
+    builder.put(List.of("a", "b"), asMsgPack("1"));
+
+    // then
+    assertEquality(builder.getVariable("a"), "{'c': 2, 'b': 1}");
+  }
+
+  @Test
   void shouldSeedNestedTargetFromScopeValue() {
     // given: scope has a = {'c': 2}
     final var builder =
-        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
+        MappingResultBuilder.forOutputMappings(
+            path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
 
     // when
     builder.put(List.of("a", "b"), asMsgPack("1"));
@@ -157,7 +250,7 @@ final class MappingResultBuilderTest {
         Map.of(
             List.of("a"), asMsgPack("{'b': {'d': 2}, 'e': 3}"),
             List.of("a", "b"), asMsgPack("{'d': 2}"));
-    final var builder = new MappingResultBuilder(scope::get);
+    final var builder = MappingResultBuilder.forOutputMappings(scope::get);
 
     // when
     builder.put(List.of("a", "b", "c"), asMsgPack("1"));
@@ -170,7 +263,8 @@ final class MappingResultBuilderTest {
   void shouldPoisonLevelWhenScopeValueIsNotAMap() {
     // given: scope has a = 5
     final var builder =
-        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
+        MappingResultBuilder.forOutputMappings(
+            path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
 
     // when
     builder.put(List.of("a", "b"), asMsgPack("1"));
@@ -183,7 +277,8 @@ final class MappingResultBuilderTest {
   @Test
   void shouldDiscardFurtherPutsUnderPoisonedLevel() {
     final var builder =
-        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
+        MappingResultBuilder.forOutputMappings(
+            path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
 
     // when
     builder.put(List.of("a", "b"), asMsgPack("1"));
@@ -196,7 +291,8 @@ final class MappingResultBuilderTest {
   @Test
   void shouldReplacePoisonedLevelWithPlainTargetPut() {
     final var builder =
-        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
+        MappingResultBuilder.forOutputMappings(
+            path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
 
     // when: a nested put poisons 'a', then a plain put replaces it
     builder.put(List.of("a", "b"), asMsgPack("1"));
@@ -210,7 +306,8 @@ final class MappingResultBuilderTest {
   void shouldReseedFromScopeWhenNestedPutFollowsPlainPut() {
     // given: scope a = {'c': 2}; a plain put stored a value buffer for 'a'
     final var builder =
-        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
+        MappingResultBuilder.forOutputMappings(
+            path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
     builder.put(List.of("a"), asMsgPack("{'z': 9}"));
 
     // when: the shape flips back to a map — the plain mapping's value is discarded and the fresh
@@ -225,12 +322,17 @@ final class MappingResultBuilderTest {
   void shouldSeedFreshMapWhenScopeValueIsNil() {
     // given: scope has a = null — FEEL's `if (a != null)` takes the else branch
     final var builder =
-        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("null") : null);
+        MappingResultBuilder.forOutputMappings(
+            path -> path.equals(List.of("a")) ? asMsgPack("null") : null);
 
     // when
     builder.put(List.of("a", "b"), asMsgPack("1"));
 
     // then
     assertEquality(builder.toDocument(), "{'a': {'b': 1}}");
+  }
+
+  private static MappingResultBuilder inputBuilder(final Map<String, DirectBuffer> scope) {
+    return MappingResultBuilder.forInputMappings(scope::get);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityInputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityInputMappingTest.java
@@ -193,6 +193,57 @@ public final class ActivityInputMappingTest {
         mapping(b -> b.zeebeInput("say \"hi\"", "greeting")),
         activityVariables(variable("greeting", "\"say \\\"hi\\\"\""))
       },
+      {
+        // per-field identity copy of one root variable: the second mapping's source resolves
+        // 'foo.baz' against the parent scope, not against the partial object the first mapping
+        // started, so both fields survive
+        // regression test for https://github.com/camunda/camunda/issues/59646
+        "{'foo': {'bar': 1, 'baz': 2}}",
+        mapping(
+            b ->
+                b.zeebeInputExpression("foo.bar", "foo.bar")
+                    .zeebeInputExpression("foo.baz", "foo.baz")),
+        activityVariables(variable("foo", "{\"bar\":1,\"baz\":2}"))
+      },
+      {
+        // ... and declaration order no longer picks which field survives
+        "{'foo': {'bar': 1, 'baz': 2}}",
+        mapping(
+            b ->
+                b.zeebeInputExpression("foo.baz", "foo.baz")
+                    .zeebeInputExpression("foo.bar", "foo.bar")),
+        activityVariables(variable("foo", "{\"baz\":2,\"bar\":1}"))
+      },
+      {
+        // the fallback recurses, so the same identity copy works one level deeper too
+        "{'foo': {'bar': {'x': 1, 'y': 2}}}",
+        mapping(
+            b ->
+                b.zeebeInputExpression("foo.bar.x", "foo.bar.x")
+                    .zeebeInputExpression("foo.bar.y", "foo.bar.y")),
+        activityVariables(variable("foo", "{\"bar\":{\"x\":1,\"y\":2}}"))
+      },
+      {
+        // completing a source lookup from the scope must NOT turn a nested input target into a
+        // merge: mapping only 'foo.bar' still drops the parent's 'baz' from the local 'foo'
+        "{'foo': {'bar': 1, 'baz': 2}}",
+        mapping(b -> b.zeebeInputExpression("foo.bar", "foo.bar")),
+        activityVariables(variable("foo", "{\"bar\":1}"))
+      },
+      {
+        // a property an earlier mapping produced wins over the parent scope's
+        "{'foo': {'bar': 1, 'baz': 2}}",
+        mapping(
+            b -> b.zeebeInputExpression("7", "foo.bar").zeebeInputExpression("foo.bar", "foo.baz")),
+        activityVariables(variable("foo", "{\"bar\":7,\"baz\":7}"))
+      },
+      {
+        // a target mapped as a WHOLE is complete: it shadows the parent scope outright, so the
+        // later source sees only what that mapping produced
+        "{'foo': {'bar': 1, 'baz': 2}}",
+        mapping(b -> b.zeebeInputExpression("{bar: 7}", "foo").zeebeInputExpression("foo", "copy")),
+        activityVariables(variable("foo", "{\"bar\":7}"), variable("copy", "{\"bar\":7}"))
+      },
     };
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
@@ -57,12 +57,71 @@ final class VariableInputMappingTransformerTest {
         "{'a':{'b':1, 'c':2}}"
       },
       {List.of(mapping("x", "a.b.c")), Map.of("x", asMsgPack("1")), "{'a':{'b':{'c':1}}}"},
-      // a mapping reads the PARTIAL object an earlier a.* mapping built so far, not the outer
-      // scope's "a"
+      // a mapping reads the object an earlier a.* mapping started, completed with the outer
+      // scope's "a" for the properties no mapping has produced - "b" is mapped, "z" defers
       {
         List.of(mapping("x", "a.b"), mapping("a", "c")),
         Map.of("x", asMsgPack("1"), "a", asMsgPack("{'z':99}")),
-        "{'a':{'b':1}, 'c':{'b':1}}"
+        "{'a':{'b':1}, 'c':{'z':99, 'b':1}}"
+      },
+      // ... but only the mapped properties are applied: "a" itself does NOT gain the scope's "z"
+      {
+        List.of(mapping("x", "a.b")),
+        Map.of("x", asMsgPack("1"), "a", asMsgPack("{'z':99}")),
+        "{'a':{'b':1}}"
+      },
+      // per-field identity copy of the same root: the second mapping's source must still see the
+      // outer scope's "foo.baz", not dead-end on the partial object the first mapping started
+      // regression test for https://github.com/camunda/camunda/issues/59646
+      {
+        List.of(mapping("foo.bar", "foo.bar"), mapping("foo.baz", "foo.baz")),
+        Map.of("foo", asMsgPack("{'bar':1, 'baz':2}")),
+        "{'foo':{'bar':1, 'baz':2}}"
+      },
+      // reversing the two lines yields the same result - declaration order no longer picks a
+      // survivor
+      {
+        List.of(mapping("foo.baz", "foo.baz"), mapping("foo.bar", "foo.bar")),
+        Map.of("foo", asMsgPack("{'bar':1, 'baz':2}")),
+        "{'foo':{'baz':2, 'bar':1}}"
+      },
+      // the same, one level deeper: the fallback has to recurse, or the dead end just moves down
+      {
+        List.of(mapping("foo.bar.x", "foo.bar.x"), mapping("foo.bar.y", "foo.bar.y")),
+        Map.of("foo", asMsgPack("{'bar':{'x':1, 'y':2}, 'other':3}")),
+        "{'foo':{'bar':{'x':1, 'y':2}}}"
+      },
+      // a mapped property still wins over the scope's: "bar" reads as the just-mapped 7, not 1
+      {
+        List.of(mapping("7", "foo.bar"), mapping("foo.bar", "foo.baz")),
+        Map.of("foo", asMsgPack("{'bar':1, 'baz':2}")),
+        "{'foo':{'bar':7, 'baz':7}}"
+      },
+      // a scope value that is not an object has no properties to defer to
+      {
+        List.of(mapping("1", "foo.bar"), mapping("foo.baz", "foo.baz")),
+        Map.of("foo", asMsgPack("5")),
+        "{'foo':{'bar':1, 'baz':null}}"
+      },
+      // ... nor does an absent one
+      {
+        List.of(mapping("1", "foo.bar"), mapping("foo.baz", "foo.baz")),
+        Map.of(),
+        "{'foo':{'bar':1, 'baz':null}}"
+      },
+      // a target mapped as a WHOLE is complete, so it shadows the scope value outright instead of
+      // deferring - unlike the partially built object above
+      {
+        List.of(mapping("{bar: 7}", "foo"), mapping("foo", "copy")),
+        Map.of("foo", asMsgPack("{'bar':1, 'baz':2}")),
+        "{'foo':{'bar':7}, 'copy':{'bar':7}}"
+      },
+      // same root, plain target first: the source reads the COMPLETE "foo" the plain mapping
+      // declared, so ".baz" misses on the number 1 rather than deferring to the scope's object
+      {
+        List.of(mapping("1", "foo"), mapping("foo.baz", "foo.baz")),
+        Map.of("foo", asMsgPack("{'bar':1, 'baz':2}")),
+        "{'foo':{'baz':null}}"
       },
       // nested source
       {List.of(mapping("x.y", "a")), Map.of("x", asMsgPack("{'y':1}")), "{'a':1}"},
@@ -200,7 +259,7 @@ final class VariableInputMappingTransformerTest {
     // when: evaluate the mappings one by one in modeling order, same as
     // BpmnVariableMappingBehavior.applyInputMappings does at runtime — accumulated results shadow
     // the base variables, which fall back for anything not mapped yet
-    final var resultBuilder = new MappingResultBuilder();
+    final var resultBuilder = MappingResultBuilder.forInputMappings(variables::get);
     for (final var mapping : inputMappings.mappings()) {
       final EvaluationContext context =
           name -> {
@@ -233,7 +292,7 @@ final class VariableInputMappingTransformerTest {
                     .isTrue());
 
     // when
-    final var resultBuilder = new MappingResultBuilder();
+    final var resultBuilder = MappingResultBuilder.forInputMappings(variables::get);
     for (final var mapping : inputMappings.mappings()) {
       final EvaluationContext context =
           name -> {
@@ -275,7 +334,7 @@ final class VariableInputMappingTransformerTest {
       final Map<String, DirectBuffer> variables,
       final ExpressionLanguage language) {
     final var inputMappings = transformer.transformInputMappings(mappings, language);
-    final var resultBuilder = new MappingResultBuilder();
+    final var resultBuilder = MappingResultBuilder.forInputMappings(variables::get);
     for (final var mapping : inputMappings.mappings()) {
       final EvaluationContext context =
           name -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
@@ -138,6 +138,19 @@ public final class VariableOutputMappingTransformerTest {
         Map.of("x", asMsgPack("1"), "y", asMsgPack("2")),
         "{'a':1}"
       },
+      // per-field identity copy of the same root - the output counterpart of #59646. Output
+      // mappings seed every path level from the scope while accumulating, so the second source
+      // already reads a complete "a"; pinned here so the two sides cannot drift apart
+      {
+        List.of(mapping("a.b", "a.b"), mapping("a.c", "a.c")),
+        Map.of("a", asMsgPack("{'b':1, 'c':2}")),
+        "{'a':{'b':1, 'c':2}}"
+      },
+      {
+        List.of(mapping("a.b.x", "a.b.x"), mapping("a.b.y", "a.b.y")),
+        Map.of("a", asMsgPack("{'b':{'x':1, 'y':2}, 'other':3}")),
+        "{'a':{'b':{'x':1, 'y':2}, 'other':3}}"
+      },
       // declaration order preserved across regrouped nested targets (#11789 / #56387): an entry
       // declared BETWEEN two entries of the same parent target sees the in-between assignment
       {
@@ -154,6 +167,20 @@ public final class VariableOutputMappingTransformerTest {
         Map.of(),
         "{'nested':{'property':'some text', 'nested':{'property':'abc'}}, "
             + "'notNested':'abc', 'notNestedAssigned':'abc'}"
+      },
+      // a back-reference to the root of an earlier nested target reads it POST-merge, so it also
+      // carries the scope's siblings ...
+      {
+        List.of(mapping("1", "a.b"), mapping("a", "d")),
+        Map.of("a", asMsgPack("{'p':0}")),
+        "{'a':{'p':0, 'b':1}, 'd':{'p':0, 'b':1}}"
+      },
+      // ... whereas declared first it reads the pre-merge scope value: output ordering observably
+      // changes what a back-reference sees
+      {
+        List.of(mapping("a", "d"), mapping("1", "a.b")),
+        Map.of("a", asMsgPack("{'p':0}")),
+        "{'d':{'p':0}, 'a':{'p':0, 'b':1}}"
       },
       // source FEEL expression
       {List.of(mapping("1", "a")), Map.of(), "{'a':1}"},
@@ -203,7 +230,7 @@ public final class VariableOutputMappingTransformerTest {
     // BpmnVariableMappingBehavior.applyOutputMappings does at runtime — accumulated results
     // shadow the scope variables, and nested targets merge with the scope value at every level
     final var resultBuilder =
-        new MappingResultBuilder(
+        MappingResultBuilder.forOutputMappings(
             path ->
                 Optional.ofNullable(variables.get(path.getFirst()))
                     .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
@@ -236,7 +263,7 @@ public final class VariableOutputMappingTransformerTest {
 
     // when: evaluate one by one, stopping at the first failure (mirrors runtime fail-fast)
     final var resultBuilder =
-        new MappingResultBuilder(
+        MappingResultBuilder.forOutputMappings(
             path ->
                 Optional.ofNullable(variables.get(path.getFirst()))
                     .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
@@ -277,7 +304,7 @@ public final class VariableOutputMappingTransformerTest {
 
     // when
     final var resultBuilder =
-        new MappingResultBuilder(
+        MappingResultBuilder.forOutputMappings(
             path ->
                 Optional.ofNullable(variables.get(path.getFirst()))
                     .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
@@ -310,7 +337,7 @@ public final class VariableOutputMappingTransformerTest {
 
     // when
     final var resultBuilder =
-        new MappingResultBuilder(
+        MappingResultBuilder.forOutputMappings(
             path ->
                 Optional.ofNullable(variables.get(path.getFirst()))
                     .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Input mappings that copy several fields of one variable into a target under that variable's own name were silently dropping every field but the first. With a parent-scope `foo = {bar: 1, baz: 2}`, mapping `foo.bar ← =foo.bar` and `foo.baz ← =foo.baz` gave you a local `foo = {bar: 1, baz: null}` — no incident, nothing but an evaluation-log entry. Swap the two lines and you lose `bar` instead, so declaration order quietly picked the winner.

Turns out this is a regression I introduced in #58801, not a long-standing bug. I only realised while writing the kill-switch tests for the follow-up PR: on the old combined-expression path the two sources sit in a *nested* FEEL context, and feel-scala doesn't let those reach the enclosing context's still-unevaluated `foo` entry, so both resolved against the parent scope and the copy was faithful. That's why the issue reports 8.7.36 and 8.8.34 — exactly the first patches carrying #58801. Anything older is fine. The issue's own Rootcause section blames the FEEL fusion and is wrong about this.

Since #58801 each source sees the results accumulated so far, and those take priority over same-named scope variables. The problem was applying that priority to a target the earlier mappings had only *partially* built: the first mapping made `foo` an object holding just `bar`, so the second mapping's `foo.baz` resolved against that half-finished object and dead-ended on `NO_PROPERTY_FOUND`. Output mappings never had it — they seed every path level from the scope while accumulating, so their `foo` is already complete when the next source reads it.

So a variable that only nested targets have contributed to is now completed from its scope value *on lookup*: mapped properties win, the rest defer up the scope chain like any other variable lookup. It has to recurse, otherwise the dead end just moves one level down. A variable a mapping produced as a whole stays complete and keeps shadowing the scope outright, so back-references to earlier mappings are untouched.

Two things I deliberately didn't do:

1. Seeding the *write* path would have been the smaller change, but it turns a nested input target into a merge and flips the documented "input overwrites, output merges" rule — mapping `foo.bar` alone must still drop the parent's `baz`. There's a test pinning that now.
2. The issue suggests evaluating every source against the pristine pre-mapping scope. That reverts #58801 wholesale and takes #11789 and the cross-root ordering fix with it. A proper kill-switch for that full revert is coming as a separate PR, based on this one.

While I was in here I also pinned two output-side cases the edge-case catalog for #56735 had left uncovered, both already passing: the output counterpart of this identity copy (so the two sides can't drift apart), and an output back-reference to the root of an earlier nested target in both declaration orders, where the order observably changes whether you read the value pre- or post-merge.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #59646 
Relates to #58801, #59542
