### PR TITLE
fix: prevent Operate Vitest OOM from colliding placeholder IDs

### DIFF
--- a/operate/client/src/modules/utils/generateUniqueID.ts
+++ b/operate/client/src/modules/utils/generateUniqueID.ts
@@ -7,7 +7,12 @@
  */
 
 const generateUniqueID = () => {
-  return (Date.now() + Math.floor(Math.random() * 100)).toString();
+  return (
+    crypto.randomUUID?.() ??
+    Array.from(crypto.getRandomValues(new Uint32Array(4)), (value) =>
+      value.toString(16).padStart(8, '0'),
+    ).join('')
+  );
 };
 
 export {generateUniqueID};


### PR DESCRIPTION
## Summary

Use Web Crypto IDs to prevent collisions that could create cyclic modification placeholders and OOM Vitest.

Issue: #59641