### PR TITLE
fix: resolve each physical tenant's own configured cluster state

### DIFF
--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -260,9 +260,7 @@ public final class BrokerTopologyManagerImpl extends Actor
 
   private void applyClusterConfiguration(final CurrentClusterConfiguration clusterConfiguration) {
     // For each known group, update the configured cluster state and notify listeners if anything
-    // changed. The default group is always updated, even if no broker has joined it yet, since the
-    // cluster configuration can be gossiped before the local membership events for that group are
-    // observed.
+    // changed.
     final Set<String> groupIds = clusterConfiguration.partitionGroups().keySet();
 
     final var allGroups =

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -164,7 +164,7 @@ public final class BrokerTopologyManagerImpl extends Actor
   private void rebuildGroupTopology(final String physicalTenantId) {
     final var groupMembers =
         memberPropertiesPerGroup.getOrDefault(physicalTenantId, Map.of()).values();
-    final var configuredState = currentConfiguredState();
+    final var configuredState = currentConfiguredState(physicalTenantId);
     final var newGroupTopology =
         BrokerClientTopologyImpl.fromMemberProperties(groupMembers, configuredState);
 
@@ -176,11 +176,10 @@ public final class BrokerTopologyManagerImpl extends Actor
     updateMetrics(physicalTenantId, newGroupTopology);
   }
 
-  private ConfiguredClusterState currentConfiguredState() {
-    return topologyPerGroup.values().stream()
-        .findFirst()
-        .map(BrokerClientTopologyImpl::configuredClusterState)
-        .orElse(BrokerClientTopologyImpl.uninitialized().configuredClusterState());
+  private ConfiguredClusterState currentConfiguredState(final String physicalTenantId) {
+    return topologyPerGroup
+        .getOrDefault(physicalTenantId, BrokerClientTopologyImpl.uninitialized())
+        .configuredClusterState();
   }
 
   @Override
@@ -264,8 +263,7 @@ public final class BrokerTopologyManagerImpl extends Actor
     // changed. The default group is always updated, even if no broker has joined it yet, since the
     // cluster configuration can be gossiped before the local membership events for that group are
     // observed.
-    final Set<String> groupIds = new HashSet<>(memberPropertiesPerGroup.keySet());
-    groupIds.add(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    final Set<String> groupIds = clusterConfiguration.partitionGroups().keySet();
 
     final var allGroups =
         groupIds.stream()

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -947,6 +947,37 @@ final class BrokerTopologyManagerTest {
   }
 
   @Test
+  void shouldUseOwnGroupsConfiguredStateWhenBrokerJoinsAfterMultiTenantConfiguration() {
+    // given -- the cluster configuration is applied for both default (3 partitions) and tenant1
+    // (1 partition), before any broker has locally joined tenant1's group
+    final var global = globalConfigWithMember(MemberId.from("1"));
+    final var defaultGroup = singleMemberGroup(MemberId.from("1"), Map.of(1, 1, 2, 1, 3, 1));
+    final var tenant1Group = singleMemberGroup(MemberId.from("1"), Map.of(5, 1));
+    topologyManager.onClusterConfigurationUpdated(
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            global,
+            Map.of(DEFAULT_PHYSICAL_TENANT_ID, defaultGroup, "tenant1", tenant1Group),
+            PhasedChangeState.empty()));
+    actorSchedulerRule.workUntilDone();
+    assertThat(topologyManager.getTopology().getPartitionsCount()).isEqualTo(3);
+
+    // when -- a broker later joins tenant1's group locally, triggering a topology rebuild for
+    // tenant1
+    final var brokerId = BrokerMemberId.from(0);
+    notifyEvent(createMemberAddedEvent(createBrokerWithGroup(brokerId, "tenant1")));
+
+    // then -- tenant1 keeps reporting its own configured partition, not the default group's
+    assertThat(topologyManager.getTopology("tenant1").getPartitionsCount())
+        .describedAs("tenant1 must report its own partition count, not the default group's")
+        .isEqualTo(1);
+    assertThat(topologyManager.getTopology("tenant1").getPartitions()).isEqualTo(List.of(5));
+
+    // and -- the default group is unaffected
+    assertThat(topologyManager.getTopology().getPartitionsCount()).isEqualTo(3);
+  }
+
+  @Test
   void shouldReturnUninitializedTopologyForUnknownGroup() {
     // given / when — no brokers added
     // then


### PR DESCRIPTION
## Summary
- Tenant-scoped `/v2/topology` responses reported the default physical tenant's `partitionsCount` for non-default tenants. `rebuildGroupTopology()` resolved the configured state from the first entry in `topologyPerGroup` instead of the entry for the tenant actually being rebuilt.
- `applyClusterConfiguration()` also derived the groups to update from locally known broker groups instead of the groups present in the gossiped configuration, so a tenant without a local broker yet was skipped entirely.
- Both now key off the requested/configured tenant explicitly.

Closes #59642
