### PR TITLE
refactor: clean up job priority code quality, preserve behavior

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/JobPriorityResolutionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/JobPriorityResolutionIT.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForJobs;
+import static io.camunda.it.util.TestHelper.waitUntilIncidentsConditionsAreMet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.IncidentErrorType;
+import io.camunda.client.api.search.enums.IncidentState;
+import io.camunda.client.api.search.response.Job;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class JobPriorityResolutionIT {
+
+  private static CamundaClient client;
+
+  @Test
+  void shouldAcceptDecimalScaleIntegerPriorityAsTaskLevelFeelExpression() {
+    // given
+    final String processId = "prio-resolution-decimal-scale";
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("prio-decimal-job").zeebeJobPriority("=1.0"))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(client, process, processId + ".bpmn");
+
+    // when
+    final long processInstanceKey = startProcessInstance(client, processId).getProcessInstanceKey();
+
+    // then
+    final Job job = waitForJobs(client, List.of(processInstanceKey)).getFirst();
+    assertThat(job.getPriority()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldFallBackToProcessLevelDefaultPriorityWhenTaskLevelAbsent() {
+    // given
+    final String processId = "prio-resolution-process-default";
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(processId)
+            .zeebeJobPriority("7")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("prio-process-default-job"))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(client, process, processId + ".bpmn");
+
+    // when
+    final long processInstanceKey = startProcessInstance(client, processId).getProcessInstanceKey();
+
+    // then
+    final Job job = waitForJobs(client, List.of(processInstanceKey)).getFirst();
+    assertThat(job.getPriority()).isEqualTo(7);
+  }
+
+  @Test
+  void shouldRaiseIncidentForFractionalPriorityInsteadOfCreatingJob() {
+    // given
+    final String processId = "prio-resolution-fractional-incident";
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask(
+                "task", t -> t.zeebeJobType("prio-fractional-job").zeebeJobPriority("=1.5"))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(client, process, processId + ".bpmn");
+
+    // when
+    final long processInstanceKey = startProcessInstance(client, processId).getProcessInstanceKey();
+
+    // then
+    waitUntilIncidentsConditionsAreMet(
+        client,
+        f -> f.state(IncidentState.ACTIVE).processInstanceKey(processInstanceKey),
+        1,
+        "should wait until the priority incident is active");
+    final var incident =
+        client
+            .newIncidentSearchRequest()
+            .filter(f -> f.state(IncidentState.ACTIVE).processInstanceKey(processInstanceKey))
+            .page(p -> p.limit(1))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+    assertThat(incident.getErrorType()).isEqualTo(IncidentErrorType.EXTRACT_VALUE_ERROR);
+    waitForJobs(client, f -> f.processInstanceKey(processInstanceKey), 0);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -604,15 +604,9 @@ public final class BpmnJobBehavior {
       return priorityFailure(priority, scopeKey, "'NUMBER', but was '" + result.getType() + "'");
     }
     final Number number = result.getNumber();
-    final BigDecimal asDecimal;
     try {
-      asDecimal = new BigDecimal(number.toString());
-    } catch (final NumberFormatException e) {
-      return priorityFailure(priority, scopeKey, "a finite number, but was '" + number + "'");
-    }
-    try {
-      // stripTrailingZeros so `1.0` is accepted as integer 1.
-      return Either.right(asDecimal.stripTrailingZeros().intValueExact());
+      // stripTrailingZeros so 1.0 is accepted as integer 1.
+      return Either.right(new BigDecimal(number.toString()).stripTrailingZeros().intValueExact());
     } catch (final ArithmeticException e) {
       return priorityFailure(
           priority,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/JobPriorityDefinitionTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/JobPriorityDefinitionTransformer.java
@@ -11,13 +11,14 @@ import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeJobPriorityDefinition;
+import org.jspecify.annotations.Nullable;
 
 public final class JobPriorityDefinitionTransformer {
 
   public void transform(
       final ExecutableJobWorkerElement element,
       final TransformContext context,
-      final ZeebeJobPriorityDefinition priorityDefinition) {
+      final @Nullable ZeebeJobPriorityDefinition priorityDefinition) {
 
     if (isNotBackedByJob(element)) {
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceEvaluationContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceEvaluationContext.java
@@ -79,7 +79,12 @@ public final class SecretReferenceEvaluationContext implements ScopedEvaluationC
         return Either.right(SecretLeafContext.INSTANCE);
       }
       final var camunda = delegateCamunda.isRight() ? delegateCamunda.get() : null;
-      return camunda != null ? camunda.getVariable(variableName) : Either.left(null);
+      return camunda != null ? camunda.getVariable(variableName) : notFound();
+    }
+
+    @SuppressWarnings("NullAway")
+    private static Either<DirectBuffer, EvaluationContext> notFound() {
+      return Either.left(null);
     }
   }
 


### PR DESCRIPTION
## Description

Closes #53520. Cleans up code-quality items from the Job Prioritization feature (PR #53226), all preservation of existing behavior: inlined the BigDecimal coercion and removed a dead `NumberFormatException` catch (FEEL numbers are `BigDecimal`-backed, so the string round-trip can't fail), and annotated the `JobPriorityDefinitionTransformer.transform` parameter as `@Nullable`. An acceptance test verifies all priority resolution paths (decimal-scale integers, process-level fallback, incident on fractions).

Issue #53520's item about reconsidering `defaultJobPriority` on `ExecutableProcess` was assessed and deemed not needed — left as-is, out of scope for this PR.

## Checklist

<!--- Please delete options that are not relevant. -->

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53520