### PR TITLE
feat: add a kill-switch for evaluating input mappings one by one

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Engine.java
+++ b/configuration/src/main/java/io/camunda/configuration/Engine.java
@@ -20,6 +20,7 @@ public class Engine {
       Set.of("zeebe.broker.experimental.engine.maxProcessDepth");
 
   private static final boolean DEFAULT_EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER = true;
+  private static final boolean DEFAULT_EVALUATE_INPUT_MAPPINGS_ONE_BY_ONE = true;
 
   /** Configuration properties for the engine's distribution settings. */
   @NestedConfigurationProperty private Distribution distribution = new Distribution();
@@ -63,6 +64,22 @@ public class Engine {
    */
   private boolean evaluateDuplicateOutputMappingTargetsInOrder =
       DEFAULT_EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER;
+
+  /**
+   * Controls how the input-variable mappings of an element are evaluated. When enabled (default),
+   * each mapping's source is evaluated on its own, in modeling order, so a later mapping can
+   * reference what an earlier one produced. When disabled, all mappings of the element are
+   * evaluated as the single combined FEEL context expression they compiled into before this change,
+   * reproducing the behavior of versions up to 8.7.35 and 8.8.33.
+   *
+   * <p>Disabling this reinstates the bugs that change fixed - a mapping declared between two
+   * mappings that share a target root is invisible to the later one, and per-field copies of one
+   * variable drop all but one field - so it is a compatibility escape hatch, not something to reach
+   * for by default. A process whose combined expression does not parse (which deploys fine either
+   * way) keeps being evaluated one mapping at a time even when this is disabled, rather than
+   * failing every activation.
+   */
+  private boolean evaluateInputMappingsOneByOne = DEFAULT_EVALUATE_INPUT_MAPPINGS_ONE_BY_ONE;
 
   public Distribution getDistribution() {
     return distribution;
@@ -143,6 +160,14 @@ public class Engine {
 
   public boolean isEvaluateDuplicateOutputMappingTargetsInOrder() {
     return evaluateDuplicateOutputMappingTargetsInOrder;
+  }
+
+  public boolean isEvaluateInputMappingsOneByOne() {
+    return evaluateInputMappingsOneByOne;
+  }
+
+  public void setEvaluateInputMappingsOneByOne(final boolean evaluateInputMappingsOneByOne) {
+    this.evaluateInputMappingsOneByOne = evaluateInputMappingsOneByOne;
   }
 
   public void setEvaluateDuplicateOutputMappingTargetsInOrder(

--- a/configuration/src/main/java/io/camunda/configuration/Engine.java
+++ b/configuration/src/main/java/io/camunda/configuration/Engine.java
@@ -20,6 +20,7 @@ public class Engine {
       Set.of("zeebe.broker.experimental.engine.maxProcessDepth");
 
   private static final boolean DEFAULT_EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER = true;
+  private static final boolean DEFAULT_EVALUATE_INPUT_MAPPINGS_ONE_BY_ONE = true;
 
   /** Configuration properties for the engine's distribution settings. */
   @NestedConfigurationProperty private Distribution distribution = new Distribution();
@@ -60,6 +61,22 @@ public class Engine {
    */
   private boolean evaluateDuplicateOutputMappingTargetsInOrder =
       DEFAULT_EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER;
+
+  /**
+   * Controls how the input-variable mappings of an element are evaluated. When enabled (default),
+   * each mapping's source is evaluated on its own, in modeling order, so a later mapping can
+   * reference what an earlier one produced. When disabled, all mappings of the element are
+   * evaluated as the single combined FEEL context expression they compiled into before this change,
+   * reproducing the behavior of versions up to 8.7.35 and 8.8.33.
+   *
+   * <p>Disabling this reinstates the bugs that change fixed - a mapping declared between two
+   * mappings that share a target root is invisible to the later one, and per-field copies of one
+   * variable drop all but one field - so it is a compatibility escape hatch, not something to reach
+   * for by default. A process whose combined expression does not parse (which deploys fine either
+   * way) keeps being evaluated one mapping at a time even when this is disabled, rather than
+   * failing every activation.
+   */
+  private boolean evaluateInputMappingsOneByOne = DEFAULT_EVALUATE_INPUT_MAPPINGS_ONE_BY_ONE;
 
   public Distribution getDistribution() {
     return distribution;
@@ -132,6 +149,14 @@ public class Engine {
 
   public boolean isEvaluateDuplicateOutputMappingTargetsInOrder() {
     return evaluateDuplicateOutputMappingTargetsInOrder;
+  }
+
+  public boolean isEvaluateInputMappingsOneByOne() {
+    return evaluateInputMappingsOneByOne;
+  }
+
+  public void setEvaluateInputMappingsOneByOne(final boolean evaluateInputMappingsOneByOne) {
+    this.evaluateInputMappingsOneByOne = evaluateInputMappingsOneByOne;
   }
 
   public void setEvaluateDuplicateOutputMappingTargetsInOrder(

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -273,6 +273,11 @@ public class BrokerBasedPropertiesOverride {
         .getFeatures()
         .setEvaluateDuplicateOutputMappingTargetsInOrder(
             camunda.getProcessing().getEngine().isEvaluateDuplicateOutputMappingTargetsInOrder());
+    override
+        .getExperimental()
+        .getFeatures()
+        .setEvaluateInputMappingsOneByOne(
+            camunda.getProcessing().getEngine().isEvaluateInputMappingsOneByOne());
 
     override
         .getExperimental()

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -269,6 +269,11 @@ public class BrokerBasedPropertiesOverride {
         .getFeatures()
         .setEvaluateDuplicateOutputMappingTargetsInOrder(
             camunda.getProcessing().getEngine().isEvaluateDuplicateOutputMappingTargetsInOrder());
+    override
+        .getExperimental()
+        .getFeatures()
+        .setEvaluateInputMappingsOneByOne(
+            camunda.getProcessing().getEngine().isEvaluateInputMappingsOneByOne());
 
     override
         .getExperimental()

--- a/configuration/src/test/java/io/camunda/configuration/EngineTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineTest.java
@@ -91,6 +91,29 @@ public class EngineTest {
       assertThat(brokerCfg.getExperimental().getFeatures())
           .returns(true, FeatureFlagsCfg::isEvaluateDuplicateOutputMappingTargetsInOrder);
     }
+
+    @Test
+    void shouldEvaluateInputMappingsOneByOneByDefault() {
+      assertThat(brokerCfg.getExperimental().getFeatures())
+          .returns(true, FeatureFlagsCfg::isEvaluateInputMappingsOneByOne);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {"camunda.processing.engine.evaluate-input-mappings-one-by-one=false"})
+  class WithEvaluateInputMappingsOneByOneConfigured {
+    final BrokerBasedProperties brokerCfg;
+
+    WithEvaluateInputMappingsOneByOneConfigured(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetEvaluateInputMappingsOneByOne() {
+      assertThat(brokerCfg.getExperimental().getFeatures())
+          .returns(false, FeatureFlagsCfg::isEvaluateInputMappingsOneByOne);
+    }
   }
 
   @Nested

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
@@ -42,6 +42,7 @@ public final class FeatureFlagsCfg {
       DEFAULT_SETTINGS.evaluateBoundaryEventCorrelationKeyInActivityScope();
   private boolean evaluateDuplicateOutputMappingTargetsInOrder =
       DEFAULT_SETTINGS.evaluateDuplicateOutputMappingTargetsInOrder();
+  private boolean evaluateInputMappingsOneByOne = DEFAULT_SETTINGS.evaluateInputMappingsOneByOne();
 
   public boolean isEnableYieldingDueDateChecker() {
     return enableYieldingDueDateChecker;
@@ -106,6 +107,14 @@ public final class FeatureFlagsCfg {
     return evaluateDuplicateOutputMappingTargetsInOrder;
   }
 
+  public boolean isEvaluateInputMappingsOneByOne() {
+    return evaluateInputMappingsOneByOne;
+  }
+
+  public void setEvaluateInputMappingsOneByOne(final boolean evaluateInputMappingsOneByOne) {
+    this.evaluateInputMappingsOneByOne = evaluateInputMappingsOneByOne;
+  }
+
   public void setEvaluateDuplicateOutputMappingTargetsInOrder(
       final boolean evaluateDuplicateOutputMappingTargetsInOrder) {
     this.evaluateDuplicateOutputMappingTargetsInOrder =
@@ -121,7 +130,8 @@ public final class FeatureFlagsCfg {
         enableStraightThroughProcessingLoopDetector,
         enableMessageBodyOnExpired,
         evaluateBoundaryEventCorrelationKeyInActivityScope,
-        evaluateDuplicateOutputMappingTargetsInOrder
+        evaluateDuplicateOutputMappingTargetsInOrder,
+        evaluateInputMappingsOneByOne
         /*, enableFoo*/ );
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -233,8 +233,10 @@ class PartitionManagerStepTest {
     @Test
     void shouldPassDistinctFeatureFlagsToEachPhysicalTenant() throws Exception {
       // given — two tenants each with a distinct FeatureFlags instance
-      final var flagsA = new FeatureFlags(true, false, false, false, false, false, true, true);
-      final var flagsB = new FeatureFlags(false, false, true, false, false, false, false, true);
+      final var flagsA =
+          new FeatureFlags(true, false, false, false, false, false, true, true, true);
+      final var flagsB =
+          new FeatureFlags(false, false, true, false, false, false, false, true, true);
       final var secondTenantId = "second";
 
       final var secCfg = EngineSecurityConfigurations.unauthenticatedAndUnauthorized();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -270,6 +270,7 @@ public final class EngineProcessors {
             messageCorrelationMetrics,
             featureFlags.evaluateBoundaryEventCorrelationKeyInActivityScope(),
             featureFlags.evaluateDuplicateOutputMappingTargetsInOrder(),
+            featureFlags.evaluateInputMappingsOneByOne(),
             cslCheck,
             tenantCheck);
 
@@ -620,6 +621,7 @@ public final class EngineProcessors {
       final MessageCorrelationMetrics messageCorrelationMetrics,
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
       final boolean evaluateDuplicateOutputMappingTargetsInOrder,
+      final boolean evaluateInputMappingsOneByOne,
       final CslAuthorizationCheck cslCheck,
       final CslTenantCheck tenantCheck) {
     return new BpmnBehaviorsImpl(
@@ -639,6 +641,7 @@ public final class EngineProcessors {
         messageCorrelationMetrics,
         evaluateBoundaryEventCorrelationKeyInActivityScope,
         evaluateDuplicateOutputMappingTargetsInOrder,
+        evaluateInputMappingsOneByOne,
         cslCheck,
         tenantCheck);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -273,6 +273,7 @@ public final class EngineProcessors {
             messageCorrelationMetrics,
             featureFlags.evaluateBoundaryEventCorrelationKeyInActivityScope(),
             featureFlags.evaluateDuplicateOutputMappingTargetsInOrder(),
+            featureFlags.evaluateInputMappingsOneByOne(),
             cslCheck,
             tenantCheck);
 
@@ -624,6 +625,7 @@ public final class EngineProcessors {
       final MessageCorrelationMetrics messageCorrelationMetrics,
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
       final boolean evaluateDuplicateOutputMappingTargetsInOrder,
+      final boolean evaluateInputMappingsOneByOne,
       final CslAuthorizationCheck cslCheck,
       final CslTenantCheck tenantCheck) {
     return new BpmnBehaviorsImpl(
@@ -643,6 +645,7 @@ public final class EngineProcessors {
         messageCorrelationMetrics,
         evaluateBoundaryEventCorrelationKeyInActivityScope,
         evaluateDuplicateOutputMappingTargetsInOrder,
+        evaluateInputMappingsOneByOne,
         cslCheck,
         tenantCheck);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -89,6 +89,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final MessageCorrelationMetrics messageCorrelationMetrics,
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
       final boolean evaluateDuplicateOutputMappingTargetsInOrder,
+      final boolean evaluateInputMappingsOneByOne,
       final CslAuthorizationCheck cslCheck,
       final CslTenantCheck tenantCheck) {
 
@@ -197,7 +198,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             processingState,
             variableBehavior,
             eventTriggerBehavior,
-            evaluateDuplicateOutputMappingTargetsInOrder);
+            evaluateDuplicateOutputMappingTargetsInOrder,
+            evaluateInputMappingsOneByOne);
 
     eventSubscriptionBehavior =
         new BpmnEventSubscriptionBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
+import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
@@ -49,13 +50,15 @@ public final class BpmnVariableMappingBehavior {
 
   private final EventTriggerBehavior eventTriggerBehavior;
   private final boolean evaluateDuplicateOutputMappingTargetsInOrder;
+  private final boolean evaluateInputMappingsOneByOne;
 
   public BpmnVariableMappingBehavior(
       final ExpressionProcessor expressionProcessor,
       final ProcessingState processingState,
       final VariableBehavior variableBehavior,
       final EventTriggerBehavior eventTriggerBehavior,
-      final boolean evaluateDuplicateOutputMappingTargetsInOrder) {
+      final boolean evaluateDuplicateOutputMappingTargetsInOrder,
+      final boolean evaluateInputMappingsOneByOne) {
     this.expressionProcessor = expressionProcessor;
     inputMappingExpressionProcessor = expressionProcessor.withSecretReferenceContext();
     elementInstanceState = processingState.getElementInstanceState();
@@ -65,6 +68,7 @@ public final class BpmnVariableMappingBehavior {
     this.eventTriggerBehavior = eventTriggerBehavior;
     this.evaluateDuplicateOutputMappingTargetsInOrder =
         evaluateDuplicateOutputMappingTargetsInOrder;
+    this.evaluateInputMappingsOneByOne = evaluateInputMappingsOneByOne;
   }
 
   /**
@@ -74,6 +78,10 @@ public final class BpmnVariableMappingBehavior {
    * sees the results of the earlier mappings (they take priority over same-named scope variables)
    * and falls back to the element's variable scope otherwise. Evaluation stops at the first failing
    * mapping and no variables are applied in that case.
+   *
+   * <p>With the {@code evaluateInputMappingsOneByOne} kill-switch disabled, the mappings are
+   * instead evaluated as the single combined FEEL context expression they compiled into before that
+   * change, see {@link #applyCombinedInputMappingExpression}.
    *
    * @param context The current bpmn element context
    * @param element The current bpmn element
@@ -87,6 +95,15 @@ public final class BpmnVariableMappingBehavior {
 
     if (inputMappings.isEmpty()) {
       return Either.right(null);
+    }
+
+    if (!evaluateInputMappingsOneByOne) {
+      final var combined = inputMappings.get().combinedExpression();
+      if (combined != null) {
+        return applyCombinedInputMappingExpression(context, element, combined, scopeKey, tenantId);
+      }
+      // the combined expression does not parse, so there is no old behavior to fall back to; the
+      // mappings are evaluated one by one below rather than failing every activation forever
     }
 
     // the resolver completes a read of a target that earlier nested mappings only partially built,
@@ -109,6 +126,31 @@ public final class BpmnVariableMappingBehavior {
       resultBuilder.put(mapping.targetPath(), result.get());
     }
     return mapLocalVariables(context, element, resultBuilder.toDocument());
+  }
+
+  /**
+   * Evaluates all input mappings as the single combined FEEL context expression they compiled into
+   * before {@code #58801} — {@code {a: x, b: {c: y}}} — and applies the resulting document as the
+   * element's local variables.
+   *
+   * <p>This is the {@code evaluateInputMappingsOneByOne} kill-switch's path. It differs from the
+   * per-mapping evaluation in ways that were the point of that change: same-root targets are
+   * regrouped to the position of the first one, so a mapping declared between them is not visible
+   * to the later one (#11789); a target superseded by a colliding one is dropped without its source
+   * ever being evaluated; and a failure names the whole combined expression rather than the one
+   * mapping that failed.
+   */
+  private Either<Failure, Void> applyCombinedInputMappingExpression(
+      final BpmnElementContext context,
+      final ExecutableFlowNode element,
+      final Expression combinedExpression,
+      final long scopeKey,
+      final String tenantId) {
+    // secret references (camunda.secrets.<name>) are resolved to their placeholder string only
+    // for input mappings, so a modeled reference survives evaluation instead of nulling
+    return inputMappingExpressionProcessor
+        .evaluateVariableMappingContextExpression(combinedExpression, scopeKey, tenantId)
+        .flatMap(result -> mapLocalVariables(context, element, result));
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
+import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
@@ -49,13 +50,15 @@ public final class BpmnVariableMappingBehavior {
 
   private final EventTriggerBehavior eventTriggerBehavior;
   private final boolean evaluateDuplicateOutputMappingTargetsInOrder;
+  private final boolean evaluateInputMappingsOneByOne;
 
   public BpmnVariableMappingBehavior(
       final ExpressionProcessor expressionProcessor,
       final ProcessingState processingState,
       final VariableBehavior variableBehavior,
       final EventTriggerBehavior eventTriggerBehavior,
-      final boolean evaluateDuplicateOutputMappingTargetsInOrder) {
+      final boolean evaluateDuplicateOutputMappingTargetsInOrder,
+      final boolean evaluateInputMappingsOneByOne) {
     this.expressionProcessor = expressionProcessor;
     inputMappingExpressionProcessor = expressionProcessor.withSecretReferenceContext();
     elementInstanceState = processingState.getElementInstanceState();
@@ -65,6 +68,7 @@ public final class BpmnVariableMappingBehavior {
     this.eventTriggerBehavior = eventTriggerBehavior;
     this.evaluateDuplicateOutputMappingTargetsInOrder =
         evaluateDuplicateOutputMappingTargetsInOrder;
+    this.evaluateInputMappingsOneByOne = evaluateInputMappingsOneByOne;
   }
 
   /**
@@ -74,6 +78,10 @@ public final class BpmnVariableMappingBehavior {
    * sees the results of the earlier mappings (they take priority over same-named scope variables)
    * and falls back to the element's variable scope otherwise. Evaluation stops at the first failing
    * mapping and no variables are applied in that case.
+   *
+   * <p>With the {@code evaluateInputMappingsOneByOne} kill-switch disabled, the mappings are
+   * instead evaluated as the single combined FEEL context expression they compiled into before that
+   * change, see {@link #applyCombinedInputMappingExpression}.
    *
    * @param context The current bpmn element context
    * @param element The current bpmn element
@@ -87,6 +95,15 @@ public final class BpmnVariableMappingBehavior {
 
     if (inputMappings.isEmpty()) {
       return Either.right(null);
+    }
+
+    if (!evaluateInputMappingsOneByOne) {
+      final var combined = inputMappings.get().combinedExpression();
+      if (combined != null) {
+        return applyCombinedInputMappingExpression(context, element, combined, scopeKey, tenantId);
+      }
+      // the combined expression does not parse, so there is no old behavior to fall back to; the
+      // mappings are evaluated one by one below rather than failing every activation forever
     }
 
     final var resultBuilder = new MappingResultBuilder();
@@ -105,6 +122,31 @@ public final class BpmnVariableMappingBehavior {
       resultBuilder.put(mapping.targetPath(), result.get());
     }
     return mapLocalVariables(context, element, resultBuilder.toDocument());
+  }
+
+  /**
+   * Evaluates all input mappings as the single combined FEEL context expression they compiled into
+   * before {@code #58801} — {@code {a: x, b: {c: y}}} — and applies the resulting document as the
+   * element's local variables.
+   *
+   * <p>This is the {@code evaluateInputMappingsOneByOne} kill-switch's path. It differs from the
+   * per-mapping evaluation in ways that were the point of that change: same-root targets are
+   * regrouped to the position of the first one, so a mapping declared between them is not visible
+   * to the later one (#11789); a target superseded by a colliding one is dropped without its source
+   * ever being evaluated; and a failure names the whole combined expression rather than the one
+   * mapping that failed.
+   */
+  private Either<Failure, Void> applyCombinedInputMappingExpression(
+      final BpmnElementContext context,
+      final ExecutableFlowNode element,
+      final Expression combinedExpression,
+      final long scopeKey,
+      final String tenantId) {
+    // secret references (camunda.secrets.<name>) are resolved to their placeholder string only
+    // for input mappings, so a modeled reference survives evaluation instead of nulling
+    return inputMappingExpressionProcessor
+        .evaluateVariableMappingContextExpression(combinedExpression, scopeKey, tenantId)
+        .flatMap(result -> mapLocalVariables(context, element, result));
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
@@ -455,6 +455,28 @@ public final class ExpressionProcessor {
   }
 
   /**
+   * Evaluates the combined FEEL context expression of a set of variable mappings and returns the
+   * result as buffer. Unlike {@link #evaluateVariableMappingExpression(Expression, long, String)},
+   * the result must be a context, because it is the whole mapping document at once.
+   *
+   * <p>Only used by the {@code evaluateInputMappingsOneByOne} kill-switch; mappings are otherwise
+   * evaluated one source at a time.
+   *
+   * @param expression the combined context expression to evaluate
+   * @param scopeKey the scope to load the variables from (a negative key is intended to imply an
+   *     empty variable context)
+   * @return either the evaluation result as buffer, or a failure
+   * @throws EvaluationException if the evaluation is interrupted or fails unexpectedly
+   */
+  public Either<Failure, DirectBuffer> evaluateVariableMappingContextExpression(
+      final Expression expression, final long scopeKey, final String tenantId) {
+    return evaluateExpressionAsEither(expression, scopeKey, tenantId)
+        .flatMap(result -> typeCheck(result, ResultType.OBJECT, scopeKey))
+        .mapLeft(failure -> new Failure(failure.getMessage(), ErrorType.IO_MAPPING_ERROR, scopeKey))
+        .map(EvaluationResult::toBuffer);
+  }
+
+  /**
    * Evaluates the source expression of a single variable mapping and returns the result as buffer.
    * A single mapping's source may produce a value of any type, which is then stored under the
    * mapping's target path.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/InputMappings.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/InputMappings.java
@@ -7,10 +7,12 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
+import io.camunda.zeebe.el.Expression;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The transformed input mappings of a flow node: one entry per {@code zeebe:input} element, in
@@ -21,9 +23,16 @@ import org.jspecify.annotations.NullMarked;
  * <p>{@code clusterVariableReferences} mirrors {@code secretReferences} for cluster-variable
  * references ({@code camunda.vars.<scope>.<name>}) detected in the input mappings, keyed by the
  * same RFC-6901 leaf JSON pointer; empty when no input mapping references a cluster variable.
+ *
+ * <p>{@code combinedExpression} is the single FEEL context expression these mappings used to
+ * compile into before they were evaluated one by one, kept only for the {@code
+ * evaluateInputMappingsOneByOne} kill-switch. It is {@code null} when that expression does not
+ * parse — see {@code VariableMappingTransformer#combinedExpression} for why that is not a
+ * deployment failure.
  */
 @NullMarked
 public record InputMappings(
     List<InputMapping> mappings,
     Map<String, Set<SecretReference>> secretReferences,
-    Map<String, Set<ClusterVariableReference>> clusterVariableReferences) {}
+    Map<String, Set<ClusterVariableReference>> clusterVariableReferences,
+    @Nullable Expression combinedExpression) {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -28,15 +28,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Transforms variable mappings.
  *
- * <p>Neither input nor output mappings are combined into a single context expression. Each mapping
- * is kept as its own parsed source expression plus its split target path (e.g. target {@code a.b.c}
- * becomes {@code [a, b, c]}), so that mappings can be evaluated one by one in modeling order at
- * runtime, with each mapping's result visible to subsequent mappings (see {@link InputMapping},
- * {@link OutputMapping} and {@code BpmnVariableMappingBehavior}).
+ * <p>Neither input nor output mappings are combined into a single context expression for normal
+ * evaluation. Each mapping is kept as its own parsed source expression plus its split target path
+ * (e.g. target {@code a.b.c} becomes {@code [a, b, c]}), so that mappings can be evaluated one by
+ * one in modeling order at runtime, with each mapping's result visible to subsequent mappings (see
+ * {@link InputMapping}, {@link OutputMapping} and {@code BpmnVariableMappingBehavior}).
  *
  * <p>Output mappings differ from input mappings in how a nested target is merged at runtime: the
  * result must be merged with the existing scope variable if that variable is a JSON object, at
@@ -70,7 +71,61 @@ public final class VariableMappingTransformer {
     return new InputMappings(
         transformedMappings,
         detectSecretReferences(context),
-        detectClusterVariableReferences(context));
+        detectClusterVariableReferences(context),
+        combinedExpression(context, expressionLanguage));
+  }
+
+  /**
+   * Builds the single FEEL context expression the input mappings compiled into before they were
+   * evaluated one by one — {@code x -> a, y -> b.c} becomes {@code ={a:x,b:{c:y}}} — so the {@code
+   * evaluateInputMappingsOneByOne} kill-switch can restore that evaluation without a redeployment.
+   * Built for every process, because the flag is broker configuration the transformer must not
+   * read: it may flip after the process was transformed into the cache.
+   *
+   * <p>Returns {@code null} when the combined expression does not parse, instead of rejecting the
+   * deployment the way the pre-{@code #58801} transformer did. No target that passes deploy-time
+   * validation is currently known to produce one: the FEEL keywords that {@code
+   * ZeebeExpressionValidator}'s reserved list does not cover ({@code some}, {@code every}, {@code
+   * return}, ...) are all accepted as context keys, which a test pins. So this is defense in depth,
+   * not a reproduced hazard — but the two alternatives are both worse than a null. Throwing would
+   * reject such a process at deployment for everyone, including the vast majority who never touch
+   * the kill-switch; failing at runtime would make it permanently un-activatable the moment someone
+   * flips the flag, with no incident to resolve.
+   */
+  private static @Nullable Expression combinedExpression(
+      final MappingContext context, final ExpressionLanguage expressionLanguage) {
+    final var expression =
+        expressionLanguage.parseExpression(EXPRESSION_MARKER + context.visit(feelContextBuilder()));
+    return expression.isValid() ? expression : null;
+  }
+
+  /**
+   * Visitor that renders a mapping context as the FEEL context expression text: a leaf becomes
+   * {@code target:source}, a nested context {@code target:{...}}. A static source is quoted as a
+   * string literal, with the {@code #16043} double-quote escaping.
+   */
+  private static MappingContextVisitor<String> feelContextBuilder() {
+    return new MappingContextVisitor<>() {
+      @Override
+      public String onEntry(final String targetKey, final Expression sourceExpression) {
+        final var expression =
+            sourceExpression instanceof StaticExpression
+                ? "\"" + sourceExpression.getExpression().replaceAll("\"", "\\\\\"") + "\""
+                : sourceExpression.getExpression();
+        return targetKey + ":" + expression;
+      }
+
+      @Override
+      public String onContext(final List<String> entries) {
+        return "{" + String.join(",", entries) + "}";
+      }
+
+      @Override
+      public String onContextEntry(
+          final String targetKey, final String contextValue, final List<String> contextPath) {
+        return targetKey + ":" + contextValue;
+      }
+    };
   }
 
   private static Expression toInputSourceExpression(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/InputMappingOneByOneFeatureFlagTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/InputMappingOneByOneFeatureFlagTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable.mapping;
+
+import static io.camunda.zeebe.engine.processing.variable.mapping.VariableValue.variable;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.SubProcessBuilder;
+import io.camunda.zeebe.model.bpmn.builder.ZeebeVariablesMappingBuilder;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Characterization tests for the {@code evaluateInputMappingsOneByOne} kill-switch: with the flag
+ * disabled, all input mappings of an element are evaluated as the single combined FEEL context
+ * expression they compiled into before #58801, reinstating the behavior of versions up to 8.7.35
+ * and 8.8.33 — including the bugs that change fixed.
+ *
+ * <p>Each case here is the mirror image of one in {@link ActivityInputMappingTest}, which asserts
+ * the same process under the default (enabled) flag — except the #59646 case below, whose
+ * counterpart arrives with the fix for that issue.
+ */
+public final class InputMappingOneByOneFeatureFlagTest {
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition().withFeatureFlags(f -> f.setEvaluateInputMappingsOneByOne(false));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldKeepSiblingFieldsOfTheSameRootWhenDisabled() {
+    // given: the #59646 scenario. Unlike the two cases below, this is not a bug the combined
+    // expression had - it is one that evaluating mappings one by one INTRODUCED, which is why the
+    // issue reports it against 8.7.36/8.8.34, the first patches carrying #58801.
+    // In the combined expression {foo: {bar: foo.bar, baz: foo.baz}} the sources sit in a NESTED
+    // context, and feel-scala does not expose the enclosing context's still-unevaluated 'foo'
+    // entry to them, so both resolve against the parent scope.
+    final var variables =
+        applyInputMappings(
+            "{'foo': {'bar': 1, 'baz': 2}}",
+            b ->
+                b.zeebeInputExpression("foo.bar", "foo.bar")
+                    .zeebeInputExpression("foo.baz", "foo.baz"),
+            1);
+
+    // then: the faithful copy. The one-by-one path still returns {bar: 1, baz: null} here until
+    // #59646 is fixed, so the kill-switch is an escape hatch from that regression too - at the
+    // price of the two bugs below
+    assertThat(variables).containsExactly(variable("foo", "{\"bar\":1,\"baz\":2}"));
+  }
+
+  @Test
+  public void shouldNotSeeAnInterleavedMappingAcrossRegroupedTargetsWhenDisabled() {
+    // given: the #11789 scenario. Regrouping hoists both 'obj.*' entries ahead of 'flat', so
+    // 'obj.second' resolves 'flat' from the outer scope, where it is absent
+    final var variables =
+        applyInputMappings(
+            "{}",
+            b ->
+                b.zeebeInputExpression("1", "obj.first")
+                    .zeebeInputExpression("2", "flat")
+                    .zeebeInputExpression("flat", "obj.second"),
+            2);
+
+    // then
+    assertThat(variables)
+        .contains(variable("obj", "{\"first\":1,\"second\":null}"), variable("flat", "2"));
+  }
+
+  @Test
+  public void shouldEvaluateOnlyTheLastDuplicateTargetSourceWhenDisabled() {
+    // given: duplicate leaf targets collapse into one context entry that keeps its FIRST
+    // occurrence's position but the LAST one's source, so 'y' reads the already-overwritten 'x'
+    final var variables =
+        applyInputMappings(
+            "{}",
+            b ->
+                b.zeebeInputExpression("1", "x")
+                    .zeebeInputExpression("x", "y")
+                    .zeebeInputExpression("2", "x"),
+            2);
+
+    // then: with the flag enabled this is x=2, y=1
+    assertThat(variables).contains(variable("x", "2"), variable("y", "2"));
+  }
+
+  @Test
+  public void shouldStillApplyUnaffectedMappingsWhenDisabled() {
+    // given: mappings that do not depend on evaluation order behave identically either way, so
+    // the kill-switch is not a blanket regression
+    final var variables =
+        applyInputMappings(
+            "{'x': 1, 'y': 2}",
+            b -> b.zeebeInputExpression("x", "a").zeebeInputExpression("y", "b.c"),
+            2);
+
+    // then
+    assertThat(variables).contains(variable("a", "1"), variable("b", "{\"c\":2}"));
+  }
+
+  private List<VariableValue> applyInputMappings(
+      final String initialVariables,
+      final Consumer<ZeebeVariablesMappingBuilder<SubProcessBuilder>> mappings,
+      final int expectedVariableCount) {
+    final var processId = "process-" + UUID.randomUUID();
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .subProcess(
+                "sub",
+                b -> {
+                  b.embeddedSubProcess().startEvent().endEvent();
+                  mappings.accept(b);
+                })
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariables(initialVariables)
+            .create();
+
+    final long subProcessKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("sub")
+            .getFirst()
+            .getKey();
+
+    return RecordingExporter.variableRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .withScopeKey(subProcessKey)
+        .limit(expectedVariableCount)
+        .map(Record::getValue)
+        .map(v -> variable(v.getName(), v.getValue()))
+        .toList();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/InputMappingOneByOneFeatureFlagTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/InputMappingOneByOneFeatureFlagTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable.mapping;
+
+import static io.camunda.zeebe.engine.processing.variable.mapping.VariableValue.variable;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.SubProcessBuilder;
+import io.camunda.zeebe.model.bpmn.builder.ZeebeVariablesMappingBuilder;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Characterization tests for the {@code evaluateInputMappingsOneByOne} kill-switch: with the flag
+ * disabled, all input mappings of an element are evaluated as the single combined FEEL context
+ * expression they compiled into before #58801, reinstating the behavior of versions up to 8.7.35
+ * and 8.8.33 — including the bugs that change fixed.
+ *
+ * <p>Each case here is the mirror image of one in {@link ActivityInputMappingTest}, which asserts
+ * the same process under the default (enabled) flag.
+ */
+public final class InputMappingOneByOneFeatureFlagTest {
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition().withFeatureFlags(f -> f.setEvaluateInputMappingsOneByOne(false));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldKeepSiblingFieldsOfTheSameRootWhenDisabled() {
+    // given: the #59646 scenario. Unlike the two cases below, this is not a bug the combined
+    // expression had - it is one that evaluating mappings one by one INTRODUCED, which is why the
+    // issue reports it against 8.7.36/8.8.34, the first patches carrying #58801.
+    // In the combined expression {foo: {bar: foo.bar, baz: foo.baz}} the sources sit in a NESTED
+    // context, and feel-scala does not expose the enclosing context's still-unevaluated 'foo'
+    // entry to them, so both resolve against the parent scope.
+    final var variables =
+        applyInputMappings(
+            "{'foo': {'bar': 1, 'baz': 2}}",
+            b ->
+                b.zeebeInputExpression("foo.bar", "foo.bar")
+                    .zeebeInputExpression("foo.baz", "foo.baz"),
+            1);
+
+    // then: the same result the one-by-one path produces once #59646 is fixed - the kill-switch
+    // is an escape hatch from that regression too, at the price of the two bugs below
+    assertThat(variables).containsExactly(variable("foo", "{\"bar\":1,\"baz\":2}"));
+  }
+
+  @Test
+  public void shouldNotSeeAnInterleavedMappingAcrossRegroupedTargetsWhenDisabled() {
+    // given: the #11789 scenario. Regrouping hoists both 'obj.*' entries ahead of 'flat', so
+    // 'obj.second' resolves 'flat' from the outer scope, where it is absent
+    final var variables =
+        applyInputMappings(
+            "{}",
+            b ->
+                b.zeebeInputExpression("1", "obj.first")
+                    .zeebeInputExpression("2", "flat")
+                    .zeebeInputExpression("flat", "obj.second"),
+            2);
+
+    // then
+    assertThat(variables)
+        .contains(variable("obj", "{\"first\":1,\"second\":null}"), variable("flat", "2"));
+  }
+
+  @Test
+  public void shouldEvaluateOnlyTheLastDuplicateTargetSourceWhenDisabled() {
+    // given: duplicate leaf targets collapse into one context entry that keeps its FIRST
+    // occurrence's position but the LAST one's source, so 'y' reads the already-overwritten 'x'
+    final var variables =
+        applyInputMappings(
+            "{}",
+            b ->
+                b.zeebeInputExpression("1", "x")
+                    .zeebeInputExpression("x", "y")
+                    .zeebeInputExpression("2", "x"),
+            2);
+
+    // then: with the flag enabled this is x=2, y=1
+    assertThat(variables).contains(variable("x", "2"), variable("y", "2"));
+  }
+
+  @Test
+  public void shouldStillApplyUnaffectedMappingsWhenDisabled() {
+    // given: mappings that do not depend on evaluation order behave identically either way, so
+    // the kill-switch is not a blanket regression
+    final var variables =
+        applyInputMappings(
+            "{'x': 1, 'y': 2}",
+            b -> b.zeebeInputExpression("x", "a").zeebeInputExpression("y", "b.c"),
+            2);
+
+    // then
+    assertThat(variables).contains(variable("a", "1"), variable("b", "{\"c\":2}"));
+  }
+
+  private List<VariableValue> applyInputMappings(
+      final String initialVariables,
+      final Consumer<ZeebeVariablesMappingBuilder<SubProcessBuilder>> mappings,
+      final int expectedVariableCount) {
+    final var processId = "process-" + UUID.randomUUID();
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .subProcess(
+                "sub",
+                b -> {
+                  b.embeddedSubProcess().startEvent().endEvent();
+                  mappings.accept(b);
+                })
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariables(initialVariables)
+            .create();
+
+    final long subProcessKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("sub")
+            .getFirst()
+            .getKey();
+
+    return RecordingExporter.variableRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .withScopeKey(subProcessKey)
+        .limit(expectedVariableCount)
+        .map(Record::getValue)
+        .map(v -> variable(v.getName(), v.getValue()))
+        .toList();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
@@ -27,6 +27,7 @@ import org.agrona.DirectBuffer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 final class VariableInputMappingTransformerTest {
 
@@ -305,6 +306,35 @@ final class VariableInputMappingTransformerTest {
 
     // then
     MsgPackUtil.assertEquality(resultBuilder.toDocument(), "{'a':{'b':1, 'd':1}, 'c':1}");
+  }
+
+  @Test
+  void shouldBuildTheCombinedExpressionForTheKillSwitch() {
+    // given: the kill-switch needs the combined FEEL context expression these mappings compiled
+    // into before #58801, built for every process so the flag can flip without a redeployment
+    final var mappings = List.of(mapping("x", "a"), mapping("y", "b.c"));
+
+    // when
+    final var inputMappings = transformer.transformInputMappings(mappings, expressionLanguage);
+
+    // then
+    assertThat(inputMappings.combinedExpression()).isNotNull();
+    assertThat(inputMappings.combinedExpression().isValid()).isTrue();
+  }
+
+  @ParameterizedTest(name = "target ''{0}''")
+  @ValueSource(strings = {"some", "every", "return", "satisfies", "in", "and", "or", "not"})
+  void shouldStillBuildTheCombinedExpressionForNonReservedFeelKeywordTargets(final String target) {
+    // given: a target that is a FEEL keyword but NOT on ZeebeExpressionValidator's reserved list,
+    // so it passes deploy-time validation and reaches the transformer
+    final var mappings = List.of(mapping("1", target));
+
+    // when
+    final var inputMappings = transformer.transformInputMappings(mappings, expressionLanguage);
+
+    // then: feel-scala accepts these as context keys, so the combined expression still parses and
+    // the kill-switch has an old behaviour to fall back to
+    assertThat(inputMappings.combinedExpression()).isNotNull();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
@@ -27,6 +27,7 @@ import org.agrona.DirectBuffer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 final class VariableInputMappingTransformerTest {
 
@@ -246,6 +247,35 @@ final class VariableInputMappingTransformerTest {
 
     // then
     MsgPackUtil.assertEquality(resultBuilder.toDocument(), "{'a':{'b':1, 'd':1}, 'c':1}");
+  }
+
+  @Test
+  void shouldBuildTheCombinedExpressionForTheKillSwitch() {
+    // given: the kill-switch needs the combined FEEL context expression these mappings compiled
+    // into before #58801, built for every process so the flag can flip without a redeployment
+    final var mappings = List.of(mapping("x", "a"), mapping("y", "b.c"));
+
+    // when
+    final var inputMappings = transformer.transformInputMappings(mappings, expressionLanguage);
+
+    // then
+    assertThat(inputMappings.combinedExpression()).isNotNull();
+    assertThat(inputMappings.combinedExpression().isValid()).isTrue();
+  }
+
+  @ParameterizedTest(name = "target ''{0}''")
+  @ValueSource(strings = {"some", "every", "return", "satisfies", "in", "and", "or", "not"})
+  void shouldStillBuildTheCombinedExpressionForNonReservedFeelKeywordTargets(final String target) {
+    // given: a target that is a FEEL keyword but NOT on ZeebeExpressionValidator's reserved list,
+    // so it passes deploy-time validation and reaches the transformer
+    final var mappings = List.of(mapping("1", target));
+
+    // when
+    final var inputMappings = transformer.transformInputMappings(mappings, expressionLanguage);
+
+    // then: feel-scala accepts these as context keys, so the combined expression still parses and
+    // the kill-switch has an old behaviour to fall back to
+    assertThat(inputMappings.combinedExpression()).isNotNull();
   }
 
   @Test

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
@@ -51,6 +51,8 @@ public final class FeatureFlags {
   private static final boolean EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE = true;
   // Kill-switch for a bug fix; intentionally enabled by default.
   private static final boolean EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER = true;
+  // Kill-switch for a bug fix; intentionally enabled by default.
+  private static final boolean EVALUATE_INPUT_MAPPINGS_ONE_BY_ONE = true;
 
   private boolean yieldingDueDateChecker;
   private boolean enableActorMetrics;
@@ -60,6 +62,7 @@ public final class FeatureFlags {
   private boolean enableMessageBodyOnExpired;
   private boolean evaluateBoundaryEventCorrelationKeyInActivityScope;
   private boolean evaluateDuplicateOutputMappingTargetsInOrder;
+  private boolean evaluateInputMappingsOneByOne;
 
   public FeatureFlags(
       final boolean yieldingDueDateChecker,
@@ -69,7 +72,8 @@ public final class FeatureFlags {
       final boolean enableStraightThroughProcessingLoopDetector,
       final boolean enableMessageBodyOnExpired,
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
-      final boolean evaluateDuplicateOutputMappingTargetsInOrder
+      final boolean evaluateDuplicateOutputMappingTargetsInOrder,
+      final boolean evaluateInputMappingsOneByOne
       /*, boolean foo*/ ) {
     this.yieldingDueDateChecker = yieldingDueDateChecker;
     this.enableActorMetrics = enableActorMetrics;
@@ -81,6 +85,7 @@ public final class FeatureFlags {
         evaluateBoundaryEventCorrelationKeyInActivityScope;
     this.evaluateDuplicateOutputMappingTargetsInOrder =
         evaluateDuplicateOutputMappingTargetsInOrder;
+    this.evaluateInputMappingsOneByOne = evaluateInputMappingsOneByOne;
   }
 
   public static FeatureFlags createDefault() {
@@ -92,7 +97,8 @@ public final class FeatureFlags {
         ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR,
         ENABLE_MESSAGE_BODY_ON_EXPIRED,
         EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE,
-        EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER
+        EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER,
+        EVALUATE_INPUT_MAPPINGS_ONE_BY_ONE
         /*, FOO_DEFAULT*/ );
   }
 
@@ -110,7 +116,8 @@ public final class FeatureFlags {
         true, /* ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR */
         false, /* ENABLE_MESSAGE_BODY_ON_EXPIRED */
         true, /* EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE */
-        true /* EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER */
+        true, /* EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER */
+        true /* EVALUATE_INPUT_MAPPINGS_ONE_BY_ONE */
         /*, FOO_DEFAULT*/ );
   }
 
@@ -144,6 +151,10 @@ public final class FeatureFlags {
 
   public boolean evaluateDuplicateOutputMappingTargetsInOrder() {
     return evaluateDuplicateOutputMappingTargetsInOrder;
+  }
+
+  public boolean evaluateInputMappingsOneByOne() {
+    return evaluateInputMappingsOneByOne;
   }
 
   public void setYieldingDueDateChecker(final boolean yieldingDueDateChecker) {
@@ -181,6 +192,10 @@ public final class FeatureFlags {
       final boolean evaluateDuplicateOutputMappingTargetsInOrder) {
     this.evaluateDuplicateOutputMappingTargetsInOrder =
         evaluateDuplicateOutputMappingTargetsInOrder;
+  }
+
+  public void setEvaluateInputMappingsOneByOne(final boolean evaluateInputMappingsOneByOne) {
+    this.evaluateInputMappingsOneByOne = evaluateInputMappingsOneByOne;
   }
 
   @Override

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
@@ -25,6 +25,7 @@ class FeatureFlagsTest {
     assertThat(sut.enableMessageBodyOnExpired()).isFalse();
     assertThat(sut.evaluateBoundaryEventCorrelationKeyInActivityScope()).isTrue();
     assertThat(sut.evaluateDuplicateOutputMappingTargetsInOrder()).isTrue();
+    assertThat(sut.evaluateInputMappingsOneByOne()).isTrue();
   }
 
   @Test
@@ -38,5 +39,6 @@ class FeatureFlagsTest {
     assertThat(sut.enableMessageBodyOnExpired()).isFalse();
     assertThat(sut.evaluateBoundaryEventCorrelationKeyInActivityScope()).isTrue();
     assertThat(sut.evaluateDuplicateOutputMappingTargetsInOrder()).isTrue();
+    assertThat(sut.evaluateInputMappingsOneByOne()).isTrue();
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

> Unstacked from #59653 — based on `main` now, and I'd like this one to land first (see the end for why).

In #58801 I stopped compiling an element's input mappings into one FEEL context expression and started evaluating each source on its own, in modeling order. That shipped in 8.7.36, 8.8.34 and 8.9, and there's currently no way to get the old behaviour back on a cluster that turns out to depend on it. #59646 showed that's not hypothetical — the change can regress a process that worked before. So this adds `evaluateInputMappingsOneByOne` (enabled by default) to restore the old evaluation without needing a redeployment.

The transformer builds the combined expression for every process again, next to the per-mapping list. It has to: the flag is broker config, and the transformer may have run long before someone flips it, so it can't read the flag itself. That's the cost the engine carried until 8.7.35 so it isn't a new burden, but it is paid by everyone for a switch few will ever touch — worth flagging in case anyone objects.

The one thing I didn't restore is failing the deployment when the combined expression doesn't parse, which the pre-#58801 transformer did. I went looking for a target that could actually produce one and couldn't find it: the FEEL keywords `ZeebeExpressionValidator`'s reserved list misses (`some`, `every`, `return`, `satisfies`, `in`, `and`, `or`, `not`) are all fine as context keys, and there's a test pinning that now. So the null path is defence in depth rather than something I reproduced. Both alternatives seemed worse than tolerating a null:

1. Throwing at transform time would reject the process at deployment for *everyone*, including the overwhelming majority who never touch the flag.
2. Failing at runtime would make an already-deployed process permanently un-activatable the moment someone flips the switch, with no incident to resolve. That's worse than the bug the switch exists to escape.

Such a process just keeps being evaluated one mapping at a time even with the flag off.

Turning the switch off is a real trade rather than a free revert, and the characterization tests spell out both directions so nobody has to guess. It reinstates #11789 (a mapping declared between two mappings sharing a target root is invisible to the later one) and the duplicate-target behaviour where a superseded source is never evaluated. It also — and this surprised me — *fixes* #59646, because on the combined path the sources sit in a nested context that can't see the enclosing context's still-unevaluated entry. That's how I found out #59646 is a regression I introduced rather than one the old code had; see the fix PR for the detail.

I originally stacked this on #59653 and have unstacked it. The semantics of that fix are still under discussion, and there's no reason to hold the escape hatch behind them: as above, turning the flag off already avoids #59646 on its own, so this gives an affected cluster something to reach for in the meantime. The flag defaults to enabled, so merging this changes nothing until someone flips it.

I've left backport labels off for now — happy to add them, just say the word.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Relates to #58801, #59646

