### PR TITLE
feat: reject physical tenants that share a backup location

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/BackupStoreLocation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/BackupStoreLocation.java
@@ -29,8 +29,8 @@ import org.jspecify.annotations.Nullable;
  * each tenant's retention lists and deletes by partition wildcard, so it also deletes the other
  * tenant's backups. Comparing key spaces is what keeps that from being expressible.
  *
- * <p>Mirrors {@link DocumentStoreLocation}, including its treatment of {@code /} as an ordinary
- * character in object keys rather than a boundary.
+ * <p>Mirrors {@link DocumentStoreLocation}, except that {@code /} does bound a base path here — see
+ * {@link #sharesKeySpaceWith}.
  */
 @NullMarked
 record BackupStoreLocation(String store, List<String> namespace, String keyPrefix) {
@@ -89,13 +89,15 @@ record BackupStoreLocation(String store, List<String> namespace, String keyPrefi
   }
 
   /**
-   * Whether the two stores could address a common key: whenever one key prefix contains the other,
-   * equal prefixes included.
+   * Whether the two stores could address a common key: whenever one base path contains the other,
+   * equal paths included. A store at a bucket root is therefore not isolated from a base path
+   * inside it.
    *
-   * <p>For object stores a separator bounds nothing — {@code /} is an ordinary character in S3 keys
-   * and GCS object names — so a store at a bucket root is not isolated from a base path inside it.
-   * For the file system the containment is checked per path segment instead, because there {@code
-   * /backups} and {@code /backups-archive} really are two directories.
+   * <p>The separator is what bounds a base path here, unlike in {@link DocumentStoreLocation}: a
+   * backup key always continues as {@code <basePath>/<partitionId>/…}, and the stores build both
+   * their keys and their list prefixes as {@code basePath + "/"}, so nothing a store writes or
+   * lists can reach a sibling whose name merely starts with the same characters. {@code backups}
+   * contains {@code backups/tenanta} but not {@code backups-tenanta}.
    */
   boolean sharesKeySpaceWith(final BackupStoreLocation other) {
     if (!store.equals(other.store) || !namespace.equals(other.namespace)) {
@@ -104,7 +106,12 @@ record BackupStoreLocation(String store, List<String> namespace, String keyPrefi
     if ("filesystem".equals(store)) {
       return pathContains(keyPrefix, other.keyPrefix) || pathContains(other.keyPrefix, keyPrefix);
     }
-    return keyPrefix.startsWith(other.keyPrefix) || other.keyPrefix.startsWith(keyPrefix);
+    return keyContains(keyPrefix, other.keyPrefix) || keyContains(other.keyPrefix, keyPrefix);
+  }
+
+  /** Whether every key below {@code inner} is also addressed by {@code outer}. */
+  private static boolean keyContains(final String outer, final String inner) {
+    return outer.isEmpty() || inner.equals(outer) || inner.startsWith(outer + "/");
   }
 
   String describe() {

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/BackupStoreLocation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/BackupStoreLocation.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.configuration.Azure;
+import io.camunda.configuration.Filesystem;
+import io.camunda.configuration.Gcs;
+import io.camunda.configuration.PrimaryStorageBackup;
+import io.camunda.configuration.S3;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The key space a primary-storage backup store occupies: a {@code namespace} no key can escape —
+ * bucket, container or directory — and the {@code keyPrefix} every key inside it starts with.
+ *
+ * <p>Backup keys are addressed by {@code partitionId/checkpointId/nodeId} alone; nothing in them
+ * names a physical tenant, and partition ids restart at 1 in every tenant's partition group. Two
+ * tenants pointed at one key space therefore write their partition 1 backups to the same keys, and
+ * each tenant's retention lists and deletes by partition wildcard, so it also deletes the other
+ * tenant's backups. Comparing key spaces is what keeps that from being expressible.
+ *
+ * <p>Mirrors {@link DocumentStoreLocation}, including its treatment of {@code /} as an ordinary
+ * character in object keys rather than a boundary.
+ */
+@NullMarked
+record BackupStoreLocation(String store, List<String> namespace, String keyPrefix) {
+
+  static @Nullable BackupStoreLocation of(final PrimaryStorageBackup backup) {
+    return switch (backup.getStore()) {
+      // no store, no keys, nothing to collide with
+      case NONE -> null;
+      case S3 -> s3(backup.getS3());
+      case GCS -> gcs(backup.getGcs());
+      case AZURE -> azure(backup.getAzure());
+      case FILESYSTEM -> filesystem(backup.getFilesystem());
+    };
+  }
+
+  /** Region is excluded because S3 bucket names are globally unique across regions. */
+  private static BackupStoreLocation s3(final S3 s3) {
+    return new BackupStoreLocation(
+        "s3",
+        List.of(normalize(s3.getBucketName()), normalize(s3.getEndpoint())),
+        keyPrefixOf(s3.getBasePath()));
+  }
+
+  private static BackupStoreLocation gcs(final Gcs gcs) {
+    return new BackupStoreLocation(
+        "gcs",
+        List.of(normalize(gcs.getBucketName()), normalize(gcs.getHost())),
+        keyPrefixOf(gcs.getBasePath()));
+  }
+
+  /**
+   * Azure has no prefix to compare: {@code basePath} names the container itself (see {@code
+   * AzureBackupStoreConfig#toStoreConfig}), and containers do not nest, so two tenants either share
+   * one container or are isolated by construction.
+   */
+  private static BackupStoreLocation azure(final Azure azure) {
+    return new BackupStoreLocation(
+        "azure",
+        List.of(
+            normalize(azure.getBasePath()),
+            normalize(azure.getEndpoint()),
+            normalize(azure.getAccountName())),
+        "");
+  }
+
+  /**
+   * The whole directory tree below {@code basePath} belongs to one store, so a tenant configured
+   * inside another tenant's tree is not isolated from it. The path is normalized so that {@code
+   * /backups/./a} and {@code /backups/a} are recognized as one location, but it is not resolved
+   * against the file system: symlinks and relative paths interpreted from different working
+   * directories are out of reach of a static check.
+   */
+  private static BackupStoreLocation filesystem(final Filesystem filesystem) {
+    return new BackupStoreLocation(
+        "filesystem", List.of(), normalizePath(filesystem.getBasePath()));
+  }
+
+  /**
+   * Whether the two stores could address a common key: whenever one key prefix contains the other,
+   * equal prefixes included.
+   *
+   * <p>For object stores a separator bounds nothing — {@code /} is an ordinary character in S3 keys
+   * and GCS object names — so a store at a bucket root is not isolated from a base path inside it.
+   * For the file system the containment is checked per path segment instead, because there {@code
+   * /backups} and {@code /backups-archive} really are two directories.
+   */
+  boolean sharesKeySpaceWith(final BackupStoreLocation other) {
+    if (!store.equals(other.store) || !namespace.equals(other.namespace)) {
+      return false;
+    }
+    if ("filesystem".equals(store)) {
+      return pathContains(keyPrefix, other.keyPrefix) || pathContains(other.keyPrefix, keyPrefix);
+    }
+    return keyPrefix.startsWith(other.keyPrefix) || other.keyPrefix.startsWith(keyPrefix);
+  }
+
+  String describe() {
+    final var location =
+        namespace.isEmpty() ? keyPrefix : namespace + ", basePath='" + keyPrefix + "'";
+    return String.format("store=%s, %s", store, location);
+  }
+
+  private static boolean pathContains(final String outer, final String inner) {
+    try {
+      return Path.of(inner).startsWith(Path.of(outer));
+    } catch (final InvalidPathException e) {
+      // a path this platform cannot parse is compared as the plain string it was configured as
+      return inner.equals(outer);
+    }
+  }
+
+  private static String normalizePath(final @Nullable String basePath) {
+    if (basePath == null || basePath.isBlank()) {
+      return "";
+    }
+    try {
+      return Path.of(basePath).normalize().toString();
+    } catch (final InvalidPathException e) {
+      return basePath.trim();
+    }
+  }
+
+  /** Bucket and container names are restricted to lower case, so folding case cannot merge two. */
+  private static String normalize(final @Nullable String value) {
+    return value == null ? "" : value.trim().toLowerCase();
+  }
+
+  private static String keyPrefixOf(final @Nullable String basePath) {
+    return Objects.requireNonNullElse(basePath, "").trim();
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/BackupStoreLocation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/BackupStoreLocation.java
@@ -46,19 +46,32 @@ record BackupStoreLocation(String store, List<String> namespace, String keyPrefi
     };
   }
 
-  /** Region is excluded because S3 bucket names are globally unique across regions. */
+  /**
+   * Region is excluded because S3 bucket names are globally unique across regions. The base path is
+   * compared as configured, since {@code S3BackupConfig} rejects one that starts or ends with
+   * {@code /} rather than accepting and trimming it.
+   */
   private static BackupStoreLocation s3(final S3 s3) {
     return new BackupStoreLocation(
         "s3",
-        List.of(normalize(s3.getBucketName()), normalize(s3.getEndpoint())),
+        List.of(
+            DocumentStoreLocation.normalizeName(s3.getBucketName()),
+            DocumentStoreLocation.normalizeEndpoint(s3.getEndpoint())),
         keyPrefixOf(s3.getBasePath()));
   }
 
+  /**
+   * The base path is stripped of surrounding {@code /} the way {@code
+   * GcsBackupConfig#sanitizeBasePath} strips it, so that {@code /backups} and {@code backups} are
+   * recognized as the one prefix they both resolve to.
+   */
   private static BackupStoreLocation gcs(final Gcs gcs) {
     return new BackupStoreLocation(
         "gcs",
-        List.of(normalize(gcs.getBucketName()), normalize(gcs.getHost())),
-        keyPrefixOf(gcs.getBasePath()));
+        List.of(
+            DocumentStoreLocation.normalizeName(gcs.getBucketName()),
+            DocumentStoreLocation.normalizeEndpoint(gcs.getHost())),
+        stripSurroundingSlashes(keyPrefixOf(gcs.getBasePath())));
   }
 
   /**
@@ -70,9 +83,9 @@ record BackupStoreLocation(String store, List<String> namespace, String keyPrefi
     return new BackupStoreLocation(
         "azure",
         List.of(
-            normalize(azure.getBasePath()),
-            normalize(azure.getEndpoint()),
-            normalize(azure.getAccountName())),
+            DocumentStoreLocation.normalizeName(azure.getBasePath()),
+            DocumentStoreLocation.normalizeEndpoint(azure.getEndpoint()),
+            DocumentStoreLocation.normalizeName(azure.getAccountName())),
         "");
   }
 
@@ -140,12 +153,18 @@ record BackupStoreLocation(String store, List<String> namespace, String keyPrefi
     }
   }
 
-  /** Bucket and container names are restricted to lower case, so folding case cannot merge two. */
-  private static String normalize(final @Nullable String value) {
-    return value == null ? "" : value.trim().toLowerCase();
-  }
-
   private static String keyPrefixOf(final @Nullable String basePath) {
     return Objects.requireNonNullElse(basePath, "").trim();
+  }
+
+  private static String stripSurroundingSlashes(final String basePath) {
+    var stripped = basePath;
+    while (stripped.startsWith("/")) {
+      stripped = stripped.substring(1);
+    }
+    while (stripped.endsWith("/")) {
+      stripped = stripped.substring(0, stripped.length() - 1);
+    }
+    return stripped;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreLocation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreLocation.java
@@ -111,8 +111,11 @@ record DocumentStoreLocation(String provider, List<String> namespace, String key
     }
   }
 
-  /** AWS and Azure restrict these names to lower case, so folding case cannot merge two. */
-  private static String normalizeName(final @Nullable String value) {
+  /**
+   * AWS and Azure restrict these names to lower case, so folding case cannot merge two. Shared with
+   * {@link BackupStoreLocation}, which describes the same kinds of value.
+   */
+  static String normalizeName(final @Nullable String value) {
     return value == null ? "" : value.trim().toLowerCase();
   }
 
@@ -124,7 +127,7 @@ record DocumentStoreLocation(String provider, List<String> namespace, String key
    * three parts — an unparseable URL is usually one whose token needed escaping, which is exactly
    * the value that must not be kept.
    */
-  private static String normalizeEndpoint(final @Nullable String value) {
+  static String normalizeEndpoint(final @Nullable String value) {
     final String endpoint = normalizeName(value);
     if (endpoint.isEmpty()) {
       return "";

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
@@ -62,7 +62,8 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
           new SecondaryStorageIsolationValidation(),
           new RetentionPolicyIsolationValidation(),
           new SecondaryStorageTypeHomogeneityValidation(),
-          new DocumentStoreIsolationValidation());
+          new DocumentStoreIsolationValidation(),
+          new PrimaryStorageBackupIsolationValidation());
 
   private final Map<String, Camunda> resolved;
 

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PrimaryStorageBackupIsolationValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PrimaryStorageBackupIsolationValidation.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.UnifiedConfigurationException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Cross-tenant rule: no two physical tenants may resolve to overlapping primary-storage backup key
+ * spaces (see {@link BackupStoreLocation}).
+ *
+ * <p>A backup is addressed by {@code partitionId/checkpointId/nodeId}, which names no tenant, and
+ * every tenant's partition group numbers its partitions from 1. Two tenants sharing a key space
+ * therefore write their partition 1 backups to the same keys, and because retention lists and
+ * deletes by partition wildcard, each tenant's retention job also deletes the other's backups — a
+ * backup that silently restores another tenant's data, or is gone when it is needed.
+ *
+ * <p>Comparing <em>fully resolved</em> locations means tenants that both inherit the root backup
+ * configuration (without overriding it) collide too, which is the case this rule mainly exists for:
+ * inheriting is the default, so a multi-tenant cluster that configures backups once at the root
+ * would otherwise point every tenant at one bucket.
+ *
+ * <p>Tenants without a backup store write no backups and are skipped. The synthesized {@code
+ * default} tenant participates like any other. Single-tenant deployments resolve to a one-entry map
+ * and are a no-op.
+ */
+@NullMarked
+class PrimaryStorageBackupIsolationValidation implements CrossTenantValidation {
+
+  @Override
+  public void validate(final Map<String, Camunda> resolvedByTenant) {
+    if (resolvedByTenant.size() <= 1) {
+      // a single tenant (the common single-tenant deployment) cannot collide with anything
+      return;
+    }
+
+    final Map<String, BackupStoreLocation> locationsByTenant = new LinkedHashMap<>();
+    resolvedByTenant.forEach(
+        (tenantId, camunda) -> {
+          final var location =
+              BackupStoreLocation.of(camunda.getData().getPrimaryStorage().getBackup());
+          if (location != null) {
+            locationsByTenant.put(tenantId, location);
+          }
+        });
+
+    final List<String> collisions = new ArrayList<>();
+    final List<String> reported = new ArrayList<>();
+    locationsByTenant.forEach(
+        (tenantId, location) -> {
+          if (reported.contains(tenantId)) {
+            return;
+          }
+          final var sharing = new ArrayList<>(List.of(tenantId));
+          locationsByTenant.forEach(
+              (otherId, otherLocation) -> {
+                if (!otherId.equals(tenantId) && location.sharesKeySpaceWith(otherLocation)) {
+                  sharing.add(otherId);
+                }
+              });
+          if (sharing.size() > 1) {
+            reported.addAll(sharing);
+            collisions.add(
+                String.format(
+                    "tenants %s share the same backup location [%s]",
+                    sharing, location.describe()));
+          }
+        });
+
+    if (!collisions.isEmpty()) {
+      throw new UnifiedConfigurationException(
+          "Physical tenants must not share a primary-storage backup location, or their backups "
+              + "would overwrite and delete each other: backups are addressed by partition id, and "
+              + "every tenant has a partition 1. Give each tenant its own bucket, container or base "
+              + "path under data.primary-storage.backup. Conflicts: "
+              + String.join("; ", collisions));
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/PrimaryStorageBackupPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/PrimaryStorageBackupPropertiesTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.zeebe.backup.schedule.Schedule.CronSchedule;
 import io.camunda.zeebe.backup.schedule.Schedule.IntervalSchedule;
 import io.camunda.zeebe.backup.schedule.Schedule.NoneSchedule;
@@ -23,6 +24,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -497,6 +502,42 @@ public class PrimaryStorageBackupPropertiesTest {
 
       // when/then - application startup should succeed
       assertThatCode(app::run).doesNotThrowAnyException();
+    }
+  }
+
+  @Nested
+  class BackupLocationIsolation {
+
+    @Test
+    void shouldRejectPhysicalTenantsResolvingToOneBackupLocation() {
+      // given a tenant that inherits the root backup store because it does not override it
+      final var environment = new MockEnvironment();
+      environment
+          .getPropertySources()
+          .addFirst(
+              new MapPropertySource(
+                  "test",
+                  Map.of(
+                      "camunda.data.primary-storage.backup.store", "FILESYSTEM",
+                      "camunda.data.primary-storage.backup.filesystem.base-path", "/backups",
+                      "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+                          "tenanta",
+                      "camunda.physical-tenants.tenanta.security.initialization.default-roles.admin.users[0]",
+                          "tenanta-admin")));
+      UnifiedConfigurationHelper.setCustomEnvironment(environment);
+
+      final var camunda = new Camunda();
+      Binder.get(environment).bind(Camunda.PREFIX, Bindable.ofInstance(camunda));
+
+      // when / then
+      try {
+        assertThatThrownBy(() -> PhysicalTenantResolver.of(environment, camunda))
+            .isInstanceOf(UnifiedConfigurationException.class)
+            .hasMessageContaining("must not share a primary-storage backup location")
+            .hasMessageContaining("tenanta");
+      } finally {
+        UnifiedConfigurationHelper.setCustomEnvironment(null);
+      }
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PrimaryStorageBackupIsolationValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PrimaryStorageBackupIsolationValidationTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Filesystem;
+import io.camunda.configuration.PrimaryStorageBackup;
+import io.camunda.configuration.PrimaryStorageBackup.BackupStoreType;
+import io.camunda.configuration.S3;
+import io.camunda.configuration.UnifiedConfigurationException;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * Unit tests for the {@link PrimaryStorageBackupIsolationValidation} cross-tenant rule: no two
+ * physical tenants may resolve to overlapping backup key spaces, because backup keys name a
+ * partition but never a tenant.
+ */
+class PrimaryStorageBackupIsolationValidationTest {
+
+  private final PrimaryStorageBackupIsolationValidation validation =
+      new PrimaryStorageBackupIsolationValidation();
+
+  @BeforeEach
+  void setUp() {
+    UnifiedConfigurationHelper.setCustomEnvironment(new MockEnvironment());
+  }
+
+  @AfterEach
+  void tearDown() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  @Test
+  void shouldRejectTenantsInheritingOneRootBackupStore() {
+    // given two tenants that both leave the root backup configuration untouched — the default, and
+    // the reason this rule exists
+    final var resolved =
+        tenants("tenanta", filesystem("/backups"), "tenantb", filesystem("/backups"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb")
+        .withMessageContaining("/backups");
+  }
+
+  @Test
+  void shouldRejectTenantNestedInsideAnotherTenantsDirectory() {
+    // given tenantb's base path sits inside tenanta's directory tree
+    final var resolved =
+        tenants("tenanta", filesystem("/backups"), "tenantb", filesystem("/backups/tenantb"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb");
+  }
+
+  @Test
+  void shouldRejectTenantsSharingBucketAndBasePathPrefix() {
+    // given both tenants write to one bucket, one base path a prefix of the other; `/` bounds
+    // nothing in an S3 key, so `backups` reaches every key under `backups/tenantb`
+    final var resolved =
+        tenants(
+            "tenanta", s3("shared-bucket", "backups"),
+            "tenantb", s3("shared-bucket", "backups/tenantb"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("shared-bucket");
+  }
+
+  @Test
+  void shouldAllowTenantsWithDistinctBasePaths() {
+    // given each tenant has its own directory, neither inside the other
+    final var resolved =
+        tenants(
+            "tenanta", filesystem("/backups/tenanta"), "tenantb", filesystem("/backups/tenantb"));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldNotConfuseSiblingDirectoriesSharingAPrefix() {
+    // given directory names where one string is a prefix of the other but the directories are
+    // siblings — on a file system, unlike in an object key, the segment boundary is real
+    final var resolved =
+        tenants("tenanta", filesystem("/backups"), "tenantb", filesystem("/backups-archive"));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldAllowTenantsWithoutABackupStore() {
+    // given tenants that take no backups at all, so they share no keys
+    final var resolved = tenants("tenanta", noStore(), "tenantb", noStore());
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldAllowASingleTenantWithABackupStore() {
+    // given the common single-tenant deployment
+    final var resolved = new LinkedHashMap<String, Camunda>();
+    resolved.put("default", camunda(filesystem("/backups")));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  private Map<String, Camunda> tenants(
+      final String firstId,
+      final Consumer<PrimaryStorageBackup> first,
+      final String secondId,
+      final Consumer<PrimaryStorageBackup> second) {
+    final var resolved = new LinkedHashMap<String, Camunda>();
+    resolved.put(firstId, camunda(first));
+    resolved.put(secondId, camunda(second));
+    return resolved;
+  }
+
+  private Camunda camunda(final Consumer<PrimaryStorageBackup> backupConfig) {
+    final var camunda = new Camunda();
+    backupConfig.accept(camunda.getData().getPrimaryStorage().getBackup());
+    return camunda;
+  }
+
+  private Consumer<PrimaryStorageBackup> filesystem(final String basePath) {
+    return backup -> {
+      backup.setStore(BackupStoreType.FILESYSTEM);
+      final var filesystem = new Filesystem();
+      filesystem.setBasePath(basePath);
+      backup.setFilesystem(filesystem);
+    };
+  }
+
+  private Consumer<PrimaryStorageBackup> s3(final String bucketName, final String basePath) {
+    return backup -> {
+      backup.setStore(BackupStoreType.S3);
+      final var s3 = new S3();
+      s3.setBucketName(bucketName);
+      s3.setBasePath(basePath);
+      backup.setS3(s3);
+    };
+  }
+
+  private Consumer<PrimaryStorageBackup> noStore() {
+    return backup -> backup.setStore(BackupStoreType.NONE);
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PrimaryStorageBackupIsolationValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PrimaryStorageBackupIsolationValidationTest.java
@@ -9,9 +9,12 @@ package io.camunda.configuration.physicaltenants;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import io.camunda.configuration.Azure;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Filesystem;
+import io.camunda.configuration.Gcs;
 import io.camunda.configuration.PrimaryStorageBackup;
 import io.camunda.configuration.PrimaryStorageBackup.BackupStoreType;
 import io.camunda.configuration.S3;
@@ -20,9 +23,13 @@ import io.camunda.configuration.UnifiedConfigurationHelper;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.mock.env.MockEnvironment;
 
 /**
@@ -71,6 +78,62 @@ class PrimaryStorageBackupIsolationValidationTest {
         .isThrownBy(() -> validation.validate(resolved))
         .withMessageContaining("tenanta")
         .withMessageContaining("tenantb");
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("sharedLocationsPerStore")
+  void shouldRejectTenantsSharingALocation(
+      final String store, final Consumer<PrimaryStorageBackup> shared) {
+    // given both tenants resolve to the same location, whichever store they use
+    final var resolved = tenants("tenanta", shared, "tenantb", shared);
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb")
+        .withMessageContaining("store=" + store);
+  }
+
+  static Stream<Arguments> sharedLocationsPerStore() {
+    return Stream.of(
+        arguments("filesystem", filesystem("/backups")),
+        arguments("s3", s3("shared-bucket", "backups")),
+        arguments("gcs", gcs("shared-bucket", "backups")),
+        arguments("azure", azure("shared-container")));
+  }
+
+  @Test
+  void shouldNormalizeTheGcsBasePathTheWayTheStoreDoes() {
+    // given base paths that differ only in the surrounding slashes GcsBackupConfig strips, so both
+    // resolve to the same prefix
+    final var resolved =
+        tenants(
+            "tenanta", gcs("shared-bucket", "/backups/"),
+            "tenantb", gcs("shared-bucket", "backups"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb");
+  }
+
+  @Test
+  void shouldNotReportCredentialsCarriedInAnEndpoint() {
+    // given an endpoint that carries a token, as a SAS-style URL does
+    final var resolved =
+        tenants(
+            "tenanta",
+                azure("shared-container", "https://account.blob.core.windows.net?sig=secret"),
+            "tenantb",
+                azure("shared-container", "https://account.blob.core.windows.net?sig=secret"));
+
+    // when / then the collision is reported without the query string it was configured with
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("account.blob.core.windows.net")
+        .withMessageNotContaining("sig=secret");
   }
 
   @Test
@@ -142,7 +205,7 @@ class PrimaryStorageBackupIsolationValidationTest {
     assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
   }
 
-  private Map<String, Camunda> tenants(
+  private static Map<String, Camunda> tenants(
       final String firstId,
       final Consumer<PrimaryStorageBackup> first,
       final String secondId,
@@ -153,13 +216,13 @@ class PrimaryStorageBackupIsolationValidationTest {
     return resolved;
   }
 
-  private Camunda camunda(final Consumer<PrimaryStorageBackup> backupConfig) {
+  private static Camunda camunda(final Consumer<PrimaryStorageBackup> backupConfig) {
     final var camunda = new Camunda();
     backupConfig.accept(camunda.getData().getPrimaryStorage().getBackup());
     return camunda;
   }
 
-  private Consumer<PrimaryStorageBackup> filesystem(final String basePath) {
+  private static Consumer<PrimaryStorageBackup> filesystem(final String basePath) {
     return backup -> {
       backup.setStore(BackupStoreType.FILESYSTEM);
       final var filesystem = new Filesystem();
@@ -168,7 +231,7 @@ class PrimaryStorageBackupIsolationValidationTest {
     };
   }
 
-  private Consumer<PrimaryStorageBackup> s3(final String bucketName, final String basePath) {
+  private static Consumer<PrimaryStorageBackup> s3(final String bucketName, final String basePath) {
     return backup -> {
       backup.setStore(BackupStoreType.S3);
       final var s3 = new S3();
@@ -178,7 +241,34 @@ class PrimaryStorageBackupIsolationValidationTest {
     };
   }
 
-  private Consumer<PrimaryStorageBackup> noStore() {
+  private static Consumer<PrimaryStorageBackup> gcs(
+      final String bucketName, final String basePath) {
+    return backup -> {
+      backup.setStore(BackupStoreType.GCS);
+      final var gcs = new Gcs();
+      gcs.setBucketName(bucketName);
+      gcs.setBasePath(basePath);
+      backup.setGcs(gcs);
+    };
+  }
+
+  private static Consumer<PrimaryStorageBackup> azure(final String containerName) {
+    return azure(containerName, "https://account.blob.core.windows.net");
+  }
+
+  /** Azure names its container with the base path, so that is what identifies the location. */
+  private static Consumer<PrimaryStorageBackup> azure(
+      final String containerName, final String endpoint) {
+    return backup -> {
+      backup.setStore(BackupStoreType.AZURE);
+      final var azure = new Azure();
+      azure.setBasePath(containerName);
+      azure.setEndpoint(endpoint);
+      backup.setAzure(azure);
+    };
+  }
+
+  private static Consumer<PrimaryStorageBackup> noStore() {
     return backup -> backup.setStore(BackupStoreType.NONE);
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PrimaryStorageBackupIsolationValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PrimaryStorageBackupIsolationValidationTest.java
@@ -89,6 +89,19 @@ class PrimaryStorageBackupIsolationValidationTest {
   }
 
   @Test
+  void shouldAllowBasePathsThatOnlyShareAStringPrefix() {
+    // given base paths where one string starts with the other, but the keys below them cannot
+    // overlap: every backup key continues as `<basePath>/<partitionId>/…`
+    final var resolved =
+        tenants(
+            "tenanta", s3("shared-bucket", "backups"),
+            "tenantb", s3("shared-bucket", "backups-tenantb"));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
   void shouldAllowTenantsWithDistinctBasePaths() {
     // given each tenant has its own directory, neither inside the other
     final var resolved =

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -15,6 +15,7 @@ import dasniko.testcontainers.keycloak.KeycloakContainer;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
+import io.camunda.configuration.PrimaryStorageBackup;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.qa.util.auth.Authenticated;
@@ -551,6 +552,10 @@ public class CamundaMultiDBExtension
         tenantId,
         camunda -> {
           configurePtStorage.accept(camunda.getData().getSecondaryStorage());
+          isolateBackupLocation(
+              springApplication.unifiedConfig().getData().getPrimaryStorage().getBackup(),
+              camunda.getData().getPrimaryStorage().getBackup(),
+              tenantId);
 
           final var init = camunda.getSecurity().getInitialization();
           init.setUsers(rootInit.getUsers());
@@ -589,6 +594,40 @@ public class CamundaMultiDBExtension
         && springApplication.property(assignedProviderProperty, String.class, null) == null) {
       springApplication.withProperty(assignedProviderProperty, "oidc");
     }
+  }
+
+  /**
+   * Gives the physical tenant its own backup location, the way it gets its own secondary storage. A
+   * tenant inherits the root backup configuration it does not override, and two tenants sharing one
+   * location would write their partition 1 backups to the same keys, which
+   * PrimaryStorageBackupIsolationValidation rejects at boot. The tenant id is appended to the
+   * configured base path rather than nested inside it, since a base path contains everything below
+   * its separator.
+   *
+   * <p>The store to isolate is read from the root configuration, not the tenant's: {@code
+   * withPtConfig} hands out a pristine {@link Camunda} whose values are only the ones this test
+   * explicitly overrides, and which is flattened into properties by diffing against a pristine
+   * instance. Everything else — including the backup store the tenant collides on — is inherited
+   * from the root at resolve time and is not visible here.
+   */
+  private static void isolateBackupLocation(
+      final PrimaryStorageBackup root, final PrimaryStorageBackup tenant, final String tenantId) {
+    switch (root.getStore()) {
+      case NONE -> {}
+      case FILESYSTEM ->
+          tenant
+              .getFilesystem()
+              .setBasePath(suffixed(root.getFilesystem().getBasePath(), tenantId));
+      case S3 -> tenant.getS3().setBasePath(suffixed(root.getS3().getBasePath(), tenantId));
+      case GCS -> tenant.getGcs().setBasePath(suffixed(root.getGcs().getBasePath(), tenantId));
+      case AZURE ->
+          tenant.getAzure().setBasePath(suffixed(root.getAzure().getBasePath(), tenantId));
+      default -> throw new IllegalArgumentException("Unsupported backup store: " + root.getStore());
+    }
+  }
+
+  private static String suffixed(final String basePath, final String tenantId) {
+    return basePath == null || basePath.isBlank() ? tenantId : basePath + "-" + tenantId;
   }
 
   private static Consumer<SecondaryStorage> configureRdbmsStorage(


### PR DESCRIPTION
Backups are addressed by partition id, checkpoint id and node id — never by physical tenant — and every tenant's partition group has a partition 1. Two tenants sharing a backup location therefore write to the same keys, and each tenant's retention deletes the other's backups.

Tenants inherit every root property they don't override, so configuring backups once at the root points all of them at one bucket. That is reachable today: a backup can be taken per tenant via `/physical-tenants/<id>/v2/backups/runtime`.

`PrimaryStorageBackupIsolationValidation` fails boot when two tenants resolve to overlapping backup key spaces, alongside the existing secondary-storage, retention-policy and document-store isolation rules. Namespacing keys by tenant would fix it properly but changes a layout restore and the backup API also read, so it needs its own design.

No backport: `stable/8.9` has no physical-tenant configuration.
