### PR TITLE
fix: prevent CI flake from stale sidebar resize timer in Tasklist header tests

### DIFF
--- a/tasklist/client/src/common/components/Layout/Header/tests/userInfo.test.tsx
+++ b/tasklist/client/src/common/components/Layout/Header/tests/userInfo.test.tsx
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {act} from 'react';
 import {
   render,
   screen,
@@ -48,6 +49,15 @@ describe('User info', () => {
     );
 
     mockGetClientConfig.mockReturnValue(actualGetClientConfig());
+  });
+
+  afterEach(async () => {
+    // Opening the settings sidebar schedules a real 120ms resize timeout
+    // inside @camunda/camunda-composite-components that is never cancelled
+    // on unmount in this version. Letting it fire here, while jsdom is
+    // still alive, avoids it firing after teardown and crashing with
+    // "window is not defined".
+    await act(() => new Promise((resolve) => setTimeout(resolve, 150)));
   });
 
   it('should render user display name', async () => {


### PR DESCRIPTION
## Description

`Tasklist / Unit - Front End` intermittently fails with `ReferenceError: window is not defined` in `userInfo.test.tsx`, caught after the jsdom test environment for the file has already been torn down. This is [INC-7080](https://app.incident.io/camunda/response/incidents/7080), which fired specifically on this branch.

Root cause: opening the settings sidebar (`@camunda/camunda-composite-components` 0.22.8, `c3-navigation-sidebar`) schedules a real 120ms `setTimeout` to recompute its scrollbar width — with **no cleanup at all** on that effect in this version. Any test that opens the sidebar leaves the timer armed regardless of unmount. Under CI load it can fire after the file's last test completes and `window` has already been destroyed, crashing inside React's scheduler.

Confirmed this is 8.8-specific: `main` runs v0.25.4 of the same component, which already has a working `clearTimeout` cleanup on unmount, so the equivalent risk doesn't reproduce there — no change needed/opened against `main`.

This is a stopgap, not the root-cause fix — that belongs upstream in the component itself (`camunda/camunda-cloud-management-apps`, `packages/c3`): cancel the timer on unmount and guard the resize handler against a missing `window`. Until that ships, this makes the affected test wait for the timer to fire while the environment is still alive, so it can no longer land after teardown.

Verified: all 7 tests in the file pass locally with this change; prettier and eslint clean.

## Related issues

Investigated from https://app.incident.io/camunda/response/incidents/7080

## Checklist

- [ ] Enable backports when necessary