### PR TITLE
docs: mark OpenSearch's LTS minor so it isn't dropped early

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -3,6 +3,9 @@
 # Single source of truth for all database versions tested in CI and deployed to SaaS.
 # Versions are specified as Docker image tags. Earlier versions *must* be listed before
 # later versions so that the last entry in each list resolves to the newest supported minor.
+# A version with a trailing `# LTS` comment has materially longer upstream support than
+# its neighbors — don't remove it from its list until it's actually out of support, even
+# once newer minors exist above it.
 #
 # ── How to use this file in CI workflows ────────────────────────────────────────
 #   CI workflows read versions from this file via the reusable action:
@@ -28,7 +31,7 @@ opensearch:
     - '2.19.6'
   os3:
     - "3.5.0"
-    - "3.6.0"
+    - "3.6.0"  # LTS (min. 18mo support) - don't remove before EOL: https://opensearch.org/blog/bridging-the-gap-recapping-the-launch-of-opensearch-long-term-support-lts/
     - "3.7.0"
     - "3.8.0"
 

--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -3,9 +3,7 @@
 # Single source of truth for all database versions tested in CI and deployed to SaaS.
 # Versions are specified as Docker image tags. Earlier versions *must* be listed before
 # later versions so that the last entry in each list resolves to the newest supported minor.
-# A version with a trailing `# LTS` comment has materially longer upstream support than
-# its neighbors — don't remove it from its list until it's actually out of support, even
-# once newer minors exist above it.
+# A trailing `# LTS` comment flags longer upstream support — don't remove that entry early.
 #
 # ── How to use this file in CI workflows ────────────────────────────────────────
 #   CI workflows read versions from this file via the reusable action:
@@ -31,7 +29,7 @@ opensearch:
     - '2.19.6'
   os3:
     - "3.5.0"
-    - "3.6.0"  # LTS (min. 18mo support) - don't remove before EOL: https://opensearch.org/blog/bridging-the-gap-recapping-the-launch-of-opensearch-long-term-support-lts/
+    - "3.6.0"  # LTS - don't remove before EOL: https://opensearch.org/blog/bridging-the-gap-recapping-the-launch-of-opensearch-long-term-support-lts/
     - "3.7.0"
     - "3.8.0"
 

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -261,7 +261,7 @@ outputs:
         steps.filter-load-test-setup.outputs.load-test-setup-change == 'true'
       }}
   scripts-changes:
-    description: Output whether any file under .github/scripts/ changed, so its Python unit tests should be run
+    description: Output whether any file under .github/scripts/ or .ci/db-versions.yml changed, so their Python unit tests should be run
     value: >-
       ${{
         github.event_name == 'push' ||
@@ -510,6 +510,7 @@ runs:
       filters: |
         scripts-change:
           - '.github/scripts/**'
+          - '.ci/db-versions.yml'
 
   # only works `on: push` and `on: pull_request` GitHub trigger events
   - id: filter-special-branch

--- a/.github/actions/read-db-versions/README.md
+++ b/.github/actions/read-db-versions/README.md
@@ -55,10 +55,8 @@ Edit `.ci/db-versions.yml`. The YAML anchor on the SaaS entry (`&saas`) ensures
 `saas` always references a version that is also present in the `es8` test list —
 update the anchor value when promoting SaaS to a new minor.
 
-A version with a trailing `# LTS` comment has materially longer upstream
-support than its neighbors — this is a human-readable note only (no tooling
-reads it); don't remove that entry from the list until it's actually out of
-support.
+A trailing `# LTS` comment flags longer upstream support (human-readable only,
+no tooling reads it) — don't remove that entry early.
 
 ## Owner
 

--- a/.github/actions/read-db-versions/README.md
+++ b/.github/actions/read-db-versions/README.md
@@ -55,6 +55,11 @@ Edit `.ci/db-versions.yml`. The YAML anchor on the SaaS entry (`&saas`) ensures
 `saas` always references a version that is also present in the `es8` test list —
 update the anchor value when promoting SaaS to a new minor.
 
+A version with a trailing `# LTS` comment has materially longer upstream
+support than its neighbors — this is a human-readable note only (no tooling
+reads it); don't remove that entry from the list until it's actually out of
+support.
+
 ## Owner
 
 @camunda/data-layer

--- a/.github/actions/read-db-versions/generate-db-versions.py
+++ b/.github/actions/read-db-versions/generate-db-versions.py
@@ -8,6 +8,8 @@ Run manually for testing:
 """
 
 import json
+import sys
+
 import yaml
 
 
@@ -15,28 +17,6 @@ def set_output(name, value):
     print(f"{name}={value}")
 
 
-with open(".ci/db-versions.yml") as f:
-    versions = yaml.safe_load(f)
-
-# ── Search database versions ──────────────────────────────────────────────────
-es8_versions = versions["elasticsearch"]["es8"]
-es9_versions = versions["elasticsearch"]["es9"]
-os2_versions = versions["opensearch"]["os2"]
-os3_versions = versions["opensearch"]["os3"]
-
-# Single-version outputs: last entry = newest supported minor version.
-set_output("elasticsearch-8", es8_versions[-1])
-set_output("elasticsearch-9", es9_versions[-1])
-set_output("opensearch-2",    os2_versions[-1])
-set_output("opensearch-3",    os3_versions[-1])
-set_output("saas",            versions["elasticsearch"]["saas"])
-
-
-# ── ES/OS matrix (zeebe-search-integration-tests.yml) ────────────────────────
-# Min and max version to test for each major series — oldest supported minor to
-# catch regressions, newest to validate against the latest release. Intermediate
-# versions are skipped to keep CI costs proportional to supported minors.
-# database-type encodes both the DB family and the version for test filtering.
 def version_slug(v):
     return v.replace(".", "_").replace("-", "_")
 
@@ -46,153 +26,179 @@ def min_max(versions):
     return list(dict.fromkeys([versions[0], versions[-1]]))
 
 
-es_os_matrix = {"include": []}
+def main():
+    with open(".ci/db-versions.yml") as f:
+        versions = yaml.safe_load(f)
 
-for v in min_max(es8_versions):
-    es_os_matrix["include"].append({
-        "database-name":          f"Elasticsearch {v}",
-        "database-type":          f"elasticsearch8_{version_slug(v)}",
-        "database-container":     "elasticsearch",
-        "database-image-version": v,
-        "it-database-type":       "es",
-    })
+    # ── Search database versions ──────────────────────────────────────────────
+    es8_versions = versions["elasticsearch"]["es8"]
+    es9_versions = versions["elasticsearch"]["es9"]
+    os2_versions = versions["opensearch"]["os2"]
+    os3_versions = versions["opensearch"]["os3"]
 
-for v in min_max(es9_versions):
-    es_os_matrix["include"].append({
-        "database-name":          f"Elasticsearch {v}",
-        "database-type":          f"elasticsearch9_{version_slug(v)}",
-        "database-container":     "elasticsearch",
-        "database-image-version": v,
-        "it-database-type":       "es",
-    })
+    # Single-version outputs: last entry = newest supported minor version.
+    set_output("elasticsearch-8", es8_versions[-1])
+    set_output("elasticsearch-9", es9_versions[-1])
+    set_output("opensearch-2",    os2_versions[-1])
+    set_output("opensearch-3",    os3_versions[-1])
+    set_output("saas",            versions["elasticsearch"]["saas"])
 
-for v in min_max(os2_versions):
-    es_os_matrix["include"].append({
-        "database-name":          f"OpenSearch {v}",
-        "database-type":          f"opensearch2_{version_slug(v)}",
-        "database-container":     "opensearch",
-        "database-image-version": v,
-        "it-database-type":       "os",
-    })
+    # ── ES/OS matrix (zeebe-search-integration-tests.yml) ──────────────────────
+    # Min and max version to test for each major series — oldest supported minor to
+    # catch regressions, newest to validate against the latest release. Intermediate
+    # versions are skipped to keep CI costs proportional to supported minors.
+    # database-type encodes both the DB family and the version for test filtering.
+    es_os_matrix = {"include": []}
 
-for v in min_max(os3_versions):
-    es_os_matrix["include"].append({
-        "database-name":          f"OpenSearch {v}",
-        "database-type":          f"opensearch3_{version_slug(v)}",
-        "database-container":     "opensearch",
-        "database-image-version": v,
-        "it-database-type":       "os",
-    })
+    for v in min_max(es8_versions):
+        es_os_matrix["include"].append({
+            "database-name":          f"Elasticsearch {v}",
+            "database-type":          f"elasticsearch8_{version_slug(v)}",
+            "database-container":     "elasticsearch",
+            "database-image-version": v,
+            "it-database-type":       "es",
+        })
 
-set_output("es-os-matrix", json.dumps(es_os_matrix))
+    for v in min_max(es9_versions):
+        es_os_matrix["include"].append({
+            "database-name":          f"Elasticsearch {v}",
+            "database-type":          f"elasticsearch9_{version_slug(v)}",
+            "database-container":     "elasticsearch",
+            "database-image-version": v,
+            "it-database-type":       "es",
+        })
 
-# ── CI database integration test matrix (ci.yml) ─────────────────────────────
-# One entry per major series using the latest supported minor, plus a static
-# H2 entry. H2 is an embedded database with no Docker image version to track.
-ci_db_matrix = {"include": [
-    {
-        "name":                   "Elasticsearch 8",
-        "database-type":          "elasticsearch",
-        "database-image-version": es8_versions[-1],
-        "database-name":          "Elasticsearch 8",
-        "it-database-type":       "es",
-    },
-    {
-        "name":                   "Elasticsearch 9",
-        "database-type":          "elasticsearch9",
-        "database-container":     "elasticsearch",
-        "database-image-version": es9_versions[-1],
-        "database-name":          "Elasticsearch 9",
-        "it-database-type":       "es",
-    },
-    {
-        "name":                   "Opensearch 2",
-        "database-type":          "opensearch2",
-        "database-container":     "opensearch",
-        "database-image-version": os2_versions[-1],
-        "database-name":          "OpenSearch 2",
-        "it-database-type":       "os",
-    },
-    {
-        "name":                   "Opensearch 3",
-        "database-type":          "opensearch3",
-        "database-container":     "opensearch",
-        "database-image-version": os3_versions[-1],
-        "database-name":          "OpenSearch 3",
-        "it-database-type":       "os",
-    },
-    {
-        "name":             "RDBMS H2",
-        "database-type":    "h2",
-        "database-name":    "H2",
-        "it-database-type": "rdbms_h2",
-    },
-]}
+    for v in min_max(os2_versions):
+        es_os_matrix["include"].append({
+            "database-name":          f"OpenSearch {v}",
+            "database-type":          f"opensearch2_{version_slug(v)}",
+            "database-container":     "opensearch",
+            "database-image-version": v,
+            "it-database-type":       "os",
+        })
 
-set_output("ci-database-matrix", json.dumps(ci_db_matrix))
+    for v in min_max(os3_versions):
+        es_os_matrix["include"].append({
+            "database-name":          f"OpenSearch {v}",
+            "database-type":          f"opensearch3_{version_slug(v)}",
+            "database-container":     "opensearch",
+            "database-image-version": v,
+            "it-database-type":       "os",
+        })
 
-# ── RDBMS matrix (zeebe-rdbms-integration-tests.yml) ─────────────────────────
-# Maps the first segment of an Oracle image tag to its display name and
-# database-type. Oracle versions use non-numeric suffixes (21c, 26ai) that
-# cannot be derived mechanically from the version number alone.
-oracle_meta = {
-    # 23.x family is branded "Oracle 26ai" since RU 23.26 (Oct 2025).
-    "23": {"name": "Oracle 26ai", "type": "oracle"},
-    "21": {"name": "Oracle 21c",  "type": "oracle-21"},
-}
+    set_output("es-os-matrix", json.dumps(es_os_matrix))
 
-rdbms_matrix = {"include": []}
+    # ── CI database integration test matrix (ci.yml) ───────────────────────────
+    # One entry per major series using the latest supported minor, plus a static
+    # H2 entry. H2 is an embedded database with no Docker image version to track.
+    ci_db_matrix = {"include": [
+        {
+            "name":                   "Elasticsearch 8",
+            "database-type":          "elasticsearch",
+            "database-image-version": es8_versions[-1],
+            "database-name":          "Elasticsearch 8",
+            "it-database-type":       "es",
+        },
+        {
+            "name":                   "Elasticsearch 9",
+            "database-type":          "elasticsearch9",
+            "database-container":     "elasticsearch",
+            "database-image-version": es9_versions[-1],
+            "database-name":          "Elasticsearch 9",
+            "it-database-type":       "es",
+        },
+        {
+            "name":                   "Opensearch 2",
+            "database-type":          "opensearch2",
+            "database-container":     "opensearch",
+            "database-image-version": os2_versions[-1],
+            "database-name":          "OpenSearch 2",
+            "it-database-type":       "os",
+        },
+        {
+            "name":                   "Opensearch 3",
+            "database-type":          "opensearch3",
+            "database-container":     "opensearch",
+            "database-image-version": os3_versions[-1],
+            "database-name":          "OpenSearch 3",
+            "it-database-type":       "os",
+        },
+        {
+            "name":             "RDBMS H2",
+            "database-type":    "h2",
+            "database-name":    "H2",
+            "it-database-type": "rdbms_h2",
+        },
+    ]}
 
-for v in versions["postgresql"]:
-    major = v.split("-")[0]
-    rdbms_matrix["include"].append({
-        "database-name":          f"Postgres {major}",
-        "database-type":          "postgres",
-        "database-image-version": v,
-        "it-database-type":       "rdbms_postgres",
-    })
+    set_output("ci-database-matrix", json.dumps(ci_db_matrix))
 
-for v in versions["mysql"]:
-    rdbms_matrix["include"].append({
-        "database-name":          f"MySQL {v}",
-        "database-type":          "mysql",
-        "database-image-version": v,
-        "it-database-type":       "rdbms_mysql",
-    })
+    # ── RDBMS matrix (zeebe-rdbms-integration-tests.yml) ───────────────────────
+    # Maps the first segment of an Oracle image tag to its display name and
+    # database-type. Oracle versions use non-numeric suffixes (21c, 26ai) that
+    # cannot be derived mechanically from the version number alone.
+    oracle_meta = {
+        # 23.x family is branded "Oracle 26ai" since RU 23.26 (Oct 2025).
+        "23": {"name": "Oracle 26ai", "type": "oracle"},
+        "21": {"name": "Oracle 21c",  "type": "oracle-21"},
+    }
 
-for v in versions["mariadb"]:
-    rdbms_matrix["include"].append({
-        "database-name":          f"MariaDB {v}",
-        "database-type":          "mariadb",
-        "database-image-version": v,
-        "it-database-type":       "rdbms_mariadb",
-    })
+    rdbms_matrix = {"include": []}
 
-for v in versions["mssql"]:
-    year = v.split("-")[0]
-    rdbms_matrix["include"].append({
-        "database-name":          f"MSSQL {year}",
-        "database-type":          "mssql",
-        "database-image-version": v,
-        "it-database-type":       "rdbms_mssql",
-    })
+    for v in versions["postgresql"]:
+        major = v.split("-")[0]
+        rdbms_matrix["include"].append({
+            "database-name":          f"Postgres {major}",
+            "database-type":          "postgres",
+            "database-image-version": v,
+            "it-database-type":       "rdbms_postgres",
+        })
 
-for v in versions["azure-sql"]:
-    rdbms_matrix["include"].append({
-        "database-name":          f"Azure SQL {v}",
-        "database-type":          "azure-sql",
-        "database-image-version": v,
-        "it-database-type":       "rdbms_mssql",
-    })
+    for v in versions["mysql"]:
+        rdbms_matrix["include"].append({
+            "database-name":          f"MySQL {v}",
+            "database-type":          "mysql",
+            "database-image-version": v,
+            "it-database-type":       "rdbms_mysql",
+        })
 
-for v in versions["oracle"]:
-    major = v.split(".")[0].split("-")[0]  # "23.26.1-slim-faststart" -> "23"; "21-slim-faststart" -> "21"
-    meta  = oracle_meta.get(major, {"name": f"Oracle {major}", "type": "oracle"})
-    rdbms_matrix["include"].append({
-        "database-name":          meta["name"],
-        "database-type":          meta["type"],
-        "database-image-version": v,
-        "it-database-type":       "rdbms_oracle",
-    })
+    for v in versions["mariadb"]:
+        rdbms_matrix["include"].append({
+            "database-name":          f"MariaDB {v}",
+            "database-type":          "mariadb",
+            "database-image-version": v,
+            "it-database-type":       "rdbms_mariadb",
+        })
 
-set_output("rdbms-matrix", json.dumps(rdbms_matrix))
+    for v in versions["mssql"]:
+        year = v.split("-")[0]
+        rdbms_matrix["include"].append({
+            "database-name":          f"MSSQL {year}",
+            "database-type":          "mssql",
+            "database-image-version": v,
+            "it-database-type":       "rdbms_mssql",
+        })
+
+    for v in versions["azure-sql"]:
+        rdbms_matrix["include"].append({
+            "database-name":          f"Azure SQL {v}",
+            "database-type":          "azure-sql",
+            "database-image-version": v,
+            "it-database-type":       "rdbms_mssql",
+        })
+
+    for v in versions["oracle"]:
+        major = v.split(".")[0].split("-")[0]  # "23.26.1-slim-faststart" -> "23"; "21-slim-faststart" -> "21"
+        meta  = oracle_meta.get(major, {"name": f"Oracle {major}", "type": "oracle"})
+        rdbms_matrix["include"].append({
+            "database-name":          meta["name"],
+            "database-type":          meta["type"],
+            "database-image-version": v,
+            "it-database-type":       "rdbms_oracle",
+        })
+
+    set_output("rdbms-matrix", json.dumps(rdbms_matrix))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/actions/read-db-versions/test_generate_db_versions.py
+++ b/.github/actions/read-db-versions/test_generate_db_versions.py
@@ -1,0 +1,125 @@
+"""Unit tests for generate-db-versions.py.
+
+Run with:
+    python3 -m unittest .github/actions/read-db-versions/test_generate_db_versions.py
+"""
+
+import importlib.util
+import io
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+# The module file name contains hyphens, so load it explicitly.
+_SPEC = importlib.util.spec_from_file_location(
+    "generate_db_versions", Path(__file__).with_name("generate-db-versions.py")
+)
+gen = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(gen)
+
+FIXTURE_DB_VERSIONS_YML = """
+elasticsearch:
+  es8:
+    - "8.19.16"
+  es9:
+    - "9.4.0"
+  saas: "8.19.16"
+
+opensearch:
+  os2:
+    - "2.19.6"
+  os3:
+    - "3.5.0"
+    - "3.6.0"
+    - "3.7.0"
+
+postgresql:
+  - "17-alpine"
+
+mysql:
+  - "8.4"
+
+mariadb:
+  - "11.8"
+
+mssql:
+  - "2022-latest"
+
+azure-sql:
+  - "1.0.7"
+
+oracle:
+  - "23.26.1-slim-faststart"
+"""
+
+
+class TestMinMax(unittest.TestCase):
+    def test_single_entry_list_returns_one_item(self):
+        self.assertEqual(gen.min_max(["8.19.16"]), ["8.19.16"])
+
+    def test_multi_entry_list_returns_first_and_last(self):
+        self.assertEqual(gen.min_max(["3.5.0", "3.6.0", "3.7.0"]), ["3.5.0", "3.7.0"])
+
+
+class TestVersionSlug(unittest.TestCase):
+    def test_replaces_dots_and_dashes(self):
+        self.assertEqual(gen.version_slug("3.7.0"), "3_7_0")
+        self.assertEqual(gen.version_slug("15-alpine"), "15_alpine")
+
+
+class TestMainEndToEnd(unittest.TestCase):
+    """Runs the real main() against a fixture db-versions.yml and checks the
+    printed GITHUB_OUTPUT lines parse as the expected JSON matrix shapes."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        ci_dir = Path(self._tmpdir.name) / ".ci"
+        ci_dir.mkdir()
+        (ci_dir / "db-versions.yml").write_text(FIXTURE_DB_VERSIONS_YML)
+        self._original_cwd = os.getcwd()
+        os.chdir(self._tmpdir.name)
+
+    def tearDown(self):
+        os.chdir(self._original_cwd)
+        self._tmpdir.cleanup()
+
+    def _run_main(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            gen.main()
+        outputs = {}
+        for line in buf.getvalue().splitlines():
+            name, _, value = line.partition("=")
+            outputs[name] = value
+        return outputs
+
+    def test_single_version_outputs(self):
+        outputs = self._run_main()
+        self.assertEqual(outputs["elasticsearch-8"], "8.19.16")
+        self.assertEqual(outputs["opensearch-3"], "3.7.0")
+        self.assertEqual(outputs["saas"], "8.19.16")
+
+    def test_es_os_matrix_covers_min_and_max_only(self):
+        outputs = self._run_main()
+        matrix = json.loads(outputs["es-os-matrix"])
+        os3_entries = [
+            e for e in matrix["include"] if e["database-type"].startswith("opensearch3_")
+        ]
+        self.assertEqual(
+            [e["database-image-version"] for e in os3_entries], ["3.5.0", "3.7.0"]
+        )
+
+    def test_rdbms_matrix_includes_every_configured_engine(self):
+        outputs = self._run_main()
+        matrix = json.loads(outputs["rdbms-matrix"])
+        database_types = {e["database-type"] for e in matrix["include"]}
+        self.assertEqual(
+            database_types, {"postgres", "mysql", "mariadb", "mssql", "azure-sql", "oracle"}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2517,7 +2517,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1
       - name: Install test dependencies
-        run: pip install --quiet pytest pyyaml
+        run: python3 -m pip install --quiet pytest -r .github/actions/read-db-versions/requirements.txt
       - name: Run unit tests
         run: pytest --verbose --color=yes --tb=short .github/scripts .github/actions/adjust-pom-for-license-analysis .github/actions/read-db-versions
       - name: Observe build status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2516,10 +2516,10 @@ jobs:
       - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1
-      - name: Install pytest
-        run: pip install --quiet pytest
+      - name: Install test dependencies
+        run: pip install --quiet pytest pyyaml
       - name: Run unit tests
-        run: pytest --verbose --color=yes --tb=short .github/scripts .github/actions/adjust-pom-for-license-analysis
+        run: pytest --verbose --color=yes --tb=short .github/scripts .github/actions/adjust-pom-for-license-analysis .github/actions/read-db-versions
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
OpenSearch 3.6 is upstream's first LTS release for the 3.x major (18mo min support). db-versions.yml gives it no special treatment, so it's just as droppable as 3.5 or 3.7 once newer minors land.

Adds a trailing `# LTS` comment on `3.6.0`, linking to upstream's LTS post. RDBMS entries in the same file don't need this: they're all either already LTS (MySQL 8.4/9.7, all four MariaDB entries, Oracle's 26ai entry) or have no LTS split at all (Postgres, MSSQL).

Also wraps generate-db-versions.py's execution in main() so it's unit-testable, adds test_generate_db_versions.py, and extends paths-filter to catch db-versions.yml-only changes.

Closes #59600
