### PR TITLE
feat: stamp agentDefinitionKey on AgentInstance creation and reject instances for elements without an agent definition

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDto.java
@@ -54,6 +54,13 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
     this.agentInstanceKey = agentInstanceKey;
   }
 
+  // Not tracked — Optimize's agent-instance import doesn't use the link back to the agent
+  // definition, so this identity is intentionally left unset rather than deserialized.
+  @Override
+  public long getAgentDefinitionKey() {
+    return -1;
+  }
+
   @Override
   public long getElementInstanceKey() {
     return elementInstanceKey;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
@@ -390,6 +390,7 @@ class AgentInstanceAuthorizationIT {
             .startEvent()
             .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
             .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .zeebeAiAgentSubProcessDefinition()
             .endEvent()
             .done();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
@@ -191,7 +191,9 @@ public class AgentHistoryCommitLifecycleIT {
             .startEvent()
             .serviceTask(
                 SERVICE_TASK_ID,
-                t -> t.zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX))
+                t ->
+                    t.zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+                        .zeebeAiAgentTaskDefinition())
             .endEvent()
             .done();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
@@ -57,6 +57,7 @@ public class AgentInstanceFetchIT {
             .startEvent()
             .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
             .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .zeebeAiAgentSubProcessDefinition()
             .endEvent("end")
             .done();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
@@ -55,6 +55,7 @@ public class AgentInstanceHistorySearchIT {
             .startEvent()
             .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
             .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .zeebeAiAgentSubProcessDefinition()
             .endEvent("end")
             .done();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceSearchIT.java
@@ -54,6 +54,7 @@ public class AgentInstanceSearchIT {
             .startEvent()
             .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
             .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .zeebeAiAgentSubProcessDefinition()
             .endEvent("end")
             .done();
 
@@ -68,6 +69,7 @@ public class AgentInstanceSearchIT {
             .startEvent()
             .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
             .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .zeebeAiAgentSubProcessDefinition()
             .endEvent("end")
             .done();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
@@ -49,7 +49,8 @@ public class AgentInstanceMigrationIT {
             client,
             Bpmn.createExecutableProcess("migration-agent-service-task_v1")
                 .startEvent()
-                .serviceTask(sourceElementId, t -> t.zeebeJobType(agentJobType))
+                .serviceTask(
+                    sourceElementId, t -> t.zeebeJobType(agentJobType).zeebeAiAgentTaskDefinition())
                 .userTask(sourceNextElementId)
                 .endEvent()
                 .done(),
@@ -102,6 +103,7 @@ public class AgentInstanceMigrationIT {
                 .startEvent()
                 .adHocSubProcess(sourceElementId, p -> p.task("agentTask"))
                 .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+                .zeebeAiAgentSubProcessDefinition()
                 .endEvent()
                 .done(),
             "migration-agent-ahsp_v1.bpmn");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
@@ -84,6 +84,7 @@ public class AgentInstanceTenancyIT {
             .startEvent()
             .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
             .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .zeebeAiAgentSubProcessDefinition()
             .endEvent()
             .done();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -49,6 +49,8 @@ public final class AgentInstanceCreateProcessor
       "Expected to create agent instance for element instance with key '%d', but it is not active.";
   private static final String ERROR_MSG_UNSUPPORTED_ELEMENT_TYPE =
       "Expected to create agent instance for element instance with key '%d', but its BPMN element type '%s' is not supported. Supported types are: %s.";
+  private static final String ERROR_MSG_NO_AGENT_DEFINITION =
+      "Expected to create agent instance for element instance with key '%d', but element '%s' has no agent definition. Mark the element with 'zeebe:agentDefinition' at deploy time.";
 
   private static final List<BpmnElementType> SUPPORTED_ELEMENT_TYPES =
       List.of(BpmnElementType.AD_HOC_SUB_PROCESS, BpmnElementType.SERVICE_TASK);
@@ -150,14 +152,22 @@ public final class AgentInstanceCreateProcessor
       return;
     }
 
-    final var deployedProcess =
-        processState.getProcessByKeyAndTenant(
-            elementInstanceValue.getProcessDefinitionKey(), elementInstanceValue.getTenantId());
-
     final var agentDefinitionKey =
         agentDefinitionState.getAgentDefinitionKey(
             elementInstanceValue.getProcessDefinitionKey(),
             elementInstanceValue.getElementIdBuffer());
+    if (agentDefinitionKey == null) {
+      writeRejection(
+          command,
+          RejectionType.INVALID_ARGUMENT,
+          ERROR_MSG_NO_AGENT_DEFINITION.formatted(
+              elementInstanceKey, elementInstanceValue.getElementId()));
+      return;
+    }
+
+    final var deployedProcess =
+        processState.getProcessByKeyAndTenant(
+            elementInstanceValue.getProcessDefinitionKey(), elementInstanceValue.getTenantId());
 
     final var agentInstanceKey = keyGenerator.nextKey();
     final var event =
@@ -171,7 +181,7 @@ public final class AgentInstanceCreateProcessor
             .setRootProcessInstanceKey(elementInstanceValue.getRootProcessInstanceKey())
             .setProcessDefinitionKey(elementInstanceValue.getProcessDefinitionKey())
             .setProcessDefinitionVersion(elementInstanceValue.getVersion())
-            .setAgentDefinitionKey(agentDefinitionKey == null ? -1L : agentDefinitionKey)
+            .setAgentDefinitionKey(agentDefinitionKey)
             .setVersionTag(deployedProcess == null ? "" : deployedProcess.getVersionTag())
             .setTenantId(elementInstanceValue.getTenantId())
             .setStatus(AgentInstanceStatus.INITIALIZING);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.AgentDefinitionState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -57,6 +58,7 @@ public final class AgentInstanceCreateProcessor
   private final TypedRejectionWriter rejectionWriter;
   private final ElementInstanceState elementInstanceState;
   private final ProcessState processState;
+  private final AgentDefinitionState agentDefinitionState;
   private final CslAuthorizationCheck cslCheck;
   private final KeyGenerator keyGenerator;
 
@@ -70,6 +72,7 @@ public final class AgentInstanceCreateProcessor
     rejectionWriter = writers.rejection();
     elementInstanceState = processingState.getElementInstanceState();
     processState = processingState.getProcessState();
+    agentDefinitionState = processingState.getAgentDefinitionState();
     this.cslCheck = cslCheck;
     this.keyGenerator = keyGenerator;
   }
@@ -151,6 +154,11 @@ public final class AgentInstanceCreateProcessor
         processState.getProcessByKeyAndTenant(
             elementInstanceValue.getProcessDefinitionKey(), elementInstanceValue.getTenantId());
 
+    final var agentDefinitionKey =
+        agentDefinitionState.getAgentDefinitionKey(
+            elementInstanceValue.getProcessDefinitionKey(),
+            elementInstanceValue.getElementIdBuffer());
+
     final var agentInstanceKey = keyGenerator.nextKey();
     final var event =
         new AgentInstanceRecord()
@@ -163,6 +171,7 @@ public final class AgentInstanceCreateProcessor
             .setRootProcessInstanceKey(elementInstanceValue.getRootProcessInstanceKey())
             .setProcessDefinitionKey(elementInstanceValue.getProcessDefinitionKey())
             .setProcessDefinitionVersion(elementInstanceValue.getVersion())
+            .setAgentDefinitionKey(agentDefinitionKey == null ? -1L : agentDefinitionKey)
             .setVersionTag(deployedProcess == null ? "" : deployedProcess.getVersionTag())
             .setTenantId(elementInstanceValue.getTenantId())
             .setStatus(AgentInstanceStatus.INITIALIZING);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
@@ -239,7 +239,8 @@ public class AgentHistoryCommitTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType(JOB_TYPE))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType(JOB_TYPE).zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateAuthorizationTest.java
@@ -147,7 +147,8 @@ public final class AgentHistoryCreateAuthorizationTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .withTenantId(tenantId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
@@ -272,7 +272,8 @@ public class AgentHistoryCreateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType(JOB_TYPE))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType(JOB_TYPE).zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobDestructionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobDestructionTest.java
@@ -140,7 +140,7 @@ public class AgentHistoryDiscardOnJobDestructionTest {
   private static BpmnModelInstance process(final String jobType) {
     return Bpmn.createExecutableProcess(PROCESS_ID)
         .startEvent()
-        .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType(jobType))
+        .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType(jobType).zeebeAiAgentTaskDefinition())
         .endEvent()
         .done();
   }
@@ -148,7 +148,7 @@ public class AgentHistoryDiscardOnJobDestructionTest {
   private static BpmnModelInstance processWithErrorBoundary(final String jobType) {
     return Bpmn.createExecutableProcess(PROCESS_ID)
         .startEvent()
-        .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType(jobType))
+        .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType(jobType).zeebeAiAgentTaskDefinition())
         .boundaryEvent(BOUNDARY_ID, b -> b.error(ERROR_CODE))
         .endEvent()
         .moveToActivity(SERVICE_TASK_ID)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardTest.java
@@ -180,7 +180,8 @@ public class AgentHistoryDiscardTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType(JOB_TYPE))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType(JOB_TYPE).zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteOnProcessInstanceLifecycleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteOnProcessInstanceLifecycleTest.java
@@ -53,7 +53,8 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(AGENT_TASK_ID, t -> t.zeebeJobType(AGENT_JOB_TYPE))
+                .serviceTask(
+                    AGENT_TASK_ID, t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -106,6 +107,7 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
                 .adHocSubProcess(
                     AGENT_TASK_ID,
                     ahsp -> {
+                      ahsp.zeebeAiAgentSubProcessDefinition();
                       ahsp.task("tool");
                       ahsp.zeebeJobType(AGENT_JOB_TYPE);
                     })
@@ -170,7 +172,8 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(AGENT_TASK_ID, t -> t.zeebeJobType(AGENT_JOB_TYPE))
+                .serviceTask(
+                    AGENT_TASK_ID, t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -208,7 +211,8 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(AGENT_TASK_ID, t -> t.zeebeJobType(agenticJobType))
+                .serviceTask(
+                    AGENT_TASK_ID, t -> t.zeebeJobType(agenticJobType).zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -271,11 +275,14 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
                 .parallelGateway("fork")
-                .serviceTask(AGENT_TASK_ID, t -> t.zeebeJobType(AGENT_JOB_TYPE))
+                .serviceTask(
+                    AGENT_TASK_ID, t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
                 .parallelGateway("join")
                 .endEvent()
                 .moveToNode("fork")
-                .serviceTask(otherAgentTaskId, t -> t.zeebeJobType(otherAgentJobType))
+                .serviceTask(
+                    otherAgentTaskId,
+                    t -> t.zeebeJobType(otherAgentJobType).zeebeAiAgentTaskDefinition())
                 .connectTo("join")
                 .done())
         .deploy();
@@ -304,7 +311,9 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(unrelatedProcessId)
                 .startEvent()
-                .serviceTask(AGENT_TASK_ID, t -> t.zeebeJobType(unrelatedAgentJobType))
+                .serviceTask(
+                    AGENT_TASK_ID,
+                    t -> t.zeebeJobType(unrelatedAgentJobType).zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -391,7 +400,8 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(childProcessId)
                 .startEvent()
-                .serviceTask(AGENT_TASK_ID, t -> t.zeebeJobType(AGENT_JOB_TYPE))
+                .serviceTask(
+                    AGENT_TASK_ID, t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -489,7 +499,8 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(childProcessId)
                 .startEvent()
-                .serviceTask(AGENT_TASK_ID, t -> t.zeebeJobType(AGENT_JOB_TYPE))
+                .serviceTask(
+                    AGENT_TASK_ID, t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteTest.java
@@ -102,14 +102,17 @@ public class AgentInstanceCompleteTest {
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
                 .parallelGateway("fork")
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .parallelGateway("join")
                 .endEvent()
                 .moveToNode("fork")
-                .serviceTask(secondTaskId, t -> t.zeebeJobType("other-agent"))
+                .serviceTask(
+                    secondTaskId, t -> t.zeebeJobType("other-agent").zeebeAiAgentTaskDefinition())
                 .connectTo("join")
                 .moveToNode("fork")
-                .serviceTask(thirdTaskId, t -> t.zeebeJobType("third-agent"))
+                .serviceTask(
+                    thirdTaskId, t -> t.zeebeJobType("third-agent").zeebeAiAgentTaskDefinition())
                 .connectTo("join")
                 .done())
         .deploy();
@@ -180,7 +183,8 @@ public class AgentInstanceCompleteTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteWithoutCommandBatchingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteWithoutCommandBatchingTest.java
@@ -50,11 +50,13 @@ public class AgentInstanceCompleteWithoutCommandBatchingTest {
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
                 .parallelGateway("fork")
-                .serviceTask(FIRST_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    FIRST_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .parallelGateway("join")
                 .endEvent()
                 .moveToNode("fork")
-                .serviceTask(SECOND_TASK_ID, t -> t.zeebeJobType("other-agent"))
+                .serviceTask(
+                    SECOND_TASK_ID, t -> t.zeebeJobType("other-agent").zeebeAiAgentTaskDefinition())
                 .connectTo("join")
                 .done())
         .deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateAuthorizationTest.java
@@ -155,7 +155,8 @@ public final class AgentInstanceCreateAuthorizationTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .withTenantId(tenantId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateTest.java
@@ -49,7 +49,8 @@ public class AgentInstanceCreateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -102,7 +103,8 @@ public class AgentInstanceCreateTest {
             .withXmlResource(
                 Bpmn.createExecutableProcess(PROCESS_ID)
                     .startEvent()
-                    .serviceTask(customElementId, t -> t.zeebeJobType("agent"))
+                    .serviceTask(
+                        customElementId, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                     .endEvent()
                     .done())
             .deploy()
@@ -152,7 +154,8 @@ public class AgentInstanceCreateTest {
             "child.bpmn",
             Bpmn.createExecutableProcess(CHILD_PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -186,7 +189,8 @@ public class AgentInstanceCreateTest {
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .versionTag(versionTag)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -239,8 +243,9 @@ public class AgentInstanceCreateTest {
   }
 
   @Test
-  public void shouldDefaultAgentDefinitionKeyToMinusOneWithoutAgentDefinition() {
-    // given -- a plain service task with no agent marker mints no AgentDefinition at deploy time.
+  public void shouldRejectWhenElementHasNoAgentDefinition() {
+    // given -- a plain service task with no agent marker mints no AgentDefinition at deploy time,
+    // so there is nothing to attach an agent instance to.
     ENGINE
         .deployment()
         .withXmlResource(
@@ -254,11 +259,20 @@ public class AgentInstanceCreateTest {
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
 
     // when
-    final var created =
-        ENGINE.agentInstances().withElementInstanceKey(serviceTaskInstance.getKey()).create();
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(serviceTaskInstance.getKey())
+            .expectRejection()
+            .create();
 
-    // then -- there is no AgentDefinition to resolve, so the key falls back to -1.
-    assertThat(created.getValue().getAgentDefinitionKey()).isEqualTo(-1L);
+    // then -- creation is rejected because the target element carries no agent definition.
+    assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason())
+        .contains(String.valueOf(serviceTaskInstance.getKey()))
+        .contains(SERVICE_TASK_ID)
+        .contains("has no agent definition");
   }
 
   @Test
@@ -269,7 +283,8 @@ public class AgentInstanceCreateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -296,7 +311,8 @@ public class AgentInstanceCreateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -327,7 +343,8 @@ public class AgentInstanceCreateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -356,7 +373,8 @@ public class AgentInstanceCreateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -384,6 +402,7 @@ public class AgentInstanceCreateTest {
                 .adHocSubProcess(
                     AD_HOC_SUB_PROCESS_ID,
                     asp -> {
+                      asp.zeebeAiAgentSubProcessDefinition();
                       asp.task("inner-task");
                       asp.completionCondition("=completionCondition");
                     })
@@ -425,6 +444,7 @@ public class AgentInstanceCreateTest {
                     SERVICE_TASK_ID,
                     t ->
                         t.zeebeJobType("agent")
+                            .zeebeAiAgentTaskDefinition()
                             .multiInstance(
                                 m ->
                                     m.zeebeInputCollectionExpression("items")
@@ -470,7 +490,8 @@ public class AgentInstanceCreateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -565,7 +586,10 @@ public class AgentInstanceCreateTest {
                 .startEvent()
                 .serviceTask(
                     SERVICE_TASK_ID,
-                    t -> t.zeebeJobType("agent").zeebeOutputExpression("assert(x, x != null)", "y"))
+                    t ->
+                        t.zeebeJobType("agent")
+                            .zeebeAiAgentTaskDefinition()
+                            .zeebeOutputExpression("assert(x, x != null)", "y"))
                 .endEvent()
                 .done())
         .deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceTo
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.AgentDefinitionIntent;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -199,6 +200,65 @@ public class AgentInstanceCreateTest {
 
     // then
     assertThat(created.getValue().getVersionTag()).isEqualTo(versionTag);
+  }
+
+  @Test
+  public void shouldStampAgentDefinitionKeyResolvedFromAgentDefinition() {
+    // given -- a service task carrying an agent marker mints an AgentDefinition at deploy time,
+    // keyed by (processDefinitionKey, elementId) in the AgentDefinitionState column family.
+    final var processMetadata =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(PROCESS_ID)
+                    .startEvent()
+                    .serviceTask(
+                        SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
+                    .endEvent()
+                    .done())
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .getFirst();
+    final var agentDefinitionKey =
+        RecordingExporter.agentDefinitionRecords(AgentDefinitionIntent.CREATED)
+            .withProcessDefinitionKey(processMetadata.getProcessDefinitionKey())
+            .getFirst()
+            .getValue()
+            .getAgentDefinitionKey();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+
+    // when
+    final var created =
+        ENGINE.agentInstances().withElementInstanceKey(serviceTaskInstance.getKey()).create();
+
+    // then -- the CREATED event links back to the element's AgentDefinition version.
+    assertThat(created.getValue().getAgentDefinitionKey()).isEqualTo(agentDefinitionKey);
+  }
+
+  @Test
+  public void shouldDefaultAgentDefinitionKeyToMinusOneWithoutAgentDefinition() {
+    // given -- a plain service task with no agent marker mints no AgentDefinition at deploy time.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+
+    // when
+    final var created =
+        ENGINE.agentInstances().withElementInstanceKey(serviceTaskInstance.getKey()).create();
+
+    // then -- there is no AgentDefinition to resolve, so the key falls back to -1.
+    assertThat(created.getValue().getAgentDefinitionKey()).isEqualTo(-1L);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateAuthorizationTest.java
@@ -166,7 +166,8 @@ public final class AgentInstanceUpdateAuthorizationTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .withTenantId(tenantId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateTest.java
@@ -46,7 +46,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -84,7 +85,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -129,7 +131,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -168,7 +171,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -208,7 +212,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -248,7 +253,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -306,7 +312,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -361,7 +368,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -399,7 +407,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -447,7 +456,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -489,7 +499,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -526,7 +537,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -573,7 +585,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -616,7 +629,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -653,7 +667,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -717,7 +732,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -754,7 +770,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -826,6 +843,7 @@ public class AgentInstanceUpdateTest {
                     SERVICE_TASK_ID,
                     t ->
                         t.zeebeJobType("agent")
+                            .zeebeAiAgentTaskDefinition()
                             .multiInstance(
                                 m ->
                                     m.zeebeInputCollectionExpression("items")
@@ -887,6 +905,7 @@ public class AgentInstanceUpdateTest {
                     SERVICE_TASK_ID,
                     t ->
                         t.zeebeJobType("agent")
+                            .zeebeAiAgentTaskDefinition()
                             .multiInstance(
                                 m ->
                                     m.zeebeInputCollectionExpression("items")
@@ -948,7 +967,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -987,7 +1007,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -1033,7 +1054,10 @@ public class AgentInstanceUpdateTest {
                 .startEvent()
                 .serviceTask(
                     SERVICE_TASK_ID,
-                    t -> t.zeebeJobType("agent").zeebeOutputExpression("assert(x, x != null)", "y"))
+                    t ->
+                        t.zeebeJobType("agent")
+                            .zeebeAiAgentTaskDefinition()
+                            .zeebeOutputExpression("assert(x, x != null)", "y"))
                 .endEvent()
                 .done())
         .deploy();
@@ -1086,7 +1110,8 @@ public class AgentInstanceUpdateTest {
             Bpmn.createExecutableProcess(mismatchProcessId)
                 .startEvent()
                 .parallelGateway("split")
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .parallelGateway("merge")
                 .endEvent()
                 .moveToNode("split")
@@ -1144,7 +1169,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(piMismatchProcessId)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -1205,6 +1231,7 @@ public class AgentInstanceUpdateTest {
                     SERVICE_TASK_ID,
                     t ->
                         t.zeebeJobType("agent")
+                            .zeebeAiAgentTaskDefinition()
                             .multiInstance(
                                 m ->
                                     m.zeebeInputCollectionExpression("items")
@@ -1269,7 +1296,8 @@ public class AgentInstanceUpdateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
@@ -53,7 +53,8 @@ public class MigrateAgentInstanceTest {
                 Bpmn.createExecutableProcess(processId)
                     .versionTag("v1")
                     .startEvent()
-                    .serviceTask("A", t -> t.zeebeJobType(AGENT_JOB_TYPE))
+                    .serviceTask(
+                        "A", t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
                     .userTask("B")
                     .endEvent()
                     .done())
@@ -138,7 +139,7 @@ public class MigrateAgentInstanceTest {
             Bpmn.createExecutableProcess(processId)
                 .versionTag("v1")
                 .startEvent()
-                .serviceTask("A", t -> t.zeebeJobType(AGENT_JOB_TYPE))
+                .serviceTask("A", t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
                 .userTask("B")
                 .endEvent()
                 .done())
@@ -236,11 +237,13 @@ public class MigrateAgentInstanceTest {
                     .versionTag("v1")
                     .startEvent()
                     .parallelGateway("fork")
-                    .serviceTask("A", t -> t.zeebeJobType(AGENT_JOB_TYPE))
+                    .serviceTask(
+                        "A", t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
                     .parallelGateway("join")
                     .endEvent()
                     .moveToNode("fork")
-                    .serviceTask("B", t -> t.zeebeJobType(otherJobType))
+                    .serviceTask(
+                        "B", t -> t.zeebeJobType(otherJobType).zeebeAiAgentTaskDefinition())
                     .connectTo("join")
                     .done())
             .withXmlResource(
@@ -362,6 +365,7 @@ public class MigrateAgentInstanceTest {
                     .adHocSubProcess(
                         "ahsp",
                         ahsp -> {
+                          ahsp.zeebeAiAgentSubProcessDefinition();
                           ahsp.task("tool");
                           ahsp.zeebeJobType(AGENT_JOB_TYPE);
                         })

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-template.json
@@ -22,6 +22,9 @@
             "agentInstanceKey": {
               "type": "long"
             },
+            "agentDefinitionKey": {
+              "type": "long"
+            },
             "elementInstanceKey": {
               "type": "long"
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-template.json
@@ -28,6 +28,9 @@
             "agentInstanceKey": {
               "type": "long"
             },
+            "agentDefinitionKey": {
+              "type": "long"
+            },
             "elementInstanceKey": {
               "type": "long"
             },

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
@@ -42,6 +42,7 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   public static final String ATTR_LIMITS = "limits";
 
   private final LongProperty agentInstanceKeyProp = new LongProperty("agentInstanceKey", -1L);
+  private final LongProperty agentDefinitionKeyProp = new LongProperty("agentDefinitionKey", -1L);
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
   private final ArrayProperty<LongValue> elementInstanceKeysProp =
       new ArrayProperty<>("elementInstanceKeys", LongValue::new);
@@ -76,8 +77,9 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
       new ArrayProperty<>("history", AgentHistoryRecord::new);
 
   public AgentInstanceRecord() {
-    super(21);
+    super(22);
     declareProperty(agentInstanceKeyProp)
+        .declareProperty(agentDefinitionKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(elementInstanceKeysProp)
         .declareProperty(elementIdProp)
@@ -107,6 +109,16 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord setAgentInstanceKey(final long agentInstanceKey) {
     agentInstanceKeyProp.setValue(agentInstanceKey);
+    return this;
+  }
+
+  @Override
+  public long getAgentDefinitionKey() {
+    return agentDefinitionKeyProp.getValue();
+  }
+
+  public AgentInstanceRecord setAgentDefinitionKey(final long agentDefinitionKey) {
+    agentDefinitionKeyProp.setValue(agentDefinitionKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -5223,6 +5223,7 @@ final class JsonSerializableToJsonTest {
                       .setBpmnProcessId("invoice-handling-process")
                       .setProcessDefinitionKey(2251799813685100L)
                       .setProcessDefinitionVersion(3)
+                      .setAgentDefinitionKey(2251799813685077L)
                       .setVersionTag("v1.2")
                       .setTenantId("<default>")
                       .setStatus(AgentInstanceStatus.TOOL_CALLING)
@@ -5262,6 +5263,7 @@ final class JsonSerializableToJsonTest {
           "bpmnProcessId": "invoice-handling-process",
           "processDefinitionKey": 2251799813685100,
           "processDefinitionVersion": 3,
+          "agentDefinitionKey": 2251799813685077,
           "versionTag": "v1.2",
           "tenantId": "<default>",
           "status": "TOOL_CALLING",
@@ -5298,6 +5300,7 @@ final class JsonSerializableToJsonTest {
           "bpmnProcessId": "",
           "processDefinitionKey": -1,
           "processDefinitionVersion": -1,
+          "agentDefinitionKey": -1,
           "versionTag": "",
           "tenantId": "<default>",
           "status": "UNSPECIFIED",
@@ -5357,6 +5360,7 @@ final class JsonSerializableToJsonTest {
           "bpmnProcessId": "",
           "processDefinitionKey": -1,
           "processDefinitionVersion": -1,
+          "agentDefinitionKey": -1,
           "versionTag": "",
           "tenantId": "<default>",
           "status": "UNSPECIFIED",

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
@@ -38,6 +38,7 @@ final class AgentInstanceRecordTest {
     assertThat(record.getProcessDefinitionKey()).isEqualTo(-1L);
     assertThat(record.getRootProcessInstanceKey()).isEqualTo(-1L);
     assertThat(record.getProcessDefinitionVersion()).isEqualTo(-1);
+    assertThat(record.getAgentDefinitionKey()).isEqualTo(-1L);
     assertThat(record.getVersionTag()).isEmpty();
     assertThat(record.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   }
@@ -55,6 +56,7 @@ final class AgentInstanceRecordTest {
             .setProcessDefinitionKey(2251799813685100L)
             .setRootProcessInstanceKey(2251799813685000L)
             .setProcessDefinitionVersion(3)
+            .setAgentDefinitionKey(2251799813685077L)
             .setVersionTag("v1.2")
             .setTenantId("acme");
 
@@ -72,6 +74,7 @@ final class AgentInstanceRecordTest {
     assertThat(copy.getRootProcessInstanceKey()).isEqualTo(original.getRootProcessInstanceKey());
     assertThat(copy.getProcessDefinitionVersion())
         .isEqualTo(original.getProcessDefinitionVersion());
+    assertThat(copy.getAgentDefinitionKey()).isEqualTo(original.getAgentDefinitionKey());
     assertThat(copy.getVersionTag()).isEqualTo(original.getVersionTag());
     assertThat(copy.getTenantId()).isEqualTo(original.getTenantId());
   }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
@@ -32,16 +32,17 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   public static final String ATTR_METRICS = "metrics";
   public static final String ATTR_TOOLS = "tools";
 
-  // Derived from a future configuration-change history entry kind on the output side (see #58794
-  // for that entry kind and #58791 for the engine processing that merges them in), never from a
-  // request-level changedAttributes entry — these are not part of ALLOWED_ATTRIBUTES in
-  // AgentInstanceUpdateProcessor, only of the output-side merge order.
+  // Derived from the CONFIGURATION history entry kind on the output side, once the engine
+  // processing that merges them in lands (see #58791) — never from a request-level
+  // changedAttributes entry. Not part of ALLOWED_ATTRIBUTES in AgentInstanceUpdateProcessor, only
+  // of the output-side merge order.
   public static final String ATTR_SYSTEM_PROMPT = "systemPrompt";
   public static final String ATTR_MODEL = "model";
   public static final String ATTR_PROVIDER = "provider";
   public static final String ATTR_LIMITS = "limits";
 
   private final LongProperty agentInstanceKeyProp = new LongProperty("agentInstanceKey", -1L);
+  private final LongProperty agentDefinitionKeyProp = new LongProperty("agentDefinitionKey", -1L);
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
   private final ArrayProperty<LongValue> elementInstanceKeysProp =
       new ArrayProperty<>("elementInstanceKeys", LongValue::new);
@@ -76,8 +77,9 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
       new ArrayProperty<>("history", AgentHistoryRecord::new);
 
   public AgentInstanceRecord() {
-    super(21);
+    super(22);
     declareProperty(agentInstanceKeyProp)
+        .declareProperty(agentDefinitionKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(elementInstanceKeysProp)
         .declareProperty(elementIdProp)
@@ -107,6 +109,16 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord setAgentInstanceKey(final long agentInstanceKey) {
     agentInstanceKeyProp.setValue(agentInstanceKey);
+    return this;
+  }
+
+  @Override
+  public long getAgentDefinitionKey() {
+    return agentDefinitionKeyProp.getValue();
+  }
+
+  public AgentInstanceRecord setAgentDefinitionKey(final long agentDefinitionKey) {
+    agentDefinitionKeyProp.setValue(agentDefinitionKey);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
@@ -30,6 +30,15 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
   long getAgentInstanceKey();
 
   /**
+   * @return the key of the agent definition this instance runs on, or {@code -1} if unset.
+   *     <p>A successfully created agent instance always resolves to a real key, since creation is
+   *     rejected for elements that have no agent definition; {@code -1} therefore only appears on
+   *     the create command before the engine stamps the value, or on legacy records predating this
+   *     field.
+   */
+  long getAgentDefinitionKey();
+
+  /**
    * @return the unique key of the element instance that the agent instance was last associated with
    */
   long getElementInstanceKey();
@@ -52,6 +61,12 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
   long getProcessInstanceKey();
 
   /**
+   * @return the key of the process definition
+   */
+  @Override
+  long getProcessDefinitionKey();
+
+  /**
    * @return the key of the root process instance in the hierarchy; for top-level process instances,
    *     this is equal to {@link #getProcessInstanceKey()}
    */
@@ -61,12 +76,6 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
    * @return the BPMN process ID of the process definition containing this agent
    */
   String getBpmnProcessId();
-
-  /**
-   * @return the key of the process definition
-   */
-  @Override
-  long getProcessDefinitionKey();
 
   /**
    * @return the version of the process definition

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
@@ -61,12 +61,6 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
   long getProcessInstanceKey();
 
   /**
-   * @return the key of the process definition
-   */
-  @Override
-  long getProcessDefinitionKey();
-
-  /**
    * @return the key of the root process instance in the hierarchy; for top-level process instances,
    *     this is equal to {@link #getProcessInstanceKey()}
    */
@@ -76,6 +70,12 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
    * @return the BPMN process ID of the process definition containing this agent
    */
   String getBpmnProcessId();
+
+  /**
+   * @return the key of the process definition
+   */
+  @Override
+  long getProcessDefinitionKey();
 
   /**
    * @return the version of the process definition

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateAgentInstanceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateAgentInstanceTest.java
@@ -105,7 +105,9 @@ public final class CreateAgentInstanceTest {
         resourcesHelper.deployProcess(
             Bpmn.createExecutableProcess("conflict-test-process")
                 .startEvent()
-                .serviceTask("service-task", t -> t.zeebeJobType("agent-conflict-job"))
+                .serviceTask(
+                    "service-task",
+                    t -> t.zeebeJobType("agent-conflict-job").zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done());
     resourcesHelper.createProcessInstance(processDefinitionKey);

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -534,11 +534,12 @@ public class CompactRecordLogger {
     return record.getValue().getClass().getSimpleName() + " " + record.getValue().toJson();
   }
 
-  private String summarizeAgentInstance(final Record<?> record) {
+  protected String summarizeAgentInstance(final Record<?> record) {
     final var value = (AgentInstanceRecordValue) record.getValue();
     final var result = new StringBuilder();
 
     result.append(shortenKey(value.getAgentInstanceKey()));
+    result.append(" def:").append(shortenKey(value.getAgentDefinitionKey()));
     result.append(summarizeElementInformation(value.getElementId(), value.getElementInstanceKey()));
     result.append(
         summarizeProcessInformation(

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/CompactRecordLoggerTest.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/CompactRecordLoggerTest.java
@@ -14,11 +14,14 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.value.AgentDefinitionType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentDefinitionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryEmbeddedToolCallValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryMessageContentValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryMetricsValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentInstanceDefinitionValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableDocumentReferenceMetadataValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableDocumentReferenceValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
@@ -203,6 +206,40 @@ class CompactRecordLoggerTest {
       // then
       assertThat(result)
           .isEqualTo("K1 AI_AGENT_TASK @\"Activity_1\" of <process \"orderProcess\"[K2] v3>");
+    }
+
+    @Test
+    void shouldSummarizeAgentInstanceRecord() {
+      // given
+      final var logger = new CompactRecordLogger(List.of());
+      final var record =
+          ImmutableRecord.builder()
+              .withValueType(ValueType.AGENT_INSTANCE)
+              .withValue(
+                  ImmutableAgentInstanceRecordValue.builder()
+                      .withAgentInstanceKey(1L)
+                      .withAgentDefinitionKey(4L)
+                      .withElementId("Activity_1")
+                      .withElementInstanceKey(3L)
+                      .withProcessDefinitionKey(2L)
+                      .withProcessInstanceKey(5L)
+                      .withStatus(AgentInstanceStatus.TOOL_CALLING)
+                      .withDefinition(
+                          ImmutableAgentInstanceDefinitionValue.builder()
+                              .withModel("gpt-4o")
+                              .withProvider("openai")
+                              .build())
+                      .withChangedAttributes(List.of("status", "metrics"))
+                      .build())
+              .build();
+
+      // when
+      final String result = logger.summarizeAgentInstance(record);
+
+      // then
+      assertThat(result)
+          .isEqualTo(
+              "K1 def:K4 @\"Activity_1\"[K3] in <process K2[K5]> model:gpt-4o/openai status:TOOL_CALLING changed:[s, m]");
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR implements the instance-to-definition linkage for the agent engine, closing two related tasks:

### 1. Stamp `agentDefinitionKey` on `AgentInstance:CREATED` (closes #59090)

`AgentInstanceRecord` now carries an `agentDefinitionKey` field. When an `AgentInstance:CREATE` command is processed, `AgentInstanceCreateProcessor` resolves the key via `AgentDefinitionState#getAgentDefinitionKey(processDefinitionKey, elementId)` — a dedicated RocksDB column-family lookup populated at deploy time by the `AgentDefinition:CREATED` applier. The resolved key is then stamped on the `CREATED` event, connecting every agent instance back to the agent definition that governs it.

### 2. Reject creation when the element has no agent definition (closes #59278)

A new validation step in `AgentInstanceCreateProcessor` rejects `AgentInstance:CREATE` with `INVALID_ARGUMENT` when the target element has no entry in `AgentDefinitionState` (i.e. was not marked with `zeebe:agentDefinition` at deploy time). This enforces the invariant that every `AgentInstance` resolves to a real `AgentDefinition`, preventing broken links in the queryable registry and REST/search results.

### Changes

- **`AgentInstanceRecord`** — new `agentDefinitionKey` long field (default `-1`); getter/setter added to `AgentInstanceRecordValue` interface and protocol-impl.
- **`AgentInstanceCreateProcessor`** — resolves `agentDefinitionKey` from `AgentDefinitionState` after the element-type check; rejects with `INVALID_ARGUMENT` if absent; sets the key on the `CREATED` event.
- **Elasticsearch/OpenSearch templates** — `agentDefinitionKey` mapped as `long`.
- **Engine tests** — all existing agent-instance tests updated to mark their target element with `.zeebeAiAgentTaskDefinition()` / `.zeebeAiAgentSubProcessDefinition()`; two new tests added to `AgentInstanceCreateTest` covering the happy path (key correctly stamped) and the rejection path (no agent definition).

## Checklist

- [ ] Enable backports when necessary.
- [ ] If this PR modifies the C8 Orchestration Cluster E2E Test Suite, the relevant tests have been run via the on-demand workflow before requesting review.

## Related issues

closes #59090
closes #59278