### PR TITLE
test: wait for processes to load

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/test/pages/CustomFiltersModal.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/pages/CustomFiltersModal.ts
@@ -29,7 +29,7 @@ class CustomFiltersModal extends View {
 	}
 
 	get processSelect() {
-		return this.dialog.getByRole('combobox', {name: /process/i});
+		return this.dialog.getByRole('combobox', {name: 'Tasks for latest process version'});
 	}
 
 	get assignedToInput() {

--- a/webapp/client/apps/orchestration-cluster-webapp/test/visual/tasklist-custom-filters.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/visual/tasklist-custom-filters.test.ts
@@ -78,6 +78,7 @@ test('should match the custom filters modal', async ({tasklistIndexPage, page}) 
 	await tasklistIndexPage.newFilterButton.click();
 
 	await expect(tasklistIndexPage.customFiltersModal.heading).toBeVisible();
+	await expect(tasklistIndexPage.customFiltersModal.processSelect).toBeVisible();
 	await expect(page).toHaveScreenshot();
 
 	await tasklistIndexPage.customFiltersModal.assigneeOption('User and group').click();
@@ -93,6 +94,7 @@ test('should match the custom filters modal with advanced filters open', async (
 	await tasklistIndexPage.customFiltersModal.advancedFiltersToggle.click();
 	await tasklistIndexPage.customFiltersModal.businessIdField.fill('ORDER-2024-0042');
 
+	await expect(tasklistIndexPage.customFiltersModal.processSelect).toBeVisible();
 	await expect(page).toHaveScreenshot();
 });
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This stabilizes the visual regression tests. Since recently they started to get flaky because of extra delay on loading the process definitions on the Tasklist custom filters


This is related to this incident: [#inc-7088-unsuccessful-job-ci-webapp-clientvisual-on-main](https://camunda.slack.com/archives/C0BNSTHFN1M)
