### PR TITLE
remove spring autoconfigure exclusion for test applications

### DIFF
--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -83,12 +83,6 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
 
     StandaloneCamunda.getDefaultProperties(false).forEach(this::withProperty);
 
-    // this is required to prevent default spring boot 4.0 security setup to kick in
-    withProperty(
-        "spring.autoconfigure.exclude",
-        "org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration,"
-            + "org.springframework.boot.security.autoconfigure.actuate.web.servlet.ManagementWebSecurityAutoConfiguration");
-
     withAdditionalProfile(Profile.BROKER);
 
     unifiedConfig.getSecurity().getAuthorizations().setEnabled(false);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Removed the exclusion of Spring Boot security autoconfiguration classes from the default properties in the `TestStandaloneBroker` constructor, as these exclusion are already defined in `application.properties` https://github.com/camunda/camunda/blob/4032f763852cda929e2b3d81928ecc327034694f/dist/src/main/resources/application.properties#L81-L83

A side effect of the existing override, was ignoring the other exclusions like `DataSourceAutoConfiguration` ... which causes the creation of useless RDBMS datasources even for ES tests

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
