### PR TITLE
Run scheduled backups and retention for every physical tenant

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
@@ -42,10 +43,14 @@ import org.slf4j.LoggerFactory;
  * Manages the retention of backups by periodically identifying old backups and routing their
  * deletion through the stream processor via {@code DELETE_BACKUP} commands.
  *
+ * <p>An instance is scoped to a single physical tenant: it only looks at that tenant's partitions
+ * and only sends delete commands to them, so tenants with different backup stores and retention
+ * windows are kept independent.
+ *
  * <h2>Retention Process</h2>
  *
  * The retention process is executed on a configurable schedule and performs the following steps for
- * each partition:
+ * each partition of the physical tenant:
  *
  * <ol>
  *   <li><b>Retrieve Backups:</b> Fetches all existing backups for the partition from the backup
@@ -100,6 +105,7 @@ public class BackupRetention extends Actor {
             }
           });
 
+  private final String physicalTenantId;
   private final Supplier<BackupStore> backupStoreFactory;
   private final BrokerClient brokerClient;
   private final Schedule retentionSchedule;
@@ -110,12 +116,15 @@ public class BackupRetention extends Actor {
   private @Nullable BackupStore backupStore;
 
   public BackupRetention(
+      final String physicalTenantId,
       final Supplier<BackupStore> backupStoreFactory,
       final BrokerClient brokerClient,
       final Schedule retentionSchedule,
       final Duration retentionWindow,
       final BrokerTopologyManager topologyManager,
       final MeterRegistry meterRegistry) {
+    super("BackupRetention", null, Map.of(ACTOR_PROP_PHYSICAL_TENANT, physicalTenantId));
+    this.physicalTenantId = physicalTenantId;
     metrics = new RetentionMetrics(meterRegistry);
     this.backupStoreFactory = backupStoreFactory;
     this.brokerClient = brokerClient;
@@ -126,7 +135,7 @@ public class BackupRetention extends Actor {
 
   @Override
   protected void onActorStarted() {
-    LOG.debug("Retention scheduler started");
+    LOG.info("Backup retention initialized with cleanup schedule {}", retentionSchedule);
     backupStore = backupStoreFactory.get();
     metrics.register();
     final var next =
@@ -169,7 +178,7 @@ public class BackupRetention extends Actor {
   private ActorFuture<Void> performRetention() {
     final ActorFuture<Void> retentionFuture = createFuture();
     final var partitionFutures =
-        topologyManager.getTopology().getPartitions().stream()
+        topologyManager.getTopology(physicalTenantId).getPartitions().stream()
             .parallel()
             .map(this::createRetentionContext)
             .map(
@@ -317,6 +326,7 @@ public class BackupRetention extends Actor {
     final var futures = new ArrayList<CompletableFuture<?>>(uniqueCheckpointIds.length);
     for (final var checkpointId : uniqueCheckpointIds) {
       final var request = new BackupDeleteRequest();
+      request.setPartitionGroup(physicalTenantId);
       request.setPartitionId(context.partitionId);
       request.setBackupId(checkpointId);
       futures.add(

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/CheckpointScheduler.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/CheckpointScheduler.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.backup.schedule;
 
-import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
-
 import io.camunda.zeebe.backup.client.api.BackupRequestHandler;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState;
@@ -21,16 +19,23 @@ import io.camunda.zeebe.util.ExponentialBackoff;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Triggers marker checkpoints and scheduled backups for a single physical tenant, on that tenant's
+ * own schedules. All requests are targeted at the tenant's partitions only, so tenants with
+ * different backup configurations never interfere with each other.
+ */
 public class CheckpointScheduler extends Actor implements AutoCloseable {
   private static final long BACKOFF_INITIAL_DELAY_MS = 1000;
   private static final long BACKOFF_MAX_DELAY_MS = 10_000;
 
   private static final Logger LOG = LoggerFactory.getLogger(CheckpointScheduler.class);
+  private final String physicalTenantId;
   private final Schedule checkpointSchedule;
   private final Schedule backupSchedule;
   private final BackupRequestHandler backupRequestHandler;
@@ -42,10 +47,13 @@ public class CheckpointScheduler extends Actor implements AutoCloseable {
   private final ExponentialBackoff backupErrorStrategy;
 
   public CheckpointScheduler(
+      final String physicalTenantId,
       final Schedule checkpointSchedule,
       final Schedule backupSchedule,
       final BackupRequestHandler backupRequestHandler,
       final MeterRegistry meterRegistry) {
+    super("CheckpointScheduler", null, Map.of(ACTOR_PROP_PHYSICAL_TENANT, physicalTenantId));
+    this.physicalTenantId = physicalTenantId;
     this.checkpointSchedule = checkpointSchedule;
     this.backupSchedule = backupSchedule;
     metrics = new SchedulerMetrics(meterRegistry);
@@ -61,9 +69,11 @@ public class CheckpointScheduler extends Actor implements AutoCloseable {
     LOG.debug("Checkpoint scheduler started");
     metrics.register();
     if (checkpointSchedule != null) {
+      LOG.info("Checkpoint scheduler initialized with interval {}", checkpointSchedule);
       actor.run(this::markerSchedulingTask);
     }
     if (backupSchedule != null) {
+      LOG.info("Backup scheduler initialized with interval {}", backupSchedule);
       actor.run(this::backupSchedulingTask);
     }
   }
@@ -106,7 +116,7 @@ public class CheckpointScheduler extends Actor implements AutoCloseable {
       final Function<CheckpointStateResponse, Set<PartitionCheckpointState>> stateFilter) {
     final ActorFuture<Set<PartitionCheckpointState>> future = createFuture();
     backupRequestHandler
-        .getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID)
+        .getCheckpointState(physicalTenantId)
         .thenApplyAsync(stateFilter, this)
         .whenCompleteAsync(future, this);
     return future;
@@ -156,7 +166,7 @@ public class CheckpointScheduler extends Actor implements AutoCloseable {
     final CompletableActorFuture<ExecutionResult> future = new CompletableActorFuture<>();
     if (nextExecution.isBefore(now) || nextExecution.equals(now)) {
       backupRequestHandler
-          .checkpoint(DEFAULT_PHYSICAL_TENANT_ID, type)
+          .checkpoint(physicalTenantId, type)
           .toCompletableFuture()
           .thenApplyAsync(
               id -> {

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/retention/RetentionTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/retention/RetentionTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.retention;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.zeebe.backup.retention.RetentionMetrics.BACKUPS_DELETED_ROUND;
 import static io.camunda.zeebe.backup.retention.RetentionMetrics.EARLIEST_BACKUP_ID;
 import static io.camunda.zeebe.backup.retention.RetentionMetrics.PARTITION_TAG;
@@ -86,7 +87,7 @@ public class RetentionTest {
     meterRegistry.clear();
     backupRetention = createBackupRetention();
 
-    doReturn(clusterState).when(topologyManager).getTopology();
+    doReturn(clusterState).when(topologyManager).getTopology(DEFAULT_PHYSICAL_TENANT_ID);
     doReturn(List.of(1)).when(clusterState).getPartitions();
 
     lenient()
@@ -180,6 +181,7 @@ public class RetentionTest {
     final var built = new AtomicInteger();
     backupRetention =
         new BackupRetention(
+            DEFAULT_PHYSICAL_TENANT_ID,
             () -> stores.get(built.getAndIncrement()),
             brokerClient,
             new IntervalSchedule(Duration.ofSeconds(10)),
@@ -200,6 +202,29 @@ public class RetentionTest {
     assertThat(built.get()).isEqualTo(2);
     verify(stores.get(0)).closeAsync();
     verify(stores.get(1), never()).closeAsync();
+  }
+
+  @Test
+  void shouldDeleteOnlyWithinItsOwnPhysicalTenant() {
+    // given
+    reset(topologyManager, clusterState);
+    doReturn(List.of(2)).when(clusterState).getPartitions();
+    doReturn(clusterState).when(topologyManager).getTopology("tenant-a");
+    backupRetention = createBackupRetention("tenant-a");
+
+    final var now = actorScheduler.getClock().instant();
+    final List<BackupStatus> backups = createDefaultBackups(2, 1, now);
+    when(backupStore.list(any())).thenReturn(CompletableFuture.completedFuture(backups));
+
+    // when
+    runRetentionCycle();
+
+    // then
+    verify(topologyManager, never()).getTopology(DEFAULT_PHYSICAL_TENANT_ID);
+    backups.subList(0, 4).stream()
+        .mapToLong(backup -> backup.id().checkpointId())
+        .distinct()
+        .forEach(checkpointId -> verifyDeleteCommandSent("tenant-a", 2, checkpointId));
   }
 
   @Test
@@ -321,7 +346,12 @@ public class RetentionTest {
   }
 
   private BackupRetention createBackupRetention() {
+    return createBackupRetention(DEFAULT_PHYSICAL_TENANT_ID);
+  }
+
+  private BackupRetention createBackupRetention(final String physicalTenantId) {
     return new BackupRetention(
+        physicalTenantId,
         () -> backupStore,
         brokerClient,
         new IntervalSchedule(Duration.ofSeconds(10)),
@@ -385,14 +415,20 @@ public class RetentionTest {
     }
   }
 
-  @SuppressWarnings("unchecked")
   private void verifyDeleteCommandSent(final int partitionId, final long checkpointId) {
+    verifyDeleteCommandSent(DEFAULT_PHYSICAL_TENANT_ID, partitionId, checkpointId);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void verifyDeleteCommandSent(
+      final String physicalTenantId, final int partitionId, final long checkpointId) {
     verify(brokerClient)
         .sendRequestWithRetry(
             (BrokerRequest<BackupStatusResponse>)
                 argThat(
                     req ->
-                        req instanceof BackupDeleteRequest deleteReq
+                        req instanceof final BackupDeleteRequest deleteReq
+                            && deleteReq.getPartitionGroup().equals(physicalTenantId)
                             && deleteReq.getPartitionId() == partitionId
                             && deleteReq.getBackupId() == checkpointId));
   }
@@ -404,7 +440,7 @@ public class RetentionTest {
             (BrokerRequest<BackupStatusResponse>)
                 argThat(
                     req ->
-                        req instanceof BackupDeleteRequest deleteReq
+                        req instanceof final BackupDeleteRequest deleteReq
                             && deleteReq.getBackupId() == checkpointId));
   }
 
@@ -415,7 +451,7 @@ public class RetentionTest {
             (BrokerRequest<BackupStatusResponse>)
                 argThat(
                     req ->
-                        req instanceof BackupDeleteRequest deleteReq
+                        req instanceof final BackupDeleteRequest deleteReq
                             && deleteReq.getPartitionId() == partitionId
                             && deleteReq.getBackupId() == checkpointId));
   }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/schedule/CheckpointScheduleTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/schedule/CheckpointScheduleTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -123,6 +124,33 @@ public class CheckpointScheduleTest {
     // initially stopped the clock
     assertThat(Instant.ofEpochMilli(recordedCheckpointIdValue))
         .isCloseTo(now, within(1, ChronoUnit.SECONDS));
+  }
+
+  @Test
+  void shouldRequestCheckpointsOnlyForItsOwnPhysicalTenant() {
+    // given
+    final var now = actorScheduler.getClock().getCurrentTime();
+    checkpointScheduler =
+        createScheduler(
+            "tenant-a",
+            new Schedule.IntervalSchedule(Duration.ofSeconds(5)),
+            new Schedule.IntervalSchedule(Duration.ofSeconds(5)));
+    when(backupRequestHandler.getCheckpointState("tenant-a"))
+        .thenReturn(
+            CompletableFuture.completedStage(
+                checkpointState(now.toEpochMilli(), now.toEpochMilli())));
+
+    // when
+    actorScheduler.submitActor(checkpointScheduler);
+    actorScheduler.workUntilDone();
+    actorScheduler.updateClock(Duration.ofSeconds(5));
+    actorScheduler.workUntilDone();
+
+    // then
+    verify(backupRequestHandler, times(1)).checkpoint("tenant-a", CheckpointType.MARKER);
+    verify(backupRequestHandler, times(1)).checkpoint("tenant-a", CheckpointType.SCHEDULED_BACKUP);
+    verify(backupRequestHandler, never()).getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID);
+    verify(backupRequestHandler, never()).checkpoint(eq(DEFAULT_PHYSICAL_TENANT_ID), any());
   }
 
   @Test
@@ -532,8 +560,15 @@ public class CheckpointScheduleTest {
 
   private CheckpointScheduler createScheduler(
       final Schedule checkpointSchedule, final Schedule backupSchedule) {
+    return createScheduler(DEFAULT_PHYSICAL_TENANT_ID, checkpointSchedule, backupSchedule);
+  }
+
+  private CheckpointScheduler createScheduler(
+      final String physicalTenantId,
+      final Schedule checkpointSchedule,
+      final Schedule backupSchedule) {
     return new CheckpointScheduler(
-        checkpointSchedule, backupSchedule, backupRequestHandler, meterRegistry);
+        physicalTenantId, checkpointSchedule, backupSchedule, backupRequestHandler, meterRegistry);
   }
 
   private Gauge getGauge(final String gaugeName, final CheckpointType type) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CheckpointSchedulerServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CheckpointSchedulerServiceStep.java
@@ -7,9 +7,12 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
 import io.camunda.zeebe.broker.system.management.CheckpointSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 public class CheckpointSchedulerServiceStep extends AbstractBrokerStartupStep {
 
@@ -19,9 +22,19 @@ public class CheckpointSchedulerServiceStep extends AbstractBrokerStartupStep {
       final ConcurrencyControl concurrencyControl,
       final ActorFuture<BrokerStartupContext> startupFuture) {
 
-    final var backupCfg = brokerStartupContext.getBrokerConfiguration().getData().getBackup();
     final var scheduler = brokerStartupContext.getActorSchedulingService();
     final var meterRegistry = brokerStartupContext.getMeterRegistry();
+
+    final Map<String, BackupCfg> backupCfgByPhysicalTenant = new LinkedHashMap<>();
+    for (final var physicalTenantId : brokerStartupContext.getPhysicalTenantIds().known()) {
+      backupCfgByPhysicalTenant.put(
+          physicalTenantId,
+          brokerStartupContext
+              .getPhysicalTenantContext(physicalTenantId)
+              .config()
+              .getData()
+              .getBackup());
+    }
 
     concurrencyControl.run(
         () -> {
@@ -29,7 +42,7 @@ public class CheckpointSchedulerServiceStep extends AbstractBrokerStartupStep {
               new CheckpointSchedulingService(
                   brokerStartupContext.getClusterServices().getMembershipService(),
                   scheduler,
-                  backupCfg,
+                  backupCfgByPhysicalTenant,
                   brokerStartupContext.getBrokerClient(),
                   meterRegistry);
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.broker.system.management;
 
-import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
-
 import io.atomix.cluster.ClusterMembershipEvent;
 import io.atomix.cluster.ClusterMembershipEvent.Type;
 import io.atomix.cluster.ClusterMembershipEventListener;
@@ -25,114 +23,92 @@ import io.camunda.zeebe.backup.schedule.Schedule.NoneSchedule;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreFactory;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.SchedulingHints;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.VisibleForTesting;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Owns the scheduled checkpoint/backup and backup retention jobs of every physical tenant this
+ * broker runs. Each tenant brings its own backup configuration, so it gets its own {@link
+ * CheckpointScheduler} and {@link BackupRetention} actors, targeting only that tenant's partitions
+ * and writing to only that tenant's backup store.
+ *
+ * <p>The jobs are cluster-wide singletons: they run on the member with the lowest id, and all
+ * tenants' jobs are started and stopped together as membership changes.
+ */
 public class CheckpointSchedulingService extends Actor implements ClusterMembershipEventListener {
 
   private static final Logger LOG = LoggerFactory.getLogger(CheckpointSchedulingService.class);
 
   private final ClusterMembershipService membershipService;
-  private final BackupCfg backupCfg;
+  private final Map<String, BackupCfg> backupCfgByPhysicalTenant;
   private final ActorSchedulingService actorScheduler;
   private final MeterRegistry meterRegistry;
   private final BrokerClient brokerClient;
-  private CheckpointScheduler checkpointScheduler;
-  private final BackupRequestHandler backupRequestHandler;
-  private BackupRetention backupRetentionJob;
+  private final List<PhysicalTenantSchedulers> tenantSchedulers = new ArrayList<>();
 
   public CheckpointSchedulingService(
       final ClusterMembershipService membershipService,
       final ActorSchedulingService actorScheduler,
-      final BackupCfg backupCfg,
+      final Map<String, BackupCfg> backupCfgByPhysicalTenant,
       final BrokerClient brokerClient,
       final MeterRegistry meterRegistry) {
     this.membershipService = membershipService;
     this.actorScheduler = actorScheduler;
-    this.backupCfg = backupCfg;
+    this.backupCfgByPhysicalTenant = new LinkedHashMap<>(backupCfgByPhysicalTenant);
     this.meterRegistry = meterRegistry;
     this.brokerClient = brokerClient;
-    backupRequestHandler =
-        new BackupRequestHandler(brokerClient, new CheckpointIdGenerator(backupCfg.getOffset()));
   }
 
   @Override
   protected void onActorStarting() {
     membershipService.addListener(this);
-    Schedule checkpointSchedule = null;
-    Schedule backupSchedule = null;
-    if (backupCfg.getCheckpointInterval() != null && !backupCfg.getCheckpointInterval().isZero()) {
-      checkpointSchedule = new IntervalSchedule(backupCfg.getCheckpointInterval());
-      LOG.info("Checkpoint scheduler initialized with interval {}", checkpointSchedule);
-    }
-    if (backupCfg.getSchedule() != null && !(backupCfg.getSchedule() instanceof NoneSchedule)) {
-      backupSchedule = backupCfg.getSchedule();
-      LOG.info("Backup scheduler initialized with interval {}", backupSchedule);
-    }
-
-    final var retentionCfg = backupCfg.getRetention();
-    if (shouldRegisterRetentionJob()) {
-      if (backupCfg.getStore() == BackupStoreType.NONE) {
-        throw new IllegalStateException("No backup store configured");
-      }
-      // The retention job owns the store: it builds one whenever it starts and releases it when it
-      // stops, so it keeps working across the stop/start cycles that follow the lowest member id.
-      backupRetentionJob =
-          new BackupRetention(
-              DEFAULT_PHYSICAL_TENANT_ID,
-              () -> BackupStoreFactory.createStore(backupCfg),
-              brokerClient,
-              retentionCfg.getCleanupSchedule(),
-              retentionCfg.getWindow(),
-              brokerClient.getTopologyManager(),
-              meterRegistry);
-      LOG.info(
-          "Backup retention initialized with cleanup schedule {}",
-          retentionCfg.getCleanupSchedule());
-    }
-
-    if (checkpointSchedule != null || backupSchedule != null) {
-      checkpointScheduler =
-          new CheckpointScheduler(
-              DEFAULT_PHYSICAL_TENANT_ID,
-              checkpointSchedule,
-              backupSchedule,
-              backupRequestHandler,
-              meterRegistry);
-    }
+    backupCfgByPhysicalTenant.forEach(
+        (physicalTenantId, backupCfg) -> {
+          final var schedulers = createSchedulers(physicalTenantId, backupCfg);
+          if (schedulers != null) {
+            tenantSchedulers.add(schedulers);
+          }
+        });
   }
 
   @Override
   protected void onActorStarted() {
-    checkedStartScheduler();
+    checkedStartSchedulers();
   }
 
   @Override
   protected void onActorCloseRequested() {
     membershipService.removeListener(this);
-    if (isSchedulerActive()) {
-      final List<ActorFuture<Void>> shutdownFutures = new ArrayList<>();
-      shutdownFutures.add(checkpointScheduler.closeAsync());
-      if (backupRetentionJob != null) {
-        shutdownFutures.add(backupRetentionJob.closeAsync());
-      }
-      actor.runOnCompletion(
-          shutdownFutures,
-          (error) -> {
-            if (error != null) {
-              LOG.error("Failed to close checkpoint creator actor", error);
-            }
-          });
-    }
+    final List<ActorFuture<Void>> shutdownFutures =
+        schedulerActors().stream()
+            .filter(actor -> !actor.isActorClosed())
+            .map(Actor::closeAsync)
+            .collect(Collectors.toCollection(ArrayList::new));
+
+    actor.runOnCompletion(
+        shutdownFutures,
+        (error) -> {
+          if (error != null) {
+            LOG.error("Failed to close checkpoint scheduling actors", error);
+          }
+          closeMeterRegistries();
+        });
   }
 
   @Override
@@ -144,38 +120,96 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
   public void event(final ClusterMembershipEvent event) {
     switch (event.type()) {
       case MEMBER_ADDED -> {
-        checkedStopScheduler();
-        checkedStartScheduler();
+        checkedStopSchedulers();
+        checkedStartSchedulers();
       }
-      case MEMBER_REMOVED -> checkedStartScheduler();
+      case MEMBER_REMOVED -> checkedStartSchedulers();
       default -> {}
     }
   }
 
-  private void checkedStopScheduler() {
-    if (shouldStopSchedulers() && isSchedulerActive()) {
-      checkpointScheduler.close();
-      if (backupRetentionJob != null) {
-        backupRetentionJob.close();
-      }
+  private @Nullable PhysicalTenantSchedulers createSchedulers(
+      final String physicalTenantId, final BackupCfg backupCfg) {
+    Schedule checkpointSchedule = null;
+    Schedule backupSchedule = null;
+    if (backupCfg.getCheckpointInterval() != null && !backupCfg.getCheckpointInterval().isZero()) {
+      checkpointSchedule = new IntervalSchedule(backupCfg.getCheckpointInterval());
     }
-  }
-
-  private void checkedStartScheduler() {
-    if (shouldStartSchedulers() && isSchedulerInactive()) {
-      actorScheduler.submitActor(checkpointScheduler, SchedulingHints.ioBound());
-      if (backupRetentionJob != null) {
-        actorScheduler.submitActor(backupRetentionJob, SchedulingHints.ioBound());
-      }
+    if (!(backupCfg.getSchedule() instanceof NoneSchedule)) {
+      backupSchedule = backupCfg.getSchedule();
     }
+    final var withRetention = shouldRegisterRetentionJob(backupCfg);
+
+    if (checkpointSchedule == null && backupSchedule == null && !withRetention) {
+      return null;
+    }
+
+    // Every tenant reports its metrics under the same names, so they are told apart by the tenant
+    // tag that this wrapped registry stamps on all of them.
+    final var tenantMeterRegistry =
+        MicrometerUtil.wrap(
+            meterRegistry, Tags.of(PartitionKeyNames.PHYSICAL_TENANT.asString(), physicalTenantId));
+
+    CheckpointScheduler checkpointScheduler = null;
+    if (checkpointSchedule != null || backupSchedule != null) {
+      final var backupRequestHandler =
+          new BackupRequestHandler(brokerClient, new CheckpointIdGenerator(backupCfg.getOffset()));
+      checkpointScheduler =
+          new CheckpointScheduler(
+              physicalTenantId,
+              checkpointSchedule,
+              backupSchedule,
+              backupRequestHandler,
+              tenantMeterRegistry);
+    }
+
+    BackupRetention backupRetentionJob = null;
+    if (withRetention) {
+      final var retentionCfg = backupCfg.getRetention();
+      final var backupStore = BackupStoreFactory.createStore(backupCfg);
+      if (backupStore == null) {
+        throw new IllegalStateException(
+            "No backup store configured for physical tenant " + physicalTenantId);
+      }
+      backupRetentionJob =
+          new BackupRetention(
+              physicalTenantId,
+              () -> backupStore,
+              brokerClient,
+              retentionCfg.getCleanupSchedule(),
+              retentionCfg.getWindow(),
+              brokerClient.getTopologyManager(),
+              tenantMeterRegistry);
+    }
+
+    return new PhysicalTenantSchedulers(
+        physicalTenantId, tenantMeterRegistry, checkpointScheduler, backupRetentionJob);
   }
 
-  private boolean isSchedulerActive() {
-    return checkpointScheduler != null && !checkpointScheduler.isActorClosed();
+  private void checkedStopSchedulers() {
+    if (!shouldStopSchedulers()) {
+      return;
+    }
+    schedulerActors().stream().filter(actor -> !actor.isActorClosed()).forEach(Actor::close);
   }
 
-  private boolean isSchedulerInactive() {
-    return checkpointScheduler != null && checkpointScheduler.isActorClosed();
+  private void checkedStartSchedulers() {
+    if (!shouldStartSchedulers()) {
+      return;
+    }
+    schedulerActors().stream()
+        .filter(Actor::isActorClosed)
+        .forEach(actor -> actorScheduler.submitActor(actor, SchedulingHints.ioBound()));
+  }
+
+  /** All physical tenants' scheduling actors, in configuration order. */
+  @VisibleForTesting
+  List<Actor> schedulerActors() {
+    return tenantSchedulers.stream().flatMap(schedulers -> schedulers.actors().stream()).toList();
+  }
+
+  private void closeMeterRegistries() {
+    tenantSchedulers.forEach(schedulers -> MicrometerUtil.close(schedulers.meterRegistry()));
   }
 
   private boolean shouldStartSchedulers() {
@@ -194,11 +228,33 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
         .orElse(false);
   }
 
-  private boolean shouldRegisterRetentionJob() {
+  private boolean shouldRegisterRetentionJob(final BackupCfg backupCfg) {
     final var retentionCfg = backupCfg.getRetention();
     return retentionCfg.getWindow() != null
         && !retentionCfg.getWindow().isZero()
         && retentionCfg.getCleanupSchedule() != null
         && !(retentionCfg.getCleanupSchedule() instanceof NoneSchedule);
+  }
+
+  /**
+   * The scheduling actors of a single physical tenant, along with the registry they report to. A
+   * tenant may have only one of the two, depending on what its backup configuration asks for.
+   */
+  private record PhysicalTenantSchedulers(
+      String physicalTenantId,
+      MeterRegistry meterRegistry,
+      @Nullable CheckpointScheduler checkpointScheduler,
+      @Nullable BackupRetention backupRetentionJob) {
+
+    List<Actor> actors() {
+      final List<Actor> actors = new ArrayList<>(2);
+      if (checkpointScheduler != null) {
+        actors.add(checkpointScheduler);
+      }
+      if (backupRetentionJob != null) {
+        actors.add(backupRetentionJob);
+      }
+      return actors;
+    }
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker.system.management;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
 import io.atomix.cluster.ClusterMembershipEvent;
 import io.atomix.cluster.ClusterMembershipEvent.Type;
 import io.atomix.cluster.ClusterMembershipEventListener;
@@ -86,6 +88,7 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
       // stops, so it keeps working across the stop/start cycles that follow the lowest member id.
       backupRetentionJob =
           new BackupRetention(
+              DEFAULT_PHYSICAL_TENANT_ID,
               () -> BackupStoreFactory.createStore(backupCfg),
               brokerClient,
               retentionCfg.getCleanupSchedule(),
@@ -100,7 +103,11 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
     if (checkpointSchedule != null || backupSchedule != null) {
       checkpointScheduler =
           new CheckpointScheduler(
-              checkpointSchedule, backupSchedule, backupRequestHandler, meterRegistry);
+              DEFAULT_PHYSICAL_TENANT_ID,
+              checkpointSchedule,
+              backupSchedule,
+              backupRequestHandler,
+              meterRegistry);
     }
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CheckpointSchedulerServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CheckpointSchedulerServiceStepTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
@@ -18,6 +19,7 @@ import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.Member;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
+import io.camunda.zeebe.broker.system.PhysicalTenantContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.CheckpointSchedulingService;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
@@ -51,7 +53,10 @@ public class CheckpointSchedulerServiceStepTest {
         .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
     final var mockClusterServices = mock(ClusterServicesImpl.class);
 
-    when(mockBrokerStartupContext.getBrokerConfiguration()).thenReturn(TEST_BROKER_CONFIG);
+    when(mockBrokerStartupContext.getPhysicalTenantIds())
+        .thenReturn(() -> Set.of(DEFAULT_PHYSICAL_TENANT_ID));
+    when(mockBrokerStartupContext.getPhysicalTenantContext(DEFAULT_PHYSICAL_TENANT_ID))
+        .thenReturn(physicalTenantContext(TEST_BROKER_CONFIG));
     when(mockBrokerStartupContext.getConcurrencyControl()).thenReturn(CONCURRENCY_CONTROL);
     when(mockBrokerStartupContext.getActorSchedulingService())
         .thenReturn(mockActorSchedulingService);
@@ -69,6 +74,10 @@ public class CheckpointSchedulerServiceStepTest {
         .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
 
     future = CONCURRENCY_CONTROL.createFuture();
+  }
+
+  private PhysicalTenantContext physicalTenantContext(final BrokerCfg config) {
+    return new PhysicalTenantContext(null, null, null, config, null, null);
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulerServiceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulerServiceTest.java
@@ -7,9 +7,12 @@
  */
 package io.camunda.zeebe.broker.system.management;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -33,12 +36,16 @@ import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupSchedulerRetentionCfg;
 import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
+import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.SchedulingHints;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.reflect.Field;
 import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import org.awaitility.Awaitility;
@@ -51,8 +58,11 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 @Execution(ExecutionMode.SAME_THREAD)
 public class CheckpointSchedulerServiceTest {
   private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
+  private static final String OTHER_TENANT_ID = "tenant-a";
+
   private CheckpointSchedulingService schedulingService;
-  private final BrokerCfg brokerConfig = new BrokerCfg();
+  private final Map<String, BackupCfg> backupCfgByTenant = new LinkedHashMap<>();
+  private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
   private BrokerClient brokerClient;
   private DefaultClusterMembershipService membershipService;
   private ActorScheduler scheduler;
@@ -78,15 +88,7 @@ public class CheckpointSchedulerServiceTest {
     scheduler = spy(ActorScheduler.newActorScheduler().build());
     scheduler.start();
 
-    brokerConfig.getData().setBackup(new BackupCfg());
-    brokerConfig.getData().getBackup().setSchedule("PT10M");
-    brokerConfig.getData().getBackup().setCheckpointInterval(Duration.ofMinutes(1L));
-    brokerConfig.getData().getBackup().setContinuous(true);
-    brokerConfig.getData().getBackup().setRetention(new BackupSchedulerRetentionCfg());
-    brokerConfig.getData().getBackup().getRetention().setCleanupSchedule("PT10M");
-    brokerConfig.getData().getBackup().getRetention().setWindow(Duration.ofHours(1L));
-    brokerConfig.getData().getBackup().setStore(BackupStoreType.FILESYSTEM);
-    brokerConfig.getData().getBackup().getFilesystem().setBasePath("base-path");
+    backupCfgByTenant.put(DEFAULT_PHYSICAL_TENANT_ID, backupCfg("base-path"));
 
     doReturn(MemberId.from("0")).when(member1).id();
     doReturn(MemberId.from("1")).when(member2).id();
@@ -96,13 +98,7 @@ public class CheckpointSchedulerServiceTest {
 
     doReturn(CONCURRENCY_CONTROL.completedFuture(null)).when(scheduler).submitActor(any());
 
-    schedulingService =
-        new CheckpointSchedulingService(
-            membershipService,
-            scheduler,
-            brokerConfig.getData().getBackup(),
-            brokerClient,
-            new SimpleMeterRegistry());
+    schedulingService = createSchedulingService();
   }
 
   @Test
@@ -128,6 +124,85 @@ public class CheckpointSchedulerServiceTest {
         .submitActor(
             argThat(BackupRetention.class::isInstance),
             argThat(arg -> arg.equals(SchedulingHints.IO_BOUND)));
+  }
+
+  @Test
+  void shouldStartSchedulersForEveryPhysicalTenant() {
+    // given
+    backupCfgByTenant.put(OTHER_TENANT_ID, backupCfg("other-base-path"));
+    schedulingService = createSchedulingService();
+    doReturn(Set.of(member1)).when(membershipService).getMembers();
+    doReturn(member1).when(membershipService).getLocalMember();
+
+    // when
+    schedulingService.onActorStarting();
+    schedulingService.onActorStarted();
+
+    // then
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              verify(scheduler, times(2))
+                  .submitActor(
+                      argThat(CheckpointScheduler.class::isInstance), eq(SchedulingHints.IO_BOUND));
+              verify(scheduler, times(2))
+                  .submitActor(
+                      argThat(BackupRetention.class::isInstance), eq(SchedulingHints.IO_BOUND));
+            });
+  }
+
+  @Test
+  void shouldReportMetricsPerPhysicalTenant() {
+    // given
+    backupCfgByTenant.put(OTHER_TENANT_ID, backupCfg("other-base-path"));
+    schedulingService = createSchedulingService();
+    doReturn(Set.of(member1)).when(membershipService).getMembers();
+    doReturn(member1).when(membershipService).getLocalMember();
+
+    // when
+    schedulingService.onActorStarting();
+    schedulingService.onActorStarted();
+
+    // then — the tenants report the same metrics, told apart by the physical tenant tag
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        meterRegistry
+                            .find("camunda.checkpoint.scheduler.last.checkpoint.id")
+                            .gauges())
+                    .extracting(gauge -> gauge.getId().getTag("physicalTenant"))
+                    .contains(DEFAULT_PHYSICAL_TENANT_ID, OTHER_TENANT_ID));
+    assertThat(meterRegistry.find("camunda.backup.retention.next.execution.millis").gauges())
+        .extracting(gauge -> gauge.getId().getTag("physicalTenant"))
+        .containsExactlyInAnyOrder(DEFAULT_PHYSICAL_TENANT_ID, OTHER_TENANT_ID);
+  }
+
+  @Test
+  void shouldOnlyStartSchedulersConfiguredForTheTenant() {
+    // given — the other tenant only schedules checkpoints, it has no retention configured
+    final var otherCfg = backupCfg("other-base-path");
+    otherCfg.setRetention(new BackupSchedulerRetentionCfg());
+    backupCfgByTenant.put(OTHER_TENANT_ID, otherCfg);
+    schedulingService = createSchedulingService();
+    doReturn(Set.of(member1)).when(membershipService).getMembers();
+    doReturn(member1).when(membershipService).getLocalMember();
+
+    // when
+    schedulingService.onActorStarting();
+    schedulingService.onActorStarted();
+
+    // then
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              verify(scheduler, times(2))
+                  .submitActor(
+                      argThat(CheckpointScheduler.class::isInstance), eq(SchedulingHints.IO_BOUND));
+              verify(scheduler, times(1))
+                  .submitActor(
+                      argThat(BackupRetention.class::isInstance), eq(SchedulingHints.IO_BOUND));
+            });
   }
 
   @Test
@@ -225,34 +300,32 @@ public class CheckpointSchedulerServiceTest {
   }
 
   @Test
-  void shouldStopSchedulerOnLowestAdded() throws NoSuchFieldException, IllegalAccessException {
+  void shouldStopSchedulersOfAllTenantsOnLowestAdded() {
     // given
-
+    backupCfgByTenant.put(OTHER_TENANT_ID, backupCfg("other-base-path"));
+    schedulingService = createSchedulingService();
     doReturn(member2).when(membershipService).getLocalMember();
     doReturn(Set.of(member2, member3)).when(membershipService).getMembers();
     schedulingService.onActorStarting();
     schedulingService.onActorStarted();
-    verify(scheduler, times(1))
+    verify(scheduler, times(2))
         .submitActor(
             argThat(CheckpointScheduler.class::isInstance),
             argThat(arg -> arg.equals(SchedulingHints.IO_BOUND)));
-    final var checkpointCreatorSpy = getCheckpointCreator(schedulingService);
-    final var retentionJobSpy = getRetentionJob(schedulingService);
 
     // when
     doReturn(Set.of(member1, member2, member3)).when(membershipService).getMembers();
     schedulingService.event(new ClusterMembershipEvent(Type.MEMBER_ADDED, member1));
 
     // then
-    assertThat(checkpointCreatorSpy.isActorClosed()).isTrue();
-    assertThat(retentionJobSpy.isActorClosed()).isTrue();
+    assertThat(schedulingService.schedulerActors()).allMatch(Actor::isActorClosed);
   }
 
   @Test
   void shouldOnlyStartCheckpointSchedulerOnEmptyString()
       throws NoSuchFieldException, IllegalAccessException {
     // given
-    brokerConfig.getData().getBackup().setSchedule("");
+    backupCfgByTenant.get(DEFAULT_PHYSICAL_TENANT_ID).setSchedule("");
 
     final var member = mock(Member.class);
     doReturn(Set.of(member)).when(membershipService).getMembers();
@@ -279,16 +352,8 @@ public class CheckpointSchedulerServiceTest {
   void shouldOnlyStartCheckpointSchedulerOnNone()
       throws NoSuchFieldException, IllegalAccessException {
     // given
-
-    brokerConfig.getData().getBackup().setSchedule("none");
-
-    schedulingService =
-        new CheckpointSchedulingService(
-            membershipService,
-            scheduler,
-            brokerConfig.getData().getBackup(),
-            brokerClient,
-            new SimpleMeterRegistry());
+    backupCfgByTenant.get(DEFAULT_PHYSICAL_TENANT_ID).setSchedule("none");
+    schedulingService = createSchedulingService();
 
     final var member = mock(Member.class);
     doReturn(Set.of(member)).when(membershipService).getMembers();
@@ -316,7 +381,7 @@ public class CheckpointSchedulerServiceTest {
   void shouldOnlyStartBackupScheduler() throws NoSuchFieldException, IllegalAccessException {
     // given
 
-    brokerConfig.getData().getBackup().setCheckpointInterval(null);
+    backupCfgByTenant.get(DEFAULT_PHYSICAL_TENANT_ID).setCheckpointInterval(null);
 
     final var member = mock(Member.class);
     doReturn(Set.of(member)).when(membershipService).getMembers();
@@ -344,7 +409,7 @@ public class CheckpointSchedulerServiceTest {
   void shouldNotRegisterRetentionJobOnEmptySchedule() {
 
     // given
-    brokerConfig.getData().getBackup().getRetention().setCleanupSchedule(null);
+    backupCfgByTenant.get(DEFAULT_PHYSICAL_TENANT_ID).getRetention().setCleanupSchedule(null);
     final var member = mock(Member.class);
     doReturn(Set.of(member)).when(membershipService).getMembers();
     doReturn(MemberId.from("0")).when(member).id();
@@ -370,7 +435,7 @@ public class CheckpointSchedulerServiceTest {
   void shouldNotRegisterRetentionJobOnNullSchedule() {
 
     // given
-    brokerConfig.getData().getBackup().getRetention().setWindow(null);
+    backupCfgByTenant.get(DEFAULT_PHYSICAL_TENANT_ID).getRetention().setWindow(null);
     final var member = mock(Member.class);
     doReturn(Set.of(member)).when(membershipService).getMembers();
     doReturn(MemberId.from("0")).when(member).id();
@@ -392,34 +457,36 @@ public class CheckpointSchedulerServiceTest {
     verify(scheduler, never()).submitActor(argThat(BackupRetention.class::isInstance), any());
   }
 
-  private CheckpointScheduler getCheckpointCreator(
-      final CheckpointSchedulingService schedulingService)
-      throws NoSuchFieldException, IllegalAccessException {
-    final Field checkpointCreatorField =
-        CheckpointSchedulingService.class.getDeclaredField("checkpointScheduler");
-    checkpointCreatorField.setAccessible(true);
-    return (CheckpointScheduler) checkpointCreatorField.get(schedulingService);
+  private CheckpointSchedulingService createSchedulingService() {
+    return new CheckpointSchedulingService(
+        membershipService, scheduler, backupCfgByTenant, brokerClient, meterRegistry);
   }
 
-  private BackupRetention getRetentionJob(final CheckpointSchedulingService schedulingService)
-      throws NoSuchFieldException, IllegalAccessException {
-    final Field retentionJobField =
-        CheckpointSchedulingService.class.getDeclaredField("backupRetentionJob");
-    retentionJobField.setAccessible(true);
-    return (BackupRetention) retentionJobField.get(schedulingService);
+  private BackupCfg backupCfg(final String basePath) {
+    final var brokerConfig = new BrokerCfg();
+    brokerConfig.getData().setBackup(new BackupCfg());
+    final var backupCfg = brokerConfig.getData().getBackup();
+    backupCfg.setSchedule("PT10M");
+    backupCfg.setCheckpointInterval(Duration.ofMinutes(1L));
+    backupCfg.setContinuous(true);
+    backupCfg.setRetention(new BackupSchedulerRetentionCfg());
+    backupCfg.getRetention().setCleanupSchedule("PT10M");
+    backupCfg.getRetention().setWindow(Duration.ofHours(1L));
+    backupCfg.setStore(BackupStoreType.FILESYSTEM);
+    backupCfg.getFilesystem().setBasePath(basePath);
+    return backupCfg;
   }
 
   private Schedule getSchedule(
       final CheckpointSchedulingService schedulingService, final String scheduleName)
       throws NoSuchFieldException, IllegalAccessException {
-    final Field checkpointCreatorField =
-        CheckpointSchedulingService.class.getDeclaredField("checkpointScheduler");
     final Field scheduleField = CheckpointScheduler.class.getDeclaredField(scheduleName);
-    checkpointCreatorField.setAccessible(true);
     scheduleField.setAccessible(true);
-    final CheckpointScheduler creator =
-        (CheckpointScheduler) checkpointCreatorField.get(schedulingService);
-
-    return (Schedule) scheduleField.get(creator);
+    final var scheduler =
+        schedulingService.schedulerActors().stream()
+            .filter(CheckpointScheduler.class::isInstance)
+            .findFirst()
+            .orElseThrow();
+    return (Schedule) scheduleField.get(scheduler);
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantScheduledBackupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantScheduledBackupIT.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.configuration.Filesystem;
+import io.camunda.configuration.PrimaryStorageBackup;
+import io.camunda.configuration.PrimaryStorageBackup.BackupStoreType;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
+import io.camunda.zeebe.backup.filesystem.FilesystemBackupConfig;
+import io.camunda.zeebe.backup.filesystem.FilesystemBackupStore;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Verifies that the checkpoint scheduler runs per physical tenant: every tenant takes scheduled
+ * backups on its own schedule and writes them to its own backup store.
+ *
+ * <p>Before the scheduler became tenant-aware it always targeted the default tenant, so a
+ * non-default tenant never got a scheduled backup even with a complete backup configuration.
+ */
+@Timeout(120)
+@ZeebeIntegration
+final class PhysicalTenantScheduledBackupIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final Duration CHECKPOINT_INTERVAL = Duration.ofSeconds(1);
+  private static final String BACKUP_SCHEDULE = "PT2S";
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  private static @TempDir Path tempDir;
+
+  private final Path defaultBasePath = tempDir.resolve(PhysicalTenantsITHelper.DEFAULT_TENANT_ID);
+  private final Path tenantABasePath = tempDir.resolve(TENANT_A);
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      TENANTS
+          .configure(new TestStandaloneBroker().withUnauthenticatedAccess())
+          .withUnifiedConfig(
+              camunda ->
+                  configureBackup(
+                      camunda.getData().getPrimaryStorage().getBackup(), defaultBasePath))
+          .withPtConfig(
+              TENANT_A,
+              camunda ->
+                  configureBackup(
+                      camunda.getData().getPrimaryStorage().getBackup(), tenantABasePath));
+
+  private BackupStore defaultStore;
+  private BackupStore tenantAStore;
+
+  @AfterEach
+  void tearDown() {
+    if (defaultStore != null) {
+      defaultStore.closeAsync().join();
+    }
+    if (tenantAStore != null) {
+      tenantAStore.closeAsync().join();
+    }
+  }
+
+  @Test
+  void shouldTakeScheduledBackupsForEveryPhysicalTenant() {
+    // given — each tenant writes to its own backup store
+    defaultStore = backupStore(defaultBasePath);
+    tenantAStore = backupStore(tenantABasePath);
+
+    // when — the schedulers of both tenants have had time to run
+    // then — each store holds completed backups of its own tenant's partitions
+    await()
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(
+            () -> {
+              assertThat(completedBackupCount(defaultStore)).isPositive();
+              assertThat(completedBackupCount(tenantAStore)).isPositive();
+            });
+  }
+
+  private static void configureBackup(final PrimaryStorageBackup backup, final Path basePath) {
+    backup.setStore(BackupStoreType.FILESYSTEM);
+    final var filesystem = new Filesystem();
+    filesystem.setBasePath(basePath.toAbsolutePath().toString());
+    backup.setFilesystem(filesystem);
+    backup.setContinuous(true);
+    backup.setCheckpointInterval(CHECKPOINT_INTERVAL);
+    backup.setSchedule(BACKUP_SCHEDULE);
+  }
+
+  private static BackupStore backupStore(final Path basePath) {
+    return FilesystemBackupStore.of(
+        new FilesystemBackupConfig(basePath.toAbsolutePath().toString()));
+  }
+
+  private static long completedBackupCount(final BackupStore store) {
+    return store
+        .list(
+            new BackupIdentifierWildcardImpl(
+                Optional.empty(), Optional.empty(), CheckpointPattern.any()))
+        .join()
+        .stream()
+        .filter(status -> status.statusCode() == BackupStatusCode.COMPLETED)
+        .count();
+  }
+}


### PR DESCRIPTION
Runs the scheduled checkpoint/backup and retention jobs per physical tenant, from each tenant's own backup configuration.

Both actors were pinned to the default tenant — the scheduler checkpointed `default`, and retention read the default topology and left the partition group unset on its `DELETE_BACKUP` commands, so a non-default tenant never got a scheduled backup or a retention run.

4119a76937aff3f6ccaf99d8694e082152824540 makes the tenant an explicit constructor argument of both actors; 393585c39d637448d4ff8cb2116a72c57da83d4e then builds one pair per configured tenant. Which broker runs them is unchanged: the member with the lowest id.

The tenants are `getPhysicalTenantIds().known()` — everything under `camunda.physical-tenants.*` plus the synthesized `default`, the same set `PartitionManagerStep` uses — not the partition groups this broker happens to host. Each gets a checkpoint scheduler if it configures a checkpoint interval or a backup schedule, and a retention job if it configures a retention window and cleanup schedule; a tenant that configures none contributes no actors.

Existing `camunda.checkpoint.scheduler.*` and `camunda.backup.retention.*` series gain a `physicalTenant` label. Retention is now also started whenever it is configured, where it previously started only alongside a checkpoint scheduler.

closes #59106
