### PR TITLE
feat: drain buffered commands in chunks when resuming a process instance

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessInstructionActivateProcessor;
 import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessInstructionCompleteProcessor;
@@ -23,6 +24,7 @@ import io.camunda.zeebe.engine.processing.message.ProcessMessageSubscriptionDele
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBatchActivateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBatchTerminateProcessor;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBufferedCommandDrainProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBusinessIdAssignProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCancelProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationCreateProcessor;
@@ -52,6 +54,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
 import io.camunda.zeebe.protocol.record.intent.ConditionalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -83,13 +86,16 @@ public final class BpmnProcessors {
       final AsyncRequestBehavior asyncRequestBehavior,
       final CslAuthorizationCheck cslCheck,
       final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
-      final ProcessEngineMetrics processEngineMetrics) {
+      final ProcessEngineMetrics processEngineMetrics,
+      final IncidentMetrics incidentMetrics) {
     final MutableProcessMessageSubscriptionState subscriptionState =
         processingState.getProcessMessageSubscriptionState();
     final var keyGenerator = processingState.getKeyGenerator();
 
     addProcessInstanceCommandProcessor(
         writers, typedRecordProcessors, processingState, asyncRequestBehavior, cslCheck);
+    addProcessInstanceBufferedCommandProcessor(
+        writers, typedRecordProcessors, processingState, keyGenerator, incidentMetrics);
 
     final var bpmnStreamProcessor =
         new BpmnStreamProcessor(
@@ -177,6 +183,19 @@ public final class BpmnProcessors {
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.SUSPEND,
         new ProcessInstanceSuspendProcessor(processingState, writers, cslCheck));
+  }
+
+  private static void addProcessInstanceBufferedCommandProcessor(
+      final Writers writers,
+      final TypedRecordProcessors typedRecordProcessors,
+      final ProcessingState processingState,
+      final KeyGenerator keyGenerator,
+      final IncidentMetrics incidentMetrics) {
+    typedRecordProcessors.onCommand(
+        ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND,
+        ProcessInstanceBufferedCommandIntent.DRAIN,
+        new ProcessInstanceBufferedCommandDrainProcessor(
+            processingState, writers, keyGenerator, incidentMetrics));
   }
 
   private static void addBpmnStepProcessor(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -339,7 +339,8 @@ public final class EngineProcessors {
             asyncRequestBehavior,
             cslCheck,
             transientProcessMessageSubscriptionState,
-            processEngineMetrics);
+            processEngineMetrics,
+            incidentMetrics);
 
     addDecisionProcessors(
         typedRecordProcessors, decisionBehavior, writers, processingState, cslCheck);
@@ -659,7 +660,8 @@ public final class EngineProcessors {
       final AsyncRequestBehavior asyncRequestBehavior,
       final CslAuthorizationCheck cslCheck,
       final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
-      final ProcessEngineMetrics processEngineMetrics) {
+      final ProcessEngineMetrics processEngineMetrics,
+      final IncidentMetrics incidentMetrics) {
     return BpmnProcessors.addBpmnStreamProcessor(
         processingState,
         scheduledTaskState,
@@ -676,7 +678,8 @@ public final class EngineProcessors {
         asyncRequestBehavior,
         cslCheck,
         transientProcessMessageSubscriptionState,
-        processEngineMetrics);
+        processEngineMetrics,
+        incidentMetrics);
   }
 
   private static void addDeploymentRelatedProcessorAndServices(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBufferedCommandDrainProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBufferedCommandDrainProcessor.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.metrics.IncidentMetrics;
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState.BufferedCommand;
+import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Replays the commands that were buffered while a process instance was suspended, one per {@code
+ * DRAIN} cycle, and writes {@code RESUMED} once the buffer is empty.
+ *
+ * <p>The drain is an iterator rather than a single atomic pass: each cycle appends one buffered
+ * command plus another {@code DRAIN} for itself. A buffer that outgrows a single record batch would
+ * otherwise make the instance permanently un-resumable, and chaining leaves the stream processor
+ * free to apply its own command batching. {@link ProcessInstanceBatchActivateProcessor} follows the
+ * same shape.
+ *
+ * <p>This processor is deliberately not {@link
+ * io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware}: the suspension gate must
+ * never buffer or reject a {@code DRAIN}, or the chain would stall with the instance stuck in
+ * {@code RESUMING}.
+ */
+@ExcludeAuthorizationCheck
+@NullMarked
+public final class ProcessInstanceBufferedCommandDrainProcessor
+    implements TypedRecordProcessor<ProcessInstanceBufferedCommandRecord> {
+
+  private static final String DRAIN_FAILED_MESSAGE =
+      """
+      Expected to resume process instance '%d' by replaying the %s command with key '%d' that was \
+      buffered while it was suspended, but it could not be written: %s. The command was dropped so \
+      that the remaining buffered commands can still be replayed.""";
+
+  private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
+  private final SuspensionState suspensionState;
+  private final ElementInstanceState elementInstanceState;
+  private final ProcessState processState;
+  private final KeyGenerator keyGenerator;
+  private final IncidentMetrics incidentMetrics;
+
+  public ProcessInstanceBufferedCommandDrainProcessor(
+      final ProcessingState processingState,
+      final Writers writers,
+      final KeyGenerator keyGenerator,
+      final IncidentMetrics incidentMetrics) {
+    stateWriter = writers.state();
+    commandWriter = writers.command();
+    suspensionState = processingState.getSuspensionState();
+    elementInstanceState = processingState.getElementInstanceState();
+    processState = processingState.getProcessState();
+    this.keyGenerator = keyGenerator;
+    this.incidentMetrics = incidentMetrics;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ProcessInstanceBufferedCommandRecord> command) {
+    final var drainValue = command.getValue();
+    final long processInstanceKey = drainValue.getProcessInstanceKey();
+
+    final var buffered = suspensionState.getOldestBufferedCommand(processInstanceKey);
+    if (buffered == null) {
+      writeResumed(processInstanceKey, drainValue);
+      return;
+    }
+
+    replay(buffered);
+    stateWriter.appendFollowUpEvent(
+        buffered.key(), ProcessInstanceBufferedCommandIntent.DRAINED, buffered.command());
+    appendNextDrainCommand(drainValue);
+  }
+
+  @Override
+  public ProcessingError tryHandleError(
+      final TypedRecord<ProcessInstanceBufferedCommandRecord> command, final Throwable error) {
+    final var drainValue = command.getValue();
+    final long processInstanceKey = drainValue.getProcessInstanceKey();
+
+    final var buffered = suspensionState.getOldestBufferedCommand(processInstanceKey);
+    if (buffered == null) {
+      // the failure did not come from replaying a buffered command, so there is nothing to drop and
+      // no way to make progress here; fall back to the generic error handling
+      return ProcessingError.UNEXPECTED_ERROR;
+    }
+
+    raiseIncident(processInstanceKey, buffered, error);
+    // Drop the command that could not be replayed, then keep the chain alive. Without the drop the
+    // next DRAIN would pick the very same command and fail again, spinning forever; without the
+    // follow-up DRAIN the instance would never leave RESUMING and stay un-resumable.
+    stateWriter.appendFollowUpEvent(
+        buffered.key(), ProcessInstanceBufferedCommandIntent.DRAINED, buffered.command());
+    appendNextDrainCommand(drainValue);
+    return ProcessingError.EXPECTED_ERROR;
+  }
+
+  private void replay(final BufferedCommand buffered) {
+    final var value = buffered.command();
+    // the replayed command carries no request metadata, so the suspension gate classifies it as
+    // internal again and lets it through while the instance is RESUMING
+    commandWriter.appendFollowUpCommand(
+        value.getCommandKey(), value.getIntent(), value.getCommandValue());
+  }
+
+  private void appendNextDrainCommand(final ProcessInstanceBufferedCommandRecord drainValue) {
+    commandWriter.appendFollowUpCommand(
+        drainValue.getProcessInstanceKey(),
+        ProcessInstanceBufferedCommandIntent.DRAIN,
+        new ProcessInstanceBufferedCommandRecord()
+            .setProcessInstanceKey(drainValue.getProcessInstanceKey())
+            .setProcessDefinitionKey(drainValue.getProcessDefinitionKey())
+            .setTenantId(drainValue.getTenantId()));
+  }
+
+  private void writeResumed(
+      final long processInstanceKey, final ProcessInstanceBufferedCommandRecord drainValue) {
+    final var elementInstance = elementInstanceState.getInstance(processInstanceKey);
+    final ProcessInstanceRecord resumedValue;
+    if (elementInstance != null) {
+      resumedValue = elementInstance.getValue();
+    } else {
+      // the instance was cancelled while it was resuming — cancellation is allowed to run on a
+      // suspended instance. RESUMED is still written so the suspension marker is removed rather
+      // than left behind; the record stays minimal, which also keeps it out of secondary storage.
+      resumedValue =
+          new ProcessInstanceRecord()
+              .setProcessInstanceKey(processInstanceKey)
+              .setProcessDefinitionKey(drainValue.getProcessDefinitionKey())
+              .setTenantId(drainValue.getTenantId());
+    }
+    stateWriter.appendFollowUpEvent(
+        processInstanceKey, ProcessInstanceIntent.RESUMED, resumedValue);
+  }
+
+  private void raiseIncident(
+      final long processInstanceKey, final BufferedCommand buffered, final Throwable error) {
+    final var value = buffered.command();
+    final var treePathProperties =
+        new ElementTreePathBuilder()
+            .withElementInstanceProvider(elementInstanceState::getInstance)
+            .withCallActivityIndexProvider(processState::getFlowElement)
+            .withElementInstanceKey(processInstanceKey)
+            .build();
+
+    final var incident =
+        new IncidentRecord()
+            .setErrorType(
+                error instanceof ExceededBatchRecordSizeException
+                    ? ErrorType.MESSAGE_SIZE_EXCEEDED
+                    : ErrorType.UNKNOWN)
+            .setErrorMessage(
+                DRAIN_FAILED_MESSAGE.formatted(
+                    processInstanceKey,
+                    value.getValueType(),
+                    value.getCommandKey(),
+                    error.getMessage()))
+            .setProcessInstanceKey(processInstanceKey)
+            .setProcessDefinitionKey(value.getProcessDefinitionKey())
+            // the buffered command is not necessarily tied to an element, so the incident is raised
+            // on the process instance itself
+            .setElementInstanceKey(processInstanceKey)
+            .setVariableScopeKey(processInstanceKey)
+            .setTenantId(value.getTenantId())
+            .setElementInstancePath(treePathProperties.elementInstancePath())
+            .setProcessDefinitionPath(treePathProperties.processDefinitionPath())
+            .setCallingElementPath(treePathProperties.callingElementPath());
+
+    final var elementInstance = elementInstanceState.getInstance(processInstanceKey);
+    if (elementInstance != null) {
+      incident
+          .setBpmnProcessId(elementInstance.getValue().getBpmnProcessIdBuffer())
+          .setElementId(elementInstance.getValue().getElementIdBuffer());
+    }
+
+    stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), IncidentIntent.CREATED, incident);
+    incidentMetrics.incidentCreated();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -22,8 +23,10 @@ import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
@@ -44,6 +47,7 @@ public final class ProcessInstanceResumeProcessor
   private final ElementInstanceState elementInstanceState;
   private final TypedResponseWriter responseWriter;
   private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final CslAuthorizationCheck cslCheck;
   private final SuspensionState suspensionState;
@@ -55,6 +59,7 @@ public final class ProcessInstanceResumeProcessor
     elementInstanceState = processingState.getElementInstanceState();
     responseWriter = writers.response();
     stateWriter = writers.state();
+    commandWriter = writers.command();
     rejectionWriter = writers.rejection();
     this.cslCheck = cslCheck;
     suspensionState = processingState.getSuspensionState();
@@ -70,11 +75,21 @@ public final class ProcessInstanceResumeProcessor
 
     final ProcessInstanceRecord value = elementInstance.getValue();
 
-    // TODO(#57792): append a DRAIN command instead of writing RESUMED directly, once chunked
-    // draining of buffered commands is implemented.
-    stateWriter.appendFollowUpEvent(command.getKey(), ProcessInstanceIntent.RESUMED, value);
+    // switch the marker to RESUMING before the first DRAIN so the commands it replays are let
+    // through by the suspension gate instead of being buffered again
+    stateWriter.appendFollowUpEvent(command.getKey(), ProcessInstanceIntent.RESUMING, value);
+    commandWriter.appendFollowUpCommand(
+        command.getKey(),
+        ProcessInstanceBufferedCommandIntent.DRAIN,
+        new ProcessInstanceBufferedCommandRecord()
+            .setProcessInstanceKey(command.getKey())
+            .setProcessDefinitionKey(value.getProcessDefinitionKey())
+            .setTenantId(value.getTenantId()));
+
+    // the request is answered as soon as resuming has started: draining the buffer spans several
+    // command batches, and RESUMED is written only once it is empty
     responseWriter.writeAcceptedResponseOnCommand(
-        command.getKey(), ProcessInstanceIntent.RESUMED, value, command);
+        command.getKey(), ProcessInstanceIntent.RESUMING, value, command);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -438,6 +438,9 @@ public final class EventAppliers implements EventApplier {
         new RuntimeInstructionInterruptedApplier(elementInstanceState));
     register(ProcessInstanceIntent.CANCELING, NOOP_EVENT_APPLIER);
     register(
+        ProcessInstanceIntent.RESUMING,
+        new ProcessInstanceResumingApplier(state.getSuspensionState()));
+    register(
         ProcessInstanceIntent.RESUMED,
         new ProcessInstanceResumedApplier(state.getSuspensionState()));
     register(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceResumingApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceResumingApplier.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
+import io.camunda.zeebe.engine.state.mutable.MutableSuspensionState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+
+/** Applier for {@link ProcessInstanceIntent#RESUMING}. */
+final class ProcessInstanceResumingApplier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableSuspensionState suspensionState;
+
+  ProcessInstanceResumingApplier(final MutableSuspensionState suspensionState) {
+    this.suspensionState = suspensionState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceRecord value) {
+    // the marker stays in place, it only switches state: the suspension gate must keep recognizing
+    // the instance so that newly arriving external commands are still rejected, while the commands
+    // replayed by the drain are let through
+    suspensionState.setSuspensionState(key, SuspensionState.State.RESUMING);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SuspensionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SuspensionState.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceBufferedCommandRecordValue;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -44,8 +45,19 @@ public interface SuspensionState {
    */
   void visitBufferedCommands(long processInstanceKey, BufferedCommandVisitor visitor);
 
+  /**
+   * Reads the head of the process instance's FIFO buffer without scanning the rest of it, so that
+   * draining one command per {@code DRAIN} cycle stays cheap no matter how much is buffered.
+   *
+   * @return the oldest buffered command, or {@code null} if the process instance has none buffered
+   */
+  @Nullable BufferedCommand getOldestBufferedCommand(long processInstanceKey);
+
   @FunctionalInterface
   interface BufferedCommandVisitor {
     void visit(long bufferedCommandKey, ProcessInstanceBufferedCommandRecordValue command);
   }
+
+  /** A buffered command together with the key it is stored under. */
+  record BufferedCommand(long key, ProcessInstanceBufferedCommandRecord command) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/DbSuspensionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/DbSuspensionState.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
 import java.util.ArrayList;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
 public final class DbSuspensionState implements MutableSuspensionState {
 
@@ -108,6 +109,33 @@ public final class DbSuspensionState implements MutableSuspensionState {
           }
           visitor.visit(bufferedKey, stored.getRecord());
         });
+  }
+
+  @Override
+  public @Nullable BufferedCommand getOldestBufferedCommand(final long key) {
+    processInstanceKey.wrapLong(key);
+    final var oldest = new BufferedCommand[1];
+    bufferedCommandByProcessInstanceKeyColumnFamily.whileEqualPrefix(
+        processInstanceKey,
+        (compositeKey, nil) -> {
+          final long bufferedKey = compositeKey.second().getValue();
+          bufferedCommandKey.wrapLong(bufferedKey);
+          final var stored =
+              bufferedCommandColumnFamily.get(
+                  bufferedCommandKey, DbProcessInstanceBufferedCommand::new);
+          if (stored == null) {
+            // see #visitBufferedCommands: a dangling secondary-index entry is a broken invariant
+            throw new IllegalStateException(
+                String.format(
+                    "Expected to find buffered command with key '%d' for process instance '%d', "
+                        + "but none was stored; the buffered-command index is inconsistent",
+                    bufferedKey, key));
+          }
+          oldest[0] = new BufferedCommand(bufferedKey, stored.getRecord());
+          // the secondary index is ordered by bufferedCommandKey, so the first hit is the oldest
+          return false;
+        });
+    return oldest[0];
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageSuspensionGateTest.java
@@ -67,7 +67,7 @@ public final class MessageSuspensionGateTest {
   @Test
   public void shouldRejectMessageCorrelateWhileResuming() {
     // given - an instance waiting on a message catch event, with the RESUMING marker seeded
-    // directly (draining is implemented in a follow-up issue)
+    // directly to isolate the gate from the drain that puts the instance into that state
     final String processId = Strings.newRandomValidBpmnId();
     final String messageName = Strings.newRandomValidBpmnId();
     final String correlationKey = Strings.newRandomValidBpmnId();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ResumeProcessInstanceDrainTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ResumeProcessInstanceDrainTest.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBufferedCommandRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+/**
+ * Verifies the chunked drain: on RESUME the instance moves to RESUMING, the commands buffered while
+ * it was suspended are replayed one {@code DRAIN} cycle at a time, and RESUMED closes the chain
+ * once the buffer is empty.
+ */
+public final class ResumeProcessInstanceDrainTest {
+
+  /** Number of parallel multi-instance children, and therefore of buffered commands, per test. */
+  private static final int BUFFERED_COMMAND_COUNT = 5;
+
+  /**
+   * Together, five commands of this size exceed the 4MB a single record batch can hold, so an
+   * unbounded atomic drain could not write them out in one go.
+   */
+  private static final String OVERSIZED_TAG = "x".repeat(1024 * 1024);
+
+  private static final Set<ProcessInstanceIntent> ELEMENT_LIFECYCLE_INTENTS =
+      EnumSet.of(
+          ProcessInstanceIntent.ELEMENT_ACTIVATING,
+          ProcessInstanceIntent.ELEMENT_ACTIVATED,
+          ProcessInstanceIntent.ELEMENT_COMPLETING,
+          ProcessInstanceIntent.ELEMENT_COMPLETED,
+          ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN);
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldDrainBufferedCommandsOneCycleAtATime() {
+    // given - an instance with several buffered commands
+    final long processInstanceKey = deployAndStart();
+    final var children = activatedChildren(processInstanceKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    bufferCompleteCommands(children);
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then - draining takes one cycle per buffered command, plus the final cycle that finds the
+    // buffer empty and writes RESUMED
+    final var bufferedCommandRecords = bufferedCommandRecordsUntilResumed(processInstanceKey);
+    assertThat(
+            recordsWithIntent(bufferedCommandRecords, ProcessInstanceBufferedCommandIntent.DRAIN))
+        .hasSize(BUFFERED_COMMAND_COUNT + 1);
+
+    // and every buffered command is drained, in the order it was buffered
+    final var buffered =
+        commandKeys(
+            recordsWithIntent(
+                bufferedCommandRecords, ProcessInstanceBufferedCommandIntent.BUFFERED));
+    final var drained =
+        commandKeys(
+            recordsWithIntent(
+                bufferedCommandRecords, ProcessInstanceBufferedCommandIntent.DRAINED));
+    assertThat(buffered).hasSize(BUFFERED_COMMAND_COUNT);
+    assertThat(drained).containsExactlyElementsOf(buffered);
+  }
+
+  @Test
+  public void shouldStayResumingUntilTheBufferIsDrained() {
+    // given
+    final long processInstanceKey = deployAndStart();
+    final var children = activatedChildren(processInstanceKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    bufferCompleteCommands(children);
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then - RESUMING is written before the drain starts, RESUMED only after the last command was
+    // drained
+    final var resuming =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.RESUMING)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    final var resumed =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.RESUMED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(resuming.getPosition()).isLessThan(resumed.getPosition());
+
+    final var drained =
+        recordsWithIntent(
+            bufferedCommandRecordsUntilResumed(processInstanceKey),
+            ProcessInstanceBufferedCommandIntent.DRAINED);
+    assertThat(drained).hasSize(BUFFERED_COMMAND_COUNT);
+    assertThat(drained.getLast().getPosition()).isLessThan(resumed.getPosition());
+
+    // and the suspension marker is gone once RESUMED has been applied
+    assertThat(
+            ((MutableProcessingState) ENGINE.getProcessingState())
+                .getSuspensionState()
+                .getSuspensionState(processInstanceKey))
+        .isNull();
+  }
+
+  @Test
+  public void shouldReachSameStateAsNeverSuspendedRun() {
+    // given - a control run that is never suspended
+    final String processId = Strings.newRandomValidBpmnId();
+    final long controlInstanceKey = deployAndStart(processId);
+    bufferCompleteCommands(activatedChildren(controlInstanceKey));
+
+    // and a run of the same process definition that is suspended while the same commands arrive,
+    // then resumed
+    final long processInstanceKey = start(processId);
+    final var children = activatedChildren(processInstanceKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    bufferCompleteCommands(children);
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then - both instances go through the same element lifecycle and complete
+    assertThat(elementLifecycle(processInstanceKey))
+        .containsExactlyInAnyOrderElementsOf(elementLifecycle(controlInstanceKey));
+  }
+
+  @Test
+  public void shouldDrainBufferLargerThanASingleRecordBatch() {
+    // given - a buffer whose commands together do not fit into a single record batch
+    final long processInstanceKey = deployAndStart();
+    final var children = activatedChildren(processInstanceKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    bufferOversizedCommands(children);
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then - every command is drained and the instance resumes, without a record batch overflow
+    final var bufferedCommandRecords = bufferedCommandRecordsUntilResumed(processInstanceKey);
+    assertThat(
+            recordsWithIntent(bufferedCommandRecords, ProcessInstanceBufferedCommandIntent.DRAINED))
+        .hasSize(BUFFERED_COMMAND_COUNT);
+    assertThat(bufferedCommandRecords)
+        .noneMatch(r -> r.getRejectionType() == RejectionType.EXCEEDED_BATCH_RECORD_SIZE);
+  }
+
+  @Test
+  public void shouldRaiseIncidentAndKeepDrainingWhenACommandCannotBeReplayed() {
+    // given - a buffered command that alone does not fit into a record batch together with the
+    // DRAINED event that removes it, so replaying it always fails
+    final long processInstanceKey = deployAndStart();
+    final var children = activatedChildren(processInstanceKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    bufferUndrainableCommand(children.getFirst());
+    bufferCompleteCommands(children);
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then - an incident is raised on the process instance instead of stranding it
+    final var incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    Assertions.assertThat(incident.getValue())
+        .hasErrorType(ErrorType.MESSAGE_SIZE_EXCEEDED)
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasElementInstanceKey(processInstanceKey);
+
+    // and the drain moves past it: every buffered command is removed and the instance resumes
+    final var bufferedCommandRecords = bufferedCommandRecordsUntilResumed(processInstanceKey);
+    assertThat(
+            recordsWithIntent(bufferedCommandRecords, ProcessInstanceBufferedCommandIntent.DRAINED))
+        .hasSize(BUFFERED_COMMAND_COUNT + 1);
+    assertThat(
+            ((MutableProcessingState) ENGINE.getProcessingState())
+                .getSuspensionState()
+                .getSuspensionState(processInstanceKey))
+        .isNull();
+  }
+
+  private static long deployAndStart() {
+    return deployAndStart(Strings.newRandomValidBpmnId());
+  }
+
+  private static long deployAndStart(final String processId) {
+    ENGINE.deployment().withXmlResource(parallelMultiInstanceProcess(processId)).deploy();
+    return start(processId);
+  }
+
+  private static long start(final String processId) {
+    return ENGINE
+        .processInstance()
+        .ofBpmnProcessId(processId)
+        .withVariable("items", IntStream.range(0, BUFFERED_COMMAND_COUNT).boxed().toList())
+        .create();
+  }
+
+  private static BpmnModelInstance parallelMultiInstanceProcess(final String processId) {
+    return Bpmn.createExecutableProcess(processId)
+        .startEvent()
+        .serviceTask(
+            "task",
+            t ->
+                t.zeebeJobType("type")
+                    .multiInstance(
+                        m -> m.zeebeInputCollectionExpression("items").zeebeInputElement("item")))
+        .endEvent()
+        .done();
+  }
+
+  private static List<Record<ProcessInstanceRecordValue>> activatedChildren(
+      final long processInstanceKey) {
+    return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.SERVICE_TASK)
+        .limit(BUFFERED_COMMAND_COUNT)
+        .asList();
+  }
+
+  /**
+   * Writes one internal {@code COMPLETE_ELEMENT} command per child. While the instance is suspended
+   * these are classified {@code BUFFER} by {@code BpmnStreamProcessor} and end up in the buffer; on
+   * a running instance they complete the children right away.
+   */
+  private static void bufferCompleteCommands(
+      final List<Record<ProcessInstanceRecordValue>> children) {
+    ENGINE.writeRecords(
+        children.stream()
+            .map(
+                child ->
+                    RecordToWrite.command()
+                        .processInstance(ProcessInstanceIntent.COMPLETE_ELEMENT, child.getValue())
+                        .key(child.getKey()))
+            .toArray(RecordToWrite[]::new));
+  }
+
+  /**
+   * Buffers commands that are individually about a megabyte, written one by one so the log append
+   * itself stays within its own limits. They target element instance keys that do not exist, so
+   * replaying them is rejected instead of carrying the oversized payload into the element
+   * lifecycle: what is under test here is that the drain manages to write them out at all.
+   */
+  private static void bufferOversizedCommands(
+      final List<Record<ProcessInstanceRecordValue>> children) {
+    for (final var child : children) {
+      final var oversizedValue = new ProcessInstanceRecord();
+      oversizedValue.wrap((ProcessInstanceRecord) child.getValue());
+      oversizedValue.setTags(Set.of(OVERSIZED_TAG));
+
+      ENGINE.writeRecords(
+          RecordToWrite.command()
+              .processInstance(ProcessInstanceIntent.COMPLETE_ELEMENT, oversizedValue)
+              .key(child.getKey() + BUFFERED_COMMAND_COUNT * 1_000_000L));
+    }
+  }
+
+  /**
+   * Buffers a single command that can never be replayed: at roughly 3MB it still fits into the
+   * record batch that buffers it, but not into the one the drain needs for the replayed command and
+   * the DRAINED event that removes it together.
+   */
+  private static void bufferUndrainableCommand(final Record<ProcessInstanceRecordValue> child) {
+    final var undrainableValue = new ProcessInstanceRecord();
+    undrainableValue.wrap((ProcessInstanceRecord) child.getValue());
+    undrainableValue.setTags(Set.of(OVERSIZED_TAG.repeat(3)));
+
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .processInstance(ProcessInstanceIntent.COMPLETE_ELEMENT, undrainableValue)
+            .key(child.getKey() + BUFFERED_COMMAND_COUNT * 1_000_000L));
+  }
+
+  private static List<Record<RecordValue>> bufferedCommandRecordsUntilResumed(
+      final long processInstanceKey) {
+    final var resumed =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.RESUMED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    return RecordingExporter.records()
+        .limit(r -> r.getPosition() >= resumed.getPosition())
+        .withValueType(ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND)
+        .filter(r -> processInstanceKeyOf(r) == processInstanceKey)
+        .asList();
+  }
+
+  private static List<Record<RecordValue>> recordsWithIntent(
+      final List<Record<RecordValue>> records, final ProcessInstanceBufferedCommandIntent intent) {
+    return records.stream().filter(r -> r.getIntent() == intent).toList();
+  }
+
+  private static List<Long> commandKeys(final List<Record<RecordValue>> records) {
+    return records.stream()
+        .map(r -> ((ProcessInstanceBufferedCommandRecordValue) r.getValue()).getCommandKey())
+        .toList();
+  }
+
+  private static long processInstanceKeyOf(final Record<RecordValue> record) {
+    return ((ProcessInstanceBufferedCommandRecordValue) record.getValue()).getProcessInstanceKey();
+  }
+
+  private static List<String> elementLifecycle(final long processInstanceKey) {
+    return RecordingExporter.processInstanceRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .limitToProcessInstanceCompleted()
+        .filter(r -> ELEMENT_LIFECYCLE_INTENTS.contains(r.getIntent()))
+        .map(r -> r.getIntent() + ":" + r.getValue().getElementId())
+        .toList();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/SuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/SuspensionGateTest.java
@@ -99,8 +99,8 @@ public final class SuspensionGateTest {
 
   @Test
   public void shouldPassThroughBufferCategoryCommandWhileResuming() {
-    // given - seed the RESUMING marker directly since it is currently unreachable in production
-    // (draining is implemented in a follow-up issue)
+    // given - seed the RESUMING marker directly to isolate the gate from the drain that puts the
+    // instance into that state in production
     final String processId = Strings.newRandomValidBpmnId();
     final String jobType = Strings.newRandomValidBpmnId();
     ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SuspensionAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SuspensionAppliersTest.java
@@ -31,6 +31,7 @@ public class SuspensionAppliersTest {
 
   private MutableSuspensionState suspensionState;
   private ProcessInstanceSuspendedApplier suspendedApplier;
+  private ProcessInstanceResumingApplier resumingApplier;
   private ProcessInstanceResumedApplier resumedApplier;
   private ProcessInstanceBufferedCommandBufferedApplier bufferedApplier;
   private ProcessInstanceBufferedCommandDrainedApplier drainedApplier;
@@ -39,6 +40,7 @@ public class SuspensionAppliersTest {
   public void setup() {
     suspensionState = processingState.getSuspensionState();
     suspendedApplier = new ProcessInstanceSuspendedApplier(suspensionState);
+    resumingApplier = new ProcessInstanceResumingApplier(suspensionState);
     resumedApplier = new ProcessInstanceResumedApplier(suspensionState);
     bufferedApplier = new ProcessInstanceBufferedCommandBufferedApplier(suspensionState);
     drainedApplier = new ProcessInstanceBufferedCommandDrainedApplier(suspensionState);
@@ -57,6 +59,33 @@ public class SuspensionAppliersTest {
     assertThat(suspensionState.isSuspended(processInstanceKey)).isTrue();
     assertThat(suspensionState.getSuspensionState(processInstanceKey))
         .isEqualTo(SuspensionState.State.SUSPENDED);
+  }
+
+  @Test
+  void shouldSwitchMarkerToResumingWithoutTouchingTheBuffer() {
+    // given
+    final long processInstanceKey = 5L;
+    final long bufferedCommandKey = 50L;
+    suspensionState.setSuspensionState(processInstanceKey, SuspensionState.State.SUSPENDED);
+    bufferedApplier.applyState(
+        bufferedCommandKey,
+        new ProcessInstanceBufferedCommandRecord()
+            .setProcessInstanceKey(processInstanceKey)
+            .setCommandKey(51L));
+
+    // when
+    resumingApplier.applyState(processInstanceKey, new ProcessInstanceRecord());
+
+    // then - the marker is still present, so the suspension gate keeps recognizing the instance
+    assertThat(suspensionState.isSuspended(processInstanceKey)).isTrue();
+    assertThat(suspensionState.getSuspensionState(processInstanceKey))
+        .isEqualTo(SuspensionState.State.RESUMING);
+
+    // and the buffered commands are left for the drain to replay
+    final List<Long> visitedKeys = new ArrayList<>();
+    suspensionState.visitBufferedCommands(
+        processInstanceKey, (key, command) -> visitedKeys.add(key));
+    assertThat(visitedKeys).containsExactly(bufferedCommandKey);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/suspension/SuspensionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/suspension/SuspensionStateTest.java
@@ -214,6 +214,58 @@ public final class SuspensionStateTest {
   }
 
   @Test
+  public void shouldGetOldestBufferedCommandRegardlessOfInsertionOrder() {
+    // given
+    final long processInstanceKey = 1L;
+    suspensionState.bufferCommand(30L, bufferedCommandRecord(processInstanceKey, 3L));
+    suspensionState.bufferCommand(10L, bufferedCommandRecord(processInstanceKey, 1L));
+    suspensionState.bufferCommand(20L, bufferedCommandRecord(processInstanceKey, 2L));
+
+    // when
+    final var oldest = suspensionState.getOldestBufferedCommand(processInstanceKey);
+
+    // then
+    assertThat(oldest).isNotNull();
+    assertThat(oldest.key()).isEqualTo(10L);
+    assertThat(oldest.command().getCommandKey()).isEqualTo(1L);
+  }
+
+  @Test
+  public void shouldGetOldestBufferedCommandOfRequestedProcessInstanceOnly() {
+    // given
+    final long processInstanceKeyA = 1L;
+    final long processInstanceKeyB = 2L;
+    suspensionState.bufferCommand(10L, bufferedCommandRecord(processInstanceKeyA, 1L));
+    suspensionState.bufferCommand(20L, bufferedCommandRecord(processInstanceKeyB, 2L));
+
+    // when - then
+    assertThat(suspensionState.getOldestBufferedCommand(processInstanceKeyB).key()).isEqualTo(20L);
+  }
+
+  @Test
+  public void shouldNotGetOldestBufferedCommandWithNothingBuffered() {
+    // given
+    final long processInstanceKey = 1L;
+
+    // when - then
+    assertThat(suspensionState.getOldestBufferedCommand(processInstanceKey)).isNull();
+  }
+
+  @Test
+  public void shouldGetNextOldestBufferedCommandAfterTheOldestIsRemoved() {
+    // given
+    final long processInstanceKey = 1L;
+    suspensionState.bufferCommand(10L, bufferedCommandRecord(processInstanceKey, 1L));
+    suspensionState.bufferCommand(20L, bufferedCommandRecord(processInstanceKey, 2L));
+
+    // when - the drain removes the head of the buffer
+    suspensionState.removeBufferedCommand(10L);
+
+    // then
+    assertThat(suspensionState.getOldestBufferedCommand(processInstanceKey).key()).isEqualTo(20L);
+  }
+
+  @Test
   public void shouldRemoveExactlyOneBufferedCommand() {
     // given
     final long processInstanceKey = 1L;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
@@ -72,7 +72,14 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
   SUSPEND((short) 17, false),
   SUSPENDED((short) 18),
   RESUME((short) 19, false),
-  RESUMED((short) 20);
+  RESUMED((short) 20),
+
+  /**
+   * Represents the intent that signals that a suspended process instance has started resuming: the
+   * commands that were buffered while it was suspended are being drained, and the instance is not
+   * fully resumed until {@link #RESUMED} is written.
+   */
+  RESUMING((short) 21);
 
   private static final Set<ProcessInstanceIntent> PROCESS_INSTANCE_COMMANDS =
       EnumSet.of(CANCEL, SUSPEND, RESUME);
@@ -144,6 +151,8 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
         return RESUME;
       case 20:
         return RESUMED;
+      case 21:
+        return RESUMING;
       default:
         return Intent.UNKNOWN;
     }
@@ -169,6 +178,7 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
       case SEQUENCE_FLOW_DELETED:
       case CANCELING:
       case SUSPENDED:
+      case RESUMING:
       case RESUMED:
         return true;
       default:

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntentTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntentTest.java
@@ -41,6 +41,7 @@ final class ProcessInstanceIntentTest {
   void shouldMarkSuspendedAndResumedAsEvents() {
     // given / when / then
     assertThat(ProcessInstanceIntent.SUSPENDED.isEvent()).isTrue();
+    assertThat(ProcessInstanceIntent.RESUMING.isEvent()).isTrue();
     assertThat(ProcessInstanceIntent.RESUMED.isEvent()).isTrue();
   }
 
@@ -58,5 +59,6 @@ final class ProcessInstanceIntentTest {
     assertThat(ProcessInstanceIntent.from((short) 18)).isEqualTo(ProcessInstanceIntent.SUSPENDED);
     assertThat(ProcessInstanceIntent.from((short) 19)).isEqualTo(ProcessInstanceIntent.RESUME);
     assertThat(ProcessInstanceIntent.from((short) 20)).isEqualTo(ProcessInstanceIntent.RESUMED);
+    assertThat(ProcessInstanceIntent.from((short) 21)).isEqualTo(ProcessInstanceIntent.RESUMING);
   }
 }


### PR DESCRIPTION
## Description

Adds the chunked drain to `ProcessInstanceResumeProcessor`.

`RESUME` now writes a new `ProcessInstanceIntent.RESUMING` event — switching the suspension marker from `SUSPENDED` to `RESUMING` so the gate lets replayed commands through — and appends the first `ProcessInstanceBufferedCommandIntent.DRAIN`. Each `DRAIN` cycle replays exactly one buffered command in FIFO order, writes `DRAINED` to remove it from the buffer, and appends the next `DRAIN` for itself. The cycle that finds the buffer empty writes `RESUMED`, which removes the marker.

Before this, `RESUME` wrote `RESUMED` directly and its applier cleared the buffer, so everything buffered during the suspension was silently dropped.

**Why an iterator instead of one pass:** batch size is independent of buffer size, so a buffer larger than one record batch can no longer strand the instance, and the stream processor keeps control over command batching. This follows `ProcessInstanceBatchActivateProcessor`. As discussed in the issue, no `canWriteCommandOfLength(next + SAFETY_MARGIN)` guard is used.

**`tryHandleError`** raises an incident on the process instance (`MESSAGE_SIZE_EXCEEDED` for a batch overflow, `UNKNOWN` otherwise) rather than letting the chain die. It also drops the offending command and appends the next `DRAIN` — without the drop the next cycle picks the same command and fails forever; without the `DRAIN` the instance never leaves `RESUMING`.

**Response timing:** the request is answered as soon as resuming starts (intent `RESUMING`), since draining spans several command batches. Actor, operation reference and batch operation reference are propagated along the chain by the stream platform, so the audit log and batch-operation tracking still see them on `RESUMED`.

### Notes for review

- `ProcessInstanceIntent.RESUMING` is a new protocol intent. It is additive; the ES/OS and RDBMS exporters whitelist the intents they handle, so they ignore it.
- Pre-existing, made visible by this change: a **batch** resume issues `RESUME` with a `batchOperationReference`, which the stream platform force-propagates to every follow-up. The replayed commands therefore no longer look internal to `BpmnStreamProcessor.suspensionBehavior` and get rejected instead of executed. Previously they were dropped silently, so this is not a regression, but it is worth a follow-up — a proper fix needs a way to append a follow-up command without the inherited batch reference.
- Full-repo `./mvnw install -Dquickly` could not complete locally: `zeebe-gateway-protocol-impl` fails to provision `protobuf-maven-plugin` ("Unable to establish loopback connection") in this environment, with and without my changes. `zeebe/protocol`, `zeebe/protocol-impl`, `zeebe/engine`, `zeebe/exporter-common` and both exporters build and their tests pass.

### Tests

- `ResumeProcessInstanceDrainTest` (new): one drain cycle per buffered command, FIFO order preserved, `RESUMING` before / `RESUMED` after the drain, a buffer larger than one record batch drains without overflow, an undrainable command raises an incident and the chain continues, and the resumed run reaches the same element lifecycle as a never-suspended control run.
- `SuspensionStateTest`, `SuspensionAppliersTest`, `ProcessInstanceIntentTest` extended for `getOldestBufferedCommand` and the `RESUMING` applier/intent.

## Checklist

- [ ] Enable backports when necessary — not needed, this is part of an unreleased feature on `main`.

## Related issues

