### PR TITLE
Support batching agent-instance history items in the Java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateAgentHistoryItemCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateAgentHistoryItemCommandStep1.java
@@ -83,7 +83,7 @@ public interface CreateAgentHistoryItemCommandStep1 {
   interface CreateAgentHistoryItemCommandStep5 {
 
     /**
-     * Sets the connector-side timestamp when this message was produced.
+     * Sets the agent-side timestamp when this message was produced.
      *
      * @param producedAt the production timestamp. Must not be null.
      * @return this builder for method chaining
@@ -95,9 +95,9 @@ public interface CreateAgentHistoryItemCommandStep1 {
       extends FinalCommandStep<CreateAgentHistoryItemResponse> {
 
     /**
-     * Sets the opaque job lease token received from the job activation response.
-     *
-     * <p>Job leasing is not yet enforced (#55033); this field is optional until support is added.
+     * Sets the opaque job lease token received from the job activation response. Disambiguates this
+     * activation from any other activation of the same job: if the job is later retried, history
+     * items submitted under a superseded lease are discarded rather than committed.
      *
      * @param jobLease the lease token. Must not be null or empty.
      * @return this builder for method chaining

--- a/clients/java/src/main/java/io/camunda/client/api/command/UpdateAgentInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UpdateAgentInstanceCommandStep1.java
@@ -16,6 +16,8 @@
 package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.UpdateAgentInstanceResponse;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 /**
@@ -105,6 +107,35 @@ public interface UpdateAgentInstanceCommandStep1 {
      * @return this builder for method chaining
      */
     UpdateAgentInstanceCommandStep2 tools(List<AgentTool> tools);
+
+    /**
+     * Sets the job key of the currently active job during which this update was produced. Required
+     * whenever {@link #history(List)} is non-empty; otherwise irrelevant to the update.
+     *
+     * @param jobKey the key of the active job. Must be greater than 0.
+     * @return this builder for method chaining
+     */
+    UpdateAgentInstanceCommandStep2 jobKey(long jobKey);
+
+    /**
+     * Sets the opaque job lease token received from the job activation response. Disambiguates this
+     * activation from any other activation of the same job: if the job is later retried, history
+     * items submitted under a superseded lease are discarded rather than committed.
+     *
+     * @param jobLease the lease token. Must not be null or blank.
+     * @return this builder for method chaining
+     */
+    UpdateAgentInstanceCommandStep2 jobLease(String jobLease);
+
+    /**
+     * Replaces the full batch of conversation history items to append to the agent instance.
+     * Requires {@link #jobKey(long)} to also be set.
+     *
+     * @param history the history items to append, in order. Must not be null; elements must not be
+     *     null.
+     * @return this builder for method chaining
+     */
+    UpdateAgentInstanceCommandStep2 history(List<HistoryItem> history);
   }
 
   /** Represents a tool available to the agent instance. */
@@ -150,6 +181,126 @@ public interface UpdateAgentInstanceCommandStep1 {
           return elementId;
         }
       };
+    }
+  }
+
+  /** A single conversation history item to append as part of an update batch. */
+  final class HistoryItem {
+    private String historyItemId;
+    private int loopIteration;
+    private AgentInstanceHistoryRole role;
+    private List<AgentInstanceHistoryContent> content;
+    private OffsetDateTime producedAt;
+    private List<AgentInstanceHistoryToolCall> toolCalls;
+    private AgentInstanceHistoryMetrics metrics;
+
+    /**
+     * Sets the caller-assigned identifier used to detect and dedupe retries of the same item.
+     *
+     * @param historyItemId the item id. Must not be null or blank.
+     * @return this builder for method chaining
+     */
+    public HistoryItem historyItemId(final String historyItemId) {
+      this.historyItemId = historyItemId;
+      return this;
+    }
+
+    /**
+     * Sets the loop iteration this item belongs to: one pass through the agent's loop, during which
+     * the model reasons, selects tools, evaluates the result, and decides whether to continue.
+     * Grouping items by iteration makes a single pass addressable, so a slice of the conversation
+     * history can be pointed at rather than the whole conversation.
+     *
+     * @param loopIteration the loop iteration number. Must be greater than 0, and increase with
+     *     each iteration.
+     * @return this builder for method chaining
+     */
+    public HistoryItem loopIteration(final int loopIteration) {
+      this.loopIteration = loopIteration;
+      return this;
+    }
+
+    /**
+     * Sets the role of this history item in the conversation.
+     *
+     * @param role the conversation role. Must not be null.
+     * @return this builder for method chaining
+     */
+    public HistoryItem role(final AgentInstanceHistoryRole role) {
+      this.role = role;
+      return this;
+    }
+
+    /**
+     * Sets the content blocks of this history item.
+     *
+     * @param content the list of content blocks. Must not be null or empty.
+     * @return this builder for method chaining
+     */
+    public HistoryItem content(final List<AgentInstanceHistoryContent> content) {
+      this.content = content;
+      return this;
+    }
+
+    /**
+     * Sets the agent-side timestamp when this message was produced.
+     *
+     * @param producedAt the production timestamp. Must not be null.
+     * @return this builder for method chaining
+     */
+    public HistoryItem producedAt(final OffsetDateTime producedAt) {
+      this.producedAt = producedAt;
+      return this;
+    }
+
+    /**
+     * Sets the tool calls associated with this history item.
+     *
+     * @param toolCalls the list of tool calls. May be null.
+     * @return this builder for method chaining
+     */
+    public HistoryItem toolCalls(final List<AgentInstanceHistoryToolCall> toolCalls) {
+      this.toolCalls = toolCalls;
+      return this;
+    }
+
+    /**
+     * Sets per-call token and latency metrics. Present on ASSISTANT items only.
+     *
+     * @param metrics the metrics. May be null.
+     * @return this builder for method chaining
+     */
+    public HistoryItem metrics(final AgentInstanceHistoryMetrics metrics) {
+      this.metrics = metrics;
+      return this;
+    }
+
+    public String getHistoryItemId() {
+      return historyItemId;
+    }
+
+    public int getLoopIteration() {
+      return loopIteration;
+    }
+
+    public AgentInstanceHistoryRole getRole() {
+      return role;
+    }
+
+    public List<AgentInstanceHistoryContent> getContent() {
+      return content;
+    }
+
+    public OffsetDateTime getProducedAt() {
+      return producedAt;
+    }
+
+    public List<AgentInstanceHistoryToolCall> getToolCalls() {
+      return toolCalls;
+    }
+
+    public AgentInstanceHistoryMetrics getMetrics() {
+      return metrics;
     }
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/UpdateAgentInstanceResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/UpdateAgentInstanceResponse.java
@@ -15,4 +15,31 @@
  */
 package io.camunda.client.api.response;
 
-public interface UpdateAgentInstanceResponse {}
+import java.util.List;
+
+public interface UpdateAgentInstanceResponse {
+
+  /**
+   * @return one entry per history item submitted on the update request, in request order
+   */
+  List<CreatedHistoryItem> getCreatedHistory();
+
+  /** A single entry describing the outcome of appending one submitted history item. */
+  interface CreatedHistoryItem {
+
+    /**
+     * @return the id of the corresponding request item, echoed back for correlation by id
+     */
+    String getHistoryItemId();
+
+    /**
+     * @return the system-generated key for the created agent history item
+     */
+    long getHistoryItemKey();
+
+    /**
+     * @return true if this item was already present and no new history entry was created for it
+     */
+    boolean isDuplicate();
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AgentInstanceHistoryMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AgentInstanceHistoryMapper.java
@@ -134,6 +134,9 @@ final class AgentInstanceHistoryMapper {
 
   static List<AgentInstanceToolCall> toProtocolToolCalls(
       final List<AgentInstanceHistoryToolCall> toolCalls) {
+    if (toolCalls == null) {
+      return null;
+    }
     final List<AgentInstanceToolCall> protocolToolCalls = new ArrayList<>(toolCalls.size());
     for (final AgentInstanceHistoryToolCall tc : toolCalls) {
       if (tc == null) {
@@ -157,6 +160,9 @@ final class AgentInstanceHistoryMapper {
 
   static AgentInstanceHistoryItemMetrics toProtocolMetrics(
       final AgentInstanceHistoryMetrics metrics) {
+    if (metrics == null) {
+      return null;
+    }
     return new AgentInstanceHistoryItemMetrics()
         .inputTokens(metrics.getInputTokens())
         .outputTokens(metrics.getOutputTokens())

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AgentInstanceHistoryMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AgentInstanceHistoryMapper.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.command.AgentInstanceHistoryContent.DocumentContent;
+import io.camunda.client.api.command.AgentInstanceHistoryContent.ObjectContent;
+import io.camunda.client.api.command.AgentInstanceHistoryContent.TextContent;
+import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
+import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
+import io.camunda.client.api.response.DocumentMetadata;
+import io.camunda.client.api.response.DocumentReferenceResponse;
+import io.camunda.client.protocol.rest.AgentInstanceDocumentContent;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryItemMetrics;
+import io.camunda.client.protocol.rest.AgentInstanceMessageContent;
+import io.camunda.client.protocol.rest.AgentInstanceObjectContent;
+import io.camunda.client.protocol.rest.AgentInstanceTextContent;
+import io.camunda.client.protocol.rest.AgentInstanceToolCall;
+import io.camunda.client.protocol.rest.DocumentMetadataResponse;
+import io.camunda.client.protocol.rest.DocumentReference;
+import io.camunda.client.protocol.rest.DocumentReference.CamundaDocumentTypeEnum;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Validates and maps the conversation-history sub-structures (content blocks, tool calls, metrics)
+ * shared between {@link CreateAgentHistoryItemCommandImpl} (a single history item) and {@link
+ * UpdateAgentInstanceCommandImpl} (a batch of history items). Both commands submit items built from
+ * the same {@link AgentInstanceHistoryContent}/{@link AgentInstanceHistoryToolCall}/ {@link
+ * AgentInstanceHistoryMetrics} API types onto the same protocol wire types, so this class keeps
+ * their validation rules and error messages in one place rather than two.
+ */
+final class AgentInstanceHistoryMapper {
+
+  private AgentInstanceHistoryMapper() {}
+
+  static List<AgentInstanceMessageContent> toProtocolContent(
+      final List<AgentInstanceHistoryContent> content) {
+    final List<AgentInstanceMessageContent> protocolContent = new ArrayList<>(content.size());
+    for (final AgentInstanceHistoryContent item : content) {
+      protocolContent.add(toProtocolContentItem(item));
+    }
+    return protocolContent;
+  }
+
+  private static AgentInstanceMessageContent toProtocolContentItem(
+      final AgentInstanceHistoryContent item) {
+    if (item == null) {
+      throw new IllegalArgumentException("content must not contain null elements");
+    }
+    if (item instanceof TextContent) {
+      final String text = ((TextContent) item).getText();
+      if (text == null || text.trim().isEmpty()) {
+        throw new IllegalArgumentException("text content value must not be null or blank");
+      }
+      return new AgentInstanceTextContent().text(text);
+    }
+    if (item instanceof ObjectContent) {
+      final Object obj = ((ObjectContent) item).getObject();
+      if (obj == null) {
+        throw new IllegalArgumentException("object content value must not be null");
+      }
+      return new AgentInstanceObjectContent()._object(obj);
+    }
+    if (item instanceof DocumentContent) {
+      return toProtocolDocumentContent((DocumentContent) item);
+    }
+    throw new IllegalArgumentException("Unsupported AgentInstanceHistoryContent type: " + item);
+  }
+
+  private static AgentInstanceDocumentContent toProtocolDocumentContent(
+      final DocumentContent item) {
+    final DocumentReferenceResponse ref = item.getDocumentReference();
+    if (ref == null) {
+      throw new IllegalArgumentException("documentReference must not be null");
+    }
+    if (ref.getDocumentId() == null || ref.getDocumentId().trim().isEmpty()) {
+      throw new IllegalArgumentException("documentReference.documentId must not be null or blank");
+    }
+    final DocumentReference protocolRef =
+        new DocumentReference()
+            .camundaDocumentType(CamundaDocumentTypeEnum.CAMUNDA)
+            .documentId(ref.getDocumentId())
+            .storeId(ref.getStoreId());
+    if (ref.getContentHash() != null) {
+      protocolRef.contentHash(ref.getContentHash());
+    }
+    final DocumentMetadata metadata = ref.getMetadata();
+    if (metadata != null) {
+      protocolRef.metadata(toProtocolDocumentMetadata(metadata));
+    }
+    return new AgentInstanceDocumentContent().documentReference(protocolRef);
+  }
+
+  private static DocumentMetadataResponse toProtocolDocumentMetadata(
+      final DocumentMetadata metadata) {
+    final DocumentMetadataResponse protocolMeta = new DocumentMetadataResponse();
+    if (metadata.getFileName() != null) {
+      protocolMeta.fileName(metadata.getFileName());
+    }
+    if (metadata.getContentType() != null) {
+      protocolMeta.contentType(metadata.getContentType());
+    }
+    if (metadata.getSize() != null) {
+      protocolMeta.size(metadata.getSize());
+    }
+    if (metadata.getExpiresAt() != null) {
+      protocolMeta.expiresAt(metadata.getExpiresAt().toString());
+    }
+    if (metadata.getProcessDefinitionId() != null) {
+      protocolMeta.processDefinitionId(metadata.getProcessDefinitionId());
+    }
+    if (metadata.getProcessInstanceKey() != null) {
+      protocolMeta.processInstanceKey(String.valueOf(metadata.getProcessInstanceKey()));
+    }
+    if (metadata.getCustomProperties() != null && !metadata.getCustomProperties().isEmpty()) {
+      protocolMeta.customProperties(metadata.getCustomProperties());
+    }
+    return protocolMeta;
+  }
+
+  static List<AgentInstanceToolCall> toProtocolToolCalls(
+      final List<AgentInstanceHistoryToolCall> toolCalls) {
+    final List<AgentInstanceToolCall> protocolToolCalls = new ArrayList<>(toolCalls.size());
+    for (final AgentInstanceHistoryToolCall tc : toolCalls) {
+      if (tc == null) {
+        throw new IllegalArgumentException("toolCalls must not contain null elements");
+      }
+      if (tc.getToolCallId() == null || tc.getToolCallId().trim().isEmpty()) {
+        throw new IllegalArgumentException("toolCallId must not be null or blank");
+      }
+      if (tc.getToolName() == null || tc.getToolName().trim().isEmpty()) {
+        throw new IllegalArgumentException("toolName must not be null or blank");
+      }
+      protocolToolCalls.add(
+          new AgentInstanceToolCall()
+              .toolCallId(tc.getToolCallId())
+              .toolName(tc.getToolName())
+              .elementId(tc.getElementId())
+              .arguments(tc.getArguments()));
+    }
+    return protocolToolCalls;
+  }
+
+  static AgentInstanceHistoryItemMetrics toProtocolMetrics(
+      final AgentInstanceHistoryMetrics metrics) {
+    return new AgentInstanceHistoryItemMetrics()
+        .inputTokens(metrics.getInputTokens())
+        .outputTokens(metrics.getOutputTokens())
+        .durationMs(metrics.getDurationMs());
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateAgentHistoryItemCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateAgentHistoryItemCommandImpl.java
@@ -18,9 +18,6 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.AgentInstanceHistoryContent;
-import io.camunda.client.api.command.AgentInstanceHistoryContent.DocumentContent;
-import io.camunda.client.api.command.AgentInstanceHistoryContent.ObjectContent;
-import io.camunda.client.api.command.AgentInstanceHistoryContent.TextContent;
 import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
 import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
 import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1;
@@ -30,27 +27,15 @@ import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.CreateAg
 import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.CreateAgentHistoryItemCommandStep5;
 import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.CreateAgentHistoryItemFinalCommandStep;
 import io.camunda.client.api.response.CreateAgentHistoryItemResponse;
-import io.camunda.client.api.response.DocumentMetadata;
-import io.camunda.client.api.response.DocumentReferenceResponse;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.CreateAgentHistoryItemResponseImpl;
-import io.camunda.client.protocol.rest.AgentInstanceDocumentContent;
 import io.camunda.client.protocol.rest.AgentInstanceHistoryItemCreationResult;
-import io.camunda.client.protocol.rest.AgentInstanceHistoryItemMetrics;
 import io.camunda.client.protocol.rest.AgentInstanceHistoryItemRequest;
 import io.camunda.client.protocol.rest.AgentInstanceHistoryRoleEnum;
-import io.camunda.client.protocol.rest.AgentInstanceMessageContent;
-import io.camunda.client.protocol.rest.AgentInstanceObjectContent;
-import io.camunda.client.protocol.rest.AgentInstanceTextContent;
-import io.camunda.client.protocol.rest.AgentInstanceToolCall;
-import io.camunda.client.protocol.rest.DocumentMetadataResponse;
-import io.camunda.client.protocol.rest.DocumentReference;
-import io.camunda.client.protocol.rest.DocumentReference.CamundaDocumentTypeEnum;
 import java.time.Duration;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -109,81 +94,8 @@ public class CreateAgentHistoryItemCommandImpl
   public CreateAgentHistoryItemCommandStep5 content(
       final List<AgentInstanceHistoryContent> content) {
     ArgumentUtil.ensureNotNull("content", content);
-    final List<AgentInstanceMessageContent> protocolContent = new ArrayList<>(content.size());
-    for (final AgentInstanceHistoryContent item : content) {
-      if (item == null) {
-        throw new IllegalArgumentException("content must not contain null elements");
-      }
-      if (item instanceof TextContent) {
-        final String text = ((TextContent) item).getText();
-        if (text == null || text.trim().isEmpty()) {
-          throw new IllegalArgumentException("text content value must not be null or blank");
-        }
-        protocolContent.add(new AgentInstanceTextContent().text(text));
-      } else if (item instanceof ObjectContent) {
-        final Object obj = ((ObjectContent) item).getObject();
-        if (obj == null) {
-          throw new IllegalArgumentException("object content value must not be null");
-        }
-        protocolContent.add(
-            new AgentInstanceObjectContent()._object(((ObjectContent) item).getObject()));
-      } else if (item instanceof DocumentContent) {
-        protocolContent.add(toProtocolDocumentContent((DocumentContent) item));
-      } else {
-        throw new IllegalArgumentException("Unsupported AgentInstanceHistoryContent type: " + item);
-      }
-    }
-    request.content(protocolContent);
+    request.content(AgentInstanceHistoryMapper.toProtocolContent(content));
     return this;
-  }
-
-  private AgentInstanceDocumentContent toProtocolDocumentContent(final DocumentContent item) {
-    final DocumentReferenceResponse ref = item.getDocumentReference();
-    if (ref == null) {
-      throw new IllegalArgumentException("documentReference must not be null");
-    }
-    if (ref.getDocumentId() == null || ref.getDocumentId().trim().isEmpty()) {
-      throw new IllegalArgumentException("documentReference.documentId must not be null or blank");
-    }
-    final DocumentReference protocolRef =
-        new DocumentReference()
-            .camundaDocumentType(CamundaDocumentTypeEnum.CAMUNDA)
-            .documentId(ref.getDocumentId())
-            .storeId(ref.getStoreId());
-    if (ref.getContentHash() != null) {
-      protocolRef.contentHash(ref.getContentHash());
-    }
-    final DocumentMetadata metadata = ref.getMetadata();
-    if (metadata != null) {
-      protocolRef.metadata(toProtocolDocumentMetadata(metadata));
-    }
-    return new AgentInstanceDocumentContent().documentReference(protocolRef);
-  }
-
-  private DocumentMetadataResponse toProtocolDocumentMetadata(final DocumentMetadata metadata) {
-    final DocumentMetadataResponse protocolMeta = new DocumentMetadataResponse();
-    if (metadata.getFileName() != null) {
-      protocolMeta.fileName(metadata.getFileName());
-    }
-    if (metadata.getContentType() != null) {
-      protocolMeta.contentType(metadata.getContentType());
-    }
-    if (metadata.getSize() != null) {
-      protocolMeta.size(metadata.getSize());
-    }
-    if (metadata.getExpiresAt() != null) {
-      protocolMeta.expiresAt(metadata.getExpiresAt().toString());
-    }
-    if (metadata.getProcessDefinitionId() != null) {
-      protocolMeta.processDefinitionId(metadata.getProcessDefinitionId());
-    }
-    if (metadata.getProcessInstanceKey() != null) {
-      protocolMeta.processInstanceKey(String.valueOf(metadata.getProcessInstanceKey()));
-    }
-    if (metadata.getCustomProperties() != null && !metadata.getCustomProperties().isEmpty()) {
-      protocolMeta.customProperties(metadata.getCustomProperties());
-    }
-    return protocolMeta;
   }
 
   @Override
@@ -216,25 +128,7 @@ public class CreateAgentHistoryItemCommandImpl
     if (toolCalls == null) {
       return this;
     }
-    final List<AgentInstanceToolCall> protocolToolCalls = new ArrayList<>(toolCalls.size());
-    for (final AgentInstanceHistoryToolCall tc : toolCalls) {
-      if (tc == null) {
-        throw new IllegalArgumentException("toolCalls must not contain null elements");
-      }
-      if (tc.getToolCallId() == null || tc.getToolCallId().trim().isEmpty()) {
-        throw new IllegalArgumentException("toolCallId must not be null or blank");
-      }
-      if (tc.getToolName() == null || tc.getToolName().trim().isEmpty()) {
-        throw new IllegalArgumentException("toolName must not be null or blank");
-      }
-      protocolToolCalls.add(
-          new AgentInstanceToolCall()
-              .toolCallId(tc.getToolCallId())
-              .toolName(tc.getToolName())
-              .elementId(tc.getElementId())
-              .arguments(tc.getArguments()));
-    }
-    request.toolCalls(protocolToolCalls);
+    request.toolCalls(AgentInstanceHistoryMapper.toProtocolToolCalls(toolCalls));
     return this;
   }
 
@@ -243,11 +137,7 @@ public class CreateAgentHistoryItemCommandImpl
     if (metrics == null) {
       return this;
     }
-    request.metrics(
-        new AgentInstanceHistoryItemMetrics()
-            .inputTokens(metrics.getInputTokens())
-            .outputTokens(metrics.getOutputTokens())
-            .durationMs(metrics.getDurationMs()));
+    request.metrics(AgentInstanceHistoryMapper.toProtocolMetrics(metrics));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAgentInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAgentInstanceCommandImpl.java
@@ -27,11 +27,14 @@ import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.UpdateAgentInstanceResponseImpl;
 import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryItem;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryRoleEnum;
 import io.camunda.client.protocol.rest.AgentInstanceMetricsDelta;
 import io.camunda.client.protocol.rest.AgentInstanceUpdateRequest;
 import io.camunda.client.protocol.rest.AgentInstanceUpdateResult;
 import io.camunda.client.protocol.rest.AgentInstanceUpdateStatusEnum;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -117,20 +120,62 @@ public class UpdateAgentInstanceCommandImpl
 
   @Override
   public UpdateAgentInstanceCommandStep2 jobKey(final long jobKey) {
-    // TODO(#58793): validate and map jobKey onto the request in the green phase.
+    ArgumentUtil.ensureGreaterThan("jobKey", jobKey, 0);
+    request.jobKey(String.valueOf(jobKey));
     return this;
   }
 
   @Override
   public UpdateAgentInstanceCommandStep2 jobLease(final String jobLease) {
-    // TODO(#58793): validate and map jobLease onto the request in the green phase.
+    ArgumentUtil.ensureNotNull("jobLease", jobLease);
+    if (jobLease.trim().isEmpty()) {
+      throw new IllegalArgumentException("jobLease must not be blank");
+    }
+    request.jobLease(jobLease);
     return this;
   }
 
   @Override
   public UpdateAgentInstanceCommandStep2 history(final List<HistoryItem> history) {
-    // TODO(#58793): validate and map the history batch onto the request in the green phase.
+    ArgumentUtil.ensureNotNull("history", history);
+    final List<AgentInstanceHistoryItem> protocolHistory = new ArrayList<>(history.size());
+    for (final HistoryItem item : history) {
+      if (item == null) {
+        throw new IllegalArgumentException("history must not contain null elements");
+      }
+      protocolHistory.add(toProtocolHistoryItem(item));
+    }
+    request.history(protocolHistory);
     return this;
+  }
+
+  private AgentInstanceHistoryItem toProtocolHistoryItem(final HistoryItem item) {
+    ArgumentUtil.ensureNotNull("historyItemId", item.getHistoryItemId());
+    if (item.getHistoryItemId().trim().isEmpty()) {
+      throw new IllegalArgumentException("historyItemId must not be blank");
+    }
+    ArgumentUtil.ensureGreaterThan("loopIteration", item.getLoopIteration(), 0);
+    ArgumentUtil.ensureNotNull("role", item.getRole());
+    ArgumentUtil.ensureNotNull("content", item.getContent());
+    if (item.getContent().isEmpty()) {
+      throw new IllegalArgumentException("content must not be empty");
+    }
+    ArgumentUtil.ensureNotNull("producedAt", item.getProducedAt());
+
+    final AgentInstanceHistoryRoleEnum protoRole =
+        AgentInstanceHistoryRoleEnum.fromValue(item.getRole().name());
+    if (protoRole == null) {
+      throw new IllegalArgumentException("Invalid role: " + item.getRole());
+    }
+
+    return new AgentInstanceHistoryItem()
+        .historyItemId(item.getHistoryItemId())
+        .loopIteration(item.getLoopIteration())
+        .role(protoRole)
+        .content(AgentInstanceHistoryMapper.toProtocolContent(item.getContent()))
+        .toolCalls(AgentInstanceHistoryMapper.toProtocolToolCalls(item.getToolCalls()))
+        .metrics(AgentInstanceHistoryMapper.toProtocolMetrics(item.getMetrics()))
+        .producedAt(item.getProducedAt().toString());
   }
 
   @Override
@@ -141,6 +186,11 @@ public class UpdateAgentInstanceCommandImpl
 
   @Override
   public CamundaFuture<UpdateAgentInstanceResponse> send() {
+    if (request.getHistory() != null
+        && !request.getHistory().isEmpty()
+        && request.getJobKey() == null) {
+      throw new IllegalArgumentException("jobKey must be set when history is not empty");
+    }
     final HttpCamundaFuture<UpdateAgentInstanceResponse> result = new HttpCamundaFuture<>();
     httpClient.patch(
         "/agent-instances/" + agentInstanceKey,

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAgentInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAgentInstanceCommandImpl.java
@@ -20,6 +20,7 @@ import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.AgentInstanceUpdateStatus;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.AgentTool;
+import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.HistoryItem;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.UpdateAgentInstanceCommandStep2;
 import io.camunda.client.api.response.UpdateAgentInstanceResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
@@ -111,6 +112,24 @@ public class UpdateAgentInstanceCommandImpl
                 })
             .collect(Collectors.toList());
     request.tools(protocolTools);
+    return this;
+  }
+
+  @Override
+  public UpdateAgentInstanceCommandStep2 jobKey(final long jobKey) {
+    // TODO(#58793): validate and map jobKey onto the request in the green phase.
+    return this;
+  }
+
+  @Override
+  public UpdateAgentInstanceCommandStep2 jobLease(final String jobLease) {
+    // TODO(#58793): validate and map jobLease onto the request in the green phase.
+    return this;
+  }
+
+  @Override
+  public UpdateAgentInstanceCommandStep2 history(final List<HistoryItem> history) {
+    // TODO(#58793): validate and map the history batch onto the request in the green phase.
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UpdateAgentInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UpdateAgentInstanceResponseImpl.java
@@ -17,8 +17,14 @@ package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.UpdateAgentInstanceResponse;
 import io.camunda.client.protocol.rest.AgentInstanceUpdateResult;
+import java.util.List;
 
 public class UpdateAgentInstanceResponseImpl implements UpdateAgentInstanceResponse {
 
   public UpdateAgentInstanceResponseImpl(final AgentInstanceUpdateResult result) {}
+
+  @Override
+  public List<CreatedHistoryItem> getCreatedHistory() {
+    return null;
+  }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UpdateAgentInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UpdateAgentInstanceResponseImpl.java
@@ -16,15 +16,56 @@
 package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.UpdateAgentInstanceResponse;
+import io.camunda.client.protocol.rest.AgentInstanceCreatedHistoryItem;
 import io.camunda.client.protocol.rest.AgentInstanceUpdateResult;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class UpdateAgentInstanceResponseImpl implements UpdateAgentInstanceResponse {
 
-  public UpdateAgentInstanceResponseImpl(final AgentInstanceUpdateResult result) {}
+  private final List<CreatedHistoryItem> createdHistory;
+
+  public UpdateAgentInstanceResponseImpl(final AgentInstanceUpdateResult result) {
+    if (result == null || result.getCreatedHistory() == null) {
+      createdHistory = Collections.emptyList();
+    } else {
+      createdHistory =
+          result.getCreatedHistory().stream()
+              .map(CreatedHistoryItemImpl::new)
+              .collect(Collectors.toList());
+    }
+  }
 
   @Override
   public List<CreatedHistoryItem> getCreatedHistory() {
-    return null;
+    return createdHistory;
+  }
+
+  private static final class CreatedHistoryItemImpl implements CreatedHistoryItem {
+    private final String historyItemId;
+    private final long historyItemKey;
+    private final boolean duplicate;
+
+    private CreatedHistoryItemImpl(final AgentInstanceCreatedHistoryItem item) {
+      historyItemId = item.getHistoryItemId();
+      historyItemKey = Long.parseLong(item.getHistoryItemKey());
+      duplicate = Boolean.TRUE.equals(item.getIsDuplicate());
+    }
+
+    @Override
+    public String getHistoryItemId() {
+      return historyItemId;
+    }
+
+    @Override
+    public long getHistoryItemKey() {
+      return historyItemKey;
+    }
+
+    @Override
+    public boolean isDuplicate() {
+      return duplicate;
+    }
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/UpdateAgentInstanceCommandTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/UpdateAgentInstanceCommandTest.java
@@ -21,12 +21,25 @@ import static org.assertj.core.groups.Tuple.tuple;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
+import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
 import io.camunda.client.api.command.AgentInstanceUpdateStatus;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.AgentTool;
+import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.HistoryItem;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.client.impl.response.DocumentReferenceResponseImpl;
+import io.camunda.client.protocol.rest.AgentInstanceDocumentContent;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryRoleEnum;
+import io.camunda.client.protocol.rest.AgentInstanceTextContent;
+import io.camunda.client.protocol.rest.AgentInstanceToolCall;
 import io.camunda.client.protocol.rest.AgentInstanceUpdateRequest;
 import io.camunda.client.protocol.rest.AgentInstanceUpdateStatusEnum;
+import io.camunda.client.protocol.rest.DocumentReference;
+import io.camunda.client.protocol.rest.DocumentReference.CamundaDocumentTypeEnum;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -37,6 +50,18 @@ class UpdateAgentInstanceCommandTest extends ClientRestTest {
 
   private static final long AGENT_INSTANCE_KEY = 1234L;
   private static final long ELEMENT_INSTANCE_KEY = 5678L;
+  private static final long JOB_KEY = 91011L;
+  private static final String JOB_LEASE = "lease-token";
+  private static final OffsetDateTime PRODUCED_AT = OffsetDateTime.parse("2025-06-01T12:00:00Z");
+
+  private static HistoryItem historyItem(final String historyItemId) {
+    return new HistoryItem()
+        .historyItemId(historyItemId)
+        .loopIteration(1)
+        .role(AgentInstanceHistoryRole.USER)
+        .content(Collections.singletonList(AgentInstanceHistoryContent.text("hello")))
+        .producedAt(PRODUCED_AT);
+  }
 
   // ── Happy-path: request routing ───────────────────────────────────────────
 
@@ -102,6 +127,9 @@ class UpdateAgentInstanceCommandTest extends ClientRestTest {
     assertThat(body.getStatus()).isNull();
     assertThat(body.getMetrics()).isNull();
     assertThat(body.getTools()).isNull();
+    assertThat(body.getJobKey()).isNull();
+    assertThat(body.getJobLease()).isNull();
+    assertThat(body.getHistory()).isNull();
   }
 
   // ── Tools mapping ─────────────────────────────────────────────────────────
@@ -220,5 +248,403 @@ class UpdateAgentInstanceCommandTest extends ClientRestTest {
                     .execute())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("elementInstanceKey must be greater than 0");
+  }
+
+  // ── Argument validation: jobKey ───────────────────────────────────────────
+
+  @ParameterizedTest(name = "jobKey={0} should be rejected")
+  @ValueSource(longs = {0L, -1L, Long.MIN_VALUE})
+  void shouldRejectNonPositiveJobKey(final long invalidKey) {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(invalidKey))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("jobKey must be greater than 0");
+  }
+
+  // ── Argument validation: jobLease ─────────────────────────────────────────
+
+  @Test
+  void shouldRejectNullJobLease() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobLease(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("jobLease must not be null");
+  }
+
+  @ParameterizedTest(name = "jobLease=''{0}'' should be rejected")
+  @ValueSource(strings = {"", " "})
+  void shouldRejectBlankJobLease(final String jobLease) {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobLease(jobLease))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("jobLease must not be blank");
+  }
+
+  // ── Happy-path: history batch ─────────────────────────────────────────────
+
+  @Test
+  void shouldSendSingleHistoryItemWithRequiredFieldsOnly() {
+    // given
+    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+
+    // when
+    client
+        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .jobKey(JOB_KEY)
+        .history(Collections.singletonList(historyItem("item-1")))
+        .execute();
+
+    // then
+    final AgentInstanceUpdateRequest body =
+        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+    assertThat(body.getHistory())
+        .singleElement()
+        .satisfies(
+            item -> {
+              assertThat(item.getHistoryItemId()).isEqualTo("item-1");
+              assertThat(item.getLoopIteration()).isEqualTo(1);
+              assertThat(item.getRole()).isEqualTo(AgentInstanceHistoryRoleEnum.USER);
+              assertThat(item.getContent()).hasSize(1);
+              assertThat(item.getContent().get(0)).isInstanceOf(AgentInstanceTextContent.class);
+              assertThat(((AgentInstanceTextContent) item.getContent().get(0)).getText())
+                  .isEqualTo("hello");
+              assertThat(item.getProducedAt()).isEqualTo("2025-06-01T12:00Z");
+              assertThat(item.getToolCalls()).isNull();
+              assertThat(item.getMetrics()).isNull();
+            });
+  }
+
+  @Test
+  void shouldMapHistoryItemWithToolCallsAndMetrics() {
+    // given
+    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+    final HistoryItem item =
+        historyItem("item-1")
+            .toolCalls(
+                Collections.singletonList(
+                    new AgentInstanceHistoryToolCall()
+                        .toolCallId("call-1")
+                        .toolName("search")
+                        .elementId("searchTask")
+                        .arguments(Collections.<String, Object>singletonMap("query", "weather"))))
+            .metrics(
+                new AgentInstanceHistoryMetrics()
+                    .inputTokens(100L)
+                    .outputTokens(50L)
+                    .durationMs(200L));
+
+    // when
+    client
+        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .jobKey(JOB_KEY)
+        .history(Collections.singletonList(item))
+        .execute();
+
+    // then
+    final AgentInstanceUpdateRequest body =
+        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+    assertThat(body.getHistory()).isNotNull().hasSize(1);
+    final io.camunda.client.protocol.rest.AgentInstanceHistoryItem mappedItem =
+        body.getHistory().get(0);
+    assertThat(mappedItem.getToolCalls())
+        .singleElement()
+        .satisfies(
+            (final AgentInstanceToolCall toolCall) -> {
+              assertThat(toolCall.getToolCallId()).isEqualTo("call-1");
+              assertThat(toolCall.getToolName()).isEqualTo("search");
+              assertThat(toolCall.getElementId()).isEqualTo("searchTask");
+              assertThat(toolCall.getArguments()).containsEntry("query", "weather");
+            });
+    assertThat(mappedItem.getMetrics().getInputTokens()).isEqualTo(100L);
+    assertThat(mappedItem.getMetrics().getOutputTokens()).isEqualTo(50L);
+    assertThat(mappedItem.getMetrics().getDurationMs()).isEqualTo(200L);
+  }
+
+  @Test
+  void shouldMapHistoryItemWithDocumentContent() {
+    // given
+    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+    final DocumentReferenceResponseImpl doc =
+        new DocumentReferenceResponseImpl(
+            new DocumentReference()
+                .camundaDocumentType(CamundaDocumentTypeEnum.CAMUNDA)
+                .documentId("doc-abc")
+                .storeId("store-1"));
+    final HistoryItem item =
+        historyItem("item-1")
+            .content(Collections.singletonList(AgentInstanceHistoryContent.document(doc)));
+
+    // when
+    client
+        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .jobKey(JOB_KEY)
+        .history(Collections.singletonList(item))
+        .execute();
+
+    // then
+    final AgentInstanceUpdateRequest body =
+        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+    assertThat(body.getHistory())
+        .singleElement()
+        .satisfies(
+            mappedItem -> {
+              assertThat(mappedItem.getContent()).hasSize(1);
+              assertThat(mappedItem.getContent().get(0))
+                  .isInstanceOf(AgentInstanceDocumentContent.class);
+              final AgentInstanceDocumentContent docContent =
+                  (AgentInstanceDocumentContent) mappedItem.getContent().get(0);
+              assertThat(docContent.getDocumentReference().getCamundaDocumentType())
+                  .isEqualTo(CamundaDocumentTypeEnum.CAMUNDA);
+              assertThat(docContent.getDocumentReference().getDocumentId()).isEqualTo("doc-abc");
+              assertThat(docContent.getDocumentReference().getStoreId()).isEqualTo("store-1");
+            });
+  }
+
+  @Test
+  void shouldSendMultipleHistoryItemsInOrder() {
+    // given
+    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+
+    // when
+    client
+        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .jobKey(JOB_KEY)
+        .history(Arrays.asList(historyItem("item-1"), historyItem("item-2"), historyItem("item-3")))
+        .execute();
+
+    // then
+    final AgentInstanceUpdateRequest body =
+        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+    assertThat(body.getHistory())
+        .extracting(io.camunda.client.protocol.rest.AgentInstanceHistoryItem::getHistoryItemId)
+        .containsExactly("item-1", "item-2", "item-3");
+  }
+
+  @Test
+  void shouldCombineJobKeyJobLeaseStatusToolsAndHistoryInOneRequest() {
+    // given
+    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+
+    // when
+    client
+        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .jobKey(JOB_KEY)
+        .jobLease(JOB_LEASE)
+        .status(AgentInstanceUpdateStatus.THINKING)
+        .tools(Collections.singletonList(AgentTool.of("search")))
+        .history(Collections.singletonList(historyItem("item-1")))
+        .execute();
+
+    // then
+    final AgentInstanceUpdateRequest body =
+        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+    assertThat(body.getJobKey()).isEqualTo("91011");
+    assertThat(body.getJobLease()).isEqualTo(JOB_LEASE);
+    assertThat(body.getStatus()).isEqualTo(AgentInstanceUpdateStatusEnum.THINKING);
+    assertThat(body.getTools())
+        .singleElement()
+        .satisfies(tool -> assertThat(tool.getName()).isEqualTo("search"));
+    assertThat(body.getHistory())
+        .singleElement()
+        .satisfies(item -> assertThat(item.getHistoryItemId()).isEqualTo("item-1"));
+  }
+
+  // ── Argument validation: history batch ────────────────────────────────────
+
+  @Test
+  void shouldRejectNullHistoryList() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .history(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("history must not be null");
+  }
+
+  @Test
+  void shouldRejectNullElementInHistoryList() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .history(Collections.singletonList(null)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("history must not contain null elements");
+  }
+
+  @Test
+  void shouldRejectNullHistoryItemId() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .history(Collections.singletonList(historyItem("item-1").historyItemId(null))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("historyItemId must not be null");
+  }
+
+  @ParameterizedTest(name = "historyItemId=''{0}'' should be rejected")
+  @ValueSource(strings = {"", " "})
+  void shouldRejectBlankHistoryItemId(final String historyItemId) {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .history(
+                        Collections.singletonList(
+                            historyItem("item-1").historyItemId(historyItemId))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("historyItemId must not be blank");
+  }
+
+  @ParameterizedTest(name = "loopIteration={0} should be rejected")
+  @ValueSource(ints = {0, -1, Integer.MIN_VALUE})
+  void shouldRejectNonPositiveLoopIteration(final int loopIteration) {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .history(
+                        Collections.singletonList(
+                            historyItem("item-1").loopIteration(loopIteration))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("loopIteration must be greater than 0");
+  }
+
+  @Test
+  void shouldRejectNullRoleInHistoryItem() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .history(Collections.singletonList(historyItem("item-1").role(null))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("role must not be null");
+  }
+
+  @Test
+  void shouldRejectNullContentInHistoryItem() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .history(Collections.singletonList(historyItem("item-1").content(null))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("content must not be null");
+  }
+
+  @Test
+  void shouldRejectNullProducedAtInHistoryItem() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .history(Collections.singletonList(historyItem("item-1").producedAt(null))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("producedAt must not be null");
+  }
+
+  @Test
+  void shouldRejectBlankTextContentInHistoryItem() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .history(
+                        Collections.singletonList(
+                            historyItem("item-1")
+                                .content(
+                                    Collections.singletonList(
+                                        AgentInstanceHistoryContent.text(" ")))))
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("text content value must not be null or blank");
+  }
+
+  @Test
+  void shouldRejectEmptyContentListInHistoryItem() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .history(
+                        Collections.singletonList(
+                            historyItem("item-1").content(Collections.emptyList())))
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("content must not be empty");
+  }
+
+  @Test
+  void shouldRejectBlankToolCallIdInHistoryItem() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .history(
+                        Collections.singletonList(
+                            historyItem("item-1")
+                                .toolCalls(
+                                    Collections.singletonList(
+                                        new AgentInstanceHistoryToolCall()
+                                            .toolCallId(" ")
+                                            .toolName("search")))))
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("toolCallId must not be null or blank");
+  }
+
+  // ── Argument validation: jobKey required when history is set ─────────────
+
+  @Test
+  void shouldRejectHistoryWithoutJobKey() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .history(Collections.singletonList(historyItem("item-1")))
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("jobKey must be set when history is not empty");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/UpdateAgentInstanceCommandTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/UpdateAgentInstanceCommandTest.java
@@ -27,13 +27,17 @@ import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
 import io.camunda.client.api.command.AgentInstanceUpdateStatus;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.AgentTool;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.HistoryItem;
+import io.camunda.client.api.response.UpdateAgentInstanceResponse;
+import io.camunda.client.api.response.UpdateAgentInstanceResponse.CreatedHistoryItem;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.client.impl.response.DocumentReferenceResponseImpl;
+import io.camunda.client.protocol.rest.AgentInstanceCreatedHistoryItem;
 import io.camunda.client.protocol.rest.AgentInstanceDocumentContent;
 import io.camunda.client.protocol.rest.AgentInstanceHistoryRoleEnum;
 import io.camunda.client.protocol.rest.AgentInstanceTextContent;
 import io.camunda.client.protocol.rest.AgentInstanceToolCall;
 import io.camunda.client.protocol.rest.AgentInstanceUpdateRequest;
+import io.camunda.client.protocol.rest.AgentInstanceUpdateResult;
 import io.camunda.client.protocol.rest.AgentInstanceUpdateStatusEnum;
 import io.camunda.client.protocol.rest.DocumentReference;
 import io.camunda.client.protocol.rest.DocumentReference.CamundaDocumentTypeEnum;
@@ -646,5 +650,64 @@ class UpdateAgentInstanceCommandTest extends ClientRestTest {
                     .execute())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("jobKey must be set when history is not empty");
+  }
+
+  // ── Response parsing: createdHistory ──────────────────────────────────────
+
+  @Test
+  void shouldParseCreatedHistoryInResponseOrderWithDuplicateFlag() {
+    // given
+    final AgentInstanceUpdateResult response =
+        new AgentInstanceUpdateResult()
+            .createdHistory(
+                Arrays.asList(
+                    new AgentInstanceCreatedHistoryItem()
+                        .historyItemId("item-1")
+                        .historyItemKey("100")
+                        .isDuplicate(false),
+                    new AgentInstanceCreatedHistoryItem()
+                        .historyItemId("item-2")
+                        .historyItemKey("101")
+                        .isDuplicate(true),
+                    new AgentInstanceCreatedHistoryItem()
+                        .historyItemId("item-3")
+                        .historyItemKey("102")
+                        .isDuplicate(false)));
+    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY, response);
+
+    // when
+    final UpdateAgentInstanceResponse result =
+        client
+            .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+            .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+            .execute();
+
+    // then
+    assertThat(result.getCreatedHistory())
+        .isNotNull()
+        .extracting(
+            CreatedHistoryItem::getHistoryItemId,
+            CreatedHistoryItem::getHistoryItemKey,
+            CreatedHistoryItem::isDuplicate)
+        .containsExactly(
+            tuple("item-1", 100L, false),
+            tuple("item-2", 101L, true),
+            tuple("item-3", 102L, false));
+  }
+
+  @Test
+  void shouldReturnEmptyCreatedHistoryWhenResponseHasNoBody() {
+    // given
+    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+
+    // when
+    final UpdateAgentInstanceResponse result =
+        client
+            .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+            .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+            .execute();
+
+    // then
+    assertThat(result.getCreatedHistory()).isNotNull().isEmpty();
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -26,6 +26,7 @@ import io.camunda.client.protocol.rest.AgentInstanceHistoryItemCreationResult;
 import io.camunda.client.protocol.rest.AgentInstanceHistorySearchQueryResult;
 import io.camunda.client.protocol.rest.AgentInstanceResult;
 import io.camunda.client.protocol.rest.AgentInstanceSearchQueryResult;
+import io.camunda.client.protocol.rest.AgentInstanceUpdateResult;
 import io.camunda.client.protocol.rest.AuditLogResult;
 import io.camunda.client.protocol.rest.AuditLogSearchQueryResult;
 import io.camunda.client.protocol.rest.AuthorizationCreateResult;
@@ -220,6 +221,10 @@ public class RestGatewayService {
 
   private void registerPut(final String url, final Object response) {
     register(WireMock.put(url), response);
+  }
+
+  private void registerPatch(final String url, final Object response) {
+    register(WireMock.patch(url), response);
   }
 
   private void register(final MappingBuilder builder, final Object response) {
@@ -421,6 +426,11 @@ public class RestGatewayService {
             WireMock.patch(
                     WireMock.urlEqualTo(RestGatewayPaths.getAgentInstanceUrl(agentInstanceKey)))
                 .willReturn(WireMock.noContent()));
+  }
+
+  public void onUpdateAgentInstanceRequest(
+      final long agentInstanceKey, final AgentInstanceUpdateResult response) {
+    registerPatch(RestGatewayPaths.getAgentInstanceUrl(agentInstanceKey), response);
   }
 
   public void onAgentInstanceGetRequest(


### PR DESCRIPTION
## Description

Stacked on #59714, which added the history batch to `PATCH /agent-instances/{key}`. This is the Java client side: `newUpdateAgentInstanceCommand(...)` gains `jobKey`, `jobLease`, and a `history` batch, and `UpdateAgentInstanceResponse` exposes `getCreatedHistory()`. Without it the endpoint's new fields are unreachable from the client.

`CreateAgentHistoryItemCommand` is deliberately left untouched rather than reshaped into sugar over a one-item batch, because #58795 deletes it once callers migrate. What the two paths share while they coexist is extracted into `AgentInstanceHistoryMapper` so they can't drift; the rejected alternative is in that `refactor:` commit's body.

Not verified end to end: the engine doesn't process the batch yet (#58791), so a real round trip still returns an empty `createdHistory[]`.

## Checklist

- [ ] Enable backports when necessary.

## Related issues

closes #58793
depends on #59714

- Related to #58791 — engine processing of the batch.
- Related to #58795 — legacy single-item command; tracks its removal and the `jobKey` tightening.
