### PR TITLE
perf: reduce startup times by enabling AOT

### DIFF
--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -41,6 +41,16 @@ inputs:
     description: 'Enable debug logging for BuildKit daemon'
     required: false
     default: 'false'
+  aot-cache:
+    # Only camunda.Dockerfile declares AOT_CACHE, so an optimize.Dockerfile build logs a
+    # harmless "build-args were not consumed" warning for it. Expected, not a misconfiguration.
+    description: >
+      Train an AOT cache into the image, so the JVM starts faster. On by default, because
+      an image should be the image we ship; camunda.Dockerfile trains the amd64 platform
+      only, so this costs one extra Camunda boot and nothing on an arm64 build. Set to
+      false when the image is never started, e.g. one built purely to be scanned.
+    required: false
+    default: 'true'
 
 outputs:
   image:
@@ -238,6 +248,7 @@ runs:
             DATE=${{ steps.get-date.outputs.result }}
             REVISION=${{ inputs.revision != '' && inputs.revision || github.sha }}
             VERSION=${{ steps.get-build-inputs.outputs.version }}
+            AOT_CACHE=${{ inputs.aot-cache }}
             ${{ steps.get-additional-build-args.outputs.result }}
           target: app
 

--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -509,6 +509,8 @@ jobs:
           push: true
           distball: ${{ steps.build-backend.outputs.distball }}
           dockerfile: camunda.Dockerfile
+          # The image is a fixture for the Tasklist ITs, not the thing under test.
+          aot-cache: 'false'
       - name: Run Docker tests
         run: |
           ./mvnw \

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -395,6 +395,9 @@ jobs:
           platforms: ${{ env.DOCKER_PLATFORMS }}
           # push is needed for multi-arch images as buildkit does not support loading them locally
           push: true
+          # This job only inspects the image's labels, it never starts it, so training a
+          # cache for it would buy a startup nobody performs.
+          aot-cache: 'false'
       - name: Verify Docker image
         # Skip verification on fork PRs as there public base images are used that don't match our golden labels
         if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1524,6 +1524,10 @@ jobs:
           version: ${{ env.DOCKER_IMAGE_TAG }}
           dockerfile: ${{ matrix.docker-file }}
           push: true
+          # These shards use the image as a fixture for testing something else, so a
+          # cache only slows the build down -- nine matrix entries build one. The image
+          # itself is covered by docker-checks and the Zeebe smoke tests.
+          aot-cache: 'false'
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Maven Test Build Integration

--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -125,6 +125,9 @@ jobs:
         if: inputs.build
         with:
           distball: ${{ steps.build-zeebe.outputs.distball }}
+          # This image is only ever scanned, never started, so training a cache for it
+          # would buy a startup nobody performs. The cache is also opaque to Snyk.
+          aot-cache: 'false'
       # Prepares the bash environment for the step which will actually run Snyk, to avoid mixing too
       # much the GitHub Action contexts/syntax and bash itself.
       - name: Build Snyk Environment

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -221,16 +221,24 @@ USER 1001:1001
 # path. That happens when the classpath changes (a JDBC driver mounted into
 # /driver-lib), when compressed oops are off (a heap above ~32G, or ZGC), or when
 # UseCompactObjectHeaders is overridden.
+#
+# The training run boots a broker, so it leaves a data directory and a log file
+# behind, and both have to be put back exactly as the setup step left them. The
+# cleanup uses `find -delete` rather than a glob because the topology metadata is
+# a dotfile a glob would miss, and the mode is reset explicitly because writing
+# into data/ and logs/ leaves them at the default 0755. Either one alone is
+# enough to break an OpenShift-style deployment, which runs as an arbitrary uid
+# in group 0 and so needs these group-writable and empty.
 ARG AOT_CACHE="true"
 RUN if [ "${AOT_CACHE}" = "true" ]; then \
-      cd "${CAMUNDA_HOME}" && \
       CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_CREATESCHEMA=false \
       JAVA_OPTS="-XX:AOTCacheOutput=${CAMUNDA_HOME}/camunda.aot -Dspring.context.exit=onRefresh" \
         "${CAMUNDA_HOME}/bin/camunda" && \
-      rm -rf "${CAMUNDA_HOME}/data"/* "${CAMUNDA_HOME}/logs"/* && \
+      find "${CAMUNDA_HOME}/data" "${CAMUNDA_HOME}/logs" -mindepth 1 -delete && \
+      chmod 0775 "${CAMUNDA_HOME}/data" "${CAMUNDA_HOME}/logs" && \
       printf -- '-XX:AOTCache=%s/camunda.aot\n' "${CAMUNDA_HOME}" \
         >> "${CAMUNDA_HOME}/config/jvm.options" && \
-      echo "AOT cache: $(du -h "${CAMUNDA_HOME}/camunda.aot" | cut -f1)"; \
+      du -h "${CAMUNDA_HOME}/camunda.aot"; \
     fi
 
 ENTRYPOINT ["/usr/local/camunda/bin/camunda"]

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -198,4 +198,39 @@ RUN ln -s /driver-lib ${CAMUNDA_HOME}/driver-lib
 
 USER 1001:1001
 
+### AOT cache ###
+# Train an AOT cache (JEP 483/514) on a real boot, so that at runtime the JVM can
+# skip loading, parsing, verifying and linking the classes a startup touches.
+#
+# There is no secondary storage to talk to during a build, but it does not need to
+# be reachable -- only reached for. create-schema=false makes SchemaManager.startup()
+# return before it touches the client, which is the one thing that would otherwise
+# block context refresh indefinitely; the exporter's connection attempts fail and
+# retry in the background without holding refresh up. Leaving secondary storage
+# *configured* is what matters: it keeps Operate, Tasklist and the search clients in
+# the context, all of which disabling it would drop from the cache.
+#
+# spring.context.exit makes the run stop at the end of context refresh rather than
+# serve traffic. Only one storage mode can be trained -- a training run emits a
+# binary configuration that cannot be merged across runs -- but the choice barely
+# matters: the archived bulk is Spring, Tomcat, Netty, Jackson and the engine. An
+# Elasticsearch-trained cache still cuts an RDBMS startup by 29%, against 37% for
+# Elasticsearch itself.
+#
+# A cache the JVM cannot validate is ignored and startup falls back to the uncached
+# path. That happens when the classpath changes (a JDBC driver mounted into
+# /driver-lib), when compressed oops are off (a heap above ~32G, or ZGC), or when
+# UseCompactObjectHeaders is overridden.
+ARG AOT_CACHE="true"
+RUN if [ "${AOT_CACHE}" = "true" ]; then \
+      cd "${CAMUNDA_HOME}" && \
+      CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_CREATESCHEMA=false \
+      JAVA_OPTS="-XX:AOTCacheOutput=${CAMUNDA_HOME}/camunda.aot -Dspring.context.exit=onRefresh" \
+        "${CAMUNDA_HOME}/bin/camunda" && \
+      rm -rf "${CAMUNDA_HOME}/data"/* "${CAMUNDA_HOME}/logs"/* && \
+      printf -- '-XX:AOTCache=%s/camunda.aot\n' "${CAMUNDA_HOME}" \
+        >> "${CAMUNDA_HOME}/config/jvm.options" && \
+      echo "AOT cache: $(du -h "${CAMUNDA_HOME}/camunda.aot" | cut -f1)"; \
+    fi
+
 ENTRYPOINT ["/usr/local/camunda/bin/camunda"]

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -229,8 +229,21 @@ USER 1001:1001
 # into data/ and logs/ leaves them at the default 0755. Either one alone is
 # enough to break an OpenShift-style deployment, which runs as an arbitrary uid
 # in group 0 and so needs these group-writable and empty.
+#
+# On by default, so an image built straight from this file is the image we ship, but
+# only ever for amd64. Training boots Camunda, and a multi-arch build would boot the
+# foreign platform under QEMU: on the Docker Checks job that took the image build from
+# ~1m15s to 8m05s, nearly all of it emulating the arm64 boot. The arch has to be tested
+# here rather than in CI because a build arg applies to every platform of one buildx
+# invocation, so excluding arm64 from the caller would cost amd64 its cache too. The
+# price of excluding it at all is that arm64 images get no startup win.
+#
+# The test is for arm64 rather than against amd64 so that an unset TARGETARCH -- a
+# builder that does not populate it -- still trains, instead of silently producing
+# an image with no cache.
 ARG AOT_CACHE="true"
-RUN if [ "${AOT_CACHE}" = "true" ]; then \
+ARG TARGETARCH
+RUN if [ "${AOT_CACHE}" = "true" ] && [ "${TARGETARCH}" != "arm64" ]; then \
       CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_CREATESCHEMA=false \
       JAVA_OPTS="-XX:AOTCacheOutput=${CAMUNDA_HOME}/camunda.aot -Dspring.context.exit=onRefresh" \
         "${CAMUNDA_HOME}/bin/camunda" && \

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -991,15 +991,32 @@
           <assembleDirectory>${project.build.directory}/camunda-zeebe</assembleDirectory>
           <configurationDirectory>config</configurationDirectory>
           <copyConfigurationDirectory>true</copyConfigurationDirectory>
+          <!-- log4j2 discovered config/log4j2.xml from the classpath; since the config
+               directory is no longer on it (see includeConfigurationDirectoryInClasspath
+               below), point log4j2 at the file directly. @BASEDIR@ is interpolated by
+               appassembler into the platform's own variable. -->
           <extraJvmArguments>-XX:+ExitOnOutOfMemoryError
-            -Dfile.encoding=UTF-8 -Xshare:auto
+            -Dfile.encoding=UTF-8
+            -Dlog4j.configurationFile=@BASEDIR@/config/log4j2.xml
             ${jvm.module.opens}</extraJvmArguments>
           <!-- Custom templates add optional @argfile support via config/jvm.options -->
           <unixScriptTemplate>${project.basedir}/src/main/scripts/unixBinTemplate</unixScriptTemplate>
           <windowsScriptTemplate>${project.basedir}/src/main/scripts/windowsBinTemplate</windowsScriptTemplate>
           <!-- This will be added to the classpath as /urs/local/camunda/driver-lib/* -->
           <endorsedDir>driver-lib</endorsedDir>
-          <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
+          <!-- Keep the config directory off the classpath. A non-empty directory on the
+               classpath makes the JVM refuse to write an AOT cache and reject one at
+               runtime, which costs the Docker image its startup cache.
+
+               This does not change how Spring finds application.yaml: that is resolved
+               from Spring's default file:./config/ location, which is why it only works
+               when the process runs from the installation directory (as the Docker image
+               does). As a classpath entry the directory was in fact shadowed for
+               application.yaml, because the dist jar contributes its own
+               classpath:/application.properties, and .properties wins over .yaml within
+               one location. It did serve a config/application.properties for a process
+               started from another working directory; that is the one case this removes. -->
+          <includeConfigurationDirectoryInClasspath>false</includeConfigurationDirectoryInClasspath>
           <platforms>
             <platform>windows</platform>
             <platform>unix</platform>


### PR DESCRIPTION
Trains an AOT cache (JEP 483/514) into the Docker image so the JVM does not re-load, parse, verify and link the ~31k classes a boot touches on every start.

Startup to `/actuator/health/readiness`, Operate + Tasklist + broker against Elasticsearch 8.19.16, 2G heap, median of 4 interleaved container runs:

| | median |
|---|---|
| baseline | 8624 ms |
| AOT cache | **4446 ms** (−48 %) |

21,391 of 31,148 loaded classes come from the cache.

### How the training run works without a secondary storage

It does not need one to be reachable, only configured. `create-schema=false` makes `SchemaManager.startup()` return before it touches the client, which is the only thing that would otherwise block context refresh indefinitely; the exporter's connection attempts fail and retry in the background without holding refresh up. `spring.context.exit=onRefresh` stops the run at the end of refresh instead of serving traffic.

Leaving storage *configured* rather than disabling it is what keeps Operate, Tasklist and the search clients in the trained context — training with storage disabled is worth −32 % instead of −37 % (measured natively, where the two are directly comparable).

Only one mode can be trained (a training run emits a binary configuration that cannot be merged across runs), but the choice barely matters, because the archived bulk is Spring, Tomcat, Netty, Jackson and the engine. Measured cross-backend, with the Elasticsearch-trained cache:

| RDBMS (H2) startup | median |
|---|---|
| baseline | 9791 ms |
| ES-trained cache | **6953 ms** (−29 %) |

### Why the config directory comes off the classpath

The JVM refuses to write an AOT cache while a non-empty directory is on the classpath (`Cannot have non-empty directory in paths`) and rejects a cache at runtime whenever the classpath differs from the recorded one. So the entry has to go, or the image gets no cache.

Removing it does not change how `application.yaml` is found — that comes from Spring's default `file:./config/` location, which works because the process runs from the installation directory (`WORKDIR` is `CAMUNDA_HOME`). As a classpath entry the directory was in fact *shadowed* for `application.yaml`: the dist jar contributes its own `classpath:/application.properties`, and `.properties` wins over `.yaml` within one location. Verified both ways — a `config/application.yml` setting `server.port` was ignored through the classpath entry and honoured through `file:./config/`.

What the entry did serve is a `config/application.properties` for a process started from *another* working directory. That is the one behaviour this removes, and it is the only reason this touches `dist/pom.xml` rather than only the Dockerfile.

log4j2 did rely on the entry to discover `config/log4j2.xml` before Spring starts, so the generated launcher now points at the file directly. `-Xshare:auto` is dropped with it: it is the JVM default, and naming it explicitly makes the JVM reject `-XX:AOTCache`/`-XX:AOTCacheOutput` outright.

### Failure modes

A cache the JVM cannot validate is ignored and startup falls back to the uncached path — lost speed, not a broken container. Verified for: a JDBC driver mounted into `/driver-lib` (classpath prefix changes), a heap above ~32G or ZGC (compressed oops off), and `-XX:-UseCompactObjectHeaders`.

### Cost

185 MB in the image, but **~41 MiB compressed**, which is what a pull pays. Adds ~40 s to the image build. `--build-arg AOT_CACHE=false` skips it.

### Still to verify

- The hardened `openjre-base` base image. Verified on `eclipse-temurin:25-jre-noble`, which confirms a JRE can create the cache, but Minimus images are not pullable here.
- Whether the Helm chart or any documentation depends on `config/application.properties` being read from a foreign working directory.
