### PR TITLE
ci: dispatch a fix agent when a SaaS run fails without a failing test

### DIFF
--- a/.github/scripts/alwaysgreen/classify.py
+++ b/.github/scripts/alwaysgreen/classify.py
@@ -100,6 +100,7 @@ def normalise_base_ref(ref: str) -> str:
 SURFACE_SM_E2E = "sm-smoke-e2e"
 SURFACE_SAAS_E2E = "saas-smoke-e2e"
 SURFACE_SAAS_PROVISIONING = "saas-provisioning"
+SURFACE_SAAS_CI = "saas-ci"
 SURFACE_SAAS_INFRA = "saas-infra"
 SURFACE_HELM_INSTALL = "helm-install"
 SURFACE_HELM_CLEANUP = "helm-cleanup"
@@ -109,7 +110,9 @@ SURFACE_CI_INFRA = "ci-infra"
 #: Surfaces dispatched to the agent. Everything else is recorded and reported but not
 #: handed over. helm-install is gated further by helm_install_verdict: the failure has
 #: to look like the chart rather than the cluster.
-DISPATCHABLE_SURFACES = frozenset({SURFACE_SM_E2E, SURFACE_SAAS_E2E, SURFACE_HELM_INSTALL})
+DISPATCHABLE_SURFACES = frozenset(
+    {SURFACE_SM_E2E, SURFACE_SAAS_E2E, SURFACE_SAAS_CI, SURFACE_HELM_INSTALL}
+)
 
 #: A pure propagator: it fails whenever the reusable helm workflow failed and
 #: carries no independent signal.
@@ -221,11 +224,19 @@ def saas_surface_from_counts(counts: SpecCounts, *, has_artifacts: bool) -> str:
     `downstream_category`: that value is produced by a one-level spec walk, so
     `product` and `mixed` are unreachable and every failure reads as
     `infrastructure`.
+
+    Zero failing specs is not the same as nothing to fix. When the reports exist
+    and every spec passed, the run went red on a job around the tests — org
+    cleanup, report merge, a TestRail upload — which is a bug in a workflow this
+    org owns and is dispatched as `saas-ci`. Only a run with no reports at all
+    stays `saas-infra`: there the downstream died before Playwright produced any
+    evidence, and the failing job is as likely to be the provisioning API as
+    anything in the repository.
     """
     if not has_artifacts or counts.total == 0:
         return SURFACE_SAAS_INFRA
     if counts.failed == 0:
-        return SURFACE_SAAS_INFRA
+        return SURFACE_SAAS_CI
     if counts.setup_failed == counts.failed:
         return SURFACE_SAAS_PROVISIONING
     return SURFACE_SAAS_E2E
@@ -360,6 +371,30 @@ class FailingSpec:
         retry fix rather than a behavioural change.
         """
         return bool(self.statuses) and all(s == "failed" for s in self.statuses)
+
+
+def ci_job_spec(
+    job_name: str, *, workflow_path: str, failing_steps: Iterable[str]
+) -> FailingSpec:
+    """Represent a failing CI job as a spec, for a run that had no failing test.
+
+    A `saas-ci` failure has no Playwright spec to name, so the job stands in for
+    one: `file` is the workflow that owns the job, which is the file the fix has
+    to change. `statuses` is a single failed attempt, so `deterministic` is True
+    and a CI bug is never mistaken for flakiness and "fixed" with a longer wait.
+    """
+    steps = [s for s in failing_steps if s]
+    return FailingSpec(
+        file=workflow_path,
+        test_name=job_leaf_name(job_name),
+        error=(
+            f"CI job failed at step: {', '.join(steps)}"
+            if steps
+            else "CI job failed with no failing step recorded"
+        ),
+        attempts=1,
+        statuses=["failed"],
+    )
 
 
 def failing_specs(report: Any, *, suite: str | None = None) -> list[FailingSpec]:

--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -226,10 +226,88 @@ def saas_candidate(run_id: str, base_ref: str, job_name: str, workdir: Path) -> 
         f"saas counts total={counts.total} failed={counts.failed} "
         f"flaky={counts.flaky} setup_failed={counts.setup_failed} -> {cand.surface}"
     )
-    if cand.surface != classify.SURFACE_SAAS_E2E:
+    if cand.surface == classify.SURFACE_SAAS_CI:
+        # Every spec passed, so the report-derived specs describe nothing that
+        # failed; the failing downstream jobs are the evidence instead.
+        cand.specs = downstream_ci_specs(downstream_id)
+        if not cand.specs:
+            log("::warning::no diagnosable failing downstream job; withholding saas-ci")
+            cand.surface = classify.SURFACE_SAAS_INFRA
+    elif cand.surface != classify.SURFACE_SAAS_E2E:
         # Only a genuine non-setup test failure is actionable in test code.
         cand.specs = []
     return cand
+
+
+#: How far back to look for the attempt that actually failed. Triage runs while
+#: that attempt is still the latest, so this only matters when a run is replayed
+#: after someone re-ran the downstream — walking the whole history would cost an
+#: API call per attempt for no benefit.
+MAX_ATTEMPT_LOOKBACK = 5
+
+
+def downstream_failing_jobs(downstream_id: str, attempts: int) -> list[dict]:
+    """Failing jobs of the most recent downstream attempt that had any.
+
+    A re-run turns every job of the latest attempt green while the parent run
+    keeps the conclusion triage reacted to, so reading only the latest attempt
+    silently loses the evidence.
+    """
+    for attempt in range(attempts, max(attempts - MAX_ATTEMPT_LOOKBACK, 0), -1):
+        data = gh_json(
+            [
+                "api",
+                f"repos/{E2E_REPO}/actions/runs/{downstream_id}"
+                f"/attempts/{attempt}/jobs?per_page=100",
+            ],
+            {},
+        )
+        failing = [
+            j
+            for j in (data.get("jobs") or [])
+            if isinstance(j, dict) and j.get("conclusion") == "failure"
+        ]
+        if failing:
+            if attempt != attempts:
+                log(f"downstream re-run since triage; reading attempt {attempt}")
+            return failing
+    return []
+
+
+def downstream_ci_specs(downstream_id: str) -> list[classify.FailingSpec]:
+    """Describe the failing jobs of a downstream run whose specs all passed.
+
+    The same noise prefilter as the parent run applies: a downstream job killed
+    by a GitHub platform error or a cancellation carries no evidence and must not
+    reach the agent.
+    """
+    run = gh_json(["api", f"repos/{E2E_REPO}/actions/runs/{downstream_id}"], {})
+    workflow_path = run.get("path") or ""
+    attempts = run.get("run_attempt") or 1
+
+    specs: list[classify.FailingSpec] = []
+    for job in downstream_failing_jobs(downstream_id, int(attempts)):
+        steps = job.get("steps") or []
+        verdict = classify.noise_verdict(
+            conclusion="failure",
+            step_count=len(steps),
+            failure_annotations=failure_annotations(job.get("check_run_url")),
+        )
+        if verdict:
+            log(f"downstream noise ({verdict}): {job.get('name')}")
+            continue
+        specs.append(
+            classify.ci_job_spec(
+                job.get("name") or "",
+                workflow_path=workflow_path,
+                failing_steps=[
+                    s.get("name") or ""
+                    for s in steps
+                    if isinstance(s, dict) and s.get("conclusion") == "failure"
+                ],
+            )
+        )
+    return specs
 
 
 # ---------------------------------------------------------------------------

--- a/.github/scripts/alwaysgreen/test_classify.py
+++ b/.github/scripts/alwaysgreen/test_classify.py
@@ -113,10 +113,14 @@ def test_helm_install_and_cleanup_are_distinct_surfaces():
 def test_dispatchable_surfaces():
     assert classify.SURFACE_SM_E2E in classify.DISPATCHABLE_SURFACES
     assert classify.SURFACE_SAAS_E2E in classify.DISPATCHABLE_SURFACES
+    # A downstream run that went red on a job rather than a spec is still a bug
+    # in a workflow this org owns, so it goes to the agent like any other.
+    assert classify.SURFACE_SAAS_CI in classify.DISPATCHABLE_SURFACES
     # Dispatchable, but gated further by helm_install_verdict.
     assert classify.SURFACE_HELM_INSTALL in classify.DISPATCHABLE_SURFACES
     assert classify.SURFACE_BUILD not in classify.DISPATCHABLE_SURFACES
     assert classify.SURFACE_HELM_CLEANUP not in classify.DISPATCHABLE_SURFACES
+    assert classify.SURFACE_SAAS_INFRA not in classify.DISPATCHABLE_SURFACES
 
 
 # ---------------------------------------------------------------------------
@@ -197,11 +201,13 @@ def test_real_test_failures_are_saas_e2e():
     )
 
 
-def test_no_failing_specs_is_infra_not_dispatchable():
+def test_no_failing_specs_with_reports_is_a_ci_job_failure():
+    # Downstream run 31357325723: 15 specs, all green, red because the
+    # `Delete created organizations` job died on a transient curl error.
     counts = classify.SpecCounts(total=15, failed=0)
     assert (
         classify.saas_surface_from_counts(counts, has_artifacts=True)
-        == classify.SURFACE_SAAS_INFRA
+        == classify.SURFACE_SAAS_CI
     )
 
 
@@ -210,6 +216,49 @@ def test_missing_artifacts_is_infra():
         classify.saas_surface_from_counts(classify.SpecCounts(), has_artifacts=False)
         == classify.SURFACE_SAAS_INFRA
     )
+
+
+def test_reports_present_but_empty_is_infra():
+    # Reports uploaded with no specs in them means Playwright never ran; the
+    # failure is upstream of anything a CI-job fix could address.
+    counts = classify.SpecCounts(total=0, failed=0)
+    assert (
+        classify.saas_surface_from_counts(counts, has_artifacts=True)
+        == classify.SURFACE_SAAS_INFRA
+    )
+
+
+# ---------------------------------------------------------------------------
+# CI-job specs
+# ---------------------------------------------------------------------------
+
+
+def test_ci_job_spec_points_at_the_owning_workflow():
+    spec = classify.ci_job_spec(
+        "Delete created organizations",
+        workflow_path=".github/workflows/playwright_saas_pr_trigger_monorepo.yml",
+        failing_steps=["Delete orgs"],
+    )
+    assert spec.file == ".github/workflows/playwright_saas_pr_trigger_monorepo.yml"
+    assert spec.test_name == "Delete created organizations"
+    assert "Delete orgs" in spec.error
+
+
+def test_ci_job_spec_is_deterministic_not_flaky():
+    # A CI-job failure must never read as flaky, or the agent "fixes" it with a
+    # longer wait instead of repairing the step.
+    spec = classify.ci_job_spec("merge-reports", workflow_path="w.yml", failing_steps=[])
+    assert spec.deterministic is True
+    assert spec.attempts == 1
+
+
+def test_ci_job_spec_uses_the_leaf_of_a_nested_job_name():
+    spec = classify.ci_job_spec(
+        "Helm chart Integration Tests / agrn / Merge E2E Reports",
+        workflow_path="w.yml",
+        failing_steps=[],
+    )
+    assert spec.test_name == "Merge E2E Reports"
 
 
 # ---------------------------------------------------------------------------

--- a/.github/scripts/alwaysgreen/test_plan.py
+++ b/.github/scripts/alwaysgreen/test_plan.py
@@ -53,6 +53,34 @@ def test_helm_install_reaches_the_agent():
     assert len(result.dispatches) == 1
 
 
+def test_saas_ci_job_failure_reaches_the_agent():
+    # A downstream run whose specs all passed still has a fixable defect: the
+    # failing job stands in for a spec, with the workflow that owns it as `file`.
+    ci_spec = classify.ci_job_spec(
+        "Delete created organizations",
+        workflow_path=".github/workflows/playwright_saas_pr_trigger_monorepo.yml",
+        failing_steps=["Delete orgs"],
+    )
+    result = _plan([_cand(surface=classify.SURFACE_SAAS_CI, specs=[ci_spec])])
+    assert len(result.dispatches) == 1
+    assert result.dispatches[0].key == "main:saas-ci"
+    assert result.dispatches[0].deterministic_specs == [ci_spec]
+
+
+def test_saas_ci_dedupes_per_job_not_per_run():
+    # Two different jobs failing must produce two fingerprints, so a PR that
+    # fixes one does not suppress dispatch for the other.
+    a = classify.ci_job_spec("Delete created organizations", workflow_path="w.yml", failing_steps=[])
+    b = classify.ci_job_spec("merge-reports", workflow_path="w.yml", failing_steps=[])
+    cand = _cand(surface=classify.SURFACE_SAAS_CI, specs=[a, b])
+    assert len(set(cand.spec_fingerprints)) == 2
+
+    covered = {cand.spec_fingerprints[0]}
+    result = _plan([cand], covered_fingerprints=covered)
+    assert len(result.dispatches) == 1
+    assert [s.test_name for s in result.dispatches[0].specs] == ["merge-reports"]
+
+
 def test_in_flight_agent_blocks_the_same_surface():
     # The 2026-07-23 case: consecutive runs, same cause, agent still working.
     cand = _cand()

--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -19,7 +19,7 @@ on:
         description: 'Branch to fix against (main, stable/8.x)'
         required: true
       surface:
-        description: 'Failing surface (sm-smoke-e2e, saas-smoke-e2e)'
+        description: 'Failing surface (sm-smoke-e2e, saas-smoke-e2e, saas-ci, helm-install)'
         required: true
       test_specs:
         description: 'JSON array of failing specs with retry history'
@@ -114,7 +114,7 @@ jobs:
             *) echo "::error::unsupported base_ref '$BASE_REF'"; exit 1 ;;
           esac
           case "$SURFACE" in
-            sm-smoke-e2e|saas-smoke-e2e|helm-install) ;;
+            sm-smoke-e2e|saas-smoke-e2e|saas-ci|helm-install) ;;
             *) echo "::error::unsupported surface '$SURFACE'"; exit 1 ;;
           esac
           # main carries the next unreleased minor; stable/X.Y carries X.Y. Bump this
@@ -402,6 +402,16 @@ jobs:
           a Playwright timeout: the assertion is correct and the environment is broken.
           Read the diagnostics dump before concluding the test is at fault. Never mask a
           real failure with a timeout bump, a weakened assertion, or a selector swap.
+
+          On surface 'saas-ci' there is no failing test to read: every Playwright spec
+          passed and the downstream run went red on a job around them (org cleanup,
+          report merge, an upload). Each entry in /tmp/test_specs.json is that job —
+          'file' is the workflow in c8-cross-component-e2e-tests that owns it, 'test_name'
+          is the job, 'error' names the failing step. Read the step from the run log
+          (gh run view <id> --repo camunda/c8-cross-component-e2e-tests --log-failed) and
+          fix the step itself. A transient external call gets retry-with-backoff and a
+          per-attempt timeout; a real defect gets the real fix. continue-on-error is never
+          the answer, and neither is telling the on-call to re-run.
 
           "No fix determined" is a legitimate outcome. Write it to /tmp/fix-meta.json
           with the evidence rather than guessing.


### PR DESCRIPTION
## Description

AlwaysGreen triage collapsed **every** SaaS downstream failure with zero failing specs into `saas-infra`, which is not dispatchable. That reading is right for a run that died before Playwright produced anything. It is wrong for a run whose reports exist and are entirely green: there the red conclusion came from a job *around* the tests — org cleanup, report merge, an artifact or TestRail upload — and that is a defect in a workflow this org owns.

### The case

[Run 31356936063](https://github.com/camunda/camunda/actions/runs/31356936063). All 15 SaaS specs passed; the [downstream run](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/31357325723) went red because `Delete created organizations` hit a transient curl error (exit 56). Triage logged:

```
saas counts total=15 failed=0 flaky=0 setup_failed=0 -> saas-infra
dispatches=0 suppressed=1 noise=0
```

No agent ran. Nobody was handed the bug, and the same blip can recur nightly. The feature flag was on (`active=true dispatch=true`) — this was purely the classification.

### The change

Split that state out as `saas-ci` and make it dispatchable:

| reports | specs | failing | surface | dispatched |
|---|---|---|---|---|
| absent | — | — | `saas-infra` | no (unchanged) |
| present | 0 | — | `saas-infra` | no (unchanged) |
| present | >0 | 0 | **`saas-ci`** | **yes (new)** |
| present | >0 | all setup | `saas-provisioning` | no (unchanged) |
| present | >0 | >0 | `saas-smoke-e2e` | yes (unchanged) |

Genuinely absent or empty reports still read as `saas-infra`: there the failing job is as likely to be the provisioning API as anything in the repository, so withholding stays correct.

A `saas-ci` candidate has no failing spec to describe, so each failing downstream job stands in for one — `file` is the workflow that owns the job and is what the fix has to change, `test_name` is the job, `error` names the failing step:

```json
{
  "file": ".github/workflows/playwright_saas_pr_trigger_monorepo.yml",
  "test_name": "Delete created organizations",
  "error": "CI job failed at step: Delete orgs",
  "attempts": 1, "statuses": ["failed"], "deterministic": true
}
```

Design points:

- **One synthetic spec per job, not per run** — a PR fixing one job does not suppress dispatch for another.
- **`statuses` is a single failed attempt**, so `deterministic` is True and a CI bug is never mistaken for flakiness and "fixed" with a longer timeout.
- **The parent run's noise prefilter is applied to downstream jobs too** — a job killed by a GitHub platform error or a cancellation carries no evidence and is dropped.
- **A candidate left with no diagnosable job falls back to `saas-infra`** rather than dispatching an agent with nothing to go on.
- **Failing jobs are read from the most recent attempt that actually had one.** A re-run turns the latest attempt green while the parent run keeps the conclusion triage reacted to, so reading only the latest attempt loses the evidence — which is exactly what replaying run 31356936063 does today.

The fix workflow accepts the new surface and carries a prompt block telling the agent not to hunt for a Playwright assertion on `saas-ci`, and that `continue-on-error` and "re-run the nightly" are not acceptable outcomes.

### Validation

Replayed the real failing run through the patched discoverer:

```
before:  total=15 failed=0 -> saas-infra    dispatches=0 suppressed=1
after:   total=15 failed=0 -> saas-ci       dispatches=1 suppressed=0
```

It lands on exactly the workflow file and step that the companion PR fixes.

Unit tests 78 → 84, all passing (`pytest .github/scripts`, already gated by `scripts-tests` in `ci.yml`).

### Blast radius

`saas-provisioning`, `helm-cleanup`, `build` and `ci-infra` stay non-dispatchable. Only the one state where we have positive evidence the tests ran fine moves. Dispatch volume stays bounded by the existing `max_dispatches: 2` cap and the one-agent-per-`main:saas-ci` in-flight lock.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Companion PR fixing the failure this one stopped suppressing: camunda/c8-cross-component-e2e-tests#2963
Originating run: https://github.com/camunda/camunda/actions/runs/31356936063