### PR TITLE
test: assert cluster variable metadata is excluded from FEEL runtime value

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/cluster_variable_metadata_isolation.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/cluster_variable_metadata_isolation.bpmn
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_ClusterVariableMetadataIsolation" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="clusterVariableMetadataIsolation" name="cluster variable metadata isolation" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_ToTask</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_ToTask" sourceRef="StartEvent_1" targetRef="isolationTask" />
+    <bpmn:serviceTask id="isolationTask" name="resolve cluster variable">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="cvMetadataIsolationWorker" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=camunda.vars.env.cvMetadataIsolationVar" target="mappedValue" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_ToTask</bpmn:incoming>
+      <bpmn:outgoing>Flow_ToEnd</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_ToEnd" sourceRef="isolationTask" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_ToEnd</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="clusterVariableMetadataIsolation">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="isolationTask_di" bpmnElement="isolationTask">
+        <dc:Bounds x="270" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="452" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_ToTask_di" bpmnElement="Flow_ToTask">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="270" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_ToEnd_di" bpmnElement="Flow_ToEnd">
+        <di:waypoint x="370" y="121" />
+        <di:waypoint x="452" y="121" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-feel-runtime-isolation.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-feel-runtime-isolation.spec.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {CREATE_CLUSTER_VARIABLE_WITH_METADATA} from '../../../../utils/beans/requestBeans';
+import {
+  generateUniqueId,
+  generateUniqueProcessDefinitionId,
+} from '../../../../utils/constants';
+import {
+  createGlobalClusterVariable,
+  createTenantClusterVariable,
+  activateFirstJobVariables,
+  assertNoMetadataLeak,
+} from '@requestHelpers';
+import {searchVariableByNameAndProcessInstanceKey} from '../../../../utils/requestHelpers/variable-requestHelpers';
+import {
+  cleanupGlobalClusterVariables,
+  cleanupTenantClusterVariables,
+} from '../../../../utils/clusterVariablesCleanup';
+import {
+  deployWithSubstitutions,
+  createSingleInstance,
+} from '../../../../utils/zeebeClient';
+
+const ISOLATION_RESOURCE =
+  './resources/cluster_variable_metadata_isolation.bpmn';
+
+// Substituted per run so parallel tests never share a definition, job type or variable.
+const PROCESS_ID_PLACEHOLDER = 'clusterVariableMetadataIsolation';
+const JOB_TYPE_PLACEHOLDER = 'cvMetadataIsolationWorker';
+const VARIABLE_NAME_PLACEHOLDER = 'cvMetadataIsolationVar';
+
+const METADATA = {
+  category: 'TAX_RATE',
+  region: 'EU',
+  year: 2026,
+};
+
+async function deployAndStartIsolationProcess(clusterVariableName: string) {
+  const processDefinitionId = generateUniqueProcessDefinitionId();
+  const jobType = `cvIsolation${generateUniqueId()}`;
+
+  await deployWithSubstitutions(ISOLATION_RESOURCE, {
+    [PROCESS_ID_PLACEHOLDER]: processDefinitionId,
+    [JOB_TYPE_PLACEHOLDER]: jobType,
+    [VARIABLE_NAME_PLACEHOLDER]: clusterVariableName,
+  });
+
+  const instance = await createSingleInstance(processDefinitionId, 1);
+
+  return {jobType, processInstanceKey: String(instance.processInstanceKey)};
+}
+
+/* eslint-disable playwright/expect-expect */
+test.describe.parallel('Cluster Variable API Tests - FEEL Isolation', () => {
+  const state: Record<string, unknown> = {};
+  const createdGlobalNames: string[] = [];
+  const createdTenantVariables: {tenantId: string; name: string}[] = [];
+
+  test.afterAll(async ({request}) => {
+    await cleanupGlobalClusterVariables(request, createdGlobalNames);
+    await cleanupTenantClusterVariables(request, createdTenantVariables);
+  });
+
+  test('Metadata Is Not Present In Job Variables Resolved Via Env Namespace', async ({
+    request,
+  }) => {
+    const variable = CREATE_CLUSTER_VARIABLE_WITH_METADATA(METADATA);
+    await createGlobalClusterVariable(request, state, 'envIsolation', variable);
+    createdGlobalNames.push(variable.name);
+
+    await test.step('Metadata is stored on the variable', async () => {
+      expect(state['envIsolationMetadata']).toEqual(METADATA);
+    });
+
+    const {jobType, processInstanceKey} = await deployAndStartIsolationProcess(
+      variable.name,
+    );
+
+    await test.step('Activated job sees only the value contents', async () => {
+      const jobVariables = await activateFirstJobVariables(
+        request,
+        jobType,
+        processInstanceKey,
+      );
+      assertNoMetadataLeak(
+        jobVariables['mappedValue'],
+        variable.value,
+        jobVariables,
+        METADATA,
+      );
+    });
+  });
+
+  test('Metadata Is Not Present In Process Instance Variables', async ({
+    request,
+  }) => {
+    const variable = CREATE_CLUSTER_VARIABLE_WITH_METADATA(METADATA);
+    await createGlobalClusterVariable(request, state, 'piIsolation', variable);
+    createdGlobalNames.push(variable.name);
+
+    const {processInstanceKey} = await deployAndStartIsolationProcess(
+      variable.name,
+    );
+
+    await test.step('Stored process variable holds only the value contents', async () => {
+      const stored = await searchVariableByNameAndProcessInstanceKey(request, {
+        processInstanceKey,
+        name: 'mappedValue',
+      });
+
+      // Search returns variable values as JSON strings.
+      const parsed = JSON.parse(stored.value);
+      assertNoMetadataLeak(parsed, variable.value, parsed, METADATA);
+    });
+  });
+
+  test('Metadata Is Not Present In FEEL Resolved Value For Tenant Scoped Variable', async ({
+    request,
+  }) => {
+    // Resolved via env against the default tenant, so the test does not depend on
+    // multiTenancy.checksEnabled being on.
+    const tenantId = '<default>';
+    const variable = CREATE_CLUSTER_VARIABLE_WITH_METADATA(METADATA);
+    await createTenantClusterVariable(
+      request,
+      state,
+      'tenantIsolation',
+      tenantId,
+      variable,
+    );
+    createdTenantVariables.push({tenantId, name: variable.name});
+
+    await test.step('Metadata is stored on the tenant scoped variable', async () => {
+      expect(state['tenantIsolationMetadata']).toEqual(METADATA);
+    });
+
+    const {jobType, processInstanceKey} = await deployAndStartIsolationProcess(
+      variable.name,
+    );
+
+    await test.step('Activated job sees only the value contents', async () => {
+      const jobVariables = await activateFirstJobVariables(
+        request,
+        jobType,
+        processInstanceKey,
+      );
+      assertNoMetadataLeak(
+        jobVariables['mappedValue'],
+        variable.value,
+        jobVariables,
+        METADATA,
+      );
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-feel-runtime-isolation.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-feel-runtime-isolation.spec.ts
@@ -57,7 +57,6 @@ async function deployAndStartIsolationProcess(clusterVariableName: string) {
   return {jobType, processInstanceKey: String(instance.processInstanceKey)};
 }
 
-/* eslint-disable playwright/expect-expect */
 test.describe.parallel('Cluster Variable API Tests - FEEL Isolation', () => {
   const state: Record<string, unknown> = {};
   const createdGlobalNames: string[] = [];
@@ -105,6 +104,10 @@ test.describe.parallel('Cluster Variable API Tests - FEEL Isolation', () => {
     await createGlobalClusterVariable(request, state, 'piIsolation', variable);
     createdGlobalNames.push(variable.name);
 
+    await test.step('Metadata is stored on the variable', async () => {
+      expect(state['piIsolationMetadata']).toEqual(METADATA);
+    });
+
     const {processInstanceKey} = await deployAndStartIsolationProcess(
       variable.name,
     );
@@ -115,9 +118,16 @@ test.describe.parallel('Cluster Variable API Tests - FEEL Isolation', () => {
         name: 'mappedValue',
       });
 
-      // Search returns variable values as JSON strings.
+      // Search returns variable values as JSON strings. Swap in the parsed value so
+      // the whole response is walked and the value is walked structurally, not as
+      // one opaque string leaf.
       const parsed = JSON.parse(stored.value);
-      assertNoMetadataLeak(parsed, variable.value, parsed, METADATA);
+      assertNoMetadataLeak(
+        parsed,
+        variable.value,
+        {...stored, value: parsed},
+        METADATA,
+      );
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -788,18 +788,6 @@ export function DECISION_DEFINITION_RESPONSE_FROM_DEPLOYMENT(
 }
 
 // Cluster Variable beans
-export const clusterVariableRequiredFields: string[] = [
-  'name',
-  'value',
-  'scope',
-];
-export const clusterVariableSearchItemRequiredFields: string[] = [
-  'name',
-  'value',
-  'scope',
-  'isTruncated',
-];
-
 export function CREATE_CLUSTER_VARIABLE() {
   const uid = generateUniqueId();
   return {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -796,6 +796,18 @@ export function CREATE_CLUSTER_VARIABLE() {
   };
 }
 
+// Name is alphanumeric: a hyphen makes camunda.vars.env.<name> parse as subtraction in FEEL.
+export function CREATE_CLUSTER_VARIABLE_WITH_METADATA(
+  metadata: Record<string, string | number>,
+) {
+  const uid = generateUniqueId();
+  return {
+    name: `clusterVar${uid}`,
+    value: {testKey: `testValue-${uid}`},
+    metadata,
+  };
+}
+
 export function UPDATE_CLUSTER_VARIABLE_VALUE(value: unknown) {
   return {
     value,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/cluster-variable-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/cluster-variable-requestHelpers.ts
@@ -24,7 +24,11 @@ export async function createGlobalClusterVariable(
   request: APIRequestContext,
   state: Record<string, unknown>,
   stateKey: string,
-  variableData?: {name: string; value: unknown},
+  variableData?: {
+    name: string;
+    value: unknown;
+    metadata?: Record<string, unknown>;
+  },
 ): Promise<void> {
   const data = variableData || CREATE_CLUSTER_VARIABLE();
 
@@ -47,6 +51,7 @@ export async function createGlobalClusterVariable(
     state[`${stateKey}Name`] = json.name;
     state[`${stateKey}Value`] = json.value;
     state[`${stateKey}Scope`] = json.scope;
+    state[`${stateKey}Metadata`] = json.metadata;
   }).toPass(defaultAssertionOptions);
 }
 
@@ -58,7 +63,11 @@ export async function createTenantClusterVariable(
   state: Record<string, unknown>,
   stateKey: string,
   tenantId: string,
-  variableData?: {name: string; value: unknown},
+  variableData?: {
+    name: string;
+    value: unknown;
+    metadata?: Record<string, unknown>;
+  },
 ): Promise<void> {
   const data = variableData || CREATE_CLUSTER_VARIABLE();
 
@@ -85,6 +94,7 @@ export async function createTenantClusterVariable(
     state[`${stateKey}Value`] = json.value;
     state[`${stateKey}Scope`] = json.scope;
     state[`${stateKey}TenantId`] = json.tenantId;
+    state[`${stateKey}Metadata`] = json.metadata;
   }).toPass(defaultAssertionOptions);
 }
 
@@ -161,6 +171,59 @@ export function assertClusterVariableInResponse(
   expect(found).toBeDefined();
   for (const key of Object.keys(expectedBody)) {
     expect(found![key]).toEqual(expectedBody[key]);
+  }
+}
+
+// Collects every object key and leaf value in a payload. Preferred over substring
+// matching on serialized JSON, which can collide with generated base36 ids.
+function collectKeysAndValues(payload: unknown): {
+  keys: string[];
+  values: unknown[];
+} {
+  const keys: string[] = [];
+  const values: unknown[] = [];
+
+  const walk = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      node.forEach(walk);
+      return;
+    }
+    if (node !== null && typeof node === 'object') {
+      for (const [key, child] of Object.entries(node)) {
+        keys.push(key);
+        walk(child);
+      }
+      return;
+    }
+    values.push(node);
+  };
+
+  walk(payload);
+  return {keys, values};
+}
+
+/**
+ * Asserts a FEEL-resolved cluster variable carries only its value, and that no
+ * metadata key or value appears anywhere in the surrounding runtime payload.
+ */
+export function assertNoMetadataLeak(
+  resolved: unknown,
+  expectedValue: Record<string, unknown>,
+  runtimePayload: unknown,
+  metadata: Record<string, string | number>,
+): void {
+  expect(resolved).toEqual(expectedValue);
+
+  const resolvedKeys = Object.keys(resolved as Record<string, unknown>);
+  expect(resolvedKeys).not.toContain('metadata');
+  expect(resolvedKeys).not.toContain('value');
+
+  const {keys, values} = collectKeysAndValues(runtimePayload);
+  for (const metadataKey of Object.keys(metadata)) {
+    expect(keys).not.toContain(metadataKey);
+  }
+  for (const metadataValue of Object.values(metadata)) {
+    expect(values).not.toContain(metadataValue);
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -60,6 +60,7 @@ export {
   activateJobToObtainAValidJobKey,
   activateJobAndGetHeaders,
   activateJobsByType,
+  activateFirstJobVariables,
   completeJob,
   countJobsByType,
   expectJobsByType,
@@ -76,6 +77,7 @@ export {
   deleteTenantClusterVariable,
   assertClusterVariableInResponse,
   assertClusterVariableUpdate,
+  assertNoMetadataLeak,
 } from './cluster-variable-requestHelpers';
 export {
   createProcessInstanceWithAJob,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
@@ -166,6 +166,31 @@ export async function activateJobsByType(
     }));
 }
 
+/**
+ * Retries until a job of the given type is available for the process instance and
+ * returns its variables. Only retrieval retries, so caller assertions on the
+ * returned variables fail immediately rather than being retried to timeout.
+ */
+export async function activateFirstJobVariables(
+  request: APIRequestContext,
+  jobType: string,
+  processInstanceKey: string,
+  assertionOptions: {
+    intervals?: number[];
+    timeout?: number;
+  } = defaultAssertionOptions,
+): Promise<Record<string, unknown>> {
+  let variables: Record<string, unknown> | undefined;
+
+  await expect(async () => {
+    const jobs = await activateJobsByType(request, jobType, processInstanceKey);
+    expect(jobs.length).toBeGreaterThan(0);
+    variables = jobs[0].variables;
+  }).toPass(assertionOptions);
+
+  return variables!;
+}
+
 export function setupProcessInstanceForTests(
   processFileName: string,
   options?: {


### PR DESCRIPTION
## What

Adds runtime-isolation coverage for the cluster variable `metadata` bag, and removes two dead constants.

## Why

The metadata bag (#54797) must never reach the FEEL-accessible runtime value. Of that feature's QA test-case list, everything else — CRUD, the full advanced-filter operator matrix, scalar-only validation, entry and size limits — is already covered by the feature team in `ClusterVariableMetadataIT` plus 2–4 layers beneath it. Deliberately not re-authored here.

Runtime isolation was the exception. The only existing coverage evaluates `camunda.vars.cluster` through the standalone expression-evaluation endpoint and asserts absence of the key `kind`, which the test never sets — so it would pass even if the entire bag leaked. Nothing covered `camunda.vars.env`, and nothing asserted against what a running process instance actually receives.

This gap surfaced while investigating #59636, a reported metadata leak that turned out to be a false positive (the reporter's JSON had been typed into the Admin UI's Value field, since that UI has no metadata input). The guarantee that issue questioned was the one guarantee without a real test.

## How

Three tests in a new spec, each resolving a metadata-carrying variable through `=camunda.vars.env.<name>` in a deployed process:

- job variables from `POST /v2/jobs/activation` contain the value contents only
- the stored process variable from `POST /v2/variables/search` likewise
- same again for a tenant-scoped variable

Two details worth noting for review:

- Assertions collect keys and values recursively from the whole runtime payload rather than substring-matching serialized JSON. The fixture's generated ids are base36, so a substring scan for a metadata key or a number could collide by chance and fail for the wrong reason.
- `toPass()` wraps only job retrieval, not the leak assertions. Wrapping both would retry a genuine leak until timeout and blur "job not ready" into "metadata leaked".

The tenant case resolves via the `env` namespace against the default tenant, so it does not depend on `multiTenancy.checksEnabled`. A dedicated `camunda.vars.tenant.<name>` case against a non-default tenant remains uncovered and is called out in the handover notes.

## Verification

- 3 new tests pass; 70 tests across `tests/api/v2/cluster-variables` pass; 78 in `tests/api/v2/authorization` pass (they share the helpers whose signatures changed).
- **Mutation-checked:** inverting the leak assertions fails all three tests, confirming they are not vacuous — the exact defect in the probe they complement.
- `tsc --noEmit` and `eslint` clean.

The `metadata` param added to `createGlobalClusterVariable` / `createTenantClusterVariable` is trailing and optional, so all existing call sites are unaffected.

## Notes

- `clusterVariableRequiredFields` and `clusterVariableSearchItemRequiredFields` are removed in a separate commit. They have had no callers since `assertRequiredFields` was replaced by `validateResponse`, and predate `metadata`/`kind`, so they under-specify the contract if anyone reaches for them.
- I also considered regenerating `json-body-assertions/_generated/`, but it produced only a formatting diff plus a timestamp — the committed set is already current, and the metadata *filter* is request-side, which that response-only extractor never captures. Left untouched.

Related: #54797, #59636 (closed as invalid), #59742 (real defect found during this investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
