### PR TITLE
Accept a batch of history items in agent-instance updates at the gateway

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAgentInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAgentInstanceCommandImpl.java
@@ -28,6 +28,7 @@ import io.camunda.client.impl.response.UpdateAgentInstanceResponseImpl;
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.protocol.rest.AgentInstanceMetricsDelta;
 import io.camunda.client.protocol.rest.AgentInstanceUpdateRequest;
+import io.camunda.client.protocol.rest.AgentInstanceUpdateResult;
 import io.camunda.client.protocol.rest.AgentInstanceUpdateStatusEnum;
 import java.time.Duration;
 import java.util.List;
@@ -126,6 +127,7 @@ public class UpdateAgentInstanceCommandImpl
         "/agent-instances/" + agentInstanceKey,
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
+        AgentInstanceUpdateResult.class,
         UpdateAgentInstanceResponseImpl::new,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UpdateAgentInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UpdateAgentInstanceResponseImpl.java
@@ -16,8 +16,9 @@
 package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.UpdateAgentInstanceResponse;
+import io.camunda.client.protocol.rest.AgentInstanceUpdateResult;
 
 public class UpdateAgentInstanceResponseImpl implements UpdateAgentInstanceResponse {
 
-  public UpdateAgentInstanceResponseImpl(final Void nothing) {}
+  public UpdateAgentInstanceResponseImpl(final AgentInstanceUpdateResult result) {}
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -149,6 +149,7 @@ public class AgentInstanceMapper {
             .map(
                 item ->
                     AgentInstanceCreatedHistoryItem.Builder.create()
+                        .historyItemId(item.getHistoryItemId())
                         .historyItemKey(KeyUtil.keyToString(item.getAgentHistoryKey()))
                         .isDuplicate(item.isDuplicate())
                         .build())

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -13,6 +13,7 @@ import io.camunda.gateway.mapping.http.validator.AgentInstanceRequestValidator;
 import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceCreationResult;
 import io.camunda.gateway.protocol.model.AgentInstanceDocumentContent;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryItem;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryItemCreationResult;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryItemRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryRoleEnum;
@@ -115,6 +116,20 @@ public class AgentInstanceMapper {
             record.addChangedAttribute("tools");
           }
 
+          if (request.getJobKey() != null) {
+            record.setJobKey(Long.parseLong(request.getJobKey()));
+          }
+
+          if (request.getJobLease() != null) {
+            record.setJobLease(request.getJobLease());
+          }
+
+          if (request.getHistory() != null) {
+            for (final AgentInstanceHistoryItem historyItem : request.getHistory()) {
+              record.addHistoryItem(mapHistoryItem(historyItem));
+            }
+          }
+
           return record;
         });
   }
@@ -178,6 +193,42 @@ public class AgentInstanceMapper {
     return AgentInstanceHistoryItemCreationResult.Builder.create()
         .historyItemKey(KeyUtil.keyToString(record.getAgentHistoryKey()))
         .build();
+  }
+
+  private AgentHistoryRecord mapHistoryItem(final AgentInstanceHistoryItem historyItem) {
+    final var record = new AgentHistoryRecord();
+
+    record.setHistoryItemId(historyItem.getHistoryItemId());
+    record.setLoopIteration(historyItem.getLoopIteration());
+    record.setRole(mapHistoryRole(historyItem.getRole()));
+    record.setProducedAt(
+        OffsetDateTime.parse(historyItem.getProducedAt()).toInstant().toEpochMilli());
+
+    for (final AgentInstanceMessageContent content : historyItem.getContent()) {
+      record.addContent(mapContent(content));
+    }
+
+    if (historyItem.getToolCalls() != null) {
+      for (final AgentInstanceToolCall toolCall : historyItem.getToolCalls()) {
+        record.addToolCall(mapToolCall(toolCall));
+      }
+    }
+
+    if (historyItem.getMetrics() != null) {
+      final var metrics = historyItem.getMetrics();
+      final var recordMetrics = record.getMetrics();
+      if (metrics.getInputTokens() != null) {
+        recordMetrics.setInputTokens(metrics.getInputTokens());
+      }
+      if (metrics.getOutputTokens() != null) {
+        recordMetrics.setOutputTokens(metrics.getOutputTokens());
+      }
+      if (metrics.getDurationMs() != null) {
+        recordMetrics.setDurationMs(metrics.getDurationMs());
+      }
+    }
+
+    return record;
   }
 
   private AgentHistoryRole mapHistoryRole(final AgentInstanceHistoryRoleEnum role) {

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -10,6 +10,7 @@ package io.camunda.gateway.mapping.http.mapper;
 import io.camunda.gateway.mapping.http.RequestMapper;
 import io.camunda.gateway.mapping.http.util.KeyUtil;
 import io.camunda.gateway.mapping.http.validator.AgentInstanceRequestValidator;
+import io.camunda.gateway.protocol.model.AgentInstanceCreatedHistoryItem;
 import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceCreationResult;
 import io.camunda.gateway.protocol.model.AgentInstanceDocumentContent;
@@ -23,6 +24,7 @@ import io.camunda.gateway.protocol.model.AgentInstanceObjectContent;
 import io.camunda.gateway.protocol.model.AgentInstanceTextContent;
 import io.camunda.gateway.protocol.model.AgentInstanceToolCall;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
+import io.camunda.gateway.protocol.model.AgentInstanceUpdateResult;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateStatusEnum;
 import io.camunda.gateway.protocol.model.AgentTool;
 import io.camunda.gateway.protocol.model.DocumentMetadataResponse;
@@ -139,6 +141,19 @@ public class AgentInstanceMapper {
     return AgentInstanceCreationResult.Builder.create()
         .agentInstanceKey(KeyUtil.keyToString(record.getAgentInstanceKey()))
         .build();
+  }
+
+  public AgentInstanceUpdateResult toAgentInstanceUpdateResult(final AgentInstanceRecord record) {
+    final List<AgentInstanceCreatedHistoryItem> createdHistory =
+        record.getHistory().stream()
+            .map(
+                item ->
+                    AgentInstanceCreatedHistoryItem.Builder.create()
+                        .historyItemKey(KeyUtil.keyToString(item.getAgentHistoryKey()))
+                        .isDuplicate(item.isDuplicate())
+                        .build())
+            .collect(Collectors.toList());
+    return AgentInstanceUpdateResult.Builder.create().createdHistory(createdHistory).build();
   }
 
   public Either<ProblemDetail, AgentHistoryRecord> toCreateAgentHistoryRecord(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -18,6 +18,7 @@ import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceDocumentContent;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryItem;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryItemRequest;
+import io.camunda.gateway.protocol.model.AgentInstanceMessageContent;
 import io.camunda.gateway.protocol.model.AgentInstanceObjectContent;
 import io.camunda.gateway.protocol.model.AgentInstanceTextContent;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
@@ -103,20 +104,7 @@ public class AgentInstanceRequestValidator {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("content"));
           } else {
             for (int i = 0; i < request.getContent().size(); i++) {
-              final var content = request.getContent().get(i);
-              if (content instanceof final AgentInstanceTextContent text) {
-                if (text.getText() == null || text.getText().isBlank()) {
-                  violations.add(
-                      ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("content[" + i + "].text"));
-                }
-              } else if (content instanceof final AgentInstanceDocumentContent doc) {
-                validateDocumentContentItem(i, doc, violations);
-              } else if (content instanceof final AgentInstanceObjectContent obj) {
-                if (obj.getObject() == null) {
-                  violations.add(
-                      ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("content[" + i + "].object"));
-                }
-              }
+              validateContentItem("content[" + i + "]", request.getContent().get(i), violations);
             }
           }
 
@@ -164,11 +152,13 @@ public class AgentInstanceRequestValidator {
             }
           }
 
+          if (request.getJobKey() != null) {
+            validatePositiveKeyFormat(request.getJobKey(), "jobKey", violations);
+          }
+
           if (request.getHistory() != null && !request.getHistory().isEmpty()) {
             if (request.getJobKey() == null) {
               violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("jobKey"));
-            } else {
-              validatePositiveKeyFormat(request.getJobKey(), "jobKey", violations);
             }
 
             for (int i = 0; i < request.getHistory().size(); i++) {
@@ -181,7 +171,13 @@ public class AgentInstanceRequestValidator {
   }
 
   private void validateHistoryItem(
-      final int index, final AgentInstanceHistoryItem historyItem, final List<String> violations) {
+      final int index,
+      final @Nullable AgentInstanceHistoryItem historyItem,
+      final List<String> violations) {
+    if (historyItem == null) {
+      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("history[" + index + "]"));
+      return;
+    }
     if (historyItem.getHistoryItemId() == null || historyItem.getHistoryItemId().isBlank()) {
       violations.add(
           ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("history[" + index + "].historyItemId"));
@@ -189,12 +185,23 @@ public class AgentInstanceRequestValidator {
     if (historyItem.getLoopIteration() == null) {
       violations.add(
           ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("history[" + index + "].loopIteration"));
+    } else if (historyItem.getLoopIteration() < 1) {
+      violations.add(
+          ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE.formatted(
+              "history[" + index + "].loopIteration", historyItem.getLoopIteration(), "> 0"));
     }
     if (historyItem.getRole() == null) {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("history[" + index + "].role"));
     }
     if (historyItem.getContent() == null || historyItem.getContent().isEmpty()) {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("history[" + index + "].content"));
+    } else {
+      for (int i = 0; i < historyItem.getContent().size(); i++) {
+        validateContentItem(
+            "history[" + index + "].content[" + i + "]",
+            historyItem.getContent().get(i),
+            violations);
+      }
     }
     if (historyItem.getProducedAt() == null || historyItem.getProducedAt().isBlank()) {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("history[" + index + "].producedAt"));
@@ -203,18 +210,35 @@ public class AgentInstanceRequestValidator {
     }
   }
 
+  private void validateContentItem(
+      final String fieldPrefix,
+      final AgentInstanceMessageContent content,
+      final List<String> violations) {
+    if (content instanceof final AgentInstanceTextContent text) {
+      if (text.getText() == null || text.getText().isBlank()) {
+        violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted(fieldPrefix + ".text"));
+      }
+    } else if (content instanceof final AgentInstanceDocumentContent doc) {
+      validateDocumentContentItem(fieldPrefix, doc, violations);
+    } else if (content instanceof final AgentInstanceObjectContent obj) {
+      if (obj.getObject() == null) {
+        violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted(fieldPrefix + ".object"));
+      }
+    }
+  }
+
   private void validateDocumentContentItem(
-      final int index, final AgentInstanceDocumentContent doc, final List<String> violations) {
+      final String fieldPrefix,
+      final AgentInstanceDocumentContent doc,
+      final List<String> violations) {
     final var ref = doc.getDocumentReference();
     if (ref == null) {
-      violations.add(
-          ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("content[" + index + "].documentReference"));
+      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted(fieldPrefix + ".documentReference"));
       return;
     }
     if (ref.getDocumentId() == null || ref.getDocumentId().isBlank()) {
       violations.add(
-          ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted(
-              "content[" + index + "].documentReference.documentId"));
+          ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted(fieldPrefix + ".documentReference.documentId"));
       return;
     }
     if (ref.getMetadata() == null) {
@@ -222,8 +246,7 @@ public class AgentInstanceRequestValidator {
     }
     final var expiresAt = ref.getMetadata().getExpiresAt();
     if (expiresAt != null && !expiresAt.isBlank()) {
-      validateDate(
-          expiresAt, "content[" + index + "].documentReference.metadata.expiresAt", violations);
+      validateDate(expiresAt, fieldPrefix + ".documentReference.metadata.expiresAt", violations);
     }
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -163,6 +163,25 @@ public class AgentInstanceRequestValidator {
             }
           }
 
+          if (request.getHistory() != null && !request.getHistory().isEmpty()) {
+            if (request.getJobKey() == null) {
+              violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("jobKey"));
+            }
+
+            for (int i = 0; i < request.getHistory().size(); i++) {
+              final var historyItem = request.getHistory().get(i);
+              if (historyItem.getHistoryItemId() == null
+                  || historyItem.getHistoryItemId().isBlank()) {
+                violations.add(
+                    ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("history[" + i + "].historyItemId"));
+              }
+              if (historyItem.getLoopIteration() == null) {
+                violations.add(
+                    ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("history[" + i + "].loopIteration"));
+              }
+            }
+          }
+
           return violations;
         });
   }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -94,11 +94,6 @@ public class AgentInstanceRequestValidator {
             validatePositiveKeyFormat(request.getJobKey(), "jobKey", violations);
           }
 
-          // TODO: validate jobLease once job leasing is implemented (#55033)
-          // if (request.getJobLease() == null || request.getJobLease().isBlank()) {
-          //   violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("jobLease"));
-          // }
-
           if (request.getRole() == null) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("role"));
           }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -16,6 +16,7 @@ import static io.camunda.gateway.mapping.http.validator.RequestValidator.validat
 
 import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceDocumentContent;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryItem;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryItemRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceObjectContent;
 import io.camunda.gateway.protocol.model.AgentInstanceTextContent;
@@ -166,24 +167,40 @@ public class AgentInstanceRequestValidator {
           if (request.getHistory() != null && !request.getHistory().isEmpty()) {
             if (request.getJobKey() == null) {
               violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("jobKey"));
+            } else {
+              validatePositiveKeyFormat(request.getJobKey(), "jobKey", violations);
             }
 
             for (int i = 0; i < request.getHistory().size(); i++) {
-              final var historyItem = request.getHistory().get(i);
-              if (historyItem.getHistoryItemId() == null
-                  || historyItem.getHistoryItemId().isBlank()) {
-                violations.add(
-                    ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("history[" + i + "].historyItemId"));
-              }
-              if (historyItem.getLoopIteration() == null) {
-                violations.add(
-                    ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("history[" + i + "].loopIteration"));
-              }
+              validateHistoryItem(i, request.getHistory().get(i), violations);
             }
           }
 
           return violations;
         });
+  }
+
+  private void validateHistoryItem(
+      final int index, final AgentInstanceHistoryItem historyItem, final List<String> violations) {
+    if (historyItem.getHistoryItemId() == null || historyItem.getHistoryItemId().isBlank()) {
+      violations.add(
+          ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("history[" + index + "].historyItemId"));
+    }
+    if (historyItem.getLoopIteration() == null) {
+      violations.add(
+          ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("history[" + index + "].loopIteration"));
+    }
+    if (historyItem.getRole() == null) {
+      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("history[" + index + "].role"));
+    }
+    if (historyItem.getContent() == null || historyItem.getContent().isEmpty()) {
+      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("history[" + index + "].content"));
+    }
+    if (historyItem.getProducedAt() == null || historyItem.getProducedAt().isBlank()) {
+      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("history[" + index + "].producedAt"));
+    } else {
+      validateDate(historyItem.getProducedAt(), "history[" + index + "].producedAt", violations);
+    }
   }
 
   private void validateDocumentContentItem(

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapperTest.java
@@ -38,6 +38,29 @@ class AgentInstanceMapperTest {
   private final AgentInstanceMapper mapper =
       new AgentInstanceMapper(new AgentInstanceRequestValidator());
 
+  private static AgentInstanceHistoryItem historyItem(
+      final String historyItemId, final AgentInstanceHistoryRoleEnum role, final String text) {
+    return historyItem(historyItemId, 1, role, text);
+  }
+
+  private static AgentInstanceHistoryItem historyItem(
+      final String historyItemId,
+      final int loopIteration,
+      final AgentInstanceHistoryRoleEnum role,
+      final String text) {
+    return AgentInstanceHistoryItem.Builder.create()
+        .historyItemId(historyItemId)
+        .loopIteration(loopIteration)
+        .role(role)
+        .content(List.of(textContent(text)))
+        .producedAt("2025-06-01T12:00:00Z")
+        .build();
+  }
+
+  private static AgentInstanceMessageContent textContent(final String text) {
+    return AgentInstanceTextContent.Builder.create().contentType("TEXT").text(text).build();
+  }
+
   @Nested
   class ExistingUpdateFieldMappingTest {
 
@@ -318,28 +341,5 @@ class AgentInstanceMapperTest {
       assertThat(record.getHistory().get(1).getHistoryItemId()).isEqualTo("item-2");
       assertThat(record.getChangedAttributes()).containsExactly("status", "metrics", "tools");
     }
-  }
-
-  private static AgentInstanceHistoryItem historyItem(
-      final String historyItemId, final AgentInstanceHistoryRoleEnum role, final String text) {
-    return historyItem(historyItemId, 1, role, text);
-  }
-
-  private static AgentInstanceHistoryItem historyItem(
-      final String historyItemId,
-      final int loopIteration,
-      final AgentInstanceHistoryRoleEnum role,
-      final String text) {
-    return AgentInstanceHistoryItem.Builder.create()
-        .historyItemId(historyItemId)
-        .loopIteration(loopIteration)
-        .role(role)
-        .content(List.of(textContent(text)))
-        .producedAt("2025-06-01T12:00:00Z")
-        .build();
-  }
-
-  private static AgentInstanceMessageContent textContent(final String text) {
-    return AgentInstanceTextContent.Builder.create().contentType("TEXT").text(text).build();
   }
 }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapperTest.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mapping.http.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.gateway.mapping.http.validator.AgentInstanceRequestValidator;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryItem;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryItemMetrics;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryRoleEnum;
+import io.camunda.gateway.protocol.model.AgentInstanceMessageContent;
+import io.camunda.gateway.protocol.model.AgentInstanceMetricsDelta;
+import io.camunda.gateway.protocol.model.AgentInstanceTextContent;
+import io.camunda.gateway.protocol.model.AgentInstanceToolCall;
+import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
+import io.camunda.gateway.protocol.model.AgentInstanceUpdateStatusEnum;
+import io.camunda.gateway.protocol.model.AgentTool;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.util.Either;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ProblemDetail;
+
+class AgentInstanceMapperTest {
+
+  private static final String AGENT_INSTANCE_KEY = "9007199254741017";
+  private static final String ELEMENT_INSTANCE_KEY = "2251799813685248";
+  private static final String JOB_KEY = "2251799813685249";
+
+  private final AgentInstanceMapper mapper =
+      new AgentInstanceMapper(new AgentInstanceRequestValidator());
+
+  @Nested
+  class ExistingUpdateFieldMappingTest {
+
+    @Test
+    void shouldMapStatusOntoRecord() {
+      // given
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setStatus(AgentInstanceUpdateStatusEnum.THINKING);
+
+      // when
+      final Either<ProblemDetail, AgentInstanceRecord> result =
+          mapper.toUpdateAgentInstanceRecord(AGENT_INSTANCE_KEY, request);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var record = result.get();
+      assertThat(record.getStatus().name()).isEqualTo("THINKING");
+      assertThat(record.getChangedAttributes()).containsExactly("status");
+    }
+
+    @Test
+    void shouldMapMetricsOntoRecord() {
+      // given
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setMetrics(AgentInstanceMetricsDelta.Builder.create().build());
+      request.getMetrics().setInputTokens(1000L);
+      request.getMetrics().setOutputTokens(500L);
+      request.getMetrics().setModelCalls(3);
+      request.getMetrics().setToolCalls(7);
+
+      // when
+      final Either<ProblemDetail, AgentInstanceRecord> result =
+          mapper.toUpdateAgentInstanceRecord(AGENT_INSTANCE_KEY, request);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var record = result.get();
+      assertThat(record.getMetrics().getInputTokens()).isEqualTo(1000L);
+      assertThat(record.getMetrics().getOutputTokens()).isEqualTo(500L);
+      assertThat(record.getMetrics().getModelCalls()).isEqualTo(3);
+      assertThat(record.getMetrics().getToolCalls()).isEqualTo(7);
+      assertThat(record.getChangedAttributes()).containsExactly("metrics");
+    }
+
+    @Test
+    void shouldMapToolsOntoRecord() {
+      // given
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setTools(
+          List.of(
+              AgentTool.Builder.create()
+                  .name("searchDatabase")
+                  .description("Searches the database")
+                  .elementId(null)
+                  .build()));
+
+      // when
+      final Either<ProblemDetail, AgentInstanceRecord> result =
+          mapper.toUpdateAgentInstanceRecord(AGENT_INSTANCE_KEY, request);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var record = result.get();
+      assertThat(record.getTools()).hasSize(1);
+      assertThat(record.getTools().get(0).getName()).isEqualTo("searchDatabase");
+      assertThat(record.getChangedAttributes()).containsExactly("tools");
+    }
+  }
+
+  @Nested
+  class HistoryBatchMappingTest {
+
+    @Test
+    void shouldMapHistoryBatchOntoRecordPreservingOrderAndFields() {
+      // given
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(
+          List.of(
+              historyItem("item-1", AgentInstanceHistoryRoleEnum.USER, "hello"),
+              historyItem("item-2", AgentInstanceHistoryRoleEnum.ASSISTANT, "hi there")));
+
+      // when
+      final Either<ProblemDetail, AgentInstanceRecord> result =
+          mapper.toUpdateAgentInstanceRecord(AGENT_INSTANCE_KEY, request);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var record = result.get();
+      assertThat(record.getHistory()).hasSize(2);
+      assertThat(record.getHistory().get(0).getHistoryItemId()).isEqualTo("item-1");
+      assertThat(record.getHistory().get(0).getRole().name()).isEqualTo("USER");
+      assertThat(record.getHistory().get(0).getContent()).hasSize(1);
+      assertThat(record.getHistory().get(0).getContent().get(0).getText()).isEqualTo("hello");
+      assertThat(record.getHistory().get(1).getHistoryItemId()).isEqualTo("item-2");
+      assertThat(record.getHistory().get(1).getRole().name()).isEqualTo("ASSISTANT");
+    }
+
+    @Test
+    void shouldMapHistoryItemToolCallsAndMetricsOntoRecord() {
+      // given
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      final var toolCall =
+          AgentInstanceToolCall.Builder.create()
+              .toolCallId("tc-001")
+              .toolName("extract_data")
+              .elementId("extract-task")
+              .arguments(null)
+              .build();
+      final var item =
+          AgentInstanceHistoryItem.Builder.create()
+              .historyItemId("item-1")
+              .loopIteration(1)
+              .role(AgentInstanceHistoryRoleEnum.ASSISTANT)
+              .content(List.of(textContent("computing")))
+              .producedAt("2025-06-01T12:00:00Z")
+              .build();
+      item.setToolCalls(List.of(toolCall));
+      item.setMetrics(
+          AgentInstanceHistoryItemMetrics.Builder.create()
+              .inputTokens(512L)
+              .outputTokens(128L)
+              .durationMs(1500L)
+              .build());
+      request.setHistory(List.of(item));
+
+      // when
+      final Either<ProblemDetail, AgentInstanceRecord> result =
+          mapper.toUpdateAgentInstanceRecord(AGENT_INSTANCE_KEY, request);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var mappedItem = result.get().getHistory().get(0);
+      assertThat(mappedItem.getToolCalls()).hasSize(1);
+      assertThat(mappedItem.getToolCalls().get(0).getToolCallId()).isEqualTo("tc-001");
+      assertThat(mappedItem.getToolCalls().get(0).getToolName()).isEqualTo("extract_data");
+      assertThat(mappedItem.getMetrics().getInputTokens()).isEqualTo(512L);
+      assertThat(mappedItem.getMetrics().getOutputTokens()).isEqualTo(128L);
+      assertThat(mappedItem.getMetrics().getDurationMs()).isEqualTo(1500L);
+      assertThat(mappedItem.getProducedAt())
+          .isEqualTo(OffsetDateTime.parse("2025-06-01T12:00:00Z").toInstant().toEpochMilli());
+    }
+
+    @Test
+    void shouldMapRequestLevelJobKeyAndJobLeaseOntoRecord() {
+      // given
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setJobLease("lease-abc");
+      request.setHistory(List.of(historyItem("item-1", AgentInstanceHistoryRoleEnum.USER, "hi")));
+
+      // when
+      final Either<ProblemDetail, AgentInstanceRecord> result =
+          mapper.toUpdateAgentInstanceRecord(AGENT_INSTANCE_KEY, request);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var record = result.get();
+      assertThat(record.getJobKey()).isEqualTo(2251799813685249L);
+      assertThat(record.getJobLease()).isEqualTo("lease-abc");
+    }
+
+    @Test
+    void shouldMapPerItemLoopIterationOntoHistoryRecord() {
+      // given
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      final var itemIterationTwo =
+          historyItem("item-1", 2, AgentInstanceHistoryRoleEnum.USER, "hi");
+      final var itemIterationThree =
+          historyItem("item-2", 3, AgentInstanceHistoryRoleEnum.USER, "still there?");
+      request.setHistory(List.of(itemIterationTwo, itemIterationThree));
+
+      // when
+      final Either<ProblemDetail, AgentInstanceRecord> result =
+          mapper.toUpdateAgentInstanceRecord(AGENT_INSTANCE_KEY, request);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var record = result.get();
+      assertThat(record.getHistory().get(0).getLoopIteration()).isEqualTo(2);
+      assertThat(record.getHistory().get(1).getLoopIteration()).isEqualTo(3);
+    }
+  }
+
+  @Nested
+  class CombinedFieldMappingTest {
+
+    @Test
+    void shouldMapStatusMetricsToolsAndHistoryTogetherWithoutLosingAny() {
+      // given
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setStatus(AgentInstanceUpdateStatusEnum.IDLE);
+      request.setMetrics(AgentInstanceMetricsDelta.Builder.create().build());
+      request.getMetrics().setInputTokens(10L);
+      request.setTools(
+          List.of(
+              AgentTool.Builder.create()
+                  .name("searchDatabase")
+                  .description(null)
+                  .elementId(null)
+                  .build()));
+      request.setJobKey(JOB_KEY);
+      request.setHistory(
+          List.of(
+              historyItem("item-1", AgentInstanceHistoryRoleEnum.USER, "hello"),
+              historyItem("item-2", AgentInstanceHistoryRoleEnum.ASSISTANT, "hi there")));
+
+      // when
+      final Either<ProblemDetail, AgentInstanceRecord> result =
+          mapper.toUpdateAgentInstanceRecord(AGENT_INSTANCE_KEY, request);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var record = result.get();
+      assertThat(record.getStatus().name()).isEqualTo("IDLE");
+      assertThat(record.getMetrics().getInputTokens()).isEqualTo(10L);
+      assertThat(record.getTools()).hasSize(1);
+      assertThat(record.getTools().get(0).getName()).isEqualTo("searchDatabase");
+      assertThat(record.getHistory()).hasSize(2);
+      assertThat(record.getHistory().get(0).getHistoryItemId()).isEqualTo("item-1");
+      assertThat(record.getHistory().get(1).getHistoryItemId()).isEqualTo("item-2");
+      assertThat(record.getChangedAttributes()).containsExactly("status", "metrics", "tools");
+    }
+  }
+
+  private static AgentInstanceHistoryItem historyItem(
+      final String historyItemId, final AgentInstanceHistoryRoleEnum role, final String text) {
+    return historyItem(historyItemId, 1, role, text);
+  }
+
+  private static AgentInstanceHistoryItem historyItem(
+      final String historyItemId,
+      final int loopIteration,
+      final AgentInstanceHistoryRoleEnum role,
+      final String text) {
+    return AgentInstanceHistoryItem.Builder.create()
+        .historyItemId(historyItemId)
+        .loopIteration(loopIteration)
+        .role(role)
+        .content(List.of(textContent(text)))
+        .producedAt("2025-06-01T12:00:00Z")
+        .build();
+  }
+
+  private static AgentInstanceMessageContent textContent(final String text) {
+    return AgentInstanceTextContent.Builder.create().contentType("TEXT").text(text).build();
+  }
+}

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapperTest.java
@@ -20,6 +20,7 @@ import io.camunda.gateway.protocol.model.AgentInstanceToolCall;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateStatusEnum;
 import io.camunda.gateway.protocol.model.AgentTool;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.util.Either;
 import java.time.OffsetDateTime;
@@ -241,6 +242,37 @@ class AgentInstanceMapperTest {
       final var record = result.get();
       assertThat(record.getHistory().get(0).getLoopIteration()).isEqualTo(2);
       assertThat(record.getHistory().get(1).getLoopIteration()).isEqualTo(3);
+    }
+  }
+
+  @Nested
+  class UpdateResultMappingTest {
+
+    @Test
+    void shouldMapCreatedHistoryFromRecordWithHistoryItemIdKeyAndDuplicateFlag() {
+      // given
+      final var record = new AgentInstanceRecord();
+      record.addHistoryItem(
+          new AgentHistoryRecord().setHistoryItemId("item-1").setAgentHistoryKey(100L));
+      record.addHistoryItem(
+          new AgentHistoryRecord()
+              .setHistoryItemId("item-2")
+              .setAgentHistoryKey(101L)
+              .setDuplicate(true));
+
+      // when
+      final var result = mapper.toAgentInstanceUpdateResult(record);
+
+      // then
+      assertThat(result.getCreatedHistory()).hasSize(2);
+      final var first = result.getCreatedHistory().get(0);
+      assertThat(first.getHistoryItemId()).isEqualTo("item-1");
+      assertThat(first.getHistoryItemKey()).isEqualTo("100");
+      assertThat(first.getIsDuplicate()).isFalse();
+      final var second = result.getCreatedHistory().get(1);
+      assertThat(second.getHistoryItemId()).isEqualTo("item-2");
+      assertThat(second.getHistoryItemKey()).isEqualTo("101");
+      assertThat(second.getIsDuplicate()).isTrue();
     }
   }
 

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mapping.http.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryItem;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryRoleEnum;
+import io.camunda.gateway.protocol.model.AgentInstanceMessageContent;
+import io.camunda.gateway.protocol.model.AgentInstanceMetricsDelta;
+import io.camunda.gateway.protocol.model.AgentInstanceTextContent;
+import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
+import io.camunda.gateway.protocol.model.AgentTool;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ProblemDetail;
+
+@DisplayName("AgentInstanceRequestValidator Tests")
+class AgentInstanceRequestValidatorTest {
+
+  private static final String AGENT_INSTANCE_KEY = "9007199254741017";
+  private static final String ELEMENT_INSTANCE_KEY = "2251799813685248";
+  private static final String JOB_KEY = "2251799813685249";
+
+  private final AgentInstanceRequestValidator validator = new AgentInstanceRequestValidator();
+
+  @Nested
+  @DisplayName("Existing update rules")
+  class ExistingUpdateRuleTest {
+
+    @Test
+    @DisplayName("Should accept a request with only elementInstanceKey")
+    void shouldAcceptValidUpdateRequest() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should reject missing elementInstanceKey")
+    void shouldRejectMissingElementInstanceKey() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create().elementInstanceKey(null).build();
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No elementInstanceKey provided.");
+    }
+
+    @Test
+    @DisplayName("Should reject a negative metrics delta")
+    void shouldRejectNegativeMetricsDelta() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setMetrics(AgentInstanceMetricsDelta.Builder.create().build());
+      request.getMetrics().setInputTokens(-1L);
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail())
+          .isEqualTo("The value for metrics.inputTokens is '-1' but must be >= 0.");
+    }
+
+    @Test
+    @DisplayName("Should reject a tool without a name")
+    void shouldRejectToolWithoutName() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setTools(
+          List.of(AgentTool.Builder.create().name("").description("d").elementId(null).build()));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No tools[0].name provided.");
+    }
+  }
+
+  @Nested
+  @DisplayName("History batch rules")
+  class HistoryBatchRuleTest {
+
+    @Test
+    @DisplayName("Should accept a batch item with a non-blank historyItemId")
+    void shouldAcceptHistoryItemWithHistoryItemId() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(List.of(historyItem("item-1")));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should reject a batch item with a missing (null) historyItemId")
+    void shouldRejectHistoryItemWithNullHistoryItemId() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(List.of(historyItem(null)));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No history[0].historyItemId provided.");
+    }
+
+    @Test
+    @DisplayName("Should reject a batch item with a blank historyItemId")
+    void shouldRejectHistoryItemWithBlankHistoryItemId() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(List.of(historyItem("  ")));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No history[0].historyItemId provided.");
+    }
+
+    @Test
+    @DisplayName("Should report the correct index for a batch item beyond the first")
+    void shouldReportCorrectIndexForSecondHistoryItem() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(List.of(historyItem("item-1"), historyItem(null)));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No history[1].historyItemId provided.");
+    }
+
+    @Test
+    @DisplayName("Should reject a batch item with a missing loopIteration")
+    void shouldRejectHistoryItemWithMissingLoopIteration() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(List.of(historyItemWithoutLoopIteration("item-1")));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No history[0].loopIteration provided.");
+    }
+
+    @Test
+    @DisplayName("Should reject a batch with history but no jobKey")
+    void shouldRejectHistoryBatchWithoutJobKey() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setHistory(List.of(historyItem("item-1")));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No jobKey provided.");
+    }
+  }
+
+  private static AgentInstanceHistoryItem historyItem(final String historyItemId) {
+    final AgentInstanceMessageContent content =
+        AgentInstanceTextContent.Builder.create().contentType("TEXT").text("hello").build();
+    return AgentInstanceHistoryItem.Builder.create()
+        .historyItemId(historyItemId)
+        .loopIteration(1)
+        .role(AgentInstanceHistoryRoleEnum.USER)
+        .content(List.of(content))
+        .producedAt("2025-06-01T12:00:00Z")
+        .build();
+  }
+
+  private static AgentInstanceHistoryItem historyItemWithoutLoopIteration(
+      final String historyItemId) {
+    final AgentInstanceMessageContent content =
+        AgentInstanceTextContent.Builder.create().contentType("TEXT").text("hello").build();
+    return AgentInstanceHistoryItem.Builder.create()
+        .historyItemId(historyItemId)
+        .loopIteration(null)
+        .role(AgentInstanceHistoryRoleEnum.USER)
+        .content(List.of(content))
+        .producedAt("2025-06-01T12:00:00Z")
+        .build();
+  }
+}

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
@@ -32,6 +32,31 @@ class AgentInstanceRequestValidatorTest {
 
   private final AgentInstanceRequestValidator validator = new AgentInstanceRequestValidator();
 
+  private static AgentInstanceHistoryItem historyItem(final String historyItemId) {
+    final AgentInstanceMessageContent content =
+        AgentInstanceTextContent.Builder.create().contentType("TEXT").text("hello").build();
+    return AgentInstanceHistoryItem.Builder.create()
+        .historyItemId(historyItemId)
+        .loopIteration(1)
+        .role(AgentInstanceHistoryRoleEnum.USER)
+        .content(List.of(content))
+        .producedAt("2025-06-01T12:00:00Z")
+        .build();
+  }
+
+  private static AgentInstanceHistoryItem historyItemWithoutLoopIteration(
+      final String historyItemId) {
+    final AgentInstanceMessageContent content =
+        AgentInstanceTextContent.Builder.create().contentType("TEXT").text("hello").build();
+    return AgentInstanceHistoryItem.Builder.create()
+        .historyItemId(historyItemId)
+        .loopIteration(null)
+        .role(AgentInstanceHistoryRoleEnum.USER)
+        .content(List.of(content))
+        .producedAt("2025-06-01T12:00:00Z")
+        .build();
+  }
+
   @Nested
   @DisplayName("Existing update rules")
   class ExistingUpdateRuleTest {
@@ -202,30 +227,5 @@ class AgentInstanceRequestValidatorTest {
       assertThat(result).isPresent();
       assertThat(result.get().getDetail()).isEqualTo("No jobKey provided.");
     }
-  }
-
-  private static AgentInstanceHistoryItem historyItem(final String historyItemId) {
-    final AgentInstanceMessageContent content =
-        AgentInstanceTextContent.Builder.create().contentType("TEXT").text("hello").build();
-    return AgentInstanceHistoryItem.Builder.create()
-        .historyItemId(historyItemId)
-        .loopIteration(1)
-        .role(AgentInstanceHistoryRoleEnum.USER)
-        .content(List.of(content))
-        .producedAt("2025-06-01T12:00:00Z")
-        .build();
-  }
-
-  private static AgentInstanceHistoryItem historyItemWithoutLoopIteration(
-      final String historyItemId) {
-    final AgentInstanceMessageContent content =
-        AgentInstanceTextContent.Builder.create().contentType("TEXT").text("hello").build();
-    return AgentInstanceHistoryItem.Builder.create()
-        .historyItemId(historyItemId)
-        .loopIteration(null)
-        .role(AgentInstanceHistoryRoleEnum.USER)
-        .content(List.of(content))
-        .producedAt("2025-06-01T12:00:00Z")
-        .build();
   }
 }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
@@ -57,6 +57,41 @@ class AgentInstanceRequestValidatorTest {
         .build();
   }
 
+  private static AgentInstanceHistoryItem historyItemWithoutRole(final String historyItemId) {
+    final AgentInstanceMessageContent content =
+        AgentInstanceTextContent.Builder.create().contentType("TEXT").text("hello").build();
+    return AgentInstanceHistoryItem.Builder.create()
+        .historyItemId(historyItemId)
+        .loopIteration(1)
+        .role(null)
+        .content(List.of(content))
+        .producedAt("2025-06-01T12:00:00Z")
+        .build();
+  }
+
+  private static AgentInstanceHistoryItem historyItemWithoutContent(final String historyItemId) {
+    return AgentInstanceHistoryItem.Builder.create()
+        .historyItemId(historyItemId)
+        .loopIteration(1)
+        .role(AgentInstanceHistoryRoleEnum.USER)
+        .content(null)
+        .producedAt("2025-06-01T12:00:00Z")
+        .build();
+  }
+
+  private static AgentInstanceHistoryItem historyItemWithProducedAt(
+      final String historyItemId, final String producedAt) {
+    final AgentInstanceMessageContent content =
+        AgentInstanceTextContent.Builder.create().contentType("TEXT").text("hello").build();
+    return AgentInstanceHistoryItem.Builder.create()
+        .historyItemId(historyItemId)
+        .loopIteration(1)
+        .role(AgentInstanceHistoryRoleEnum.USER)
+        .content(List.of(content))
+        .producedAt(producedAt)
+        .build();
+  }
+
   @Nested
   @DisplayName("Existing update rules")
   class ExistingUpdateRuleTest {
@@ -226,6 +261,97 @@ class AgentInstanceRequestValidatorTest {
 
       assertThat(result).isPresent();
       assertThat(result.get().getDetail()).isEqualTo("No jobKey provided.");
+    }
+
+    @Test
+    @DisplayName("Should reject a batch with a non-numeric jobKey")
+    void shouldRejectHistoryBatchWithMalformedJobKey() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey("not-a-number");
+      request.setHistory(List.of(historyItem("item-1")));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail())
+          .isEqualTo(
+              "The provided jobKey 'not-a-number' is not a valid key. Expected a numeric value."
+                  + " Did you pass an entity id instead of an entity key?.");
+    }
+
+    @Test
+    @DisplayName("Should reject a batch item with a missing role")
+    void shouldRejectHistoryItemWithMissingRole() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(List.of(historyItemWithoutRole("item-1")));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No history[0].role provided.");
+    }
+
+    @Test
+    @DisplayName("Should reject a batch item with missing content")
+    void shouldRejectHistoryItemWithMissingContent() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(List.of(historyItemWithoutContent("item-1")));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No history[0].content provided.");
+    }
+
+    @Test
+    @DisplayName("Should reject a batch item with a missing producedAt")
+    void shouldRejectHistoryItemWithMissingProducedAt() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(List.of(historyItemWithProducedAt("item-1", null)));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No history[0].producedAt provided.");
+    }
+
+    @Test
+    @DisplayName("Should reject a batch item with a malformed producedAt")
+    void shouldRejectHistoryItemWithMalformedProducedAt() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(List.of(historyItemWithProducedAt("item-1", "not-a-date")));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail())
+          .isEqualTo(
+              "The provided history[0].producedAt 'not-a-date' cannot be parsed as a date"
+                  + " according to RFC 3339, section 5.6.");
     }
   }
 }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
@@ -9,13 +9,16 @@ package io.camunda.gateway.mapping.http.validator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.gateway.protocol.model.AgentInstanceDocumentContent;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryItem;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryRoleEnum;
 import io.camunda.gateway.protocol.model.AgentInstanceMessageContent;
 import io.camunda.gateway.protocol.model.AgentInstanceMetricsDelta;
+import io.camunda.gateway.protocol.model.AgentInstanceObjectContent;
 import io.camunda.gateway.protocol.model.AgentInstanceTextContent;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
 import io.camunda.gateway.protocol.model.AgentTool;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -89,6 +92,30 @@ class AgentInstanceRequestValidatorTest {
         .role(AgentInstanceHistoryRoleEnum.USER)
         .content(List.of(content))
         .producedAt(producedAt)
+        .build();
+  }
+
+  private static AgentInstanceHistoryItem historyItemWithLoopIteration(
+      final String historyItemId, final int loopIteration) {
+    final AgentInstanceMessageContent content =
+        AgentInstanceTextContent.Builder.create().contentType("TEXT").text("hello").build();
+    return AgentInstanceHistoryItem.Builder.create()
+        .historyItemId(historyItemId)
+        .loopIteration(loopIteration)
+        .role(AgentInstanceHistoryRoleEnum.USER)
+        .content(List.of(content))
+        .producedAt("2025-06-01T12:00:00Z")
+        .build();
+  }
+
+  private static AgentInstanceHistoryItem historyItemWithContent(
+      final String historyItemId, final List<AgentInstanceMessageContent> content) {
+    return AgentInstanceHistoryItem.Builder.create()
+        .historyItemId(historyItemId)
+        .loopIteration(1)
+        .role(AgentInstanceHistoryRoleEnum.USER)
+        .content(content)
+        .producedAt("2025-06-01T12:00:00Z")
         .build();
   }
 
@@ -352,6 +379,141 @@ class AgentInstanceRequestValidatorTest {
           .isEqualTo(
               "The provided history[0].producedAt 'not-a-date' cannot be parsed as a date"
                   + " according to RFC 3339, section 5.6.");
+    }
+
+    @Test
+    @DisplayName("Should reject a malformed jobKey even without a history batch")
+    void shouldRejectMalformedJobKeyWithoutHistory() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey("not-a-number");
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail())
+          .isEqualTo(
+              "The provided jobKey 'not-a-number' is not a valid key. Expected a numeric value."
+                  + " Did you pass an entity id instead of an entity key?.");
+    }
+
+    @Test
+    @DisplayName("Should reject a null history item in the batch")
+    void shouldRejectNullHistoryItemInBatch() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      final var history = new ArrayList<AgentInstanceHistoryItem>();
+      history.add(null);
+      request.setHistory(history);
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No history[0] provided.");
+    }
+
+    @Test
+    @DisplayName("Should reject a batch item with a zero loopIteration")
+    void shouldRejectHistoryItemWithZeroLoopIteration() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(List.of(historyItemWithLoopIteration("item-1", 0)));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail())
+          .isEqualTo("The value for history[0].loopIteration is '0' but must be > 0.");
+    }
+
+    @Test
+    @DisplayName("Should reject a batch item with a negative loopIteration")
+    void shouldRejectHistoryItemWithNegativeLoopIteration() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(List.of(historyItemWithLoopIteration("item-1", -1)));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail())
+          .isEqualTo("The value for history[0].loopIteration is '-1' but must be > 0.");
+    }
+
+    @Test
+    @DisplayName("Should reject a batch item with blank text content")
+    void shouldRejectHistoryItemWithBlankTextContent() {
+      final AgentInstanceMessageContent content =
+          AgentInstanceTextContent.Builder.create().contentType("TEXT").text("  ").build();
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(List.of(historyItemWithContent("item-1", List.of(content))));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No history[0].content[0].text provided.");
+    }
+
+    @Test
+    @DisplayName("Should reject a batch item with document content missing a documentReference")
+    void shouldRejectHistoryItemWithDocumentContentMissingDocumentReference() {
+      final AgentInstanceMessageContent content =
+          AgentInstanceDocumentContent.Builder.create()
+              .contentType("DOCUMENT")
+              .documentReference(null)
+              .build();
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(List.of(historyItemWithContent("item-1", List.of(content))));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail())
+          .isEqualTo("No history[0].content[0].documentReference provided.");
+    }
+
+    @Test
+    @DisplayName("Should reject a batch item with object content missing an object")
+    void shouldRejectHistoryItemWithObjectContentMissingObject() {
+      final AgentInstanceMessageContent content =
+          AgentInstanceObjectContent.Builder.create().contentType("OBJECT").object(null).build();
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(List.of(historyItemWithContent("item-1", List.of(content))));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No history[0].content[0].object provided.");
     }
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -114,9 +114,10 @@ paths:
         - basicAuth: []
       summary: Update agent instance
       description: |
-        Updates the mutable fields of an agent instance: status, metric counters, and
-        tools. Metric values are treated as deltas and applied immediately to the
-        aggregate counters. Tool updates replace the existing tool list.
+        Updates the mutable fields of an agent instance (status, metric counters, and
+        tools) and appends a batch of history items to its conversation history. Metric
+        values are treated as deltas and applied immediately to the aggregate counters.
+        Tool updates replace the existing tool list.
       parameters:
         - name: agentInstanceKey
           in: path
@@ -734,6 +735,30 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AgentTool'
+        jobKey:
+          description: |
+            The key of the job activation during which this update is being made.
+            Required whenever history is provided.
+          nullable: true
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/JobKey'
+        jobLease:
+          description: |
+            Opaque lease token received from the job activation response. Disambiguates
+            this activation from any other activation of the same job: if the job is
+            later retried, history items submitted under a superseded lease are discarded
+            rather than committed.
+          nullable: true
+          type: string
+        history:
+          description: |
+            A batch of history items to append to the agent instance's conversation
+            history, in request order. Each created item is echoed back in the
+            response's createdHistory, positionally correlated.
+          nullable: true
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentInstanceHistoryItem'
 
     ## Filters
 
@@ -830,6 +855,58 @@ components:
             - $ref: '#/components/schemas/AgentInstanceHistoryItemMetrics'
         producedAt:
           description: The connector-side timestamp of when this message was produced.
+          type: string
+          format: date-time
+
+    AgentInstanceHistoryItem:
+      description: |
+        A single history item to append to the agent instance's conversation history,
+        submitted as part of the batch on an agent instance update request.
+      type: object
+      required:
+        - historyItemId
+        - loopIteration
+        - role
+        - content
+        - producedAt
+      properties:
+        historyItemId:
+          description: |
+            Caller-assigned identifier used to detect and dedupe retries of the same
+            item. For example, when a retried job activation resubmits history items
+            it already sent in an earlier attempt, those items are not rejected; they
+            are flagged via isDuplicate in the response instead. Must be non-blank.
+          type: string
+        loopIteration:
+          description: The loop iteration this item belongs to.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/LoopIterationId'
+        role:
+          description: The role of this history item in the conversation.
+          allOf:
+            - $ref: '#/components/schemas/AgentInstanceHistoryRoleEnum'
+        content:
+          description: The content blocks of this history item.
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentInstanceMessageContent'
+        toolCalls:
+          description: |
+            Tool calls associated with this history item.
+            For ASSISTANT items: tool calls dispatched by this LLM response, with arguments populated.
+            For TOOL_RESULT items: single-entry array referencing the originating tool call, with arguments null.
+            Omit for USER items.
+          type: array
+          nullable: true
+          items:
+            $ref: '#/components/schemas/AgentInstanceToolCall'
+        metrics:
+          description: Per-call token and latency metrics. Present on ASSISTANT items only.
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/AgentInstanceHistoryItemMetrics'
+        producedAt:
+          description: The agent-side timestamp of when this message was produced.
           type: string
           format: date-time
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -853,7 +853,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/AgentInstanceHistoryItemMetrics'
         producedAt:
-          description: The connector-side timestamp of when this message was produced.
+          description: The agent-side timestamp of when this message was produced.
           type: string
           format: date-time
 
@@ -1070,7 +1070,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/AgentInstanceHistoryCommitStatusEnum'
         producedAt:
-          description: The connector-side timestamp of when this message was produced.
+          description: The agent-side timestamp of when this message was produced.
           type: string
           format: date-time
     AgentInstanceHistoryRoleEnum:

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -823,9 +823,8 @@ components:
           type: string
         loopIteration:
           description: |
-            The loopIteration this item belongs to. A loopIteration is one pass through the agent
-            feedback loop: one LLM call, its tool dispatches, and their results. Omit if not grouping
-            items by loopIteration.
+            The loop iteration this item belongs to. Omit if not grouping items by
+            loopIteration.
           nullable: true
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/LoopIterationId'
@@ -976,7 +975,7 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/JobKeyFilterProperty'
         loopIteration:
-          description: Filter by loopIteration number. A loopIteration is one pass through the agent feedback loop (one LLM call, its tool dispatches, and their results).
+          description: Filter by loop iteration number.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/IntegerFilterProperty'
         commitStatus:
@@ -1041,9 +1040,7 @@ components:
           description: The lease token of the activation that produced this item.
           type: string
         loopIteration:
-          description: |
-            The loopIteration this item belongs to. A loopIteration is one pass through the agent
-            feedback loop: one LLM call, its tool dispatches, and their results.
+          description: The loop iteration this item belongs to.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/LoopIterationId'
         role:

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -841,8 +841,8 @@ components:
         toolCalls:
           description: |
             Tool calls associated with this history item.
-            For ASSISTANT items: tool calls dispatched by this LLM response, with arguments populated.
-            For TOOL_RESULT items: single-entry array referencing the originating tool call, with arguments null.
+            For ASSISTANT items: tool calls dispatched by this LLM response.
+            For TOOL_RESULT items: single-entry array referencing the originating tool call.
             Omit for USER items.
           type: array
           nullable: true
@@ -893,8 +893,8 @@ components:
         toolCalls:
           description: |
             Tool calls associated with this history item.
-            For ASSISTANT items: tool calls dispatched by this LLM response, with arguments populated.
-            For TOOL_RESULT items: single-entry array referencing the originating tool call, with arguments null.
+            For ASSISTANT items: tool calls dispatched by this LLM response.
+            For TOOL_RESULT items: single-entry array referencing the originating tool call.
             Omit for USER items.
           type: array
           nullable: true
@@ -1058,8 +1058,8 @@ components:
         toolCalls:
           description: |
             Tool calls for this item. Empty for USER items and ASSISTANT items with no tool dispatches.
-            ASSISTANT items: dispatched tool calls with arguments populated.
-            TOOL_RESULT items: single-entry array referencing the originating tool call (arguments null).
+            ASSISTANT items: dispatched tool calls.
+            TOOL_RESULT items: single-entry array referencing the originating tool call.
           type: array
           items:
             $ref: '#/components/schemas/AgentInstanceToolCall'
@@ -1176,7 +1176,6 @@ components:
     AgentInstanceToolCall:
       description: |
         A tool call associated with a history item. Used in both ASSISTANT and TOOL_RESULT items.
-        ASSISTANT items carry arguments; TOOL_RESULT items carry arguments as null.
       type: object
       required:
         - toolCallId
@@ -1195,7 +1194,9 @@ components:
           type: string
           nullable: true
         arguments:
-          description: The tool call arguments as provided by the LLM. Null on TOOL_RESULT items.
+          description: |
+            The tool call arguments as provided by the LLM. May be null or populated on
+            any item, including TOOL_RESULT.
           type: object
           nullable: true
           additionalProperties: true

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -117,7 +117,8 @@ paths:
         Updates the mutable fields of an agent instance (status, metric counters, and
         tools) and appends a batch of history items to its conversation history. Metric
         values are treated as deltas and applied immediately to the aggregate counters.
-        Tool updates replace the existing tool list.
+        Tool updates replace the existing tool list. Each history item created for this
+        request is echoed back in the response.
       parameters:
         - name: agentInstanceKey
           in: path
@@ -132,8 +133,12 @@ paths:
             schema:
               $ref: '#/components/schemas/AgentInstanceUpdateRequest'
       responses:
-        "204":
+        "200":
           description: The agent instance was updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentInstanceUpdateResult'
         "400":
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "401":
@@ -759,6 +764,41 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AgentInstanceHistoryItem'
+
+    AgentInstanceUpdateResult:
+      description: Response returned after successfully updating an agent instance.
+      type: object
+      required:
+        - createdHistory
+      properties:
+        createdHistory:
+          description: |
+            One entry per history item submitted in the request, in request order.
+            Empty when no history items were submitted.
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentInstanceCreatedHistoryItem'
+
+    AgentInstanceCreatedHistoryItem:
+      description: |
+        The outcome of appending a single history item from an update request's
+        history batch.
+      type: object
+      required:
+        - historyItemKey
+        - isDuplicate
+      properties:
+        historyItemKey:
+          description: |
+            The system-generated key for the history item. When isDuplicate is true,
+            this is the key of the original entry, not a new one.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/AgentHistoryItemKey'
+        isDuplicate:
+          description: |
+            True if this item had already been recorded and no new AGENT_HISTORY event
+            was created for it; false if a new event was created.
+          type: boolean
 
     ## Filters
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -785,9 +785,15 @@ components:
         history batch.
       type: object
       required:
+        - historyItemId
         - historyItemKey
         - isDuplicate
       properties:
+        historyItemId:
+          description: |
+            The historyItemId of the corresponding item in the request, echoed back
+            so callers can correlate response entries with request items by id.
+          type: string
         historyItemKey:
           description: |
             The system-generated key for the history item. When isDuplicate is true,

--- a/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -205,9 +205,12 @@ components:
 
     LoopIterationId:
       description: |
-        A client-provided sequential integer identifying one pass through the agent
-        feedback loop: one LLM call, its tool dispatches, and their results. Must be
-        a positive integer, increasing with each loopIteration. Established by the
+        A client-provided sequential integer identifying a loop iteration: one pass
+        through an AI agent's loop, during which the model reasons, selects tools,
+        evaluates the result, and decides whether to continue. One iteration covers
+        the input for the LLM call, the call itself, and the tools it dispatches;
+        the results of those tool calls are input to the next iteration. Must be a
+        positive integer, increasing with each loopIteration. Established by the
         connector when appending the first history item of a loopIteration.
       type: integer
       format: int32

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceController.java
@@ -142,8 +142,10 @@ public class AgentInstanceController {
       final String physicalTenantId, final AgentInstanceRecord record) {
     final var agentInstanceServices = serviceRegistry.agentInstanceServices(physicalTenantId);
     final var authentication = authenticationProvider.getCamundaAuthentication();
-    return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> agentInstanceServices.updateAgentInstance(record, authentication));
+    return RequestExecutor.executeServiceMethod(
+        () -> agentInstanceServices.updateAgentInstance(record, authentication),
+        mapper::toAgentInstanceUpdateResult,
+        HttpStatus.OK);
   }
 
   private CompletableFuture<ResponseEntity<Object>> createHistoryItem(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -801,6 +801,199 @@ class AgentInstanceControllerTest extends RestControllerTest {
   }
 
   @Nested
+  class UpdateWithHistoryBatchTest {
+
+    private static final long HISTORY_ITEM_KEY_1 = 9007199254741019L;
+    private static final long HISTORY_ITEM_KEY_2 = 9007199254741020L;
+    private static final long HISTORY_ITEM_KEY_3 = 9007199254741021L;
+
+    @Test
+    void shouldReturn200WithCreatedHistoryInRequestOrderFlaggingDuplicates() {
+      // given
+      final var responseRecord = new AgentInstanceRecord();
+      responseRecord.addHistoryItem(
+          new AgentHistoryRecord().setAgentHistoryKey(HISTORY_ITEM_KEY_1));
+      responseRecord.addHistoryItem(
+          new AgentHistoryRecord().setAgentHistoryKey(HISTORY_ITEM_KEY_2).setDuplicate(true));
+      responseRecord.addHistoryItem(
+          new AgentHistoryRecord().setAgentHistoryKey(HISTORY_ITEM_KEY_3));
+      when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
+          .thenReturn(CompletableFuture.completedFuture(responseRecord));
+
+      final var requestBody =
+          """
+          {
+            "elementInstanceKey": "%d",
+            "jobKey": "%d",
+            "jobLease": "lease-abc",
+            "history": [
+              %s,
+              %s,
+              %s
+            ]
+          }
+          """
+              .formatted(
+                  ELEMENT_INSTANCE_KEY,
+                  JOB_KEY,
+                  historyItemJson("item-1", "USER", "hello"),
+                  historyItemJson("item-2", "ASSISTANT", "hi there"),
+                  historyItemJson("item-3", "USER", "thanks"));
+
+      // when / then
+      webClient
+          .patch()
+          .uri(AGENT_INSTANCES_URL + "/%d".formatted(AGENT_INSTANCE_KEY))
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(requestBody)
+          .exchange()
+          .expectStatus()
+          .isOk()
+          .expectBody()
+          .json(
+              """
+              {
+                "createdHistory": [
+                  { "historyItemKey": "%d", "isDuplicate": false },
+                  { "historyItemKey": "%d", "isDuplicate": true },
+                  { "historyItemKey": "%d", "isDuplicate": false }
+                ]
+              }
+              """
+                  .formatted(HISTORY_ITEM_KEY_1, HISTORY_ITEM_KEY_2, HISTORY_ITEM_KEY_3),
+              JsonCompareMode.STRICT);
+
+      verify(agentInstanceServices)
+          .updateAgentInstance(
+              assertArg(
+                  record -> {
+                    assertThat(record.getJobKey()).isEqualTo(JOB_KEY);
+                    assertThat(record.getJobLease()).isEqualTo("lease-abc");
+                    assertThat(record.getHistory()).hasSize(3);
+                    assertThat(record.getHistory().get(0).getHistoryItemId()).isEqualTo("item-1");
+                    assertThat(record.getHistory().get(0).getContent().get(0).getText())
+                        .isEqualTo("hello");
+                    assertThat(record.getHistory().get(1).getHistoryItemId()).isEqualTo("item-2");
+                    assertThat(record.getHistory().get(2).getHistoryItemId()).isEqualTo("item-3");
+                  }),
+              any());
+    }
+
+    @Test
+    void shouldReturnEmptyCreatedHistoryWhenHistoryIsEmptyArray() {
+      // given
+      when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
+          .thenReturn(CompletableFuture.completedFuture(new AgentInstanceRecord()));
+
+      final var requestBody =
+          """
+          {
+            "elementInstanceKey": "%d",
+            "history": []
+          }
+          """
+              .formatted(ELEMENT_INSTANCE_KEY);
+
+      // when / then
+      webClient
+          .patch()
+          .uri(AGENT_INSTANCES_URL + "/%d".formatted(AGENT_INSTANCE_KEY))
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(requestBody)
+          .exchange()
+          .expectStatus()
+          .isOk()
+          .expectBody()
+          .json(
+              """
+              { "createdHistory": [] }
+              """,
+              JsonCompareMode.STRICT);
+    }
+
+    @Test
+    void shouldReturn400WhenHistoryItemRejectedByBrokerWithMessageIntact() {
+      // given -- a distinct, unrelated invalidity (job no longer active for the batch); an
+      // intra-batch duplicate historyItemId is deliberately not this kind of rejection
+      final var rejectionReason =
+          ("Expected job with key '%d' referenced by history[1].historyItemId 'item-2' to be"
+                  + " currently activated for agent instance with key '%d', but it is not.")
+              .formatted(JOB_KEY, AGENT_INSTANCE_KEY);
+      final var expectedDetail =
+          "Command 'UPDATE' rejected with code 'INVALID_ARGUMENT': " + rejectionReason;
+      when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
+          .thenReturn(
+              CompletableFuture.failedFuture(
+                  ErrorMapper.mapBrokerRejection(
+                      new BrokerRejection(
+                          AgentInstanceIntent.UPDATE,
+                          AGENT_INSTANCE_KEY,
+                          RejectionType.INVALID_ARGUMENT,
+                          rejectionReason))));
+
+      final var requestBody =
+          """
+          {
+            "elementInstanceKey": "%d",
+            "jobKey": "%d",
+            "jobLease": "lease-abc",
+            "history": [
+              %s,
+              %s
+            ]
+          }
+          """
+              .formatted(
+                  ELEMENT_INSTANCE_KEY,
+                  JOB_KEY,
+                  historyItemJson("item-1", "USER", "hello"),
+                  historyItemJson("item-2", "USER", "hello again"));
+
+      // when / then
+      webClient
+          .patch()
+          .uri(AGENT_INSTANCES_URL + "/%d".formatted(AGENT_INSTANCE_KEY))
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(requestBody)
+          .exchange()
+          .expectStatus()
+          .isEqualTo(HttpStatus.BAD_REQUEST)
+          .expectHeader()
+          .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+          .expectBody()
+          .json(
+              """
+              {
+                "type": "about:blank",
+                "title": "INVALID_ARGUMENT",
+                "status": 400,
+                "detail": "%s",
+                "instance": "/v2/agent-instances/%d"
+              }
+              """
+                  .formatted(expectedDetail, AGENT_INSTANCE_KEY),
+              JsonCompareMode.STRICT);
+    }
+
+    private String historyItemJson(
+        final String historyItemId, final String role, final String text) {
+      return """
+          {
+            "historyItemId": "%s",
+            "loopIteration": 1,
+            "role": "%s",
+            "content": [{ "contentType": "TEXT", "text": "%s" }],
+            "producedAt": "2025-06-01T12:00:00Z"
+          }
+          """
+          .formatted(historyItemId, role, text);
+    }
+  }
+
+  @Nested
   class CreateHistoryItemTest {
 
     private static final long HISTORY_ITEM_KEY = 9007199254741018L;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -440,7 +440,13 @@ class AgentInstanceControllerTest extends RestControllerTest {
         .bodyValue(requestBody)
         .exchange()
         .expectStatus()
-        .isNoContent();
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            { "createdHistory": [] }
+            """,
+            JsonCompareMode.STRICT);
 
     verify(agentInstanceServices)
         .updateAgentInstance(
@@ -483,7 +489,13 @@ class AgentInstanceControllerTest extends RestControllerTest {
         .bodyValue(requestBody)
         .exchange()
         .expectStatus()
-        .isNoContent();
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            { "createdHistory": [] }
+            """,
+            JsonCompareMode.STRICT);
 
     verify(agentInstanceServices)
         .updateAgentInstance(
@@ -528,7 +540,13 @@ class AgentInstanceControllerTest extends RestControllerTest {
         .bodyValue(requestBody)
         .exchange()
         .expectStatus()
-        .isNoContent();
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            { "createdHistory": [] }
+            """,
+            JsonCompareMode.STRICT);
 
     verify(agentInstanceServices)
         .updateAgentInstance(
@@ -568,7 +586,13 @@ class AgentInstanceControllerTest extends RestControllerTest {
         .bodyValue(requestBody)
         .exchange()
         .expectStatus()
-        .isNoContent();
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            { "createdHistory": [] }
+            """,
+            JsonCompareMode.STRICT);
 
     verify(agentInstanceServices)
         .updateAgentInstance(
@@ -603,7 +627,13 @@ class AgentInstanceControllerTest extends RestControllerTest {
         .bodyValue(requestBody)
         .exchange()
         .expectStatus()
-        .isNoContent();
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            { "createdHistory": [] }
+            """,
+            JsonCompareMode.STRICT);
 
     verify(agentInstanceServices)
         .updateAgentInstance(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -803,18 +803,18 @@ class AgentInstanceControllerTest extends RestControllerTest {
   @Nested
   class CreateHistoryItemTest {
 
-  private static final long HISTORY_ITEM_KEY = 9007199254741018L;
+    private static final long HISTORY_ITEM_KEY = 9007199254741018L;
 
-  @Test
-  void shouldCreateAgentHistoryItemWithTextContent() {
-    // given
-    final var responseRecord = new AgentHistoryRecord();
-    responseRecord.setAgentHistoryKey(HISTORY_ITEM_KEY);
-    when(agentHistoryServices.createAgentHistoryItem(any(AgentHistoryRecord.class), any()))
-        .thenReturn(CompletableFuture.completedFuture(responseRecord));
+    @Test
+    void shouldCreateAgentHistoryItemWithTextContent() {
+      // given
+      final var responseRecord = new AgentHistoryRecord();
+      responseRecord.setAgentHistoryKey(HISTORY_ITEM_KEY);
+      when(agentHistoryServices.createAgentHistoryItem(any(AgentHistoryRecord.class), any()))
+          .thenReturn(CompletableFuture.completedFuture(responseRecord));
 
-    final var requestBody =
-        """
+      final var requestBody =
+          """
         {
           "elementInstanceKey": "%d",
           "jobKey": "%d",
@@ -826,56 +826,56 @@ class AgentInstanceControllerTest extends RestControllerTest {
           "producedAt": "2025-06-01T12:00:00Z"
         }
         """
-            .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY);
+              .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY);
 
-    // when / then
-    webClient
-        .post()
-        .uri(AGENT_INSTANCES_URL + "/%d/history".formatted(AGENT_INSTANCE_KEY))
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(requestBody)
-        .exchange()
-        .expectStatus()
-        .isCreated()
-        .expectBody()
-        .json(
-            """
+      // when / then
+      webClient
+          .post()
+          .uri(AGENT_INSTANCES_URL + "/%d/history".formatted(AGENT_INSTANCE_KEY))
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(requestBody)
+          .exchange()
+          .expectStatus()
+          .isCreated()
+          .expectBody()
+          .json(
+              """
             { "historyItemKey": "%d" }
             """
-                .formatted(HISTORY_ITEM_KEY),
-            JsonCompareMode.STRICT);
+                  .formatted(HISTORY_ITEM_KEY),
+              JsonCompareMode.STRICT);
 
-    verify(agentHistoryServices)
-        .createAgentHistoryItem(
-            assertArg(
-                record -> {
-                  assertThat(record.getAgentInstanceKey()).isEqualTo(AGENT_INSTANCE_KEY);
-                  assertThat(record.getElementInstanceKey()).isEqualTo(ELEMENT_INSTANCE_KEY);
-                  assertThat(record.getJobKey()).isEqualTo(JOB_KEY);
-                  assertThat(record.getJobLease()).isEqualTo("lease-abc");
-                  assertThat(record.getRole().name()).isEqualTo("ASSISTANT");
-                  assertThat(record.getContent()).hasSize(1);
-                  assertThat(record.getContent().get(0).getText())
-                      .isEqualTo("I will process the invoice.");
-                  // no metrics in the request — protocol record carries the -1 sentinel
-                  assertThat(record.getMetrics().getInputTokens()).isEqualTo(-1L);
-                  assertThat(record.getMetrics().getOutputTokens()).isEqualTo(-1L);
-                  assertThat(record.getMetrics().getDurationMs()).isEqualTo(-1L);
-                }),
-            any());
-  }
+      verify(agentHistoryServices)
+          .createAgentHistoryItem(
+              assertArg(
+                  record -> {
+                    assertThat(record.getAgentInstanceKey()).isEqualTo(AGENT_INSTANCE_KEY);
+                    assertThat(record.getElementInstanceKey()).isEqualTo(ELEMENT_INSTANCE_KEY);
+                    assertThat(record.getJobKey()).isEqualTo(JOB_KEY);
+                    assertThat(record.getJobLease()).isEqualTo("lease-abc");
+                    assertThat(record.getRole().name()).isEqualTo("ASSISTANT");
+                    assertThat(record.getContent()).hasSize(1);
+                    assertThat(record.getContent().get(0).getText())
+                        .isEqualTo("I will process the invoice.");
+                    // no metrics in the request — protocol record carries the -1 sentinel
+                    assertThat(record.getMetrics().getInputTokens()).isEqualTo(-1L);
+                    assertThat(record.getMetrics().getOutputTokens()).isEqualTo(-1L);
+                    assertThat(record.getMetrics().getDurationMs()).isEqualTo(-1L);
+                  }),
+              any());
+    }
 
-  @Test
-  void shouldCreateAgentHistoryItemWithAllFields() {
-    // given
-    final var responseRecord = new AgentHistoryRecord();
-    responseRecord.setAgentHistoryKey(HISTORY_ITEM_KEY);
-    when(agentHistoryServices.createAgentHistoryItem(any(AgentHistoryRecord.class), any()))
-        .thenReturn(CompletableFuture.completedFuture(responseRecord));
+    @Test
+    void shouldCreateAgentHistoryItemWithAllFields() {
+      // given
+      final var responseRecord = new AgentHistoryRecord();
+      responseRecord.setAgentHistoryKey(HISTORY_ITEM_KEY);
+      when(agentHistoryServices.createAgentHistoryItem(any(AgentHistoryRecord.class), any()))
+          .thenReturn(CompletableFuture.completedFuture(responseRecord));
 
-    final var requestBody =
-        """
+      final var requestBody =
+          """
         {
           "elementInstanceKey": "%d",
           "jobKey": "%d",
@@ -897,45 +897,46 @@ class AgentInstanceControllerTest extends RestControllerTest {
           "producedAt": "2025-06-01T12:00:00Z"
         }
         """
-            .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY);
+              .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY);
 
-    // when / then
-    webClient
-        .post()
-        .uri(AGENT_INSTANCES_URL + "/%d/history".formatted(AGENT_INSTANCE_KEY))
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(requestBody)
-        .exchange()
-        .expectStatus()
-        .isCreated();
+      // when / then
+      webClient
+          .post()
+          .uri(AGENT_INSTANCES_URL + "/%d/history".formatted(AGENT_INSTANCE_KEY))
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(requestBody)
+          .exchange()
+          .expectStatus()
+          .isCreated();
 
-    verify(agentHistoryServices)
-        .createAgentHistoryItem(
-            assertArg(
-                record -> {
-                  assertThat(record.getLoopIteration()).isEqualTo(2);
-                  assertThat(record.getContent()).hasSize(2);
-                  assertThat(record.getToolCalls()).hasSize(1);
-                  assertThat(record.getToolCalls().get(0).getToolCallId()).isEqualTo("tc-001");
-                  assertThat(record.getToolCalls().get(0).getToolName()).isEqualTo("extract_data");
-                  assertThat(record.getMetrics().getInputTokens()).isEqualTo(512L);
-                  assertThat(record.getMetrics().getOutputTokens()).isEqualTo(128L);
-                  assertThat(record.getMetrics().getDurationMs()).isEqualTo(1500L);
-                }),
-            any());
-  }
+      verify(agentHistoryServices)
+          .createAgentHistoryItem(
+              assertArg(
+                  record -> {
+                    assertThat(record.getLoopIteration()).isEqualTo(2);
+                    assertThat(record.getContent()).hasSize(2);
+                    assertThat(record.getToolCalls()).hasSize(1);
+                    assertThat(record.getToolCalls().get(0).getToolCallId()).isEqualTo("tc-001");
+                    assertThat(record.getToolCalls().get(0).getToolName())
+                        .isEqualTo("extract_data");
+                    assertThat(record.getMetrics().getInputTokens()).isEqualTo(512L);
+                    assertThat(record.getMetrics().getOutputTokens()).isEqualTo(128L);
+                    assertThat(record.getMetrics().getDurationMs()).isEqualTo(1500L);
+                  }),
+              any());
+    }
 
-  @Test
-  void shouldCreateAgentHistoryItemWithDocumentContent() {
-    // given
-    final var responseRecord = new AgentHistoryRecord();
-    responseRecord.setAgentHistoryKey(HISTORY_ITEM_KEY);
-    when(agentHistoryServices.createAgentHistoryItem(any(AgentHistoryRecord.class), any()))
-        .thenReturn(CompletableFuture.completedFuture(responseRecord));
+    @Test
+    void shouldCreateAgentHistoryItemWithDocumentContent() {
+      // given
+      final var responseRecord = new AgentHistoryRecord();
+      responseRecord.setAgentHistoryKey(HISTORY_ITEM_KEY);
+      when(agentHistoryServices.createAgentHistoryItem(any(AgentHistoryRecord.class), any()))
+          .thenReturn(CompletableFuture.completedFuture(responseRecord));
 
-    final var requestBody =
-        """
+      final var requestBody =
+          """
         {
           "elementInstanceKey": "%d",
           "jobKey": "%d",
@@ -964,55 +965,57 @@ class AgentInstanceControllerTest extends RestControllerTest {
           "producedAt": "2025-06-01T12:00:00Z"
         }
         """
-            .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY, ELEMENT_INSTANCE_KEY);
+              .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY, ELEMENT_INSTANCE_KEY);
 
-    // when / then
-    webClient
-        .post()
-        .uri(AGENT_INSTANCES_URL + "/%d/history".formatted(AGENT_INSTANCE_KEY))
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(requestBody)
-        .exchange()
-        .expectStatus()
-        .isCreated();
+      // when / then
+      webClient
+          .post()
+          .uri(AGENT_INSTANCES_URL + "/%d/history".formatted(AGENT_INSTANCE_KEY))
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(requestBody)
+          .exchange()
+          .expectStatus()
+          .isCreated();
 
-    verify(agentHistoryServices)
-        .createAgentHistoryItem(
-            assertArg(
-                record -> {
-                  assertThat(record.getContent()).hasSize(1);
-                  final var docContent = record.getContent().get(0);
-                  assertThat(docContent.getContentType())
-                      .isEqualTo(AgentHistoryContentType.DOCUMENT);
-                  final var docRef = docContent.getDocumentReference();
-                  assertThat(docRef.getDocumentId()).isEqualTo("doc-abc");
-                  assertThat(docRef.getStoreId()).isEqualTo("store-1");
-                  assertThat(docRef.getContentHash()).isEqualTo("sha256:deadbeef");
-                  final var meta = docRef.getMetadata();
-                  assertThat(meta.getContentType()).isEqualTo("application/pdf");
-                  assertThat(meta.getFileName()).isEqualTo("invoice.pdf");
-                  assertThat(meta.getExpiresAt())
-                      .isEqualTo(
-                          OffsetDateTime.parse("2025-12-31T23:59:59Z").toInstant().toEpochMilli());
-                  assertThat(meta.getSize()).isEqualTo(12345L);
-                  assertThat(meta.getProcessDefinitionId()).isEqualTo("invoice-process");
-                  assertThat(meta.getProcessInstanceKey()).isEqualTo(ELEMENT_INSTANCE_KEY);
-                  assertThat(meta.getCustomProperties()).containsEntry("source", "email");
-                }),
-            any());
-  }
+      verify(agentHistoryServices)
+          .createAgentHistoryItem(
+              assertArg(
+                  record -> {
+                    assertThat(record.getContent()).hasSize(1);
+                    final var docContent = record.getContent().get(0);
+                    assertThat(docContent.getContentType())
+                        .isEqualTo(AgentHistoryContentType.DOCUMENT);
+                    final var docRef = docContent.getDocumentReference();
+                    assertThat(docRef.getDocumentId()).isEqualTo("doc-abc");
+                    assertThat(docRef.getStoreId()).isEqualTo("store-1");
+                    assertThat(docRef.getContentHash()).isEqualTo("sha256:deadbeef");
+                    final var meta = docRef.getMetadata();
+                    assertThat(meta.getContentType()).isEqualTo("application/pdf");
+                    assertThat(meta.getFileName()).isEqualTo("invoice.pdf");
+                    assertThat(meta.getExpiresAt())
+                        .isEqualTo(
+                            OffsetDateTime.parse("2025-12-31T23:59:59Z")
+                                .toInstant()
+                                .toEpochMilli());
+                    assertThat(meta.getSize()).isEqualTo(12345L);
+                    assertThat(meta.getProcessDefinitionId()).isEqualTo("invoice-process");
+                    assertThat(meta.getProcessInstanceKey()).isEqualTo(ELEMENT_INSTANCE_KEY);
+                    assertThat(meta.getCustomProperties()).containsEntry("source", "email");
+                  }),
+              any());
+    }
 
-  @Test
-  void shouldCreateAgentHistoryItemWithNonMapObjectContent() {
-    // given
-    final var responseRecord = new AgentHistoryRecord();
-    responseRecord.setAgentHistoryKey(HISTORY_ITEM_KEY);
-    when(agentHistoryServices.createAgentHistoryItem(any(AgentHistoryRecord.class), any()))
-        .thenReturn(CompletableFuture.completedFuture(responseRecord));
+    @Test
+    void shouldCreateAgentHistoryItemWithNonMapObjectContent() {
+      // given
+      final var responseRecord = new AgentHistoryRecord();
+      responseRecord.setAgentHistoryKey(HISTORY_ITEM_KEY);
+      when(agentHistoryServices.createAgentHistoryItem(any(AgentHistoryRecord.class), any()))
+          .thenReturn(CompletableFuture.completedFuture(responseRecord));
 
-    final var requestBody =
-        """
+      final var requestBody =
+          """
         {
           "elementInstanceKey": "%d",
           "jobKey": "%d",
@@ -1025,55 +1028,55 @@ class AgentInstanceControllerTest extends RestControllerTest {
           "producedAt": "2025-06-01T12:00:00Z"
         }
         """
-            .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY);
+              .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY);
 
-    // when / then
-    webClient
-        .post()
-        .uri(AGENT_INSTANCES_URL + "/%d/history".formatted(AGENT_INSTANCE_KEY))
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(requestBody)
-        .exchange()
-        .expectStatus()
-        .isCreated();
+      // when / then
+      webClient
+          .post()
+          .uri(AGENT_INSTANCES_URL + "/%d/history".formatted(AGENT_INSTANCE_KEY))
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(requestBody)
+          .exchange()
+          .expectStatus()
+          .isCreated();
 
-    verify(agentHistoryServices)
-        .createAgentHistoryItem(
-            assertArg(
-                record -> {
-                  assertThat(record.getContent()).hasSize(2);
-                  final var arrayContent = record.getContent().get(0);
-                  assertThat(arrayContent.getContentType())
-                      .isEqualTo(AgentHistoryContentType.OBJECT);
-                  assertThat(arrayContent.getObject()).isEqualTo(List.of(10, 20, 30));
-                  final var scalarContent = record.getContent().get(1);
-                  assertThat(scalarContent.getContentType())
-                      .isEqualTo(AgentHistoryContentType.OBJECT);
-                  assertThat(scalarContent.getObject()).isEqualTo(42);
-                }),
-            any());
-  }
+      verify(agentHistoryServices)
+          .createAgentHistoryItem(
+              assertArg(
+                  record -> {
+                    assertThat(record.getContent()).hasSize(2);
+                    final var arrayContent = record.getContent().get(0);
+                    assertThat(arrayContent.getContentType())
+                        .isEqualTo(AgentHistoryContentType.OBJECT);
+                    assertThat(arrayContent.getObject()).isEqualTo(List.of(10, 20, 30));
+                    final var scalarContent = record.getContent().get(1);
+                    assertThat(scalarContent.getContentType())
+                        .isEqualTo(AgentHistoryContentType.OBJECT);
+                    assertThat(scalarContent.getObject()).isEqualTo(42);
+                  }),
+              any());
+    }
 
-  @ParameterizedTest(name = "[{index}] {0}")
-  @MethodSource("invalidHistoryItemRequests")
-  void shouldRejectInvalidHistoryItemRequest(
-      final HistoryItemRequest request, final String expectedDetail) {
-    // when / then
-    webClient
-        .post()
-        .uri(AGENT_INSTANCES_URL + "/%s/history".formatted(request.agentInstanceKeyPath()))
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request.requestBody())
-        .exchange()
-        .expectStatus()
-        .isBadRequest()
-        .expectHeader()
-        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
-        .expectBody()
-        .json(
-            """
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("invalidHistoryItemRequests")
+    void shouldRejectInvalidHistoryItemRequest(
+        final HistoryItemRequest request, final String expectedDetail) {
+      // when / then
+      webClient
+          .post()
+          .uri(AGENT_INSTANCES_URL + "/%s/history".formatted(request.agentInstanceKeyPath()))
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request.requestBody())
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectHeader()
+          .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+          .expectBody()
+          .json(
+              """
             {
               "type": "about:blank",
               "title": "INVALID_ARGUMENT",
@@ -1082,16 +1085,16 @@ class AgentInstanceControllerTest extends RestControllerTest {
               "instance": "/v2/agent-instances/%s/history"
             }
             """
-                .formatted(expectedDetail, request.agentInstanceKeyPath()),
-            JsonCompareMode.STRICT);
+                  .formatted(expectedDetail, request.agentInstanceKeyPath()),
+              JsonCompareMode.STRICT);
 
-    verifyNoInteractions(agentHistoryServices);
-  }
+      verifyNoInteractions(agentHistoryServices);
+    }
 
-  static Stream<Arguments> invalidHistoryItemRequests() {
-    final String validKey = String.valueOf(AGENT_INSTANCE_KEY);
-    final String validBody =
-        """
+    static Stream<Arguments> invalidHistoryItemRequests() {
+      final String validKey = String.valueOf(AGENT_INSTANCE_KEY);
+      final String validBody =
+          """
         {
           "elementInstanceKey": "%d",
           "jobKey": "%d",
@@ -1101,23 +1104,23 @@ class AgentInstanceControllerTest extends RestControllerTest {
           "producedAt": "2025-06-01T12:00:00Z"
         }
         """
-            .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY);
+              .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY);
 
-    return Stream.of(
-        Arguments.of(
-            named("zero agentInstanceKey", new HistoryItemRequest("0", validBody)),
-            "The value for agentInstanceKey is '0' but must be > 0."),
-        Arguments.of(
-            named("non-numeric agentInstanceKey", new HistoryItemRequest("not-a-key", validBody)),
-            "The provided agentInstanceKey 'not-a-key' is not a valid key."
-                + " Expected a numeric value."
-                + " Did you pass an entity id instead of an entity key?."),
-        Arguments.of(
-            named(
-                "missing elementInstanceKey",
-                new HistoryItemRequest(
-                    validKey,
-                    """
+      return Stream.of(
+          Arguments.of(
+              named("zero agentInstanceKey", new HistoryItemRequest("0", validBody)),
+              "The value for agentInstanceKey is '0' but must be > 0."),
+          Arguments.of(
+              named("non-numeric agentInstanceKey", new HistoryItemRequest("not-a-key", validBody)),
+              "The provided agentInstanceKey 'not-a-key' is not a valid key."
+                  + " Expected a numeric value."
+                  + " Did you pass an entity id instead of an entity key?."),
+          Arguments.of(
+              named(
+                  "missing elementInstanceKey",
+                  new HistoryItemRequest(
+                      validKey,
+                      """
                     {
                       "jobKey": "%d",
                       "jobLease": "lease-abc",
@@ -1126,14 +1129,14 @@ class AgentInstanceControllerTest extends RestControllerTest {
                       "producedAt": "2025-06-01T12:00:00Z"
                     }
                     """
-                        .formatted(JOB_KEY))),
-            "No elementInstanceKey provided."),
-        Arguments.of(
-            named(
-                "zero elementInstanceKey",
-                new HistoryItemRequest(
-                    validKey,
-                    """
+                          .formatted(JOB_KEY))),
+              "No elementInstanceKey provided."),
+          Arguments.of(
+              named(
+                  "zero elementInstanceKey",
+                  new HistoryItemRequest(
+                      validKey,
+                      """
                     {
                       "elementInstanceKey": "0",
                       "jobKey": "%d",
@@ -1143,14 +1146,14 @@ class AgentInstanceControllerTest extends RestControllerTest {
                       "producedAt": "2025-06-01T12:00:00Z"
                     }
                     """
-                        .formatted(JOB_KEY))),
-            "The value for elementInstanceKey is '0' but must be > 0."),
-        Arguments.of(
-            named(
-                "missing jobKey",
-                new HistoryItemRequest(
-                    validKey,
-                    """
+                          .formatted(JOB_KEY))),
+              "The value for elementInstanceKey is '0' but must be > 0."),
+          Arguments.of(
+              named(
+                  "missing jobKey",
+                  new HistoryItemRequest(
+                      validKey,
+                      """
                     {
                       "elementInstanceKey": "%d",
                       "jobLease": "lease-abc",
@@ -1159,14 +1162,14 @@ class AgentInstanceControllerTest extends RestControllerTest {
                       "producedAt": "2025-06-01T12:00:00Z"
                     }
                     """
-                        .formatted(ELEMENT_INSTANCE_KEY))),
-            "No jobKey provided."),
-        Arguments.of(
-            named(
-                "missing role",
-                new HistoryItemRequest(
-                    validKey,
-                    """
+                          .formatted(ELEMENT_INSTANCE_KEY))),
+              "No jobKey provided."),
+          Arguments.of(
+              named(
+                  "missing role",
+                  new HistoryItemRequest(
+                      validKey,
+                      """
                     {
                       "elementInstanceKey": "%d",
                       "jobKey": "%d",
@@ -1175,14 +1178,14 @@ class AgentInstanceControllerTest extends RestControllerTest {
                       "producedAt": "2025-06-01T12:00:00Z"
                     }
                     """
-                        .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
-            "No role provided."),
-        Arguments.of(
-            named(
-                "missing producedAt",
-                new HistoryItemRequest(
-                    validKey,
-                    """
+                          .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
+              "No role provided."),
+          Arguments.of(
+              named(
+                  "missing producedAt",
+                  new HistoryItemRequest(
+                      validKey,
+                      """
                     {
                       "elementInstanceKey": "%d",
                       "jobKey": "%d",
@@ -1191,14 +1194,14 @@ class AgentInstanceControllerTest extends RestControllerTest {
                       "content": [{ "contentType": "TEXT", "text": "hello" }]
                     }
                     """
-                        .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
-            "No producedAt provided."),
-        Arguments.of(
-            named(
-                "invalid producedAt format",
-                new HistoryItemRequest(
-                    validKey,
-                    """
+                          .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
+              "No producedAt provided."),
+          Arguments.of(
+              named(
+                  "invalid producedAt format",
+                  new HistoryItemRequest(
+                      validKey,
+                      """
                     {
                       "elementInstanceKey": "%d",
                       "jobKey": "%d",
@@ -1208,15 +1211,15 @@ class AgentInstanceControllerTest extends RestControllerTest {
                       "producedAt": "not-a-date"
                     }
                     """
-                        .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
-            "The provided producedAt 'not-a-date' cannot be parsed as a date"
-                + " according to RFC 3339, section 5.6."),
-        Arguments.of(
-            named(
-                "invalid document metadata expiresAt format",
-                new HistoryItemRequest(
-                    validKey,
-                    """
+                          .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
+              "The provided producedAt 'not-a-date' cannot be parsed as a date"
+                  + " according to RFC 3339, section 5.6."),
+          Arguments.of(
+              named(
+                  "invalid document metadata expiresAt format",
+                  new HistoryItemRequest(
+                      validKey,
+                      """
                     {
                       "elementInstanceKey": "%d",
                       "jobKey": "%d",
@@ -1242,15 +1245,15 @@ class AgentInstanceControllerTest extends RestControllerTest {
                       "producedAt": "2025-06-01T12:00:00Z"
                     }
                     """
-                        .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
-            "The provided content[0].documentReference.metadata.expiresAt 'not-a-date'"
-                + " cannot be parsed as a date according to RFC 3339, section 5.6."),
-        Arguments.of(
-            named(
-                "TEXT content missing text field",
-                new HistoryItemRequest(
-                    validKey,
-                    """
+                          .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
+              "The provided content[0].documentReference.metadata.expiresAt 'not-a-date'"
+                  + " cannot be parsed as a date according to RFC 3339, section 5.6."),
+          Arguments.of(
+              named(
+                  "TEXT content missing text field",
+                  new HistoryItemRequest(
+                      validKey,
+                      """
                     {
                       "elementInstanceKey": "%d",
                       "jobKey": "%d",
@@ -1259,14 +1262,14 @@ class AgentInstanceControllerTest extends RestControllerTest {
                       "producedAt": "2025-06-01T12:00:00Z"
                     }
                     """
-                        .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
-            "No content[0].text provided."),
-        Arguments.of(
-            named(
-                "DOCUMENT content missing documentReference",
-                new HistoryItemRequest(
-                    validKey,
-                    """
+                          .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
+              "No content[0].text provided."),
+          Arguments.of(
+              named(
+                  "DOCUMENT content missing documentReference",
+                  new HistoryItemRequest(
+                      validKey,
+                      """
                     {
                       "elementInstanceKey": "%d",
                       "jobKey": "%d",
@@ -1275,14 +1278,14 @@ class AgentInstanceControllerTest extends RestControllerTest {
                       "producedAt": "2025-06-01T12:00:00Z"
                     }
                     """
-                        .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
-            "No content[0].documentReference provided."),
-        Arguments.of(
-            named(
-                "OBJECT content missing object field",
-                new HistoryItemRequest(
-                    validKey,
-                    """
+                          .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
+              "No content[0].documentReference provided."),
+          Arguments.of(
+              named(
+                  "OBJECT content missing object field",
+                  new HistoryItemRequest(
+                      validKey,
+                      """
                     {
                       "elementInstanceKey": "%d",
                       "jobKey": "%d",
@@ -1291,14 +1294,14 @@ class AgentInstanceControllerTest extends RestControllerTest {
                       "producedAt": "2025-06-01T12:00:00Z"
                     }
                     """
-                        .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
-            "No content[0].object provided."),
-        Arguments.of(
-            named(
-                "DOCUMENT content with missing documentId",
-                new HistoryItemRequest(
-                    validKey,
-                    """
+                          .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
+              "No content[0].object provided."),
+          Arguments.of(
+              named(
+                  "DOCUMENT content with missing documentId",
+                  new HistoryItemRequest(
+                      validKey,
+                      """
                     {
                       "elementInstanceKey": "%d",
                       "jobKey": "%d",
@@ -1307,24 +1310,24 @@ class AgentInstanceControllerTest extends RestControllerTest {
                       "producedAt": "2025-06-01T12:00:00Z"
                     }
                     """
-                        .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
-            "No content[0].documentReference.documentId provided."));
-  }
+                          .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
+              "No content[0].documentReference.documentId provided."));
+    }
 
-  @Test
-  void shouldReturn5xxOnHistoryItemServiceError() {
-    // given
-    when(agentHistoryServices.createAgentHistoryItem(any(AgentHistoryRecord.class), any()))
-        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("broker unavailable")));
+    @Test
+    void shouldReturn5xxOnHistoryItemServiceError() {
+      // given
+      when(agentHistoryServices.createAgentHistoryItem(any(AgentHistoryRecord.class), any()))
+          .thenReturn(CompletableFuture.failedFuture(new RuntimeException("broker unavailable")));
 
-    // when / then
-    webClient
-        .post()
-        .uri(AGENT_INSTANCES_URL + "/%d/history".formatted(AGENT_INSTANCE_KEY))
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(
-            """
+      // when / then
+      webClient
+          .post()
+          .uri(AGENT_INSTANCES_URL + "/%d/history".formatted(AGENT_INSTANCE_KEY))
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(
+              """
             {
               "elementInstanceKey": "%d",
               "jobKey": "%d",
@@ -1334,13 +1337,13 @@ class AgentInstanceControllerTest extends RestControllerTest {
               "producedAt": "2025-06-01T12:00:00Z"
             }
             """
-                .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))
-        .exchange()
-        .expectStatus()
-        .is5xxServerError();
-  }
+                  .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))
+          .exchange()
+          .expectStatus()
+          .is5xxServerError();
+    }
 
-  private record HistoryItemRequest(String agentInstanceKeyPath, String requestBody) {}
+    private record HistoryItemRequest(String agentInstanceKeyPath, String requestBody) {}
   }
 
   private record UpdateRequest(long agentInstanceKey, String requestBody) {}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -911,6 +911,153 @@ class AgentInstanceControllerTest extends RestControllerTest {
     }
 
     @Test
+    void shouldAcceptHistoryBatchWithoutJobLease() {
+      // given
+      final var responseRecord = new AgentInstanceRecord();
+      responseRecord.addHistoryItem(
+          new AgentHistoryRecord().setAgentHistoryKey(HISTORY_ITEM_KEY_1));
+      responseRecord.addHistoryItem(
+          new AgentHistoryRecord().setAgentHistoryKey(HISTORY_ITEM_KEY_2));
+      when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
+          .thenReturn(CompletableFuture.completedFuture(responseRecord));
+
+      final var requestBody =
+          """
+          {
+            "elementInstanceKey": "%d",
+            "jobKey": "%d",
+            "history": [
+              %s,
+              %s
+            ]
+          }
+          """
+              .formatted(
+                  ELEMENT_INSTANCE_KEY,
+                  JOB_KEY,
+                  historyItemJson("item-1", "USER", "hello"),
+                  historyItemJson("item-2", "ASSISTANT", "hi there"));
+
+      // when / then
+      webClient
+          .patch()
+          .uri(AGENT_INSTANCES_URL + "/%d".formatted(AGENT_INSTANCE_KEY))
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(requestBody)
+          .exchange()
+          .expectStatus()
+          .isOk()
+          .expectBody()
+          .json(
+              """
+              {
+                "createdHistory": [
+                  { "historyItemKey": "%d", "isDuplicate": false },
+                  { "historyItemKey": "%d", "isDuplicate": false }
+                ]
+              }
+              """
+                  .formatted(HISTORY_ITEM_KEY_1, HISTORY_ITEM_KEY_2),
+              JsonCompareMode.STRICT);
+
+      verify(agentInstanceServices)
+          .updateAgentInstance(
+              assertArg(
+                  record -> {
+                    assertThat(record.getJobKey()).isEqualTo(JOB_KEY);
+                    assertThat(record.getJobLease()).isEmpty();
+                    assertThat(record.getHistory()).hasSize(2);
+                  }),
+              any());
+    }
+
+    @Test
+    void shouldReturn200WhenHistoryBatchCombinedWithStatusMetricsAndTools() {
+      // given
+      final var responseRecord = new AgentInstanceRecord();
+      responseRecord.addHistoryItem(
+          new AgentHistoryRecord().setAgentHistoryKey(HISTORY_ITEM_KEY_1));
+      responseRecord.addHistoryItem(
+          new AgentHistoryRecord().setAgentHistoryKey(HISTORY_ITEM_KEY_2));
+      when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
+          .thenReturn(CompletableFuture.completedFuture(responseRecord));
+
+      final var requestBody =
+          """
+          {
+            "elementInstanceKey": "%d",
+            "status": "THINKING",
+            "metrics": {
+              "inputTokens": 1000,
+              "outputTokens": 500,
+              "modelCalls": 3,
+              "toolCalls": 7
+            },
+            "tools": [
+              {
+                "name": "searchDatabase",
+                "description": "Searches the database",
+                "elementId": "searchTask"
+              }
+            ],
+            "jobKey": "%d",
+            "jobLease": "lease-abc",
+            "history": [
+              %s,
+              %s
+            ]
+          }
+          """
+              .formatted(
+                  ELEMENT_INSTANCE_KEY,
+                  JOB_KEY,
+                  historyItemJson("item-1", "USER", "hello"),
+                  historyItemJson("item-2", "ASSISTANT", "hi there"));
+
+      // when / then
+      webClient
+          .patch()
+          .uri(AGENT_INSTANCES_URL + "/%d".formatted(AGENT_INSTANCE_KEY))
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(requestBody)
+          .exchange()
+          .expectStatus()
+          .isOk()
+          .expectBody()
+          .json(
+              """
+              {
+                "createdHistory": [
+                  { "historyItemKey": "%d", "isDuplicate": false },
+                  { "historyItemKey": "%d", "isDuplicate": false }
+                ]
+              }
+              """
+                  .formatted(HISTORY_ITEM_KEY_1, HISTORY_ITEM_KEY_2),
+              JsonCompareMode.STRICT);
+
+      verify(agentInstanceServices)
+          .updateAgentInstance(
+              assertArg(
+                  record -> {
+                    assertThat(record.getStatus().name()).isEqualTo("THINKING");
+                    assertThat(record.getMetrics().getInputTokens()).isEqualTo(1000L);
+                    assertThat(record.getTools()).hasSize(1);
+                    assertThat(record.getTools().get(0).getName()).isEqualTo("searchDatabase");
+                    assertThat(record.getJobKey()).isEqualTo(JOB_KEY);
+                    assertThat(record.getJobLease()).isEqualTo("lease-abc");
+                    assertThat(record.getHistory()).hasSize(2);
+                    assertThat(record.getHistory().get(0).getHistoryItemId()).isEqualTo("item-1");
+                    assertThat(record.getHistory().get(1).getHistoryItemId()).isEqualTo("item-2");
+                    assertThat(record.getChangedAttributes())
+                        .containsExactlyInAnyOrder("status", "metrics", "tools");
+                  }),
+              any());
+    }
+
+    @Test
     void shouldReturnEmptyCreatedHistoryWhenHistoryIsEmptyArray() {
       // given
       when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -49,7 +50,6 @@ class AgentInstanceControllerTest extends RestControllerTest {
   private static final long ELEMENT_INSTANCE_KEY = 2251799813685248L;
   private static final long AGENT_INSTANCE_KEY = 9007199254741017L;
   private static final long JOB_KEY = 2251799813685249L;
-  private static final long HISTORY_ITEM_KEY = 9007199254741018L;
 
   @MockitoBean private AgentInstanceServices agentInstanceServices;
   @MockitoBean private AgentHistoryServices agentHistoryServices;
@@ -800,7 +800,10 @@ class AgentInstanceControllerTest extends RestControllerTest {
         .is5xxServerError();
   }
 
-  // --------------------------------- history item tests -----------------------------------------
+  @Nested
+  class CreateHistoryItemTest {
+
+  private static final long HISTORY_ITEM_KEY = 9007199254741018L;
 
   @Test
   void shouldCreateAgentHistoryItemWithTextContent() {
@@ -1337,7 +1340,8 @@ class AgentInstanceControllerTest extends RestControllerTest {
         .is5xxServerError();
   }
 
-  private record UpdateRequest(long agentInstanceKey, String requestBody) {}
-
   private record HistoryItemRequest(String agentInstanceKeyPath, String requestBody) {}
+  }
+
+  private record UpdateRequest(long agentInstanceKey, String requestBody) {}
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -842,11 +842,18 @@ class AgentInstanceControllerTest extends RestControllerTest {
       // given
       final var responseRecord = new AgentInstanceRecord();
       responseRecord.addHistoryItem(
-          new AgentHistoryRecord().setAgentHistoryKey(HISTORY_ITEM_KEY_1));
+          new AgentHistoryRecord()
+              .setAgentHistoryKey(HISTORY_ITEM_KEY_1)
+              .setHistoryItemId("item-1"));
       responseRecord.addHistoryItem(
-          new AgentHistoryRecord().setAgentHistoryKey(HISTORY_ITEM_KEY_2).setDuplicate(true));
+          new AgentHistoryRecord()
+              .setAgentHistoryKey(HISTORY_ITEM_KEY_2)
+              .setHistoryItemId("item-2")
+              .setDuplicate(true));
       responseRecord.addHistoryItem(
-          new AgentHistoryRecord().setAgentHistoryKey(HISTORY_ITEM_KEY_3));
+          new AgentHistoryRecord()
+              .setAgentHistoryKey(HISTORY_ITEM_KEY_3)
+              .setHistoryItemId("item-3"));
       when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
           .thenReturn(CompletableFuture.completedFuture(responseRecord));
 
@@ -885,9 +892,9 @@ class AgentInstanceControllerTest extends RestControllerTest {
               """
               {
                 "createdHistory": [
-                  { "historyItemKey": "%d", "isDuplicate": false },
-                  { "historyItemKey": "%d", "isDuplicate": true },
-                  { "historyItemKey": "%d", "isDuplicate": false }
+                  { "historyItemId": "item-1", "historyItemKey": "%d", "isDuplicate": false },
+                  { "historyItemId": "item-2", "historyItemKey": "%d", "isDuplicate": true },
+                  { "historyItemId": "item-3", "historyItemKey": "%d", "isDuplicate": false }
                 ]
               }
               """
@@ -915,9 +922,13 @@ class AgentInstanceControllerTest extends RestControllerTest {
       // given
       final var responseRecord = new AgentInstanceRecord();
       responseRecord.addHistoryItem(
-          new AgentHistoryRecord().setAgentHistoryKey(HISTORY_ITEM_KEY_1));
+          new AgentHistoryRecord()
+              .setAgentHistoryKey(HISTORY_ITEM_KEY_1)
+              .setHistoryItemId("item-1"));
       responseRecord.addHistoryItem(
-          new AgentHistoryRecord().setAgentHistoryKey(HISTORY_ITEM_KEY_2));
+          new AgentHistoryRecord()
+              .setAgentHistoryKey(HISTORY_ITEM_KEY_2)
+              .setHistoryItemId("item-2"));
       when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
           .thenReturn(CompletableFuture.completedFuture(responseRecord));
 
@@ -953,8 +964,8 @@ class AgentInstanceControllerTest extends RestControllerTest {
               """
               {
                 "createdHistory": [
-                  { "historyItemKey": "%d", "isDuplicate": false },
-                  { "historyItemKey": "%d", "isDuplicate": false }
+                  { "historyItemId": "item-1", "historyItemKey": "%d", "isDuplicate": false },
+                  { "historyItemId": "item-2", "historyItemKey": "%d", "isDuplicate": false }
                 ]
               }
               """
@@ -977,9 +988,13 @@ class AgentInstanceControllerTest extends RestControllerTest {
       // given
       final var responseRecord = new AgentInstanceRecord();
       responseRecord.addHistoryItem(
-          new AgentHistoryRecord().setAgentHistoryKey(HISTORY_ITEM_KEY_1));
+          new AgentHistoryRecord()
+              .setAgentHistoryKey(HISTORY_ITEM_KEY_1)
+              .setHistoryItemId("item-1"));
       responseRecord.addHistoryItem(
-          new AgentHistoryRecord().setAgentHistoryKey(HISTORY_ITEM_KEY_2));
+          new AgentHistoryRecord()
+              .setAgentHistoryKey(HISTORY_ITEM_KEY_2)
+              .setHistoryItemId("item-2"));
       when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
           .thenReturn(CompletableFuture.completedFuture(responseRecord));
 
@@ -1030,8 +1045,8 @@ class AgentInstanceControllerTest extends RestControllerTest {
               """
               {
                 "createdHistory": [
-                  { "historyItemKey": "%d", "isDuplicate": false },
-                  { "historyItemKey": "%d", "isDuplicate": false }
+                  { "historyItemId": "item-1", "historyItemKey": "%d", "isDuplicate": false },
+                  { "historyItemId": "item-2", "historyItemKey": "%d", "isDuplicate": false }
                 ]
               }
               """

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceRequestValidatorSpecSyncTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceRequestValidatorSpecSyncTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.gateway.mapping.http.validator.AgentInstanceRequestValidator;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * {@code historyItemId} and {@code loopIteration}'s requiredness on {@code
+ * AgentInstanceHistoryItem} in {@code agent-instances.yaml} is documentation only: like every other
+ * constraint declared there, the generated request model's {@code @NotNull} is not enforced during
+ * deserialization (see the comment on {@link AgentInstanceRequestValidator#validateUpdateRequest}).
+ * {@link AgentInstanceRequestValidator}'s manual null/blank check is the only real enforcement.
+ * This test guards the spec side of that pair: if a future edit removes one of these fields from
+ * {@code AgentInstanceHistoryItem}'s {@code required} list, the published contract would stop
+ * matching a validator that still rejects the request. The validator side needs no guard here --
+ * {@code AgentInstanceRequestValidatorTest} already fails if either rule is relaxed.
+ *
+ * <p>Reads {@code agent-instances.yaml} as plain text (bundled onto this module's classpath by the
+ * {@code zeebe-gateway-protocol} dependency), the same approach as {@link
+ * SecretRequestValidatorSpecSyncTest}, and for the same reason: the file is referenced piecemeal by
+ * {@code rest-api.yaml}, so a full-spec parse does not reliably resolve its schemas.
+ */
+class AgentInstanceRequestValidatorSpecSyncTest {
+
+  private static final String AGENT_INSTANCES_YAML_CLASSPATH_RESOURCE = "v2/agent-instances.yaml";
+  private static final String SCHEMA_UNDER_TEST = "AgentInstanceHistoryItem";
+
+  @ParameterizedTest(name = "{0}")
+  @ValueSource(strings = {"historyItemId", "loopIteration"})
+  void shouldDeclareHistoryItemFieldRequiredInSpec(final String fieldUnderTest) {
+    // given the required: list declared on the AgentInstanceHistoryItem schema in
+    // agent-instances.yaml
+    final var declaredRequired = requiredFieldsOf(schemaUnderTest());
+
+    // then
+    assertThat(declaredRequired)
+        .as(
+            ("Expected the '%s' schema in '%s' to declare '%s' as required, matching the rule"
+                    + " AgentInstanceRequestValidator enforces.")
+                .formatted(
+                    SCHEMA_UNDER_TEST, AGENT_INSTANCES_YAML_CLASSPATH_RESOURCE, fieldUnderTest))
+        .contains(fieldUnderTest);
+  }
+
+  private static List<String> requiredFieldsOf(final String schemaBlock) {
+    final var requiredBlock =
+        Pattern.compile("required:\\n((?:\\s+- \\w+\\n)+)").matcher(schemaBlock);
+    if (!requiredBlock.find()) {
+      throw new AssertionError(
+          "Expected the '%s' schema in '%s' to declare a 'required' list, but none was found."
+              .formatted(SCHEMA_UNDER_TEST, AGENT_INSTANCES_YAML_CLASSPATH_RESOURCE));
+    }
+    final var itemPattern = Pattern.compile("- (\\w+)");
+    final Matcher itemMatcher = itemPattern.matcher(requiredBlock.group(1));
+    final var fields = new java.util.ArrayList<String>();
+    while (itemMatcher.find()) {
+      fields.add(itemMatcher.group(1));
+    }
+    return fields;
+  }
+
+  /**
+   * Slices {@code agent-instances.yaml} down to the {@code AgentInstanceHistoryItem} schema block:
+   * from its declaration to the next top-level ({@code schemaName:}, 4-space indented) schema key.
+   */
+  private static String schemaUnderTest() {
+    final var yaml = agentInstancesYaml();
+    // exact match on "AgentInstanceHistoryItem:" -- the colon excludes the similarly-prefixed
+    // sibling schemas AgentInstanceHistoryItemRequest, AgentInstanceHistoryItemResult, etc.
+    final var start = yaml.indexOf(SCHEMA_UNDER_TEST + ":");
+    if (start < 0) {
+      throw new AssertionError(
+          "Expected '%s' to declare a '%s' schema, but none was found."
+              .formatted(AGENT_INSTANCES_YAML_CLASSPATH_RESOURCE, SCHEMA_UNDER_TEST));
+    }
+    final var nextSchema =
+        Pattern.compile("\\n {4}\\w+:")
+            .matcher(yaml)
+            .region(start + SCHEMA_UNDER_TEST.length(), yaml.length());
+    final var end = nextSchema.find() ? nextSchema.start() : yaml.length();
+    return yaml.substring(start, end);
+  }
+
+  private static String agentInstancesYaml() {
+    try (var in =
+        AgentInstanceRequestValidatorSpecSyncTest.class
+            .getClassLoader()
+            .getResourceAsStream(AGENT_INSTANCES_YAML_CLASSPATH_RESOURCE)) {
+      if (in == null) {
+        throw new AssertionError(
+            "Classpath resource not found: " + AGENT_INSTANCES_YAML_CLASSPATH_RESOURCE);
+      }
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
@@ -71,8 +71,10 @@ public interface AgentHistoryRecordValue extends RecordValue, TenantOwned, Proce
   String getJobLease();
 
   /**
-   * Returns the loopIteration counter: one pass through the agent feedback loop (one LLM call, its
-   * tool dispatches, and their results).
+   * Returns the loopIteration counter. A loop iteration is one pass through an AI agent's loop,
+   * during which the model reasons, selects tools, evaluates the result, and decides whether to
+   * continue. One iteration covers the input for the LLM call, the call itself, and the tools it
+   * dispatches; the results of those tool calls are input to the next iteration.
    */
   int getLoopIteration();
 


### PR DESCRIPTION
## Description

`PATCH /agent-instances/{key}` now accepts a batch of history items in a single request, alongside the existing `status`/`metrics`/`tools` fields, and responds `200` with a `createdHistory[]` entry per submitted item (echoing its `historyItemId`, the assigned key, and whether it was a duplicate). Today, appending history to an agent instance costs several separate round trips per LLM turn because each history item requires its own request; this lets a caller submit a whole turn's worth of history in one call.

This is a REST-layer-only change: request/response schema, validation, and mapping. The engine does not yet process the batch or deduplicate resent items, so until that lands, a batched `PATCH` returns `200` with an **empty** `createdHistory[]` regardless of what was submitted — the array shape and status code are already correct, the population is not. Follow-up e2e verification belongs with the related engine-side issues below, not here.

A few things worth flagging that the diff alone won't make obvious:

- **`204` → `200` is not a breaking change here.** The endpoint has never shipped on a stable release, and this repo's API guidelines already call for `200` whenever a response carries a body — `204` was only ever a placeholder for the no-batch shape.
- **`jobKey` is required only when `history` is non-empty, not unconditionally.** The connector's existing status/metrics/tools-only calls omit it today, so requiring it everywhere now would break them before they've adopted the batch endpoint. Tightening it to unconditional is an expected follow-up once the connectors team has migrated onto it.
- **`AgentInstanceMapper.toUpdateAgentInstanceRecord` deliberately does not add `"history"` to `changedAttributes`.** The processor that applies updates currently only permits `status`/`metrics`/`tools` and would reject anything else. This is a reasonable stance given the engine doesn't process history yet, but it's a design call no test pins down, so flagging it for a second opinion.
- **The three `docs:` commits are unrelated, pre-existing inaccuracies**, not new behavior: a wrong claim about `arguments` being null on `TOOL_RESULT` items (duplicated across four schemas), a backwards `loopIteration` pass-boundary description, and a "connector-side" mischaracterization of `producedAt`. All were noticed while touching the same files for this feature and folded in here rather than opened as separate PRs. Same for the two mechanical `refactor:`/`style:` commits that reindent `AgentInstanceControllerTest` after nesting it — no behavior change, just whitespace.

Out of scope, deliberately: the engine actually processing the batch, per-item deduplication, the Java client (separate stacked PR), a batch size cap (no AC asks for one, and it's not this repo's convention), and persisting/exposing `historyItemId` in secondary storage or the read API.

## Related issues

part of #58793 (1 of 2)
closes #57817 — pre-existing `TOOL_RESULT` `arguments` doc inaccuracy, fixed here as an unrelated `docs:` commit, folded in rather than opened as its own PR.

- Related to #58791 — engine processing of the batch; `createdHistory[]` stays empty until this lands.
- Related to #58792 — per-item deduplication; `isDuplicate` behavior depends on this.
- Related to #58795 — legacy single-item endpoint; tracks tightening `jobKey` to unconditionally required once callers migrate.
- Related to #58794 — planned home for persisting/exposing `historyItemId` in secondary storage.
