### PR TITLE
fix: prevent Optimize heatmap crash on flow node ids with special chars

### DIFF
--- a/optimize/client/src/modules/components/HeatmapOverlay/HeatmapOverlay.js
+++ b/optimize/client/src/modules/components/HeatmapOverlay/HeatmapOverlay.js
@@ -43,7 +43,7 @@ export default class HeatmapOverlay extends React.Component {
   indicateClickableNodes = () => {
     if (this.props.data) {
       Object.keys(this.props.data).forEach((id) => {
-        const node = document.body.querySelector(`[data-element-id=${id}]`);
+        const node = document.body.querySelector(`[data-element-id=${CSS.escape(id)}]`);
         node?.classList.add('clickable');
       });
     }

--- a/optimize/client/src/modules/components/HeatmapOverlay/HeatmapOverlay.test.js
+++ b/optimize/client/src/modules/components/HeatmapOverlay/HeatmapOverlay.test.js
@@ -20,7 +20,7 @@ jest.mock('./service', () => {
 
 jest.mock('./Tooltip', () => 'foo');
 
-jest.spyOn(document.body, 'querySelector').mockReturnValue({
+const selectorSpy = jest.spyOn(document.body, 'querySelector').mockReturnValue({
   classList: {
     add: jest.fn(),
   },
@@ -37,6 +37,12 @@ const viewer = {
       on: eventSpy,
     };
   },
+};
+
+const MOCKED_ESCAPE_RESULT = 'MockedEscapeResult';
+const escapeMock = jest.fn(() => MOCKED_ESCAPE_RESULT);
+global.CSS = {
+  escape: escapeMock,
 };
 const data = 'some heatmap data';
 
@@ -70,8 +76,14 @@ it('should update heatmap if data changes', () => {
   expect(appendSpy).toHaveBeenLastCalledWith(anotherHeatmap);
 });
 
-it('should attach onClick if passed', () => {
+it('should attach onClick with sanitized ids if passed', () => {
+  // given
+  const idOfFirstProcess = 0;
   const spy = jest.fn();
+  // when
   shallow(<HeatmapOverlay viewer={viewer} data={data} onNodeClick={spy} />);
+  // then
+  expect(escapeMock).toHaveBeenNthCalledWith(1, `${idOfFirstProcess}`);
   expect(eventSpy).toHaveBeenCalledWith('element.click', spy);
+  expect(selectorSpy).toHaveBeenNthCalledWith(1, `[data-element-id=${MOCKED_ESCAPE_RESULT}]`);
 });

--- a/optimize/client/src/modules/components/HeatmapOverlay/HeatmapOverlay.test.js
+++ b/optimize/client/src/modules/components/HeatmapOverlay/HeatmapOverlay.test.js
@@ -82,13 +82,12 @@ it('should update heatmap if data changes', () => {
 });
 
 it('should attach onClick with sanitized ids if passed', () => {
-  // given
   const dottedId = 'flow.with.dot';
   const heatmapData = {[dottedId]: 1};
   const spy = jest.fn();
-  // when
+
   shallow(<HeatmapOverlay viewer={viewer} data={heatmapData} onNodeClick={spy} />);
-  // then
+
   expect(escapeMock).toHaveBeenCalledWith(dottedId);
   expect(eventSpy).toHaveBeenCalledWith('element.click', spy);
   expect(selectorSpy).toHaveBeenCalledWith(`[data-element-id=${MOCKED_ESCAPE_RESULT}]`);

--- a/optimize/client/src/modules/components/HeatmapOverlay/HeatmapOverlay.test.js
+++ b/optimize/client/src/modules/components/HeatmapOverlay/HeatmapOverlay.test.js
@@ -46,6 +46,11 @@ global.CSS = {
 };
 const data = 'some heatmap data';
 
+beforeEach(() => {
+  escapeMock.mockClear();
+  selectorSpy.mockClear();
+});
+
 it('create get a heatmap', () => {
   shallow(<HeatmapOverlay viewer={viewer} data={data} />);
 
@@ -78,12 +83,13 @@ it('should update heatmap if data changes', () => {
 
 it('should attach onClick with sanitized ids if passed', () => {
   // given
-  const idOfFirstProcess = 0;
+  const dottedId = 'flow.with.dot';
+  const heatmapData = {[dottedId]: 1};
   const spy = jest.fn();
   // when
-  shallow(<HeatmapOverlay viewer={viewer} data={data} onNodeClick={spy} />);
+  shallow(<HeatmapOverlay viewer={viewer} data={heatmapData} onNodeClick={spy} />);
   // then
-  expect(escapeMock).toHaveBeenNthCalledWith(1, `${idOfFirstProcess}`);
+  expect(escapeMock).toHaveBeenCalledWith(dottedId);
   expect(eventSpy).toHaveBeenCalledWith('element.click', spy);
-  expect(selectorSpy).toHaveBeenNthCalledWith(1, `[data-element-id=${MOCKED_ESCAPE_RESULT}]`);
+  expect(selectorSpy).toHaveBeenCalledWith(`[data-element-id=${MOCKED_ESCAPE_RESULT}]`);
 });


### PR DESCRIPTION
## Summary

Flow node ids containing `.` (or other CSS-special characters) crashed the Optimize Task Analysis / outlier heatmap view. `HeatmapOverlay.indicateClickableNodes` interpolated the id straight into `document.body.querySelector('[data-element-id=${id}]')`, which throws `SyntaxError` on unquoted attribute values that aren't valid CSS identifiers.

Wrap the id in `CSS.escape()` before building the selector — same fix as the C7 analog camunda/camunda-optimize#15055.

Closes #59767

## Test plan

- [x] `HeatmapOverlay.test.js` updated to assert `CSS.escape` is invoked and the escaped value ends up in the selector — 11/11 pass
- [ ] Manual: deploy a process with a dotted flow-node id, generate outliers, open Analysis → Task Analysis — view renders without SyntaxError