### PR TITLE
test: assert metadata absence against keys the isolation test actually sets

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableMetadataIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableMetadataIT.java
@@ -642,29 +642,35 @@ public class ClusterVariableMetadataIT {
   void shouldNotLeakMetadataIntoRuntimeValue() {
     // given - a variable with both a value and metadata
     final var name = "runtimeVar_" + UUID.randomUUID().toString().replace("-", "");
+    final var metadata = otherMetadata("testValue", "CREDENTIAL", "schemaVersion", 2);
     camundaClient
         .newGloballyScopedClusterVariableCreateRequest()
         .create(name, Map.of("user", "alice"))
-        .metadata(otherMetadata("testValue", "CREDENTIAL", "schemaVersion", 2))
+        .metadata(metadata)
         .send()
         .join();
 
     // when / then - the FEEL-accessible value exposes only the value contents
-    final var valueResult =
-        camundaClient
-            .newEvaluateExpressionCommand()
-            .expression("=camunda.vars.cluster." + name + ".user")
-            .send()
-            .join();
-    assertThat(valueResult.getResult()).isEqualTo("alice");
+    for (final var namespace : List.of("camunda.vars.cluster", "camunda.vars.env")) {
+      assertThat(evaluateExpression(namespace + "." + name + ".user"))
+          .as("value contents must stay reachable via %s", namespace)
+          .isEqualTo("alice");
 
-    // metadata keys are not reachable through the runtime value
-    final var metadataResult =
-        camundaClient
-            .newEvaluateExpressionCommand()
-            .expression("=camunda.vars.cluster." + name + ".kind")
-            .send()
-            .join();
-    assertThat(metadataResult.getResult()).isNull();
+      // every key the metadata bag actually carries must be unreachable
+      for (final var metadataKey : metadata.keySet()) {
+        assertThat(evaluateExpression(namespace + "." + name + "." + metadataKey))
+            .as("metadata key '%s' must not be reachable via %s", metadataKey, namespace)
+            .isNull();
+      }
+    }
+  }
+
+  private Object evaluateExpression(final String path) {
+    return camundaClient
+        .newEvaluateExpressionCommand()
+        .expression("=" + path)
+        .send()
+        .join()
+        .getResult();
   }
 }


### PR DESCRIPTION
> **Draft, and a proposal rather than a request.** This touches a test the Zeebe feature team owns. Take it, amend it, or close it — whichever you prefer. I am not going to chase it.

## The problem

`ClusterVariableMetadataIT.shouldNotLeakMetadataIntoRuntimeValue` cannot fail.

It creates the variable with `otherMetadata("testValue", "CREDENTIAL", "schemaVersion", 2)`, so the bag holds `group`, `testValue` and `schemaVersion`. The negative assertion then checks:

```java
.expression("=camunda.vars.cluster." + name + ".kind")
...
assertThat(metadataResult.getResult()).isNull();
```

`kind` is never in the bag. The expression resolves to `null` whether or not metadata leaks into the runtime value, so the assertion passes unconditionally — including in the exact scenario the test exists to catch.

## The change

Assert over the bag's own `keySet()` instead of a hardcoded key, and cover `camunda.vars.env` alongside `camunda.vars.cluster`. `env` is the namespace process models typically use and had no isolation coverage at all.

Both loops share a small `evaluateExpression` helper to keep it readable.

## Context

Found while adding e2e runtime-isolation coverage for the same guarantee in the orchestration cluster suite (#59744), after #59636 was reported as a metadata leak and turned out to be a false positive. That investigation made it clear this guarantee had no test that could actually detect a regression.

## Verification

`test-compile` passes. I have **not** run the `@MultiDbTest` suite — it needs the full multi-DB harness, and if you would rather own this change, running it here would be wasted effort. Please treat the assertion logic as reviewed-by-reading, not verified-by-execution.

Related: #54797, #55094 (the sub-issue that added this IT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
