### PR TITLE
Add OpenAPI spec for AgentDefinition get and search endpoints

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-definitions.yaml
@@ -1,0 +1,197 @@
+## Schema definitions
+
+components:
+  schemas:
+    AgentDefinitionSearchQuerySortRequest:
+      type: object
+      required:
+        - field
+      properties:
+        field:
+          description: The field to sort by.
+          type: string
+          enum:
+            - agentDefinitionKey
+            - agentType
+            - name
+            - elementId
+            - processDefinitionId
+            - processDefinitionKey
+            - processDefinitionVersion
+            - processDefinitionVersionTag
+            - tenantId
+        order:
+          $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'
+
+    AgentDefinitionSearchQuery:
+      description: Agent definition search request.
+      type: object
+      additionalProperties: false
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryRequest'
+      properties:
+        sort:
+          description: Sort field criteria.
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentDefinitionSearchQuerySortRequest'
+        filter:
+          description: The agent definition search filters.
+          allOf:
+            - $ref: '#/components/schemas/AgentDefinitionFilter'
+
+    AgentDefinitionFilter:
+      description: Agent definition search filter.
+      type: object
+      properties:
+        agentDefinitionKey:
+          description: The unique key of the agent definition.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/AgentDefinitionKeyFilterProperty'
+        agentType:
+          description: The kind of agent this definition describes.
+          allOf:
+            - $ref: '#/components/schemas/AgentDefinitionTypeFilterProperty'
+        name:
+          description: The human-readable name of the process element that owns the agent.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+        elementId:
+          description: The BPMN element ID of the process element that owns the agent.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/ElementIdFilterProperty'
+        processDefinitionId:
+          description: The BPMN process ID of the process definition that owns the agent.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionIdFilterProperty'
+        processDefinitionKey:
+          description: The key of the process definition that owns the agent.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKeyFilterProperty'
+        processDefinitionVersion:
+          description: The version of the process definition that owns the agent.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/IntegerFilterProperty'
+        processDefinitionVersionTag:
+          description: The version tag of the process definition that owns the agent.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+        tenantId:
+          description: The tenant ID of the agent definition.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+
+    AgentDefinitionSearchQueryResult:
+      description: Agent definition search response.
+      type: object
+      required:
+        - items
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching agent definitions.
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentDefinitionResult'
+
+    AgentDefinitionResult:
+      description: An agent definition, minted at deploy time for a process element that owns an agent.
+      type: object
+      required:
+        - agentDefinitionKey
+        - agentType
+        - name
+        - elementId
+        - processDefinitionId
+        - processDefinitionKey
+        - processDefinitionVersion
+        - processDefinitionVersionTag
+        - tenantId
+      properties:
+        agentDefinitionKey:
+          description: The unique key for this agent definition.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/AgentDefinitionKey'
+        agentType:
+          $ref: '#/components/schemas/AgentDefinitionTypeEnum'
+        name:
+          description: |
+            The human-readable name of the process element that owns the agent. Falls back to
+            elementId when the element has no BPMN name configured.
+          type: string
+        elementId:
+          description: The BPMN element ID of the process element that owns the agent.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/ElementId'
+        processDefinitionId:
+          description: The BPMN process ID of the process definition that owns the agent.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
+        processDefinitionKey:
+          description: The key of the process definition that owns the agent.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
+        processDefinitionVersion:
+          type: integer
+          format: int32
+          description: The version of the process definition that owns the agent.
+        processDefinitionVersionTag:
+          type: string
+          nullable: true
+          description: The version tag of the process definition that owns the agent.
+        tenantId:
+          description: The tenant ID of this agent definition.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/TenantId'
+
+    ## Enums
+
+    AgentDefinitionTypeEnum:
+      description: The kind of agent an agent definition describes.
+      type: string
+      enum:
+        - AI_AGENT_SUB_PROCESS
+        - AI_AGENT_TASK
+        - EXTERNAL_AGENT
+
+    ## Filters
+
+    AgentDefinitionTypeFilterProperty:
+      description: AgentDefinitionTypeEnum property with full advanced search capabilities.
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: '#/components/schemas/AgentDefinitionTypeEnum'
+        - $ref: '#/components/schemas/AdvancedAgentDefinitionTypeFilter'
+
+    AdvancedAgentDefinitionTypeFilter:
+      title: Advanced filter
+      description: Advanced AgentDefinitionTypeEnum filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/AgentDefinitionTypeEnum'
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/AgentDefinitionTypeEnum'
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentDefinitionTypeEnum'
+        $notIn:
+          description: Checks if the property matches none of the provided values.
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentDefinitionTypeEnum'
+        $like:
+          $ref: 'filters.yaml#/components/schemas/LikeFilter'

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-definitions.yaml
@@ -1,7 +1,7 @@
 ## Endpoint definitions
 
 paths:
-  /agents/search:
+  /agent-definitions/search:
     post:
       x-eventually-consistent: true
       tags:
@@ -38,7 +38,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
 
-  /agents/{agentDefinitionKey}:
+  /agent-definitions/{agentDefinitionKey}:
     get:
       x-eventually-consistent: true
       tags:

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-definitions.yaml
@@ -1,3 +1,88 @@
+## Endpoint definitions
+
+paths:
+  /agents/search:
+    post:
+      x-eventually-consistent: true
+      tags:
+        - Agent definition
+      operationId: searchAgentDefinitions
+      x-permission-enforcement: filter
+      x-required-permissions:
+        - { resourceType: PROCESS_DEFINITION, permissionType: READ_PROCESS_DEFINITION }
+      security:
+        - bearerAuth: []
+        - basicAuth: []
+      summary: Search agent definitions
+      description: Search for agent definitions based on given criteria.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentDefinitionSearchQuery'
+      responses:
+        "200":
+          description: The agent definition search result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentDefinitionSearchQueryResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.10"
+
+  /agents/{agentDefinitionKey}:
+    get:
+      x-eventually-consistent: true
+      tags:
+        - Agent definition
+      operationId: getAgentDefinition
+      x-required-permissions:
+        - { resourceType: PROCESS_DEFINITION, permissionType: READ_PROCESS_DEFINITION }
+      security:
+        - bearerAuth: []
+        - basicAuth: []
+      summary: Get agent definition
+      description: Returns an agent definition by key.
+      parameters:
+        - name: agentDefinitionKey
+          in: path
+          required: true
+          description: The assigned key of the agent definition, which acts as a unique identifier for this agent definition.
+          schema:
+            $ref: 'keys.yaml#/components/schemas/AgentDefinitionKey'
+      responses:
+        "200":
+          description: The agent definition is successfully returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentDefinitionResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "404":
+          description: >
+            The agent definition with the given key was not found.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.10"
+
 ## Schema definitions
 
 components:

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-definitions.yaml
@@ -134,31 +134,31 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/AgentDefinitionKeyFilterProperty'
         agentType:
-          description: The kind of agent this definition describes.
+          description: The kind of agent this agent definition describes.
           allOf:
             - $ref: '#/components/schemas/AgentDefinitionTypeFilterProperty'
         name:
-          description: The human-readable name of the process element that owns the agent.
+          description: The human-readable name of the process element that owns the agent definition.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
         elementId:
-          description: The BPMN element ID of the process element that owns the agent.
+          description: The BPMN element ID of the process element that owns the agent definition.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ElementIdFilterProperty'
         processDefinitionId:
-          description: The BPMN process ID of the process definition that owns the agent.
+          description: The BPMN process ID of the process definition that owns the agent definition.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionIdFilterProperty'
         processDefinitionKey:
-          description: The key of the process definition that owns the agent.
+          description: The key of the process definition that owns the agent definition.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKeyFilterProperty'
         processDefinitionVersion:
-          description: The version of the process definition that owns the agent.
+          description: The version of the process definition that owns the agent definition.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/IntegerFilterProperty'
         processDefinitionVersionTag:
-          description: The version tag of the process definition that owns the agent.
+          description: The version tag of the process definition that owns the agent definition.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
         tenantId:
@@ -181,7 +181,7 @@ components:
             $ref: '#/components/schemas/AgentDefinitionResult'
 
     AgentDefinitionResult:
-      description: An agent definition, minted at deploy time for a process element that owns an agent.
+      description: An agent definition, created at deploy time for the process element it belongs to.
       type: object
       required:
         - agentDefinitionKey
@@ -195,36 +195,37 @@ components:
         - tenantId
       properties:
         agentDefinitionKey:
-          description: The unique key for this agent definition.
+          description: |
+            The unique key for this agent definition. Unique across process definition versions.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/AgentDefinitionKey'
         agentType:
           $ref: '#/components/schemas/AgentDefinitionTypeEnum'
         name:
           description: |
-            The human-readable name of the process element that owns the agent. Falls back to
-            elementId when the element has no BPMN name configured.
+            The human-readable name of the process element that owns the agent definition. Falls
+            back to elementId when the element has no BPMN name configured.
           type: string
         elementId:
-          description: The BPMN element ID of the process element that owns the agent.
+          description: The BPMN element ID of the process element that owns the agent definition.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ElementId'
         processDefinitionId:
-          description: The BPMN process ID of the process definition that owns the agent.
+          description: The BPMN process ID of the process definition that owns the agent definition.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
         processDefinitionKey:
-          description: The key of the process definition that owns the agent.
+          description: The key of the process definition that owns the agent definition.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
         processDefinitionVersion:
           type: integer
           format: int32
-          description: The version of the process definition that owns the agent.
+          description: The version of the process definition that owns the agent definition.
         processDefinitionVersionTag:
           type: string
           nullable: true
-          description: The version tag of the process definition that owns the agent.
+          description: The version tag of the process definition that owns the agent definition.
         tenantId:
           description: The tenant ID of this agent definition.
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
@@ -155,6 +155,15 @@ components:
       format: int64
       minimum: 1
 
+    AgentDefinitionKey:
+      description: System-generated key for an agent definition.
+      format: AgentDefinitionKey
+      x-semantic-type: AgentDefinitionKey
+      example: "2251799813691958"
+      type: string
+      allOf:
+        - $ref: '#/components/schemas/LongKey'
+
     AgentInstanceKey:
       description: System-generated key for an agent instance.
       format: AgentInstanceKey
@@ -548,6 +557,43 @@ components:
           addedInVersion: "8.9"
         - propertyName: "$notIn"
           addedInVersion: "8.9"
+
+    AgentDefinitionKeyFilterProperty:
+      description: AgentDefinitionKey property with full advanced search capabilities.
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: "#/components/schemas/AgentDefinitionKey"
+        - $ref: '#/components/schemas/AdvancedAgentDefinitionKeyFilter'
+
+    AdvancedAgentDefinitionKeyFilter:
+      title: Advanced filter
+      description: Advanced AgentDefinitionKey filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/AgentDefinitionKey"
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/AgentDefinitionKey"
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentDefinitionKey"
+        $notIn:
+          description: Checks if the property matches none of the provided values.
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentDefinitionKey"
 
     AgentInstanceKeyFilterProperty:
       description: AgentInstanceKey property with full advanced search capabilities.

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -42,6 +42,7 @@ servers:
         description: The schema of the Orchestration Cluster REST API server.
 tags:
   - name: Ad-hoc sub-process
+  - name: Agent definition
   - name: Agent instance
   - name: Audit Log
   - name: Authentication
@@ -84,6 +85,12 @@ tags:
   - name: Variable
 
 paths:
+  # Agent definition endpoints
+  /agents/{agentDefinitionKey}:
+    $ref: 'agent-definitions.yaml#/paths/~1agents~1{agentDefinitionKey}'
+  /agents/search:
+    $ref: 'agent-definitions.yaml#/paths/~1agents~1search'
+
   # Agent instance endpoints
   /agent-instances:
     $ref: 'agent-instances.yaml#/paths/~1agent-instances'

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -86,10 +86,10 @@ tags:
 
 paths:
   # Agent definition endpoints
-  /agents/{agentDefinitionKey}:
-    $ref: 'agent-definitions.yaml#/paths/~1agents~1{agentDefinitionKey}'
-  /agents/search:
-    $ref: 'agent-definitions.yaml#/paths/~1agents~1search'
+  /agent-definitions/{agentDefinitionKey}:
+    $ref: 'agent-definitions.yaml#/paths/~1agent-definitions~1{agentDefinitionKey}'
+  /agent-definitions/search:
+    $ref: 'agent-definitions.yaml#/paths/~1agent-definitions~1search'
 
   # Agent instance endpoints
   /agent-instances:


### PR DESCRIPTION
## Description

Adds the OpenAPI contract for the new `AgentDefinition` resource: `GET /agent-definitions/{agentDefinitionKey}` and `POST /agent-definitions/search`.

### What this enables

An `AgentDefinition` is minted at deploy time (one per process definition version) for every `ai-agent` sub-process/task element in a BPMN model (`AgentDefinitionRecordValue`, see #59715). Right now nothing can read that data back over the REST API - this PR closes that gap by defining the get-by-key and search contract so:

- Operate/Optimize (and any future consumer) can list and inspect agent definitions the same way they already do for process/decision definitions, unblocking dashboards and detail views that need to show "which agents exist in my process".
- Client/codegen (`gateway-model`, `gateway-rest`, Java client) can be generated against a reviewed, stable contract before the storage/controller/service layer is built on top of it in a follow-up PR - the usual contract-first flow used for every other `v2` resource in this repo.
- Callers can list every version of an agent definition for a given process by filtering on `processDefinitionId` + `elementId`, since `agentDefinitionKey` is not stable across process versions (this intentionally diverges from the epic's original assumption of a version-independent key - see camunda/product-hub#3703 - as the engine mints a new key per process definition version, matching other definition-scoped key such as `processDefinitionKey`/`decisionDefinitionKey`).

### Path naming: `/agent-definitions` instead of `/agents`

The PDP epic's Implementation Notes (camunda/product-hub#3703) literally spell out `/agents/...`, and the spec initially followed that wording. However, every other definition-style resource in this API uses the plural resource name as the path segment - `/process-definitions/search`, `/decision-definitions/search` - so `/agent-definitions/...` is the naturally consistent choice for a new definition resource, and is what this PR now uses. Tag name (`Agent definition`), schema names, and `operationId`s were already aligned with this convention and are unaffected - only the path segment changed.

### Scope

This PR is **spec-only**: no controller, service, storage (ES/OS/RDBMS), or Java client changes. Those will land in follow-up PRs.

### Filterable & sortable properties

Both endpoints expose the same 9 properties for filtering (`AgentDefinitionFilter`, with full advanced-search support - `$eq`/`$neq`/`$exists`/`$in`/`$notIn`/`$like` where applicable) and sorting (`AgentDefinitionSearchQuerySortRequest`):

- `agentDefinitionKey`
- `agentType`
- `name`
- `elementId`
- `processDefinitionId`
- `processDefinitionKey`
- `processDefinitionVersion`
- `processDefinitionVersionTag`
- `tenantId`

<details>
<summary><h3>Response shape</h3></summary>

**`GET /agent-definitions/{agentDefinitionKey}`** returns a single `AgentDefinitionResult`:

```json
{
  "agentDefinitionKey": "2251799813691958",
  "agentType": "AI_AGENT_SUB_PROCESS",
  "name": "Support Assistant",
  "elementId": "Activity_106kosb",
  "processDefinitionId": "new-account-onboarding",
  "processDefinitionKey": "2251799813686741",
  "processDefinitionVersion": 3,
  "processDefinitionVersionTag": null,
  "tenantId": "customer-service"
}
```

**`POST /agent-definitions/search`** returns a page of the same shape:

```json
{
  "items": [
    {
      "agentDefinitionKey": "2251799813691958",
      "agentType": "AI_AGENT_SUB_PROCESS",
      "name": "Support Assistant",
      "elementId": "Activity_106kosb",
      "processDefinitionId": "new-account-onboarding",
      "processDefinitionKey": "2251799813686741",
      "processDefinitionVersion": 3,
      "processDefinitionVersionTag": null,
      "tenantId": "customer-service"
    }
  ],
  "page": {
    "totalItems": 1,
    "hasMoreTotalItems": false,
    "startCursor": "WzIyNTE3OTk4MTM2OTE5NTgi",
    "endCursor": "WzIyNTE3OTk4MTM2OTE5NTgi"
  }
}
```

`processDefinitionVersionTag` is nullable (empty when the deployed process definition has no version tag); every other field is always present.

</details>

<details>
<summary><h3>Preview (Redoc)</h3></summary>

Rendered locally from this spec with `@redocly/cli build-docs` for easier review (see how-to below).

**Get agent definition**
![Get agent definition endpoint](https://github.com/user-attachments/assets/20ac19dc-0a95-439f-8beb-9c4cf06732a6)

**Search agent definitions (with AgentDefinitionFilter expanded)**
![Search agent definitions endpoint with filter expanded](https://github.com/user-attachments/assets/7fe41e54-221b-4fdc-aeab-66bbc3081ae1)

<details>
<summary>How to regenerate these screenshots locally</summary>

```bash
cd zeebe/gateway-protocol/src/main/proto/v2
npx @redocly/cli build-docs rest-api.yaml -o /tmp/agent-definition-docs.html
python3 -m http.server 8811 --directory /tmp &
open http://localhost:8811/agent-definition-docs.html
```

</details>

</details>

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #59076
