### PR TITLE
fix: report completed status for batch operations that match no items

### DIFF
--- a/operate/client/src/App/BatchOperations/BatchItemsCount.test.tsx
+++ b/operate/client/src/App/BatchOperations/BatchItemsCount.test.tsx
@@ -23,6 +23,20 @@ describe('<BatchItemsCount />', () => {
     expect(screen.getByLabelText('not started')).toBeInTheDocument();
   });
 
+  it('should render no items state when the batch operation has no items', () => {
+    render(
+      <BatchItemsCount
+        operationsCompletedCount={0}
+        operationsFailedCount={0}
+        operationsTotalCount={0}
+      />,
+    );
+
+    expect(screen.getByLabelText('no items')).toBeInTheDocument();
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(screen.queryByLabelText('not started')).not.toBeInTheDocument();
+  });
+
   it('should filter out items with 0 count', () => {
     render(
       <BatchItemsCount

--- a/operate/client/src/App/BatchOperations/BatchItemsCount.tsx
+++ b/operate/client/src/App/BatchOperations/BatchItemsCount.tsx
@@ -37,8 +37,9 @@ const BatchItemsCount: React.FC<{
   const pendingCount = operationsTotalCount - successCount - failedCount;
   const hasAnyProgress = successCount > 0 || failedCount > 0;
 
-  if (!hasAnyProgress && pendingCount > 0) {
-    const description = 'not started';
+  if (!hasAnyProgress) {
+    // A retry whose selection contained no instance with an incident ends up with no items at all.
+    const description = pendingCount > 0 ? 'not started' : 'no items';
     return (
       <Tooltip description={description} align="bottom">
         <Item color="var(--cds-status-gray)" aria-label={description}>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationResolveIncidentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationResolveIncidentIT.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.CreateBatchOperationResponse;
 import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.response.BatchOperationItems.BatchOperationItem;
 import io.camunda.client.api.search.response.Incident;
@@ -29,7 +30,9 @@ import io.camunda.qa.util.multidb.MultiDbTest;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.Future;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -202,5 +205,38 @@ public class BatchOperationResolveIncidentIT {
     assertThat(itemKeys).containsExactlyInAnyOrderElementsOf(activeIncidentKeys);
     assertThat(itemsObj.items().stream().map(BatchOperationItem::getStatus).distinct().toList())
         .containsExactly(BatchOperationItemState.COMPLETED);
+  }
+
+  @Test
+  void shouldFinishBatchOperationThatMatchedNoItems() {
+    // given a filter that no process instance can match, so the batch operation gets no items at
+    // all
+    final var unknownProcessDefinitionId = "no-such-process-" + UUID.randomUUID();
+
+    // when
+    final Future<CreateBatchOperationResponse> result =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .resolveIncident()
+            .filter(f -> f.processDefinitionId(unknownProcessDefinitionId))
+            .send();
+
+    // then it is reported as finished, with an end date, instead of staying open forever
+    final var batchOperationKey =
+        assertThat(result)
+            .succeedsWithin(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
+            .actual()
+            .getBatchOperationKey();
+    Awaitility.await("should finish batch operation that matched no items")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var batchOperation =
+                  camundaClient.newBatchOperationGetRequest(batchOperationKey).execute();
+              assertThat(batchOperation.getStatus()).isEqualTo(BatchOperationState.COMPLETED);
+              assertThat(batchOperation.getOperationsTotalCount()).isZero();
+              assertThat(batchOperation.getEndDate()).isNotNull();
+            });
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepository.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.tasks.batchoperations;
 
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
 import io.camunda.webapps.schema.entities.operation.OperationState;
 import java.util.Collection;
 import java.util.List;
@@ -17,10 +18,15 @@ import java.util.concurrent.CompletionStage;
 public interface BatchOperationUpdateRepository extends AutoCloseable {
 
   /**
-   * Returns the list of not finished batch operations. We can use endDate field to distinguish
-   * finished from running.
+   * Returns the not finished batch operations. We can use endDate field to distinguish finished
+   * from running.
+   *
+   * <p>The state and the total operations count are returned alongside the key because a batch
+   * operation with no single operations at all is indistinguishable, from the aggregation alone,
+   * from one whose single operations are simply not in the operation index anymore. See {@link
+   * BatchOperationUpdateTask}.
    */
-  CompletionStage<Collection<String>> getNotFinishedBatchOperations();
+  CompletionStage<Collection<NotFinishedBatchOperation>> getNotFinishedBatchOperations();
 
   /**
    * Counts amount of single operations by state that are included in given batch operations.
@@ -39,6 +45,17 @@ public interface BatchOperationUpdateRepository extends AutoCloseable {
    * @return the number of updated documents
    */
   CompletionStage<Integer> bulkUpdate(List<DocumentUpdate> documentUpdates);
+
+  /**
+   * A batch operation that has no endDate yet, with the two stored fields the update task needs to
+   * decide whether an endDate can be derived for it.
+   *
+   * @param id the batch operation key
+   * @param state the stored state, {@code null} if the document had no readable source
+   * @param operationsTotalCount the number of items the engine selected for this batch operation
+   */
+  record NotFinishedBatchOperation(
+      String id, BatchOperationState state, long operationsTotalCount) {}
 
   /**
    * Represents a specific document store agnostic update to execute.
@@ -74,7 +91,7 @@ public interface BatchOperationUpdateRepository extends AutoCloseable {
   class NoopBatchOperationUpdateRepository implements BatchOperationUpdateRepository {
 
     @Override
-    public CompletionStage<Collection<String>> getNotFinishedBatchOperations() {
+    public CompletionStage<Collection<NotFinishedBatchOperation>> getNotFinishedBatchOperations() {
       return CompletableFuture.completedFuture(List.of());
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTask.java
@@ -8,14 +8,18 @@
 package io.camunda.exporter.tasks.batchoperations;
 
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.DocumentUpdate;
+import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.NotFinishedBatchOperation;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.OperationsAggData;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
 import io.camunda.zeebe.exporter.common.tasks.BackgroundTask;
 import io.camunda.zeebe.util.FunctionUtil;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 
 public class BatchOperationUpdateTask implements BackgroundTask {
@@ -48,15 +52,17 @@ public class BatchOperationUpdateTask implements BackgroundTask {
   }
 
   private CompletionStage<Integer> updateBatchOperations(
-      final Collection<String> batchOperationKeys) {
-    if (batchOperationKeys.isEmpty()) {
+      final Collection<NotFinishedBatchOperation> batchOperations) {
+    if (batchOperations.isEmpty()) {
       return CompletableFuture.completedFuture(NO_UPDATES);
     }
 
+    final var batchOperationKeys =
+        batchOperations.stream().map(NotFinishedBatchOperation::id).toList();
     final var response = batchOperationUpdateRepository.getOperationsCount(batchOperationKeys);
 
     return response
-        .thenApplyAsync(this::collectDocumentUpdates, executor)
+        .thenApplyAsync(counts -> collectDocumentUpdates(batchOperations, counts), executor)
         .thenComposeAsync(batchOperationUpdateRepository::bulkUpdate, executor)
         .thenApplyAsync(
             FunctionUtil.peek(
@@ -66,16 +72,46 @@ public class BatchOperationUpdateTask implements BackgroundTask {
   }
 
   private List<DocumentUpdate> collectDocumentUpdates(
+      final Collection<NotFinishedBatchOperation> batchOperations,
       final List<OperationsAggData> finishedSingleOperationsCount) {
-    return finishedSingleOperationsCount.stream()
-        .map(
-            d ->
-                new DocumentUpdate(
-                    d.batchOperationKey(),
-                    d.getFinishedOperationsCount(),
-                    d.getFailedOperationsCount(),
-                    d.getCompletedOperationsCount(),
-                    d.getTotalOperationsCount()))
-        .toList();
+    final var countsByBatchOperationKey =
+        finishedSingleOperationsCount.stream()
+            .collect(Collectors.toMap(OperationsAggData::batchOperationKey, counts -> counts));
+
+    final var updates = new ArrayList<DocumentUpdate>(batchOperations.size());
+    for (final var batchOperation : batchOperations) {
+      final var counts = countsByBatchOperationKey.get(batchOperation.id());
+      if (counts != null) {
+        updates.add(
+            new DocumentUpdate(
+                batchOperation.id(),
+                counts.getFinishedOperationsCount(),
+                counts.getFailedOperationsCount(),
+                counts.getCompletedOperationsCount(),
+                counts.getTotalOperationsCount()));
+      } else if (canBeFinalizedWithoutOperations(batchOperation)) {
+        updates.add(new DocumentUpdate(batchOperation.id(), 0, 0, 0, 0));
+      }
+    }
+
+    return updates;
+  }
+
+  /**
+   * A batch operation whose item query matched nothing - a retry on instances without an incident,
+   * for example - has no single operations, so it never shows up in the aggregation and its endDate
+   * would never be written. This finalizes it with zeroed counts.
+   *
+   * <p>Any other absent aggregation bucket is left alone. The counts are then merely unknown: the
+   * single operations may not be exported yet, or they may have been archived out of the operation
+   * index, and writing zeros would overwrite counts we never measured. The condition deliberately
+   * mirrors the update script's own guard, so an emitted update always results in an endDate.
+   * Emitting one that does not would keep the batch operation in the selection of every following
+   * run, and a run that reports work never lets the task back off.
+   */
+  private static boolean canBeFinalizedWithoutOperations(
+      final NotFinishedBatchOperation batchOperation) {
+    return batchOperation.state() == BatchOperationState.COMPLETED
+        && batchOperation.operationsTotalCount() == 0;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepository.java
@@ -62,12 +62,15 @@ public class ElasticsearchBatchOperationUpdateRepository extends ElasticsearchRe
   }
 
   @Override
-  public CompletionStage<Collection<String>> getNotFinishedBatchOperations() {
+  public CompletionStage<Collection<NotFinishedBatchOperation>> getNotFinishedBatchOperations() {
     final var request =
         new SearchRequest.Builder()
             .index(batchOperationIndex)
             .query(q -> q.bool(b -> b.mustNot(m -> m.exists(e -> e.field(END_DATE)))));
-    return fetchUnboundedDocumentCollection(request, BatchOperationEntity.class, Hit::id);
+    return fetchUnboundedDocumentCollection(
+        request,
+        BatchOperationEntity.class,
+        ElasticsearchBatchOperationUpdateRepository::toNotFinishedBatchOperation);
   }
 
   @Override
@@ -128,6 +131,17 @@ public class ElasticsearchBatchOperationUpdateRepository extends ElasticsearchRe
               }
               return CompletableFuture.completedFuture(r.items().size());
             });
+  }
+
+  private static NotFinishedBatchOperation toNotFinishedBatchOperation(
+      final Hit<BatchOperationEntity> hit) {
+    final var source = hit.source();
+    if (source == null) {
+      return new NotFinishedBatchOperation(hit.id(), null, 0);
+    }
+    final var totalCount = source.getOperationsTotalCount();
+    return new NotFinishedBatchOperation(
+        hit.id(), source.getState(), totalCount == null ? 0 : totalCount);
   }
 
   private List<OperationsAggData> processAggregations(final SearchResponse<Void> response) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepository.java
@@ -66,12 +66,15 @@ public class OpensearchBatchOperationUpdateRepository extends OpensearchReposito
   }
 
   @Override
-  public CompletionStage<Collection<String>> getNotFinishedBatchOperations() {
+  public CompletionStage<Collection<NotFinishedBatchOperation>> getNotFinishedBatchOperations() {
     final var request =
         new SearchRequest.Builder()
             .index(batchOperationIndex)
             .query(q -> q.bool(b -> b.mustNot(m -> m.exists(e -> e.field(END_DATE)))));
-    return fetchUnboundedDocumentCollection(request, BatchOperationEntity.class, Hit::id);
+    return fetchUnboundedDocumentCollection(
+        request,
+        BatchOperationEntity.class,
+        OpensearchBatchOperationUpdateRepository::toNotFinishedBatchOperation);
   }
 
   @Override
@@ -183,6 +186,17 @@ public class OpensearchBatchOperationUpdateRepository extends OpensearchReposito
                     .lang(ScriptLanguage.builder().builtin(BuiltinScriptLanguage.Painless).build())
                     .params(parameters))
         .build();
+  }
+
+  private static NotFinishedBatchOperation toNotFinishedBatchOperation(
+      final Hit<BatchOperationEntity> hit) {
+    final var source = hit.source();
+    if (source == null) {
+      return new NotFinishedBatchOperation(hit.id(), null, 0);
+    }
+    final var totalCount = source.getOperationsTotalCount();
+    return new NotFinishedBatchOperation(
+        hit.id(), source.getState(), totalCount == null ? 0 : totalCount);
   }
 
   private List<OperationsAggData> processAggregations(final SearchResponse<Void> response) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryIT.java
@@ -18,6 +18,7 @@ import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.DocumentUpdate;
+import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.NotFinishedBatchOperation;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.OperationsAggData;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.schema.SearchEngineClient;
@@ -173,17 +174,34 @@ abstract class BatchOperationUpdateRepositoryIT {
       // then
       assertThat(documents)
           .succeedsWithin(REQUEST_TIMEOUT)
-          .asInstanceOf(InstanceOfAssertFactories.list(String.class))
+          .asInstanceOf(InstanceOfAssertFactories.list(NotFinishedBatchOperation.class))
           .isEmpty();
     }
 
     @Test
-    void shouldReturnBatchOperationIds() throws PersistenceException {
+    void shouldReturnBatchOperationsWithStateAndTotalCount() throws PersistenceException {
       // given
       final var repository = createRepository();
-      createBatchOperationEntity("1", OffsetDateTime.now());
-      createBatchOperationEntity("2", OffsetDateTime.now());
-      final var expected = createBatchOperationEntity("3", null);
+      createBatchOperationEntity("1", OffsetDateTime.now(), BatchOperationState.COMPLETED, 2);
+      createBatchOperationEntity("2", OffsetDateTime.now(), BatchOperationState.COMPLETED, 2);
+      createBatchOperationEntity("3", null, BatchOperationState.ACTIVE, 5);
+
+      // when
+      final var documents = repository.getNotFinishedBatchOperations();
+
+      // then the update task can tell how many items the batch operation has, and whether it is
+      // finished, without a second request
+      assertThat(documents)
+          .succeedsWithin(REQUEST_TIMEOUT)
+          .asInstanceOf(InstanceOfAssertFactories.list(NotFinishedBatchOperation.class))
+          .containsExactly(new NotFinishedBatchOperation("3", BatchOperationState.ACTIVE, 5));
+    }
+
+    @Test
+    void shouldReturnBatchOperationWithoutItems() throws PersistenceException {
+      // given a completed batch operation whose item query matched nothing
+      final var repository = createRepository();
+      createBatchOperationEntity("1", null, BatchOperationState.COMPLETED, 0);
 
       // when
       final var documents = repository.getNotFinishedBatchOperations();
@@ -191,16 +209,22 @@ abstract class BatchOperationUpdateRepositoryIT {
       // then
       assertThat(documents)
           .succeedsWithin(REQUEST_TIMEOUT)
-          .asInstanceOf(InstanceOfAssertFactories.list(String.class))
-          .hasSize(1)
-          .contains(expected.getId());
+          .asInstanceOf(InstanceOfAssertFactories.list(NotFinishedBatchOperation.class))
+          .containsExactly(new NotFinishedBatchOperation("1", BatchOperationState.COMPLETED, 0));
     }
 
-    private BatchOperationEntity createBatchOperationEntity(
-        final String id, final OffsetDateTime endTime) throws PersistenceException {
-      final var batchOperationEntity = new BatchOperationEntity().setId(id).setEndDate(endTime);
-      indexBatchOperation(batchOperationEntity);
-      return batchOperationEntity;
+    private void createBatchOperationEntity(
+        final String id,
+        final OffsetDateTime endTime,
+        final BatchOperationState state,
+        final int operationsTotalCount)
+        throws PersistenceException {
+      indexBatchOperation(
+          new BatchOperationEntity()
+              .setId(id)
+              .setEndDate(endTime)
+              .setState(state)
+              .setOperationsTotalCount(operationsTotalCount));
     }
   }
 
@@ -323,6 +347,27 @@ abstract class BatchOperationUpdateRepositoryIT {
       final BatchOperationEntity batchOperationEntity4 = getBatchOperationEntity("4");
       assertThat(batchOperationEntity4.getEndDate()).isNull();
       assertThat(batchOperationEntity4.getOperationsFinishedCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldSetEndDateOfCompletedBatchOperationWithoutOperations()
+        throws PersistenceException {
+      // given a completed batch operation whose item query matched nothing, so it has no items
+      final var repository = createRepository();
+      createBatchOperationEntity("1", 0, BatchOperationState.COMPLETED);
+
+      // when
+      final var updated = repository.bulkUpdate(List.of(new DocumentUpdate("1", 0, 0, 0, 0)));
+
+      // then
+      assertThat(updated)
+          .succeedsWithin(REQUEST_TIMEOUT)
+          .asInstanceOf(InstanceOfAssertFactories.type(Integer.class))
+          .isEqualTo(1);
+
+      final BatchOperationEntity batchOperationEntity = getBatchOperationEntity("1");
+      assertThat(batchOperationEntity.getEndDate()).isNotNull();
+      assertThat(batchOperationEntity.getOperationsFinishedCount()).isEqualTo(0);
     }
 
     private BatchOperationEntity createBatchOperationEntity(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTaskTest.java
@@ -10,7 +10,9 @@ package io.camunda.exporter.tasks.batchoperations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.DocumentUpdate;
+import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.NotFinishedBatchOperation;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.OperationsAggData;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -44,46 +46,94 @@ public class BatchOperationUpdateTaskTest {
   }
 
   @Test
-  void shouldReturnZeroIfNoDocumentUpdatesRequired() {
-    // given - when
-    repository.batchOperationKeys.add("1");
+  void shouldUpdateCompletedBatchOperationWithoutItemsWithZeroCounts() {
+    // given a completed batch operation whose item query matched nothing, so it has no items and no
+    // single operations
+    repository.batchOperations.add(
+        new NotFinishedBatchOperation("1", BatchOperationState.COMPLETED, 0));
+
+    // when
     final var result = task.execute();
 
-    // then
+    // then it is still updated, which is what sets its end date
+    assertThat(result)
+        .succeedsWithin(REQUEST_TIMEOUT)
+        .asInstanceOf(InstanceOfAssertFactories.type(Integer.class))
+        .isEqualTo(1);
+    assertThat(repository.documentUpdates).containsExactly(new DocumentUpdate("1", 0L, 0L, 0L, 0L));
+  }
+
+  @Test
+  void shouldNotUpdateRunningBatchOperationWithoutSingleOperations() {
+    // given a running batch operation whose single operations are not exported yet
+    repository.batchOperations.add(
+        new NotFinishedBatchOperation("1", BatchOperationState.ACTIVE, 5));
+
+    // when
+    final var result = task.execute();
+
+    // then no zeroed update is written, as it could not set an end date anyway
     assertThat(result)
         .succeedsWithin(REQUEST_TIMEOUT)
         .asInstanceOf(InstanceOfAssertFactories.type(Integer.class))
         .isEqualTo(0);
+    assertThat(repository.documentUpdates).isEmpty();
+  }
+
+  @Test
+  void shouldNotUpdateBatchOperationWithItemsButNoSingleOperationsLeft() {
+    // given a completed batch operation that had items, but whose single operations left the
+    // operation index, for example because they were archived
+    repository.batchOperations.add(
+        new NotFinishedBatchOperation("1", BatchOperationState.COMPLETED, 5));
+
+    // when
+    final var result = task.execute();
+
+    // then its previously written counts are left untouched instead of being zeroed
+    assertThat(result)
+        .succeedsWithin(REQUEST_TIMEOUT)
+        .asInstanceOf(InstanceOfAssertFactories.type(Integer.class))
+        .isEqualTo(0);
+    assertThat(repository.documentUpdates).isEmpty();
   }
 
   @Test
   void shouldUpdateBatchOperations() {
     // given - when
-    repository.batchOperationKeys.add("1");
-    repository.batchOperationKeys.add("2");
-    repository.batchOperationKeys.add("3");
+    repository.batchOperations.add(
+        new NotFinishedBatchOperation("1", BatchOperationState.ACTIVE, 5));
+    repository.batchOperations.add(
+        new NotFinishedBatchOperation("2", BatchOperationState.ACTIVE, 6));
+    repository.batchOperations.add(
+        new NotFinishedBatchOperation("3", BatchOperationState.COMPLETED, 0));
+    repository.batchOperations.add(
+        new NotFinishedBatchOperation("4", BatchOperationState.ACTIVE, 7));
     repository.finishedOperationsCount.add(new OperationsAggData("1", Map.of("COMPLETED", 5L)));
     repository.finishedOperationsCount.add(new OperationsAggData("2", Map.of("COMPLETED", 6L)));
     final var result = task.execute();
 
-    // then
+    // then batch operations with single operations and those completed without items are updated,
+    // while the one whose counts are simply unknown is skipped
     assertThat(result)
         .succeedsWithin(REQUEST_TIMEOUT)
         .asInstanceOf(InstanceOfAssertFactories.type(Integer.class))
-        .isEqualTo(2);
-    assertThat(repository.documentUpdates).hasSize(2);
+        .isEqualTo(3);
     assertThat(repository.documentUpdates)
-        .contains(new DocumentUpdate("1", 5L, 0L, 5L, 5L), new DocumentUpdate("2", 6L, 0L, 6L, 6L));
+        .containsExactlyInAnyOrder(
+            new DocumentUpdate("1", 5L, 0L, 5L, 5L),
+            new DocumentUpdate("2", 6L, 0L, 6L, 6L),
+            new DocumentUpdate("3", 0L, 0L, 0L, 0L));
   }
 
   private static final class TestRepository implements BatchOperationUpdateRepository {
-    List<String> batchOperationKeys = new ArrayList<>();
+    List<NotFinishedBatchOperation> batchOperations = new ArrayList<>();
     List<OperationsAggData> finishedOperationsCount = new ArrayList<>();
     private List<DocumentUpdate> documentUpdates = new ArrayList<>();
 
     @Override
-    public CompletionStage<Collection<String>> getNotFinishedBatchOperations() {
-      return CompletableFuture.completedFuture(batchOperationKeys);
+    public CompletionStage<Collection<NotFinishedBatchOperation>> getNotFinishedBatchOperations() {
+      return CompletableFuture.completedFuture(batchOperations);
     }
 
     @Override


### PR DESCRIPTION
## Description

Follow-up to #56965 review note:  stop an empty retry batch operation being created through the API. 

A batch operation whose item query matches nothing (a retry on instances without an incident, or a single-instance retry of an already-resolved incident) never got an end date on Elasticsearch/OpenSearch: `BatchOperationUpdateTask` derived its updates from an aggregation over the operation index, and with zero items there are no operation documents and therefore no bucket. The document was also re-selected by the task on every run, forever. RDBMS was never affected.

- `BatchOperationUpdateTask` now emits one update per selected batch operation, zeroed when the aggregation has no bucket for it, so the existing Painless script finalizes it. Covers ES and OS; no script or schema change.
- Operate's item summary now renders an explicit "no items" indicator instead of an empty cell when the total is 0.

Creation-time rejection was considered and is not possible, the item query runs asynchronously in the engine after the batch operation key has been returned to the caller.

Not included, both pre-existing and out of scope: `
FAILED` / `PARTIALLY_COMPLETED` batch operations never get an end date on ES/OS either, and `ItemProviderFactory.forResolveIncident` does not pre-filter instances on `hasIncident`.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #40995
