### PR TITLE
fix: prevent orphaned suspension state when terminating a suspended instance

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -403,6 +403,15 @@ public final class EventAppliers implements EventApplier {
             multiInstanceState,
             bufferedStartMessageEventStateApplier));
     register(
+        ProcessInstanceIntent.ELEMENT_TERMINATED,
+        3,
+        new ProcessInstanceElementTerminatedV3Applier(
+            elementInstanceState,
+            eventScopeInstanceState,
+            multiInstanceState,
+            bufferedStartMessageEventStateApplier,
+            state.getSuspensionState()));
+    register(
         ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN,
         new ProcessInstanceSequenceFlowTakenApplier(elementInstanceState, processState));
     register(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementTerminatedV3Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementTerminatedV3Applier.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableMultiInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableSuspensionState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+
+/**
+ * Applies state changes for `ProcessInstance:Element_Terminated`.
+ *
+ * <p>Identical to {@link ProcessInstanceElementTerminatedV2Applier}, plus: whenever a process
+ * instance's own root element terminates — including a call activity's child process instance,
+ * which can be suspended independently of its parent — clears any suspension marker and buffered
+ * commands left behind if it was terminated while {@code SUSPENDED} or {@code RESUMING}. Otherwise
+ * that state would remain forever, since only the {@code RESUMED} applier used to clear it. Unlike
+ * the business-id index below, this is intentionally not restricted to instances without a parent
+ * process instance: suspension is not a root-only concept.
+ */
+final class ProcessInstanceElementTerminatedV3Applier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+  private final MutableEventScopeInstanceState eventScopeInstanceState;
+  private final MutableMultiInstanceState multiInstanceState;
+  private final BufferedStartMessageEventStateApplier bufferedStartMessageEventStateApplier;
+  private final MutableSuspensionState suspensionState;
+
+  public ProcessInstanceElementTerminatedV3Applier(
+      final MutableElementInstanceState elementInstanceState,
+      final MutableEventScopeInstanceState eventScopeInstanceState,
+      final MutableMultiInstanceState multiInstanceState,
+      final BufferedStartMessageEventStateApplier bufferedStartMessageEventStateApplier,
+      final MutableSuspensionState suspensionState) {
+    this.elementInstanceState = elementInstanceState;
+    this.eventScopeInstanceState = eventScopeInstanceState;
+    this.multiInstanceState = multiInstanceState;
+    this.bufferedStartMessageEventStateApplier = bufferedStartMessageEventStateApplier;
+    this.suspensionState = suspensionState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceRecord value) {
+
+    bufferedStartMessageEventStateApplier.removeMessageLock(value);
+
+    if (value.getBpmnElementType() == BpmnElementType.MULTI_INSTANCE_BODY) {
+      multiInstanceState.deleteInputCollection(key);
+    }
+
+    eventScopeInstanceState.deleteInstance(key);
+    elementInstanceState.removeInstance(key);
+
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      elementInstanceState.removeRuntimeInstructions(key);
+      suspensionState.removeSuspensionState(key);
+      suspensionState.clearBufferedCommands(key);
+    }
+
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS
+        && !value.hasParentProcessInstance()) {
+      deleteBusinessIdIndex(value);
+    }
+
+    final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
+
+    if (flowScopeInstance == null) {
+      return;
+    }
+
+    final var flowScopeElementType = flowScopeInstance.getValue().getBpmnElementType();
+    manageMultiInstance(flowScopeInstance, flowScopeElementType);
+  }
+
+  private void manageMultiInstance(
+      final ElementInstance flowScopeInstance, final BpmnElementType flowScopeElementType) {
+    if (flowScopeElementType == BpmnElementType.MULTI_INSTANCE_BODY) {
+      // update the numberOfTerminatedInstances of the multi-instance body
+      flowScopeInstance.incrementNumberOfTerminatedElementInstances();
+      elementInstanceState.updateInstance(flowScopeInstance);
+    }
+  }
+
+  private void deleteBusinessIdIndex(final ProcessInstanceRecord value) {
+    final String businessId = value.getBusinessId();
+    if (!businessId.isEmpty()) {
+      elementInstanceState.deleteProcessInstanceKeyMappingByBusinessId(
+          businessId, value.getBpmnProcessId(), value.getTenantId(), value.getProcessInstanceKey());
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspensionGateTest.java
@@ -7,15 +7,22 @@
  */
 package io.camunda.zeebe.engine.processing.processinstance;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,5 +55,90 @@ public final class ProcessInstanceSuspensionGateTest {
             .withElementId(processId)
             .getFirst();
     Assertions.assertThat(terminated.getValue()).hasProcessInstanceKey(processInstanceKey);
+    assertThat(ENGINE.getProcessingState().getSuspensionState().isSuspended(processInstanceKey))
+        .describedAs("terminating a suspended root must clear its suspension marker")
+        .isFalse();
+  }
+
+  @Test
+  public void shouldClearBufferedCommandsWhenCancellingSuspendedProcessInstance() {
+    // given - a suspended instance with a buffered command left over from while it was SUSPENDED
+    // (seeded directly: buffering a real internal command is exercised by other suites, this test
+    // only needs a buffered entry to exist to verify termination cleans it up)
+    final String processId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId).startEvent().userTask().endEvent().done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    final var suspensionState =
+        ((MutableProcessingState) ENGINE.getProcessingState()).getSuspensionState();
+    final long bufferedCommandKey = Long.MAX_VALUE - processInstanceKey;
+    suspensionState.bufferCommand(
+        bufferedCommandKey,
+        new ProcessInstanceBufferedCommandRecord()
+            .setProcessInstanceKey(processInstanceKey)
+            .setCommandKey(bufferedCommandKey));
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then - no orphan buffered command remains for the now-terminated root instance
+    final List<Long> remainingBufferedCommands = new ArrayList<>();
+    suspensionState.visitBufferedCommands(
+        processInstanceKey, (key, command) -> remainingBufferedCommands.add(key));
+    assertThat(remainingBufferedCommands)
+        .describedAs("terminating a suspended root must clear its buffered commands")
+        .isEmpty();
+  }
+
+  @Test
+  public void shouldClearSuspensionStateForCallActivityChildInstanceOnCascadedTermination() {
+    // given - a call activity child instance, suspended independently of its parent (suspension
+    // does not cascade), then terminated as a side effect of the parent being cancelled
+    final String parentProcessId = Strings.newRandomValidBpmnId();
+    final String childProcessId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(childProcessId).startEvent().userTask().endEvent().done())
+        .deploy();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(parentProcessId)
+                .startEvent()
+                .callActivity("call", c -> c.zeebeProcessId(childProcessId))
+                .endEvent()
+                .done())
+        .deploy();
+    final long parentInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(parentProcessId).create();
+    final long childInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withBpmnProcessId(childProcessId)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+    ENGINE.processInstance().withInstanceKey(childInstanceKey).suspend();
+
+    // when - cancelling the root cascades termination down into the suspended child instance
+    ENGINE.processInstance().withInstanceKey(parentInstanceKey).cancel();
+
+    // then
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+        .withProcessInstanceKey(childInstanceKey)
+        .withBpmnProcessId(childProcessId)
+        .withElementType(BpmnElementType.PROCESS)
+        .getFirst();
+    assertThat(ENGINE.getProcessingState().getSuspensionState().isSuspended(childInstanceKey))
+        .describedAs(
+            "terminating a suspended call activity child instance must clear its suspension"
+                + " marker too, since suspension is not restricted to top-level root instances")
+        .isFalse();
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_TERMINATED_v3.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_TERMINATED_v3.golden
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableMultiInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableSuspensionState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+
+/**
+ * Applies state changes for `ProcessInstance:Element_Terminated`.
+ *
+ * <p>Identical to {@link ProcessInstanceElementTerminatedV2Applier}, plus: whenever a process
+ * instance's own root element terminates — including a call activity's child process instance,
+ * which can be suspended independently of its parent — clears any suspension marker and buffered
+ * commands left behind if it was terminated while {@code SUSPENDED} or {@code RESUMING}. Otherwise
+ * that state would remain forever, since only the {@code RESUMED} applier used to clear it. Unlike
+ * the business-id index below, this is intentionally not restricted to instances without a parent
+ * process instance: suspension is not a root-only concept.
+ */
+final class ProcessInstanceElementTerminatedV3Applier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+  private final MutableEventScopeInstanceState eventScopeInstanceState;
+  private final MutableMultiInstanceState multiInstanceState;
+  private final BufferedStartMessageEventStateApplier bufferedStartMessageEventStateApplier;
+  private final MutableSuspensionState suspensionState;
+
+  public ProcessInstanceElementTerminatedV3Applier(
+      final MutableElementInstanceState elementInstanceState,
+      final MutableEventScopeInstanceState eventScopeInstanceState,
+      final MutableMultiInstanceState multiInstanceState,
+      final BufferedStartMessageEventStateApplier bufferedStartMessageEventStateApplier,
+      final MutableSuspensionState suspensionState) {
+    this.elementInstanceState = elementInstanceState;
+    this.eventScopeInstanceState = eventScopeInstanceState;
+    this.multiInstanceState = multiInstanceState;
+    this.bufferedStartMessageEventStateApplier = bufferedStartMessageEventStateApplier;
+    this.suspensionState = suspensionState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceRecord value) {
+
+    bufferedStartMessageEventStateApplier.removeMessageLock(value);
+
+    if (value.getBpmnElementType() == BpmnElementType.MULTI_INSTANCE_BODY) {
+      multiInstanceState.deleteInputCollection(key);
+    }
+
+    eventScopeInstanceState.deleteInstance(key);
+    elementInstanceState.removeInstance(key);
+
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      elementInstanceState.removeRuntimeInstructions(key);
+      suspensionState.removeSuspensionState(key);
+      suspensionState.clearBufferedCommands(key);
+    }
+
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS
+        && !value.hasParentProcessInstance()) {
+      deleteBusinessIdIndex(value);
+    }
+
+    final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
+
+    if (flowScopeInstance == null) {
+      return;
+    }
+
+    final var flowScopeElementType = flowScopeInstance.getValue().getBpmnElementType();
+    manageMultiInstance(flowScopeInstance, flowScopeElementType);
+  }
+
+  private void manageMultiInstance(
+      final ElementInstance flowScopeInstance, final BpmnElementType flowScopeElementType) {
+    if (flowScopeElementType == BpmnElementType.MULTI_INSTANCE_BODY) {
+      // update the numberOfTerminatedInstances of the multi-instance body
+      flowScopeInstance.incrementNumberOfTerminatedElementInstances();
+      elementInstanceState.updateInstance(flowScopeInstance);
+    }
+  }
+
+  private void deleteBusinessIdIndex(final ProcessInstanceRecord value) {
+    final String businessId = value.getBusinessId();
+    if (!businessId.isEmpty()) {
+      elementInstanceState.deleteProcessInstanceKeyMappingByBusinessId(
+          businessId, value.getBpmnProcessId(), value.getTenantId(), value.getProcessInstanceKey());
+    }
+  }
+}


### PR DESCRIPTION
## Description

Terminating a suspended process instance removed the element instance but left the `SUSPENDED_PROCESS_INSTANCES` marker and any `BUFFERED_PROCESS_INSTANCE_COMMANDS` entries behind: only the `RESUMED` applier ever cleared them. Cancellation is already allowed on a suspended instance (`ProcessInstanceCancelProcessor` classifies `CANCEL` as `SuspensionBehavior.PROCESS`), so cancelling while suspended orphaned that state permanently under the now-nonexistent instance key.

`ProcessInstanceElementTerminatedV1Applier`/`V2Applier` already shipped in 8.9.0, so this adds a `V3Applier` rather than editing them: identical logic, plus clearing the suspension marker and buffered commands whenever a process instance's own root element (`BpmnElementType.PROCESS`) terminates.

This clearing is **not** restricted to top-level root instances. `ProcessInstanceSuspendProcessor`/`ResumeProcessor` only reject on `elementInstance.getParentKey() > 0` (flow-scope parent within the instance's own tree) and never check `hasParentProcessInstance()`, so a call activity's child process instance can be suspended independently of its parent (suspension does not cascade) and can hold its own marker/buffered commands under its own key. Cascaded termination of that child (e.g. the true root getting cancelled) needs the same cleanup, one level down — so the suspension-state clearing sits in the branch that already runs unconditionally for any `PROCESS`-type element, separate from the businessId-index deletion right below it, which stays root-only.

Tests (all in `ProcessInstanceSuspensionGateTest`, real `EngineRule` stream-processor pipeline):
- extends the existing cancel-while-suspended test to assert the marker is cleared
- seeds a buffered command and verifies it's cleared on cancel
- suspends a call activity's child instance directly, cancels the parent, and verifies the child's marker clears when termination cascades down to it

No export-layer surface exists for this fix — the affected column families are never read by any exporter.

### Other #57524 preconditions verified, not touched by this PR

- **Jobs of a terminated (suspended) instance are correctly cleaned up.** `BpmnJobBehavior.CANCELABLE_STATES` already includes `State.SUSPENDED`, and `JobCanceledV4Applier` → `DbJobState.cancel`/`delete` is state-agnostic — it deletes the job record, index entries, deadline and backoff regardless of which state the job was in. This is pre-existing behavior from the job-suspension feature, already covered by `JobSuspensionHandoutTest#shouldDeleteParkedJobWhenInstanceIsTerminated`. Not a gap; unaffected by this change.
- **Scaling to a large buffer.** Considered a chunked/paginated discard mirroring the resume-drain design (`DRAIN`/`DRAINED`, see #59816), but this path has a different risk profile: `clearBufferedCommands` never appends log records (it's RocksDB deletes only, no replay, no per-item command), so it cannot hit `ExceededBatchRecordSizeException` and its per-item cost is far cheaper than resume's drain. Decided a chunked discard is over-engineered for now — filed as a forward-looking design note on #57524 in case a future benchmark shows otherwise.

Backport: not applicable — the suspend/resume feature (including these column families) is unreleased, main-only; no stable branch carries it yet.

## Checklist

- [x] Enable backports when necessary — n/a, feature unreleased on any stable branch.
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57524
