### PR TITLE
56997 exporter storage ordinal support

### DIFF
--- a/qa/archunit-tests/src/test/java/io/camunda/exporter/ExportHandlerArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/exporter/ExportHandlerArchTest.java
@@ -22,7 +22,7 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 import io.camunda.archunit.DoNotIncludeTestsOrTestJars;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.handlers.MainIndexExporterHandler;
-import io.camunda.exporter.handlers.StorageOrdinalKeyExportHandler;
+import io.camunda.exporter.handlers.OrdinalIndexExportHandler;
 import io.camunda.exporter.handlers.auditlog.AuditLogCleanupHandler;
 import io.camunda.exporter.handlers.auditlog.AuditLogHandler;
 import io.camunda.exporter.store.BatchRequest;
@@ -86,7 +86,7 @@ public class ExportHandlerArchTest {
           .notBeAssignableTo(
               DescribedPredicate.and(
                   Predicates.assignableTo(MainIndexExporterHandler.class),
-                  Predicates.assignableTo(StorageOrdinalKeyExportHandler.class)));
+                  Predicates.assignableTo(OrdinalIndexExportHandler.class)));
 
   @ArchTest
   static final ArchRule EXPORT_HANDLERS_SHOULD_IMPLEMENT_MAIN_OR_ORDINAL_INTERFACES =
@@ -111,7 +111,7 @@ public class ExportHandlerArchTest {
           .beAssignableTo(
               DescribedPredicate.or(
                   Predicates.assignableTo(MainIndexExporterHandler.class),
-                  Predicates.assignableTo(StorageOrdinalKeyExportHandler.class)));
+                  Predicates.assignableTo(OrdinalIndexExportHandler.class)));
 
   @ArchTest
   static final ArchRule

--- a/qa/archunit-tests/src/test/java/io/camunda/exporter/ExportHandlerArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/exporter/ExportHandlerArchTest.java
@@ -23,6 +23,8 @@ import io.camunda.archunit.DoNotIncludeTestsOrTestJars;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.handlers.MainIndexExporterHandler;
 import io.camunda.exporter.handlers.StorageOrdinalKeyExportHandler;
+import io.camunda.exporter.handlers.auditlog.AuditLogCleanupHandler;
+import io.camunda.exporter.handlers.auditlog.AuditLogHandler;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.zeebe.protocol.record.value.StorageOrdinalKeyRelated;
 import java.util.List;
@@ -94,10 +96,15 @@ public class ExportHandlerArchTest {
           .and()
           .doNotHaveModifier(JavaModifier.ABSTRACT)
           .and()
-          // TODO remove this exclusion once we have refactored the handlers to implement the
+          .areNotAssignableTo(
+              DescribedPredicate.or(
+                  // audit log handlers have custom handling
+                  Predicates.assignableTo(AuditLogHandler.class),
+                  Predicates.assignableTo(AuditLogCleanupHandler.class)))
+          .and()
+          // TODO remove these exclusions once we have refactored the handlers to implement the
           // correct interface
           .resideOutsideOfPackages(
-              "io.camunda.exporter.handlers.auditlog..",
               "io.camunda.exporter.handlers.batchoperation..",
               "io.camunda.exporter.handlers.operation..",
               "io.camunda.exporter.handlers.waitstate..")

--- a/qa/archunit-tests/src/test/java/io/camunda/exporter/ExportHandlerArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/exporter/ExportHandlerArchTest.java
@@ -106,8 +106,7 @@ public class ExportHandlerArchTest {
           // correct interface
           .resideOutsideOfPackages(
               "io.camunda.exporter.handlers.batchoperation..",
-              "io.camunda.exporter.handlers.operation..",
-              "io.camunda.exporter.handlers.waitstate..")
+              "io.camunda.exporter.handlers.operation..")
           .should()
           .beAssignableTo(
               DescribedPredicate.or(

--- a/qa/archunit-tests/src/test/java/io/camunda/exporter/ExportHandlerArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/exporter/ExportHandlerArchTest.java
@@ -7,8 +7,11 @@
  */
 package io.camunda.exporter;
 
+import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaCall;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClass.Predicates;
+import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchCondition;
@@ -18,7 +21,10 @@ import com.tngtech.archunit.lang.SimpleConditionEvent;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 import io.camunda.archunit.DoNotIncludeTestsOrTestJars;
 import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.handlers.MainIndexExporterHandler;
+import io.camunda.exporter.handlers.StorageOrdinalKeyExportHandler;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.zeebe.protocol.record.value.StorageOrdinalKeyRelated;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -68,4 +74,72 @@ public class ExportHandlerArchTest {
                   }
                 }
               });
+
+  @ArchTest
+  static final ArchRule EXPORT_HANDLERS_SHOULD_NOT_IMPLEMENT_MAIN_AND_ORDINAL_INTERFACES =
+      ArchRuleDefinition.classes()
+          .that()
+          .areAssignableTo(ExportHandler.class)
+          .should()
+          .notBeAssignableTo(
+              DescribedPredicate.and(
+                  Predicates.assignableTo(MainIndexExporterHandler.class),
+                  Predicates.assignableTo(StorageOrdinalKeyExportHandler.class)));
+
+  @ArchTest
+  static final ArchRule EXPORT_HANDLERS_SHOULD_IMPLEMENT_MAIN_OR_ORDINAL_INTERFACES =
+      ArchRuleDefinition.classes()
+          .that()
+          .areAssignableTo(ExportHandler.class)
+          .and()
+          .doNotHaveModifier(JavaModifier.ABSTRACT)
+          .and()
+          // TODO remove this exclusion once we have refactored the handlers to implement the
+          // correct interface
+          .resideOutsideOfPackages(
+              "io.camunda.exporter.handlers.auditlog..",
+              "io.camunda.exporter.handlers.batchoperation..",
+              "io.camunda.exporter.handlers.operation..",
+              "io.camunda.exporter.handlers.waitstate..")
+          .should()
+          .beAssignableTo(
+              DescribedPredicate.or(
+                  Predicates.assignableTo(MainIndexExporterHandler.class),
+                  Predicates.assignableTo(StorageOrdinalKeyExportHandler.class)));
+
+  @ArchTest
+  static final ArchRule
+      EXPORT_HANDLERS_SHOULD_NOT_IMPLEMENT_MAIN_FOR_STORAGE_ORDINAL_KEY_RELATED_RECORDS =
+          ArchRuleDefinition.classes()
+              .that()
+              .areAssignableTo(MainIndexExporterHandler.class)
+              .and()
+              .doNotHaveModifier(JavaModifier.ABSTRACT)
+              .should(
+                  new ArchCondition<>(
+                      StorageOrdinalKeyRelated.class.getSimpleName()
+                          + " records should not target main indexes") {
+                    @Override
+                    public void check(final JavaClass item, final ConditionEvents events) {
+                      for (final var clazz : item.getClassHierarchy()) {
+                        for (final var interf : clazz.getInterfaces()) {
+                          for (final var rawType : interf.getAllInvolvedRawTypes()) {
+                            if (rawType.isAssignableTo(StorageOrdinalKeyRelated.class)) {
+                              events.add(
+                                  SimpleConditionEvent.violated(
+                                      item,
+                                      "Class "
+                                          + item.getName()
+                                          + " implements "
+                                          + MainIndexExporterHandler.class.getSimpleName()
+                                          + " but handles a record type ("
+                                          + rawType.getName()
+                                          + ") that implements "
+                                          + StorageOrdinalKeyRelated.class.getSimpleName()));
+                            }
+                          }
+                        }
+                      }
+                    }
+                  });
 }

--- a/qa/archunit-tests/src/test/java/io/camunda/exporter/TargetIndexArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/exporter/TargetIndexArchTest.java
@@ -26,7 +26,7 @@ public class TargetIndexArchTest {
           .areDeclaredInClassesThat()
           .areAssignableTo(TargetIndex.class)
           .and()
-          .haveNameNotMatching("^(name|equals|hashCode|toString).*")
+          .haveNameNotMatching("^(name|getIndexFamilyFromName|equals|hashCode|toString).*")
           .should()
           .onlyBeCalled()
           .byClassesThat()

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformer.java
@@ -32,6 +32,8 @@ public interface AuditLogTransformer<R extends RecordValue> {
 
   TransformerConfig config();
 
+  Class<R> getRecordValueType();
+
   default AuditLogEntry create(final Record<R> record) {
     final AuditLogEntry log = AuditLogEntry.of(record);
 

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuthorizationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuthorizationAuditLogTransformer.java
@@ -21,6 +21,11 @@ public class AuthorizationAuditLogTransformer
   }
 
   @Override
+  public Class<AuthorizationRecordValue> getRecordValueType() {
+    return AuthorizationRecordValue.class;
+  }
+
+  @Override
   public void transform(final Record<AuthorizationRecordValue> record, final AuditLogEntry log) {
     final AuthorizationRecordValue value = record.getValue();
     log.setRelatedEntityKey(value.getOwnerId());

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/BatchOperationCreationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/BatchOperationCreationAuditLogTransformer.java
@@ -20,6 +20,11 @@ public class BatchOperationCreationAuditLogTransformer
   }
 
   @Override
+  public Class<BatchOperationCreationRecordValue> getRecordValueType() {
+    return BatchOperationCreationRecordValue.class;
+  }
+
+  @Override
   public void transform(
       final Record<BatchOperationCreationRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/BatchOperationLifecycleManagementAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/BatchOperationLifecycleManagementAuditLogTransformer.java
@@ -20,6 +20,11 @@ public class BatchOperationLifecycleManagementAuditLogTransformer
   }
 
   @Override
+  public Class<BatchOperationLifecycleManagementRecordValue> getRecordValueType() {
+    return BatchOperationLifecycleManagementRecordValue.class;
+  }
+
+  @Override
   public void transform(
       final Record<BatchOperationLifecycleManagementRecordValue> record, final AuditLogEntry log) {
     // Since RESUME, CANCEL and SUSPEND logs use a different key, we override the entity key

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionAuditLogTransformer.java
@@ -19,6 +19,11 @@ public class DecisionAuditLogTransformer implements AuditLogTransformer<Decision
   }
 
   @Override
+  public Class<DecisionRecordValue> getRecordValueType() {
+    return DecisionRecordValue.class;
+  }
+
+  @Override
   public void transform(final Record<DecisionRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
     log.setEntityKey(String.valueOf(value.getDecisionKey()))

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformer.java
@@ -21,6 +21,11 @@ public class DecisionEvaluationAuditLogTransformer
   }
 
   @Override
+  public Class<DecisionEvaluationRecordValue> getRecordValueType() {
+    return DecisionEvaluationRecordValue.class;
+  }
+
+  @Override
   public void transform(
       final Record<DecisionEvaluationRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionRequirementsRecordAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionRequirementsRecordAuditLogTransformer.java
@@ -20,6 +20,11 @@ public class DecisionRequirementsRecordAuditLogTransformer
   }
 
   @Override
+  public Class<DecisionRequirementsRecordValue> getRecordValueType() {
+    return DecisionRequirementsRecordValue.class;
+  }
+
+  @Override
   public void transform(
       final Record<DecisionRequirementsRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/FormAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/FormAuditLogTransformer.java
@@ -19,6 +19,11 @@ public class FormAuditLogTransformer implements AuditLogTransformer<Form> {
   }
 
   @Override
+  public Class<Form> getRecordValueType() {
+    return Form.class;
+  }
+
+  @Override
   public void transform(final Record<Form> record, final AuditLogEntry log) {
     final var value = record.getValue();
     log.setEntityKey(String.valueOf(value.getFormKey()))

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupAuditLogTransformer.java
@@ -19,6 +19,11 @@ public class GroupAuditLogTransformer implements AuditLogTransformer<GroupRecord
   }
 
   @Override
+  public Class<GroupRecordValue> getRecordValueType() {
+    return GroupRecordValue.class;
+  }
+
+  @Override
   public void transform(final Record<GroupRecordValue> record, final AuditLogEntry log) {
     final GroupRecordValue value = record.getValue();
     log.setEntityKey(value.getGroupId()).setEntityDescription(value.getName());

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupEntityAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupEntityAuditLogTransformer.java
@@ -19,6 +19,11 @@ public class GroupEntityAuditLogTransformer implements AuditLogTransformer<Group
   }
 
   @Override
+  public Class<GroupRecordValue> getRecordValueType() {
+    return GroupRecordValue.class;
+  }
+
+  @Override
   public void transform(final Record<GroupRecordValue> record, final AuditLogEntry log) {
     final GroupRecordValue value = record.getValue();
     log.setEntityKey(value.getGroupId())

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/HistoryDeletionAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/HistoryDeletionAuditLogTransformer.java
@@ -22,6 +22,11 @@ public class HistoryDeletionAuditLogTransformer
   }
 
   @Override
+  public Class<HistoryDeletionRecordValue> getRecordValueType() {
+    return HistoryDeletionRecordValue.class;
+  }
+
+  @Override
   public boolean supports(final Record<HistoryDeletionRecordValue> record) {
     if (!config().supports(record)) {
       return false;

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/IncidentResolutionAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/IncidentResolutionAuditLogTransformer.java
@@ -20,6 +20,11 @@ public class IncidentResolutionAuditLogTransformer
   }
 
   @Override
+  public Class<IncidentRecordValue> getRecordValueType() {
+    return IncidentRecordValue.class;
+  }
+
+  @Override
   public void transform(final Record<IncidentRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
     log.setJobKey(value.getJobKey());

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/JobAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/JobAuditLogTransformer.java
@@ -19,6 +19,11 @@ public class JobAuditLogTransformer implements AuditLogTransformer<JobRecordValu
   }
 
   @Override
+  public Class<JobRecordValue> getRecordValueType() {
+    return JobRecordValue.class;
+  }
+
+  @Override
   public void transform(final Record<JobRecordValue> record, final AuditLogEntry log) {
     log.setJobKey(record.getKey());
     final var value = record.getValue();

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/MappingRuleAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/MappingRuleAuditLogTransformer.java
@@ -19,6 +19,11 @@ public class MappingRuleAuditLogTransformer implements AuditLogTransformer<Mappi
   }
 
   @Override
+  public Class<MappingRuleRecordValue> getRecordValueType() {
+    return MappingRuleRecordValue.class;
+  }
+
+  @Override
   public void transform(final Record<MappingRuleRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
     log.setEntityKey(value.getMappingRuleId()).setEntityDescription(value.getName());

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessAuditLogTransformer.java
@@ -19,6 +19,11 @@ public class ProcessAuditLogTransformer implements AuditLogTransformer<Process> 
   }
 
   @Override
+  public Class<Process> getRecordValueType() {
+    return Process.class;
+  }
+
+  @Override
   public void transform(final Record<Process> record, final AuditLogEntry log) {
     final var value = record.getValue();
     log.setEntityKey(String.valueOf(value.getProcessDefinitionKey()))

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCancelAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCancelAuditLogTransformer.java
@@ -18,4 +18,9 @@ public class ProcessInstanceCancelAuditLogTransformer
   public TransformerConfig config() {
     return PROCESS_INSTANCE_CANCEL_CONFIG;
   }
+
+  @Override
+  public Class<ProcessInstanceRecordValue> getRecordValueType() {
+    return ProcessInstanceRecordValue.class;
+  }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCreationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCreationAuditLogTransformer.java
@@ -20,6 +20,11 @@ public class ProcessInstanceCreationAuditLogTransformer
   }
 
   @Override
+  public Class<ProcessInstanceCreationRecordValue> getRecordValueType() {
+    return ProcessInstanceCreationRecordValue.class;
+  }
+
+  @Override
   public void transform(
       final Record<ProcessInstanceCreationRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceMigrationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceMigrationAuditLogTransformer.java
@@ -22,6 +22,11 @@ public class ProcessInstanceMigrationAuditLogTransformer
   }
 
   @Override
+  public Class<ProcessInstanceMigrationRecordValue> getRecordValueType() {
+    return ProcessInstanceMigrationRecordValue.class;
+  }
+
+  @Override
   public void transform(
       final Record<ProcessInstanceMigrationRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceModificationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceModificationAuditLogTransformer.java
@@ -18,4 +18,9 @@ public class ProcessInstanceModificationAuditLogTransformer
   public TransformerConfig config() {
     return PROCESS_INSTANCE_MODIFICATION_CONFIG;
   }
+
+  @Override
+  public Class<ProcessInstanceModificationRecordValue> getRecordValueType() {
+    return ProcessInstanceModificationRecordValue.class;
+  }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceSuspendResumeAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceSuspendResumeAuditLogTransformer.java
@@ -18,4 +18,9 @@ public class ProcessInstanceSuspendResumeAuditLogTransformer
   public TransformerConfig config() {
     return PROCESS_INSTANCE_SUSPEND_RESUME_CONFIG;
   }
+
+  @Override
+  public Class<ProcessInstanceRecordValue> getRecordValueType() {
+    return ProcessInstanceRecordValue.class;
+  }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ResourceAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ResourceAuditLogTransformer.java
@@ -19,6 +19,11 @@ public class ResourceAuditLogTransformer implements AuditLogTransformer<Resource
   }
 
   @Override
+  public Class<Resource> getRecordValueType() {
+    return Resource.class;
+  }
+
+  @Override
   public void transform(final Record<Resource> record, final AuditLogEntry log) {
     final var value = record.getValue();
     log.setEntityKey(String.valueOf(value.getResourceKey()))

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/RoleAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/RoleAuditLogTransformer.java
@@ -19,6 +19,11 @@ public class RoleAuditLogTransformer implements AuditLogTransformer<RoleRecordVa
   }
 
   @Override
+  public Class<RoleRecordValue> getRecordValueType() {
+    return RoleRecordValue.class;
+  }
+
+  @Override
   public void transform(final Record<RoleRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
     log.setEntityKey(value.getRoleId()).setEntityDescription(value.getName());

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/RoleEntityAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/RoleEntityAuditLogTransformer.java
@@ -19,6 +19,11 @@ public class RoleEntityAuditLogTransformer implements AuditLogTransformer<RoleRe
   }
 
   @Override
+  public Class<RoleRecordValue> getRecordValueType() {
+    return RoleRecordValue.class;
+  }
+
+  @Override
   public void transform(final Record<RoleRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
     log.setEntityKey(value.getRoleId())

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantAuditLogTransformer.java
@@ -19,6 +19,11 @@ public class TenantAuditLogTransformer implements AuditLogTransformer<TenantReco
   }
 
   @Override
+  public Class<TenantRecordValue> getRecordValueType() {
+    return TenantRecordValue.class;
+  }
+
+  @Override
   public void transform(final Record<TenantRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
     log.setEntityKey(value.getTenantId()).setEntityDescription(value.getName());

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantEntityAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantEntityAuditLogTransformer.java
@@ -19,6 +19,11 @@ public class TenantEntityAuditLogTransformer implements AuditLogTransformer<Tena
   }
 
   @Override
+  public Class<TenantRecordValue> getRecordValueType() {
+    return TenantRecordValue.class;
+  }
+
+  @Override
   public void transform(final Record<TenantRecordValue> record, final AuditLogEntry log) {
     final TenantRecordValue value = record.getValue();
     log.setEntityKey(value.getTenantId())

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserAuditLogTransformer.java
@@ -19,6 +19,11 @@ public class UserAuditLogTransformer implements AuditLogTransformer<UserRecordVa
   }
 
   @Override
+  public Class<UserRecordValue> getRecordValueType() {
+    return UserRecordValue.class;
+  }
+
+  @Override
   public void transform(final Record<UserRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
     log.setEntityKey(value.getUsername()).setEntityDescription(value.getName());

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserTaskAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserTaskAuditLogTransformer.java
@@ -21,6 +21,11 @@ public class UserTaskAuditLogTransformer implements AuditLogTransformer<UserTask
   }
 
   @Override
+  public Class<UserTaskRecordValue> getRecordValueType() {
+    return UserTaskRecordValue.class;
+  }
+
+  @Override
   public void transform(final Record<UserTaskRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
     log.setUserTaskKey(value.getUserTaskKey()).setEntityKey(String.valueOf(value.getUserTaskKey()));

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformer.java
@@ -21,6 +21,11 @@ public class VariableAddUpdateAuditLogTransformer
   }
 
   @Override
+  public Class<VariableRecordValue> getRecordValueType() {
+    return VariableRecordValue.class;
+  }
+
+  @Override
   public void transform(final Record<VariableRecordValue> record, final AuditLogEntry log) {
     final VariableRecordValue value = record.getValue();
     log.setEntityDescription(value.getName());

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerTest.java
@@ -13,6 +13,7 @@ import io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
@@ -184,6 +185,11 @@ class AuditLogTransformerTest {
             public TransformerConfig config() {
               return TransformerConfig.with(record.getValueType()).withIntents(record.getIntent());
             }
+
+            @Override
+            public Class<RecordValue> getRecordValueType() {
+              return RecordValue.class;
+            }
           };
 
       final var log = transformer.create(record);
@@ -209,6 +215,11 @@ class AuditLogTransformerTest {
               return TransformerConfig.with(record.getValueType())
                   .withRejections(record.getIntent(), record.getRejectionType());
             }
+
+            @Override
+            public Class<RecordValue> getRecordValueType() {
+              return RecordValue.class;
+            }
           };
 
       final var log = transformer.create(record);
@@ -230,6 +241,11 @@ class AuditLogTransformerTest {
             @Override
             public TransformerConfig config() {
               return TransformerConfig.with(record.getValueType()).withIntents(record.getIntent());
+            }
+
+            @Override
+            public Class<RecordValue> getRecordValueType() {
+              return RecordValue.class;
             }
 
             @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -106,6 +106,7 @@ import io.camunda.exporter.handlers.operation.OperationFromVariableDocumentHandl
 import io.camunda.exporter.handlers.usage.UsageMetricExportedHandler;
 import io.camunda.exporter.handlers.usage.UsageMetricTUExportedHandler;
 import io.camunda.exporter.handlers.waitstate.WaitStateHandlerBuilder;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
@@ -533,7 +534,10 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
   @Override
   public BiConsumer<String, Error> getCustomErrorHandlers() {
     return (index, error) -> {
-      indicesWithCustomErrorHandlers.getOrDefault(index, ErrorHandlers.THROWING).handle(error);
+      final var indexFamily = TargetIndex.getIndexFamilyFromName(index);
+      indicesWithCustomErrorHandlers
+          .getOrDefault(indexFamily.name(), ErrorHandlers.THROWING)
+          .handle(error);
     };
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
@@ -49,7 +49,7 @@ import java.util.Set;
  * </ul>
  */
 public class AgentHistoryHandler
-    implements StorageOrdinalKeyExportHandler<AgentHistoryEntity, AgentHistoryRecordValue> {
+    implements OrdinalIndexExportHandler<AgentHistoryEntity, AgentHistoryRecordValue> {
 
   private static final Set<AgentHistoryIntent> HANDLED_INTENTS =
       Set.of(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
@@ -49,7 +49,7 @@ import java.util.Set;
  * </ul>
  */
 public class AgentHistoryHandler
-    implements ExportHandler<AgentHistoryEntity, AgentHistoryRecordValue> {
+    implements StorageOrdinalKeyExportHandler<AgentHistoryEntity, AgentHistoryRecordValue> {
 
   private static final Set<AgentHistoryIntent> HANDLED_INTENTS =
       Set.of(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
@@ -43,7 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class AgentInstanceHandler
-    implements StorageOrdinalKeyExportHandler<AgentInstanceEntity, AgentInstanceRecordValue> {
+    implements OrdinalIndexExportHandler<AgentInstanceEntity, AgentInstanceRecordValue> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AgentInstanceHandler.class);
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
@@ -43,7 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class AgentInstanceHandler
-    implements ExportHandler<AgentInstanceEntity, AgentInstanceRecordValue> {
+    implements StorageOrdinalKeyExportHandler<AgentInstanceEntity, AgentInstanceRecordValue> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AgentInstanceHandler.class);
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandler.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Set;
 
 public class AuthorizationCreatedUpdatedHandler
-    implements ExportHandler<AuthorizationEntity, AuthorizationRecordValue> {
+    implements MainIndexExporterHandler<AuthorizationEntity, AuthorizationRecordValue> {
   private static final Set<Intent> SUPPORTED_INTENTS =
       Set.of(AuthorizationIntent.CREATED, AuthorizationIntent.UPDATED);
   private final String indexName;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationDeletedHandler.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import java.util.List;
 
 public class AuthorizationDeletedHandler
-    implements ExportHandler<AuthorizationEntity, AuthorizationRecordValue> {
+    implements MainIndexExporterHandler<AuthorizationEntity, AuthorizationRecordValue> {
   private final String indexName;
 
   public AuthorizationDeletedHandler(final String indexName) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class ClusterVariableCreatedUpdatedHandler
-    implements ExportHandler<ClusterVariableEntity, ClusterVariableRecordValue> {
+    implements MainIndexExporterHandler<ClusterVariableEntity, ClusterVariableRecordValue> {
 
   private static final Set<Intent> SUPPORTED_INTENTS =
       Set.of(ClusterVariableIntent.CREATED, ClusterVariableIntent.UPDATED);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandler.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
 import java.util.List;
 
 public class ClusterVariableDeletedHandler
-    implements ExportHandler<ClusterVariableEntity, ClusterVariableRecordValue> {
+    implements MainIndexExporterHandler<ClusterVariableEntity, ClusterVariableRecordValue> {
 
   private static final ClusterVariableIntent SUPPORTED_INTENT = ClusterVariableIntent.DELETED;
   private final String indexName;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandler.java
@@ -19,7 +19,9 @@ import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecor
 import java.util.Set;
 
 public class CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandler
-    extends AbstractCorrelatedMessageSubscriptionHandler<MessageStartEventSubscriptionRecordValue> {
+    extends AbstractCorrelatedMessageSubscriptionHandler<MessageStartEventSubscriptionRecordValue>
+    implements MainIndexExporterHandler<
+        CorrelatedMessageSubscriptionEntity, MessageStartEventSubscriptionRecordValue> {
 
   private static final Set<Intent> SUPPORTED_INTENTS =
       Set.of(MessageStartEventSubscriptionIntent.CORRELATED);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandler.java
@@ -20,7 +20,7 @@ import java.util.Set;
 
 public class CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandler
     extends AbstractCorrelatedMessageSubscriptionHandler<ProcessMessageSubscriptionRecordValue>
-    implements StorageOrdinalKeyExportHandler<
+    implements OrdinalIndexExportHandler<
         CorrelatedMessageSubscriptionEntity, ProcessMessageSubscriptionRecordValue> {
 
   private static final Set<Intent> SUPPORTED_INTENTS =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandler.java
@@ -19,7 +19,9 @@ import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordVa
 import java.util.Set;
 
 public class CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandler
-    extends AbstractCorrelatedMessageSubscriptionHandler<ProcessMessageSubscriptionRecordValue> {
+    extends AbstractCorrelatedMessageSubscriptionHandler<ProcessMessageSubscriptionRecordValue>
+    implements StorageOrdinalKeyExportHandler<
+        CorrelatedMessageSubscriptionEntity, ProcessMessageSubscriptionRecordValue> {
 
   private static final Set<Intent> SUPPORTED_INTENTS =
       Set.of(ProcessMessageSubscriptionIntent.CORRELATED);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionEvaluationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionEvaluationHandler.java
@@ -33,8 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DecisionEvaluationHandler
-    implements StorageOrdinalKeyExportHandler<
-        DecisionInstanceEntity, DecisionEvaluationRecordValue> {
+    implements OrdinalIndexExportHandler<DecisionInstanceEntity, DecisionEvaluationRecordValue> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DecisionEvaluationHandler.class);
   private static final String ID_PATTERN = "%s-%d";

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionEvaluationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionEvaluationHandler.java
@@ -33,7 +33,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DecisionEvaluationHandler
-    implements ExportHandler<DecisionInstanceEntity, DecisionEvaluationRecordValue> {
+    implements StorageOrdinalKeyExportHandler<
+        DecisionInstanceEntity, DecisionEvaluationRecordValue> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DecisionEvaluationHandler.class);
   private static final String ID_PATTERN = "%s-%d";

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionHandler.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Set;
 
 public class DecisionHandler
-    implements ExportHandler<DecisionDefinitionEntity, DecisionRecordValue> {
+    implements MainIndexExporterHandler<DecisionDefinitionEntity, DecisionRecordValue> {
 
   private static final Set<String> STATES = Set.of(ProcessIntent.CREATED.name());
   private final String indexName;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionRequirementsHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionRequirementsHandler.java
@@ -23,7 +23,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class DecisionRequirementsHandler
-    implements ExportHandler<DecisionRequirementsEntity, DecisionRequirementsRecordValue> {
+    implements MainIndexExporterHandler<
+        DecisionRequirementsEntity, DecisionRequirementsRecordValue> {
   private static final Charset CHARSET = StandardCharsets.UTF_8;
 
   private final String indexName;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/EmbeddedFormHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/EmbeddedFormHandler.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.util.modelreader.ProcessModelReader.EmbeddedForm;
 import java.util.List;
 import java.util.Optional;
 
-public class EmbeddedFormHandler implements ExportHandler<EmbeddedFormBatch, Process> {
+public class EmbeddedFormHandler implements MainIndexExporterHandler<EmbeddedFormBatch, Process> {
 
   private static final String FORM_ID_PATTERN = "%s_%s";
   private final String indexName;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ExportHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ExportHandler.java
@@ -56,7 +56,7 @@ public interface ExportHandler<T extends ExporterEntity<T>, R extends RecordValu
       final TargetIndexLocator indexLocator, final Record<R> record) {
     final var indexName = getIndexName();
     return generateIds(record).stream()
-        .map(id -> new IdAndIndex(id, indexLocator.locate(indexName)))
+        .map(id -> new IdAndIndex(id, indexLocator.locateMainIndex(indexName)))
         .toList();
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandler.java
@@ -24,7 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class FlowNodeInstanceFromIncidentHandler
-    implements StorageOrdinalKeyExportHandler<FlowNodeInstanceEntity, IncidentRecordValue> {
+    implements OrdinalIndexExportHandler<FlowNodeInstanceEntity, IncidentRecordValue> {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(FlowNodeInstanceFromIncidentHandler.class);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandler.java
@@ -24,7 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class FlowNodeInstanceFromIncidentHandler
-    implements ExportHandler<FlowNodeInstanceEntity, IncidentRecordValue> {
+    implements StorageOrdinalKeyExportHandler<FlowNodeInstanceEntity, IncidentRecordValue> {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(FlowNodeInstanceFromIncidentHandler.class);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
@@ -40,7 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class FlowNodeInstanceFromProcessInstanceHandler
-    implements StorageOrdinalKeyExportHandler<FlowNodeInstanceEntity, ProcessInstanceRecordValue> {
+    implements OrdinalIndexExportHandler<FlowNodeInstanceEntity, ProcessInstanceRecordValue> {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(FlowNodeInstanceFromProcessInstanceHandler.class);
   private static final Set<Intent> AI_FINISH_STATES = Set.of(ELEMENT_COMPLETED, ELEMENT_TERMINATED);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
@@ -40,7 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class FlowNodeInstanceFromProcessInstanceHandler
-    implements ExportHandler<FlowNodeInstanceEntity, ProcessInstanceRecordValue> {
+    implements StorageOrdinalKeyExportHandler<FlowNodeInstanceEntity, ProcessInstanceRecordValue> {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(FlowNodeInstanceFromProcessInstanceHandler.class);
   private static final Set<Intent> AI_FINISH_STATES = Set.of(ELEMENT_COMPLETED, ELEMENT_TERMINATED);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandler.java
@@ -37,7 +37,7 @@ import java.util.Map;
  * the element that was activated (e.g. {@code listUsers} → "List users").
  */
 public class FlowNodeInstanceNameFromAdHocActivityHandler
-    implements ExportHandler<FlowNodeInstanceEntity, ProcessInstanceRecordValue> {
+    implements StorageOrdinalKeyExportHandler<FlowNodeInstanceEntity, ProcessInstanceRecordValue> {
 
   /**
    * Painless script that sets {@code flowNodeName} only when it is not already set (first-writer

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandler.java
@@ -37,7 +37,7 @@ import java.util.Map;
  * the element that was activated (e.g. {@code listUsers} → "List users").
  */
 public class FlowNodeInstanceNameFromAdHocActivityHandler
-    implements StorageOrdinalKeyExportHandler<FlowNodeInstanceEntity, ProcessInstanceRecordValue> {
+    implements OrdinalIndexExportHandler<FlowNodeInstanceEntity, ProcessInstanceRecordValue> {
 
   /**
    * Painless script that sets {@code flowNodeName} only when it is not already set (first-writer

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FormHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FormHandler.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.protocol.record.value.deployment.Form;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-public class FormHandler implements ExportHandler<FormEntity, Form> {
+public class FormHandler implements MainIndexExporterHandler<FormEntity, Form> {
 
   private final String indexName;
   private final ExporterEntityCache<String, CachedFormEntity> formCache;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GlobalListenerCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GlobalListenerCreatedUpdatedHandler.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Set;
 
 public class GlobalListenerCreatedUpdatedHandler
-    implements ExportHandler<GlobalListenerEntity, GlobalListenerRecordValue> {
+    implements MainIndexExporterHandler<GlobalListenerEntity, GlobalListenerRecordValue> {
 
   private static final Set<Intent> SUPPORTED_INTENTS =
       Set.of(GlobalListenerIntent.CREATED, GlobalListenerIntent.UPDATED);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GlobalListenerDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GlobalListenerDeletedHandler.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
 import java.util.List;
 
 public class GlobalListenerDeletedHandler
-    implements ExportHandler<GlobalListenerEntity, GlobalListenerRecordValue> {
+    implements MainIndexExporterHandler<GlobalListenerEntity, GlobalListenerRecordValue> {
 
   private static final GlobalListenerIntent SUPPORTED_INTENT = GlobalListenerIntent.DELETED;
   private final String indexName;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandler.java
@@ -20,7 +20,8 @@ import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import java.util.List;
 import java.util.Set;
 
-public class GroupCreatedUpdatedHandler implements ExportHandler<GroupEntity, GroupRecordValue> {
+public class GroupCreatedUpdatedHandler
+    implements MainIndexExporterHandler<GroupEntity, GroupRecordValue> {
 
   private static final Set<Intent> SUPPORTED_INTENTS =
       Set.of(GroupIntent.CREATED, GroupIntent.UPDATED);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupDeletedHandler.java
@@ -18,7 +18,8 @@ import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import java.util.List;
 
-public class GroupDeletedHandler implements ExportHandler<GroupEntity, GroupRecordValue> {
+public class GroupDeletedHandler
+    implements MainIndexExporterHandler<GroupEntity, GroupRecordValue> {
 
   private final String indexName;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
@@ -19,7 +19,8 @@ import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import java.util.List;
 
-public class GroupEntityAddedHandler implements ExportHandler<GroupMemberEntity, GroupRecordValue> {
+public class GroupEntityAddedHandler
+    implements MainIndexExporterHandler<GroupMemberEntity, GroupRecordValue> {
 
   private final String indexName;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import java.util.List;
 
 public class GroupEntityRemovedHandler
-    implements ExportHandler<GroupMemberEntity, GroupRecordValue> {
+    implements MainIndexExporterHandler<GroupMemberEntity, GroupRecordValue> {
 
   private final String indexName;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/HistoryDeletionDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/HistoryDeletionDeletedHandler.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.protocol.record.value.HistoryDeletionRecordValue;
 import java.util.List;
 
 public class HistoryDeletionDeletedHandler
-    implements ExportHandler<HistoryDeletionEntity, HistoryDeletionRecordValue> {
+    implements MainIndexExporterHandler<HistoryDeletionEntity, HistoryDeletionRecordValue> {
 
   private static final String ID_PATTERN = "%s_%s";
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
@@ -35,7 +35,8 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRecordValue> {
+public class IncidentHandler
+    implements StorageOrdinalKeyExportHandler<IncidentEntity, IncidentRecordValue> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IncidentHandler.class);
   private static final Set<IncidentIntent> SUPPORTED_INTENTS =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
@@ -36,7 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class IncidentHandler
-    implements StorageOrdinalKeyExportHandler<IncidentEntity, IncidentRecordValue> {
+    implements OrdinalIndexExportHandler<IncidentEntity, IncidentRecordValue> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IncidentHandler.class);
   private static final Set<IncidentIntent> SUPPORTED_INTENTS =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobBatchMetricsExportedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobBatchMetricsExportedHandler.java
@@ -23,7 +23,7 @@ import java.time.ZoneOffset;
 import java.util.List;
 
 public class JobBatchMetricsExportedHandler
-    implements ExportHandler<JobMetricsBatchEntity, JobMetricsBatchRecordValue> {
+    implements MainIndexExporterHandler<JobMetricsBatchEntity, JobMetricsBatchRecordValue> {
 
   private final String indexName;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class JobHandler implements StorageOrdinalKeyExportHandler<JobEntity, JobRecordValue> {
+public class JobHandler implements OrdinalIndexExportHandler<JobEntity, JobRecordValue> {
   protected static final Set<JobIntent> JOB_EVENTS =
       Set.of(
           JobIntent.CREATED,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
+public class JobHandler implements StorageOrdinalKeyExportHandler<JobEntity, JobRecordValue> {
   protected static final Set<JobIntent> JOB_EVENTS =
       Set.of(
           JobIntent.CREATED,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandler.java
@@ -27,8 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ListViewFlowNodeFromIncidentHandler
-    implements StorageOrdinalKeyExportHandler<
-        FlowNodeInstanceForListViewEntity, IncidentRecordValue> {
+    implements OrdinalIndexExportHandler<FlowNodeInstanceForListViewEntity, IncidentRecordValue> {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ListViewFlowNodeFromIncidentHandler.class);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandler.java
@@ -27,7 +27,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ListViewFlowNodeFromIncidentHandler
-    implements ExportHandler<FlowNodeInstanceForListViewEntity, IncidentRecordValue> {
+    implements StorageOrdinalKeyExportHandler<
+        FlowNodeInstanceForListViewEntity, IncidentRecordValue> {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ListViewFlowNodeFromIncidentHandler.class);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandler.java
@@ -24,7 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ListViewFlowNodeFromJobHandler
-    implements ExportHandler<FlowNodeInstanceForListViewEntity, JobRecordValue> {
+    implements StorageOrdinalKeyExportHandler<FlowNodeInstanceForListViewEntity, JobRecordValue> {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ListViewFlowNodeFromJobHandler.class);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandler.java
@@ -24,7 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ListViewFlowNodeFromJobHandler
-    implements StorageOrdinalKeyExportHandler<FlowNodeInstanceForListViewEntity, JobRecordValue> {
+    implements OrdinalIndexExportHandler<FlowNodeInstanceForListViewEntity, JobRecordValue> {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ListViewFlowNodeFromJobHandler.class);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandler.java
@@ -30,7 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ListViewFlowNodeFromProcessInstanceHandler
-    implements StorageOrdinalKeyExportHandler<
+    implements OrdinalIndexExportHandler<
         FlowNodeInstanceForListViewEntity, ProcessInstanceRecordValue> {
 
   private static final Logger LOGGER =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandler.java
@@ -30,7 +30,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ListViewFlowNodeFromProcessInstanceHandler
-    implements ExportHandler<FlowNodeInstanceForListViewEntity, ProcessInstanceRecordValue> {
+    implements StorageOrdinalKeyExportHandler<
+        FlowNodeInstanceForListViewEntity, ProcessInstanceRecordValue> {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ListViewFlowNodeFromProcessInstanceHandler.class);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler.java
@@ -29,7 +29,7 @@ import java.util.Map;
  * feature.
  */
 public class ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler
-    implements ExportHandler<
+    implements StorageOrdinalKeyExportHandler<
         ProcessInstanceForListViewEntity, ProcessInstanceBusinessIdRecordValue> {
 
   private final String indexName;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler.java
@@ -29,7 +29,7 @@ import java.util.Map;
  * feature.
  */
 public class ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler
-    implements StorageOrdinalKeyExportHandler<
+    implements OrdinalIndexExportHandler<
         ProcessInstanceForListViewEntity, ProcessInstanceBusinessIdRecordValue> {
 
   private final String indexName;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -36,7 +36,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ListViewProcessInstanceFromProcessInstanceHandler
-    implements ExportHandler<ProcessInstanceForListViewEntity, ProcessInstanceRecordValue> {
+    implements StorageOrdinalKeyExportHandler<
+        ProcessInstanceForListViewEntity, ProcessInstanceRecordValue> {
 
   protected static final int EMPTY_PARENT_PROCESS_INSTANCE_ID = -1;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -36,7 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ListViewProcessInstanceFromProcessInstanceHandler
-    implements StorageOrdinalKeyExportHandler<
+    implements OrdinalIndexExportHandler<
         ProcessInstanceForListViewEntity, ProcessInstanceRecordValue> {
 
   protected static final int EMPTY_PARENT_PROCESS_INSTANCE_ID = -1;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandler.java
@@ -26,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ListViewVariableFromVariableHandler
-    implements StorageOrdinalKeyExportHandler<VariableForListViewEntity, VariableRecordValue> {
+    implements OrdinalIndexExportHandler<VariableForListViewEntity, VariableRecordValue> {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ListViewVariableFromVariableHandler.class);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandler.java
@@ -26,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ListViewVariableFromVariableHandler
-    implements ExportHandler<VariableForListViewEntity, VariableRecordValue> {
+    implements StorageOrdinalKeyExportHandler<VariableForListViewEntity, VariableRecordValue> {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ListViewVariableFromVariableHandler.class);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MainIndexExporterHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MainIndexExporterHandler.java
@@ -20,7 +20,7 @@ public interface MainIndexExporterHandler<T extends ExporterEntity<T>, R extends
   default List<IdAndIndex> extractIdAndIndexes(
       final TargetIndexLocator indexLocator, final Record<R> record) {
     final var indexName = getIndexName();
-    final var index = indexLocator.locate(indexName);
+    final var index = indexLocator.locateMainIndex(indexName);
     return generateIds(record).stream().map(id -> new IdAndIndex(id, index)).toList();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MainIndexExporterHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MainIndexExporterHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.index.TargetIndexLocator;
+import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import java.util.List;
+
+public interface MainIndexExporterHandler<T extends ExporterEntity<T>, R extends RecordValue>
+    extends ExportHandler<T, R> {
+
+  @Override
+  default List<IdAndIndex> extractIdAndIndexes(
+      final TargetIndexLocator indexLocator, final Record<R> record) {
+    final var indexName = getIndexName();
+    final var index = indexLocator.locate(indexName);
+    return generateIds(record).stream().map(id -> new IdAndIndex(id, index)).toList();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingRuleCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingRuleCreatedUpdatedHandler.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Set;
 
 public class MappingRuleCreatedUpdatedHandler
-    implements ExportHandler<MappingRuleEntity, MappingRuleRecordValue> {
+    implements MainIndexExporterHandler<MappingRuleEntity, MappingRuleRecordValue> {
   private static final Set<Intent> SUPPORTED_INTENTS =
       Set.of(MappingRuleIntent.CREATED, MappingRuleIntent.UPDATED);
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingRuleDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingRuleDeletedHandler.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.protocol.record.value.MappingRuleRecordValue;
 import java.util.List;
 
 public class MappingRuleDeletedHandler
-    implements ExportHandler<MappingRuleEntity, MappingRuleRecordValue> {
+    implements MainIndexExporterHandler<MappingRuleEntity, MappingRuleRecordValue> {
   private final String indexName;
 
   public MappingRuleDeletedHandler(final String indexName) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandler.java
@@ -27,7 +27,9 @@ import java.util.List;
 import java.util.Set;
 
 public class MessageSubscriptionFromMessageStartEventSubscriptionHandler
-    extends AbstractEventHandler<MessageStartEventSubscriptionRecordValue> {
+    extends AbstractEventHandler<MessageStartEventSubscriptionRecordValue>
+    implements MainIndexExporterHandler<
+        MessageSubscriptionEntity, MessageStartEventSubscriptionRecordValue> {
 
   static final Set<Intent> STATES =
       Set.of(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandler.java
@@ -28,7 +28,7 @@ import java.util.Set;
 
 public class MessageSubscriptionFromProcessMessageSubscriptionHandler
     extends AbstractEventHandler<ProcessMessageSubscriptionRecordValue>
-    implements StorageOrdinalKeyExportHandler<
+    implements OrdinalIndexExportHandler<
         MessageSubscriptionEntity, ProcessMessageSubscriptionRecordValue> {
 
   public static final Set<Intent> STATES =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandler.java
@@ -27,7 +27,9 @@ import java.util.List;
 import java.util.Set;
 
 public class MessageSubscriptionFromProcessMessageSubscriptionHandler
-    extends AbstractEventHandler<ProcessMessageSubscriptionRecordValue> {
+    extends AbstractEventHandler<ProcessMessageSubscriptionRecordValue>
+    implements StorageOrdinalKeyExportHandler<
+        MessageSubscriptionEntity, ProcessMessageSubscriptionRecordValue> {
 
   public static final Set<Intent> STATES =
       Set.of(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MigratedVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MigratedVariableHandler.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 public class MigratedVariableHandler
-    implements StorageOrdinalKeyExportHandler<VariableEntity, VariableRecordValue> {
+    implements OrdinalIndexExportHandler<VariableEntity, VariableRecordValue> {
 
   private final String indexName;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MigratedVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MigratedVariableHandler.java
@@ -20,7 +20,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class MigratedVariableHandler implements ExportHandler<VariableEntity, VariableRecordValue> {
+public class MigratedVariableHandler
+    implements StorageOrdinalKeyExportHandler<VariableEntity, VariableRecordValue> {
 
   private final String indexName;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/OrdinalIndexExportHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/OrdinalIndexExportHandler.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.value.StorageOrdinalKeyRelated;
 import java.util.List;
 
-public interface StorageOrdinalKeyExportHandler<
+public interface OrdinalIndexExportHandler<
         T extends ExporterEntity<T>, R extends RecordValue & StorageOrdinalKeyRelated>
     extends ExportHandler<T, R> {
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Set;
 
 public class PostImporterQueueFromIncidentHandler
-    implements ExportHandler<PostImporterQueueEntity, IncidentRecordValue> {
+    implements StorageOrdinalKeyExportHandler<PostImporterQueueEntity, IncidentRecordValue> {
 
   private static final Set<IncidentIntent> SUPPORTED_INTENTS =
       EnumSet.of(IncidentIntent.CREATED, IncidentIntent.MIGRATED, IncidentIntent.RESOLVED);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Set;
 
 public class PostImporterQueueFromIncidentHandler
-    implements StorageOrdinalKeyExportHandler<PostImporterQueueEntity, IncidentRecordValue> {
+    implements OrdinalIndexExportHandler<PostImporterQueueEntity, IncidentRecordValue> {
 
   private static final Set<IncidentIntent> SUPPORTED_INTENTS =
       EnumSet.of(IncidentIntent.CREATED, IncidentIntent.MIGRATED, IncidentIntent.RESOLVED);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessDeletedHandler.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import java.util.List;
 import java.util.Map;
 
-public class ProcessDeletedHandler implements ExportHandler<ProcessEntity, Process> {
+public class ProcessDeletedHandler implements MainIndexExporterHandler<ProcessEntity, Process> {
 
   private final String indexName;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessDrainingHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessDrainingHandler.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import java.util.List;
 import java.util.Map;
 
-public class ProcessDrainingHandler implements ExportHandler<ProcessEntity, Process> {
+public class ProcessDrainingHandler implements MainIndexExporterHandler<ProcessEntity, Process> {
 
   private final String indexName;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
@@ -24,7 +24,7 @@ import io.camunda.zeebe.util.modelreader.ProcessModelReader;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
+public class ProcessHandler implements MainIndexExporterHandler<ProcessEntity, Process> {
 
   private final String indexName;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ResourceCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ResourceCreatedHandler.java
@@ -18,7 +18,8 @@ import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
 import io.camunda.zeebe.protocol.record.value.deployment.Resource;
 import java.util.List;
 
-public class ResourceCreatedHandler implements ExportHandler<DeployedResourceEntity, Resource> {
+public class ResourceCreatedHandler
+    implements MainIndexExporterHandler<DeployedResourceEntity, Resource> {
 
   private static final List<ResourceIntent> SUPPORTED_INTENTS =
       List.of(ResourceIntent.CREATED, ResourceIntent.REEXPORTED);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ResourceDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ResourceDeletedHandler.java
@@ -17,7 +17,8 @@ import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
 import io.camunda.zeebe.protocol.record.value.deployment.Resource;
 import java.util.List;
 
-public class ResourceDeletedHandler implements ExportHandler<DeployedResourceEntity, Resource> {
+public class ResourceDeletedHandler
+    implements MainIndexExporterHandler<DeployedResourceEntity, Resource> {
 
   private static final ResourceIntent SUPPORTED_INTENT = ResourceIntent.DELETED;
   private final String indexName;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleCreateUpdateHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleCreateUpdateHandler.java
@@ -18,7 +18,8 @@ import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
 import java.util.List;
 
-public class RoleCreateUpdateHandler implements ExportHandler<RoleEntity, RoleRecordValue> {
+public class RoleCreateUpdateHandler
+    implements MainIndexExporterHandler<RoleEntity, RoleRecordValue> {
   private final String indexName;
 
   public RoleCreateUpdateHandler(final String indexName) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleDeletedHandler.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
 import java.util.List;
 import java.util.Set;
 
-public class RoleDeletedHandler implements ExportHandler<RoleEntity, RoleRecordValue> {
+public class RoleDeletedHandler implements MainIndexExporterHandler<RoleEntity, RoleRecordValue> {
   private static final Set<Intent> SUPPORTED_INTENTS = Set.of(RoleIntent.DELETED);
   private final String indexName;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberAddedHandler.java
@@ -19,7 +19,8 @@ import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
 import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
 import java.util.List;
 
-public class RoleMemberAddedHandler implements ExportHandler<RoleMemberEntity, RoleRecordValue> {
+public class RoleMemberAddedHandler
+    implements MainIndexExporterHandler<RoleMemberEntity, RoleRecordValue> {
 
   private final String indexName;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberRemovedHandler.java
@@ -19,7 +19,8 @@ import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
 import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
 import java.util.List;
 
-public class RoleMemberRemovedHandler implements ExportHandler<RoleMemberEntity, RoleRecordValue> {
+public class RoleMemberRemovedHandler
+    implements MainIndexExporterHandler<RoleMemberEntity, RoleRecordValue> {
   private final String indexName;
 
   public RoleMemberRemovedHandler(final String indexName) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandler.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import java.util.List;
 
 public class SequenceFlowDeletedHandler
-    implements ExportHandler<SequenceFlowEntity, ProcessInstanceRecordValue> {
+    implements StorageOrdinalKeyExportHandler<SequenceFlowEntity, ProcessInstanceRecordValue> {
 
   private static final String ID_PATTERN = "%s_%s";
   private final String indexName;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandler.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import java.util.List;
 
 public class SequenceFlowDeletedHandler
-    implements StorageOrdinalKeyExportHandler<SequenceFlowEntity, ProcessInstanceRecordValue> {
+    implements OrdinalIndexExportHandler<SequenceFlowEntity, ProcessInstanceRecordValue> {
 
   private static final String ID_PATTERN = "%s_%s";
   private final String indexName;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowHandler.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import java.util.List;
 
 public class SequenceFlowHandler
-    implements StorageOrdinalKeyExportHandler<SequenceFlowEntity, ProcessInstanceRecordValue> {
+    implements OrdinalIndexExportHandler<SequenceFlowEntity, ProcessInstanceRecordValue> {
 
   private static final String ID_PATTERN = "%s_%s";
   private final String indexName;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowHandler.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import java.util.List;
 
 public class SequenceFlowHandler
-    implements ExportHandler<SequenceFlowEntity, ProcessInstanceRecordValue> {
+    implements StorageOrdinalKeyExportHandler<SequenceFlowEntity, ProcessInstanceRecordValue> {
 
   private static final String ID_PATTERN = "%s_%s";
   private final String indexName;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/StorageOrdinalKeyExportHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/StorageOrdinalKeyExportHandler.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.index.TargetIndexLocator;
+import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.value.StorageOrdinalKeyRelated;
+import java.util.List;
+
+public interface StorageOrdinalKeyExportHandler<
+        T extends ExporterEntity<T>, R extends RecordValue & StorageOrdinalKeyRelated>
+    extends ExportHandler<T, R> {
+
+  @Override
+  default List<IdAndIndex> extractIdAndIndexes(
+      final TargetIndexLocator indexLocator, final Record<R> record) {
+    final var indexName = getIndexName();
+    final var index = indexLocator.locateOrdinalIndex(indexName, record.getValue());
+    return generateIds(record).stream().map(id -> new IdAndIndex(id, index)).toList();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantCreateUpdateHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantCreateUpdateHandler.java
@@ -20,7 +20,8 @@ import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
 import java.util.List;
 import java.util.Set;
 
-public class TenantCreateUpdateHandler implements ExportHandler<TenantEntity, TenantRecordValue> {
+public class TenantCreateUpdateHandler
+    implements MainIndexExporterHandler<TenantEntity, TenantRecordValue> {
   private static final Set<Intent> SUPPORTED_INTENTS =
       Set.of(TenantIntent.CREATED, TenantIntent.UPDATED);
   private final String indexName;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantDeletedHandler.java
@@ -20,7 +20,8 @@ import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
 import java.util.List;
 import java.util.Set;
 
-public class TenantDeletedHandler implements ExportHandler<TenantEntity, TenantRecordValue> {
+public class TenantDeletedHandler
+    implements MainIndexExporterHandler<TenantEntity, TenantRecordValue> {
   private static final Set<Intent> SUPPORTED_INTENTS = Set.of(TenantIntent.DELETED);
   private final String indexName;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityAddedHandler.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
 import java.util.List;
 
 public class TenantEntityAddedHandler
-    implements ExportHandler<TenantMemberEntity, TenantRecordValue> {
+    implements MainIndexExporterHandler<TenantMemberEntity, TenantRecordValue> {
 
   private final String indexName;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityRemovedHandler.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
 import java.util.List;
 
 public class TenantEntityRemovedHandler
-    implements ExportHandler<TenantMemberEntity, TenantRecordValue> {
+    implements MainIndexExporterHandler<TenantMemberEntity, TenantRecordValue> {
 
   private final String indexName;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandler.java
@@ -19,7 +19,8 @@ import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import java.util.List;
 import java.util.Set;
 
-public class UserCreatedUpdatedHandler implements ExportHandler<UserEntity, UserRecordValue> {
+public class UserCreatedUpdatedHandler
+    implements MainIndexExporterHandler<UserEntity, UserRecordValue> {
   private static final Set<Intent> SUPPORTED_INTENTS =
       Set.of(UserIntent.CREATED, UserIntent.UPDATED);
   private final String indexName;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserDeletedHandler.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import java.util.List;
 import java.util.Set;
 
-public class UserDeletedHandler implements ExportHandler<UserEntity, UserRecordValue> {
+public class UserDeletedHandler implements MainIndexExporterHandler<UserEntity, UserRecordValue> {
   private static final Set<Intent> SUPPORTED_INTENTS = Set.of(UserIntent.DELETED);
   private final String indexName;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class UserTaskCompletionVariableHandler
-    implements StorageOrdinalKeyExportHandler<SnapshotTaskVariableBatch, UserTaskRecordValue> {
+    implements OrdinalIndexExportHandler<SnapshotTaskVariableBatch, UserTaskRecordValue> {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(UserTaskCompletionVariableHandler.class);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class UserTaskCompletionVariableHandler
-    implements ExportHandler<SnapshotTaskVariableBatch, UserTaskRecordValue> {
+    implements StorageOrdinalKeyExportHandler<SnapshotTaskVariableBatch, UserTaskRecordValue> {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(UserTaskCompletionVariableHandler.class);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCreatingHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCreatingHandler.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Set;
 
 public class UserTaskCreatingHandler
-    implements StorageOrdinalKeyExportHandler<TaskEntity, UserTaskRecordValue> {
+    implements OrdinalIndexExportHandler<TaskEntity, UserTaskRecordValue> {
 
   private static final Set<UserTaskIntent> SUPPORTED_INTENTS = EnumSet.of(UserTaskIntent.CREATING);
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCreatingHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCreatingHandler.java
@@ -30,7 +30,8 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
-public class UserTaskCreatingHandler implements ExportHandler<TaskEntity, UserTaskRecordValue> {
+public class UserTaskCreatingHandler
+    implements StorageOrdinalKeyExportHandler<TaskEntity, UserTaskRecordValue> {
 
   private static final Set<UserTaskIntent> SUPPORTED_INTENTS = EnumSet.of(UserTaskIntent.CREATING);
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -34,7 +34,8 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecordValue> {
+public class UserTaskHandler
+    implements StorageOrdinalKeyExportHandler<TaskEntity, UserTaskRecordValue> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UserTaskHandler.class);
   private static final Set<UserTaskIntent> SUPPORTED_INTENTS =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -34,8 +34,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class UserTaskHandler
-    implements StorageOrdinalKeyExportHandler<TaskEntity, UserTaskRecordValue> {
+public class UserTaskHandler implements OrdinalIndexExportHandler<TaskEntity, UserTaskRecordValue> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UserTaskHandler.class);
   private static final Set<UserTaskIntent> SUPPORTED_INTENTS =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
@@ -44,7 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class UserTaskJobBasedHandler
-    implements StorageOrdinalKeyExportHandler<TaskEntity, JobRecordValue> {
+    implements OrdinalIndexExportHandler<TaskEntity, JobRecordValue> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UserTaskJobBasedHandler.class);
   private static final Pattern EMBEDDED_FORMS_PATTERN = Pattern.compile("^camunda-forms:bpmn:.*");

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
@@ -43,7 +43,8 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class UserTaskJobBasedHandler implements ExportHandler<TaskEntity, JobRecordValue> {
+public class UserTaskJobBasedHandler
+    implements StorageOrdinalKeyExportHandler<TaskEntity, JobRecordValue> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UserTaskJobBasedHandler.class);
   private static final Pattern EMBEDDED_FORMS_PATTERN = Pattern.compile("^camunda-forms:bpmn:.*");

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandler.java
@@ -21,7 +21,8 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import java.util.List;
 
 public class UserTaskProcessInstanceHandler
-    implements ExportHandler<TaskProcessInstanceEntity, ProcessInstanceRecordValue> {
+    implements StorageOrdinalKeyExportHandler<
+        TaskProcessInstanceEntity, ProcessInstanceRecordValue> {
 
   private final String indexName;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandler.java
@@ -21,8 +21,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import java.util.List;
 
 public class UserTaskProcessInstanceHandler
-    implements StorageOrdinalKeyExportHandler<
-        TaskProcessInstanceEntity, ProcessInstanceRecordValue> {
+    implements OrdinalIndexExportHandler<TaskProcessInstanceEntity, ProcessInstanceRecordValue> {
 
   private final String indexName;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskVariableHandler.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class UserTaskVariableHandler
-    implements ExportHandler<UserTaskVariableBatch, VariableRecordValue> {
+    implements StorageOrdinalKeyExportHandler<UserTaskVariableBatch, VariableRecordValue> {
 
   private static final Logger LOG = LoggerFactory.getLogger(UserTaskVariableHandler.class);
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskVariableHandler.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class UserTaskVariableHandler
-    implements StorageOrdinalKeyExportHandler<UserTaskVariableBatch, VariableRecordValue> {
+    implements OrdinalIndexExportHandler<UserTaskVariableBatch, VariableRecordValue> {
 
   private static final Logger LOG = LoggerFactory.getLogger(UserTaskVariableHandler.class);
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/VariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/VariableHandler.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import java.util.List;
 
 public class VariableHandler
-    implements StorageOrdinalKeyExportHandler<VariableEntity, VariableRecordValue> {
+    implements OrdinalIndexExportHandler<VariableEntity, VariableRecordValue> {
 
   private final int variableSizeThreshold;
   private final String indexName;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/VariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/VariableHandler.java
@@ -19,7 +19,8 @@ import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import java.util.List;
 
-public class VariableHandler implements ExportHandler<VariableEntity, VariableRecordValue> {
+public class VariableHandler
+    implements StorageOrdinalKeyExportHandler<VariableEntity, VariableRecordValue> {
 
   private final int variableSizeThreshold;
   private final String indexName;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/AbstractAuditLogHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/AbstractAuditLogHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers.auditlog;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogEntityType;
@@ -52,8 +53,17 @@ abstract class AbstractAuditLogHandler<T extends ExporterEntity<T>, R extends Re
   }
 
   @Override
+  public List<IdAndIndex> extractIdAndIndexes(
+      final TargetIndexLocator indexLocator, final Record<R> record) {
+    final var id = record.getPartitionId() + "-" + record.getPosition();
+    final var index = locateTargetIndex(indexLocator, record);
+    return List.of(new IdAndIndex(id, index));
+  }
+
+  @Override
   public List<String> generateIds(final Record<R> record) {
-    return List.of(record.getPartitionId() + "-" + record.getPosition());
+    throw new UnsupportedOperationException(
+        "generateIds is not supported for audit log handlers. Use extractIdAndIndexes instead.");
   }
 
   @Override
@@ -66,6 +76,9 @@ abstract class AbstractAuditLogHandler<T extends ExporterEntity<T>, R extends Re
   public String getIndexName() {
     return indexName;
   }
+
+  abstract TargetIndex locateTargetIndex(
+      final TargetIndexLocator indexLocator, final Record<R> record);
 
   protected AuditLogEntityType mapEntityType(
       final io.camunda.search.entities.AuditLogEntity.AuditLogEntityType entityType) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/AuditLogCleanupHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/AuditLogCleanupHandler.java
@@ -61,7 +61,7 @@ public class AuditLogCleanupHandler<R extends RecordValue>
 
   @Override
   TargetIndex locateTargetIndex(final TargetIndexLocator indexLocator, final Record<R> record) {
-    return indexLocator.locate(getIndexName());
+    return indexLocator.locateMainIndex(getIndexName());
   }
 
   @VisibleForTesting

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/AuditLogCleanupHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/AuditLogCleanupHandler.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.exporter.handlers.auditlog;
 
+import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogCleanupEntity;
@@ -55,6 +57,11 @@ public class AuditLogCleanupHandler<R extends RecordValue>
       return auditLogEntityType != AuditLogEntityType.DECISION;
     }
     return false;
+  }
+
+  @Override
+  TargetIndex locateTargetIndex(final TargetIndexLocator indexLocator, final Record<R> record) {
+    return indexLocator.locate(getIndexName());
   }
 
   @VisibleForTesting

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/AuditLogHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/AuditLogHandler.java
@@ -125,7 +125,7 @@ public class AuditLogHandler<R extends RecordValue>
   }
 
   TargetIndex locateMainIndex(final TargetIndexLocator indexLocator, final Record<R> record) {
-    return indexLocator.locate(getIndexName());
+    return indexLocator.locateMainIndex(getIndexName());
   }
 
   TargetIndex locateOrdinalIndex(final TargetIndexLocator indexLocator, final Record<R> record) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/AuditLogHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/AuditLogHandler.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.exporter.handlers.auditlog;
 
+import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogActorType;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogOperationCategory;
@@ -20,6 +22,7 @@ import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransforme
 import io.camunda.zeebe.protocol.record.Agent;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.value.StorageOrdinalKeyRelated;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Objects;
 
@@ -42,12 +45,20 @@ import java.util.Objects;
  */
 public class AuditLogHandler<R extends RecordValue>
     extends AbstractAuditLogHandler<AuditLogEntity, R> {
+  private final AuditLogIndexLocator<R> auditLogIndexLocator;
 
   public AuditLogHandler(
       final String indexName,
       final AuditLogTransformer<R> transformer,
       final AuditLogConfiguration configuration) {
     super(indexName, transformer, configuration);
+
+    // vary the logic we use for picking indexes based on what kind of record we are processing.
+    if (StorageOrdinalKeyRelated.class.isAssignableFrom(transformer.getRecordValueType())) {
+      auditLogIndexLocator = this::locateOrdinalIndex;
+    } else {
+      auditLogIndexLocator = this::locateMainIndex;
+    }
   }
 
   @Override
@@ -113,6 +124,20 @@ public class AuditLogHandler<R extends RecordValue>
     return transformer;
   }
 
+  TargetIndex locateMainIndex(final TargetIndexLocator indexLocator, final Record<R> record) {
+    return indexLocator.locate(getIndexName());
+  }
+
+  TargetIndex locateOrdinalIndex(final TargetIndexLocator indexLocator, final Record<R> record) {
+    return indexLocator.locateOrdinalIndex(
+        getIndexName(), (StorageOrdinalKeyRelated) record.getValue());
+  }
+
+  @Override
+  TargetIndex locateTargetIndex(final TargetIndexLocator indexLocator, final Record<R> record) {
+    return auditLogIndexLocator.locate(indexLocator, record);
+  }
+
   private AuditLogOperationResult mapResult(final AuditLogEntry log) {
     return Objects.nonNull(log.getResult())
         ? AuditLogOperationResult.valueOf(log.getResult().name())
@@ -142,5 +167,9 @@ public class AuditLogHandler<R extends RecordValue>
         .map(AuditLogTenant::scope)
         .map(t -> io.camunda.webapps.schema.entities.auditlog.AuditLogTenantScope.valueOf(t.name()))
         .orElse(AuditLogTenantScope.GLOBAL);
+  }
+
+  interface AuditLogIndexLocator<R extends RecordValue> {
+    TargetIndex locate(final TargetIndexLocator indexLocator, final Record<R> record);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/usage/AbstractUsageMetricExportedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/usage/AbstractUsageMetricExportedHandler.java
@@ -11,7 +11,7 @@ import static io.camunda.webapps.schema.entities.metrics.UsageMetricsEventType.E
 import static io.camunda.webapps.schema.entities.metrics.UsageMetricsEventType.RPI;
 import static io.camunda.webapps.schema.entities.metrics.UsageMetricsEventType.TU;
 
-import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.handlers.MainIndexExporterHandler;
 import io.camunda.exporter.handlers.usage.AbstractUsageMetricExportedHandler.Batch;
 import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 
 abstract class AbstractUsageMetricExportedHandler<
         T extends ExporterEntity<T>, B extends Batch<B, T>>
-    implements ExportHandler<B, UsageMetricRecordValue> {
+    implements MainIndexExporterHandler<B, UsageMetricRecordValue> {
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
   private final String indexName;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/AbstractWaitStateHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/AbstractWaitStateHandler.java
@@ -9,7 +9,7 @@ package io.camunda.exporter.handlers.waitstate;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.handlers.StorageOrdinalKeyExportHandler;
 import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateDetails;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  */
 @NullMarked
 public abstract class AbstractWaitStateHandler<R extends RecordValue & WaitStateRelated>
-    implements ExportHandler<WaitStateEntity, R> {
+    implements StorageOrdinalKeyExportHandler<WaitStateEntity, R> {
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractWaitStateHandler.class);
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/AbstractWaitStateHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/AbstractWaitStateHandler.java
@@ -9,7 +9,7 @@ package io.camunda.exporter.handlers.waitstate;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.exporter.handlers.StorageOrdinalKeyExportHandler;
+import io.camunda.exporter.handlers.OrdinalIndexExportHandler;
 import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateDetails;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  */
 @NullMarked
 public abstract class AbstractWaitStateHandler<R extends RecordValue & WaitStateRelated>
-    implements StorageOrdinalKeyExportHandler<WaitStateEntity, R> {
+    implements OrdinalIndexExportHandler<WaitStateEntity, R> {
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractWaitStateHandler.class);
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateRemoveHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateRemoveHandler.java
@@ -8,7 +8,7 @@
 package io.camunda.exporter.handlers.waitstate;
 
 import io.camunda.exporter.exceptions.PersistenceException;
-import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.handlers.StorageOrdinalKeyExportHandler;
 import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
@@ -28,7 +28,7 @@ import java.util.List;
  * @param <R> the record value type handled by the injected transformer
  */
 public class WaitStateRemoveHandler<R extends RecordValue & WaitStateRelated>
-    implements ExportHandler<WaitStateEntity, R> {
+    implements StorageOrdinalKeyExportHandler<WaitStateEntity, R> {
 
   private final String indexName;
   private final WaitStateTransformer<R> transformer;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateRemoveHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateRemoveHandler.java
@@ -8,7 +8,7 @@
 package io.camunda.exporter.handlers.waitstate;
 
 import io.camunda.exporter.exceptions.PersistenceException;
-import io.camunda.exporter.handlers.StorageOrdinalKeyExportHandler;
+import io.camunda.exporter.handlers.OrdinalIndexExportHandler;
 import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
@@ -28,7 +28,7 @@ import java.util.List;
  * @param <R> the record value type handled by the injected transformer
  */
 public class WaitStateRemoveHandler<R extends RecordValue & WaitStateRelated>
-    implements StorageOrdinalKeyExportHandler<WaitStateEntity, R> {
+    implements OrdinalIndexExportHandler<WaitStateEntity, R> {
 
   private final String indexName;
   private final WaitStateTransformer<R> transformer;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/IndexFamily.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/IndexFamily.java
@@ -7,15 +7,6 @@
  */
 package io.camunda.exporter.index;
 
-record MainIndex(String name) implements TargetIndex, IndexFamily {
-  MainIndex {
-    if (name == null || name.isBlank()) {
-      throw new IllegalArgumentException("Main index name must not be null or blank");
-    }
-  }
-
-  @Override
-  public IndexFamily getIndexFamily() {
-    return this;
-  }
+public interface IndexFamily {
+  String name();
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/IndexFamilyImpl.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/IndexFamilyImpl.java
@@ -7,15 +7,4 @@
  */
 package io.camunda.exporter.index;
 
-record MainIndex(String name) implements TargetIndex, IndexFamily {
-  MainIndex {
-    if (name == null || name.isBlank()) {
-      throw new IllegalArgumentException("Main index name must not be null or blank");
-    }
-  }
-
-  @Override
-  public IndexFamily getIndexFamily() {
-    return this;
-  }
-}
+record IndexFamilyImpl(String name) implements IndexFamily {}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/OrdinalIndex.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/OrdinalIndex.java
@@ -7,4 +7,32 @@
  */
 package io.camunda.exporter.index;
 
-public record OrdinalIndex(String prefix, int ordinal, String name) implements TargetIndex {}
+import com.google.common.base.Strings;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+record OrdinalIndex(IndexFamily indexFamily, int ordinal, String name) implements TargetIndex {
+  static final String ORDINAL_SUFFIX = "ord";
+  static final Pattern ORDINAL_INDEX_PATTERN =
+      Pattern.compile("^(.*)" + Pattern.quote(ORDINAL_SUFFIX) + "(\\d{5})$");
+
+  static Optional<TargetIndex> fromName(final String indexName) {
+    final var matcher = ORDINAL_INDEX_PATTERN.matcher(indexName);
+    if (!matcher.matches()) {
+      return Optional.empty();
+    }
+    final var prefix = matcher.group(1);
+    final var ordinal = Integer.parseInt(matcher.group(2));
+    return Optional.of(of(prefix, ordinal));
+  }
+
+  static OrdinalIndex of(final String prefix, final int ordinal) {
+    final var name = prefix + ORDINAL_SUFFIX + Strings.padStart(String.valueOf(ordinal), 5, '0');
+    return new OrdinalIndex(new IndexFamilyImpl(prefix), ordinal, name);
+  }
+
+  @Override
+  public IndexFamily getIndexFamily() {
+    return indexFamily;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/OrdinalIndex.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/OrdinalIndex.java
@@ -16,6 +16,12 @@ record OrdinalIndex(IndexFamily indexFamily, int ordinal, String name) implement
   static final Pattern ORDINAL_INDEX_PATTERN =
       Pattern.compile("^(.*)" + Pattern.quote(ORDINAL_SUFFIX) + "(\\d{5})$");
 
+  OrdinalIndex {
+    if (ordinal <= 0) {
+      throw new IllegalArgumentException("Ordinal must be greater than 0");
+    }
+  }
+
   static Optional<TargetIndex> fromName(final String indexName) {
     final var matcher = ORDINAL_INDEX_PATTERN.matcher(indexName);
     if (!matcher.matches()) {
@@ -27,6 +33,9 @@ record OrdinalIndex(IndexFamily indexFamily, int ordinal, String name) implement
   }
 
   static OrdinalIndex of(final String prefix, final int ordinal) {
+    if (prefix == null || prefix.isBlank()) {
+      throw new IllegalArgumentException("Ordinal index prefix must not be null or blank");
+    }
     final var name = prefix + ORDINAL_SUFFIX + Strings.padStart(String.valueOf(ordinal), 5, '0');
     return new OrdinalIndex(new IndexFamilyImpl(prefix), ordinal, name);
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/OrdinalIndex.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/OrdinalIndex.java
@@ -15,7 +15,7 @@ record OrdinalIndex(IndexFamily indexFamily, int ordinal, String name) implement
   static final int DEFAULT_ORDINAL = 0;
   static final String ORDINAL_SUFFIX = "ord";
   static final Pattern ORDINAL_INDEX_PATTERN =
-      Pattern.compile("^(.*)" + Pattern.quote(ORDINAL_SUFFIX) + "(\\d{5})$");
+      Pattern.compile("^(.*)" + Pattern.quote(ORDINAL_SUFFIX) + "(\\d{5,})$");
 
   OrdinalIndex {
     if (ordinal <= DEFAULT_ORDINAL) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/OrdinalIndex.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/OrdinalIndex.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.index;
+
+public record OrdinalIndex(String prefix, int ordinal, String name) implements TargetIndex {}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/OrdinalIndex.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/OrdinalIndex.java
@@ -12,13 +12,14 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 
 record OrdinalIndex(IndexFamily indexFamily, int ordinal, String name) implements TargetIndex {
+  static final int DEFAULT_ORDINAL = 0;
   static final String ORDINAL_SUFFIX = "ord";
   static final Pattern ORDINAL_INDEX_PATTERN =
       Pattern.compile("^(.*)" + Pattern.quote(ORDINAL_SUFFIX) + "(\\d{5})$");
 
   OrdinalIndex {
-    if (ordinal <= 0) {
-      throw new IllegalArgumentException("Ordinal must be greater than 0");
+    if (ordinal <= DEFAULT_ORDINAL) {
+      throw new IllegalArgumentException("Ordinal must be greater than " + DEFAULT_ORDINAL);
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/OrdinalIndex.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/OrdinalIndex.java
@@ -13,9 +13,9 @@ import java.util.regex.Pattern;
 
 record OrdinalIndex(IndexFamily indexFamily, int ordinal, String name) implements TargetIndex {
   static final int DEFAULT_ORDINAL = 0;
-  static final String ORDINAL_SUFFIX = "ord";
+  static final String ORDINAL_SUFFIX_START = "ord";
   static final Pattern ORDINAL_INDEX_PATTERN =
-      Pattern.compile("^(.*)" + Pattern.quote(ORDINAL_SUFFIX) + "(\\d{5,})$");
+      Pattern.compile("^(.*)" + Pattern.quote(ORDINAL_SUFFIX_START) + "(\\d{5,})$");
 
   OrdinalIndex {
     if (ordinal <= DEFAULT_ORDINAL) {
@@ -37,7 +37,8 @@ record OrdinalIndex(IndexFamily indexFamily, int ordinal, String name) implement
     if (prefix == null || prefix.isBlank()) {
       throw new IllegalArgumentException("Ordinal index prefix must not be null or blank");
     }
-    final var name = prefix + ORDINAL_SUFFIX + Strings.padStart(String.valueOf(ordinal), 5, '0');
+    final var name =
+        prefix + ORDINAL_SUFFIX_START + Strings.padStart(String.valueOf(ordinal), 5, '0');
     return new OrdinalIndex(new IndexFamilyImpl(prefix), ordinal, name);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/TargetIndex.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/TargetIndex.java
@@ -7,10 +7,17 @@
  */
 package io.camunda.exporter.index;
 
-public sealed interface TargetIndex permits MainIndex {
+import com.google.common.base.Strings;
+
+public sealed interface TargetIndex permits MainIndex, OrdinalIndex {
   String name();
 
   static TargetIndex mainIndex(final String name) {
     return new MainIndex(name);
+  }
+
+  static TargetIndex ordinalIndex(final String prefix, final int ordinal) {
+    final var suffix = "ord" + Strings.padStart(String.valueOf(ordinal), 5, '0');
+    return new OrdinalIndex(suffix, ordinal, prefix + suffix);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/TargetIndex.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/TargetIndex.java
@@ -7,17 +7,25 @@
  */
 package io.camunda.exporter.index;
 
-import com.google.common.base.Strings;
-
 public sealed interface TargetIndex permits MainIndex, OrdinalIndex {
   String name();
+
+  /*
+   * Returns the index family for this target index - for a main index this will be
+   * the name of the index itself, but for ordinal indexes it will be the part of the name
+   * prior to the ordinal part.
+   */
+  IndexFamily getIndexFamily();
+
+  static IndexFamily getIndexFamilyFromName(final String name) {
+    return OrdinalIndex.fromName(name).orElseGet(() -> new MainIndex(name)).getIndexFamily();
+  }
 
   static TargetIndex mainIndex(final String name) {
     return new MainIndex(name);
   }
 
   static TargetIndex ordinalIndex(final String prefix, final int ordinal) {
-    final var suffix = "ord" + Strings.padStart(String.valueOf(ordinal), 5, '0');
-    return new OrdinalIndex(suffix, ordinal, prefix + suffix);
+    return OrdinalIndex.of(prefix, ordinal);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/TargetIndexLocator.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/TargetIndexLocator.java
@@ -20,7 +20,7 @@ public class TargetIndexLocator {
     return TargetIndex.ordinalIndex(indexName, ordinal);
   }
 
-  public TargetIndex locate(final String indexName) {
+  public TargetIndex locateMainIndex(final String indexName) {
     return TargetIndex.mainIndex(indexName);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/TargetIndexLocator.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/TargetIndexLocator.java
@@ -15,7 +15,7 @@ public class TargetIndexLocator {
   public TargetIndex locateOrdinalIndex(
       final String indexName, final StorageOrdinalKeyRelated ordinalKeyRelated) {
     final var ordinal = ordinalKeyRelated.getStorageOrdinalKey();
-    if (ordinal == DEFAULT_ORDINAL) {
+    if (ordinal <= DEFAULT_ORDINAL) {
       return TargetIndex.mainIndex(indexName);
     }
     return TargetIndex.ordinalIndex(indexName, ordinal);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/TargetIndexLocator.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/TargetIndexLocator.java
@@ -7,7 +7,20 @@
  */
 package io.camunda.exporter.index;
 
+import io.camunda.zeebe.protocol.record.value.StorageOrdinalKeyRelated;
+
 public class TargetIndexLocator {
+  private static final int DEFAULT_ORDINAL = 0;
+
+  public TargetIndex locateOrdinalIndex(
+      final String indexName, final StorageOrdinalKeyRelated ordinalKeyRelated) {
+    final var ordinal = ordinalKeyRelated.getStorageOrdinalKey();
+    if (ordinal == DEFAULT_ORDINAL) {
+      return TargetIndex.mainIndex(indexName);
+    }
+    return TargetIndex.ordinalIndex(indexName, ordinal);
+  }
+
   public TargetIndex locate(final String indexName) {
     return TargetIndex.mainIndex(indexName);
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/TargetIndexLocator.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/TargetIndexLocator.java
@@ -10,12 +10,11 @@ package io.camunda.exporter.index;
 import io.camunda.zeebe.protocol.record.value.StorageOrdinalKeyRelated;
 
 public class TargetIndexLocator {
-  private static final int DEFAULT_ORDINAL = 0;
 
   public TargetIndex locateOrdinalIndex(
       final String indexName, final StorageOrdinalKeyRelated ordinalKeyRelated) {
     final var ordinal = ordinalKeyRelated.getStorageOrdinalKey();
-    if (ordinal <= DEFAULT_ORDINAL) {
+    if (ordinal <= OrdinalIndex.DEFAULT_ORDINAL) {
       return TargetIndex.mainIndex(indexName);
     }
     return TargetIndex.ordinalIndex(indexName, ordinal);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -9,11 +9,14 @@ package io.camunda.exporter;
 
 import static io.camunda.exporter.DefaultExporterResourceProvider.PROCESS_DEFINITION_PARTITION;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.Mockito.mock;
 
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.errorhandling.Error;
+import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.handlers.auditlog.AuditLogCleanupHandler;
 import io.camunda.exporter.handlers.auditlog.AuditLogHandler;
@@ -37,6 +40,7 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -44,6 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class DefaultExporterResourceProviderTest {
 
@@ -368,6 +373,53 @@ public class DefaultExporterResourceProviderTest {
                 .isEqualTo(expectedValueType);
           }
         });
+  }
+
+  @Test
+  void shouldNotIgnoreErrorsByDefault() {
+    final var handlers = getCustomErrorHandlers();
+    assertThatThrownBy(
+            () -> handlers.accept("some-index", new Error("Simulated error", "problem", 404)))
+        .isInstanceOf(PersistenceException.class)
+        .hasMessageContaining("Simulated error");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"operate-operation-8.4.1_", "operate-list-view-8.3.0_"})
+  void shouldIgnoreDocumentDoesNotExistForAppropriateIndexes(final String index) {
+    final var handlers = getCustomErrorHandlers();
+    handlers.accept(
+        index,
+        new io.camunda.exporter.errorhandling.Error(
+            "Simulated error", "document_missing_exception", 500));
+    handlers.accept(index, new Error("Simulated error", "problem", 404));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"operate-operation-8.4.1_ord00001", "operate-list-view-8.3.0_ord12345"})
+  void shouldIgnoreDocumentDoesNotExistForAppropriateOrdinalIndexes(final String index) {
+    final var handlers = getCustomErrorHandlers();
+    handlers.accept(
+        index,
+        new io.camunda.exporter.errorhandling.Error(
+            "Simulated error", "document_missing_exception", 500));
+    handlers.accept(index, new Error("Simulated error", "problem", 404));
+  }
+
+  private static BiConsumer<String, Error> getCustomErrorHandlers() {
+    final var config = new ExporterConfiguration();
+
+    // when
+    final var provider = new DefaultExporterResourceProvider();
+    provider.init(
+        config,
+        mock(ExporterEntityCacheProvider.class),
+        new ExporterTestContext(),
+        new ExporterMetadata(TestObjectMapper.objectMapper()),
+        TestObjectMapper.objectMapper());
+
+    final var handlers = provider.getCustomErrorHandlers();
+    return handlers;
   }
 
   /**

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
@@ -11,10 +11,15 @@ import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplat
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryCommitStatus;
@@ -82,12 +87,16 @@ final class AgentHistoryHandlerTest {
   }
 
   @Test
-  void shouldGenerateIdFromRecordKey() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final Record<AgentHistoryRecordValue> record = factory.generateRecord(ValueType.AGENT_HISTORY);
 
     // when - then
-    assertThat(underTest.generateIds(record)).containsExactly(String.valueOf(record.getKey()));
+    assertThat(underTest.extractIdAndIndexes(indexLocator, record))
+        .containsExactly(new IdAndIndex(String.valueOf(record.getKey()), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
@@ -22,10 +22,16 @@ import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTempla
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOL_CALLS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.VERSION_TAG;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate;
 import io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity;
@@ -84,13 +90,17 @@ final class AgentInstanceHandlerTest {
   }
 
   @Test
-  void shouldGenerateIdFromRecordKey() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final Record<AgentInstanceRecordValue> record =
         factory.generateRecord(ValueType.AGENT_INSTANCE);
 
     // when - then
-    assertThat(underTest.generateIds(record)).containsExactly(String.valueOf(record.getKey()));
+    assertThat(underTest.extractIdAndIndexes(indexLocator, record))
+        .containsExactly(new IdAndIndex(String.valueOf(record.getKey()), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
@@ -8,11 +8,16 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.descriptors.template.CorrelatedMessageSubscriptionTemplate;
@@ -26,7 +31,6 @@ import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordVa
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.time.Instant;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -89,8 +93,11 @@ final class CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTe
   }
 
   @Test
-  void shouldGenerateCompositeId() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final Record<ProcessMessageSubscriptionRecordValue> record =
         factory.generateRecord(
             ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
@@ -103,11 +110,10 @@ final class CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTe
                             .withMessageKey(67890L)
                             .build()));
 
-    // when
-    final List<String> ids = underTest.generateIds(record);
-
-    // then
-    assertThat(ids).hasSize(1).containsExactly("67890_12345");
+    // when - then
+    final String compositeId = "67890_12345";
+    assertThat(underTest.extractIdAndIndexes(indexLocator, record))
+        .containsExactly(new IdAndIndex(compositeId, index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionEvaluationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionEvaluationHandlerTest.java
@@ -8,11 +8,16 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.dmn.DecisionInstanceEntity;
 import io.camunda.webapps.schema.entities.dmn.DecisionInstanceState;
@@ -64,14 +69,16 @@ public class DecisionEvaluationHandlerTest {
   }
 
   @Test
-  void shouldGenerateIds() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final ImmutableEvaluatedDecisionValue decisionValue =
         ImmutableEvaluatedDecisionValue.builder()
             .from(factory.generateObject(EvaluatedDecisionValue.class))
             .withDecisionEvaluationInstanceKey("123-1")
             .build();
-    final long expectedId = 123;
     final DecisionEvaluationRecordValue decisionRecordValue =
         ImmutableDecisionEvaluationRecordValue.builder()
             .from(factory.generateObject(DecisionEvaluationRecordValue.class))
@@ -86,11 +93,9 @@ public class DecisionEvaluationHandlerTest {
                     .withValue(decisionRecordValue)
                     .withKey(123L));
 
-    // when
-    final var idList = underTest.generateIds(decisionRecord);
-
-    // then
-    assertThat(idList).containsExactly(expectedId + "-" + 1);
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, decisionRecord))
+        .containsExactly(new IdAndIndex("123-1", index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandlerTest.java
@@ -8,11 +8,16 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
@@ -47,19 +52,20 @@ public class FlowNodeInstanceFromIncidentHandlerTest {
   }
 
   @Test
-  public void shouldGenerateIds() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final IncidentRecordValue incidentRecordValue =
         factory.generateObject(ImmutableIncidentRecordValue.Builder.class).build();
     final Record<IncidentRecordValue> incidentRecord =
         factory.generateRecord(ValueType.INCIDENT, i -> i.withValue(incidentRecordValue));
 
-    // when
-    final var idList = underTest.generateIds(incidentRecord);
-
-    // then
-    assertThat(idList)
-        .containsExactly(String.valueOf(incidentRecord.getValue().getElementInstanceKey()));
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, incidentRecord))
+        .containsExactly(
+            new IdAndIndex(String.valueOf(incidentRecordValue.getElementInstanceKey()), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
@@ -8,12 +8,17 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.cache.TestProcessCache;
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
@@ -144,13 +149,17 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
   }
 
   @Test
-  public void shouldGenerateIds() {
-    final Record<ProcessInstanceRecordValue> processInstanceRecord =
+  void shouldExtractIdAndIndexes() {
+    // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
+    final Record<ProcessInstanceRecordValue> record =
         createRecord(ProcessInstanceIntent.ELEMENT_ACTIVATING);
-    final var idList = underTest.generateIds(processInstanceRecord);
 
-    assertThat(idList).isNotNull();
-    assertThat(idList).containsExactly(String.valueOf(processInstanceRecord.getKey()));
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, record))
+        .containsExactly(new IdAndIndex(String.valueOf(record.getKey()), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandlerTest.java
@@ -8,13 +8,17 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.cache.TestProcessCache;
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
@@ -86,16 +90,17 @@ public class FlowNodeInstanceNameFromAdHocActivityHandlerTest {
   }
 
   @Test
-  public void shouldGenerateInnerInstanceIdFromFlowScopeKey() {
+  void shouldExtractIdAndIndexesFromFlowScopeKey() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final Record<ProcessInstanceRecordValue> record =
         createRecord(ProcessInstanceIntent.ELEMENT_ACTIVATING, "listUsers", 222L, 999L);
 
-    // when
-    final var idList = underTest.generateIds(record);
-
-    // then
-    assertThat(idList).containsExactly("999");
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, record))
+        .containsExactly(new IdAndIndex("999", index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
@@ -8,12 +8,17 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.cache.TestProcessCache;
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
@@ -78,8 +83,11 @@ public class IncidentHandlerTest {
   }
 
   @Test
-  void shouldGenerateIds() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final long expectedId = 123;
     final IncidentRecordValue incidentRecordValue =
         ImmutableIncidentRecordValue.builder()
@@ -94,11 +102,9 @@ public class IncidentHandlerTest {
                     .withValue(incidentRecordValue)
                     .withKey(expectedId));
 
-    // when
-    final var idList = underTest.generateIds(incidentRecord);
-
-    // then
-    assertThat(idList).containsExactly(String.valueOf(expectedId));
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, incidentRecord))
+        .containsExactly(new IdAndIndex(String.valueOf(expectedId), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
@@ -24,11 +24,16 @@ import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PROCESS
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.RETRIES;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.TIME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.JobTemplate;
 import io.camunda.webapps.schema.entities.JobEntity;
@@ -117,15 +122,16 @@ final class JobHandlerTest {
   }
 
   @Test
-  void testGenerateIds() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final Record<JobRecordValue> record = factory.generateRecord(ValueType.JOB);
 
-    // when
-    final var ids = underTest.generateIds(record);
-
-    // then
-    assertThat(ids).containsExactly(String.valueOf(record.getKey()));
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, record))
+        .containsExactly(new IdAndIndex(String.valueOf(record.getKey()), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandlerTest.java
@@ -12,7 +12,9 @@ import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.IN
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.listview.FlowNodeInstanceForListViewEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -45,14 +47,18 @@ public class ListViewFlowNodeFromIncidentHandlerTest {
   }
 
   @Test
-  public void shouldGenerateIds() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final Record<IncidentRecordValue> incidentRecord = factory.generateRecord(ValueType.INCIDENT);
-    // when
-    final var idList = underTest.generateIds(incidentRecord);
-    // then
-    assertThat(idList)
-        .containsExactly(String.valueOf(incidentRecord.getValue().getElementInstanceKey()));
+
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, incidentRecord))
+        .containsExactly(
+            new IdAndIndex(
+                String.valueOf(incidentRecord.getValue().getElementInstanceKey()), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandlerTest.java
@@ -11,7 +11,9 @@ import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.JO
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.listview.FlowNodeInstanceForListViewEntity;
@@ -99,16 +101,17 @@ public class ListViewFlowNodeFromJobHandlerTest {
   }
 
   @Test
-  public void shouldGenerateIds() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final Record<JobRecordValue> jobRecord = factory.generateRecord(ValueType.JOB);
 
-    // when
-    final var idList = underTest.generateIds(jobRecord);
-
-    // then
-    assertThat(idList)
-        .containsExactly(String.valueOf(jobRecord.getValue().getElementInstanceKey()));
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, jobRecord))
+        .containsExactly(
+            new IdAndIndex(String.valueOf(jobRecord.getValue().getElementInstanceKey()), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandlerTest.java
@@ -11,7 +11,9 @@ import static io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor.POSI
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeState;
@@ -144,8 +146,11 @@ public class ListViewFlowNodeFromProcessInstanceHandlerTest {
   }
 
   @Test
-  public void shouldGenerateIds() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final ProcessInstanceRecordValue processInstanceRecordValue =
         ImmutableProcessInstanceRecordValue.builder()
             .from(factory.generateObject(ProcessInstanceRecordValue.class))
@@ -159,11 +164,9 @@ public class ListViewFlowNodeFromProcessInstanceHandlerTest {
                 r.withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
                     .withValue(processInstanceRecordValue));
 
-    // when
-    final var idList = underTest.generateIds(processInstanceRecord);
-
-    // then
-    assertThat(idList).containsExactly(String.valueOf(processInstanceRecord.getKey()));
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, processInstanceRecord))
+        .containsExactly(new IdAndIndex(String.valueOf(processInstanceRecord.getKey()), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandlerTest.java
@@ -8,11 +8,16 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
@@ -69,18 +74,19 @@ public class ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandl
   }
 
   @Test
-  public void shouldGenerateIds() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final long expectedId = 123;
     final Record<ProcessInstanceBusinessIdRecordValue> record =
         createRecord(
             ProcessInstanceBusinessIdIntent.ASSIGNED, b -> b.withProcessInstanceKey(expectedId));
 
-    // when
-    final var idList = underTest.generateIds(record);
-
-    // then
-    assertThat(idList).containsExactly(String.valueOf(expectedId));
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, record))
+        .containsExactly(new IdAndIndex(String.valueOf(expectedId), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
@@ -13,12 +13,17 @@ import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEM
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.RESUMED;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.SUSPENDED;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.cache.TestProcessCache;
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.operate.TreePath;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
@@ -126,8 +131,11 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
   }
 
   @Test
-  public void shouldGenerateIds() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final long expectedId = 123;
     final ProcessInstanceRecordValue processInstanceRecordValue =
         ImmutableProcessInstanceRecordValue.builder()
@@ -141,11 +149,9 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
             ValueType.PROCESS_INSTANCE,
             r -> r.withIntent(ELEMENT_ACTIVATING).withValue(processInstanceRecordValue));
 
-    // when
-    final var idList = underTest.generateIds(processInstanceRecord);
-
-    // then
-    assertThat(idList).containsExactly(String.valueOf(expectedId));
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, processInstanceRecord))
+        .containsExactly(new IdAndIndex(String.valueOf(expectedId), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandlerTest.java
@@ -11,11 +11,16 @@ import static io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor.POSI
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.VAR_NAME;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.VAR_VALUE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.listview.VariableForListViewEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -78,19 +83,20 @@ public class ListViewVariableFromVariableHandlerTest {
   }
 
   @Test
-  public void shouldGenerateIds() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final Record<VariableRecordValue> variableRecord =
         factory.generateRecord(ValueType.VARIABLE, r -> r.withIntent(VariableIntent.CREATED));
     final String expectedId =
         VariableForListViewEntity.getIdBy(
             variableRecord.getValue().getScopeKey(), variableRecord.getValue().getName());
 
-    // when
-    final var idList = underTest.generateIds(variableRecord);
-
-    // then
-    assertThat(idList).containsExactly(expectedId);
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, variableRecord))
+        .containsExactly(new IdAndIndex(expectedId, index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
@@ -12,12 +12,17 @@ import static io.camunda.webapps.schema.descriptors.template.MessageSubscription
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.MESSAGE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate;
@@ -103,8 +108,11 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
   }
 
   @Test
-  void testGenerateIds() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final long processInstanceKey = 123L;
     final long elementInstanceKey = 456L;
     final var recordValue =
@@ -116,17 +124,20 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
         factory.generateRecord(
             ValueType.PROCESS_MESSAGE_SUBSCRIPTION, r -> r.withValue(recordValue));
 
-    // when
-    final var ids = underTest.generateIds(record);
-
-    // then
-    assertThat(ids)
-        .containsExactly(String.format(ID_PATTERN, processInstanceKey, elementInstanceKey));
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, record))
+        .containsExactly(
+            new IdAndIndex(
+                String.format(ID_PATTERN, processInstanceKey, elementInstanceKey), index));
   }
 
   @Test
-  void shouldGenerateIdForNewVersionRecord() {
+  void shouldExtractIdAndIndexesForNewVersionRecord() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
+
     final long recordKey = 110L;
     exporterMetadata.setFirstProcessMessageSubscriptionKey(recordKey - 1);
     final var recordValue =
@@ -143,16 +154,20 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
                     .withValue(recordValue));
 
     // when
-    final var ids = underTest.generateIds(record);
+    final var idsAndIndexes = underTest.extractIdAndIndexes(indexLocator, record);
 
     // then
-    assertThat(ids).containsExactly(String.valueOf(recordKey));
+    assertThat(idsAndIndexes).containsExactly(new IdAndIndex(String.valueOf(recordKey), index));
     assertThat(exporterMetadata.getFirstProcessMessageSubscriptionKey()).isEqualTo(recordKey - 1);
   }
 
   @Test
-  void shouldGenerateIdForOldVersionRecord() {
+  void shouldExtractIdAndIndexesForOldVersionRecord() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
+
     final long recordKey = 90L;
     final int processInstanceKey = 123;
     final int elementInstanceKey = 456;
@@ -171,17 +186,23 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
                     .withValue(recordValue));
 
     // when
-    final var ids = underTest.generateIds(record);
+    final var idsAndIndexes = underTest.extractIdAndIndexes(indexLocator, record);
 
     // then
-    assertThat(ids)
-        .containsExactly(String.format(ID_PATTERN, processInstanceKey, elementInstanceKey));
+    assertThat(idsAndIndexes)
+        .containsExactly(
+            new IdAndIndex(
+                String.format(ID_PATTERN, processInstanceKey, elementInstanceKey), index));
     assertThat(exporterMetadata.getFirstProcessMessageSubscriptionKey()).isEqualTo(recordKey + 1);
   }
 
   @Test
   void shouldSetFirstProcessMessageSubscriptionKeyOnCreatedIntent() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
+
     final long recordKey = 100L;
     final var recordValue =
         ImmutableProcessMessageSubscriptionRecordValue.builder()
@@ -197,10 +218,10 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
                     .withValue(recordValue));
 
     // when
-    final var ids = underTest.generateIds(record);
+    final var idsAndIndexes = underTest.extractIdAndIndexes(indexLocator, record);
 
     // then
-    assertThat(ids).containsExactly(String.valueOf(recordKey));
+    assertThat(idsAndIndexes).containsExactly(new IdAndIndex(String.valueOf(recordKey), index));
     assertThat(exporterMetadata.getFirstProcessMessageSubscriptionKey()).isEqualTo(recordKey);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MigratedVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MigratedVariableHandlerTest.java
@@ -8,11 +8,16 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
 import io.camunda.webapps.schema.entities.VariableEntity;
@@ -69,8 +74,11 @@ public class MigratedVariableHandlerTest {
   }
 
   @Test
-  void shouldGenerateIds() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final VariableRecordValue variableRecordValue =
         ImmutableVariableRecordValue.builder()
             .from(factory.generateObject(VariableRecordValue.class))
@@ -81,12 +89,11 @@ public class MigratedVariableHandlerTest {
             ValueType.VARIABLE,
             r -> r.withIntent(VariableIntent.CREATED).withValue(variableRecordValue));
 
-    // when
-    final var idList = underTest.generateIds(variableRecord);
-
-    // then
-    assertThat(idList)
-        .containsExactly(variableRecordValue.getScopeKey() + "-" + variableRecordValue.getName());
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, variableRecord))
+        .containsExactly(
+            new IdAndIndex(
+                variableRecordValue.getScopeKey() + "-" + variableRecordValue.getName(), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
@@ -8,11 +8,16 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.post.PostImporterActionType;
 import io.camunda.webapps.schema.entities.post.PostImporterQueueEntity;
@@ -67,8 +72,12 @@ public class PostImporterQueueFromIncidentHandlerTest {
   }
 
   @Test
-  void shouldGenerateIdsForCreated() {
+  void shouldExtractIdAndIndexesForCreated() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
+
     final long expectedId = 123;
     final IncidentRecordValue decisionRecordValue =
         ImmutableIncidentRecordValue.builder()
@@ -83,16 +92,18 @@ public class PostImporterQueueFromIncidentHandlerTest {
                     .withValue(decisionRecordValue)
                     .withKey(expectedId));
 
-    // when
-    final var idList = underTest.generateIds(decisionRecord);
-
-    // then
-    assertThat(idList).containsExactly(expectedId + "-" + IncidentIntent.CREATED);
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, decisionRecord))
+        .containsExactly(new IdAndIndex(expectedId + "-" + IncidentIntent.CREATED, index));
   }
 
   @Test
-  void shouldGenerateIdsForMigrated() {
+  void shouldExtractIdAndIndexesForMigrated() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
+
     final long expectedId = 123;
     final IncidentRecordValue decisionRecordValue =
         ImmutableIncidentRecordValue.builder()
@@ -107,11 +118,9 @@ public class PostImporterQueueFromIncidentHandlerTest {
                     .withValue(decisionRecordValue)
                     .withKey(expectedId));
 
-    // when
-    final var idList = underTest.generateIds(decisionRecord);
-
-    // then
-    assertThat(idList).containsExactly(expectedId + "-" + IncidentIntent.CREATED);
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, decisionRecord))
+        .containsExactly(new IdAndIndex(expectedId + "-" + IncidentIntent.CREATED, index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandlerTest.java
@@ -8,11 +8,16 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.SequenceFlowEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -69,8 +74,11 @@ public class SequenceFlowDeletedHandlerTest {
   }
 
   @Test
-  void shouldGenerateIds() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final ProcessInstanceRecordValue sequenceFlowRecordValue =
         ImmutableProcessInstanceRecordValue.builder()
             .from(factory.generateObject(ProcessInstanceRecordValue.class))
@@ -83,14 +91,14 @@ public class SequenceFlowDeletedHandlerTest {
                 r.withIntent(ProcessInstanceIntent.SEQUENCE_FLOW_DELETED)
                     .withValue(sequenceFlowRecordValue));
 
-    // when
-    final var idList = underTest.generateIds(sequenceFlowRecord);
-    // then
-    assertThat(idList)
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, sequenceFlowRecord))
         .containsExactly(
-            sequenceFlowRecordValue.getProcessInstanceKey()
-                + "_"
-                + sequenceFlowRecordValue.getElementId());
+            new IdAndIndex(
+                sequenceFlowRecordValue.getProcessInstanceKey()
+                    + "_"
+                    + sequenceFlowRecordValue.getElementId(),
+                index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowHandlerTest.java
@@ -8,11 +8,16 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.SequenceFlowEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -67,8 +72,11 @@ public class SequenceFlowHandlerTest {
   }
 
   @Test
-  void shouldGenerateIds() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final ProcessInstanceRecordValue sequenceFlowRecordValue =
         ImmutableProcessInstanceRecordValue.builder()
             .from(factory.generateObject(ProcessInstanceRecordValue.class))
@@ -81,14 +89,14 @@ public class SequenceFlowHandlerTest {
                 r.withIntent(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
                     .withValue(sequenceFlowRecordValue));
 
-    // when
-    final var idList = underTest.generateIds(sequenceFlowRecord);
-    // then
-    assertThat(idList)
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, sequenceFlowRecord))
         .containsExactly(
-            sequenceFlowRecordValue.getProcessInstanceKey()
-                + "_"
-                + sequenceFlowRecordValue.getElementId());
+            new IdAndIndex(
+                sequenceFlowRecordValue.getProcessInstanceKey()
+                    + "_"
+                    + sequenceFlowRecordValue.getElementId(),
+                index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
@@ -8,12 +8,17 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.handlers.UserTaskCompletionVariableHandler.SnapshotTaskVariableBatch;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.template.SnapshotTaskVariableTemplate;
@@ -108,16 +113,18 @@ public class UserTaskCompletionVariableHandlerTest {
   }
 
   @Test
-  void shouldGenerateIds() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final long elementInstanceKey = 123L;
     final Record<UserTaskRecordValue> variableRecord =
         generateRecordWithVariables(elementInstanceKey, Map.of("var1", "val1", "var2", 2));
-    // when
-    final var idList = underTest.generateIds(variableRecord);
 
-    // then
-    assertThat(idList).containsExactlyInAnyOrder(String.valueOf(elementInstanceKey));
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, variableRecord))
+        .containsExactly(new IdAndIndex(String.valueOf(elementInstanceKey), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCreatingHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCreatingHandlerTest.java
@@ -8,15 +8,20 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.cache.TestFormCache;
 import io.camunda.exporter.cache.TestProcessCache;
 import io.camunda.exporter.cache.form.CachedFormEntity;
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.search.test.utils.TestObjectMapper;
@@ -79,8 +84,12 @@ public class UserTaskCreatingHandlerTest {
   }
 
   @Test
-  void shouldGenerateIdForNewVersionReferenceRecord() {
+  void shouldExtractIdAndIndexesForNewVersionReferenceRecord() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
+
     /* For 8.7 Ingested records, the recordKey has to be greater than the firstIngestedUserTaskKey */
     final long firstIngestedUserTaskKey = 100;
     final long recordKey = 110;
@@ -101,16 +110,18 @@ public class UserTaskCreatingHandlerTest {
                             .withElementInstanceKey(flowNodeInstanceKey)
                             .build()));
 
-    // when
-    final var idList = underTest.generateIds(userTaskRecord);
-
-    // then
-    assertThat(idList).containsExactly(String.valueOf(flowNodeInstanceKey));
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, userTaskRecord))
+        .containsExactly(new IdAndIndex(String.valueOf(flowNodeInstanceKey), index));
   }
 
   @Test
-  void shouldGenerateIdForPreviousVersionReferenceRecord() {
+  void shouldExtractIdAndIndexesForPreviousVersionReferenceRecord() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
+
     /* For 8.7 Ingested records referencing 8.6 records, the recordKey has to be less than the firstIngestedUserTaskKey */
     final long firstIngestedUserTaskKey = 100;
     final long recordKey = 90;
@@ -132,10 +143,10 @@ public class UserTaskCreatingHandlerTest {
                             .build()));
 
     // when
-    final var idList = underTest.generateIds(userTaskRecord);
+    final var idAndIndexList = underTest.extractIdAndIndexes(indexLocator, userTaskRecord);
 
     // then
-    assertThat(idList).containsExactly(String.valueOf(recordKey));
+    assertThat(idAndIndexList).containsExactly(new IdAndIndex(String.valueOf(recordKey), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -8,14 +8,18 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.cache.TestProcessCache;
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.search.test.utils.TestObjectMapper;
@@ -123,8 +127,12 @@ public class UserTaskHandlerTest {
   }
 
   @Test
-  void shouldGenerateIdForNewVersionReferenceRecord() {
+  void shouldExtractIdAndIndexesForNewVersionReferenceRecord() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
+
     /* For 8.7 Ingested records, the recordKey has to be greater than the firstIngestedUserTaskKey */
     final long firstIngestedUserTaskKey = 100;
     final long recordKey = 110;
@@ -145,16 +153,18 @@ public class UserTaskHandlerTest {
                             .withElementInstanceKey(flowNodeInstanceKey)
                             .build()));
 
-    // when
-    final var idList = underTest.generateIds(userTaskRecord);
-
-    // then
-    assertThat(idList).containsExactly(String.valueOf(flowNodeInstanceKey));
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, userTaskRecord))
+        .containsExactly(new IdAndIndex(String.valueOf(flowNodeInstanceKey), index));
   }
 
   @Test
-  void shouldGenerateIdForPreviousVersionReferenceRecord() {
+  void shouldExtractIdAndIndexesForPreviousVersionReferenceRecord() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
+
     /* For 8.7 Ingested records referencing 8.6 records, the recordKey has to be less than the firstIngestedUserTaskKey */
     final long firstIngestedUserTaskKey = 100;
     final long recordKey = 90;
@@ -176,10 +186,10 @@ public class UserTaskHandlerTest {
                             .build()));
 
     // when
-    final var idList = underTest.generateIds(userTaskRecord);
+    final var idAndIndexList = underTest.extractIdAndIndexes(indexLocator, userTaskRecord);
 
     // then
-    assertThat(idList).containsExactly(String.valueOf(recordKey));
+    assertThat(idAndIndexList).containsExactly(new IdAndIndex(String.valueOf(recordKey), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
@@ -8,16 +8,21 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.cache.TestFormCache;
 import io.camunda.exporter.cache.TestProcessCache;
 import io.camunda.exporter.cache.form.CachedFormEntity;
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.search.test.utils.TestObjectMapper;
@@ -221,8 +226,12 @@ public class UserTaskJobBasedHandlerTest {
   }
 
   @Test
-  void shouldGenerateIdForNewVersionReferenceRecord() {
+  void shouldExtractIdAndIndexesForNewVersionReferenceRecord() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
+
     /* For 8.7 Ingested records, the recordKey has to be greater than the firstIngestedUserTaskKey */
     final long firstIngestedUserTaskKey = 100;
     final long recordKey = 110;
@@ -241,16 +250,18 @@ public class UserTaskJobBasedHandlerTest {
                             .withElementInstanceKey(flowNodeInstanceKey)
                             .build()));
 
-    // when
-    final var idList = underTest.generateIds(jobRecord);
-
-    // then
-    assertThat(idList).containsExactly(String.valueOf(flowNodeInstanceKey));
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, jobRecord))
+        .containsExactly(new IdAndIndex(String.valueOf(flowNodeInstanceKey), index));
   }
 
   @Test
-  void shouldGenerateIdForPreviousVersionReferenceRecord() {
+  void shouldExtractIdAndIndexesForPreviousVersionReferenceRecord() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
+
     /* For 8.7 Ingested records, the recordKey has to be greater than the firstIngestedUserTaskKey */
     final long firstIngestedUserTaskKey = 100;
     final long recordKey = 90;
@@ -269,11 +280,9 @@ public class UserTaskJobBasedHandlerTest {
                             .withElementInstanceKey(flowNodeInstanceKey)
                             .build()));
 
-    // when
-    final var idList = underTest.generateIds(jobRecord);
-
-    // then
-    assertThat(idList).containsExactly(String.valueOf(recordKey));
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, jobRecord))
+        .containsExactly(new IdAndIndex(String.valueOf(recordKey), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandlerTest.java
@@ -8,11 +8,16 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
 import io.camunda.webapps.schema.entities.usertask.TaskProcessInstanceEntity;
@@ -90,8 +95,11 @@ public class UserTaskProcessInstanceHandlerTest {
   }
 
   @Test
-  void shouldGenerateIds() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final long expectedId = 123;
 
     final Record<ProcessInstanceRecordValue> processInstanceRecord =
@@ -99,11 +107,9 @@ public class UserTaskProcessInstanceHandlerTest {
             ValueType.PROCESS_INSTANCE,
             r -> r.withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING).withKey(expectedId));
 
-    // when
-    final var idList = underTest.generateIds(processInstanceRecord);
-
-    // then
-    assertThat(idList).containsExactly(String.valueOf(expectedId));
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, processInstanceRecord))
+        .containsExactly(new IdAndIndex(String.valueOf(expectedId), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskVariableHandlerTest.java
@@ -8,14 +8,18 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.cache.TestProcessCache;
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.handlers.UserTaskVariableHandler.UserTaskVariableBatch;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
@@ -150,8 +154,11 @@ public class UserTaskVariableHandlerTest {
   }
 
   @Test
-  void shouldGenerateId() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final long processInstanceKey = 123L;
     final String name = "name";
     final Record<VariableRecordValue> processInstanceRecord =
@@ -166,11 +173,9 @@ public class UserTaskVariableHandlerTest {
                             .withScopeKey(processInstanceKey)
                             .build()));
 
-    // when
-    final var idList = underTest.generateIds(processInstanceRecord);
-
-    // then
-    assertThat(idList).containsExactly(processInstanceKey + "-" + name);
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, processInstanceRecord))
+        .containsExactly(new IdAndIndex(String.valueOf(processInstanceKey + "-" + name), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/VariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/VariableHandlerTest.java
@@ -8,11 +8,16 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.VariableEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -67,8 +72,11 @@ public class VariableHandlerTest {
   }
 
   @Test
-  void shouldGenerateIds() {
+  void shouldExtractIdAndIndexes() {
     // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
     final VariableRecordValue variableRecordValue =
         ImmutableVariableRecordValue.builder()
             .from(factory.generateObject(VariableRecordValue.class))
@@ -79,12 +87,11 @@ public class VariableHandlerTest {
             ValueType.VARIABLE,
             r -> r.withIntent(VariableIntent.CREATED).withValue(variableRecordValue));
 
-    // when
-    final var idList = underTest.generateIds(variableRecord);
-
-    // then
-    assertThat(idList)
-        .containsExactly(variableRecordValue.getScopeKey() + "-" + variableRecordValue.getName());
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, variableRecord))
+        .containsExactly(
+            new IdAndIndex(
+                variableRecordValue.getScopeKey() + "-" + variableRecordValue.getName(), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/AuditLogCleanupHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/AuditLogCleanupHandlerTest.java
@@ -16,7 +16,9 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogCleanupEntity;
@@ -129,11 +131,16 @@ public class AuditLogCleanupHandlerTest {
   }
 
   @Test
-  void shouldGenerateIds() {
-    final var idList = handler.generateIds(record);
+  void shouldExtractIdAndIndexes() {
+    final var indexLocator = mock(TargetIndexLocator.class);
+    final var index = TargetIndex.mainIndex("test-index");
+    when(indexLocator.locate(INDEX_NAME)).thenReturn(index);
 
-    assertThat(idList).hasSize(1);
-    assertThat(idList.getFirst()).isEqualTo(record.getPartitionId() + "-" + record.getPosition());
+    final var idAndIndexes = handler.extractIdAndIndexes(indexLocator, record);
+
+    assertThat(idAndIndexes)
+        .containsExactly(
+            new IdAndIndex(record.getPartitionId() + "-" + record.getPosition(), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/AuditLogCleanupHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/AuditLogCleanupHandlerTest.java
@@ -134,7 +134,7 @@ public class AuditLogCleanupHandlerTest {
   void shouldExtractIdAndIndexes() {
     final var indexLocator = mock(TargetIndexLocator.class);
     final var index = TargetIndex.mainIndex("test-index");
-    when(indexLocator.locate(INDEX_NAME)).thenReturn(index);
+    when(indexLocator.locateMainIndex(INDEX_NAME)).thenReturn(index);
 
     final var idAndIndexes = handler.extractIdAndIndexes(indexLocator, record);
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/AuditLogHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/AuditLogHandlerTest.java
@@ -9,13 +9,17 @@ package io.camunda.exporter.handlers.auditlog;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
 import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogActorType;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
@@ -33,6 +37,7 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -70,6 +75,7 @@ class AuditLogHandlerTest {
   void setUp() {
     config = mock(AuditLogConfiguration.class);
     transformer = mock(AuditLogTransformer.class);
+    when(transformer.getRecordValueType()).thenReturn(RecordValue.class);
     handler = new AuditLogHandler<>(INDEX_NAME, transformer, config);
   }
 
@@ -106,11 +112,33 @@ class AuditLogHandlerTest {
   }
 
   @Test
-  void shouldGenerateIds() {
-    final var idList = handler.generateIds(record);
+  void shouldExtractIdAndIndexesForNonOrdinalRecord() {
+    final var indexLocator = mock(TargetIndexLocator.class);
+    final var index = TargetIndex.mainIndex("test-index");
+    when(indexLocator.locate(INDEX_NAME)).thenReturn(index);
 
-    assertThat(idList).hasSize(1);
-    assertThat(idList.getFirst()).isEqualTo(record.getPartitionId() + "-" + record.getPosition());
+    final var idAndIndexes = handler.extractIdAndIndexes(indexLocator, record);
+
+    assertThat(idAndIndexes)
+        .containsExactly(
+            new IdAndIndex(record.getPartitionId() + "-" + record.getPosition(), index));
+  }
+
+  @Test
+  void shouldExtractIdAndIndexesForOrdinalRecord() {
+    reset(transformer);
+    when(transformer.getRecordValueType()).thenReturn((Class) IncidentRecordValue.class);
+    handler = new AuditLogHandler<>(INDEX_NAME, transformer, config);
+
+    final var indexLocator = mock(TargetIndexLocator.class);
+    final var index = TargetIndex.ordinalIndex("test-index", 123);
+    when(indexLocator.locateOrdinalIndex(eq(INDEX_NAME), any())).thenReturn(index);
+
+    final var idAndIndexes = handler.extractIdAndIndexes(indexLocator, record);
+
+    assertThat(idAndIndexes)
+        .containsExactly(
+            new IdAndIndex(record.getPartitionId() + "-" + record.getPosition(), index));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/AuditLogHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/AuditLogHandlerTest.java
@@ -115,7 +115,7 @@ class AuditLogHandlerTest {
   void shouldExtractIdAndIndexesForNonOrdinalRecord() {
     final var indexLocator = mock(TargetIndexLocator.class);
     final var index = TargetIndex.mainIndex("test-index");
-    when(indexLocator.locate(INDEX_NAME)).thenReturn(index);
+    when(indexLocator.locateMainIndex(INDEX_NAME)).thenReturn(index);
 
     final var idAndIndexes = handler.extractIdAndIndexes(indexLocator, record);
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/index/TargetIndexLocatorTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/index/TargetIndexLocatorTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.index;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.protocol.record.value.StorageOrdinalKeyRelated;
+import org.junit.jupiter.api.Test;
+
+class TargetIndexLocatorTest {
+  private final TargetIndexLocator targetIndexLocator = new TargetIndexLocator();
+
+  @Test
+  void shouldLocateOrdinalIndexFromOrdinal() {
+    final var ordinalRelated = mock(StorageOrdinalKeyRelated.class);
+    when(ordinalRelated.getStorageOrdinalKey()).thenReturn(5);
+
+    final var targetIndex = targetIndexLocator.locateOrdinalIndex("test-index", ordinalRelated);
+    assertThat(targetIndex.name()).isEqualTo("test-indexord00005");
+  }
+
+  @Test
+  void shouldLocateOrdinalIndexFromDefaultOrdinal() {
+    final var ordinalRelated = mock(StorageOrdinalKeyRelated.class);
+    when(ordinalRelated.getStorageOrdinalKey()).thenReturn(0);
+
+    final var targetIndex = targetIndexLocator.locateOrdinalIndex("test-index", ordinalRelated);
+    assertThat(targetIndex.name()).isEqualTo("test-index");
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/index/TargetIndexLocatorTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/index/TargetIndexLocatorTest.java
@@ -34,4 +34,13 @@ class TargetIndexLocatorTest {
     final var targetIndex = targetIndexLocator.locateOrdinalIndex("test-index", ordinalRelated);
     assertThat(targetIndex.name()).isEqualTo("test-index");
   }
+
+  @Test
+  void shouldLocateOrdinalIndexFromNegativeOrdinal() {
+    final var ordinalRelated = mock(StorageOrdinalKeyRelated.class);
+    when(ordinalRelated.getStorageOrdinalKey()).thenReturn(-1);
+
+    final var targetIndex = targetIndexLocator.locateOrdinalIndex("test-index", ordinalRelated);
+    assertThat(targetIndex.name()).isEqualTo("test-index");
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/index/TargetIndexTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/index/TargetIndexTest.java
@@ -8,8 +8,12 @@
 package io.camunda.exporter.index;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class TargetIndexTest {
 
@@ -20,11 +24,35 @@ class TargetIndexTest {
     assertThat(index.getIndexFamily()).isEqualTo(index);
   }
 
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldFailToCreateMainIndexWithEmptyName(final String name) {
+    assertThatThrownBy(() -> TargetIndex.mainIndex(name))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Main index name must not be null or blank");
+  }
+
   @Test
   void shouldCreateOrdinalIndex() {
     final var index = TargetIndex.ordinalIndex("index-name", 12);
     assertThat(index.name()).isEqualTo("index-nameord00012");
     assertThat(index.getIndexFamily()).isEqualTo(new IndexFamilyImpl("index-name"));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldFailToCreateOrdinalIndexWithEmptyPrefix(final String prefix) {
+    assertThatThrownBy(() -> TargetIndex.ordinalIndex(prefix, 12))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Ordinal index prefix must not be null or blank");
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, -1, -5})
+  void shouldFailToCreateOrdinalIndexWithInvalidOrdinal(final int ordinal) {
+    assertThatThrownBy(() -> TargetIndex.ordinalIndex("index-name", ordinal))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Ordinal must be greater than 0");
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/index/TargetIndexTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/index/TargetIndexTest.java
@@ -60,9 +60,15 @@ class TargetIndexTest {
     assertThat(TargetIndex.getIndexFamilyFromName("index-name1").name()).isEqualTo("index-name1");
   }
 
-  @Test
-  void shouldReturnIndexFamilyFromNameForOrdinalIndex() {
-    assertThat(TargetIndex.getIndexFamilyFromName("index-name2ord00012").name())
-        .isEqualTo("index-name2");
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "index-name2ord00012",
+        "index-name2ord00001",
+        "index-name2ord00099",
+        "index-name2ord999999"
+      })
+  void shouldReturnIndexFamilyFromNameForOrdinalIndex(final String indexName) {
+    assertThat(TargetIndex.getIndexFamilyFromName(indexName).name()).isEqualTo("index-name2");
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/index/TargetIndexTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/index/TargetIndexTest.java
@@ -17,11 +17,24 @@ class TargetIndexTest {
   void shouldCreateMainIndex() {
     final var index = TargetIndex.mainIndex("index-name");
     assertThat(index.name()).isEqualTo("index-name");
+    assertThat(index.getIndexFamily()).isEqualTo(index);
   }
 
   @Test
   void shouldCreateOrdinalIndex() {
     final var index = TargetIndex.ordinalIndex("index-name", 12);
     assertThat(index.name()).isEqualTo("index-nameord00012");
+    assertThat(index.getIndexFamily()).isEqualTo(new IndexFamilyImpl("index-name"));
+  }
+
+  @Test
+  void shouldReturnIndexFamilyFromNameForMainIndex() {
+    assertThat(TargetIndex.getIndexFamilyFromName("index-name1").name()).isEqualTo("index-name1");
+  }
+
+  @Test
+  void shouldReturnIndexFamilyFromNameForOrdinalIndex() {
+    assertThat(TargetIndex.getIndexFamilyFromName("index-name2ord00012").name())
+        .isEqualTo("index-name2");
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/index/TargetIndexTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/index/TargetIndexTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.index;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TargetIndexTest {
+
+  @Test
+  void shouldCreateMainIndex() {
+    final var index = TargetIndex.mainIndex("index-name");
+    assertThat(index.name()).isEqualTo("index-name");
+  }
+
+  @Test
+  void shouldCreateOrdinalIndex() {
+    final var index = TargetIndex.ordinalIndex("index-name", 12);
+    assertThat(index.name()).isEqualTo("index-nameord00012");
+  }
+}


### PR DESCRIPTION
## Description

This adds the initial support for ordinal indexes in the Camunda Exporter.  It does not currently handle batch operations (this will be handled later).

It is mostly just concerned with looking up the "storage ordinal key" for a given record value type and using that to determine the correct index to use.

## Related issues

closes #56997
