### PR TITLE
feat: restore cache access metrics for authorization lookup caches

### DIFF
--- a/monitor/grafana/dashboards/identity/overview.json
+++ b/monitor/grafana/dashboards/identity/overview.json
@@ -545,7 +545,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Latency of authorization checks in AuthorizationCheckBehavior, including the fast path when checks are disabled",
+      "description": "Latency of each authorization check",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/monitor/grafana/dashboards/identity/overview.json
+++ b/monitor/grafana/dashboards/identity/overview.json
@@ -997,7 +997,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Rate of authorization cache hits and misses, per cache (membership, scope)",
+      "description": "Rate of authorization cache hits and misses, per cache (membership, scope). These caches avoid a RocksDB state read on every authorization check; a rising miss rate means checks increasingly fall through to the slower state-read path, which shows up as higher Authorization Check Latency.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1110,7 +1110,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Rate of evictions from the authorization caches, per cache",
+      "description": "Rate of evictions from the authorization caches, per cache. Entries are evicted once the configured size or TTL limit (authorizationsCacheCapacity/authorizationsCacheTtl) is exceeded; sustained evictions mean the cache is undersized for the number of distinct principals/scopes in use, causing churn where entries get reloaded shortly after being evicted.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1223,7 +1223,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "p99 duration of successful authorization cache loads (state read on a cache miss), per cache",
+      "description": "p99 duration of successful authorization cache loads (state read on a cache miss), per cache. This load happens synchronously inside the authorization check, so a growing p99 here directly inflates Authorization Check Latency and Slow Authorization Checks; use it to tell whether tail latency comes from the state read itself rather than from cache misses or the check logic.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1336,7 +1336,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Rate of successful authorization cache loads (i.e. cache-miss state reads), per cache",
+      "description": "Rate of successful authorization cache loads (i.e. cache-miss state reads), per cache. Concurrent misses for the same key are de-duplicated into a single load, so this can run lower than the miss rate above under contention; track it alongside Eviction Rate to see how much churn turns into actual state reads.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/monitor/grafana/dashboards/identity/overview.json
+++ b/monitor/grafana/dashboards/identity/overview.json
@@ -1419,6 +1419,471 @@
         }
       ],
       "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
+      "id": 17,
+      "panels": [],
+      "title": "Authorization Caches",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Rate of authorization cache hits and misses, per cache (membership, scope)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 52
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(zeebe_authorization_membership_result_total{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (type)",
+          "legendFormat": "membership {{type}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(zeebe_authorization_scope_result_total{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (type)",
+          "legendFormat": "scope {{type}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Authorization Cache Access Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Rate of evictions from the authorization caches, per cache",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 52
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(zeebe_authorization_membership_evictions_total{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "membership",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(zeebe_authorization_scope_evictions_total{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "scope",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Authorization Cache Eviction Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "p99 duration of successful authorization cache loads (state read on a cache miss), per cache",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 60
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(zeebe_authorization_membership_load_duration_success_seconds_bucket{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (le))",
+          "legendFormat": "membership p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(zeebe_authorization_scope_load_duration_success_seconds_bucket{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (le))",
+          "legendFormat": "scope p99",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Authorization Cache Load Duration (p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Rate of successful authorization cache loads (i.e. cache-miss state reads), per cache",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 60
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(zeebe_authorization_membership_load_duration_success_seconds_count{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "membership",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(zeebe_authorization_scope_load_duration_success_seconds_count{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "scope",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Authorization Cache Load Rate",
+      "type": "timeseries"
     }
   ],
   "preload": false,
@@ -1535,5 +2000,5 @@
   "timezone": "browser",
   "title": "Identity Overview",
   "uid": "identity",
-  "version": 8
+  "version": 9
 }

--- a/monitor/grafana/dashboards/identity/overview.json
+++ b/monitor/grafana/dashboards/identity/overview.json
@@ -987,6 +987,471 @@
         "x": 0,
         "y": 34
       },
+      "id": 17,
+      "panels": [],
+      "title": "Authorization Caches",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Rate of authorization cache hits and misses, per cache (membership, scope)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(zeebe_authorization_membership_result_total{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (type)",
+          "legendFormat": "membership {{type}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(zeebe_authorization_scope_result_total{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (type)",
+          "legendFormat": "scope {{type}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Authorization Cache Access Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Rate of evictions from the authorization caches, per cache",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(zeebe_authorization_membership_evictions_total{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "membership",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(zeebe_authorization_scope_evictions_total{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "scope",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Authorization Cache Eviction Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "p99 duration of successful authorization cache loads (state read on a cache miss), per cache",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(zeebe_authorization_membership_load_duration_success_seconds_bucket{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (le))",
+          "legendFormat": "membership p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(zeebe_authorization_scope_load_duration_success_seconds_bucket{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (le))",
+          "legendFormat": "scope p99",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Authorization Cache Load Duration (p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Rate of successful authorization cache loads (i.e. cache-miss state reads), per cache",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(zeebe_authorization_membership_load_duration_success_seconds_count{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "membership",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(zeebe_authorization_scope_load_duration_success_seconds_count{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "scope",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Authorization Cache Load Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
       "id": 7,
       "panels": [],
       "title": "API Errors",
@@ -1054,7 +1519,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 35
+        "y": 52
       },
       "id": 9,
       "options": {
@@ -1134,7 +1599,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 52
       },
       "id": 6,
       "options": {
@@ -1265,7 +1730,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 43
+        "y": 60
       },
       "id": 10,
       "options": {
@@ -1352,7 +1817,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 43
+        "y": 60
       },
       "id": 8,
       "options": {
@@ -1419,471 +1884,6 @@
         }
       ],
       "type": "table"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 51
-      },
-      "id": 17,
-      "panels": [],
-      "title": "Authorization Caches",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Rate of authorization cache hits and misses, per cache (membership, scope)",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 52
-      },
-      "id": 18,
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(zeebe_authorization_membership_result_total{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (type)",
-          "legendFormat": "membership {{type}}",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(zeebe_authorization_scope_result_total{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (type)",
-          "legendFormat": "scope {{type}}",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Authorization Cache Access Rate",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Rate of evictions from the authorization caches, per cache",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 52
-      },
-      "id": 19,
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(zeebe_authorization_membership_evictions_total{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval]))",
-          "legendFormat": "membership",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(zeebe_authorization_scope_evictions_total{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval]))",
-          "legendFormat": "scope",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Authorization Cache Eviction Rate",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "p99 duration of successful authorization cache loads (state read on a cache miss), per cache",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 60
-      },
-      "id": 20,
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(zeebe_authorization_membership_load_duration_success_seconds_bucket{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (le))",
-          "legendFormat": "membership p99",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(zeebe_authorization_scope_load_duration_success_seconds_bucket{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (le))",
-          "legendFormat": "scope p99",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Authorization Cache Load Duration (p99)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Rate of successful authorization cache loads (i.e. cache-miss state reads), per cache",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 60
-      },
-      "id": 21,
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(zeebe_authorization_membership_load_duration_success_seconds_count{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval]))",
-          "legendFormat": "membership",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(zeebe_authorization_scope_load_duration_success_seconds_count{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval]))",
-          "legendFormat": "scope",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Authorization Cache Load Rate",
-      "type": "timeseries"
     }
   ],
   "preload": false,

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.bouncycastle>1.85</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha64</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha65</version.camunda-security-library>
     <version.checkstyle>13.9.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>

--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -27,6 +27,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-security-core</artifactId>
     </dependency>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.protocol.record.intent.DeploymentIntent.CREATE;
 
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.secretstore.SecretStoreRegistry;
+import io.camunda.security.api.context.MembershipResolutionContextPropagator;
 import io.camunda.security.api.context.PropertyAuthorizationEvaluator;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
@@ -65,6 +66,7 @@ import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
 import io.camunda.zeebe.engine.processing.identity.RoleProcessors;
 import io.camunda.zeebe.engine.processing.identity.adapter.AuthorizationScopeStateAdapter;
 import io.camunda.zeebe.engine.processing.identity.adapter.MembershipStateAdapter;
+import io.camunda.zeebe.engine.processing.identity.adapter.MicrometerAuthorizationCheckLatencyRecorder;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.incident.IncidentEventProcessors;
@@ -252,7 +254,10 @@ public final class EngineProcessors {
             securityConfig.isMultiTenancyChecksEnabled(),
             Authorization.AUTHORIZED_USERNAME,
             Authorization.AUTHORIZED_CLIENT_ID,
-            false);
+            false,
+            MembershipResolutionContextPropagator.identity(),
+            new MicrometerAuthorizationCheckLatencyRecorder(
+                typedRecordProcessorContext.getMeterRegistry()));
     final AuthorizationCheckPort authzService = ports.checkPort();
     final LazyTokenClaimsConverter claimsConverter =
         (LazyTokenClaimsConverter) ports.claimsResolver();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -255,8 +255,6 @@ public final class EngineProcessors {
             Authorization.AUTHORIZED_USERNAME,
             Authorization.AUTHORIZED_CLIENT_ID,
             false,
-            // Identity: the engine has no Spring context to enrich membership resolution with,
-            // unlike CSL's spring-boot-starter adapter of the same port.
             MembershipResolutionContextPropagator.identity(),
             new MicrometerAuthorizationCheckLatencyRecorder(
                 typedRecordProcessorContext.getMeterRegistry()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -187,9 +187,15 @@ public final class EngineProcessors {
     // Build CSL authorization ports for identity, UserTask, and Job domain processors
     final var membershipStateAdapter =
         new MembershipStateAdapter(
-            processingState.getMappingRuleState(), processingState.getMembershipState(), config);
+            processingState.getMappingRuleState(),
+            processingState.getMembershipState(),
+            config,
+            typedRecordProcessorContext.getMeterRegistry());
     final var authorizationScopeStateAdapter =
-        new AuthorizationScopeStateAdapter(processingState.getAuthorizationState(), config);
+        new AuthorizationScopeStateAdapter(
+            processingState.getAuthorizationState(),
+            config,
+            typedRecordProcessorContext.getMeterRegistry());
     final var ports =
         AuthorizationPortsFactory.create(
             authorizationScopeStateAdapter,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -255,6 +255,8 @@ public final class EngineProcessors {
             Authorization.AUTHORIZED_USERNAME,
             Authorization.AUTHORIZED_CLIENT_ID,
             false,
+            // Identity: the engine has no Spring context to enrich membership resolution with,
+            // unlike CSL's spring-boot-starter adapter of the same port.
             MembershipResolutionContextPropagator.identity(),
             new MicrometerAuthorizationCheckLatencyRecorder(
                 typedRecordProcessorContext.getMeterRegistry()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationCacheMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationCacheMetrics.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity.adapter;
+
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+final class AuthorizationCacheMetrics {
+
+  // Dashboard queries hardcode the resulting zeebe_authorization_* metric names.
+  static final String NAMESPACE = "zeebe.authorization";
+
+  private AuthorizationCacheMetrics() {}
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.zeebe.engine.processing.identity.adapter;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.api.model.authz.AuthorizationScope;
 import io.camunda.security.api.model.authz.EntityType;
@@ -21,6 +21,8 @@ import io.camunda.zeebe.engine.state.authorization.PersistedAuthorization;
 import io.camunda.zeebe.engine.state.immutable.AuthorizationState;
 import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -32,6 +34,8 @@ import org.slf4j.Logger;
 @NullMarked
 public final class AuthorizationScopeStateAdapter implements AuthorizationScopeRepositoryPort {
 
+  private static final String NAMESPACE = "zeebe.authorization";
+
   private static final Logger LOG = Loggers.ENGINE_IDENTITY_LOGGER;
 
   private final AuthorizationState authorizationState;
@@ -40,12 +44,16 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
       scopeCache;
 
   public AuthorizationScopeStateAdapter(
-      final AuthorizationState authorizationState, final EngineConfiguration config) {
+      final AuthorizationState authorizationState,
+      final EngineConfiguration config,
+      final MeterRegistry meterRegistry) {
     this.authorizationState = authorizationState;
+    final var statsCounter = new CaffeineCacheStatsCounter(NAMESPACE, "scope", meterRegistry);
     scopeCache =
-        CacheBuilder.newBuilder()
+        Caffeine.newBuilder()
             .expireAfterWrite(config.getAuthorizationsCacheTtl())
             .maximumSize(config.getAuthorizationsCacheCapacity())
+            .recordStats(() -> statsCounter)
             .build(new ScopeCacheLoader(authorizationState));
   }
 
@@ -145,8 +153,7 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
       final String ownerId,
       final io.camunda.zeebe.protocol.record.value.AuthorizationResourceType resourceType,
       final io.camunda.zeebe.protocol.record.value.PermissionType permissionType) {
-    return scopeCache.getUnchecked(
-        new ScopeCacheKey(ownerType, ownerId, resourceType, permissionType));
+    return scopeCache.get(new ScopeCacheKey(ownerType, ownerId, resourceType, permissionType));
   }
 
   /** Converts a CSL {@link EntityType} to the Zeebe {@link AuthorizationOwnerType}. */
@@ -189,7 +196,7 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
 
   /** Loads authorization scopes from {@link AuthorizationState}, bypassing the cache. */
   private static final class ScopeCacheLoader
-      extends CacheLoader<
+      implements CacheLoader<
           ScopeCacheKey, Set<io.camunda.zeebe.protocol.record.value.AuthorizationScope>> {
 
     private final AuthorizationState authorizationState;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
@@ -34,8 +34,6 @@ import org.slf4j.Logger;
 @NullMarked
 public final class AuthorizationScopeStateAdapter implements AuthorizationScopeRepositoryPort {
 
-  private static final String NAMESPACE = "zeebe.authorization";
-
   private static final Logger LOG = Loggers.ENGINE_IDENTITY_LOGGER;
 
   private final AuthorizationState authorizationState;
@@ -48,7 +46,8 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
       final EngineConfiguration config,
       final MeterRegistry meterRegistry) {
     this.authorizationState = authorizationState;
-    final var statsCounter = new CaffeineCacheStatsCounter(NAMESPACE, "scope", meterRegistry);
+    final var statsCounter =
+        new CaffeineCacheStatsCounter(AuthorizationCacheMetrics.NAMESPACE, "scope", meterRegistry);
     scopeCache =
         Caffeine.newBuilder()
             .expireAfterWrite(config.getAuthorizationsCacheTtl())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.zeebe.engine.processing.identity.adapter;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.camunda.security.core.auth.MappingRuleMatcher;
 import io.camunda.security.core.port.out.MembershipPort;
 import io.camunda.security.core.port.out.MembershipQuery;
@@ -21,6 +21,8 @@ import io.camunda.zeebe.engine.state.authorization.PersistedMappingRule;
 import io.camunda.zeebe.engine.state.immutable.MappingRuleState;
 import io.camunda.zeebe.engine.state.immutable.MembershipState;
 import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -31,6 +33,8 @@ import org.slf4j.Logger;
 @NullMarked
 public final class MembershipStateAdapter implements MembershipPort {
 
+  private static final String NAMESPACE = "zeebe.authorization";
+
   private static final Logger LOG = Loggers.ENGINE_IDENTITY_LOGGER;
 
   private final MappingRuleState mappingRuleState;
@@ -40,13 +44,16 @@ public final class MembershipStateAdapter implements MembershipPort {
   public MembershipStateAdapter(
       final MappingRuleState mappingRuleState,
       final MembershipState membershipState,
-      final EngineConfiguration config) {
+      final EngineConfiguration config,
+      final MeterRegistry meterRegistry) {
     this.mappingRuleState = mappingRuleState;
     this.membershipState = membershipState;
+    final var statsCounter = new CaffeineCacheStatsCounter(NAMESPACE, "membership", meterRegistry);
     membershipCache =
-        CacheBuilder.newBuilder()
+        Caffeine.newBuilder()
             .expireAfterWrite(config.getAuthorizationsCacheTtl())
             .maximumSize(config.getAuthorizationsCacheCapacity())
+            .recordStats(() -> statsCounter)
             .build(new MembershipCacheLoader(membershipState));
   }
 
@@ -153,7 +160,7 @@ public final class MembershipStateAdapter implements MembershipPort {
   /** Returns cached memberships, loading from state on cache miss. */
   private List<String> getMemberships(
       final EntityType entityType, final String entityId, final RelationType relationType) {
-    return membershipCache.getUnchecked(new MembershipCacheKey(entityType, entityId, relationType));
+    return membershipCache.get(new MembershipCacheKey(entityType, entityId, relationType));
   }
 
   /** Converts a {@link PrincipalType} to the Zeebe {@link EntityType}. */
@@ -169,7 +176,7 @@ public final class MembershipStateAdapter implements MembershipPort {
 
   /** Loads memberships from {@link MembershipState}, bypassing the cache. */
   private static final class MembershipCacheLoader
-      extends CacheLoader<MembershipCacheKey, List<String>> {
+      implements CacheLoader<MembershipCacheKey, List<String>> {
 
     private final MembershipState membershipState;
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
@@ -33,8 +33,6 @@ import org.slf4j.Logger;
 @NullMarked
 public final class MembershipStateAdapter implements MembershipPort {
 
-  private static final String NAMESPACE = "zeebe.authorization";
-
   private static final Logger LOG = Loggers.ENGINE_IDENTITY_LOGGER;
 
   private final MappingRuleState mappingRuleState;
@@ -48,7 +46,9 @@ public final class MembershipStateAdapter implements MembershipPort {
       final MeterRegistry meterRegistry) {
     this.mappingRuleState = mappingRuleState;
     this.membershipState = membershipState;
-    final var statsCounter = new CaffeineCacheStatsCounter(NAMESPACE, "membership", meterRegistry);
+    final var statsCounter =
+        new CaffeineCacheStatsCounter(
+            AuthorizationCacheMetrics.NAMESPACE, "membership", meterRegistry);
     membershipCache =
         Caffeine.newBuilder()
             .expireAfterWrite(config.getAuthorizationsCacheTtl())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MicrometerAuthorizationCheckLatencyRecorder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MicrometerAuthorizationCheckLatencyRecorder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity.adapter;
+
+import io.camunda.security.core.port.out.AuthorizationCheckLatencyRecorder;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Micrometer-backed {@link AuthorizationCheckLatencyRecorder}, engine-local since {@code core}'s
+ * {@link io.camunda.security.core.authz.AuthorizationPortsFactory} is called directly by {@link
+ * io.camunda.zeebe.engine.processing.EngineProcessors} with no Spring container available. Builds
+ * its {@link Timer} from the port's name, description, and SLO-bucket constants, matching {@code
+ * spring-boot-starter}'s Spring adapter of the same port. {@code METRIC_BASE_UNIT} is excepted —
+ * {@code Timer.Builder} has no {@code baseUnit(...)} setter, so this meter does not carry it. See
+ * camunda-security-library's ADR-0041.
+ */
+@NullMarked
+public final class MicrometerAuthorizationCheckLatencyRecorder
+    implements AuthorizationCheckLatencyRecorder {
+
+  private final Timer timer;
+
+  public MicrometerAuthorizationCheckLatencyRecorder(final MeterRegistry meterRegistry) {
+    timer =
+        Timer.builder(METRIC_NAME)
+            .description(METRIC_DESCRIPTION)
+            .serviceLevelObjectives(METRIC_SLO_BUCKETS.toArray(new Duration[0]))
+            .register(meterRegistry);
+  }
+
+  @Override
+  public void record(final long durationNanos) {
+    timer.record(durationNanos, TimeUnit.NANOSECONDS);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapterTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapterTest.java
@@ -20,11 +20,13 @@ import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,16 +38,23 @@ final class AuthorizationScopeStateAdapterTest {
   private MutableProcessingState processingState;
 
   private AuthorizationScopeStateAdapter adapter;
+  private SimpleMeterRegistry meterRegistry;
   private AuthorizationCreatedApplier authorizationCreatedApplier;
   private final Random random = new Random();
 
   @BeforeEach
   void setup() {
+    meterRegistry = new SimpleMeterRegistry();
     adapter =
         new AuthorizationScopeStateAdapter(
-            processingState.getAuthorizationState(), new EngineConfiguration());
+            processingState.getAuthorizationState(), new EngineConfiguration(), meterRegistry);
     authorizationCreatedApplier =
         new AuthorizationCreatedApplier(processingState.getAuthorizationState());
+  }
+
+  @AfterEach
+  void tearDown() {
+    meterRegistry.close();
   }
 
   @Test
@@ -231,6 +240,48 @@ final class AuthorizationScopeStateAdapterTest {
                 PermissionType.READ,
                 List.of("any-process-id")))
         .isTrue();
+  }
+
+  @Test
+  void shouldRecordCacheMissThenHitOnRepeatedScopeLookup() {
+    // given
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(
+        "user1",
+        AuthorizationOwnerType.USER,
+        io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION,
+        io.camunda.zeebe.protocol.record.value.PermissionType.READ,
+        resourceId);
+    final var ownerIds = Map.of(EntityType.USER, Set.of("user1"));
+
+    // when — first lookup misses and loads, second lookup hits the cache
+    adapter.findAuthorizedScopes(
+        ownerIds, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.READ);
+    adapter.findAuthorizedScopes(
+        ownerIds, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.READ);
+
+    // then
+    assertThat(
+            meterRegistry
+                .get("zeebe.authorization.scope.result")
+                .tag("type", "MISS")
+                .counter()
+                .count())
+        .isEqualTo(1.0);
+    assertThat(
+            meterRegistry
+                .get("zeebe.authorization.scope.result")
+                .tag("type", "HIT")
+                .counter()
+                .count())
+        .isEqualTo(1.0);
+    assertThat(meterRegistry.get("zeebe.authorization.scope.load.duration.success").timer())
+        .isNotNull();
+  }
+
+  @Test
+  void shouldRegisterEvictionsMeter() {
+    assertThat(meterRegistry.get("zeebe.authorization.scope.evictions").counter()).isNotNull();
   }
 
   // --- helpers ---

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapterTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapterTest.java
@@ -29,10 +29,12 @@ import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.test.util.Strings;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,6 +46,7 @@ final class MembershipStateAdapterTest {
   private MutableProcessingState processingState;
 
   private MembershipStateAdapter adapter;
+  private SimpleMeterRegistry meterRegistry;
   private MappingRuleCreatedApplier mappingRuleCreatedApplier;
   private GroupCreatedApplier groupCreatedApplier;
   private GroupEntityAddedApplier groupEntityAddedApplier;
@@ -55,11 +58,13 @@ final class MembershipStateAdapterTest {
 
   @BeforeEach
   void setup() {
+    meterRegistry = new SimpleMeterRegistry();
     adapter =
         new MembershipStateAdapter(
             processingState.getMappingRuleState(),
             processingState.getMembershipState(),
-            new EngineConfiguration());
+            new EngineConfiguration(),
+            meterRegistry);
     mappingRuleCreatedApplier =
         new MappingRuleCreatedApplier(processingState.getMappingRuleState());
     groupCreatedApplier = new GroupCreatedApplier(processingState.getGroupState());
@@ -68,6 +73,11 @@ final class MembershipStateAdapterTest {
     roleEntityAddedApplier = new RoleEntityAddedApplier(processingState);
     tenantCreatedApplier = new TenantCreatedApplier(processingState.getTenantState());
     tenantEntityAddedApplier = new TenantEntityAddedApplier(processingState);
+  }
+
+  @AfterEach
+  void tearDown() {
+    meterRegistry.close();
   }
 
   @Test
@@ -280,6 +290,41 @@ final class MembershipStateAdapterTest {
 
     // then
     assertThat(result).containsExactly(tenantId);
+  }
+
+  @Test
+  void shouldRecordCacheMissThenHitOnRepeatedGroupIdsLookup() {
+    // given
+    final var userId = Strings.newRandomValidIdentityId();
+    createGroupAndAssignEntity(userId, EntityType.USER);
+    final var query = new MembershipQuery(Map.of(), userId, PrincipalType.USER);
+
+    // when — first lookup misses and loads, second lookup hits the cache
+    adapter.groupIds(query);
+    adapter.groupIds(query);
+
+    // then
+    assertThat(
+            meterRegistry
+                .get("zeebe.authorization.membership.result")
+                .tag("type", "MISS")
+                .counter()
+                .count())
+        .isEqualTo(1.0);
+    assertThat(
+            meterRegistry
+                .get("zeebe.authorization.membership.result")
+                .tag("type", "HIT")
+                .counter()
+                .count())
+        .isEqualTo(1.0);
+    assertThat(meterRegistry.get("zeebe.authorization.membership.load.duration.success").timer())
+        .isNotNull();
+  }
+
+  @Test
+  void shouldRegisterEvictionsMeter() {
+    assertThat(meterRegistry.get("zeebe.authorization.membership.evictions").counter()).isNotNull();
   }
 
   // --- helpers ---

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/MicrometerAuthorizationCheckLatencyRecorderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/MicrometerAuthorizationCheckLatencyRecorderTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.core.port.out.AuthorizationCheckLatencyRecorder;
+import io.micrometer.core.instrument.distribution.CountAtBucket;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.Test;
+
+final class MicrometerAuthorizationCheckLatencyRecorderTest {
+
+  @Test
+  void shouldRecordATimerMatchingTheSharedSpec() {
+    // given
+    final var registry = new SimpleMeterRegistry();
+    final var recorder = new MicrometerAuthorizationCheckLatencyRecorder(registry);
+
+    // when
+    recorder.record(TimeUnit.MILLISECONDS.toNanos(5));
+
+    // then
+    final var timer = registry.find(AuthorizationCheckLatencyRecorder.METRIC_NAME).timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.getId().getDescription())
+        .isEqualTo(AuthorizationCheckLatencyRecorder.METRIC_DESCRIPTION);
+    assertThat(timer.count()).isEqualTo(1);
+    assertThat(timer.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(5.0);
+  }
+
+  @Test
+  void shouldPublishTheSharedSloBucketsExactly() {
+    // given
+    final var registry = new SimpleMeterRegistry();
+    final var recorder = new MicrometerAuthorizationCheckLatencyRecorder(registry);
+
+    // when
+    recorder.record(1);
+
+    // then — the SLO boundaries actually published must track the shared spec constant, since
+    // the Grafana SLO-breach ratios are computed from these buckets
+    final var timer = registry.find(AuthorizationCheckLatencyRecorder.METRIC_NAME).timer();
+    final var actualBucketsNanos =
+        Arrays.stream(timer.takeSnapshot().histogramCounts())
+            .mapToDouble(CountAtBucket::bucket)
+            .toArray();
+    final var expectedBucketsNanos =
+        AuthorizationCheckLatencyRecorder.METRIC_SLO_BUCKETS.stream()
+            .mapToDouble(Duration::toNanos)
+            .toArray();
+    assertThat(actualBucketsNanos).containsExactly(expectedBucketsNanos, Offset.offset(1e-9));
+  }
+}


### PR DESCRIPTION
## Summary

Implements cache hit/miss/eviction/load-time metrics for the authorization
lookup caches in `MembershipStateAdapter` and `AuthorizationScopeStateAdapter`
— the engine-side adapters implementing CSL's `MembershipPort` and
`AuthorizationScopeRepositoryPort`. This was never previously instrumented:
the pre-migration `AuthorizationCheckBehavior` only recorded a check-latency
Timer around its cache lookup, never hit/miss/eviction counters (confirmed by
inspecting it at `18abcca81828aa9180e9970f6e599f281d2fc299^`, the commit
before it was deleted by #58368). Per [ADR-0028](https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0028-unified-authz-framework-in-core.md),
caching is an adapter-layer
concern, so the metric is added here rather than in CSL core.

- Migrates both adapters from Guava's `CacheBuilder`/`LoadingCache` to
  Caffeine, so they can reuse `CaffeineCacheStatsCounter` (zeebe/util) — the
  same Micrometer-backed `StatsCounter` already used by
  `service/.../cache/ProcessCache.java`.
- Caches are namespaced `zeebe.authorization`, with cache names `membership`
  and `scope`, yielding meters such as `zeebe.authorization.membership.result`
  (tagged `type=HIT`/`MISS`), `.evictions`, and
  `.load.duration.success`/`.failure`.
- Aggregate only, no per-user/per-client tags — the issue's literal "by
  user/client" wording was rejected as a cardinality risk (flagged in
  npepinpe's original review comment on the issue).
- `MeterRegistry` is threaded through both adapters' constructors from
  `EngineProcessors`, matching the pattern used for the sibling `*Metrics`
  classes constructed alongside them.
- Adds an explicit `caffeine` dependency to `zeebe/engine/pom.xml` — it was
  only available transitively via `zeebe-util`, and `dependency:analyze-only`
  fails the build on used-but-undeclared dependencies once these adapters
  import Caffeine types directly.
- Checked `monitor/` for existing dashboards referencing these meters. The
  restored `zeebe.authorization.check.latency` Timer already has a live
  dashboard (`identity/overview.json`'s "Zeebe Engine - Authorization" row) —
  same metric name and SLO bucket boundaries as the pre-migration baseline,
  so those panels resume working unchanged. The new cache
  hit/miss/eviction/load-duration metrics had no prior dashboard (they never
  shipped before); this PR adds a new "Authorization Caches" panel group to
  the same dashboard for them.
- Bumps `version.camunda-security-library` to `0.1.0-alpha65`, which includes
  camunda-security-library#604 — the companion change natively
  re-implementing the `zeebe.authorization.check.latency` Timer in CSL's
  `AuthorizationService` (see camunda-security-library#568). Adds an
  engine-local, Micrometer-backed `AuthorizationCheckLatencyRecorder`
  (`zeebe/engine` has no Spring container, so it can't reuse CSL's
  `spring-boot-starter` adapter of the same port) and passes it to the 10-arg
  `AuthorizationPortsFactory.create(...)` overload in `EngineProcessors`,
  alongside `MembershipResolutionContextPropagator.identity()` — the same
  propagator the previously-used 8-arg overload defaulted to internally, so
  membership resolution is unaffected.

Closes https://github.com/camunda/camunda/issues/45046

## Scope note

This was originally split into two coordinated PRs: this one for the
cache-metrics half (#45046), and
https://github.com/camunda/camunda-security-library/pull/604 for the
`zeebe.authorization.check.latency` Timer restoration in CSL. #604 has since
merged and released as `0.1.0-alpha65`, so this PR now also includes the
version bump and engine-side wiring for that Timer — both halves of the
cross-repo change land together here.

## Test plan

- [x] `./mvnw verify -pl zeebe/engine -Dtest=MembershipStateAdapterTest,AuthorizationScopeStateAdapterTest -DskipTests=false -DskipITs -Dquickly` — cache meters registered and increment on hit/miss/eviction
- [x] `./mvnw verify -pl zeebe/engine -Dtest=MicrometerAuthorizationCheckLatencyRecorderTest -DskipTests=false -DskipITs -Dquickly` — Timer matches CSL's shared spec constants (name, description, SLO buckets)
- [x] `./mvnw verify -pl zeebe/engine -Dtest='io.camunda.zeebe.engine.processing.authorization.**' -DskipTests=false -DskipITs -Dquickly` — 63/63 green; exercises the new `AuthorizationPortsFactory.create(...)` wiring end to end via `EngineRule`
- [x] `./mvnw verify -pl zeebe/engine -Dtest='io.camunda.zeebe.engine.processing.identity.**' -DskipTests=false -DskipITs -Dquickly` — 134/134 green
- [x] `./mvnw verify -pl zeebe/engine -DskipTests -DskipITs -Dspotless.check.skip=true -Dcheckstyle.skip=true -Drevapi.skip=true -Dlicense.skip=true` — confirms `dependency:analyze-only` passes with the new `caffeine` declaration
- [x] `./mvnw install -Dquickly -T1C` (full repo) — confirms the alpha65 bump compiles everywhere; alpha64's CSL#602 scoped-authorization-ports API is additive and unconsumed here, so skipping straight to alpha65 is safe
- [x] `./mvnw license:format spotless:apply` — formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


