### PR TITLE
[Backport stable/8.8] test: add timeout guard to ScaleUpPartitionsTest

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -52,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
@@ -60,6 +61,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -70,6 +72,10 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @ZeebeIntegration
+// Interrupt any test method hanging longer than 10 minutes so the remaining tests still run and
+// the failure is attributed with a stack trace, instead of the CI job timing out with no test
+// results at all (see https://github.com/camunda/camunda/issues/56666).
+@Timeout(value = 10, unit = TimeUnit.MINUTES)
 public class ScaleUpPartitionsTest {
   private static final Logger LOG = LoggerFactory.getLogger(ScaleUpPartitionsTest.class);
 


### PR DESCRIPTION
Manual partial backport of #57150 (issue #56666) to stable/8.8.

Adds only the class-level `@Timeout(10, MINUTES)` guard to
`ScaleUpPartitionsTest`. The `awaitCompleteTopology = false` change and the
rest of #57150 are deliberately excluded.

**Why:** the suite hangs intermittently on this branch and the job is killed
at the GHA level with no Failsafe report written, so each recurrence produces
zero diagnostics (INC-7059, INC-6852). This guard makes a hanging test method
fail with a stack trace and lets the remaining tests run.

**This does not fix the underlying hang.** #59100 stays open. The likely
culprit is the unbounded `CompletableFuture.allOf(futures).join()` in the
group-creation batch loop, but that needs a stack trace from a caught hang to
confirm, which is what this change enables.

Refs #59100, #56666, #57150
