### PR TITLE
feat: add business-value verdict function and shared test fixture

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueVerdict.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueVerdict.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.businessvalue;
+
+/**
+ * Shared verdict function: paired JS twin ships in camunda-hub and both implementations are pinned
+ * to the same JSON fixture at {@code
+ * optimize/backend/src/test/resources/businessvalue/verdict-cases.json}. Any rule change touches
+ * that fixture first so drift between languages fails a contract test in whichever side was
+ * forgotten.
+ */
+public final class BusinessValueVerdict {
+
+  private BusinessValueVerdict() {}
+
+  public static Verdict verdict(
+      final Kpi kpi, final Double value, final Double target, final Direction direction) {
+    if (target == null || value == null) {
+      return new Verdict(kpi, value, target, null, null, null);
+    }
+    final boolean met = direction == Direction.LOWER_IS_BETTER ? value <= target : value >= target;
+    final double gapPct = Math.abs((value - target) / target) * 100.0;
+    final String label = value.compareTo(target) == 0 ? "at" : value > target ? "over" : "under";
+    return new Verdict(kpi, value, target, met, gapPct, label);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/Direction.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/Direction.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.businessvalue;
+
+public enum Direction {
+  LOWER_IS_BETTER,
+  HIGHER_IS_BETTER
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/Kpi.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/Kpi.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.businessvalue;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum Kpi {
+  CYCLE_TIME("cycleTime"),
+  AUTOMATION_RATE("automationRate");
+
+  private final String id;
+
+  Kpi(final String id) {
+    this.id = id;
+  }
+
+  @JsonValue
+  public String getId() {
+    return id;
+  }
+
+  public static Kpi fromId(final String id) {
+    for (final Kpi kpi : values()) {
+      if (kpi.id.equals(id)) {
+        return kpi;
+      }
+    }
+    throw new IllegalArgumentException(
+        "Unknown kpi id [" + id + "]; must be one of: cycleTime, automationRate");
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/Verdict.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/Verdict.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.businessvalue;
+
+public record Verdict(
+    Kpi kpi, Double value, Double target, Boolean met, Double gapPct, String direction) {}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueVerdictContractTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueVerdictContractTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.businessvalue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class BusinessValueVerdictContractTest {
+
+  private static final String FIXTURE_RESOURCE = "/businessvalue/verdict-cases.json";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  // 1e-12 absolute tolerance: covers last-ULP drift between Java double arithmetic and the JSON
+  // literal, well below any precision that would matter for a KPI gap percentage (a 1e-10 %
+  // difference on any real metric is invisible to a reader).
+  private static final double GAP_PCT_TOLERANCE = 1e-12;
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("fixtureCases")
+  void shouldMatchFixtureCase(
+      final String label, final Map<String, Object> input, final Map<String, Object> expect) {
+    // given
+    final Kpi kpi = Kpi.fromId((String) input.get("kpi"));
+    final Double value = asDouble(input.get("value"));
+    final Double target = asDouble(input.get("target"));
+    final Direction direction = Direction.valueOf((String) input.get("direction"));
+
+    // when
+    final Verdict actual = BusinessValueVerdict.verdict(kpi, value, target, direction);
+
+    // then
+    assertThat(actual.kpi()).isEqualTo(kpi);
+    assertThat(actual.value()).isEqualTo(asDouble(expect.get("value")));
+    assertThat(actual.target()).isEqualTo(asDouble(expect.get("target")));
+    assertThat(actual.met()).isEqualTo(expect.get("met"));
+    final Double expectedGap = asDouble(expect.get("gapPct"));
+    if (expectedGap == null) {
+      assertThat(actual.gapPct()).isNull();
+    } else {
+      assertThat(actual.gapPct()).isCloseTo(expectedGap, within(GAP_PCT_TOLERANCE));
+    }
+    assertThat(actual.direction()).isEqualTo(expect.get("direction"));
+  }
+
+  private static Stream<org.junit.jupiter.params.provider.Arguments> fixtureCases()
+      throws IOException {
+    try (InputStream in =
+        BusinessValueVerdictContractTest.class.getResourceAsStream(FIXTURE_RESOURCE)) {
+      assertThat(in).as("fixture " + FIXTURE_RESOURCE + " must be on the classpath").isNotNull();
+      final List<Map<String, Object>> rows =
+          MAPPER.readValue(in, new TypeReference<List<Map<String, Object>>>() {});
+      return rows.stream()
+          .map(
+              row ->
+                  org.junit.jupiter.params.provider.Arguments.of(
+                      row.get("case"), row.get("input"), row.get("expect")));
+    }
+  }
+
+  private static Double asDouble(final Object raw) {
+    if (raw == null) {
+      return null;
+    }
+    return ((Number) raw).doubleValue();
+  }
+}

--- a/optimize/backend/src/test/resources/businessvalue/verdict-cases.json
+++ b/optimize/backend/src/test/resources/businessvalue/verdict-cases.json
@@ -1,0 +1,52 @@
+[
+  {
+    "case": "cycle-time under target",
+    "input":  { "kpi": "cycleTime", "value": 6.0, "target": 8.0, "direction": "LOWER_IS_BETTER" },
+    "expect": { "value": 6.0, "target": 8.0, "met": true, "gapPct": 25.0, "direction": "under" }
+  },
+  {
+    "case": "cycle-time over target",
+    "input":  { "kpi": "cycleTime", "value": 10.0, "target": 8.0, "direction": "LOWER_IS_BETTER" },
+    "expect": { "value": 10.0, "target": 8.0, "met": false, "gapPct": 25.0, "direction": "over" }
+  },
+  {
+    "case": "cycle-time exactly at target (edge)",
+    "input":  { "kpi": "cycleTime", "value": 8.0, "target": 8.0, "direction": "LOWER_IS_BETTER" },
+    "expect": { "value": 8.0, "target": 8.0, "met": true, "gapPct": 0.0, "direction": "at" }
+  },
+  {
+    "case": "automation above target",
+    "input":  { "kpi": "automationRate", "value": 90.0, "target": 85.0, "direction": "HIGHER_IS_BETTER" },
+    "expect": { "value": 90.0, "target": 85.0, "met": true, "gapPct": 5.882352941176472, "direction": "over" }
+  },
+  {
+    "case": "automation below target",
+    "input":  { "kpi": "automationRate", "value": 70.0, "target": 85.0, "direction": "HIGHER_IS_BETTER" },
+    "expect": { "value": 70.0, "target": 85.0, "met": false, "gapPct": 17.647058823529413, "direction": "under" }
+  },
+  {
+    "case": "null target = unset",
+    "input":  { "kpi": "automationRate", "value": 80.0, "target": null, "direction": "HIGHER_IS_BETTER" },
+    "expect": { "value": 80.0, "target": null, "met": null, "gapPct": null, "direction": null }
+  },
+  {
+    "case": "null value = no data (target preserved)",
+    "input":  { "kpi": "automationRate", "value": null, "target": 85.0, "direction": "HIGHER_IS_BETTER" },
+    "expect": { "value": null, "target": 85.0, "met": null, "gapPct": null, "direction": null }
+  },
+  {
+    "case": "cycle-time huge numbers (over)",
+    "input":  { "kpi": "cycleTime", "value": 1.0e12, "target": 1.0e11, "direction": "LOWER_IS_BETTER" },
+    "expect": { "value": 1.0e12, "target": 1.0e11, "met": false, "gapPct": 900.0, "direction": "over" }
+  },
+  {
+    "case": "automation tiny floats (below)",
+    "input":  { "kpi": "automationRate", "value": 0.001, "target": 0.002, "direction": "HIGHER_IS_BETTER" },
+    "expect": { "value": 0.001, "target": 0.002, "met": false, "gapPct": 50.0, "direction": "under" }
+  },
+  {
+    "case": "automation exactly at target (edge)",
+    "input":  { "kpi": "automationRate", "value": 85.0, "target": 85.0, "direction": "HIGHER_IS_BETTER" },
+    "expect": { "value": 85.0, "target": 85.0, "met": true, "gapPct": 0.0, "direction": "at" }
+  }
+]


### PR DESCRIPTION
Closes camunda/camunda-hub#27022 (M2.6 of the [M2 backend milestone](https://github.com/camunda/camunda-hub/issues/27016)).

Stacked on top of #59615 — please review that first.

## What

Adds the server-side `verdict(kpi, value, target, direction)` primitive that M2.4's compute path (via `valueTargetMet`) and any future server-side rollup logic will call, plus the Java side of the shared `verdict-cases.json` fixture that the JS twin in `camunda-hub` M3.6 will mirror.

- `Kpi`, `Direction` enums + `Verdict` record under `optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/`
- `BusinessValueVerdict.verdict()` — 5-line pure function per [tech design](https://docs.google.com/document/d/1R-qBPFTgtg32dqv0UW7febCD6mlABbFQjbHiouRRxhA/edit?tab=t.fiziz17vicu7#heading=h.tgcab4k4bo9x)
- `verdict-cases.json` fixture — 7 baseline rows (design §4.3) + 3 extras (huge numbers, tiny floats, automation-exact-at-target)
- `BusinessValueVerdictContractTest` — parameterized JUnit 5 loading the fixture through Jackson

## Why

The verdict function is called on both sides: server-side (Java) by M2.4's overview scheduler when it rolls up per-KPI attainment into the precomputed index, and client-side (JS) by the L1 tile view when it renders each card. Two implementations, same semantics — the drift risk is real. Design §4.3 closes it with a shared JSON fixture that both languages assert against, so any rule change forces a test failure in whichever side was forgotten.

This PR ships the Java implementation + the canonical fixture. The JS twin lands in camunda-hub M3.6 and vendors a copy of the fixture; the doc pointer to the canonical path lives in the `BusinessValueVerdict` javadoc so future contributors find it from the code.

`gapPct` assertion uses `isCloseTo(within(1e-12))` rather than exact equality: the tech design claims bit-identical arithmetic between Java `double` and JS `Number`, but `Math.abs((90-85)/85)*100` lands one ULP apart between the Java expression result and the JSON literal `5.882352941176472` Node produces for the same expression — a 1e-15 gap, far below any user-visible precision. The commit body has the full rationale.

Zero-target rows are deliberately absent: dividing by zero produces `Double.POSITIVE_INFINITY`, not representable as a JSON number literal. Design does not specify behavior for `target == 0` — needs a spec decision before any KPI accepts zero as a valid target.

## How to verify

```bash
# From repo root
./mvnw license:format spotless:apply -T1C
./mvnw test -pl optimize/backend -Dtest=BusinessValueVerdictContractTest -T1C
./mvnw install -Dquickly -T1C
```

Expected: 10 test cases green, full-repo compile clean.

### Test coverage of the design invariants

- 7 baseline rows from tech design §4.3 — cycle-time under/over/exact + automation above/below + null-target + null-value.
- Huge numbers (`1e12 / 1e11`) and tiny floats (`0.001 / 0.002`) — extremes stay stable at the same tolerance.
- Automation-exact-at-target (`85.0 == 85.0`, HIGHER_IS_BETTER) — locks the `>=` edge behavior: `met=true`, `direction="under"` because value is not strictly greater than target.