### PR TITLE
Fix job activation when task listener action is missing

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -262,6 +262,11 @@ public final class ResponseMapper {
     }
 
     final var headers = job.getCustomHeaders();
+    final var action = headers.get(Protocol.USER_TASK_ACTION_HEADER_NAME);
+    if (action == null) {
+      return null;
+    }
+
     return UserTaskProperties.Builder.create()
         .candidateGroups(
             mapStringToList(headers.get(Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME)))
@@ -269,7 +274,7 @@ public final class ResponseMapper {
             mapStringToList(headers.get(Protocol.USER_TASK_CANDIDATE_USERS_HEADER_NAME)))
         .changedAttributes(
             mapStringToList(headers.get(Protocol.USER_TASK_CHANGED_ATTRIBUTES_HEADER_NAME)))
-        .action(requireNonNull(headers.get(Protocol.USER_TASK_ACTION_HEADER_NAME), "action"))
+        .action(action)
         .assignee(headers.get(Protocol.USER_TASK_ASSIGNEE_HEADER_NAME))
         .dueDate(headers.get(Protocol.USER_TASK_DUE_DATE_HEADER_NAME))
         .followUpDate(headers.get(Protocol.USER_TASK_FOLLOW_UP_DATE_HEADER_NAME))

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/ResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/ResponseMapperTest.java
@@ -413,6 +413,15 @@ class ResponseMapperTest {
                           "User task properties should be null for TASK_LISTENER jobs with no headers")
                       .isNull()),
           new ActivatedJobWithUserTaskPropsCase(
+              "TASK_LISTENER job with headers but no action",
+              JobKind.TASK_LISTENER,
+              Map.of(Protocol.USER_TASK_KEY_HEADER_NAME, "100"),
+              props ->
+                  assertThat(props)
+                      .as(
+                          "User task properties should be null for TASK_LISTENER jobs with no action")
+                      .isNull()),
+          new ActivatedJobWithUserTaskPropsCase(
               "BPMN_ELEMENT with no user task properties",
               JobKind.BPMN_ELEMENT,
               Collections.singletonMap("someHeader", "someValue"),


### PR DESCRIPTION
## Summary

Task listener jobs for lifecycle events such as `creating` and `canceling` can contain user task headers without an action. The REST response mapper required that header and threw an exception, which dropped the activation response batch.

This change omits the optional `userTask` response section when the action is unavailable, while keeping the activated job in the response. A mapper test covers non-empty task listener headers without an action.

Returning a `userTask` object with a null action was not chosen because `action` is required by the REST schema.

## Testing

- `./mvnw verify -pl gateways/gateway-mapping-http -Dquickly -DskipTests=false -T1C`
- `./mvnw install -Dquickly -T1C`

Closes #58193