### PR TITLE
ci: drop OpenSearch 3.5 from test matrix

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -28,7 +28,6 @@ opensearch:
     # renovate: datasource=docker depName=opensearchproject/opensearch
     - '2.19.6'
   os3:
-    - "3.5.0"
     - "3.6.0"  # LTS - don't remove before EOL: https://opensearch.org/blog/bridging-the-gap-recapping-the-launch-of-opensearch-long-term-support-lts/
     - "3.7.0"
     - "3.8.0"


### PR DESCRIPTION
AWS-Managed OpenSearch Service advanced to engine version 3.7 (2026-07-30). Camunda's support window for OpenSearch tracks the AWS-Managed service, testing the latest 1-2 releases available there. With AWS-Managed now at 3.7, OpenSearch 3.5 fell out of that window.

This drops the `3.5.0` entry from `.ci/db-versions.yml`'s `os3` list, leaving 3.6.0 as the new minimum. The matrix generator (`generate-db-versions.py`) derives min/max from the list automatically, so no other CI configuration needs to change.

Closes #59422.