### PR TITLE
fix: include phases in configuration change response

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationChangeResponse.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationChangeResponse.java
@@ -12,6 +12,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -51,12 +52,12 @@ public record ClusterConfigurationChangeResponse(
   public record CurrentConfigurationChangeResponse(
       CurrentClusterConfiguration currentConfiguration,
       CurrentClusterConfiguration expectedConfiguration,
-      List<ClusterConfigurationChangeOperation> plannedChanges) {
+      List<Phase> phases) {
 
     public CurrentConfigurationChangeResponse {
       Objects.requireNonNull(currentConfiguration, "currentConfiguration must not be null");
       Objects.requireNonNull(expectedConfiguration, "expectedConfiguration must not be null");
-      Objects.requireNonNull(plannedChanges, "plannedChanges must not be null");
+      Objects.requireNonNull(phases, "phases must not be null");
     }
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -303,11 +303,11 @@ public final class ClusterConfigurationManagementRequestsHandler
                     new ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse(
                         result.currentConfiguration().members(),
                         result.finalConfiguration().members(),
-                        result.operations()),
+                        result.legacyOperations()),
                     new ClusterConfigurationChangeResponse.CurrentConfigurationChangeResponse(
                         result.currentMultiConfiguration(),
                         result.finalMultiConfiguration(),
-                        result.operations())),
+                        result.phases())),
             executor);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinator.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinator.java
@@ -73,7 +73,8 @@ public interface ConfigurationChangeCoordinator {
       CurrentClusterConfiguration finalMultiConfiguration,
       long changeId,
       // The operations that will be applied to the current configuration.
-      List<ClusterConfigurationChangeOperation> operations) {}
+      List<ClusterConfigurationChangeOperation> legacyOperations,
+      List<Phase> phases) {}
 
   @FunctionalInterface
   interface ConfigurationChangeRequest {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
@@ -203,6 +203,7 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
                   .lastChange()
                   .map(CompletedPhasedChange::id)
                   .orElse(0L),
+              List.of(),
               List.of()));
       return;
     }
@@ -232,7 +233,8 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
                     currentConfiguration,
                     simulatedFinalConfiguration,
                     changeId,
-                    operations));
+                    operations,
+                    phases));
             return;
           }
 
@@ -257,7 +259,8 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
                             currentConfiguration,
                             simulatedFinalConfiguration,
                             changeId,
-                            operations));
+                            operations,
+                            phases));
                   },
                   executor);
         });

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1692,6 +1692,7 @@ public class ProtoBufSerializer
               encodeCurrentClusterConfigurationProto(response.currentConfiguration()))
           .setExpectedConfiguration(
               encodeCurrentClusterConfigurationProto(response.expectedConfiguration()));
+      response.phases().forEach(phase -> builder.addPhases(encodePhase(phase)));
     }
 
     return builder;
@@ -1714,7 +1715,7 @@ public class ProtoBufSerializer
                 decodeCurrentClusterConfiguration(topologyChangeResponse.getCurrentConfiguration()),
                 decodeCurrentClusterConfiguration(
                     topologyChangeResponse.getExpectedConfiguration()),
-                legacyResponse.plannedChanges())
+                topologyChangeResponse.getPhasesList().stream().map(this::decodePhase).toList())
             : null;
 
     return new ClusterConfigurationChangeResponse(

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -151,10 +151,10 @@ message TopologyChangeResponse {
   map<string, topology_protocol.MemberState> expectedTopology = 3;
   repeated topology_protocol.TopologyChangeOperation plannedChanges = 4;
   // The new multi-partition-group configuration, in addition to the legacy
-  // default-group projection above. plannedChanges is shared between both
-  // views (same operations), so it is not duplicated here.
+  // default-group projection above.
   topology_protocol.CurrentClusterConfiguration currentConfiguration = 5;
   topology_protocol.CurrentClusterConfiguration expectedConfiguration = 6;
+  repeated topology_protocol.PhasedChangePlanPhase phases = 7;
 }
 
 message Response {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelConfigurationChangeCoordinatorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelConfigurationChangeCoordinatorTest.java
@@ -178,7 +178,7 @@ final class NewModelConfigurationChangeCoordinatorTest {
     final var result = coordinator.applyOperations(request).join();
 
     // then — the generated operations are returned, the plan drains phase by phase and completes
-    assertThat(result.operations())
+    assertThat(result.legacyOperations())
         .containsExactly(
             new PreScalingOperation(MEMBER_0, Set.of(MEMBER_0, MEMBER_1)),
             new PartitionLeaveOperation(MEMBER_0, 1, 1));
@@ -248,7 +248,8 @@ final class NewModelConfigurationChangeCoordinatorTest {
     final var result = coordinator.simulateOperations(request).join();
 
     // then — the operations are returned but no plan is started
-    assertThat(result.operations()).containsExactly(new PartitionLeaveOperation(MEMBER_0, 1, 1));
+    assertThat(result.legacyOperations())
+        .containsExactly(new PartitionLeaveOperation(MEMBER_0, 1, 1));
     assertThat(configuration().phasedChangeState().pending()).isEmpty();
     final var defaultGroup =
         configuration().partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
@@ -286,7 +287,7 @@ final class NewModelConfigurationChangeCoordinatorTest {
     final var result = coordinator.applyOperations(request).join();
 
     // then
-    assertThat(result.operations()).isEmpty();
+    assertThat(result.legacyOperations()).isEmpty();
     assertThat(configuration().phasedChangeState().pending()).isEmpty();
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandlerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandlerTest.java
@@ -62,6 +62,7 @@ final class ClusterConfigurationManagementRequestsHandlerTest {
                     CurrentClusterConfiguration.fromLegacy(config),
                     CurrentClusterConfiguration.fromLegacy(config),
                     1L,
+                    List.of(),
                     List.of())));
 
     // when
@@ -86,6 +87,7 @@ final class ClusterConfigurationManagementRequestsHandlerTest {
                     CurrentClusterConfiguration.fromLegacy(config),
                     CurrentClusterConfiguration.fromLegacy(config),
                     1L,
+                    List.of(),
                     List.of())));
 
     // when

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RecordingChangeCoordinator.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RecordingChangeCoordinator.java
@@ -54,7 +54,8 @@ final class RecordingChangeCoordinator implements ConfigurationChangeCoordinator
             CurrentClusterConfiguration.fromLegacy(currentTopology),
             CurrentClusterConfiguration.fromLegacy(newTopology),
             newTopology.pendingChanges().map(ClusterChangePlan::id).orElse(0L),
-            operations));
+            operations,
+            List.of()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -51,7 +51,9 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
 import java.time.Instant;
@@ -311,6 +313,21 @@ final class ProtoBufSerializerTest {
             new AwaitModeChangeOperation(MemberId.from("2"), Mode.RECOVERING),
             new PartitionPreRestoreOperation(MemberId.from("1"), 1),
             new PartitionRestoreOperation(MemberId.from("1"), 1, new TreeSet<>(List.of(1L, 2L))));
+    final List<Phase> phases =
+        List.of(
+            new GlobalPhase(List.of(new MemberLeaveOperation(MemberId.from("1")))),
+            new PartitionGroupParallelPhase(
+                Map.of(
+                    "default",
+                    List.of(
+                        new PartitionJoinOperation(MemberId.from("2"), 1, 2),
+                        new ModeChangeOperation(MemberId.from("2"), Mode.RECOVERING),
+                        new AwaitModeChangeOperation(MemberId.from("2"), Mode.RECOVERING)),
+                    "anothertenant",
+                    List.of(
+                        new PartitionPreRestoreOperation(MemberId.from("1"), 1),
+                        new PartitionRestoreOperation(
+                            MemberId.from("1"), 1, new TreeSet<>(List.of(1L, 2L)))))));
     final var currentMultiConfiguration = CurrentClusterConfiguration.init();
     final var expectedMultiConfiguration =
         CurrentClusterConfiguration.fromLegacy(
@@ -328,7 +345,7 @@ final class ProtoBufSerializerTest {
                 Map.of(MemberId.from("2"), MemberState.initializeAsActive(Map.of())),
                 plannedChanges),
             new ClusterConfigurationChangeResponse.CurrentConfigurationChangeResponse(
-                currentMultiConfiguration, expectedMultiConfiguration, plannedChanges));
+                currentMultiConfiguration, expectedMultiConfiguration, phases));
 
     // when
     final var encodedResponse = protoBufSerializer.encodeResponse(topologyChangeResponse);


### PR DESCRIPTION
## Description

Flattened operations lost the information about which physical tenant they belong to. Including the phases as it is will help translate that to the user response correctly.

PS:- The new field is not yet used by the endpoints. 

## Related issues

related to #57016 
related to #https://github.com/camunda/camunda/issues/59406 
