### PR TITLE
Prepare cluster actuator endpoint to send pt-aware response for planned operations

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
@@ -30,10 +31,12 @@ import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PostScalingOp
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PreScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.FixedConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.DeleteHistoryOperation;
@@ -77,6 +80,7 @@ import io.camunda.zeebe.management.cluster.PartitionConfig;
 import io.camunda.zeebe.management.cluster.PartitionDistributionConfig.TypeEnum;
 import io.camunda.zeebe.management.cluster.PartitionState;
 import io.camunda.zeebe.management.cluster.PartitionStateCode;
+import io.camunda.zeebe.management.cluster.PhysicalTenantState;
 import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.management.cluster.RequestHandling;
 import io.camunda.zeebe.management.cluster.RequestHandlingActivePartitions;
@@ -91,6 +95,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedMap;
 import java.util.concurrent.CompletionException;
@@ -175,11 +180,12 @@ final class ClusterApiUtils {
       final ClusterConfigurationChangeResponse response) {
     // response.response() is absent when the responding peer hasn't populated the new
     // multi-partition-group data (e.g. a peer still running old code); fall back to the
-    // legacy plannedChanges in that case.
+    // legacy data in that case.
+    final var multiConfigResponse = response.response();
     final List<Operation> operations =
-        response.response() == null
+        multiConfigResponse == null
             ? mapOperations(response.legacyResponse().plannedChanges())
-            : response.response().phases().stream()
+            : multiConfigResponse.phases().stream()
                 .flatMap(
                     phase ->
                         switch (phase) {
@@ -192,10 +198,18 @@ final class ClusterApiUtils {
                                           mapOperations(entry.getKey(), entry.getValue()).stream());
                         })
                 .toList();
+    final List<BrokerState> currentTopology =
+        multiConfigResponse == null
+            ? mapBrokerStates(response.legacyResponse().currentConfiguration())
+            : mapBrokerStatesFromPhysicalTenantsConfig(multiConfigResponse.currentConfiguration());
+    final List<BrokerState> expectedTopology =
+        multiConfigResponse == null
+            ? mapBrokerStates(response.legacyResponse().expectedConfiguration())
+            : mapBrokerStatesFromPhysicalTenantsConfig(multiConfigResponse.expectedConfiguration());
     return new PlannedOperationsResponse()
         .changeId(response.changeId())
-        .currentTopology(mapBrokerStates(response.legacyResponse().currentConfiguration()))
-        .expectedTopology(mapBrokerStates(response.legacyResponse().expectedConfiguration()))
+        .currentTopology(currentTopology)
+        .expectedTopology(expectedTopology)
         .plannedChanges(operations);
   }
 
@@ -338,6 +352,68 @@ final class ClusterApiUtils {
         .toList();
   }
 
+  /**
+   * Flattens the new multi-partition-group model into the flat {@code BrokerState} list expected by
+   * the REST response: each broker's partitions from every physical tenant it participates in are
+   * merged onto that one broker entry, tagged with their owning tenant.
+   */
+  private static List<BrokerState> mapBrokerStatesFromPhysicalTenantsConfig(
+      final CurrentClusterConfiguration configuration) {
+    final Map<String, PartitionGroupConfiguration> partitionGroups =
+        configuration.partitionGroups();
+    return configuration.globalConfiguration().members().entrySet().stream()
+        .map(
+            entry ->
+                mapBrokerStateFromPhysicalTenantsConfig(
+                    entry.getKey(), entry.getValue(), partitionGroups))
+        .toList();
+  }
+
+  private static BrokerState mapBrokerStateFromPhysicalTenantsConfig(
+      final MemberId memberId,
+      final io.camunda.zeebe.dynamic.config.state.BrokerState brokerState,
+      final Map<String, PartitionGroupConfiguration> partitionGroups) {
+    final List<PartitionState> partitions = new ArrayList<>();
+    final List<PhysicalTenantState> physicalTenants = new ArrayList<>();
+    partitionGroups.forEach(
+        (physicalTenantId, group) -> {
+          final var brokerPartitionState = group.members().get(memberId);
+          if (brokerPartitionState != null) {
+            physicalTenants.add(
+                new PhysicalTenantState()
+                    .id(physicalTenantId)
+                    .mode(mapPhysicalTenantMode(brokerPartitionState.mode())));
+            partitions.addAll(
+                mapPartitionStates(physicalTenantId, brokerPartitionState.partitions()));
+          }
+        });
+    return new BrokerState()
+        .id(brokerIdValue(memberId))
+        .state(mapBrokerLifecycleState(brokerState.state()))
+        .lastUpdatedAt(mapInstantToDateTime(brokerState.lastUpdated()))
+        .version(brokerState.version())
+        .partitions(partitions)
+        .physicalTenants(physicalTenants);
+  }
+
+  private static BrokerStateCode mapBrokerLifecycleState(
+      final io.camunda.zeebe.dynamic.config.state.BrokerState.State state) {
+    return switch (state) {
+      case ACTIVE -> BrokerStateCode.ACTIVE;
+      case JOINING -> BrokerStateCode.JOINING;
+      case LEAVING -> BrokerStateCode.LEAVING;
+      case LEFT -> BrokerStateCode.LEFT;
+      case UNINITIALIZED -> BrokerStateCode.UNKNOWN;
+    };
+  }
+
+  private static PhysicalTenantState.ModeEnum mapPhysicalTenantMode(final Mode mode) {
+    return switch (mode) {
+      case PROCESSING -> PhysicalTenantState.ModeEnum.PROCESSING;
+      case RECOVERING -> PhysicalTenantState.ModeEnum.RECOVERING;
+    };
+  }
+
   private static OffsetDateTime mapInstantToDateTime(final Instant timestamp) {
     // Instant.MIN ("-1000000000-01-01T00:00Z") is not compliant with rfc3339 parsers
     // as year field has is not 4 digits, so we replace here with the min possible.
@@ -360,11 +436,18 @@ final class ClusterApiUtils {
 
   private static List<PartitionState> mapPartitionStates(
       final SortedMap<Integer, io.camunda.zeebe.dynamic.config.state.PartitionState> partitions) {
+    return mapPartitionStates(null, partitions);
+  }
+
+  private static List<PartitionState> mapPartitionStates(
+      final String physicalTenantId,
+      final SortedMap<Integer, io.camunda.zeebe.dynamic.config.state.PartitionState> partitions) {
     return partitions.entrySet().stream()
         .map(
             entry ->
                 new PartitionState()
                     .id(entry.getKey())
+                    .physicalTenant(physicalTenantId)
                     .priority(entry.getValue().priority())
                     .state(mapPartitionState(entry.getValue().state()))
                     .config(mapPartitionConfig(entry.getValue().config())))
@@ -415,7 +498,10 @@ final class ClusterApiUtils {
 
   private static GetTopologyResponse mapClusterTopology(final ClusterConfiguration topology) {
     final var response = new GetTopologyResponse();
-    final List<BrokerState> brokers = mapBrokerStates(topology.members());
+    // temp: convert to new model from legacy, because the query response from the coordinator now
+    // only returns the legacy format.
+    final List<BrokerState> brokers =
+        mapBrokerStatesFromPhysicalTenantsConfig(CurrentClusterConfiguration.fromLegacy(topology));
 
     response.version(topology.version()).brokers(brokers);
     topology.lastChange().ifPresent(change -> response.lastChange(mapCompletedChange(change)));

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.FixedConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.DeleteHistoryOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ExportingStateChangeOperation;
@@ -54,6 +55,8 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOper
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
@@ -170,158 +173,155 @@ final class ClusterApiUtils {
 
   private static PlannedOperationsResponse mapResponseType(
       final ClusterConfigurationChangeResponse response) {
+    // response.response() is absent when the responding peer hasn't populated the new
+    // multi-partition-group data (e.g. a peer still running old code); fall back to the
+    // legacy plannedChanges in that case.
+    final List<Operation> operations =
+        response.response() == null
+            ? mapOperations(response.legacyResponse().plannedChanges())
+            : response.response().phases().stream()
+                .flatMap(
+                    phase ->
+                        switch (phase) {
+                          case final GlobalPhase globalPhase ->
+                              mapOperations(null, globalPhase.operations()).stream();
+                          case final PartitionGroupParallelPhase partitionGroupPhase ->
+                              partitionGroupPhase.groupOperations().entrySet().stream()
+                                  .flatMap(
+                                      entry ->
+                                          mapOperations(entry.getKey(), entry.getValue()).stream());
+                        })
+                .toList();
     return new PlannedOperationsResponse()
         .changeId(response.changeId())
         .currentTopology(mapBrokerStates(response.legacyResponse().currentConfiguration()))
         .expectedTopology(mapBrokerStates(response.legacyResponse().expectedConfiguration()))
-        .plannedChanges(mapOperations(response.legacyResponse().plannedChanges()));
+        .plannedChanges(operations);
   }
 
   private static List<Operation> mapOperations(
       final List<ClusterConfigurationChangeOperation> operations) {
-    return operations.stream().map(ClusterApiUtils::mapOperation).toList();
+    return mapOperations(null, operations);
   }
 
-  static Operation mapOperation(final ClusterConfigurationChangeOperation operation) {
-    return switch (operation) {
-      case final MemberJoinOperation join ->
-          new Operation()
-              .operation(OperationEnum.BROKER_ADD)
-              .brokerId(brokerIdValue(join.memberId()));
-      case final MemberLeaveOperation leave ->
-          new Operation()
-              .operation(OperationEnum.BROKER_REMOVE)
-              .brokerId(brokerIdValue(leave.memberId()));
-      case final PartitionJoinOperation join ->
-          new Operation()
-              .operation(OperationEnum.PARTITION_JOIN)
-              .brokerId(brokerIdValue(join.memberId()))
-              .partitionId(join.partitionId())
-              .priority(join.priority());
-      case final PartitionLeaveOperation leave ->
-          new Operation()
-              .operation(OperationEnum.PARTITION_LEAVE)
-              .brokerId(brokerIdValue(leave.memberId()))
-              .partitionId(leave.partitionId());
-      case final PartitionReconfigurePriorityOperation reconfigure ->
-          new Operation()
-              .operation(OperationEnum.PARTITION_RECONFIGURE_PRIORITY)
-              .brokerId(brokerIdValue(reconfigure.memberId()))
-              .partitionId(reconfigure.partitionId())
-              .priority(reconfigure.priority());
-      case final PartitionForceReconfigureOperation partitionForceReconfigureOperation ->
-          new Operation()
-              .operation(OperationEnum.PARTITION_FORCE_RECONFIGURE)
-              .brokerId(brokerIdValue(partitionForceReconfigureOperation.memberId()))
-              .partitionId(partitionForceReconfigureOperation.partitionId())
-              .brokers(
-                  partitionForceReconfigureOperation.members().stream()
-                      .map(m -> brokerIdValue(m))
-                      .collect(toList()));
-      case final MemberRemoveOperation memberRemoveOperation ->
-          new Operation()
-              .operation(OperationEnum.BROKER_REMOVE)
-              .brokerId(brokerIdValue(memberRemoveOperation.memberId()))
-              .brokers(List.of(brokerIdValue(memberRemoveOperation.memberToRemove())));
-      case final PartitionDisableExporterOperation disableExporterOperation ->
-          new Operation()
-              .operation(OperationEnum.PARTITION_DISABLE_EXPORTER)
-              .brokerId(brokerIdValue(disableExporterOperation.memberId()))
-              .partitionId(disableExporterOperation.partitionId())
-              .exporterId(disableExporterOperation.exporterId());
-      case final PartitionEnableExporterOperation enableExporterOperation ->
-          new Operation()
-              .operation(OperationEnum.PARTITION_ENABLE_EXPORTER)
-              .brokerId(brokerIdValue(enableExporterOperation.memberId()))
-              .partitionId(enableExporterOperation.partitionId())
-              .exporterId(enableExporterOperation.exporterId());
-      case final PartitionDeleteExporterOperation deleteExporterOperation ->
-          new Operation()
-              .operation(OperationEnum.PARTITION_DELETE_EXPORTER)
-              .brokerId(brokerIdValue(deleteExporterOperation.memberId()))
-              .partitionId(deleteExporterOperation.partitionId())
-              .exporterId(deleteExporterOperation.exporterId());
-      case final StartPartitionScaleUp startScaleUp ->
-          new Operation()
-              .operation(OperationEnum.START_PARTITION_SCALE_UP)
-              .brokerId(brokerIdValue(startScaleUp.memberId()));
-      case final PartitionBootstrapOperation bootstrapOperation ->
-          new Operation()
-              .operation(OperationEnum.PARTITION_BOOTSTRAP)
-              .brokerId(brokerIdValue(bootstrapOperation.memberId()))
-              .partitionId(bootstrapOperation.partitionId())
-              .priority(bootstrapOperation.priority());
-      case final PartitionPreRestoreOperation preRestoreOperation ->
-          new Operation()
-              .operation(OperationEnum.PARTITION_PRE_RESTORE)
-              .brokerId(brokerIdValue(preRestoreOperation.memberId()))
-              .partitionId(preRestoreOperation.partitionId());
-      case final PartitionRestoreOperation restoreOperation ->
-          new Operation()
-              .operation(OperationEnum.PARTITION_RESTORE)
-              .brokerId(brokerIdValue(restoreOperation.memberId()))
-              .partitionId(restoreOperation.partitionId());
-      case final DeleteHistoryOperation deleteHistoryOperation ->
-          new Operation().operation(OperationEnum.DELETE_HISTORY);
-      case final AwaitRedistributionCompletion redistributionCompletion ->
-          new Operation()
-              .operation(OperationEnum.AWAIT_REDISTRIBUTION)
-              .brokerId(brokerIdValue(redistributionCompletion.memberId()));
-      case final AwaitRelocationCompletion relocationCompletion ->
-          new Operation()
-              .operation(OperationEnum.AWAIT_RELOCATION)
-              .brokerId(brokerIdValue(relocationCompletion.memberId()));
-      case final UpdateRoutingState updateRoutingState ->
-          new Operation()
-              .operation(OperationEnum.UPDATE_ROUTING_STATE)
-              .brokerId(brokerIdValue(updateRoutingState.memberId()));
-      case final UpdateIncarnationNumberOperation updateIncarnationNumberOperation ->
-          new Operation().operation(OperationEnum.UPDATE_INCARNATION_NUMBER);
-      case final PreScalingOperation preScalingOperation ->
-          new Operation()
-              .operation(OperationEnum.PRE_SCALING)
-              .brokerId(brokerIdValue(preScalingOperation.memberId()))
-              .brokers(
-                  preScalingOperation.clusterMembers().stream()
-                      .map(m -> brokerIdValue(m))
-                      .toList());
-      case final PostScalingOperation postScalingOperation ->
-          new Operation()
-              .operation(OperationEnum.POST_SCALING)
-              .brokerId(brokerIdValue(postScalingOperation.memberId()))
-              .brokers(
-                  postScalingOperation.clusterMembers().stream()
-                      .map(m -> brokerIdValue(m))
-                      .toList());
-      case final UpdatePartitionDistributorConfigOperation
-              updatePartitionDistributorConfigOperation ->
-          new Operation()
-              .brokerId(brokerIdValue(updatePartitionDistributorConfigOperation.memberId()))
-              .operation(OperationEnum.UPDATE_PARTITION_DISTRIBUTOR_CONFIG)
-              .partitionDistributionConfig(
-                  toPartitionDistributionConfig(updatePartitionDistributorConfigOperation));
-      case final ModeChangeOperation modeChange ->
-          switch (modeChange.mode()) {
-            case RECOVERING ->
-                new Operation()
-                    .operation(OperationEnum.ENTER_RECOVERY)
-                    .brokerId(brokerIdValue(modeChange.memberId()));
-            case PROCESSING ->
-                new Operation()
-                    .operation(OperationEnum.EXIT_RECOVERY)
-                    .brokerId(brokerIdValue(modeChange.memberId()));
-          };
-      case final AwaitModeChangeOperation modeChange ->
-          new Operation()
-              .operation(OperationEnum.AWAIT_MODE_CHANGE)
-              .brokerId(brokerIdValue(modeChange.memberId()));
-      case final ExportingStateChangeOperation exportingStateChangeOperation ->
-          new Operation()
-              .operation(OperationEnum.EXPORTING_STATE_CHANGE)
-              .brokerId(brokerIdValue(exportingStateChangeOperation.memberId()))
-              .exportingState(mapExportingState(exportingStateChangeOperation.state()));
-      default -> new Operation().operation(OperationEnum.UNKNOWN);
-    };
+  private static List<Operation> mapOperations(
+      final String physicalTenantId,
+      final List<? extends ClusterConfigurationChangeOperation> operations) {
+    return operations.stream().map(op -> mapOperation(physicalTenantId, op)).toList();
+  }
+
+  static Operation mapOperation(
+      final String physicalTenantId, final ClusterConfigurationChangeOperation operation) {
+    final var convertedOperation =
+        switch (operation) {
+          case final MemberJoinOperation join ->
+              new Operation().operation(OperationEnum.BROKER_ADD);
+          case final MemberLeaveOperation leave ->
+              new Operation().operation(OperationEnum.BROKER_REMOVE);
+          case final PartitionJoinOperation join ->
+              new Operation()
+                  .operation(OperationEnum.PARTITION_JOIN)
+                  .partitionId(join.partitionId())
+                  .priority(join.priority());
+          case final PartitionLeaveOperation leave ->
+              new Operation()
+                  .operation(OperationEnum.PARTITION_LEAVE)
+                  .partitionId(leave.partitionId());
+          case final PartitionReconfigurePriorityOperation reconfigure ->
+              new Operation()
+                  .operation(OperationEnum.PARTITION_RECONFIGURE_PRIORITY)
+                  .partitionId(reconfigure.partitionId())
+                  .priority(reconfigure.priority());
+          case final PartitionForceReconfigureOperation partitionForceReconfigureOperation ->
+              new Operation()
+                  .operation(OperationEnum.PARTITION_FORCE_RECONFIGURE)
+                  .partitionId(partitionForceReconfigureOperation.partitionId())
+                  .brokers(
+                      partitionForceReconfigureOperation.members().stream()
+                          .map(m -> brokerIdValue(m))
+                          .collect(toList()));
+          case final MemberRemoveOperation memberRemoveOperation ->
+              new Operation()
+                  .operation(OperationEnum.BROKER_REMOVE)
+                  .brokers(List.of(brokerIdValue(memberRemoveOperation.memberToRemove())));
+          case final PartitionDisableExporterOperation disableExporterOperation ->
+              new Operation()
+                  .operation(OperationEnum.PARTITION_DISABLE_EXPORTER)
+                  .partitionId(disableExporterOperation.partitionId())
+                  .exporterId(disableExporterOperation.exporterId());
+          case final PartitionEnableExporterOperation enableExporterOperation ->
+              new Operation()
+                  .operation(OperationEnum.PARTITION_ENABLE_EXPORTER)
+                  .partitionId(enableExporterOperation.partitionId())
+                  .exporterId(enableExporterOperation.exporterId());
+          case final PartitionDeleteExporterOperation deleteExporterOperation ->
+              new Operation()
+                  .operation(OperationEnum.PARTITION_DELETE_EXPORTER)
+                  .partitionId(deleteExporterOperation.partitionId())
+                  .exporterId(deleteExporterOperation.exporterId());
+          case final StartPartitionScaleUp startScaleUp ->
+              new Operation().operation(OperationEnum.START_PARTITION_SCALE_UP);
+          case final PartitionBootstrapOperation bootstrapOperation ->
+              new Operation()
+                  .operation(OperationEnum.PARTITION_BOOTSTRAP)
+                  .partitionId(bootstrapOperation.partitionId())
+                  .priority(bootstrapOperation.priority());
+          case final PartitionPreRestoreOperation preRestoreOperation ->
+              new Operation()
+                  .operation(OperationEnum.PARTITION_PRE_RESTORE)
+                  .partitionId(preRestoreOperation.partitionId());
+          case final PartitionRestoreOperation restoreOperation ->
+              new Operation()
+                  .operation(OperationEnum.PARTITION_RESTORE)
+                  .partitionId(restoreOperation.partitionId());
+          case final DeleteHistoryOperation deleteHistoryOperation ->
+              new Operation().operation(OperationEnum.DELETE_HISTORY);
+          case final AwaitRedistributionCompletion redistributionCompletion ->
+              new Operation().operation(OperationEnum.AWAIT_REDISTRIBUTION);
+          case final AwaitRelocationCompletion relocationCompletion ->
+              new Operation().operation(OperationEnum.AWAIT_RELOCATION);
+          case final UpdateRoutingState updateRoutingState ->
+              new Operation().operation(OperationEnum.UPDATE_ROUTING_STATE);
+          case final UpdateIncarnationNumberOperation updateIncarnationNumberOperation ->
+              new Operation().operation(OperationEnum.UPDATE_INCARNATION_NUMBER);
+          case final PreScalingOperation preScalingOperation ->
+              new Operation()
+                  .operation(OperationEnum.PRE_SCALING)
+                  .brokers(
+                      preScalingOperation.clusterMembers().stream()
+                          .map(m -> brokerIdValue(m))
+                          .toList());
+          case final PostScalingOperation postScalingOperation ->
+              new Operation()
+                  .operation(OperationEnum.POST_SCALING)
+                  .brokers(
+                      postScalingOperation.clusterMembers().stream()
+                          .map(m -> brokerIdValue(m))
+                          .toList());
+          case final UpdatePartitionDistributorConfigOperation
+                  updatePartitionDistributorConfigOperation ->
+              new Operation()
+                  .operation(OperationEnum.UPDATE_PARTITION_DISTRIBUTOR_CONFIG)
+                  .partitionDistributionConfig(
+                      toPartitionDistributionConfig(updatePartitionDistributorConfigOperation));
+          case final ModeChangeOperation modeChange ->
+              switch (modeChange.mode()) {
+                case RECOVERING -> new Operation().operation(OperationEnum.ENTER_RECOVERY);
+                case PROCESSING -> new Operation().operation(OperationEnum.EXIT_RECOVERY);
+              };
+          case final AwaitModeChangeOperation modeChange ->
+              new Operation().operation(OperationEnum.AWAIT_MODE_CHANGE);
+          case final ExportingStateChangeOperation exportingStateChangeOperation ->
+              new Operation()
+                  .operation(OperationEnum.EXPORTING_STATE_CHANGE)
+                  .exportingState(mapExportingState(exportingStateChangeOperation.state()));
+        };
+
+    convertedOperation.brokerId(brokerIdValue(operation.memberId()));
+    if (operation instanceof PartitionGroupOperation) {
+      convertedOperation.setPhysicalTenant(physicalTenantId);
+    }
+    return convertedOperation;
   }
 
   private static List<BrokerState> mapBrokerStates(

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -459,6 +459,8 @@ schemas:
         $ref: "components.yaml#/schemas/BrokerId"
       partitionId:
         $ref: "components.yaml#/schemas/PartitionId"
+      physicalTenant:
+        $ref: "components.yaml#/schemas/PhysicalTenantId"
       priority:
         type: integer
         format: int32
@@ -498,6 +500,25 @@ schemas:
         type: array
         items:
           $ref: "components.yaml#/schemas/PartitionState"
+      physicalTenants:
+        type: array
+        items:
+          $ref: "components.yaml#/schemas/PhysicalTenantState"
+
+  PhysicalTenantState:
+    title: PhysicalTenantState
+    description: State of a physical tenant
+    type: object
+    properties:
+      id:
+        $ref: "components.yaml#/schemas/PhysicalTenantId"
+      mode:
+        type: string
+        description: The mode of the physical tenant
+        enum:
+          - UNKNOWN
+          - PROCESSING
+          - RECOVERING
 
   BrokerStateCode:
     title: BrokerStateCode
@@ -516,6 +537,8 @@ schemas:
     properties:
       id:
         $ref: "components.yaml#/schemas/PartitionId"
+      physicalTenant:
+        $ref: "components.yaml#/schemas/PhysicalTenantId"
       state:
         $ref: "components.yaml#/schemas/PartitionStateCode"
       priority:
@@ -601,6 +624,12 @@ schemas:
     type: integer
     format: int32
     example: 1
+
+  PhysicalTenantId:
+    title: PhysicalTenantId
+    description: The ID of a physical tenant
+    type: string
+    example: "mytenant"
 
   ExporterId:
     title: Exporter

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -8,11 +8,16 @@
 package io.camunda.zeebe.shared.management;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.CurrentConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
@@ -30,6 +35,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.FixedConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.DeleteHistoryOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ExportingStateChangeOperation;
@@ -50,6 +56,9 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOper
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.management.cluster.BrokerState;
 import io.camunda.zeebe.management.cluster.ExporterStatus;
@@ -57,6 +66,7 @@ import io.camunda.zeebe.management.cluster.ExporterStatus.StatusEnum;
 import io.camunda.zeebe.management.cluster.GetTopologyResponse;
 import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
 import io.camunda.zeebe.management.cluster.PartitionDistributionConfig.TypeEnum;
+import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.management.cluster.TopologyChangeCompletedInner;
 import io.camunda.zeebe.util.Either;
 import java.time.Instant;
@@ -91,7 +101,7 @@ final class ClusterApiUtilsTest {
   @ParameterizedTest
   @MethodSource("generateAllClusterConfigurationChangeOperationsAsArguments")
   void shouldMapClusterChangeOperation(final ClusterConfigurationChangeOperation operation) {
-    final var encoded = ClusterApiUtils.mapOperation(operation);
+    final var encoded = ClusterApiUtils.mapOperation(null, operation);
     assertThat(encoded).isNotNull();
     assertThat(encoded.getOperation()).isNotEqualTo(OperationEnum.UNKNOWN);
     assertThat(OperationEnum.values())
@@ -112,6 +122,82 @@ final class ClusterApiUtilsTest {
         .contains(encoded.getOperation());
   }
 
+  @ParameterizedTest
+  @MethodSource("generateAllClusterConfigurationChangeOperationsAsArguments")
+  void shouldTagOnlyPartitionGroupOperationsWithPhysicalTenant(
+      final ClusterConfigurationChangeOperation operation) {
+    // when
+    final var encoded = ClusterApiUtils.mapOperation("tenant-a", operation);
+
+    // then
+    if (operation instanceof PartitionGroupOperation) {
+      assertThat(encoded.getPhysicalTenant()).isEqualTo("tenant-a");
+    } else {
+      assertThat(encoded.getPhysicalTenant()).isNull();
+    }
+  }
+
+  @Test
+  void shouldMapPhasedResponseIntoPlannedChangesTaggedByTenant() {
+    // given
+    final var globalOperation = new MemberJoinOperation(member(1));
+    final var tenantAOperation = new DeleteHistoryOperation(member(1));
+    final var tenantBOperation = new DeleteHistoryOperation(member(2));
+    final List<Phase> phases =
+        List.of(
+            new GlobalPhase(List.of(globalOperation)),
+            new PartitionGroupParallelPhase(
+                Map.of(
+                    "tenant-a", List.of(tenantAOperation),
+                    "tenant-b", List.of(tenantBOperation))));
+    final var response =
+        new ClusterConfigurationChangeResponse(
+            1,
+            new LegacyConfigurationChangeResponse(Map.of(), Map.of(), List.of()),
+            new CurrentConfigurationChangeResponse(
+                CurrentClusterConfiguration.init(), CurrentClusterConfiguration.init(), phases));
+
+    // when
+    final var result = ClusterApiUtils.mapOperationResponse(Either.right(response));
+
+    // then
+    assertThat(result.getStatusCode().value()).isEqualTo(202);
+    final var body = (PlannedOperationsResponse) result.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.getPlannedChanges())
+        .filteredOn(op -> op.getPhysicalTenant() == null)
+        .extracting(op -> op.getOperation())
+        .containsExactly(OperationEnum.BROKER_ADD);
+    assertThat(body.getPlannedChanges())
+        .filteredOn(op -> "tenant-a".equals(op.getPhysicalTenant()))
+        .extracting(op -> op.getOperation())
+        .containsExactly(OperationEnum.DELETE_HISTORY);
+    assertThat(body.getPlannedChanges())
+        .filteredOn(op -> "tenant-b".equals(op.getPhysicalTenant()))
+        .extracting(op -> op.getOperation())
+        .containsExactly(OperationEnum.DELETE_HISTORY);
+  }
+
+  @Test
+  void shouldFallBackToLegacyPlannedChangesWhenMultiConfigurationResponseIsAbsent() {
+    // given — a peer that hasn't populated the new multi-partition-group response, e.g. one still
+    // running old code (see ClusterConfigurationChangeResponse.response()).
+    final var operation = new MemberLeaveOperation(member(1));
+    final var response =
+        new ClusterConfigurationChangeResponse(
+            1, new LegacyConfigurationChangeResponse(Map.of(), Map.of(), List.of(operation)), null);
+
+    // when
+    final var result = ClusterApiUtils.mapOperationResponse(Either.right(response));
+
+    // then
+    final var body = (PlannedOperationsResponse) result.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.getPlannedChanges())
+        .extracting(op -> op.getOperation(), op -> op.getPhysicalTenant())
+        .containsExactly(tuple(OperationEnum.BROKER_REMOVE, null));
+  }
+
   @Test
   void shouldUseBrokerIdAsIntegerForNonZoneAwareBroker() {
     // given
@@ -119,7 +205,7 @@ final class ClusterApiUtilsTest {
     final var operation = new MemberJoinOperation(memberId);
 
     // when
-    final var encoded = ClusterApiUtils.mapOperation(operation);
+    final var encoded = ClusterApiUtils.mapOperation(null, operation);
 
     // then
     assertThat(encoded.getBrokerId()).isEqualTo(1);
@@ -132,7 +218,7 @@ final class ClusterApiUtilsTest {
     final var operation = new MemberJoinOperation(memberId);
 
     // when
-    final var encoded = ClusterApiUtils.mapOperation(operation);
+    final var encoded = ClusterApiUtils.mapOperation(null, operation);
 
     // then
     assertThat(encoded.getBrokerId()).isEqualTo("zone-a_0");

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -14,6 +14,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.CurrentConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
@@ -29,12 +30,14 @@ import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberRemoveO
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PostScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PreScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.FixedConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.DeleteHistoryOperation;
@@ -59,6 +62,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.management.cluster.BrokerState;
 import io.camunda.zeebe.management.cluster.ExporterStatus;
@@ -66,6 +70,7 @@ import io.camunda.zeebe.management.cluster.ExporterStatus.StatusEnum;
 import io.camunda.zeebe.management.cluster.GetTopologyResponse;
 import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
 import io.camunda.zeebe.management.cluster.PartitionDistributionConfig.TypeEnum;
+import io.camunda.zeebe.management.cluster.PhysicalTenantState;
 import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.management.cluster.TopologyChangeCompletedInner;
 import io.camunda.zeebe.util.Either;
@@ -196,6 +201,106 @@ final class ClusterApiUtilsTest {
     assertThat(body.getPlannedChanges())
         .extracting(op -> op.getOperation(), op -> op.getPhysicalTenant())
         .containsExactly(tuple(OperationEnum.BROKER_REMOVE, null));
+  }
+
+  @Test
+  void shouldFlattenPartitionsFromAllPhysicalTenantsOntoTheOwningBroker() {
+    // given — broker 1 participates in both tenants, broker 2 only in tenant-b, and is recovering
+    // there.
+    final var member1 = member(1);
+    final var member2 = member(2);
+    final var globalConfiguration =
+        new GlobalConfiguration(
+            1,
+            Optional.empty(),
+            Map.of(
+                member1,
+                new io.camunda.zeebe.dynamic.config.state.BrokerState(
+                    0,
+                    Instant.ofEpochSecond(1),
+                    io.camunda.zeebe.dynamic.config.state.BrokerState.State.ACTIVE),
+                member2,
+                new io.camunda.zeebe.dynamic.config.state.BrokerState(
+                    0,
+                    Instant.ofEpochSecond(2),
+                    io.camunda.zeebe.dynamic.config.state.BrokerState.State.ACTIVE)),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var tenantA =
+        new PartitionGroupConfiguration(
+            1,
+            0,
+            Map.of(
+                member1,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init())))),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var tenantB =
+        new PartitionGroupConfiguration(
+            1,
+            0,
+            Map.of(
+                member1,
+                BrokerPartitionState.initialize(
+                    Map.of(2, PartitionState.active(1, DynamicPartitionConfig.init()))),
+                member2,
+                BrokerPartitionState.initialize(
+                        Map.of(2, PartitionState.active(1, DynamicPartitionConfig.init())))
+                    .setMode(Mode.RECOVERING)),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var multiConfig =
+        new CurrentClusterConfiguration(
+            0,
+            globalConfiguration,
+            Map.of("tenant-a", tenantA, "tenant-b", tenantB),
+            PhasedChangeState.empty());
+    final var response =
+        new ClusterConfigurationChangeResponse(
+            1,
+            new LegacyConfigurationChangeResponse(Map.of(), Map.of(), List.of()),
+            new CurrentConfigurationChangeResponse(multiConfig, multiConfig, List.of()));
+
+    // when
+    final var result = ClusterApiUtils.mapOperationResponse(Either.right(response));
+
+    // then
+    final var body = (PlannedOperationsResponse) result.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.getCurrentTopology())
+        .extracting(BrokerState::getId)
+        .extracting(String::valueOf)
+        .containsExactlyInAnyOrder("1", "2");
+
+    final var broker1 =
+        body.getCurrentTopology().stream()
+            .filter(b -> "1".equals(String.valueOf(b.getId())))
+            .findFirst()
+            .orElseThrow();
+    assertThat(broker1.getPartitions())
+        .extracting(p -> p.getId(), p -> p.getPhysicalTenant())
+        .containsExactlyInAnyOrder(tuple(1, "tenant-a"), tuple(2, "tenant-b"));
+    assertThat(broker1.getPhysicalTenants())
+        .extracting(PhysicalTenantState::getId, PhysicalTenantState::getMode)
+        .containsExactlyInAnyOrder(
+            tuple("tenant-a", PhysicalTenantState.ModeEnum.PROCESSING),
+            tuple("tenant-b", PhysicalTenantState.ModeEnum.PROCESSING));
+
+    final var broker2 =
+        body.getCurrentTopology().stream()
+            .filter(b -> "2".equals(String.valueOf(b.getId())))
+            .findFirst()
+            .orElseThrow();
+    assertThat(broker2.getPartitions())
+        .extracting(p -> p.getId(), p -> p.getPhysicalTenant())
+        .containsExactly(tuple(2, "tenant-b"));
+    assertThat(broker2.getPhysicalTenants())
+        .extracting(PhysicalTenantState::getId, PhysicalTenantState::getMode)
+        .containsExactly(tuple("tenant-b", PhysicalTenantState.ModeEnum.RECOVERING));
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ClusterEndpointResponseIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ClusterEndpointResponseIT.java
@@ -51,6 +51,7 @@ final class ClusterEndpointResponseIT {
                 "partitions": [
                   {
                     "id": 1,
+                    "physicalTenant": "default",
                     "state": "ACTIVE",
                     "priority": 1,
                     "config":{
@@ -58,6 +59,12 @@ final class ClusterEndpointResponseIT {
                           "exporters": []
                        }
                     }
+                  }
+                ],
+                "physicalTenants":[
+                  {
+                    "id":"default",
+                    "mode":"PROCESSING"
                   }
                 ]
               }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.it.cluster.management;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.zeebe.qa.util.cluster.util.ZoneFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -207,31 +208,37 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
                       .operation(OperationEnum.PARTITION_JOIN)
                       .brokerId(brokerId(2))
                       .partitionId(1)
+                      .physicalTenant(DEFAULT_PHYSICAL_TENANT_ID)
                       .priority(2),
                   new Operation()
                       .operation(OperationEnum.PARTITION_RECONFIGURE_PRIORITY)
                       .brokerId(brokerId(0))
                       .partitionId(1)
+                      .physicalTenant(DEFAULT_PHYSICAL_TENANT_ID)
                       .priority(3),
                   new Operation()
                       .operation(OperationEnum.PARTITION_JOIN)
                       .brokerId(brokerId(0))
                       .partitionId(2)
+                      .physicalTenant(DEFAULT_PHYSICAL_TENANT_ID)
                       .priority(2),
                   new Operation()
                       .operation(OperationEnum.PARTITION_RECONFIGURE_PRIORITY)
                       .brokerId(brokerId(2))
                       .partitionId(2)
+                      .physicalTenant(DEFAULT_PHYSICAL_TENANT_ID)
                       .priority(3),
                   new Operation()
                       .operation(OperationEnum.PARTITION_JOIN)
                       .brokerId(brokerId(2))
                       .partitionId(3)
+                      .physicalTenant(DEFAULT_PHYSICAL_TENANT_ID)
                       .priority(2),
                   new Operation()
                       .operation(OperationEnum.PARTITION_RECONFIGURE_PRIORITY)
                       .brokerId(brokerId(0))
                       .partitionId(3)
+                      .physicalTenant(DEFAULT_PHYSICAL_TENANT_ID)
                       .priority(3)));
 
       Awaitility.await()

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/topology/ClusterActuatorAssert.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/topology/ClusterActuatorAssert.java
@@ -58,6 +58,7 @@ public final class ClusterActuatorAssert
     Assertions.assertThat(currentTopology)
         .usingRecursiveComparison()
         .ignoringFieldsOfTypes(OffsetDateTime.class)
+        .ignoringFields("version")
         .isEqualTo(expectedTopology);
     return this;
   }


### PR DESCRIPTION
## Description

This PR adds necessary support to send multi-physical-tenant aware response for cluster actuator operation. The data model for PlannedOperationResponse is updated to include physical tenant information without breaking compatibility with existing api.

* Adapt the open-api spec for PlannedOperationResponse
   * A physical tenant id is added to partition state. A broker state flattens partitions from all physical tenants, instead of keeping a map of physical tenants. This ensures backwards compatibility. There is no need to match the response to the internal data structure.
   * Each operation also have an additional PhysicalTenantId along with the PartitionId to correctly identify the physical tenant that it applies to.
* The mapper in ClusterApiUtils now use the new model if available. 

Note the response for the /actuator/cluster query that returns the full cluster configuration is not updated. It only adds the physical tenant id in the PartitionState. The overall response schema needs to be updated to support per-physical tenant routingstate, pending changes etc. This will be done in a followup.

## Related issues

related to #57016 
