### PR TITLE
test: harden stable/8.8 nightly e2e incident popover and DRD navigation

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
@@ -235,8 +235,6 @@ export class OperateDiagramPage {
   }
 
   async verifyIncidentInPopover(incidentPattern: RegExp) {
-    await this.monacoAriaContainer.waitFor({state: 'visible'});
-
     await expect(
       this.popover.getByRole('heading', {
         name: 'Incident',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
@@ -12,6 +12,7 @@ import {deploy, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {jsonHeaders} from 'utils/http';
+import {waitForAssertion} from 'utils/waitForAssertion';
 
 type ProcessInstance = {
   processInstanceKey: string;
@@ -266,19 +267,30 @@ test.describe('Decision Navigation', () => {
       ).not.toHaveCount(0);
     });
 
+    const viewDecisionInstanceLink = operateDecisionsPage.decisionInstancesList
+      .getByRole('row')
+      .filter({
+        hasText: processInstanceWithSuccessfulDecision.processInstanceKey,
+      })
+      .getByRole('link', {name: /View decision instance/})
+      .first();
+
     await test.step('Open the first Assign Approver Group decision instance', async () => {
-      await operateDecisionsPage.decisionInstancesList
-        .getByRole('row')
-        .filter({
-          hasText: processInstanceWithSuccessfulDecision.processInstanceKey,
-        })
-        .getByRole('link', {name: /View decision instance/})
-        .first()
-        .click();
+      await viewDecisionInstanceLink.click();
     });
 
     await test.step('Verify we are on the Assign Approver Group decision instance', async () => {
-      await expect(operateDecisionInstancePage.decisionPanel).toBeVisible();
+      // The decision instances list live-updates as new instances are indexed;
+      // a re-render can drop the SPA navigation triggered by the row link click,
+      // leaving the app on the list page. Re-click until the instance renders.
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateDecisionInstancePage.decisionPanel).toBeVisible();
+        },
+        onFailure: async () => {
+          await viewDecisionInstanceLink.click();
+        },
+      });
       // Input column header for Assign Approver Group is "Invoice Classification"
       await expect(
         operateDecisionInstancePage.decisionPanel.getByText(
@@ -298,10 +310,27 @@ test.describe('Decision Navigation', () => {
     });
 
     await test.step('Verify navigation to Invoice Classification instance with updated input data', async () => {
-      await expect(operateDecisionInstancePage.decisionPanel).toBeVisible();
-      await expect(
-        operateDecisionInstancePage.decisionPanel.getByText('Invoice Amount'),
-      ).toBeVisible();
+      await expect(operateDecisionInstancePage.decisionPanel).toBeVisible({
+        timeout: 30000,
+      });
+      // The decision panel keeps the same test id across instances, so it stays
+      // visible while the newly selected instance is still loading. A dropped
+      // DRD click leaves the previous decision rendered — re-click until the
+      // Invoice Classification input columns appear.
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateDecisionInstancePage.decisionPanel.getByText(
+              'Invoice Amount',
+            ),
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await operateDecisionInstancePage.clickDrdDecisionNode(
+            'Invoice Classification',
+          );
+        },
+      });
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -1132,7 +1132,7 @@ test.describe('Parallel job-based user task migration', () => {
       });
 
       await expect(
-        operateProcessesPage.versionCells(targetVersion),
+        operateProcessesPage.getVersionCells(targetVersion),
       ).toHaveCount(totalV2InstanceCount, {timeout: 30000});
     });
 


### PR DESCRIPTION
Fixes the failures in the [stable/8.8 nightly E2E run](https://github.com/camunda/camunda/actions/runs/31368728810) (v2 job). The same three failures also appeared in the [2026-08-08 scheduled run](https://github.com/camunda/camunda/actions/runs/31231981272), so this is recurring, not a one-off.

### 1. `Migrated tasks` — hard failure (`processInstanceMigration.spec.ts`)

```
TimeoutError: locator.waitFor: Timeout 10000ms exceeded.
  - waiting for locator('.monaco-aria-container') to be visible
  at OperateDiagramPage.verifyIncidentInPopover (pages/OperateDiagramPage.ts:238)
```

`verifyIncidentInPopover` waited for `.monaco-aria-container` before asserting on the incident popover. The incident popover contains no Monaco editor — that container only exists while the metadata modal is mounted. The step that runs immediately before (`Verify Task G migration`) opens and then closes that modal, so the wait only ever passed when a stale container happened to still be attached to the DOM.

The wait was added to stable/8.8 only, in 44985aeb380 (`fix: resolve flaky test`). Neither `main` nor `stable/8.9` carries it — this change brings 8.8 in line with both.

### 2. `Auto mapping migration` — flaky, cascade of the above

Attempt 0 passed and attempt 1 failed (`toHaveCount` expected 6, received 3). Because the suite is `test.describe.serial`, the `Migrated tasks` failure forces a retry of the whole block, and the migration performed on attempt 0 is not undone — only 3 unmigrated instances remain. Fixing (1) removes the retry and therefore this failure.

### 3. `should navigate through DRD to another decision instance` — flaky (`decisionNavigation.spec.ts`)

```
Locator: getByTestId('decision-panel').getByText('Invoice Amount')
Expected: visible / element(s) not found
```

The decision instances list live-updates as new instances are indexed, and a re-render can drop the SPA navigation triggered by the row link click. The decision panel also keeps the same test id across instances, so it stays visible while the newly selected instance is still loading. Both navigation steps now re-click on failure via `waitForAssertion` — the same hardening `main` already carries for the first of the two steps.

### 4. `versionCells` → `getVersionCells` typo

`npx tsc --noEmit` fails on `stable/8.8` today:

```
tests/operate/processInstanceMigration.spec.ts(1135,30): error TS2551:
  Property 'versionCells' does not exist on type 'OperateProcessesPage'.
```

Pre-existing on the branch tip (it sits inside a skipped test, so Playwright never transpiled it). Included here so `npm run lint` passes.

## Test plan

- `npx tsc --noEmit` — clean (was failing before this PR)
- `npx eslint` on the changed files — 0 errors (remaining warnings are pre-existing `no-force-option` / `no-skipped-test`)
- `npx prettier --check` on the changed files — clean
- No assertion was removed or weakened.

### Verification run — green

[C8 Orchestration Cluster E2E Tests On Demand #31377532553](https://github.com/camunda/camunda/actions/runs/31377532553) — `branch: harden-88-nightly-e2e-incident-popover`, base detected as `stable/8.8`.

| Job | Result |
|---|---|
| `validate-branch` | passed — base `stable/8.8` |
| E2E Tests (Mode profiles, Tasklist **v2**) | passed — **154 passed**, 0 failed, 0 flaky |
| E2E Tests (Mode profiles, Tasklist v1) | passed |
| API Tests (Mode profiles) | passed |
| API Tests (H2/RDBMS) | skipped (8.9 / main only) |

The v2 job runs `tests/ --grep-invert '@v1-only'` — the same selection as the nightly's v2 job. All three
previously-failing tests passed on the first attempt, with no retry and therefore no flaky classification:

```
* 67  decisionNavigation.spec.ts:253       > should navigate through DRD to another decision instance (13.5s)
* 79  processInstanceMigration.spec.ts:144 > Auto mapping migration (18.8s)
* 98  processInstanceMigration.spec.ts:694 > Migrated tasks (13.4s)
```

`Auto mapping migration` passing without a retry confirms it was a cascade of the `Migrated tasks` failure
rather than an independent flake.
