### PR TITLE
fix: allow startup with the webapps enabled but no secondary storage

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/rest/HttpMessageConverterConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rest/HttpMessageConverterConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.application.commons.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import java.nio.charset.StandardCharsets;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -63,6 +64,7 @@ public class HttpMessageConverterConfiguration {
   @Bean
   @Order(2)
   @Profile("operate")
+  @ConditionalOnSecondaryStorageEnabled
   public MappingJackson2HttpMessageConverter operateV1MappingJackson2HttpMessageConverter(
       @Qualifier("operateObjectMapper") final ObjectMapper objectMapper) {
     final PackageSpecificJackson2HttpMessageConverter messageConverter =
@@ -74,6 +76,7 @@ public class HttpMessageConverterConfiguration {
   @Bean
   @Order(3)
   @Profile("tasklist")
+  @ConditionalOnSecondaryStorageEnabled
   public MappingJackson2HttpMessageConverter tasklistV1MappingJackson2HttpMessageConverter(
       @Qualifier("tasklistObjectMapper") final ObjectMapper objectMapper) {
     final PackageSpecificJackson2HttpMessageConverter messageConverter =

--- a/dist/src/test/java/io/camunda/application/commons/rest/HttpMessageConverterConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/rest/HttpMessageConverterConfigurationTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+
+class HttpMessageConverterConfigurationTest {
+
+  private ApplicationContextRunner runnerWithProfiles(final String... profiles) {
+    return new ApplicationContextRunner()
+        .withUserConfiguration(HttpMessageConverterConfiguration.class)
+        .withBean(ObjectMapper.class, ObjectMapper::new)
+        .withPropertyValues("spring.profiles.active=" + String.join(",", profiles));
+  }
+
+  @Test
+  void shouldStartWithoutWebappConvertersWhenSecondaryStorageIsDisabled() {
+    // given the operate and tasklist profiles, but no secondary storage: the object mappers the
+    // webapp converters depend on come from module configurations that are themselves conditional
+    // on secondary storage, so requiring them here would fail the whole context
+
+    // when/then
+    runnerWithProfiles("operate", "tasklist")
+        .withPropertyValues("camunda.data.secondary-storage.type=none")
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed();
+              assertThat(context).doesNotHaveBean("operateV1MappingJackson2HttpMessageConverter");
+              assertThat(context).doesNotHaveBean("tasklistV1MappingJackson2HttpMessageConverter");
+              assertThat(context).hasBean("defaultRestMappingJackson2HttpMessageConverter");
+            });
+  }
+
+  @Test
+  void shouldRegisterWebappConvertersWhenSecondaryStorageIsEnabled() {
+    // given
+    final var operateObjectMapper = new ObjectMapper();
+    final var tasklistObjectMapper = new ObjectMapper();
+
+    // when/then
+    runnerWithProfiles("operate", "tasklist")
+        .withPropertyValues("camunda.data.secondary-storage.type=elasticsearch")
+        .withBean("operateObjectMapper", ObjectMapper.class, () -> operateObjectMapper)
+        .withBean("tasklistObjectMapper", ObjectMapper.class, () -> tasklistObjectMapper)
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed();
+              assertThat(context)
+                  .getBean(
+                      "operateV1MappingJackson2HttpMessageConverter",
+                      MappingJackson2HttpMessageConverter.class)
+                  .isNotNull();
+              assertThat(context)
+                  .getBean(
+                      "tasklistV1MappingJackson2HttpMessageConverter",
+                      MappingJackson2HttpMessageConverter.class)
+                  .isNotNull();
+            });
+  }
+}


### PR DESCRIPTION
Starting the orchestration cluster with `camunda.data.secondary-storage.type=none` fails during context refresh:

```
No qualifying bean of type 'com.fasterxml.jackson.databind.ObjectMapper' available:
expected at least 1 bean which qualifies as autowire candidate.
Dependency annotations: {@Qualifier("operateObjectMapper")}
```

`StandaloneCamunda` activates the operate and tasklist profiles by default, so the two v1 webapp message converters are always registered. They are gated on the profile alone, while the object mappers they inject come from the Operate and Tasklist module configurations, which are additionally gated on `@ConditionalOnSecondaryStorageEnabled`. With no secondary storage those module configurations drop out, their component scans never run, and the converters are left asking for beans nobody defines.

This gates the two converters on secondary storage as well, so they disappear together with the modules that supply their dependencies. The remaining converters are storage-independent and stay registered.

Note this only moves the failure one step: with the webapps enabled and no secondary storage, startup then fails on `BasicAuthenticationNotSupportedException`. That one is deliberate — there is no user store to authenticate against, so such a deployment has to use OIDC — and is left alone.

Found while evaluating AOT caching for the Docker image, where a training run without secondary storage was one of the options considered.
