### PR TITLE
test: skip leaking Operate history panel tests on 8.8

### DIFF
--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/v2/modificationPlaceholders.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/v2/modificationPlaceholders.test.tsx
@@ -37,7 +37,7 @@ import {
 import {mockNestedSubProcessBusinessObjects} from 'modules/mocks/mockNestedSubProcessBusinessObjects';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 
-describe('FlowNodeInstancesTree - Modification placeholders', () => {
+describe.skip('FlowNodeInstancesTree - Modification placeholders', () => {
   beforeEach(async () => {
     mockFetchProcessInstanceDeprecated().withSuccess(
       multiInstanceProcessInstance,

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/v2/modificationPlaceholders.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/v2/modificationPlaceholders.test.tsx
@@ -37,7 +37,8 @@ import {
 import {mockNestedSubProcessBusinessObjects} from 'modules/mocks/mockNestedSubProcessBusinessObjects';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 
-describe.skip('FlowNodeInstancesTree - Modification placeholders', () => {
+// TODO: https://github.com/camunda/camunda/issues/59641
+describe.todo('FlowNodeInstancesTree - Modification placeholders', () => {
   beforeEach(async () => {
     mockFetchProcessInstanceDeprecated().withSuccess(
       multiInstanceProcessInstance,

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/v2/nestedSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/v2/nestedSubprocess.test.tsx
@@ -27,7 +27,7 @@ import {mockFetchFlowNodeInstances} from 'modules/mocks/api/fetchFlowNodeInstanc
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 
-describe('FlowNodeInstancesTree - Nested Subprocesses', () => {
+describe.skip('FlowNodeInstancesTree - Nested Subprocesses', () => {
   beforeEach(async () => {
     mockFetchProcessInstanceDeprecated().withSuccess(
       nestedSubProcessesInstance,

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/v2/nestedSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/v2/nestedSubprocess.test.tsx
@@ -27,7 +27,8 @@ import {mockFetchFlowNodeInstances} from 'modules/mocks/api/fetchFlowNodeInstanc
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 
-describe.skip('FlowNodeInstancesTree - Nested Subprocesses', () => {
+// TODO: https://github.com/camunda/camunda/issues/59641
+describe.todo('FlowNodeInstancesTree - Nested Subprocesses', () => {
   beforeEach(async () => {
     mockFetchProcessInstanceDeprecated().withSuccess(
       nestedSubProcessesInstance,


### PR DESCRIPTION
## Summary

Ignore the history panel tests that cause memory leaks in the Operate Vitest job on stable/8.8.

A final fix would require refactoring the history panel, which is not targeted at this time.

Issue: #59641