### PR TITLE
fix: prevent CI flake from stale sidebar resize timer in Tasklist header tests

### DIFF
--- a/tasklist/client/src/pages/Layout/Header/tests/userInfo.test.tsx
+++ b/tasklist/client/src/pages/Layout/Header/tests/userInfo.test.tsx
@@ -42,6 +42,15 @@ describe('User info', () => {
     );
   });
 
+  afterEach(async () => {
+    // Opening the settings sidebar schedules a real 120ms resize timeout
+    // inside @camunda/camunda-composite-components that isn't reliably
+    // cancelled on unmount. Letting it fire here, while jsdom is still
+    // alive, avoids it firing after teardown and crashing with
+    // "window is not defined".
+    await act(() => new Promise((resolve) => setTimeout(resolve, 150)));
+  });
+
   it('should render user display name', async () => {
     nodeMockServer.use(
       http.get(


### PR DESCRIPTION
## Description

`Tasklist / Unit - Front End` intermittently fails with `ReferenceError: window is not defined` in `userInfo.test.tsx`, caught after the jsdom test environment for the file has already been torn down (INC-7080).

Root cause: opening the settings sidebar (`@camunda/camunda-composite-components`, `c3-navigation-sidebar`) schedules a real 120ms `setTimeout` to recompute its scrollbar width. That timer isn't reliably cancelled on unmount. A test that opens the sidebar and finishes before 120ms elapses leaves it pending; under CI load it can fire after the file's last test completes and `window` has already been destroyed, crashing inside React's scheduler.

This is a stopgap, not the root-cause fix — the real fix belongs upstream in that component (guard the resize handler against a missing `window`, matching the guard already present in its other effect: https://github.com/camunda/camunda-cloud-management-apps, `packages/c3`). Until that ships, this makes the affected test wait for the timer to fire while the environment is still alive, so it can no longer land after teardown.

Same underlying bug is also present on `stable/8.8` (older component version, v0.22.8, with *no* cleanup at all on that timer — more exposed than main's v0.25.4). That branch's equivalent test file lives at a different path (`tasklist/client/src/common/components/Layout/Header/tests/userInfo.test.tsx`, pre-NAV-V2-migration structure), so it isn't a clean cherry-pick — will need a manual backport.

## Related issues

Investigated from https://app.incident.io/camunda/response/incidents/7080

## Checklist

- [ ] Enable backports when necessary