### PR TITLE
test: add Elasticsearch 9.5 to test matrix

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -19,7 +19,7 @@ elasticsearch:
     # renovate: datasource=docker depName=docker.elastic.co/elasticsearch/elasticsearch
     - &saas '8.19.16'
   es9:
-    - "9.4.0"
+    - "9.5.0"
   saas: *saas
 
 opensearch:


### PR DESCRIPTION
Elasticsearch 9.5.0 was released on 2026-08-04 (confirmed via the GitHub release tag and the elastic/elasticsearch Docker Hub image; endoflife.date has not catalogued the 9.5 cycle yet).

Per policy of testing the latest ES9 minor, this bumps `.ci/db-versions.yml` to replace 9.4 with 9.5 as the sole tested es9 version.

Closes #59601.