### PR TITLE
refactor: dedup anonymous-command check in engine CSL authorization checks

### DIFF
--- a/docs/adr/security/002-tenant-access-provider-ownership-and-seam.md
+++ b/docs/adr/security/002-tenant-access-provider-ownership-and-seam.md
@@ -108,3 +108,15 @@ and the `TenantAccessProvider` interface, not the implementation.
   share the concrete provider only on the read path. Because the engine's tenant policy stays
   engine-side, a future change to it does not touch CSL or the search read path.
 
+**Revisited for camunda-security-library#587.** That issue asked whether the read and write paths'
+differing anonymous-detection mechanisms (a `CamundaAuthentication` predicate on the read path vs. a
+raw claims-map key on the write path) could be standardized. They can't: the write path's only
+entry point is the command record's deserialized claims map (`TypedRecord.getAuthorizations()`),
+and the shared converter to `CamundaAuthentication` (`TokenClaimsAuthenticationResolver.resolve()`)
+throws when no username/client-id claim is present — which is exactly what an anonymous claims map
+looks like. The raw-key read must happen before a `CamundaAuthentication` can safely be built, not
+after, so the "one dumb provider" alternative above stays rejected for this reason too. The
+monorepo addressed the issue's narrower "or via one shared short-circuit" framing by collapsing the
+three duplicate raw-key checks inside the engine (`CslTenantCheck`, `CslAuthorizationCheck`) into
+one helper, `CslTenantCheck.isAnonymousCommand`.
+

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
@@ -84,7 +84,7 @@ public final class CslAuthorizationCheck {
       return Either.right(Optional.empty());
     }
     final var authorizations = command.getAuthorizations();
-    if (Boolean.TRUE.equals(authorizations.get(Authorization.AUTHORIZED_ANONYMOUS_USER))) {
+    if (CslTenantCheck.isAnonymousCommand(authorizations)) {
       LOG.trace(
           "Skipping authorization check for anonymous user on command {}", command.getIntent());
       return Either.right(Optional.empty());
@@ -204,7 +204,7 @@ public final class CslAuthorizationCheck {
       final T value,
       final Rejection noPrincipalRejection,
       final Function<AuthorizationRejection, Rejection> denialMapper) {
-    if (Boolean.TRUE.equals(claims.get(Authorization.AUTHORIZED_ANONYMOUS_USER))) {
+    if (CslTenantCheck.isAnonymousCommand(claims)) {
       return Either.right(value);
     }
     if (claims.get(Authorization.AUTHORIZED_USERNAME) == null

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslTenantCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslTenantCheck.java
@@ -74,9 +74,9 @@ public final class CslTenantCheck {
   }
 
   /**
-   * True when the command's claims mark it as an anonymous caller. Checked against the raw map
-   * because the map is the command record's wire format — there is no resolved {@link
-   * io.camunda.security.api.model.CamundaAuthentication} yet at this point in the write path.
+   * True when the raw claims/authorizations map marks the caller as an anonymous user. Checked on
+   * the raw map because some write-path call sites run before (or without) building a {@link
+   * io.camunda.security.api.model.CamundaAuthentication}.
    */
   static boolean isAnonymousCommand(final Map<String, Object> authorizations) {
     return Boolean.TRUE.equals(authorizations.get(Authorization.AUTHORIZED_ANONYMOUS_USER));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslTenantCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslTenantCheck.java
@@ -57,7 +57,7 @@ public final class CslTenantCheck {
    * io.camunda.security.api.model.CamundaAuthentication}.
    */
   public TenantAccess resolveAuthorizedTenants(final Map<String, Object> authorizations) {
-    if (Boolean.TRUE.equals(authorizations.get(Authorization.AUTHORIZED_ANONYMOUS_USER))) {
+    if (isAnonymousCommand(authorizations)) {
       return TenantAccess.wildcard(List.of());
     }
     if (!securityConfig.isMultiTenancyChecksEnabled()) {
@@ -71,6 +71,15 @@ public final class CslTenantCheck {
     final var tenantIds =
         Objects.requireNonNullElse(authentication.authenticatedTenantIds(), List.<String>of());
     return TenantAccess.allowed(tenantIds);
+  }
+
+  /**
+   * True when the command's claims mark it as an anonymous caller. Checked against the raw map
+   * because the map is the command record's wire format — there is no resolved {@link
+   * io.camunda.security.api.model.CamundaAuthentication} yet at this point in the write path.
+   */
+  static boolean isAnonymousCommand(final Map<String, Object> authorizations) {
+    return Boolean.TRUE.equals(authorizations.get(Authorization.AUTHORIZED_ANONYMOUS_USER));
   }
 
   public boolean isMultiTenancyChecksEnabled() {


### PR DESCRIPTION
## Summary

Evaluates [camunda-security-library#587](https://github.com/camunda/camunda-security-library/issues/587) (standardize anonymous-caller detection across the read and write paths) and lands the part of it that's safely achievable.

- **Evaluation result (no code change needed on the shared mechanism):** the write path's entry point is the command record's deserialized claims map (`TypedRecord.getAuthorizations()`), and the shared claims-to-`CamundaAuthentication` converter (`TokenClaimsAuthenticationResolver.resolve()`) throws when no username/client-id claim is present — which is exactly what an anonymous claims map looks like. The raw-key read has to happen *before* a `CamundaAuthentication` can safely be built, so read and write paths can't share one detection mechanism the way `docs/adr/security/002-tenant-access-provider-ownership-and-seam.md`'s "one dumb provider" alternative envisioned. That ADR is updated with a note recording this so the question isn't re-litigated from scratch.
- **What is fixed:** the same one-line raw-key check (`Authorization.AUTHORIZED_ANONYMOUS_USER`) was independently copy-pasted at three call sites across `CslTenantCheck` and `CslAuthorizationCheck` — two classes that already form one component. Collapsed into one helper, `CslTenantCheck.isAnonymousCommand`. Pure, behavior-preserving extraction.

## Test plan

- [x] `./mvnw license:format spotless:apply -T1C`
- [x] `./mvnw verify -pl zeebe/engine -Dtest=CslTenantCheckTest,CslAuthorizationCheckTest,JobBatchActivateAuthorizationTest -DskipTests=false -DskipITs -Dquickly` — 28/28 passing, zero test edits needed
- [x] `./mvnw install -Dquickly -T1C` — full-repo compile green

🤖 Generated with [Claude Code](https://claude.com/claude-code)