### PR TITLE
Hand parked jobs out again when a process instance resumes

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
@@ -9,6 +9,7 @@ package io.camunda.it.client;
 
 import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeCompleted;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeSuspended;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
@@ -85,25 +86,16 @@ public class ProcessInstanceSuspendResumeIT {
                       assertThat(instance.getSuspendedDate()).isNull();
                     }));
 
-    // TODO(#59812): re-instate once resume hands parked jobs out again. Suspend already parks
-    // every ACTIVATABLE job out of the hand-out index, but nothing writes Job.RESUMED yet, so the
-    // resumed instance never gets its job back and only the never-suspended instance can be
-    // activated below.
     // when - both instances driven through the same three sequential tasks
-    // for (final String jobType : process.jobTypes()) {
-    //   activateAndCompleteJobs(jobType, 2);
-    // }
+    for (final String jobType : process.jobTypes()) {
+      activateAndCompleteJobs(jobType, 2);
+    }
 
     // then - both complete, with the same elements in the same end state
-    // waitForProcessInstancesToBeCompleted(
-    //     camundaClient, f -> f.processInstanceKey(b -> b.in(suspendedKey, notSuspendedKey)), 2);
-    // assertThat(elementIdsAndStates(suspendedKey))
-    //     .containsExactlyInAnyOrderElementsOf(elementIdsAndStates(notSuspendedKey));
-
-    // with the job flow disabled above, both instances are left waiting at taskA; cancel them so
-    // they don't linger on the shared broker for the rest of the suite
-    camundaClient.newCancelInstanceCommand(suspendedKey).send().join();
-    camundaClient.newCancelInstanceCommand(notSuspendedKey).send().join();
+    waitForProcessInstancesToBeCompleted(
+        camundaClient, f -> f.processInstanceKey(b -> b.in(suspendedKey, notSuspendedKey)), 2);
+    assertThat(elementIdsAndStates(suspendedKey))
+        .containsExactlyInAnyOrderElementsOf(elementIdsAndStates(notSuspendedKey));
   }
 
   @Test

--- a/zeebe/docs/adr/0008-810-suspended-job-state.md
+++ b/zeebe/docs/adr/0008-810-suspended-job-state.md
@@ -55,12 +55,21 @@ documented as a caller obligation.
 
 **D2. Suspend and resume walk the element instance tree and write one job event per affected job.**
 Both use `ProcessInstanceSuspensionJobBehavior` (same `ArrayDeque` walk pattern as migration). Cost
-is paid once per suspend/resume, not on every poll.
+is paid once per suspend, and once per resume cycle, not on every poll.
 
 - **Suspend:** append `Job.SUSPENDED` for every `ACTIVATABLE` or `WAITING_FOR_SECRET_RESOLUTION` job,
-  then append `ProcessInstance.SUSPENDED`. Job parking finishes before the instance marker is set.
-- **Resume:** append `Job.RESUMED` for every `SUSPENDED` job, then call
-  `BpmnJobActivationBehavior.publishWork` so stream and poll workers see the job again.
+  then append `ProcessInstance.SUSPENDED`. Suspending every job finishes before the instance marker
+  is set, in one record batch: `Job.SUSPENDED` carries the job's own record, including its variables,
+  so it is not fixed-size, but it is the only record suspend writes per job — no activation record
+  alongside it. The batch's size scales with the aggregate serialized size of every job the walk
+  suspends, since suspend does not chunk (see Consequences).
+- **Resume:** a `RESUME_JOBS` command walks the tree, finds the first still-`SUSPENDED` job, appends
+  `Job.RESUMED` for it, and calls `BpmnJobActivationBehavior.publishWork` so stream and poll workers
+  see the job again, before appending the next `RESUME_JOBS` for what it did not reach. One job per
+  cycle bounds each cycle's batch to that job's own hand-out cost, the same limit any other hand-out
+  already has: publishing a job a stream is waiting for appends a `JobBatch.ACTIVATED` on top of
+  `Job.RESUMED`, carrying the job's fetched variables a second time, so a resume cycle's size depends
+  on the one job it reaches rather than on every job the instance suspended.
 - **Child instances:** left untouched. `ElementInstanceState.getChildren` does not return a child
   instance root, so the walk never reaches those jobs.
 - **Other job states at suspend time:** `ACTIVATED`, `FAILED`, and `ERROR_THROWN` stay as they are
@@ -115,21 +124,37 @@ instance level only.
   by index prefix instead of walking the element instance tree. Rejected because it changes the
   activatable index layout and activation order for a benefit — a different lookup path for a rare
   operation — that does not offset the risk to the hot activation path.
+- **A dedicated index of suspended jobs by process instance.** A new column family keyed
+  `(processInstanceKey, jobKey)`, populated by `Job.SUSPENDED` and cleared by `Job.RESUMED` or job
+  deletion, would let resume prefix-seek its jobs instead of re-walking the element instance tree once
+  per `RESUME_JOBS` cycle. Deferred rather than rejected: it touches only a new, previously-empty
+  index (no migration, since no 8.9 job can be `SUSPENDED`), not the activatable index the point above
+  protects, so the risk this ADR weighs against does not transfer. Not built for the initial 8.10
+  change so the walk-based design could ship without it; tracked as a concrete follow-up in
+  [#60323](https://github.com/camunda/camunda/issues/60323).
 - **Lazy eviction.** Leave the job in the index and reject or discard it at hand-out time if its
   instance is suspended. Still pays a per-job cost on every poll, the same problem as gating at
   hand-out time.
 
 ## Consequences
 
-- One `Job.SUSPENDED` / `Job.RESUMED` event per affected job in the same batch as the instance
-  marker. A very large instance can hit the max record batch size (same limit as migration).
-  Chunking via a `SUSPENDING` intermediate state is a possible later extension.
+- One `Job.SUSPENDED` event per affected job in the same batch as the instance marker. A very large
+  instance can still hit the max record batch size on suspend (same limit as migration); suspend does
+  not chunk. Resume does not share this limit: one job per `RESUME_JOBS` cycle keeps each cycle's
+  batch bounded to that job's own activation cost.
+- Each `RESUME_JOBS` cycle re-walks the element instance tree from the root to find its one job,
+  visiting every active element the previous cycles already resumed along the way, so a large
+  instance's resume cost is quadratic in its suspended job count. Accepted for the same reason as the
+  walk itself: resume is rare. Tracked for removal by
+  [#60323](https://github.com/camunda/camunda/issues/60323), which replaces the re-walk with the
+  dedicated index of suspended jobs by process instance (see Alternatives).
 - The walk visits every active element of the instance, not only job-backed ones, and blocks the
   partition while it runs. Accepted because suspend/resume are rare; the same cost on activation
   would not be. We run on the same path as process instance migration which is fine so far.
 - No downgrade once a job is parked: older brokers fail on the unknown `SUSPENDED` enum name.
 - Every new exhaustive `JobState.State` switch must handle `SUSPENDED`.
-- Out of scope: child-instance suspension, export to secondary storage/Operate, batch chunking.
+- Out of scope: child-instance suspension, export to secondary storage/Operate, batch chunking for
+  suspend.
 
 ## Open questions
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessInstruc
 import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessInstructionCompleteProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnStreamProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.conditional.ConditionalSubscriptionTriggerProcessor;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
@@ -32,6 +33,7 @@ import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreatio
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationHelper;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationMigrateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceModificationModifyProcessor;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceResumeJobsProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceResumeProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceSuspendProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -97,7 +99,8 @@ public final class BpmnProcessors {
         processingState,
         asyncRequestBehavior,
         cslCheck,
-        timerChecker);
+        timerChecker,
+        bpmnBehaviors.jobActivationBehavior());
     addProcessInstanceBufferedCommandProcessor(writers, typedRecordProcessors, processingState);
 
     final var bpmnStreamProcessor =
@@ -173,7 +176,8 @@ public final class BpmnProcessors {
       final ProcessingState processingState,
       final AsyncRequestBehavior asyncRequestBehavior,
       final CslAuthorizationCheck cslCheck,
-      final DueDateTimerCheckScheduler timerChecker) {
+      final DueDateTimerCheckScheduler timerChecker,
+      final BpmnJobActivationBehavior jobActivationBehavior) {
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.CANCEL,
@@ -183,6 +187,10 @@ public final class BpmnProcessors {
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.RESUME,
         new ProcessInstanceResumeProcessor(processingState, writers, cslCheck));
+    typedRecordProcessors.onCommand(
+        ValueType.PROCESS_INSTANCE,
+        ProcessInstanceIntent.RESUME_JOBS,
+        new ProcessInstanceResumeJobsProcessor(processingState, writers, jobActivationBehavior));
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.COMPLETE_RESUMING,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBufferedCommandDrainProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBufferedCommandDrainProcessor.java
@@ -25,20 +25,16 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Drains buffered commands one per {@code DRAIN} cycle, then re-checks the buffer (already up to
- * date, since event appliers run synchronously): if more remains it appends the next {@code DRAIN},
- * otherwise it appends {@code COMPLETE_RESUMING} directly to hand the resume finalization off to
- * {@link ProcessInstanceCompleteResumingProcessor} without an extra empty cycle. The bounded-batch
- * iterator shape follows the same pattern as {@link ProcessInstanceBatchActivateProcessor}. Each
- * drained command reaches its own processor unchanged; this processor raises no incidents. {@link
- * SuspensionBehavior#PROCESS} is unconditional: gating a {@code DRAIN} strands the instance in
- * {@code RESUMING} forever.
+ * Drains buffered commands one per {@code DRAIN} cycle, then re-checks the buffer — already
+ * current, since event appliers run synchronously — to decide the next step: another {@code DRAIN}
+ * if more remains, or {@code RESUME_JOBS} to hand off to {@link
+ * ProcessInstanceResumeJobsProcessor}, which un-parks jobs and appends {@code COMPLETE_RESUMING}
+ * itself. {@link SuspensionBehavior#PROCESS} is unconditional: gating a {@code DRAIN} would strand
+ * the instance in {@code RESUMING} forever.
  *
- * <p>If a cycle fails to write (e.g. the re-emitted command plus its bookkeeping records exceed the
- * batch size limit), draining halts rather than dropping the command: the engine's default error
- * handling logs the failure and rejects the {@code DRAIN} command — without banning the instance
- * ({@code DRAIN.shouldBanInstance == false}). The buffered command is preserved and the instance
- * stays in {@code RESUMING} until a fresh {@code RESUME} restarts the drain (see {@link
+ * <p>A cycle that fails to write (e.g. batch size exceeded) halts rather than drops the command:
+ * the default error handling rejects {@code DRAIN} without banning the instance, and it stays
+ * {@code RESUMING} until a fresh {@code RESUME} restarts the drain (see {@link
  * ProcessInstanceResumeProcessor}).
  */
 @ExcludeAuthorizationCheck
@@ -65,7 +61,7 @@ public final class ProcessInstanceBufferedCommandDrainProcessor
 
     final var buffered = suspensionState.getOldestBufferedCommand(processInstanceKey).orElse(null);
     if (buffered == null) {
-      appendCompleteResuming(drainValue);
+      appendResumeJobs(drainValue);
       return;
     }
 
@@ -75,7 +71,7 @@ public final class ProcessInstanceBufferedCommandDrainProcessor
     // DRAINED already applied (event appliers run synchronously), so this reflects the buffer as
     // it stands now, without an extra empty DRAIN cycle to find out
     if (suspensionState.getOldestBufferedCommand(processInstanceKey).isEmpty()) {
-      appendCompleteResuming(drainValue);
+      appendResumeJobs(drainValue);
     } else {
       appendNextDrainCommand(drainValue);
     }
@@ -120,10 +116,10 @@ public final class ProcessInstanceBufferedCommandDrainProcessor
             .setTenantId(drainValue.getTenantId()));
   }
 
-  private void appendCompleteResuming(final ProcessInstanceBufferedCommandRecord drainValue) {
+  private void appendResumeJobs(final ProcessInstanceBufferedCommandRecord drainValue) {
     commandWriter.appendFollowUpCommand(
         drainValue.getProcessInstanceKey(),
-        ProcessInstanceIntent.COMPLETE_RESUMING,
+        ProcessInstanceIntent.RESUME_JOBS,
         new ProcessInstanceRecord()
             .setProcessInstanceKey(drainValue.getProcessInstanceKey())
             .setProcessDefinitionKey(drainValue.getProcessDefinitionKey())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeJobsProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeJobsProcessor.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+import org.agrona.collections.MutableBoolean;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Resumes one job of the process instance per {@code RESUME_JOBS} cycle: finds the next job still
+ * {@link JobIntent#SUSPENDED}, writes {@link JobIntent#RESUMED} for it, publishes it via {@link
+ * BpmnJobActivationBehavior#publishWork} — a job stream is push-only, so a stream worker learns
+ * about the job only from that call — then appends the next {@code RESUME_JOBS}. Once none are
+ * left, it appends {@code COMPLETE_RESUMING} to hand the resume finalization off to {@link
+ * ProcessInstanceCompleteResumingProcessor}.
+ *
+ * <p>One job per cycle instead of all of them in this command's own batch: resuming a job that a
+ * stream is waiting for also appends a {@code JobBatch.ACTIVATED} with its fetched variables.
+ * Written in one batch per instance, that can exceed the max record batch size on a large instance
+ * with many stream-activatable jobs — the same instance whose suspend could always fit in one
+ * batch, since suspending writes only one bounded {@code Job.SUSPENDED} per job. Splitting resume
+ * into one job per command batch bounds each cycle to a single job's own activation, the same limit
+ * that already applies to any other job activation — see {@link
+ * #shouldProcessResultsInSeparateBatches} for what actually keeps cycles from accumulating into one
+ * another. Publishing is called unconditionally either way: {@link
+ * BpmnJobActivationBehavior#publishWork} self-manages a hand-out that does not fit the batch by
+ * leaving the job activatable for polling instead of failing the command (see {@code
+ * JobSuspensionSecretResumeTest} for the resume-specific regression coverage of the same safety net
+ * for secret references).
+ *
+ * <p>A cycle is rejected instead of appending a follow-up if the instance no longer exists
+ * (cancelled mid-resume), its suspension marker is no longer {@code RESUMING} (a concurrent resume
+ * chain already finalized it, see {@code ProcessInstanceCompleteResumingProcessor}), or the element
+ * is ending ({@code ELEMENT_TERMINATING}/{@code ELEMENT_COMPLETING}): resuming and publishing a job
+ * in any of those cases would act on a resume this cycle no longer owns.
+ *
+ * <p>{@link SuspensionBehavior#PROCESS} is unconditional: the marker is still {@code RESUMING} at
+ * this point, and gating would strand the instance there forever.
+ */
+@ExcludeAuthorizationCheck
+@NullMarked
+public final class ProcessInstanceResumeJobsProcessor
+    implements TypedRecordProcessor<ProcessInstanceRecord>, SuspensionAware<ProcessInstanceRecord> {
+
+  private static final String INSTANCE_GONE_MESSAGE =
+      "Expected to resume the suspended jobs of process instance '%d', but it no longer exists — "
+          + "likely cancelled while resuming.";
+  private static final String ALREADY_FINALIZED_MESSAGE =
+      "Expected to resume the suspended jobs of process instance '%d', but its suspension marker "
+          + "is no longer RESUMING — likely already finalized by a concurrent resume.";
+  private static final String LIFECYCLE_ENDING_MESSAGE =
+      "Expected to resume the suspended jobs of process instance '%d', but it is %s — resume is "
+          + "superseded by the ending lifecycle.";
+  private static final Set<ProcessInstanceIntent> LIFECYCLE_ENDING_STATES =
+      EnumSet.of(
+          ProcessInstanceIntent.ELEMENT_TERMINATING, ProcessInstanceIntent.ELEMENT_COMPLETING);
+
+  private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final ElementInstanceState elementInstanceState;
+  private final SuspensionState suspensionState;
+  private final ProcessInstanceSuspensionJobBehavior suspensionJobBehavior;
+  private final BpmnJobActivationBehavior jobActivationBehavior;
+
+  public ProcessInstanceResumeJobsProcessor(
+      final ProcessingState processingState,
+      final Writers writers,
+      final BpmnJobActivationBehavior jobActivationBehavior) {
+    stateWriter = writers.state();
+    commandWriter = writers.command();
+    rejectionWriter = writers.rejection();
+    elementInstanceState = processingState.getElementInstanceState();
+    suspensionState = processingState.getSuspensionState();
+    suspensionJobBehavior =
+        new ProcessInstanceSuspensionJobBehavior(
+            elementInstanceState, processingState.getJobState(), stateWriter);
+    this.jobActivationBehavior = jobActivationBehavior;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ProcessInstanceRecord> command) {
+    final long processInstanceKey = command.getKey();
+    final var processInstance = elementInstanceState.getInstance(processInstanceKey);
+    if (processInstance == null) {
+      reject(command, INSTANCE_GONE_MESSAGE.formatted(processInstanceKey));
+      return;
+    }
+    if (suspensionState.getSuspensionState(processInstanceKey) != SuspensionState.State.RESUMING) {
+      reject(command, ALREADY_FINALIZED_MESSAGE.formatted(processInstanceKey));
+      return;
+    }
+    final var lifecycleState = processInstance.getState();
+    if (LIFECYCLE_ENDING_STATES.contains(lifecycleState)) {
+      reject(command, LIFECYCLE_ENDING_MESSAGE.formatted(processInstanceKey, lifecycleState));
+      return;
+    }
+
+    final boolean resumedAJob = resumeNextJob(processInstance);
+    final var nextIntent =
+        resumedAJob ? ProcessInstanceIntent.RESUME_JOBS : ProcessInstanceIntent.COMPLETE_RESUMING;
+    commandWriter.appendFollowUpCommand(processInstanceKey, nextIntent, processInstance.getValue());
+  }
+
+  /**
+   * Resumes and hands out the first still-suspended job the walk finds; returns whether one was
+   * found. Stops the walk after that one job: one per cycle, see class javadoc.
+   */
+  private boolean resumeNextJob(final ElementInstance processInstance) {
+    final var resumedOne = new MutableBoolean(false);
+    suspensionJobBehavior.forEachSuspendedJob(
+        processInstance,
+        (jobKey, job) -> {
+          stateWriter.appendFollowUpEvent(jobKey, JobIntent.RESUMED, job);
+          jobActivationBehavior.publishWork(jobKey, job, new HashSet<>());
+          resumedOne.set(true);
+          return false;
+        });
+    return resumedOne.get();
+  }
+
+  /**
+   * A cycle's own writes are small on their own — one {@code Job.RESUMED}, at most one {@code
+   * JobBatch.ACTIVATED}, one follow-up command — but without this override the stream processor
+   * keeps reusing the same result builder across consecutive {@code RESUME_JOBS} cycles instead of
+   * starting a fresh one per command, so an instance with many suspended jobs would still
+   * accumulate every cycle's hand-out into that one shared batch until it exceeds the log's maximum
+   * fragment size — the same reasoning {@code SecretReferenceBatchReactivateJobsProcessor} gives
+   * for its own override. Isolating each cycle keeps the batch bounded by one job's hand-out,
+   * matching what already holds for that job at creation time.
+   */
+  @Override
+  public boolean shouldProcessResultsInSeparateBatches() {
+    return true;
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<ProcessInstanceRecord> record) {
+    return SuspensionBehavior.PROCESS;
+  }
+
+  private void reject(final TypedRecord<ProcessInstanceRecord> command, final String reason) {
+    rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, reason);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspensionJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspensionJobBehavior.java
@@ -17,28 +17,29 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import java.util.ArrayDeque;
 import java.util.EnumSet;
 import java.util.Set;
-import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Parks jobs of a process instance so they are no longer handed out while the instance is
- * suspended.
+ * Parks and un-parks the jobs of a process instance while it is suspended, walking its
+ * element-instance tree.
  *
- * <p>Jobs of called child instances are left untouched. {@link ElementInstanceState#getChildren}
- * does not return a child instance's root for the given element instance key, so the walk never
- * reaches those jobs. The {@code processInstanceKey} filter below is only a defensive check of that
- * boundary.
+ * <p>Jobs of called child instances are untouched — {@link ElementInstanceState#getChildren} never
+ * returns a child instance's root, so the walk can't reach them; the {@code processInstanceKey}
+ * filter below is a defensive backstop for that.
  */
 @NullMarked
 public final class ProcessInstanceSuspensionJobBehavior {
 
   /**
-   * States that {@link JobIntent#SUSPENDED} may leave. Matches {@code JobSuspendedApplier}: secret
-   * waiting is overridden so a later secret reactivation cannot put the job back into the hand-out
-   * index while the process instance is still suspended.
+   * States {@link JobIntent#SUSPENDED} may leave from; includes secret-waiting so a later
+   * resolution can't reactivate a job while its instance stays suspended.
    */
   private static final Set<State> SUSPENDABLE_STATES =
       EnumSet.of(State.ACTIVATABLE, State.WAITING_FOR_SECRET_RESOLUTION);
+
+  /** The only state {@link JobIntent#RESUMED} leaves; see {@code JobResumedApplier}. */
+  private static final Set<State> RESUMABLE_STATES = EnumSet.of(State.SUSPENDED);
 
   private final ElementInstanceState elementInstanceState;
   private final JobState jobState;
@@ -53,33 +54,49 @@ public final class ProcessInstanceSuspensionJobBehavior {
     this.stateWriter = stateWriter;
   }
 
-  /**
-   * Appends {@link JobIntent#SUSPENDED} for every suspendable job of the process instance ({@link
-   * State#ACTIVATABLE} and {@link State#WAITING_FOR_SECRET_RESOLUTION}), which parks each job out
-   * of the hand-out index.
-   */
+  /** Appends {@link JobIntent#SUSPENDED} for every job in {@link #SUSPENDABLE_STATES}. */
   public void suspendJobs(final long processInstanceKey) {
-    forEachJobInStates(
-        processInstanceKey,
-        SUSPENDABLE_STATES,
-        (jobKey, job) -> stateWriter.appendFollowUpEvent(jobKey, JobIntent.SUSPENDED, job));
-  }
-
-  private void forEachJobInStates(
-      final long processInstanceKey,
-      final Set<State> states,
-      final BiConsumer<Long, JobRecord> consumer) {
     final var processInstance = elementInstanceState.getInstance(processInstanceKey);
     if (processInstance == null) {
       return;
     }
+    walk(
+        processInstance,
+        // never stops early: every suspendable job must be parked
+        elementInstance ->
+            visitJobInStates(
+                elementInstance,
+                SUSPENDABLE_STATES,
+                (jobKey, job) -> {
+                  stateWriter.appendFollowUpEvent(jobKey, JobIntent.SUSPENDED, job);
+                  return true;
+                }));
+  }
 
-    // a queue instead of recursion, to not blow the stack on a deeply nested instance
+  /**
+   * Visits {@link State#SUSPENDED} jobs of the process instance until {@code visitor} stops the
+   * walk, without changing their state. Takes the already-loaded root so a per-cycle caller doesn't
+   * re-read it.
+   */
+  public void forEachSuspendedJob(final ElementInstance processInstance, final JobVisitor visitor) {
+    walk(
+        processInstance,
+        elementInstance -> visitJobInStates(elementInstance, RESUMABLE_STATES, visitor));
+  }
+
+  /**
+   * Walks the element-instance tree breadth-first, calling {@code visitor} per element until it
+   * returns {@code false}. A queue (not recursion) avoids blowing the stack on a deep instance.
+   */
+  private void walk(final ElementInstance root, final Predicate<ElementInstance> visitor) {
+    final long processInstanceKey = root.getValue().getProcessInstanceKey();
     final var elementInstances = new ArrayDeque<ElementInstance>();
-    elementInstances.add(processInstance);
+    elementInstances.add(root);
     while (!elementInstances.isEmpty()) {
       final var elementInstance = elementInstances.poll();
-      visitJob(elementInstance, states, consumer);
+      if (!visitor.test(elementInstance)) {
+        return;
+      }
       // defensive invariant, see class javadoc: getChildren never returns a child instance's root
       elementInstanceState.getChildren(elementInstance.getKey()).stream()
           .filter(child -> child.getValue().getProcessInstanceKey() == processInstanceKey)
@@ -87,17 +104,28 @@ public final class ProcessInstanceSuspensionJobBehavior {
     }
   }
 
-  private void visitJob(
-      final ElementInstance elementInstance,
-      final Set<State> states,
-      final BiConsumer<Long, JobRecord> consumer) {
+  /**
+   * Passes this element's job to {@code visitor} if it is in one of {@code states}; otherwise
+   * continues the walk.
+   */
+  private boolean visitJobInStates(
+      final ElementInstance elementInstance, final Set<State> states, final JobVisitor visitor) {
     final long jobKey = elementInstance.getJobKey();
     if (jobKey <= 0 || !states.contains(jobState.getState(jobKey))) {
-      return;
+      return true;
     }
     final var job = jobState.getJob(jobKey);
-    if (job != null) {
-      consumer.accept(jobKey, job);
-    }
+    return job == null || visitor.visit(jobKey, job);
+  }
+
+  /** Visits one job of the process instance and reports whether the walk continues. */
+  @FunctionalInterface
+  public interface JobVisitor {
+
+    /**
+     * @param job valid only for this call — the job state reuses one record instance on every read,
+     *     so copy what you need rather than hold the reference.
+     */
+    boolean visit(long jobKey, JobRecord job);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSuspensionJobStreamPushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSuspensionJobStreamPushTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordingJobStreamer;
+import io.camunda.zeebe.engine.util.RecordingJobStreamer.RecordingJobStream;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.stream.job.JobActivationPropertiesImpl;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+import java.util.Set;
+import org.agrona.DirectBuffer;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+/**
+ * Covers the job-stream push path for a suspended and resumed process instance. A job stream is
+ * push-only, so a stream worker learns about a parked job only from the {@code publishWork} call
+ * that the {@code RESUME_JOBS} loop in {@code ProcessInstanceResumeJobsProcessor} makes for each
+ * un-parked {@code Job.RESUMED}. This needs its own {@link EngineRule} with a {@link
+ * RecordingJobStreamer}, so it lives apart from {@code JobSuspensionHandoutTest}.
+ */
+public final class JobSuspensionJobStreamPushTest {
+
+  private static final RecordingJobStreamer JOB_STREAMER = new RecordingJobStreamer();
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition().withJobStreamer(JOB_STREAMER);
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldNotPushSuspendedJobButPushItAfterResume() {
+    // given - a job that reaches ACTIVATABLE with no stream registered yet, so it is not
+    // immediately activated and pushed on creation
+    final String jobType = Strings.newRandomValidBpmnId();
+    final String processId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(jobType))
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when - the instance is suspended, parking the still-activatable job
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    final DirectBuffer worker = BufferUtil.wrapString("test");
+    final var jobActivationProperties =
+        new JobActivationPropertiesImpl()
+            .setWorker(worker, 0, worker.capacity())
+            .setTimeout(30_000L)
+            .setTenantIds(List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
+            .setFetchVariables(Set.of(new StringValue("a")));
+    final RecordingJobStream jobStream =
+        JOB_STREAMER.addJobStream(BufferUtil.wrapString(jobType), jobActivationProperties);
+
+    // then - the parked job is not pushed to a stream waiting for its type
+    assertThat(jobStream.getActivatedJobs()).isEmpty();
+
+    // when - the instance is resumed
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then - the RESUME_JOBS cycle that un-parks this job also publishes it
+    await("push after resume")
+        .untilAsserted(() -> assertThat(jobStream.getActivatedJobs()).hasSize(1));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSuspensionSecretResumeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSuspensionSecretResumeTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.secretstore.SecretErrorCode;
+import io.camunda.secretstore.SecretResolutionResult;
+import io.camunda.secretstore.SecretResolutionResult.Failed;
+import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import io.camunda.secretstore.SecretStore;
+import io.camunda.secretstore.SecretStoreRegistry;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordingJobStreamer;
+import io.camunda.zeebe.engine.util.RecordingJobStreamer.RecordingJobStream;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.stream.job.JobActivationPropertiesImpl;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.agrona.DirectBuffer;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+/**
+ * Covers resume of a job that was suspended while waiting for secret resolution. Resume must mirror
+ * long-poll activation: restart resolution when references are uncached and withhold hand-out;
+ * publish work immediately when secrets are already cached.
+ */
+public final class JobSuspensionSecretResumeTest {
+
+  private static final String SECRET_NAME = "token";
+  private static final String SECRET_VALUE = "resolved-secret";
+
+  @Rule public final EngineRule engine;
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  private final CountDownLatch allowResolve = new CountDownLatch(1);
+  private final RecordingJobStreamer jobStreamer = new RecordingJobStreamer();
+
+  public JobSuspensionSecretResumeTest() {
+    engine =
+        EngineRule.singlePartition()
+            .withJobStreamer(jobStreamer)
+            .withSecretStoreRegistry(
+                new SecretStoreRegistry(
+                    Map.of(
+                        SecretStoreRegistry.DEFAULT_STORE_ID,
+                        new GatedSecretStore(allowResolve, Map.of(SECRET_NAME, SECRET_VALUE)))))
+            .withEngineConfig(config -> config.setSecretResolutionInterval(Duration.ofMillis(100)));
+  }
+
+  @After
+  public void openGate() {
+    // unblock any store call still waiting if the test failed before opening the gate
+    allowResolve.countDown();
+  }
+
+  @Test
+  public void shouldNotHandOutSecretWaitingJobOnResumeBeforeResolution() {
+    // given - a job parked for an uncached secret, suspended while resolution is still gated
+    final String jobType = Strings.newRandomValidBpmnId();
+    final long processInstanceKey = createSecretJobInstance(jobType);
+    final long jobKey = jobKeyOf(processInstanceKey);
+
+    parkForSecret(jobType, jobKey);
+    engine.processInstance().withInstanceKey(processInstanceKey).suspend();
+    RecordingExporter.jobRecords(JobIntent.SUSPENDED).withRecordKey(jobKey).await();
+
+    final RecordingJobStream jobStream = addJobStream(jobType);
+
+    // when - resume while the secret store is still blocked
+    engine.processInstance().withInstanceKey(processInstanceKey).resume();
+    final var resumed =
+        RecordingExporter.jobRecords(JobIntent.RESUMED).withRecordKey(jobKey).getFirst();
+
+    // then - the RESUME_JOBS cycle for this job restarts resolution; neither stream push nor poll
+    // hands the job out
+    final var reRequested =
+        RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_REQUESTED)
+            .withSecretReference(SECRET_NAME)
+            .skipUntil(r -> r.getPosition() > resumed.getPosition())
+            .getFirst();
+    assertThat(reRequested.getValue().getJobKeys()).contains(jobKey);
+    assertThat(jobStream.getActivatedJobs()).isEmpty();
+
+    final Record<JobBatchRecordValue> whileWaiting =
+        engine.jobs().withType(jobType).withRequestStreamId(2).withRequestId(2L).activate();
+    assertThat(whileWaiting.getValue().getJobKeys()).isEmpty();
+
+    // and - once the store answers, reactivation hands the job to the registered stream: the same
+    // publishWork call that resume itself would have made, now made by the resolution's own
+    // reactivation cycle (see SecretReferenceBatchReactivateJobsProcessor)
+    allowResolve.countDown();
+    await("push once the secret resolves")
+        .untilAsserted(() -> assertThat(jobStream.getActivatedJobs()).hasSize(1));
+    assertThat(jobStream.getActivatedJobs().get(0).jobKey()).isEqualTo(jobKey);
+  }
+
+  @Test
+  public void shouldPushJobOnResumeWhenSecretsAlreadyCached() {
+    // given - secrets resolve while the instance is still suspended, so the cache is warm at resume
+    final String jobType = Strings.newRandomValidBpmnId();
+    final long processInstanceKey = createSecretJobInstance(jobType);
+    final long jobKey = jobKeyOf(processInstanceKey);
+
+    parkForSecret(jobType, jobKey);
+    engine.processInstance().withInstanceKey(processInstanceKey).suspend();
+    RecordingExporter.jobRecords(JobIntent.SUSPENDED).withRecordKey(jobKey).await();
+
+    allowResolve.countDown();
+    RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_COMPLETED)
+        .withSecretReference(SECRET_NAME)
+        .getFirst();
+    RecordingExporter.secretReferenceRecords(SecretReferenceIntent.BATCH_JOBS_REACTIVATED)
+        .withSecretReference(SECRET_NAME)
+        .getFirst();
+
+    // job stays out of the hand-out index while suspended (see JobSuspensionSecretWaitingTest)
+    final Record<JobBatchRecordValue> whileSuspended =
+        engine.jobs().withType(jobType).withRequestStreamId(2).withRequestId(2L).activate();
+    assertThat(whileSuspended.getValue().getJobKeys()).isEmpty();
+
+    final RecordingJobStream jobStream = addJobStream(jobType);
+
+    // when - resume with secrets already cached
+    engine.processInstance().withInstanceKey(processInstanceKey).resume();
+    RecordingExporter.jobRecords(JobIntent.RESUMED).withRecordKey(jobKey).await();
+
+    // then - the RESUME_JOBS cycle publishes work immediately (stream push), without restarting
+    // resolution
+    await("push after resume with cached secrets")
+        .untilAsserted(() -> assertThat(jobStream.getActivatedJobs()).hasSize(1));
+    assertThat(jobStream.getActivatedJobs().get(0).jobKey()).isEqualTo(jobKey);
+  }
+
+  private RecordingJobStream addJobStream(final String jobType) {
+    final DirectBuffer worker = BufferUtil.wrapString("test");
+    final var jobActivationProperties =
+        new JobActivationPropertiesImpl()
+            .setWorker(worker, 0, worker.capacity())
+            .setTimeout(30_000L)
+            .setTenantIds(List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
+            .setFetchVariables(Set.of(new StringValue("authorization")));
+    return jobStreamer.addJobStream(BufferUtil.wrapString(jobType), jobActivationProperties);
+  }
+
+  private long createSecretJobInstance(final String jobType) {
+    final String processId = Strings.newRandomValidBpmnId();
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask(
+                    "task",
+                    t ->
+                        t.zeebeJobType(jobType)
+                            .zeebeInputExpression(
+                                "\"Bearer \"+camunda.secrets." + SECRET_NAME, "authorization"))
+                .done())
+        .deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    return processInstanceKey;
+  }
+
+  private long jobKeyOf(final long processInstanceKey) {
+    return RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst()
+        .getKey();
+  }
+
+  private void parkForSecret(final String jobType, final long jobKey) {
+    final Record<JobBatchRecordValue> parked =
+        engine.jobs().withType(jobType).withRequestStreamId(1).withRequestId(1L).activate();
+    assertThat(parked.getValue().getJobs()).isEmpty();
+    final var requested =
+        RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_REQUESTED)
+            .withSecretReference(SECRET_NAME)
+            .getFirst();
+    assertThat(requested.getValue().getJobKeys()).contains(jobKey);
+  }
+
+  /**
+   * Blocks {@link #resolve} until the test opens the latch, so secret completion cannot race past
+   * process-instance suspend or resume.
+   */
+  private record GatedSecretStore(CountDownLatch allowResolve, Map<String, String> secrets)
+      implements SecretStore {
+    private GatedSecretStore(final CountDownLatch allowResolve, final Map<String, String> secrets) {
+      this.allowResolve = allowResolve;
+      this.secrets = Map.copyOf(secrets);
+    }
+
+    @Override
+    public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
+      try {
+        if (!allowResolve.await(10, TimeUnit.SECONDS)) {
+          throw new IllegalStateException("timed out waiting for test to open the secret store");
+        }
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException("interrupted waiting for test to open the secret store", e);
+      }
+      return names.stream()
+          .collect(
+              Collectors.toMap(
+                  name -> name,
+                  name ->
+                      Optional.ofNullable(secrets.get(name))
+                          .<SecretResolutionResult>map(Resolved::new)
+                          .orElseGet(
+                              () ->
+                                  new Failed(SecretErrorCode.NOT_FOUND, "no such secret", null))));
+    }
+
+    @Override
+    public List<String> list() {
+      return List.copyOf(secrets.keySet());
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBufferedCommandDrainProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBufferedCommandDrainProcessorTest.java
@@ -83,7 +83,7 @@ public final class ProcessInstanceBufferedCommandDrainProcessorTest {
   }
 
   @Test
-  void shouldAppendCompleteResumingWhenBufferEmpty() {
+  void shouldAppendResumeJobsWhenBufferEmpty() {
     // when
     processor.processRecord(drainCommand());
 
@@ -91,7 +91,7 @@ public final class ProcessInstanceBufferedCommandDrainProcessorTest {
     verify(commandWriter)
         .appendFollowUpCommand(
             eq(PROCESS_INSTANCE_KEY),
-            eq(ProcessInstanceIntent.COMPLETE_RESUMING),
+            eq(ProcessInstanceIntent.RESUME_JOBS),
             any(ProcessInstanceRecord.class));
     verify(stateWriter, never()).appendFollowUpEvent(anyLong(), any(), any());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeJobsProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeJobsProcessorTest.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableSuspensionState;
+import io.camunda.zeebe.engine.util.MockTypedRecord;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Uses real element-instance/job/suspension state (via {@link ProcessingStateExtension}), mocking
+ * only the writers and {@link BpmnJobActivationBehavior} — the same split {@code
+ * ProcessInstanceBufferedCommandDrainProcessorTest} uses for the sibling processor in this resume
+ * chain. The hand-out-declines-room case still needs the behavior mock to return false; everything
+ * about the element and job state itself is real.
+ */
+@ExtendWith(ProcessingStateExtension.class)
+public final class ProcessInstanceResumeJobsProcessorTest {
+
+  private static final long PROCESS_INSTANCE_KEY = 100L;
+  private static final long CHILD_ELEMENT_KEY = 101L;
+  private static final long JOB_KEY = 200L;
+  private static final long CHILD_JOB_KEY = 201L;
+
+  private MutableProcessingState processingState;
+
+  private MutableElementInstanceState elementInstanceState;
+  private MutableJobState jobState;
+  private MutableSuspensionState suspensionState;
+  private StateWriter stateWriter;
+  private TypedCommandWriter commandWriter;
+  private TypedRejectionWriter rejectionWriter;
+  private BpmnJobActivationBehavior jobActivationBehavior;
+  private ProcessInstanceResumeJobsProcessor processor;
+
+  @BeforeEach
+  void setUp() {
+    elementInstanceState = processingState.getElementInstanceState();
+    jobState = processingState.getJobState();
+    suspensionState = processingState.getSuspensionState();
+    stateWriter = mock(StateWriter.class);
+    commandWriter = mock(TypedCommandWriter.class);
+    rejectionWriter = mock(TypedRejectionWriter.class);
+    jobActivationBehavior = mock(BpmnJobActivationBehavior.class);
+    // a hand-out that takes the job, unless a test overrides it to prove the chain still advances
+    // when it doesn't
+    when(jobActivationBehavior.publishWork(anyLong(), any(), any())).thenReturn(true);
+
+    final var writers = mock(Writers.class);
+    when(writers.state()).thenReturn(stateWriter);
+    when(writers.command()).thenReturn(commandWriter);
+    when(writers.rejection()).thenReturn(rejectionWriter);
+
+    processor =
+        new ProcessInstanceResumeJobsProcessor(processingState, writers, jobActivationBehavior);
+
+    // the cycle owns the resume by default: marker still RESUMING, as it is throughout a resume
+    // that nothing else interferes with
+    suspensionState.setSuspensionState(PROCESS_INSTANCE_KEY, SuspensionState.State.RESUMING);
+  }
+
+  @Test
+  void shouldAppendCompleteResumingWhenNoParkedJobsRemain() {
+    // given - the instance has no job at all, so there is nothing left to un-park
+    rootInstance(ProcessInstanceIntent.ELEMENT_ACTIVATED);
+
+    // when
+    processor.processRecord(resumeJobsCommand());
+
+    // then
+    verify(commandWriter)
+        .appendFollowUpCommand(
+            eq(PROCESS_INSTANCE_KEY),
+            eq(ProcessInstanceIntent.COMPLETE_RESUMING),
+            any(ProcessInstanceRecord.class));
+    verify(commandWriter, never())
+        .appendFollowUpCommand(anyLong(), eq(ProcessInstanceIntent.RESUME_JOBS), any());
+    verify(jobActivationBehavior, never()).publishWork(anyLong(), any(), any());
+    verify(rejectionWriter, never()).appendRejection(any(), any(), any());
+  }
+
+  @Test
+  void shouldRequestSeparateBatchForEachCycle() {
+    // given - without this, the RESUME_JOBS chain would accumulate every cycle's hand-out into
+    // the same result builder instead of one job's per batch
+
+    // when / then
+    assertThat(processor.shouldProcessResultsInSeparateBatches()).isTrue();
+  }
+
+  @Test
+  void shouldResumeOneParkedJobAndAppendNextResumeJobs() {
+    // given - the instance still has one job parked from suspension
+    rootInstance(ProcessInstanceIntent.ELEMENT_ACTIVATED);
+    parkJob(PROCESS_INSTANCE_KEY, JOB_KEY);
+
+    // when
+    processor.processRecord(resumeJobsCommand());
+
+    // then - the job is un-parked and pushed/notified, and the loop continues instead of handing
+    // off to COMPLETE_RESUMING in this same cycle
+    verify(stateWriter).appendFollowUpEvent(eq(JOB_KEY), eq(JobIntent.RESUMED), any());
+    verify(jobActivationBehavior).publishWork(eq(JOB_KEY), any(), any());
+    verify(commandWriter)
+        .appendFollowUpCommand(
+            eq(PROCESS_INSTANCE_KEY),
+            eq(ProcessInstanceIntent.RESUME_JOBS),
+            any(ProcessInstanceRecord.class));
+    verify(commandWriter, never())
+        .appendFollowUpCommand(anyLong(), eq(ProcessInstanceIntent.COMPLETE_RESUMING), any());
+  }
+
+  @Test
+  void shouldResumeOnlyTheFirstOfSeveralParkedJobsInOneCycle() {
+    // given - two parked jobs on two element instances of the same instance
+    seedTwoParkedJobs();
+
+    // when
+    processor.processRecord(resumeJobsCommand());
+
+    // then - one cycle un-parks and hands out exactly one, leaving the other for the next cycle
+    verify(stateWriter, times(1)).appendFollowUpEvent(anyLong(), eq(JobIntent.RESUMED), any());
+    verify(jobActivationBehavior, times(1)).publishWork(anyLong(), any(), any());
+    verify(commandWriter)
+        .appendFollowUpCommand(
+            eq(PROCESS_INSTANCE_KEY),
+            eq(ProcessInstanceIntent.RESUME_JOBS),
+            any(ProcessInstanceRecord.class));
+  }
+
+  @Test
+  void shouldStillAdvanceTheChainWhenTheHandOutDoesNotFitTheBatch() {
+    // given - one parked job, and a hand-out that reports the batch has no room for it
+    rootInstance(ProcessInstanceIntent.ELEMENT_ACTIVATED);
+    parkJob(PROCESS_INSTANCE_KEY, JOB_KEY);
+    when(jobActivationBehavior.publishWork(anyLong(), any(), any())).thenReturn(false);
+
+    // when
+    processor.processRecord(resumeJobsCommand());
+
+    // then - the job is still un-parked (publishWork itself leaves it activatable for polling when
+    // it doesn't fit, see its own contract) and the chain still advances instead of stalling
+    verify(stateWriter).appendFollowUpEvent(eq(JOB_KEY), eq(JobIntent.RESUMED), any());
+    verify(jobActivationBehavior).publishWork(eq(JOB_KEY), any(), any());
+    verify(commandWriter)
+        .appendFollowUpCommand(
+            eq(PROCESS_INSTANCE_KEY),
+            eq(ProcessInstanceIntent.RESUME_JOBS),
+            any(ProcessInstanceRecord.class));
+    verify(commandWriter, never())
+        .appendFollowUpCommand(anyLong(), eq(ProcessInstanceIntent.COMPLETE_RESUMING), any());
+  }
+
+  @Test
+  void shouldRejectWhenInstanceCancelledMidResume() {
+    // given - no element instance seeded; getInstance returns null
+
+    // when
+    processor.processRecord(resumeJobsCommand());
+
+    // then - neither a job nor COMPLETE_RESUMING is appended for a gone instance; the command is
+    // rejected instead of silently dropped, so it isn't reconsidered
+    verify(stateWriter, never()).appendFollowUpEvent(anyLong(), any(), any());
+    verify(commandWriter, never()).appendFollowUpCommand(anyLong(), any(), any());
+    verify(jobActivationBehavior, never()).publishWork(anyLong(), any(), any());
+    final var reasonCaptor = ArgumentCaptor.forClass(String.class);
+    verify(rejectionWriter)
+        .appendRejection(any(), eq(RejectionType.INVALID_STATE), reasonCaptor.capture());
+    assertThat(reasonCaptor.getValue()).contains("no longer exists");
+  }
+
+  @Test
+  void shouldRejectWhenSuspensionMarkerNoLongerResuming() {
+    // given - a concurrent resume chain already finalized (marker cleared) or restarted a fresh
+    // one, and a later suspend re-parked the job before this stale cycle got to run
+    rootInstance(ProcessInstanceIntent.ELEMENT_ACTIVATED);
+    parkJob(PROCESS_INSTANCE_KEY, JOB_KEY);
+    suspensionState.setSuspensionState(PROCESS_INSTANCE_KEY, SuspensionState.State.SUSPENDED);
+
+    // when
+    processor.processRecord(resumeJobsCommand());
+
+    // then - this stale cycle is rejected instead of un-parking a job the resume it belonged to
+    // no longer owns
+    verify(stateWriter, never()).appendFollowUpEvent(anyLong(), any(), any());
+    verify(commandWriter, never()).appendFollowUpCommand(anyLong(), any(), any());
+    verify(jobActivationBehavior, never()).publishWork(anyLong(), any(), any());
+    final var reasonCaptor = ArgumentCaptor.forClass(String.class);
+    verify(rejectionWriter)
+        .appendRejection(any(), eq(RejectionType.INVALID_STATE), reasonCaptor.capture());
+    assertThat(reasonCaptor.getValue()).contains("no longer RESUMING");
+  }
+
+  @Test
+  void shouldRejectWhenInstanceIsTerminating() {
+    // given - a cancel landed between two RESUME_JOBS cycles; the root is still present but ending
+    rootInstance(ProcessInstanceIntent.ELEMENT_TERMINATING);
+
+    // when
+    processor.processRecord(resumeJobsCommand());
+
+    // then - the cycle is rejected instead of handing a worker a job the termination is about to
+    // cancel
+    verify(stateWriter, never()).appendFollowUpEvent(anyLong(), any(), any());
+    verify(commandWriter, never()).appendFollowUpCommand(anyLong(), any(), any());
+    verify(jobActivationBehavior, never()).publishWork(anyLong(), any(), any());
+    final var reasonCaptor = ArgumentCaptor.forClass(String.class);
+    verify(rejectionWriter)
+        .appendRejection(any(), eq(RejectionType.INVALID_STATE), reasonCaptor.capture());
+    assertThat(reasonCaptor.getValue()).contains(ProcessInstanceIntent.ELEMENT_TERMINATING.name());
+  }
+
+  @Test
+  void shouldRejectWhenInstanceIsCompleting() {
+    // given - the root reached its own completing phase between two RESUME_JOBS cycles
+    rootInstance(ProcessInstanceIntent.ELEMENT_COMPLETING);
+
+    // when
+    processor.processRecord(resumeJobsCommand());
+
+    // then - the cycle is rejected instead of handing a worker a job the completion is about to
+    // finish without
+    verify(stateWriter, never()).appendFollowUpEvent(anyLong(), any(), any());
+    verify(commandWriter, never()).appendFollowUpCommand(anyLong(), any(), any());
+    verify(jobActivationBehavior, never()).publishWork(anyLong(), any(), any());
+    final var reasonCaptor = ArgumentCaptor.forClass(String.class);
+    verify(rejectionWriter)
+        .appendRejection(any(), eq(RejectionType.INVALID_STATE), reasonCaptor.capture());
+    assertThat(reasonCaptor.getValue()).contains(ProcessInstanceIntent.ELEMENT_COMPLETING.name());
+  }
+
+  /**
+   * Seeds a root element instance holding {@code JOB_KEY} and a child holding {@code
+   * CHILD_JOB_KEY}.
+   */
+  private void seedTwoParkedJobs() {
+    rootInstance(ProcessInstanceIntent.ELEMENT_ACTIVATED);
+    childInstance(CHILD_ELEMENT_KEY);
+    parkJob(PROCESS_INSTANCE_KEY, JOB_KEY);
+    parkJob(CHILD_ELEMENT_KEY, CHILD_JOB_KEY);
+  }
+
+  private void rootInstance(final ProcessInstanceIntent state) {
+    final var record = processInstanceRecord(PROCESS_INSTANCE_KEY);
+    elementInstanceState.newInstance(PROCESS_INSTANCE_KEY, record, state);
+  }
+
+  private void childInstance(final long elementKey) {
+    final var parent = elementInstanceState.getInstance(PROCESS_INSTANCE_KEY);
+    final var record = processInstanceRecord(PROCESS_INSTANCE_KEY);
+    elementInstanceState.newInstance(
+        parent, elementKey, record, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+  }
+
+  /** Attaches a job to the given element and parks it, as if it had already been suspended. */
+  private void parkJob(final long elementKey, final long jobKey) {
+    final var jobRecord =
+        new JobRecord()
+            .setType("test")
+            .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+            .setRetries(3)
+            .setPriority(50)
+            .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    jobState.insertJobRecordActivatable(jobKey, jobRecord);
+    jobState.makeJobActivatableByPriority(
+        jobRecord.getTypeBuffer(), jobKey, jobRecord.getTenantId(), jobRecord.getPriority());
+    jobState.updateJobState(
+        jobKey, io.camunda.zeebe.engine.state.immutable.JobState.State.SUSPENDED);
+    jobState.makeJobNotActivatable(jobKey, jobRecord);
+    elementInstanceState.updateInstance(elementKey, ei -> ei.setJobKey(jobKey));
+  }
+
+  private ProcessInstanceRecord processInstanceRecord(final long processInstanceKey) {
+    return new ProcessInstanceRecord()
+        .setElementId("process")
+        .setBpmnProcessId("process")
+        .setProcessInstanceKey(processInstanceKey)
+        .setFlowScopeKey(-1L)
+        .setVersion(1)
+        .setProcessDefinitionKey(1L)
+        .setBpmnElementType(BpmnElementType.PROCESS);
+  }
+
+  private MockTypedRecord<ProcessInstanceRecord> resumeJobsCommand() {
+    return new MockTypedRecord<>(
+        PROCESS_INSTANCE_KEY,
+        new RecordMetadata(),
+        new ProcessInstanceRecord().setProcessInstanceKey(PROCESS_INSTANCE_KEY));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspensionJobBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspensionJobBehaviorTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.state.immutable.JobState.State;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import java.util.ArrayList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+final class ProcessInstanceSuspensionJobBehaviorTest {
+
+  private static final long PROCESS_INSTANCE_KEY = 100L;
+  private static final long CHILD_ELEMENT_KEY = 101L;
+  private static final long JOB_KEY = 200L;
+  private static final long CHILD_JOB_KEY = 201L;
+
+  private MutableProcessingState processingState;
+
+  private MutableElementInstanceState elementInstanceState;
+  private MutableJobState jobState;
+  private StateWriter stateWriter;
+  private ProcessInstanceSuspensionJobBehavior behavior;
+
+  @BeforeEach
+  void setUp() {
+    elementInstanceState = processingState.getElementInstanceState();
+    jobState = processingState.getJobState();
+    stateWriter = mock(StateWriter.class);
+    behavior =
+        new ProcessInstanceSuspensionJobBehavior(elementInstanceState, jobState, stateWriter);
+  }
+
+  @Test
+  void shouldSuspendActivatableJob() {
+    // given
+    rootInstance();
+    activatableJob(PROCESS_INSTANCE_KEY, JOB_KEY);
+
+    // when
+    behavior.suspendJobs(PROCESS_INSTANCE_KEY);
+
+    // then
+    verify(stateWriter).appendFollowUpEvent(eq(JOB_KEY), eq(JobIntent.SUSPENDED), any());
+  }
+
+  @Test
+  void shouldSuspendJobWaitingForSecretResolution() {
+    // given - suspension overrides secret-waiting, so a later resolution can't reactivate the job
+    // while the instance stays suspended
+    rootInstance();
+    secretWaitingJob(PROCESS_INSTANCE_KEY, JOB_KEY);
+
+    // when
+    behavior.suspendJobs(PROCESS_INSTANCE_KEY);
+
+    // then
+    verify(stateWriter).appendFollowUpEvent(eq(JOB_KEY), eq(JobIntent.SUSPENDED), any());
+  }
+
+  @Test
+  void shouldNotSuspendAlreadyActivatedJob() {
+    // given - a job a worker already picked up is already off the activatable index; suspend has
+    // nothing to do for it
+    rootInstance();
+    activatedJob(PROCESS_INSTANCE_KEY, JOB_KEY);
+
+    // when
+    behavior.suspendJobs(PROCESS_INSTANCE_KEY);
+
+    // then
+    verify(stateWriter, never()).appendFollowUpEvent(anyLong(), eq(JobIntent.SUSPENDED), any());
+  }
+
+  @Test
+  void shouldSuspendJobsAcrossTheWholeElementInstanceTree() {
+    // given - a job on the root and a job on a child element
+    rootInstance();
+    childInstance(CHILD_ELEMENT_KEY, PROCESS_INSTANCE_KEY);
+    activatableJob(PROCESS_INSTANCE_KEY, JOB_KEY);
+    activatableJob(CHILD_ELEMENT_KEY, CHILD_JOB_KEY);
+
+    // when
+    behavior.suspendJobs(PROCESS_INSTANCE_KEY);
+
+    // then - the walk reaches both, not only the root's own job
+    verify(stateWriter).appendFollowUpEvent(eq(JOB_KEY), eq(JobIntent.SUSPENDED), any());
+    verify(stateWriter).appendFollowUpEvent(eq(CHILD_JOB_KEY), eq(JobIntent.SUSPENDED), any());
+  }
+
+  @Test
+  void shouldDoNothingWhenProcessInstanceIsGone() {
+    // given - no element instance seeded; getInstance returns null
+
+    // when
+    behavior.suspendJobs(PROCESS_INSTANCE_KEY);
+
+    // then
+    verify(stateWriter, never()).appendFollowUpEvent(anyLong(), any(), any());
+  }
+
+  @Test
+  void shouldNotSuspendJobOfADifferentProcessInstance() {
+    // given - defensive backstop: a child element instance carrying a different
+    // processInstanceKey must still be filtered out, even though getChildren returns it as a
+    // child of the root
+    rootInstance();
+    childInstance(CHILD_ELEMENT_KEY, 999L);
+    activatableJob(CHILD_ELEMENT_KEY, CHILD_JOB_KEY);
+
+    // when
+    behavior.suspendJobs(PROCESS_INSTANCE_KEY);
+
+    // then
+    verify(stateWriter, never()).appendFollowUpEvent(eq(CHILD_JOB_KEY), any(), any());
+  }
+
+  @Test
+  void shouldVisitOnlySuspendedJobs() {
+    // given - one SUSPENDED job and one still-ACTIVATABLE job
+    rootInstance();
+    childInstance(CHILD_ELEMENT_KEY, PROCESS_INSTANCE_KEY);
+    suspendedJob(PROCESS_INSTANCE_KEY, JOB_KEY);
+    activatableJob(CHILD_ELEMENT_KEY, CHILD_JOB_KEY);
+    final var visited = new ArrayList<Long>();
+
+    // when
+    behavior.forEachSuspendedJob(
+        elementInstanceState.getInstance(PROCESS_INSTANCE_KEY),
+        (jobKey, job) -> {
+          visited.add(jobKey);
+          return true;
+        });
+
+    // then
+    assertThat(visited).containsExactly(JOB_KEY);
+  }
+
+  @Test
+  void shouldStopTheWalkWhenVisitorReturnsFalse() {
+    // given - two suspended jobs
+    rootInstance();
+    childInstance(CHILD_ELEMENT_KEY, PROCESS_INSTANCE_KEY);
+    suspendedJob(PROCESS_INSTANCE_KEY, JOB_KEY);
+    suspendedJob(CHILD_ELEMENT_KEY, CHILD_JOB_KEY);
+    final var visited = new ArrayList<Long>();
+
+    // when - the visitor stops after the first job it sees
+    behavior.forEachSuspendedJob(
+        elementInstanceState.getInstance(PROCESS_INSTANCE_KEY),
+        (jobKey, job) -> {
+          visited.add(jobKey);
+          return false;
+        });
+
+    // then
+    assertThat(visited).hasSize(1);
+  }
+
+  @Test
+  void shouldNotVisitAnyJobWhenNoneAreSuspended() {
+    // given
+    rootInstance();
+    activatableJob(PROCESS_INSTANCE_KEY, JOB_KEY);
+    final var visited = new ArrayList<Long>();
+
+    // when
+    behavior.forEachSuspendedJob(
+        elementInstanceState.getInstance(PROCESS_INSTANCE_KEY),
+        (jobKey, job) -> {
+          visited.add(jobKey);
+          return true;
+        });
+
+    // then
+    assertThat(visited).isEmpty();
+  }
+
+  private void rootInstance() {
+    final var record = processInstanceRecord(PROCESS_INSTANCE_KEY);
+    elementInstanceState.newInstance(
+        PROCESS_INSTANCE_KEY, record, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+  }
+
+  private void childInstance(final long elementKey, final long processInstanceKey) {
+    final var parent = elementInstanceState.getInstance(PROCESS_INSTANCE_KEY);
+    final var record = processInstanceRecord(processInstanceKey);
+    elementInstanceState.newInstance(
+        parent, elementKey, record, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+  }
+
+  private void activatableJob(final long elementKey, final long jobKey) {
+    final var record = jobRecord();
+    jobState.insertJobRecordActivatable(jobKey, record);
+    jobState.makeJobActivatableByPriority(
+        record.getTypeBuffer(), jobKey, record.getTenantId(), record.getPriority());
+    elementInstanceState.updateInstance(elementKey, ei -> ei.setJobKey(jobKey));
+  }
+
+  private void secretWaitingJob(final long elementKey, final long jobKey) {
+    final var record = jobRecord();
+    jobState.insertJobRecordActivatable(jobKey, record);
+    jobState.makeJobActivatableByPriority(
+        record.getTypeBuffer(), jobKey, record.getTenantId(), record.getPriority());
+    jobState.parkForSecretResolution(jobKey, record);
+    elementInstanceState.updateInstance(elementKey, ei -> ei.setJobKey(jobKey));
+  }
+
+  private void activatedJob(final long elementKey, final long jobKey) {
+    final var record = jobRecord();
+    jobState.insertJobRecordActivatable(jobKey, record);
+    jobState.makeJobActivatableByPriority(
+        record.getTypeBuffer(), jobKey, record.getTenantId(), record.getPriority());
+    jobState.activate(jobKey, record);
+    elementInstanceState.updateInstance(elementKey, ei -> ei.setJobKey(jobKey));
+  }
+
+  private void suspendedJob(final long elementKey, final long jobKey) {
+    final var record = jobRecord();
+    jobState.insertJobRecordActivatable(jobKey, record);
+    jobState.makeJobActivatableByPriority(
+        record.getTypeBuffer(), jobKey, record.getTenantId(), record.getPriority());
+    jobState.updateJobState(jobKey, State.SUSPENDED);
+    jobState.makeJobNotActivatable(jobKey, record);
+    elementInstanceState.updateInstance(elementKey, ei -> ei.setJobKey(jobKey));
+  }
+
+  private ProcessInstanceRecord processInstanceRecord(final long processInstanceKey) {
+    return new ProcessInstanceRecord()
+        .setElementId("process")
+        .setBpmnProcessId("process")
+        .setProcessInstanceKey(processInstanceKey)
+        .setFlowScopeKey(-1L)
+        .setVersion(1)
+        .setProcessDefinitionKey(1L)
+        .setBpmnElementType(BpmnElementType.PROCESS);
+  }
+
+  private static JobRecord jobRecord() {
+    return new JobRecord()
+        .setType("test")
+        .setRetries(3)
+        .setPriority(50)
+        .setDeadline(256L)
+        .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ResumeProcessInstanceJobDrainTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ResumeProcessInstanceJobDrainTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+/**
+ * Covers resuming the parked jobs of an instance one at a time via the {@code RESUME_JOBS} loop in
+ * {@link ProcessInstanceResumeJobsProcessor}, instead of writing every job's {@code Job.RESUMED}
+ * (and, for a stream-activatable job, its {@code JobBatch.ACTIVATED}) into the single batch that
+ * finishes the drain. One job per cycle bounds each cycle's batch to a single job's own activation
+ * regardless of how many jobs the instance parked at suspend time.
+ */
+public final class ResumeProcessInstanceJobDrainTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final int JOB_COUNT = 5;
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldResumeEveryParkedJobOneCycleAtATime() {
+    // given
+    final String jobType = Strings.newRandomValidBpmnId();
+    final String processId = Strings.newRandomValidBpmnId();
+    deploy(processId, jobType);
+    final long processInstanceKey = start(processId, JOB_COUNT);
+    final var jobKeys = createdJobKeys(processInstanceKey, JOB_COUNT);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    assertThat(ENGINE.jobs().withType(jobType).activate().getValue().getJobKeys()).isEmpty();
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then - one RESUME_JOBS cycle un-parks exactly one job, plus a final cycle that finds none
+    // left and hands off to COMPLETE_RESUMING
+    final var resumeJobsCount =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.RESUME_JOBS)
+            .withProcessInstanceKey(processInstanceKey)
+            .limit(JOB_COUNT + 1)
+            .count();
+    assertThat(resumeJobsCount).isEqualTo(JOB_COUNT + 1);
+
+    final var resumedJobKeys =
+        RecordingExporter.jobRecords(JobIntent.RESUMED)
+            .withProcessInstanceKey(processInstanceKey)
+            .limit(JOB_COUNT)
+            .map(Record::getKey)
+            .toList();
+    assertThat(resumedJobKeys).containsExactlyInAnyOrderElementsOf(jobKeys);
+
+    // every RESUMED job is handed out again with the priority it had before suspend
+    final Record<JobBatchRecordValue> batch =
+        ENGINE.jobs().withType(jobType).withMaxJobsToActivate(JOB_COUNT).activate();
+    assertThat(batch.getValue().getJobKeys()).containsExactlyInAnyOrderElementsOf(jobKeys);
+    assertThat(batch.getValue().getJobs())
+        .allSatisfy(job -> assertThat(job.getPriority()).isEqualTo(42));
+  }
+
+  @Test
+  public void shouldNotResumeParkedJobOfAnotherSuspendedInstance() {
+    // given - two instances of the same process; only one is resumed
+    final String jobType = Strings.newRandomValidBpmnId();
+    final String processId = Strings.newRandomValidBpmnId();
+    deploy(processId, jobType);
+    final long resumedInstanceKey = start(processId, 1);
+    final long resumedJobKey = createdJobKeys(resumedInstanceKey, 1).getFirst();
+    final long otherInstanceKey = start(processId, 1);
+    createdJobKeys(otherInstanceKey, 1);
+    ENGINE.processInstance().withInstanceKey(resumedInstanceKey).suspend();
+    ENGINE.processInstance().withInstanceKey(otherInstanceKey).suspend();
+
+    // when
+    ENGINE.processInstance().withInstanceKey(resumedInstanceKey).resume();
+
+    // then - only the resumed instance's job is un-parked and handed out again; the other
+    // instance's job stays parked, so it does not appear in this activation
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.RESUMED).withRecordKey(resumedJobKey).exists())
+        .isTrue();
+    assertThat(ENGINE.jobs().withType(jobType).activate().getValue().getJobKeys())
+        .containsExactly(resumedJobKey);
+  }
+
+  private static void deploy(final String processId, final String jobType) {
+    ENGINE.deployment().withXmlResource(parallelMultiInstanceProcess(processId, jobType)).deploy();
+  }
+
+  private static long start(final String processId, final int jobCount) {
+    return ENGINE
+        .processInstance()
+        .ofBpmnProcessId(processId)
+        .withVariable("items", IntStream.range(0, jobCount).boxed().toList())
+        .create();
+  }
+
+  private static BpmnModelInstance parallelMultiInstanceProcess(
+      final String processId, final String jobType) {
+    return Bpmn.createExecutableProcess(processId)
+        .startEvent()
+        .serviceTask(
+            "task",
+            t ->
+                t.zeebeJobType(jobType)
+                    .zeebeJobPriority("42")
+                    .multiInstance(
+                        m -> m.zeebeInputCollectionExpression("items").zeebeInputElement("item")))
+        .endEvent()
+        .done();
+  }
+
+  private static List<Long> createdJobKeys(final long processInstanceKey, final int jobCount) {
+    return RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .limit(jobCount)
+        .map(Record::getKey)
+        .toList();
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
@@ -82,15 +82,21 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
   RESUMING((short) 21),
 
   /**
-   * Represents the internal command that finalizes the resume lifecycle once the buffered-command
-   * drain is complete. The drain processor writes this command when the buffer is empty; a
-   * dedicated processor reacts by writing {@link #RESUMED} and triggering any post-resume actions
-   * (e.g. resuming suspended jobs).
+   * Represents the internal command that finalizes the resume lifecycle once every parked job has
+   * been un-parked. {@link #RESUME_JOBS} writes this command once none are left; a dedicated
+   * processor reacts by writing {@link #RESUMED}.
    */
-  COMPLETE_RESUMING((short) 22, false);
+  COMPLETE_RESUMING((short) 22, false),
+
+  /**
+   * Represents the internal command that un-parks suspended jobs of the instance, appending itself
+   * again until none are left, then handing off to {@link #COMPLETE_RESUMING}. The drain processor
+   * writes the first cycle when the buffered-command drain is complete.
+   */
+  RESUME_JOBS((short) 23, false);
 
   private static final Set<ProcessInstanceIntent> PROCESS_INSTANCE_COMMANDS =
-      EnumSet.of(CANCEL, SUSPEND, RESUME, COMPLETE_RESUMING);
+      EnumSet.of(CANCEL, SUSPEND, RESUME, COMPLETE_RESUMING, RESUME_JOBS);
   private static final Set<ProcessInstanceIntent> BPMN_ELEMENT_COMMANDS =
       EnumSet.of(
           ACTIVATE_ELEMENT,
@@ -163,6 +169,8 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
         return RESUMING;
       case 22:
         return COMPLETE_RESUMING;
+      case 23:
+        return RESUME_JOBS;
       default:
         return Intent.UNKNOWN;
     }

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntentTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntentTest.java
@@ -62,5 +62,6 @@ final class ProcessInstanceIntentTest {
     assertThat(ProcessInstanceIntent.from((short) 21)).isEqualTo(ProcessInstanceIntent.RESUMING);
     assertThat(ProcessInstanceIntent.from((short) 22))
         .isEqualTo(ProcessInstanceIntent.COMPLETE_RESUMING);
+    assertThat(ProcessInstanceIntent.from((short) 23)).isEqualTo(ProcessInstanceIntent.RESUME_JOBS);
   }
 }


### PR DESCRIPTION
## Merge order

Stacked on top of #59617.

## Summary

When a process instance resumes, its parked jobs must be available to workers again without a migration or a further state transition.

This change extends `ProcessInstanceResumeProcessor` to walk the same element-instance tree as suspend and append `Job.RESUMED` for every parked job, which puts the job back into the hand-out index with its own priority. It then calls `BpmnJobActivationBehavior.publishWork` for each job, the same pattern the backoff recurrence uses after reactivation: a job stream is push-only, so without that call a stream worker would never learn the job is available again, while a polling worker gets the job-available notification.

## Changes

- Thread `BpmnJobActivationBehavior` into the resume processor through `BpmnProcessors`
- Resume parked jobs on process-instance resume and publish work for each
- Add `JobSuspensionJobStreamPushTest` for the push path (load-bearing for `publishWork`)
- Extend `JobSuspensionHandoutTest` for the poll path after resume
- ADR notes on resume batch size and legacy `JOB_ACTIVATABLE` ordering

## Testing

- After resume, a parked job is activatable again by the next poll
- After resume, a waiting job-stream worker receives the job
- Nothing is pushed while the instance stays suspended
- Priority is kept across suspend and resume

## Links

- Depends on: #59617 / #59558
- Parent: #58088
- Epic: #57507

Closes #59559