### PR TITLE
docs: add missing dry run flag on restore for openapi spec

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -161,6 +161,8 @@ paths:
         or by a time range (`from`/`to`) that selects the backups to restore. This endpoint is only
         accessible while the cluster is in recovery mode; requests are rejected otherwise. The
         request is validated and acknowledged, but the restore itself is performed asynchronously.
+      parameters:
+        - $ref: '#/components/parameters/DryRunParameter'
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Add missing `dryRun` flag in the `cluster.yaml` API spec. The endpoint already supports this but was missed in the docs.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
