### PR TITLE
fix: release the backup store when the retention job stops

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
@@ -33,6 +33,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,22 +100,24 @@ public class BackupRetention extends Actor {
             }
           });
 
-  private final BackupStore backupStore;
+  private final Supplier<BackupStore> backupStoreFactory;
   private final BrokerClient brokerClient;
   private final Schedule retentionSchedule;
   private final Duration retentionWindow;
   private final BrokerTopologyManager topologyManager;
   private final RetentionMetrics metrics;
 
+  private @Nullable BackupStore backupStore;
+
   public BackupRetention(
-      final BackupStore backupStore,
+      final Supplier<BackupStore> backupStoreFactory,
       final BrokerClient brokerClient,
       final Schedule retentionSchedule,
       final Duration retentionWindow,
       final BrokerTopologyManager topologyManager,
       final MeterRegistry meterRegistry) {
     metrics = new RetentionMetrics(meterRegistry);
-    this.backupStore = backupStore;
+    this.backupStoreFactory = backupStoreFactory;
     this.brokerClient = brokerClient;
     this.retentionSchedule = retentionSchedule;
     this.retentionWindow = retentionWindow;
@@ -123,6 +127,7 @@ public class BackupRetention extends Actor {
   @Override
   protected void onActorStarted() {
     LOG.debug("Retention scheduler started");
+    backupStore = backupStoreFactory.get();
     metrics.register();
     final var next =
         retentionSchedule.nextExecution(Instant.ofEpochMilli(ActorClock.currentTimeMillis()));
@@ -135,6 +140,11 @@ public class BackupRetention extends Actor {
   protected void onActorClosed() {
     LOG.debug("Retention scheduler stopped");
     metrics.close();
+    if (backupStore != null) {
+      // Initiated but not awaited because it's a resource leak only, not a fatal error.
+      backupStore.closeAsync();
+      backupStore = null;
+    }
   }
 
   private void reschedulingTask() {

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/retention/RetentionTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/retention/RetentionTest.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -53,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -92,6 +94,7 @@ public class RetentionTest {
             CompletableFuture.completedFuture(new BrokerResponse<>(new BackupStatusResponse())))
         .when(brokerClient)
         .sendRequestWithRetry(any());
+    lenient().doReturn(CompletableFuture.completedFuture(null)).when(backupStore).closeAsync();
 
     actorScheduler.getClock().pinCurrentTime();
   }
@@ -143,6 +146,60 @@ public class RetentionTest {
     // then
     backupsPerPartition.forEach(
         (partition, backups) -> verifyDeleteCommandsSent(partition, backups.subList(0, 4)));
+  }
+
+  @Test
+  void shouldReleaseTheBackupStoreWhenStopped() {
+    // given a store that closes asynchronously, as the real ones do — no retention round runs, so
+    // the topology is never consulted
+    reset(topologyManager, clusterState);
+    final var storeClosing = new CompletableFuture<Void>();
+    doReturn(storeClosing).when(backupStore).closeAsync();
+    actorScheduler.submitActor(backupRetention);
+    actorScheduler.workUntilDone();
+
+    // when
+    final var closed = backupRetention.closeAsync();
+    actorScheduler.workUntilDone();
+
+    // then the store is released, and the actor does not wait for it to drain — waiting would
+    // deadlock, since the store completes its future outside the actor
+    verify(backupStore).closeAsync();
+    assertThat(closed.isDone()).isTrue();
+  }
+
+  @Test
+  void shouldBuildANewBackupStoreEachTimeItStarts() {
+    // given a retention job that is stopped and started again, as it is whenever this broker loses
+    // and regains the lowest member id; no retention round runs, so the topology is never consulted
+    reset(topologyManager, clusterState);
+    final var stores = List.of(mock(BackupStore.class), mock(BackupStore.class));
+    stores.forEach(
+        store ->
+            lenient().doReturn(CompletableFuture.completedFuture(null)).when(store).closeAsync());
+    final var built = new AtomicInteger();
+    backupRetention =
+        new BackupRetention(
+            () -> stores.get(built.getAndIncrement()),
+            brokerClient,
+            new IntervalSchedule(Duration.ofSeconds(10)),
+            Duration.ofMinutes(1),
+            topologyManager,
+            meterRegistry);
+
+    actorScheduler.submitActor(backupRetention);
+    actorScheduler.workUntilDone();
+    backupRetention.closeAsync();
+    actorScheduler.workUntilDone();
+
+    // when
+    actorScheduler.submitActor(backupRetention);
+    actorScheduler.workUntilDone();
+
+    // then — the restarted job runs with a fresh store, not the one it just released
+    assertThat(built.get()).isEqualTo(2);
+    verify(stores.get(0)).closeAsync();
+    verify(stores.get(1), never()).closeAsync();
   }
 
   @Test
@@ -265,7 +322,7 @@ public class RetentionTest {
 
   private BackupRetention createBackupRetention() {
     return new BackupRetention(
-        backupStore,
+        () -> backupStore,
         brokerClient,
         new IntervalSchedule(Duration.ofSeconds(10)),
         Duration.ofMinutes(1),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.backup.schedule.Schedule.NoneSchedule;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreFactory;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.SchedulingHints;
@@ -78,13 +79,14 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
 
     final var retentionCfg = backupCfg.getRetention();
     if (shouldRegisterRetentionJob()) {
-      final var backupStore = BackupStoreFactory.createStore(backupCfg);
-      if (backupStore == null) {
+      if (backupCfg.getStore() == BackupStoreType.NONE) {
         throw new IllegalStateException("No backup store configured");
       }
+      // The retention job owns the store: it builds one whenever it starts and releases it when it
+      // stops, so it keeps working across the stop/start cycles that follow the lowest member id.
       backupRetentionJob =
           new BackupRetention(
-              backupStore,
+              () -> BackupStoreFactory.createStore(backupCfg),
               brokerClient,
               retentionCfg.getCleanupSchedule(),
               retentionCfg.getWindow(),


### PR DESCRIPTION
The backup store was built by `CheckpointSchedulingService` whenever retention is configured, on every broker regardless of leadership, and never closed — leaking its client connections and executor threads.

`BackupRetention` now owns it: it builds a store when it starts and releases it when it stops. That matters for more than tidiness, because the service closes the retention job whenever this broker stops being the lowest member and submits the same instance again when it becomes lowest, so a store released on the way out has to be replaced on the way back in. Since `BackupCfg` and its `BackupStoreFactory` live in the broker module, which depends on this one, the job takes a factory bound to the configuration rather than the configuration itself.

The close is not awaited: its future completes on a store thread, and the only actor-safe way to chain onto it — `whenCompleteAsync(callback, actor)`, as `CompletableFutureCallbackArchTest` requires — submits the callback from outside the actor, where it is dropped once the actor is closing.

Backport to 8.9, which has the same store creation. 8.8 and 8.7 have no `CheckpointSchedulingService`.
